### PR TITLE
Add 10u of plasma to SyndieJuice

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -53,6 +53,7 @@
     JugSugar: 3
     JugSulfur: 1
     JugWeldingFuel: 1
+    PlasmaChemistryVial: 1
   contrabandInventory:
     DrinkLithiumFlask: 1
     StrangePill: 3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
PR adds a small vial of plasma (10u) to the NukeOp's chemistry vending machine.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is a small convenience change for nuke agents. Grabbing plasteel to grind down for plasma feels strange and unintuitive, as if the Syndicate didn't actually prep for this mission (they probably didn't). The 10 units of plasma isn't enough for the chems that cost plasma so it's not completely removed, but will make using plasma as a catalyst less annoying.

## Technical details
<!-- Summary of code changes for easier review. -->
Same entity as the one in chemist lockers.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: aada
- add: SyndieJuice now comes with 10 units of liquid plasma.