### PR TITLE
Typo fix in Syndicate agent locale resources

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
@@ -31,7 +31,7 @@ traitor-role-greeting =
 traitor-role-codewords =
     The codewords are: [color = lightgray]
     {$codewords}.[/color]
-    Codewords can be used in regular conversation to identify yourself discretely to other syndicate agents.
+    Codewords can be used in regular conversation to identify yourself discreetly to other syndicate agents.
     Listen for them, and keep them secret.
 traitor-role-uplink-code =
     Set your ringtone to the notes [color = lightgray]{$code}[/color] to lock or unlock your uplink.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -316,7 +316,7 @@ uplink-clothing-no-slips-shoes-name = No-slip Shoes
 uplink-clothing-no-slips-shoes-desc = Chameleon shoes that protect you from slips.
 
 uplink-clothing-thieving-gloves-name = Thieving Gloves
-uplink-clothing-thieving-gloves-desc = Discretely steal from pockets and improve your thieving technique with these fancy new gloves. They even look like normal gloves!
+uplink-clothing-thieving-gloves-desc = Discreetly steal from pockets and improve your thieving technique with these fancy new gloves. They even look like normal gloves!
 
 uplink-clothing-outer-vest-web-name = Web Vest
 uplink-clothing-outer-vest-web-desc = A synthetic armor vest. This one has added webbing and ballistic plates.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Corrected the word "discretely" (meaning "separately") to "discreetly" (meaning "secretly" or "quietly") in the Thieving Gloves' uplink catalog description, and the codewords section of a Syndicate agent's character menu.

## Why / Balance
They're two words that, while very easy to mix up, mean different things. I believe "discreetly" is more appropriate in the given context.

## Technical details
Changed the word "discretely" to "discreetly" in [Resources/Locale/en-US/store/uplink-catalog.ftl](https://github.com/space-wizards/space-station-14/blob/a4ba5ff4081a92b6b4a69267ce7103c723e462d6/Resources/Locale/en-US/store/uplink-catalog.ftl#L319) and [Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl](https://github.com/space-wizards/space-station-14/blob/a4ba5ff4081a92b6b4a69267ce7103c723e462d6/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl#L34).

## Media
Don't think it's needed for something this small?

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->