### PR TITLE
Tilestack system (aka tile smoothing)

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -28,6 +28,7 @@ namespace Content.Server.Explosion.EntitySystems;
 public sealed partial class ExplosionSystem
 {
     [Dependency] private readonly FlammableSystem _flammableSystem = default!;
+    [Dependency] private readonly TileSystem _tile = default!;
 
     /// <summary>
     ///     Used to limit explosion processing time. See <see cref="MaxProcessingTime"/>.
@@ -527,7 +528,6 @@ public sealed partial class ExplosionSystem
             tileBreakages++;
             effectiveIntensity -= type.TileBreakRerollReduction;
 
-            // does this have a base-turf that we can break it down to?
             if (string.IsNullOrEmpty(tileDef.BaseTurf))
                 break;
 
@@ -537,7 +537,8 @@ public sealed partial class ExplosionSystem
             if (newDef.MapAtmosphere && !canCreateVacuum)
                 break;
 
-            tileDef = newDef;
+            // do not assign newDef directly, that would ignore tilestacks
+            _tile.DeconstructTile(tileRef);
         }
 
         if (tileDef.TileId == tileRef.Tile.TypeId)

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -44,6 +44,13 @@ namespace Content.Shared.Maps
         [DataField("baseTurf")]
         public string BaseTurf { get; private set; } = string.Empty;
 
+        /// <summary>
+        ///     A list of all the possible base turfs. doesn't have to contain <see cref="BaseTurf"/>.
+        ///     You can place a tile on BaseTurf and all the tiles listed here; if it's not placed on BaseTurf, a tilestack is created in <see cref="TileStackMapComponent"/>.
+        /// </summary>
+        [DataField]
+        public string[] PossibleBaseTurfs = [];
+
         [DataField]
         public PrototypeFlags<ToolQualityPrototype> DeconstructTools { get; set; } = new();
 

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -49,7 +49,7 @@ namespace Content.Shared.Maps
         ///     You can place a tile on BaseTurf and all the tiles listed here; if it's not placed on BaseTurf, a tilestack is created in <see cref="TileStackMapComponent"/>.
         /// </summary>
         [DataField]
-        public string[] PossibleBaseTurfs = [];
+        public HashSet<string> PossibleBaseTurfs = [];
 
         [DataField]
         public PrototypeFlags<ToolQualityPrototype> DeconstructTools { get; set; } = new();

--- a/Content.Shared/Maps/TileStackMapComponent.cs
+++ b/Content.Shared/Maps/TileStackMapComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Maps;
+
+/// <summary>
+///     This component goes on the grid and stores non-standard sets of tiles.
+///     Standard = each tile is on its respective BaseTurf
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TileStackMapComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Dictionary<Vector2i, List<ContentTileDefinition>> Data = new();
+}

--- a/Content.Shared/Maps/TileStackMapComponent.cs
+++ b/Content.Shared/Maps/TileStackMapComponent.cs
@@ -10,5 +10,5 @@ namespace Content.Shared.Maps;
 public sealed partial class TileStackMapComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public Dictionary<Vector2i, List<ContentTileDefinition>> Data = new();
+    public Dictionary<Vector2i, List<string>> Data = new();
 }

--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -168,8 +168,11 @@ public sealed class TileSystem : EntitySystem
         if (_tileStack.HasTileStack(tileRef))
         {
             ref var tilestacks = ref Comp<TileStackMapComponent>(gridUid).Data;
-            var tileId = tilestacks[tileRef.GridIndices][tilestacks[tileRef.GridIndices].Count - 1];
-            tilestacks[tileRef.GridIndices].RemoveAt(tilestacks[tileRef.GridIndices].Count - 1);
+            var tilestack = tilestacks[tileRef.GridIndices];
+            var tileId = tilestack[^1];
+            tilestack.RemoveAt(tilestack.Count - 1);
+            if (tilestack.Count == 0)
+                tilestacks.Remove(tileRef.GridIndices);
             var newTile = new Tile(((ContentTileDefinition)_tileDefinitionManager[tileId]).TileId);
             _maps.SetTile(gridUid, mapGrid, tileRef.GridIndices, newTile);
         }

--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -165,22 +165,20 @@ public sealed class TileSystem : EntitySystem
             _decal.RemoveDecal(tileRef.GridUid, id);
         }
 
-        if (_tileStack.HasTileStack(tileRef))
-        {
-            ref var tilestacks = ref Comp<TileStackMapComponent>(gridUid).Data;
-            var tilestack = tilestacks[tileRef.GridIndices];
-            var tileId = tilestack[^1];
-            tilestack.RemoveAt(tilestack.Count - 1);
-            if (tilestack.Count == 0)
-                tilestacks.Remove(tileRef.GridIndices);
-            var newTile = new Tile(((ContentTileDefinition)_tileDefinitionManager[tileId]).TileId);
-            _maps.SetTile(gridUid, mapGrid, tileRef.GridIndices, newTile);
-        }
-        else
+        if (!_tileStack.HasTileStack(tileRef))
         {
             var plating = _tileDefinitionManager[tileDef.BaseTurf];
             _maps.SetTile(gridUid, mapGrid, tileRef.GridIndices, new Tile(plating.TileId));
+            return true;
         }
