### PR TITLE
Removes Emag from the Thief antagonist

### DIFF
--- a/Resources/Locale/en-US/thief/backpack.ftl
+++ b/Resources/Locale/en-US/thief/backpack.ftl
@@ -39,7 +39,7 @@ thief-backpack-category-syndie-name = syndie kit
 thief-backpack-category-syndie-description =
     Trinkets from a disavowed past, or stolen from a careless agent?
     You've made some connections. Whiskey, echo...
-    Includes: An Emag, Access Breaker, Interdyne cigs, a Syndicate codeword,
+    Includes: An Access Breaker, Interdyne cigs, a Syndicate codeword,
     a Radio Jammer, a lighter and some strange red crystals.
 
 thief-backpack-category-sleeper-name = sleeper kit

--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -53,7 +53,6 @@
   content:
   - RadioJammer
   - TraitorCodePaper
-  - Emag
   - AccessBreaker
   - Lighter
   - CigPackSyndicate


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed the Emag from the Thief's syndicate kit

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
When the Emag was split into the Access Breaker and Emag, the Thief kept both as part of their syndicate kit. The Access Breaker makes perfect sense for the Thief to have, but I don't believe the current functionality of the Emag really aligns with any of the Thief's goals currently. I could be wrong and would love to hear if anyone thinks otherwise!

One use I could kind of think of would be a Thief Emagging borgs to do their dirty work, but you can make them do this anyways by just telling them "Law 2: steal X for me and put it in Y location and don't tell anyone you're doing it for me". Another is a converted Thief during revolutionaries using the Emag to convert borgs onto the side of the revolution and Emagging lathes for ammo, but an item that only really comes into play during another gamemode when the Thief has altered objectives seems wrong for them to have. 

The main, most offensive use of the Emag in my opinion, is the fact that they can Emag recyclers to gib people, which is antithetical to the whole pacifist design of the thief. I don't see why an antag designed to be a pacifist should be able to round remove people flushing themselves down disposals. 

## Technical details
<!-- Summary of code changes for easier review. -->
Removed Emag line from the thief toolbox .yml and edited the .ftl line to no longer include reference to it as well

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Emag no longer part of syndicate kit description
![image](https://github.com/user-attachments/assets/65f80dee-3139-4e3c-8b6f-32f49f8824f2)
Emag absent from redeemed syndicate kit
![image](https://github.com/user-attachments/assets/d87ff578-6c22-40b1-a80b-60748bd23eb5)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Removed the Emag from the Thief's syndicate kit
