### PR TITLE
Add unique fibers to the thieving gloves

### DIFF
--- a/Resources/Locale/en-US/forensics/fibers.ftl
+++ b/Resources/Locale/en-US/forensics/fibers.ftl
@@ -9,7 +9,8 @@ fibers-durathread = durathread
 fibers-latex = latex
 fibers-nitrile = nitrile
 fibers-nanomachines = insulative nanomachine
-fibers-chameleon = holographic chameleon
+fibers-holographic-chameleon = holographic chameleon
+fibers-chameleon = chameleon
 fibers-holographic = holographic
 fibers-rubber = rubber
 

--- a/Resources/Locale/en-US/forensics/fibers.ftl
+++ b/Resources/Locale/en-US/forensics/fibers.ftl
@@ -10,6 +10,7 @@ fibers-latex = latex
 fibers-nitrile = nitrile
 fibers-nanomachines = insulative nanomachine
 fibers-chameleon = holographic chameleon
+fibers-holographic = holographic
 fibers-rubber = rubber
 
 fibers-purple = purple

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -373,6 +373,8 @@
   - type: Thieving
     stripTimeReduction: 1.5
     stealthy: true
+  - type: Fiber
+    fiberMaterial: fibers-holographic
 
 - type: entity
   parent: ClothingHandsGlovesColorWhite

--- a/Resources/Prototypes/Entities/Clothing/Hands/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/specific.yml
@@ -30,3 +30,5 @@
   - type: Thieving
     stripTimeReduction: 2
     stealthy: true
+  - type: Fiber
+    fiberMaterial: fibers-holographic-chameleon

--- a/Resources/ServerInfo/Guidebook/Security/Forensics.xml
+++ b/Resources/ServerInfo/Guidebook/Security/Forensics.xml
@@ -40,7 +40,7 @@
   ## Fibers
   Whenenever people wearing gloves touch anything on the station, they are bound to leave behind some fibers. This complicates things, but nothing is unsolvable for a real detective.
 
-  There are up to [color=red]26[/color] different types of fibers possible. Can that stop you from solving the case?
+  There are up to [color=red]27[/color] different types of fibers possible. Can that stop you from solving the case?
 
   <Box>
     <GuideEntityEmbed Entity="ComputerStationRecords"/>

--- a/Resources/ServerInfo/Guidebook/Security/Forensics.xml
+++ b/Resources/ServerInfo/Guidebook/Security/Forensics.xml
@@ -40,7 +40,7 @@
   ## Fibers
   Whenenever people wearing gloves touch anything on the station, they are bound to leave behind some fibers. This complicates things, but nothing is unsolvable for a real detective.
 
-  There are up to [color=red]27[/color] different types of fibers possible. Can that stop you from solving the case?
+  There are up to [color=red]28[/color] different types of fibers possible. Can that stop you from solving the case?
 
   <Box>
     <GuideEntityEmbed Entity="ComputerStationRecords"/>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds holographic fibers which are not holographic chameleon, and applies them to the traitor thieving gloves.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Thieving gloves have no unique fibers, so this adds unique fibers. The forensic scanner will now be able to show that traitor specific thieving gloves are in use by someone, instead of being completely invisible.
Alternative to #36369.
## Technical details
<!-- Summary of code changes for easier review. -->
fibers.ftl there are now holographic chameleon fibers, chameleon fibers, and holographic fibers.
specific.yml chameleon thieving gloves now use fibers-holographic-chameleon
gloves.yml add holographic fiber to traitor thieving gloves
Forensics.xml there are now 28 fibers
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/12d7d832-6199-4673-8295-549feeee33f3)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Fibers for holographic chameleon have been split into:
holographic chameleon
holographic
chameleon
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Minemoder
- add: Holographic chameleon fibers have been split into holographic chameleon, holographic, and chameleon.
- tweak: Chameleon kit gloves now only have chameleon fibers.
- tweak: The traitor thieving gloves now leave behind holographic fibers for the forensic analyzer to find. The gloves are not chameleon.
