### PR TITLE
Fix entities burning to ash not using identity, and bad formatting

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/BurnBodyBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/BurnBodyBehavior.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Body.Components;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory;
 using Content.Shared.Popups;
 using JetBrains.Annotations;
@@ -25,7 +26,8 @@ public sealed partial class BurnBodyBehavior : IThresholdBehavior
             }
         }
 
-        sharedPopupSystem.PopupCoordinates(Loc.GetString("bodyburn-text-others", ("name", bodyId)), transformSystem.GetMoverCoordinates(bodyId), PopupType.LargeCaution);
+        var bodyIdentity = Identity.Entity(bodyId, system.EntityManager);
+        sharedPopupSystem.PopupCoordinates(Loc.GetString("bodyburn-text-others", ("name", bodyIdentity)), transformSystem.GetMoverCoordinates(bodyId), PopupType.LargeCaution);
 
         system.EntityManager.QueueDeleteEntity(bodyId);
     }

--- a/Resources/Locale/en-US/burning/bodyburn.ftl
+++ b/Resources/Locale/en-US/burning/bodyburn.ftl
@@ -1,1 +1,1 @@
-﻿bodyburn-text-others = {$name} burns to ash!
+﻿bodyburn-text-others = {CAPITALIZE(THE($name))} burns to ash!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When entities burn to ash, the popup message no longer reveals their true identity, instead respecting anything that might be hiding or disguising it (like a mask).
Additionally, the popup message now displays properly for entities that are not proper nouns, so instead of "young man burns to ash!", it will show as "The young man burns to ash!"

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Just a couple of tiny bug fixes.

## Technical details
<!-- Summary of code changes for easier review. -->
- `Identity.Entity`
- `CAPITALIZE(THE($name))`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->