### PR TITLE
Fix blocked UI interaction on unpowered devices

### DIFF
--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Held.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Held.cs
@@ -121,18 +121,19 @@ public abstract partial class SharedStationAiSystem
         if (ev.Actor == ev.Target)
             return;
 
-        // no need to show menu if device is not powered.
-        if (!PowerReceiver.IsPowered(ev.Target))
-        {
-            ShowDeviceNotRespondingPopup(ev.Actor);
-            ev.Cancel();
-            return;
-        }
-
         if (TryComp(ev.Actor, out StationAiHeldComponent? aiComp) &&
            (!TryComp(ev.Target, out StationAiWhitelistComponent? whitelistComponent) ||
             !ValidateAi((ev.Actor, aiComp))))
         {
+            // Don't allow the AI to interact with anything that isn't powered.
+            if (!PowerReceiver.IsPowered(ev.Target))
+            {
+                ShowDeviceNotRespondingPopup(ev.Actor);
+                ev.Cancel();
+                return;
+            }
+
+            // Don't allow the AI to interact with anything that it isn't allowed to (ex. AI wire is cut)
             if (whitelistComponent is { Enabled: false })
             {
                 ShowDeviceNotRespondingPopup(ev.Actor);
@@ -172,7 +173,7 @@ public abstract partial class SharedStationAiSystem
         var verb = new AlternativeVerb
         {
             Text = isOpen ? Loc.GetString("ai-close") : Loc.GetString("ai-open"),
-            Act = () => 
+            Act = () =>
             {
                 if (isOpen)
                 {


### PR DESCRIPTION
## About the PR
This PR fixes UI interaction (ex. opening) being blocked if the device is unpowered.

## Why / Balance
It was a bug.

Fixes #36242.

## Technical details
Right now this checks if the device is unpowered, if it is, it blocks the interaction:
```C#
    private void OnMessageAttempt(BoundUserInterfaceMessageAttempt ev)
    {
        if (ev.Actor == ev.Target)
            return;

        // no need to show menu if device is not powered.
        if (!PowerReceiver.IsPowered(ev.Target))
        {
            ShowDeviceNotRespondingPopup(ev.Actor);
            ev.Cancel();
            return;
        }
```

This is not a good idea as you're blocking every single interaction that comes through if the device is unpowered.

To fix this, we just move the check into the realm where we check if the person interacting is an AI. If the person interacting is an AI, and if the device is unpowered, then block the interaction.

The rest of that logic also blocks the interaction if it's disallowed by the component (AI wire being cut for example).

## Media
Door is depowered and I can still interact with it and cut wires.
![Content Client_mI3IUpIhNQ](https://github.com/user-attachments/assets/e899d003-5582-488a-b5ca-ce1f29dc2a3e)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed players being unable to interact with or open any machine UI if the machine is unpowered (ex. wirepanels).
