### PR TITLE
EntityEffectConditions changed to be inclusive of min/max

### DIFF
--- a/Content.Server/EntityEffects/EffectConditions/BodyTemperature.cs
+++ b/Content.Server/EntityEffects/EffectConditions/BodyTemperature.cs
@@ -15,11 +15,12 @@ public sealed partial class Temperature : EntityEffectCondition
 
     [DataField]
     public float Max = float.PositiveInfinity;
+
     public override bool Condition(EntityEffectBaseArgs args)
     {
         if (args.EntityManager.TryGetComponent(args.TargetEntity, out TemperatureComponent? temp))
         {
-            if (temp.CurrentTemperature > Min && temp.CurrentTemperature < Max)
+            if (temp.CurrentTemperature >= Min && temp.CurrentTemperature <= Max)
                 return true;
         }
 

--- a/Content.Server/EntityEffects/EffectConditions/SolutionTemperature.cs
+++ b/Content.Server/EntityEffects/EffectConditions/SolutionTemperature.cs
@@ -14,15 +14,16 @@ public sealed partial class SolutionTemperature : EntityEffectCondition
 
     [DataField]
     public float Max = float.PositiveInfinity;
+
     public override bool Condition(EntityEffectBaseArgs args)
     {
         if (args is EntityEffectReagentArgs reagentArgs)
         {
             if (reagentArgs.Source == null)
                 return false;
-            if (reagentArgs.Source.Temperature < Min)
+            if (reagentArgs.Source.Temperature <= Min)
                 return false;
-            if (reagentArgs.Source.Temperature > Max)
+            if (reagentArgs.Source.Temperature >= Max)
                 return false;
             return true;
         }

--- a/Content.Server/EntityEffects/EffectConditions/TotalDamage.cs
+++ b/Content.Server/EntityEffects/EffectConditions/TotalDamage.cs
@@ -18,7 +18,7 @@ public sealed partial class TotalDamage : EntityEffectCondition
         if (args.EntityManager.TryGetComponent(args.TargetEntity, out DamageableComponent? damage))
         {
             var total = damage.TotalDamage;
-            if (total > Min && total < Max)
+            if (total >= Min && total <= Max)
                 return true;
         }
 

--- a/Content.Server/EntityEffects/EffectConditions/TotalHunger.cs
+++ b/Content.Server/EntityEffects/EffectConditions/TotalHunger.cs
@@ -18,7 +18,7 @@ public sealed partial class Hunger : EntityEffectCondition
         if (args.EntityManager.TryGetComponent(args.TargetEntity, out HungerComponent? hunger))
         {
             var total = args.EntityManager.System<HungerSystem>().GetHunger(hunger);
-            if (total > Min && total < Max)
+            if (total >= Min && total <= Max)
                 return true;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Change to conditions used for entity effects to include the min/max values, i.e. lipolicide deals poison damage _at_ 0 and 50 instead of between 0 and 50.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Started as a bugfix for lipolicide not dealing damage if the person is at 0 hunger, and expanded to include all conditions for consistency. Besides the bugfix I feel it's generally more intuitive, and the language used in the guidebook implies this is how the condition works.

This doesn't change OD thresholds, as those were already inclusive.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: aada
- fix: Lipolicide now continues to poison at 0 hunger.
- tweak: Tricordrazine now heals at exactly 50 damage instead of needing to be below 50.