### PR TITLE
Printable vials

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -15,6 +15,7 @@
   - Syringe
   - PillCanister
   - HandLabeler
+  - BaseChemistryEmptyVial
 
 - type: latheRecipePack
   parent: BasicChemistryStatic

--- a/Resources/Prototypes/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/Recipes/Lathes/chemistry.yml
@@ -95,8 +95,8 @@
   result: BaseChemistryEmptyVial
   completetime: 2
   materials:
-    Glass: 200
-    Wood: 50
+    Glass: 100
+    Wood: 20
 
 - type: latheRecipe
   id: ClothingEyesGlassesChemical

--- a/Resources/Prototypes/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/Recipes/Lathes/chemistry.yml
@@ -91,6 +91,14 @@
     Steel: 250
 
 - type: latheRecipe
+  id: vial
+  result: vial
+  completetime: 2
+  materials:
+    Glass: 200
+    Wood: 50
+
+- type: latheRecipe
   id: ClothingEyesGlassesChemical
   result: ClothingEyesGlassesChemical
   completetime: 2

--- a/Resources/Prototypes/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/Recipes/Lathes/chemistry.yml
@@ -91,8 +91,8 @@
     Steel: 250
 
 - type: latheRecipe
-  id: vial
-  result: vial
+  id: BaseChemistryEmptyVial
+  result: BaseChemistryEmptyVial
   completetime: 2
   materials:
     Glass: 200

--- a/Resources/Prototypes/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/Recipes/Lathes/chemistry.yml
@@ -95,7 +95,7 @@
   result: BaseChemistryEmptyVial
   completetime: 2
   materials:
-    Glass: 100
+    Glass: 50
     Wood: 20
 
 - type: latheRecipe


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added empty vials as a printable item from the Autolathe, Protolathe, and Medical Techfab.

## Why / Balance
The centrifuge as a machine requires a vial for its use, however vials are not easily obtained. This change would both allow chemists to resupply their stock in the event of damage, while also encouraging the broader use of vials station-wide.

## Technical details
Added the following lines:

/Resources/Prototypes/Recipes/Lathes/chemistry.yml
```
- type: latheRecipe
  id: BaseChemistryEmptyVial
  result: BaseChemistryEmptyVial
  completetime: 2
  materials:
    Glass: 50
    Wood: 20
```

/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
```
- type: latheRecipePack
  id: BasicChemistryStatic
  recipes:
  - Beaker
  - LargeBeaker
  - Syringe
  - PillCanister
  - HandLabeler
  - BaseChemistryEmptyVial
```

## Media
![image](https://github.com/user-attachments/assets/831e035e-b9ba-484e-bcd0-f9c510f61064)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
🆑
- add: Vial Recipe to lathes