### PR TITLE
Fix ninjas not being able to hack criminal records

### DIFF
--- a/Content.Server/CriminalRecords/Systems/CriminalRecordsHackerSystem.cs
+++ b/Content.Server/CriminalRecords/Systems/CriminalRecordsHackerSystem.cs
@@ -4,7 +4,7 @@ using Content.Server.StationRecords.Systems;
 using Content.Shared.CriminalRecords;
 using Content.Shared.CriminalRecords.Components;
 using Content.Shared.CriminalRecords.Systems;
-using Content.Shared.Dataset;
+using Content.Shared.Random.Helpers;
 using Content.Shared.Security;
 using Content.Shared.StationRecords;
 using Robust.Shared.Prototypes;
@@ -36,10 +36,10 @@ public sealed class CriminalRecordsHackerSystem : SharedCriminalRecordsHackerSys
         if (_station.GetOwningStation(ent) is not {} station)
             return;
 
-        var reasons = _proto.Index<DatasetPrototype>(ent.Comp.Reasons);
+        var reasons = _proto.Index(ent.Comp.Reasons);
         foreach (var (key, record) in _records.GetRecordsOfType<CriminalRecord>(station))
         {
-            var reason = _random.Pick(reasons.Values);
+            var reason = _random.Pick(reasons);
             _criminalRecords.OverwriteStatus(new StationRecordKey(key, station), record, SecurityStatus.Wanted, reason);
             // no radio message since spam
             // no history since lazy and its easy to remove anyway


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Space ninjas can once again use their gloves to hack criminal records consoles.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/36286

## Technical details
<!-- Summary of code changes for easier review. -->
The placeholder reasons `Dataset` prototype was converted to a `LocalizedDataset` by https://github.com/space-wizards/space-station-14/pull/35810, but `CriminalRecordsHackerSystem` was coded to read the prototype as a `Dataset` when hacking. Since no `Dataset` with that `ProtoId` exists anymore, `PrototypeManager.Index` was throwing an exception.

`CriminalRecordsHackerSystem` has been modified to use generic type inference for the `Index` call instead of explicitly calling `Index<DatasetPrototype>` - it will figure out the right type from the `ProtoId` type in the component. Additionally, the `IRobustRandom.Pick` extension method taking a `LocalizedDataset` as a parameter is now used so the resulting strings are localized.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="699" alt="Screenshot 2025-04-04 at 12 03 50 PM" src="https://github.com/user-attachments/assets/16ead063-80db-47be-aa96-3de92b4fec72" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed ninjas being unable to hack criminal records consoles.