### PR TITLE
Fix a few loc bugs with magic mirror/scissors

### DIFF
--- a/Content.Server/MagicMirror/MagicMirrorSystem.cs
+++ b/Content.Server/MagicMirror/MagicMirrorSystem.cs
@@ -59,7 +59,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             _popup.PopupEntity(
                 component.Target == message.Actor
                     ? Loc.GetString("magic-mirror-blocked-by-hat-self")
-                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target"),
+                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target", ("target", Identity.Entity(message.Actor, EntityManager))),
                 message.Actor,
                 message.Actor,
                 PopupType.Medium);

--- a/Content.Server/MagicMirror/MagicMirrorSystem.cs
+++ b/Content.Server/MagicMirror/MagicMirrorSystem.cs
@@ -95,7 +95,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         }
         else
         {
-            _popup.PopupEntity(Loc.GetString("magic-mirror-change-slot-target", ("user", Identity.Name(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
+            _popup.PopupEntity(Loc.GetString("magic-mirror-change-slot-target", ("user", Identity.Entity(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
         }
 
         component.DoAfter = doAfterId;
@@ -175,7 +175,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         }
         else
         {
-            _popup.PopupEntity(Loc.GetString("magic-mirror-change-color-target", ("user", Identity.Name(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
+            _popup.PopupEntity(Loc.GetString("magic-mirror-change-color-target", ("user", Identity.Entity(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
         }
 
         component.DoAfter = doAfterId;
@@ -253,7 +253,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         }
         else
         {
-            _popup.PopupEntity(Loc.GetString("magic-mirror-remove-slot-target", ("user", Identity.Name(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
+            _popup.PopupEntity(Loc.GetString("magic-mirror-remove-slot-target", ("user", Identity.Entity(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
         }
 
         component.DoAfter = doAfterId;
@@ -331,7 +331,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         }
         else
         {
-            _popup.PopupEntity(Loc.GetString("magic-mirror-add-slot-target", ("user", Identity.Name(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
+            _popup.PopupEntity(Loc.GetString("magic-mirror-add-slot-target", ("user", Identity.Entity(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
         }
 
         component.DoAfter = doAfterId;

--- a/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
+++ b/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
@@ -6,10 +6,10 @@ magic-mirror-remove-slot-self = You're removing some of your hair.
 magic-mirror-change-slot-self = You're changing your hairstyle.
 magic-mirror-change-color-self = You're changing your hair color.
 
-magic-mirror-add-slot-target = Hair is being added to you by {$user}.
-magic-mirror-remove-slot-target = Your hair is being cut off by {$user}.
-magic-mirror-change-slot-target = Your hairstyle is being changed by {$user}.
-magic-mirror-change-color-target = Your hair color is being changed by {$user}.
+magic-mirror-add-slot-target = Hair is being added to you by {THE($user)}.
+magic-mirror-remove-slot-target = Your hair is being cut off by {THE($user)}.
+magic-mirror-change-slot-target = Your hairstyle is being changed by {THE($user)}.
+magic-mirror-change-color-target = Your hair color is being changed by {THE($user)}.
 
 magic-mirror-blocked-by-hat-self = You need to take off your hat before changing your hair.
 magic-mirror-blocked-by-hat-self-target = You try to change their hair but their clothes gets in the way.

--- a/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
+++ b/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
@@ -12,4 +12,4 @@ magic-mirror-change-slot-target = Your hairstyle is being changed by {THE($user)
 magic-mirror-change-color-target = Your hair color is being changed by {THE($user)}.
 
 magic-mirror-blocked-by-hat-self = You need to take off your hat before changing your hair.
-magic-mirror-blocked-by-hat-self-target = You try to change their hair but their clothes gets in the way.
+magic-mirror-blocked-by-hat-self-target = You try to change {POSS-ADJ($target)} hair but {POSS-ADJ($target)} clothes get in the way.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed a few bugs with the popup messages displayed by the magic mirror system (which is also used for barber scissors).
- Messages now use the target/user's identity and won't blow their disguise.
- Messages a now formatted correctly when the user is not a proper noun ("Your hairstyle is being changed by young man" -> "Your hairstyle is being changed by the young man").
- The message displayed when the target's hair is blocked by their clothing now uses the target's appropriate pronouns.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Just some more little bug fixes.

## Technical details
<!-- Summary of code changes for easier review. -->
- `Identity.Entity`
- `THE($user)`
- `POSS-ADJ($target)`

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="503" alt="Screenshot 2025-04-02 at 10 13 58 PM" src="https://github.com/user-attachments/assets/ddff8f58-3210-4230-bc84-40d65e20f815" />
<img width="498" alt="Screenshot 2025-04-02 at 10 19 38 PM" src="https://github.com/user-attachments/assets/0d050ab1-b471-43c5-8e6c-ab7df3ea061b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->