### PR TITLE
Antagonist roles now require 1h playtime.

### DIFF
--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -9,7 +9,6 @@
   - !type:OverallPlaytimeRequirement
     time: 3600 # 1h
 
-
 - type: antag
   id: Rev
   name: roles-antag-rev-name

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -5,6 +5,10 @@
   setPreference: true
   objective: roles-antag-rev-head-objective
   guides: [ Revolutionaries ]
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 3600 # 1h
+
 
 - type: antag
   id: Rev

--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -5,6 +5,9 @@
   setPreference: true
   objective: roles-antag-thief-objective
   guides: [ Thieves ]
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 3600 # 1h
 
 - type: startingGear
   id: ThiefGear

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -5,6 +5,9 @@
   setPreference: true
   objective: roles-antag-syndicate-agent-objective
   guides: [ Traitors ]
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 3600 # 1h
 
 - type: antag
   id: TraitorSleeper
@@ -13,6 +16,9 @@
   setPreference: true
   objective: roles-antag-syndicate-agent-sleeper-objective
   guides: [ Traitors ]
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 3600 # 1h
 
 # Syndicate Operative Outfit - Monkey
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -5,6 +5,9 @@
   setPreference: true
   objective: roles-antag-initial-infected-objective
   guides: [ Zombies ]
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 3600 # 1h
 
 - type: antag
   id: Zombie


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made all the basic antag roles (sleeper, syndie, thief, infected, headrev) require 1h playtime.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Before everyone throws rocks at me for a change that doesn't affect anyone ever, this is meant to solve two issues:
- Stop new players from getting antagonist as their first game to let them learn in peace. Throwing someone into deep water is not a good idea.
- Stop new but not new players (Raiders) from getting antagonist roles. One common thing ive witnessed that happens too often is when a raider joins and they get an antagonist role. Now in a situation like this, as an admin, im forced to watch them until i get absolute concrete proof they are a raider. And it happened several times where they even got DAGD, making it impossible to judge.

#### Ultimately this change simply does not matter for regular players, needing to play a singular shift to get antag is a non-issue, meanwhile raiders can no longer yell out "Im syndi" in ahelp and have it be a valid excuse.

Now you may ask... What if a raider sits for 1h gaining playtime? No issue. That is their time wasted while we still take less than 5 minutes to dispose of them :) This just ensures they have it harder and players have an easier time knowing who a raider is
## Technical details
<!-- Summary of code changes for easier review. -->
Yaml only.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/8af82a08-7b6f-4dba-b70c-5f66f209f5fc)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Players now require 1h of playtime before selecting any antagonist role. 
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
