### PR TITLE
Clean up TitleWindowManager.cs

### DIFF
--- a/Content.Client/GameTicking/Managers/TitleWindowManager.cs
+++ b/Content.Client/GameTicking/Managers/TitleWindowManager.cs
@@ -15,48 +15,35 @@ public sealed class TitleWindowManager
 
     public void Initialize()
     {
-        _cfg.OnValueChanged(CVars.GameHostName, OnHostnameChange, true);
-        _cfg.OnValueChanged(CCVars.GameHostnameInTitlebar, OnHostnameTitleChange, true);
+        _cfg.OnValueChanged(CVars.GameHostName, _ => OnHostnameChange(), true);
+        _cfg.OnValueChanged(CCVars.GameHostnameInTitlebar, _ => OnHostnameChange(), true);
 
-        _client.RunLevelChanged += OnRunLevelChangedChange;
+        _client.RunLevelChanged += (_, _) => OnHostnameChange();
     }
 
     public void Shutdown()
     {
-        _cfg.UnsubValueChanged(CVars.GameHostName, OnHostnameChange);
-        _cfg.UnsubValueChanged(CCVars.GameHostnameInTitlebar, OnHostnameTitleChange);
+        _cfg.UnsubValueChanged(CVars.GameHostName, _ => OnHostnameChange());
+        _cfg.UnsubValueChanged(CCVars.GameHostnameInTitlebar, _ => OnHostnameChange());
     }
 
-    private void OnHostnameChange(string hostname)
+    private void OnHostnameChange()
     {
         var defaultWindowTitle = _gameController.GameTitle();
 
-        // Since the game assumes the server name is MyServer and that GameHostnameInTitlebar CCVar is true by default
-        // Lets just... not show anything. This also is used to revert back to just the game title on disconnect.
-        if (_client.RunLevel == ClientRunLevel.Initialize)
+        // When the client starts connecting, it will be using either the default hostname, or whatever hostname
+        // is set in its config file (aka the last server they connected to) until it receives the latest cvars.
+        // If they are not connected then we will not show anything other than the usual window title.
+        if (_client.RunLevel != ClientRunLevel.InGame)
         {
             _clyde.SetWindowTitle(defaultWindowTitle);
             return;
         }
 
-        if (_cfg.GetCVar(CCVars.GameHostnameInTitlebar))
-            // If you really dislike the dash I guess change it here
-            _clyde.SetWindowTitle(hostname + " - " + defaultWindowTitle);
-        else
-            _clyde.SetWindowTitle(defaultWindowTitle);
+        _clyde.SetWindowTitle(
+            _cfg.GetCVar(CCVars.GameHostnameInTitlebar)
+                ? _cfg.GetCVar(CVars.GameHostName) + " - " + defaultWindowTitle
+                : defaultWindowTitle);
     }
-
-    // Clients by default assume game.hostname_in_titlebar is true
-    // but we need to clear it as soon as we join and actually receive the servers preference on this.
-    // This will ensure we rerun OnHostnameChange and set the correct title bar name.
-    private void OnHostnameTitleChange(bool colonthree)
-    {
-        OnHostnameChange(_cfg.GetCVar(CVars.GameHostName));
-    }
-
-    // This is just used we can rerun the hostname change function when we disconnect to revert back to just the games title.
-    private void OnRunLevelChangedChange(object? sender, RunLevelChangedEventArgs runLevelChangedEventArgs)
-    {
-        OnHostnameChange(_cfg.GetCVar(CVars.GameHostName));
-    }
+    // You thought I would remove the :3 from this code? You were wrong.
 }


### PR DESCRIPTION
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

- I did not like how `OnHostnameChange()` always needed a string even though that string would always just be the hostname, so now it's just part of its function
- The extra function made to just trigger `OnHostnameChange()` are removed. It just runs the right function off the bat.
- Checking for `ClientRunLevel.InGame` for setting the title without the hostname, which means the previous joined server won't appear for a split second before being corrected by the new cvars being set. Or if the server prefers no host name in the titlebar by the time we connect.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
