### PR TITLE
Fix loc issues with suicide popup

### DIFF
--- a/Content.Server/Chat/SuicideSystem.cs
+++ b/Content.Server/Chat/SuicideSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Chat;
 using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.Hands.Components;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
 using Content.Shared.Mind;
@@ -149,7 +150,7 @@ public sealed class SuicideSystem : EntitySystem
         if (args.Handled)
             return;
 
-        var othersMessage = Loc.GetString("suicide-command-default-text-others", ("name", victim));
+        var othersMessage = Loc.GetString("suicide-command-default-text-others", ("name", Identity.Entity(victim, EntityManager)));
         _popup.PopupEntity(othersMessage, victim, Filter.PvsExcept(victim), true);
 
         var selfMessage = Loc.GetString("suicide-command-default-text-self");

--- a/Resources/Locale/en-US/chat/commands/suicide-command.ftl
+++ b/Resources/Locale/en-US/chat/commands/suicide-command.ftl
@@ -3,7 +3,7 @@ suicide-command-help-text = The suicide command gives you a quick way out of a r
                             The method varies, first it will attempt to use the held item in your active hand.
                             If that fails, it will attempt to use an object in the environment.
                             Finally, if neither of the above worked, you will die by biting your tongue.
-suicide-command-default-text-others = {$name} is attempting to bite their own tongue!
+suicide-command-default-text-others = {CAPITALIZE(THE($name))} is attempting to bite {POSS-ADJ($name)} own tongue!
 suicide-command-default-text-self = You attempt to bite your own tongue!
 suicide-command-already-dead = You can't suicide. You're dead.
 suicide-command-no-mind = You have no mind!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed a few minor issues with the popup message displayed to other players when someone uses the generic suicide command.
- The player's identity is used.
- The message is now properly formatted for non-proper nouns ("young man is..." -> "**The** young man is...").
- The gender-appropriate pronoun is now used instead of always using "their" ("...is attempting to bite **his** own tongue!")

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
More little bug fixes.

## Technical details
<!-- Summary of code changes for easier review. -->
- `Identity.Entity`
- `CAPITALIZE(THE($name))`
- `POSS-ADJ($name)`

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="498" alt="Screenshot 2025-04-03 at 8 23 08 PM" src="https://github.com/user-attachments/assets/d7cc39c6-7c1f-4e4d-adfa-2aad5c634cd0" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->