### PR TITLE
Fix: Wall-mounted SpawnPrototype Issue.

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/curtains.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/curtains.yml
@@ -109,7 +109,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: MaterialCloth1
               amount: 2
           steps:
@@ -120,7 +120,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: MaterialCloth1
               amount: 2
           steps:
@@ -132,7 +132,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemBlack
               amount: 1
           steps:
@@ -143,7 +143,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemBlack
               amount: 1
           steps:
@@ -155,7 +155,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemBlue
               amount: 1
           steps:
@@ -166,7 +166,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemBlue
               amount: 1
           steps:
@@ -178,7 +178,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemCyan
               amount: 1
           steps:
@@ -189,7 +189,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemCyan
               amount: 1
           steps:
@@ -201,7 +201,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemGreen
               amount: 1
           steps:
@@ -212,7 +212,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemGreen
               amount: 1
           steps:
@@ -224,7 +224,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemOrange
               amount: 1
           steps:
@@ -235,7 +235,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemOrange
               amount: 1
           steps:
@@ -247,7 +247,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemPink
               amount: 1
           steps:
@@ -258,7 +258,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemPink
               amount: 1
           steps:
@@ -270,7 +270,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemPurple
               amount: 1
           steps:
@@ -281,7 +281,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemPurple
               amount: 1
           steps:
@@ -293,7 +293,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemRed
               amount: 1
           steps:
@@ -304,7 +304,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemRed
               amount: 1
           steps:
@@ -316,7 +316,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemWhite
               amount: 1
           steps:
@@ -327,7 +327,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: FloorCarpetItemWhite
               amount: 1
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/noticeboard.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/noticeboard.yml
@@ -18,7 +18,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: MaterialWoodPlank
               amount: 3
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/shelfs.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/shelfs.yml
@@ -118,7 +118,7 @@
         - to: start
           completed:
             - !type:EmptyAllContainers
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: MaterialWoodPlank1
                 amount: 4
           steps:
@@ -131,7 +131,7 @@
         - to: start
           completed:
             - !type:EmptyAllContainers
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: SheetSteel1
                 amount: 5
           steps:
@@ -144,7 +144,7 @@
         - to: start
           completed:
             - !type:EmptyAllContainers
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: SheetGlass1
                 amount: 4
           steps:
@@ -157,10 +157,10 @@
         - to: start
           completed:
             - !type:EmptyAllContainers
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: MaterialWoodPlank1
                 amount: 8
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: CableApcStack1
                 amount: 2
           steps:
@@ -175,13 +175,13 @@
         - to: start
           completed:
             - !type:EmptyAllContainers
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: SheetPlasteel1
                 amount: 5
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: SheetRGlass1
                 amount: 5
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: CableApcStack1
                 amount: 3
           steps:
@@ -196,13 +196,13 @@
         - to: start
           completed:
             - !type:EmptyAllContainers
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: SheetPlastic1
                 amount: 5
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: SheetRGlass1
                 amount: 5
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: CableApcStack1
                 amount: 2
           steps:
@@ -218,7 +218,7 @@
         - to: start
           completed:
             - !type:EmptyAllContainers
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: MaterialWoodPlank1
                 amount: 6
           steps:
@@ -231,13 +231,13 @@
         - to: start
           completed:
             - !type:EmptyAllContainers
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: PartRodMetal
                 amount: 2
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: SheetSteel1
                 amount: 5
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: MaterialWoodPlank1
                 amount: 3
           steps:
@@ -254,16 +254,16 @@
         - to: start
           completed:
             - !type:EmptyAllContainers
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: SheetPlasteel1
                 amount: 2
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: SheetPlastic1
                 amount: 5
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: SheetRGlass1
                 amount: 5
