### PR TITLE
Remove "SHUTTLES" from the allergy list in ion_storm.yml

### DIFF
--- a/Resources/Prototypes/Datasets/ion_storm.yml
+++ b/Resources/Prototypes/Datasets/ion_storm.yml
@@ -188,7 +188,6 @@
   - PLANTS
   - PLASMA
   - ROBOTS
-  - SHUTTLES
   - SPACE
   - SUNLIGHT
   - WATER


### PR DESCRIPTION
## About the PR
Removes the "SHUTTLES" from the allergy list in ion_storm.yml as a possible option when generating an ion law to further prevent possible roundstall, with accordance of reducing roundstall in #35751 

## Why / Balance
Though unlikely to happen, it's still possible for a corrupted law to happen which could encourage round stall, if the generated ion law is of the "ion-storm-law-allergic" type, and specifically picks "SHUTTLES" as an allergen.

## Technical details

- Removed "- SHUTTLES" from ion_storm.yml

## Media
![image](https://github.com/user-attachments/assets/1712ebb8-a2f0-458d-b81b-01e060f3ae2e)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

