### PR TITLE
Removes storage implant

### DIFF
--- a/Resources/Locale/en-US/thief/backpack.ftl
+++ b/Resources/Locale/en-US/thief/backpack.ftl
@@ -32,7 +32,7 @@ thief-backpack-category-tools-description =
 thief-backpack-category-chemistry-name = anatomy kit
 thief-backpack-category-chemistry-description =
     You've reached peak physical performance... with a little help.
-    Includes: Storage implanter, DNA scrambler implanter,
+    Includes: DNA scrambler implanter,
     ephedrine bottle, syringe, empty shaker, and omega soap
 
 thief-backpack-category-syndie-name = syndie kit

--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -36,7 +36,6 @@
     sprite: Objects/Specific/Medical/implanter.rsi
     state: implanter0
   content:
-  - StorageImplanter
   - DnaScramblerImplanter
   - ChemistryBottleEphedrine
   - SoapOmega

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1267,25 +1267,6 @@
 # Implants
 
 - type: listing
-  id: UplinkStorageImplanter
-  name: uplink-storage-implanter-name
-  description: uplink-storage-implanter-desc
-  icon: { sprite: /Textures/Clothing/Back/Backpacks/backpack.rsi, state: icon }
-  productEntity: StorageImplanter
-  discountCategory: rareDiscounts
-  discountDownTo:
-    Telecrystal: 4
-  cost:
-    Telecrystal: 8
-  categories:
-    - UplinkImplants
-  conditions:
-    - !type:StoreWhitelistCondition
-      blacklist:
-        tags:
-          - NukeOpsUplink
-
-- type: listing
   id: UplinkFreedomImplanter
   name: uplink-freedom-implanter-name
   description: uplink-freedom-implanter-desc


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The storage implant has been removed from the game. It is no longer in the traitor uplink or the thief chemistry kit.

## Why / Balance
The point of antagonists is to disrupt the round and make it interesting. It is ironic that the traitor meta literally disrupts the round as little as possible. The thief gloves let you steal off someone without them noticing. No interesting murder or any confrontation of any kind. But atleast there is gameplay for other people created here! Now that an item has been stolen, sec must track down who took it. But here we run into our second friend, the storage implant.

Let's do a walkthrough of the storage implant + thief gloves meta from the point of view of an antagonist
>be me, urist mc traitor
>buy thief gloves and storage implanter
>inject the implant and leave it in maints somewhere, don't bother scrubbing it with soap
>random secoff says 'i'm suspicious', search me, they find nothing
>steal the CMO's hypospray with my thieving gloves
>put it in my storage implant
>wait for evac
>secoff mass searching people
>'no problem, officer'
>they search me, find nothing
>greentext

Kinda boring, right?

Now lets look at the same thing from sec's perspective.
>be sec
>find syndicate implant in maints
>have det scan it, it was used by urist mc traitor
>oknowwhat.jpeg. You can't remove it if you don't know what it is. Some people decide to arrest the dude for syndie contra, counting the implant inside of them as the contra - but then still can't remove it. Most of the time you just search the dude and move on.
>Search urist mc traitor. He is obviously wearing thieving gloves, but you can't do anything cause that would be ❌METAGAMING❌. So you let the guy go.  You probably should give him brig time for having the implant in his body but you will have to put up with him rules lawyering you and whining, saying shitsec is arresting him despite not possessing any contra. Besides it's futile, he will still have the implant.
>wait
>cmo says their hypospray has been stolen
>start searching people, trying to find it. follow leads but come up with nothing

I actually don't know if you are allowed to implant check a guy who has an implant for a storage implant because something is missing. The guy you try and search will tell you are not, in LOOC of course. The rules are a mess.

Man that sucks. You have to tiptoe around the metashield and end up doing nothing. Sucks that syndicate implanters don't have labels but that has been vetoed for some reason.

Let's look at it from the CMO's perspective
>be cmo
>hypospray disappears
>tell sec
>never get it back

Is your round disrupted? Is it interesting?

The storage implanter + thieving gloves meta needs to be removed. #36272 has nerfed the size, but since you can still steal grand theft objectives off people and store them in the implant, the problem is not fixed and the meta is still alive and well. The nerf only stops the CE magboots and digiboard from being stored, most grand theft items are quite small and still fit. If you have an idea that will stop the meta then I will happily change my tune and advocate for that instead of the admittedly crazy idea of just straight up removing the storage implanter. But I don't think there is one.

The storage implanter just sucks. It causes massive LOOC rows whenever it's used. Admins constantly have to write rules to stop it from being metagamed. It is boring and uninteresting to play with or against.

## Technical details
* removed listing for storage implant from traitor uplink
* removed storage implant from thief chemistry kit
* changed thief chemistry kit translation, no longer mentions the storage implant

## Media
The traitor uplink, implants section
The storage implant is missing
![image](https://github.com/user-attachments/assets/f108e3b4-1de7-47c8-a9f9-9237826febf6)

The thief toolbox, anatomy kit listing
The storage implant is missing
![image](https://github.com/user-attachments/assets/4e662474-c47c-48ff-bcc2-8fe89fb7309b)

The thief toolbox, with anatomy kit redeemed
There is no storage implant
![image](https://github.com/user-attachments/assets/c83fbdbe-f3ac-4d95-b764-66f7249c9b40)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: The storage implant has been removed

