### PR TITLE
Fixed the empty mass scanner still being a normal item, whoops.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -13,7 +13,7 @@
       - state: icon
       - state: scanner
         shader: unshaded
-        visible: true
+        visible: false
         map: [ "enum.PowerDeviceVisualLayers.Powered" ]
   - type: RadarConsole
     maxRange: 256
@@ -48,17 +48,6 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-  - type: Item
-    sprite: Objects/Tools/handheld_mass_scanner.rsi
-  - type: Sprite
-    sprite: Objects/Tools/handheld_mass_scanner.rsi
-    state: icon
-    layers:
-      - state: icon
-      - state: scanner
-        shader: unshaded
-        visible: false
-        map: [ "enum.PowerDeviceVisualLayers.Powered" ]
 
 - type: entity
   id: HandHeldMassScannerBorg

--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -5,7 +5,6 @@
   description: A hand-held mass scanner.
   components:
   - type: Item
-    size: Normal
     sprite: Objects/Tools/handheld_mass_scanner.rsi
   - type: Sprite
     sprite: Objects/Tools/handheld_mass_scanner.rsi
@@ -50,7 +49,6 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
   - type: Item
-    size: Normal
     sprite: Objects/Tools/handheld_mass_scanner.rsi
   - type: Sprite
     sprite: Objects/Tools/handheld_mass_scanner.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Finishes what #36013 started. I forgor that there's a separate yaml entry for an empty version of the handheld mass scanner, which is the one printed by science. So currently there's a 2x2 mass scanner and a 1x2 mass scanner in game. oops.

Additionally, it looks like an issue with the sprite layering was causing the empty version of the Handheld to show it's screen as active despite having no battery, which has also been fixed as part of the cleanup.

## Why / Balance
Finishing what I started.

## Technical details
Finishes removal of the Normal size category from both the regular handheld mass scanner and the empty version, thus fixing their unintentional size increase.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed empty handheld mass scanners being 2x2.
