### PR TITLE
remove evil shitcode from randommetadata

### DIFF
--- a/Content.Server/RandomMetadata/RandomMetadataComponent.cs
+++ b/Content.Server/RandomMetadata/RandomMetadataComponent.cs
@@ -1,3 +1,6 @@
+using Content.Shared.Dataset;
+using Robust.Shared.Prototypes;
+
 ﻿namespace Content.Server.RandomMetadata;
 
 /// <summary>
@@ -6,15 +9,15 @@
 [RegisterComponent]
 public sealed partial class RandomMetadataComponent : Component
 {
-    [DataField("descriptionSegments")]
-    public List<string>? DescriptionSegments;
+    [DataField]
+    public List<ProtoId<LocalizedDatasetPrototype>>? DescriptionSegments;
 
-    [DataField("nameSegments")]
-    public List<string>? NameSegments;
+    [DataField]
+    public List<ProtoId<LocalizedDatasetPrototype>>? NameSegments;
 
-    [DataField("nameSeparator")]
+    [DataField]
     public string NameSeparator = " ";
 
-    [DataField("descriptionSeparator")]
+    [DataField]
     public string DescriptionSeparator = " ";
 }

--- a/Content.Server/RandomMetadata/RandomMetadataSystem.cs
+++ b/Content.Server/RandomMetadata/RandomMetadataSystem.cs
@@ -12,6 +12,8 @@ public sealed class RandomMetadataSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
 
+    private List<string> _outputSegments = new();
+
     public override void Initialize()
     {
         base.Initialize();
@@ -43,28 +45,14 @@ public sealed class RandomMetadataSystem : EntitySystem
     /// <param name="separator">The separator that will be inbetween each segment</param>
     /// <returns>The newly generated string</returns>
     [PublicAPI]
-    public string GetRandomFromSegments(List<string> segments, string? separator)
+    public string GetRandomFromSegments(List<ProtoId<LocalizedDatasetPrototype>> segments, string? separator)
     {
-        var outputSegments = new List<string>();
+        _outputSegments.Clear();
         foreach (var segment in segments)
         {
-            if (_prototype.TryIndex<LocalizedDatasetPrototype>(segment, out var localizedProto))
-            {
-                outputSegments.Add(_random.Pick(localizedProto));
-            }
-            else if (_prototype.TryIndex<DatasetPrototype>(segment, out var proto))
-            {
-                var random = _random.Pick(proto.Values);
-                if (Loc.TryGetString(random, out var localizedSegment))
-                    outputSegments.Add(localizedSegment);
-                else
-                    outputSegments.Add(random);
-            }
-            else if (Loc.TryGetString(segment, out var localizedSegment))
-                outputSegments.Add(localizedSegment);
-            else
-                outputSegments.Add(segment);
+            var localizedProto = _prototype.Index(segment);
+            _outputSegments.Add(_random.Pick(localizedProto));
         }
-        return string.Join(separator, outputSegments);
+        return string.Join(separator, _outputSegments);
     }
 }

--- a/Resources/Locale/en-US/datasets/names/joining.ftl
+++ b/Resources/Locale/en-US/datasets/names/joining.ftl
@@ -1,0 +1,2 @@
+names-word-the-1 = The
+names-word-of-1 = of

--- a/Resources/Locale/en-US/datasets/names/nukie_first.ftl
+++ b/Resources/Locale/en-US/datasets/names/nukie_first.ftl
@@ -1,0 +1,3 @@
+names-nukie-commander-1 = Commander
+names-nukie-agent-1 = Agent
+names-nukie-operator-1 = Operator

--- a/Resources/Prototypes/Datasets/Names/joining.yml
+++ b/Resources/Prototypes/Datasets/Names/joining.yml
@@ -1,0 +1,14 @@
+# These can be inserted inbetween name datasets
+# Ideally it would be localized since just swapping words doesnt help much for a lot of languages
+
+- type: localizedDataset
+  id: WordThe
+  values:
+    prefix: names-word-the-
+    count: 1
+
+- type: localizedDataset
+  id: WordOf
+  values:
+    prefix: names-word-of-
+    count: 1

--- a/Resources/Prototypes/Datasets/Names/nukies.yml
+++ b/Resources/Prototypes/Datasets/Names/nukies.yml
@@ -1,0 +1,17 @@
+- type: localizedDataset
+  id: NamesNukieFirstCommander
+  values:
+    prefix: names-nukie-commander-
+    count: 1
+
+- type: localizedDataset
+  id: NamesNukieFirstAgent
+  values:
+    prefix: names-nukie-agent-
+    count: 1
+
+- type: localizedDataset
+  id: NamesNukieFirstOperator
+  values:
+    prefix: names-nukie-operator-
+    count: 1

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -72,9 +72,9 @@
     - StolenEssence
   - type: RandomMetadata
     nameSegments:
-    - The
+    - WordThe
     - NamesRevenantType
-    - of
+    - WordOf
     - NamesRevenantAdjective
     - NamesRevenantTheme
   - type: Speech

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -68,7 +68,7 @@
   - type: NukeOperative
   - type: RandomMetadata
     nameSegments:
-    - nukeops-role-operator
+    - NamesNukieFirstOperator
     - NamesSyndicateNormal
   - type: Loadout
     prototypes: [SyndicateOperativeGearFullNoUplink]

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -129,7 +129,7 @@
       - type: NukeOperative
       - type: RandomMetadata
         nameSegments:
-        - nukeops-role-commander
+        - NamesNukieFirstCommander
         - NamesSyndicateElite
       - type: NpcFactionMember
         factions:
@@ -146,7 +146,7 @@
       - type: NukeOperative
       - type: RandomMetadata
         nameSegments:
-        - nukeops-role-agent
+        - NamesNukieFirstAgent
         - NamesSyndicateNormal
       - type: NpcFactionMember
         factions:
@@ -165,7 +165,7 @@
       - type: NukeOperative
       - type: RandomMetadata
         nameSegments:
-        - nukeops-role-operator
+        - NamesNukieFirstOperator
         - NamesSyndicateNormal
       - type: NpcFactionMember
         factions:


### PR DESCRIPTION
## About the PR
refactoring of random metadata to remove everything but LocalizedDataset, which it now uses protoid for

## Why / Balance
HMM LETS SEE WHICH IS MORE BREAKING SILENTLY USING NamesSomeRenamedIdThatDoesntExist AS A MOBS NAME OR READING ERRORS IN A TEST FAIL I FUCKING WONDER HOWEVER SHALL I COPE WITH MobErtSuperman invalid ProtoId names_super_hero
THIS SHIT DRIVES ME UP THE WALL

## Technical details
reused the list of random segments to not spam reallocate a 2-3 item list for every mob

## Media
:trollface:

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
any RandomMetadata using a regular dataset, loc or bare string will now have to be changed to a LocalizedDataset
the yml linter will reveal any offenders

**Changelog**
