### PR TITLE
Rotate Adv Mineral Scanner in Inventory

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/scanner.yml
@@ -67,6 +67,8 @@
       shader: unshaded
       visible: false
       map: ["enum.ToggleVisuals.Layer"]
+  - type: Item
+    storedRotation: -90
   - type: MiningScanner
     range: 10
 


### PR DESCRIPTION
## About the PR
Minor inventory layout issue.

## Why / Balance
- Adv Mineral Scanner rotated to align to sprite better in backpacks

## Technical details
- Rotated advanced mineral scanner in inventory to match sprite orientation

## Media
Advanced Mineral Scanner Rotation:
Before: 
![Before](https://github.com/user-attachments/assets/bab4b9bd-e47d-4845-8a13-b8e9bba0dc8a)
After: 
![After](https://github.com/user-attachments/assets/ba302cf9-fb1c-4fe2-aa06-adf4c15f9e3a)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Aligned Adv. Mineral Scanner rotation in inventory