### PR TITLE
[Hotfix] Fix the walking alert

### DIFF
--- a/Content.Client/Alerts/ClientAlertsSystem.cs
+++ b/Content.Client/Alerts/ClientAlertsSystem.cs
@@ -52,7 +52,22 @@ public sealed class ClientAlertsSystem : AlertsSystem
         if (args.Current is not AlertComponentState cast)
             return;
 
+        // Temporarily store all clientside alerts in another dictionary.
+        var clientAlertStorage = new Dictionary<AlertKey, AlertState>();
+        foreach (var clientAlert in alerts.Comp.Alerts)
+        {
+            if (clientAlert.Value.ClientOnly)
+                clientAlertStorage.Add(clientAlert.Key, clientAlert.Value);
+        }
+
         alerts.Comp.Alerts = new(cast.Alerts);
+
+        // Reapply the stored alerts after they have been removed.
+        foreach (var clientAlert in clientAlertStorage)
+        {
+            if (!alerts.Comp.Alerts.ContainsKey(clientAlert.Key))
+                alerts.Comp.Alerts[clientAlert.Key] = clientAlert.Value;
+        }
 
         UpdateHud(alerts);
     }

--- a/Content.Server/Alert/ServerAlertsSystem.cs
+++ b/Content.Server/Alert/ServerAlertsSystem.cs
@@ -1,5 +1,7 @@
 using Content.Shared.Alert;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Alert;
 
@@ -10,6 +12,24 @@ internal sealed class ServerAlertsSystem : AlertsSystem
         base.Initialize();
 
         SubscribeLocalEvent<AlertsComponent, ComponentGetState>(OnGetState);
+    }
+
+    public override void ShowAlert(
+        EntityUid euid,
+        ProtoId<AlertPrototype> alertType,
+        short? severity = null,
+        (TimeSpan, TimeSpan)? cooldown = null,
+        bool autoRemove = false,
+        bool showCooldown = true)
+    {
+#if DEBUG
+        if (!TryGet(alertType, out var alert))
+            return;
+
+        DebugTools.Assert(!alert.ClientOnly, "Tried to set a client-only alert on the server.");
+#endif
+
+        base.ShowAlert(euid, alertType, severity, cooldown, autoRemove, showCooldown);
     }
 
     private void OnGetState(Entity<AlertsComponent> alerts, ref ComponentGetState args)

--- a/Content.Shared/Alert/AlertPrototype.cs
+++ b/Content.Shared/Alert/AlertPrototype.cs
@@ -82,6 +82,12 @@ public sealed partial class AlertPrototype : IPrototype
     [DataField]
     public BaseAlertEvent? ClickEvent;
 
+    /// <summary>
+    /// This alert should only be set from the client.
+    /// </summary>
+    [DataField]
+    public bool ClientOnly;
+
     /// <param name="severity">severity level, if supported by this alert</param>
     /// <returns>the icon path to the texture for the provided severity level</returns>
     public SpriteSpecifier GetIcon(short? severity = null)

--- a/Content.Shared/Alert/AlertState.cs
+++ b/Content.Shared/Alert/AlertState.cs
@@ -11,4 +11,5 @@ public struct AlertState
     public bool AutoRemove;
     public bool ShowCooldown;
     public ProtoId<AlertPrototype> Type;
+    public bool ClientOnly;
 }

--- a/Content.Shared/Alert/AlertsSystem.cs
+++ b/Content.Shared/Alert/AlertsSystem.cs
@@ -78,7 +78,7 @@ public abstract class AlertsSystem : EntitySystem
     ///     be erased if there is currently a cooldown for the alert)</param>
     /// <param name="autoRemove">if true, the alert will be removed at the end of the cooldown</param>
     /// <param name="showCooldown">if true, the cooldown will be visibly shown over the alert icon</param>
-    public void ShowAlert(EntityUid euid, ProtoId<AlertPrototype> alertType, short? severity = null, (TimeSpan, TimeSpan)? cooldown = null, bool autoRemove = false, bool showCooldown = true )
+    public virtual void ShowAlert(EntityUid euid, ProtoId<AlertPrototype> alertType, short? severity = null, (TimeSpan, TimeSpan)? cooldown = null, bool autoRemove = false, bool showCooldown = true )
     {
         // This should be handled as part of networking.
         if (_timing.ApplyingState)

--- a/Content.Shared/Alert/AlertsSystem.cs
+++ b/Content.Shared/Alert/AlertsSystem.cs
@@ -105,7 +105,7 @@ public abstract class AlertsSystem : EntitySystem
             alertsComponent.Alerts.Remove(alert.AlertKey);
 
             var state = new AlertState
-                { Cooldown = cooldown, Severity = severity, Type = alertType, AutoRemove = autoRemove, ShowCooldown = showCooldown};
+                { Cooldown = cooldown, Severity = severity, Type = alertType, AutoRemove = autoRemove, ShowCooldown = showCooldown, ClientOnly = alert.ClientOnly };
             alertsComponent.Alerts[alert.AlertKey] = state;
 
             // Keeping a list of AutoRemove alerts, so Update() doesn't need to check every alert
@@ -222,7 +222,8 @@ public abstract class AlertsSystem : EntitySystem
                 Cooldown = cooldown,
                 ShowCooldown = alert.Value.ShowCooldown,
                 AutoRemove = alert.Value.AutoRemove,
-                Type = alert.Value.Type
+                Type = alert.Value.Type,
+                ClientOnly = alert.Value.ClientOnly,
             };
             alertComp.Alerts[alert.Key] = state;
             dirty = true;

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -492,3 +492,12 @@
     state: critical
   name: Debug6
   description: Debug
+
+- type: alert
+  id: DebugClient
+  icons:
+  - sprite: /Textures/Interface/Alerts/human_dead.rsi
+    state: dead
+  name: DebugClient
+  description: Debug
+  clientOnly: true

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -134,6 +134,7 @@
     state: walking
   name: alerts-walking-name
   description: alerts-walking-desc
+  clientOnly: true
 
 - type: alert
   id: Stun


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I fixed the walking alert hiding itself shortly after starting to walk with toggle walk.
I also added a test to make sure that client-sided alerts do not break again.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
99% of Space Station 14 players agree that alerts should not hide themselves when they are still relevant.

## Technical details
<!-- Summary of code changes for easier review. -->
The alert prototype now contains a `ClientOnly` field which is copied to the alert state.
Client-sided alerts are temporarily held in another dictionary when handling the state and readded after the server state is applied.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/a39d755c-3ea6-4475-84f7-65b1a7883e34


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Client-sided alerts now require that the `ClientOnly` datafield on the alert prototype is set to true.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The walking alert will no longer hide itself shortly after appearing.