### PR TITLE
Convert AgentIDCard message to use a Fluent selector

### DIFF
--- a/Content.Server/Access/Systems/AgentIDCardSystem.cs
+++ b/Content.Server/Access/Systems/AgentIDCardSystem.cs
@@ -42,21 +42,9 @@ namespace Content.Server.Access.Systems
             access.Tags.UnionWith(targetAccess.Tags);
             var addedLength = access.Tags.Count - beforeLength;
 
-            if (addedLength == 0)
-            {
-                _popupSystem.PopupEntity(Loc.GetString("agent-id-no-new", ("card", args.Target)), args.Target.Value, args.User);
-                return;
-            }
-
-            Dirty(uid, access);
-
-            if (addedLength == 1)
-            {
-                _popupSystem.PopupEntity(Loc.GetString("agent-id-new-1", ("card", args.Target)), args.Target.Value, args.User);
-                return;
-            }
-
             _popupSystem.PopupEntity(Loc.GetString("agent-id-new", ("number", addedLength), ("card", args.Target)), args.Target.Value, args.User);
+            if (addedLength > 0)
+                Dirty(uid, access);
         }
 
         private void AfterUIOpen(EntityUid uid, AgentIDCardComponent component, AfterActivatableUIOpenEvent args)

--- a/Resources/Locale/en-US/access/components/agent-id-card-component.ftl
+++ b/Resources/Locale/en-US/access/components/agent-id-card-component.ftl
@@ -1,6 +1,9 @@
-agent-id-no-new = Didn't gain any new accesses from {THE($card)}.
-agent-id-new-1 = Gained one new access from {THE($card)}.
-agent-id-new = Gained {$number} new accesses from {THE($card)}.
+agent-id-new = { $number ->
+    [0] Didn't gain any new accesses from {THE($card)}.
+    [one] Gained one new access from {THE($card)}.
+   *[other] Gained {$number} new accesses from {THE($card)}.
+}
+
 agent-id-card-current-name = Name:
 agent-id-card-current-job = Job:
 agent-id-card-job-icon-label = Job icon:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Moved the logic for selecting the correct message from C# to Fluent for the popup displayed when gaining new accesses with the Agent ID card.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Selecting between "You didn't gain any", "You gained one", and "You gained X" in the game code is bad for localization - different languages have different ways of handling pluralization, and this logic should be handled by the localization system, not the game code. Fluent has the tools to do this easily.

## Technical details
<!-- Summary of code changes for easier review. -->
The `_popupSystem.PopupEntity` calls for the different forms were consolidated into a single call that always passes in the number of accesses changed. A [Fluent selector](https://projectfluent.org/fluent/guide/selectors.html) handles picking the right message automatically.
The code flow was modified a little bit to ensure that `Dirty` is still only called when at least one access is added.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->