+        ref var tilestacks = ref Comp<TileStackMapComponent>(gridUid).Data;
+        var tilestack = tilestacks[tileRef.GridIndices];
+        var tileId = tilestack[^1];
+        tilestack.RemoveAt(tilestack.Count - 1);
+        if (tilestack.Count == 0)
+            tilestacks.Remove(tileRef.GridIndices);
+        var newTile = new Tile(((ContentTileDefinition)_tileDefinitionManager[tileId]).TileId);
+        _maps.SetTile(gridUid, mapGrid, tileRef.GridIndices, newTile);
         return true;
     }
 }

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -136,8 +136,9 @@ public sealed class FloorTileSystem : EntitySystem
 
                 var tile = _map.GetTileRef(gridUid, mapGrid, location);
                 var baseTurf = (ContentTileDefinition) _tileDefinitionManager[tile.Tile.TypeId];
-
-                if (HasBaseTurf(currentTileDefinition, baseTurf.ID))
+                // even if we put a tile on a standard turf, it has to be handled by the tilestack system if it already has a tilestack
+                // otherwise the tilestack doesn't update properly
+                if (HasBaseTurf(currentTileDefinition, baseTurf.ID) && !_tileStack.HasTileStack(tile))
                 {
                     if (!_stackSystem.Use(uid, 1, stack))
                         continue;

--- a/Content.Shared/Tiles/TileStackSystem.cs
+++ b/Content.Shared/Tiles/TileStackSystem.cs
@@ -1,0 +1,58 @@
+using Content.Shared.Maps;
+using Robust.Shared.Map;
+
+namespace Content.Shared.Tiles;
+
+/// <summary>
+/// This handles...
+/// </summary>
+public sealed class TileStackSystem : EntitySystem
+{
+    [Dependency] private readonly ITileDefinitionManager _tileDefinitionManager = default!;
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<GridInitializeEvent>(OnGridInit);
+        SubscribeLocalEvent<GridRemovalEvent>(OnGridRemoved);
+    }
+
+    private void OnGridInit(GridInitializeEvent ev)
+    {
+        EnsureComp<TileStackMapComponent>(ev.EntityUid);
+    }
+
+    private void OnGridRemoved(GridRemovalEvent ev)
+    {
+        RemComp<TileStackMapComponent>(ev.EntityUid);
+    }
+
+    public bool HasTileStack(TileRef tileRef)
+    {
+        return HasTileStack(tileRef.GridIndices, tileRef.GridUid);
+    }
+
+    public bool HasTileStack(Vector2i gridIndices, EntityUid gridUid)
+    {
+        if (!TryComp<TileStackMapComponent>(gridUid, out var tileStackMap))
+            return false;
+        return tileStackMap.Data.ContainsKey(gridIndices);
+    }
+
+    /// <summary>
+    ///     Creates a tilestack at the location of the tile ref.
+    /// </summary>
+    public void CreateTileStack(TileRef tileRef)
+    {
+        var tilestack = new List<string>();
+        var curtile = tileRef.GetContentTileDefinition().ID;
+        while (!string.IsNullOrEmpty(curtile))
+        {
+            tilestack.Insert(0, _tileDefinitionManager[curtile].ID);
+            curtile = ((ContentTileDefinition) _tileDefinitionManager[curtile]).BaseTurf;
+        }
+        if (!TryComp<TileStackMapComponent>(tileRef.GridUid, out var tileStackMap))
+            return;
+        tileStackMap.Data.Add(tileRef.GridIndices, tilestack);
+    }
+}

--- a/Content.Shared/Tiles/TileStackSystem.cs
+++ b/Content.Shared/Tiles/TileStackSystem.cs
@@ -45,7 +45,7 @@ public sealed class TileStackSystem : EntitySystem
     public void CreateTileStack(TileRef tileRef)
     {
         var tilestack = new List<string>();
-        var curtile = tileRef.GetContentTileDefinition().ID;
+        var curtile = tileRef.GetContentTileDefinition().BaseTurf;
         while (!string.IsNullOrEmpty(curtile))
         {
             tilestack.Insert(0, _tileDefinitionManager[curtile].ID);

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -243,6 +243,8 @@
   - 1.0
   - 1.0
   baseTurf: Plating
+  possibleBaseTurfs:
+  - FloorSteel
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -243,8 +243,6 @@
   - 1.0
   - 1.0
   baseTurf: Plating
-  possibleBaseTurfs:
-  - FloorSteel
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:


### PR DESCRIPTION
## About the PR
A base system for supporting tilestacks - non-standard tile configurations (like wood floor on steel floor in this example, not actually part of the PR)
it's not yet actually in the game, this PR only introduces the tech itself - there are different problems with tiles that need to be fixed before implementing this fully, such as tile parenting and stuff
i might have missed something, so please think of any problems that might arise

## Why / Balance
it cool

## Technical details
every grid gets a TileStackMapComponent, which stores tilestacks. Tilestacks are lists of strings which are ContentTileDefinion (we cannot replace those directly since ContentTileDefinion cannot be serialized)
TilestackSystem handles some basic functions like creating and checking for tilestacks, as well as actually giving all grids the TileStackMapComponent
ContentTileDefinition also got a field called PossibleBaseTurfs - you can place a tile BOTH on BaseTurf and PossibleBaseTurfs. Placing it on PossibleBaseTurfs creates the tilestack
then we add some additional logic to TileSystem, FloorTileSystem and ExplosionSystem... and waow floor system

## Media
https://github.com/user-attachments/assets/082da01c-4bfe-448b-9b23-1e8b8589d4ff

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Tilestack support (aka tile smoothing) has been added. This comes with some changes to TileSystem.DeconstructTile, FloorTileSystem.OnAfterInteract and ExplosionSystem.Processing.DamageFloorTile.

**Changelog**
not player facing
