### PR TITLE
fix special scrubber/vent tags

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -25,10 +25,6 @@
       Ammonia: stationAmmonia
       NitrousOxide: stationNO
       Frezon: danger
-  - type: Tag
-    tags:
-      - AirSensor
-      - ForceFixRotations
   - type: GuideHelp
     guides:
     - DeviceMonitoringAndControl
@@ -90,6 +86,10 @@
         enum.PowerDeviceVisualLayers.Powered:
           True: { state: gsensor1 }
           False: { state: gsensor0 }
+  - type: Tag
+    tags:
+    - AirSensor
+    - ForceFixRotations
 
 - type: entity
   parent: BaseItem


### PR DESCRIPTION
## About the PR
vox/freezer scrubbers and vents were being broken by the `fixrotations` command since they had air sensor tags from AirSensorBase
moved them to air sensor since its nothing to do with the monitoring functionality

it also meant vox/freezer scrubbers/vents didnt have the scrubber/vent and unstackable tags