-            - !type:SpawnPrototype
+            - !type:GivePrototype
                 prototype: CableApcStack1
                 amount: 2
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/switching.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/switching.yml
@@ -52,10 +52,10 @@
             - tool: Screwing
               doAfter: 2.0
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetSteel1
               amount: 1
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: CableApcStack1
               amount: 1
             - !type:DeleteEntity {}
@@ -81,10 +81,10 @@
             - tool: Screwing
               doAfter: 2.0
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetSteel1
               amount: 1
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: CableApcStack1
               amount: 1
             - !type:DeleteEntity {}
@@ -110,10 +110,10 @@
             - tool: Screwing
               doAfter: 2.0
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetSteel1
               amount: 1
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: CableApcStack1
               amount: 1
             - !type:DeleteEntity {}
@@ -139,10 +139,10 @@
             - tool: Screwing
               doAfter: 2.0
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetSteel1
               amount: 1
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: CableApcStack1
               amount: 1
             - !type:DeleteEntity {}
@@ -168,10 +168,10 @@
             - tool: Screwing
               doAfter: 2.0
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetSteel1
               amount: 1
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: CableApcStack1
               amount: 1
             - !type:DeleteEntity {}
@@ -197,10 +197,10 @@
             - tool: Screwing
               doAfter: 2.0
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetSteel1
               amount: 1
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: CableApcStack1
               amount: 1
             - !type:DeleteEntity {}

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/window.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/window.yml
@@ -65,7 +65,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -80,7 +80,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetRGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -103,7 +103,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetRGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -122,7 +122,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetPGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -141,7 +141,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetRPGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -164,7 +164,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetUGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -183,7 +183,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetRUGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -206,7 +206,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetClockworkGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -229,10 +229,10 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetRGlass1
               amount: 2
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetPlasteel1
               amount: 2
             - !type:DeleteEntity {}

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/window_diagonal.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/window_diagonal.yml
@@ -51,7 +51,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -66,7 +66,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetRGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -89,7 +89,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetClockworkGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -112,7 +112,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetPGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -131,7 +131,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetRPGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -154,7 +154,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetUGlass1
               amount: 2
             - !type:DeleteEntity {}
@@ -173,7 +173,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetRUGlass1
               amount: 2
             - !type:DeleteEntity {}

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/windowdirectional.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/windowdirectional.yml
@@ -51,7 +51,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetGlass1
               amount: 1
             - !type:DeleteEntity {}
@@ -66,7 +66,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetRGlass1
               amount: 1
             - !type:DeleteEntity {}
@@ -85,7 +85,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetPGlass1
               amount: 1
             - !type:DeleteEntity {}
@@ -104,7 +104,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetClockworkGlass1
               amount: 1
             - !type:DeleteEntity {}
@@ -123,7 +123,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetRPGlass1
               amount: 1
             - !type:DeleteEntity {}
@@ -141,7 +141,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetUGlass1
               amount: 1
             - !type:DeleteEntity {}
@@ -160,7 +160,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetRUGlass1
               amount: 1
             - !type:DeleteEntity {}

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/cameras.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/cameras.yml
@@ -20,7 +20,7 @@
               doAfter: 1
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetSteel1
               amount: 2
             - !type:DeleteEntity {}
@@ -47,7 +47,7 @@
             - !type:AllWiresCut {}
             - !type:WirePanel {}
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetSteel1
               amount: 2
             - !type:DeleteEntity {}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Every wall-mounted prototype that used to, upon it's deconstruction, spawn the entity inside the wall or on the other side of it,  now gives the entity to the user, or drops it on the ground in case their hands are full.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #34569 

## Technical details
<!-- Summary of code changes for easier review. -->
Modified all prototypes on Resources/Prototypes/Recipes/Construction/Graphs that are wall-mounted prototypes and that used SpawnPrototype to now use GivePrototype in it's deconstruction.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/11bafef7-3a4f-4a1a-acbf-3402078ad946

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed wall-mounted objects so that after their deconstruction they don't spawn the result inside a wall, or on the other side of it.
