### PR TITLE
fix rmobjective command and add completion options

### DIFF
--- a/Content.Server/Objectives/Commands/RemoveObjectiveCommand.cs
+++ b/Content.Server/Objectives/Commands/RemoveObjectiveCommand.cs
@@ -1,52 +1,81 @@
 ﻿using Content.Server.Administration;
 using Content.Shared.Administration;
 using Content.Shared.Mind;
+using Content.Shared.Objectives.Systems;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 
 namespace Content.Server.Objectives.Commands
 {
     [AdminCommand(AdminFlags.Admin)]
-    public sealed class RemoveObjectiveCommand : IConsoleCommand
+    public sealed class RemoveObjectiveCommand : LocalizedEntityCommands
     {
-        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IPlayerManager _players = default!;
+        [Dependency] private readonly SharedMindSystem _mind = default!;
+        [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
 
-        public string Command => "rmobjective";
-        public string Description => "Removes an objective from the player's mind.";
-        public string Help => "rmobjective <username> <index>";
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        public override string Command => "rmobjective";
+        public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length != 2)
             {
-                shell.WriteLine("Expected exactly 2 arguments.");
+                shell.WriteError(Loc.GetString(Loc.GetString("cmd-rmobjective-invalid-args")));
                 return;
             }
 
-            var mgr = IoCManager.Resolve<IPlayerManager>();
-            var minds = _entityManager.System<SharedMindSystem>();
-            if (!mgr.TryGetSessionByUsername(args[0], out var session))
+            if (!_players.TryGetSessionByUsername(args[0], out var session))
             {
-                shell.WriteLine("Can't find the playerdata.");
+                shell.WriteError(Loc.GetString("cmd-rmojective-player-not-found"));
                 return;
             }
 
-            if (!minds.TryGetMind(session, out var mindId, out var mind))
+            if (!_mind.TryGetMind(session, out var mindId, out var mind))
             {
-                shell.WriteLine("Can't find the mind.");
+                shell.WriteError(Loc.GetString("cmd-rmojective-mind-not-found"));
                 return;
             }
 
             if (int.TryParse(args[1], out var i))
             {
-                var mindSystem = _entityManager.System<SharedMindSystem>();
-                shell.WriteLine(mindSystem.TryRemoveObjective(mindId, mind, i)
-                    ? "Objective successfully removed!"
-                    : "Objective removing failed. Maybe the index is out of bounds? Check lsobjectives!");
+                shell.WriteLine(Loc.GetString(_mind.TryRemoveObjective(mindId, mind, i)
+                    ? "cmd-rmobjective-success"
+                    : "cmd-rmobjective-failed"));
             }
             else
             {
-                shell.WriteLine($"Invalid index {args[1]}!");
+                shell.WriteError(Loc.GetString("cmd-rmobjective-invalid-index", ("index", args[1])));
             }
+        }
+
+        public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        {
+            if (args.Length == 1)
+            {
+                return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), LocalizationManager.GetString("shell-argument-username-hint"));
+            }
+            if (args.Length == 2)
+            {
+                if (!_players.TryGetSessionByUsername(args[0], out var session))
+                    return CompletionResult.Empty;
+
+                if (!_mind.TryGetMind(session, out var mindId, out var mind))
+                    return CompletionResult.Empty;
+
+                if (mind.Objectives.Count == 0)
+                    return CompletionResult.Empty;
+
+                var options = new List<CompletionOption>();
+                for (int i = 0; i < mind.Objectives.Count; i++)
+                {
+                    var info = _objectives.GetInfo(mind.Objectives[i], mindId, mind);
+                    var hint = info == null ? Loc.GetString("cmd-rmobjective-invalid-objective-info") : $"{mind.Objectives[i]} ({info.Value.Title})";
+                    options.Add(new CompletionOption(i.ToString(), hint));
+                }
+
+                return CompletionResult.FromOptions(options);
+            }
+
+            return CompletionResult.Empty;
         }
     }
 }

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -371,7 +371,7 @@ public abstract partial class SharedMindSystem : EntitySystem
 
         // garbage collection - only delete the objective entity if no mind uses it anymore
         // This comes up for stuff like paradox clones where the objectives share the same entity
-        var mindQuery = new AllEntityQueryEnumerator<MindComponent>();
+        var mindQuery = AllEntityQuery<MindComponent>();
         while (mindQuery.MoveNext(out _, out var queryComp))
         {
             if (queryComp.Objectives.Contains(objective))

--- a/Resources/Locale/en-US/objectives/commands/rmobjective.ftl
+++ b/Resources/Locale/en-US/objectives/commands/rmobjective.ftl
@@ -1,0 +1,14 @@
+# addobjectives
+cmd-rmobjective-desc = Removes an objective from the player's mind.
+cmd-rmobjective-help = rmobjective <username> <index>
+
+cmd-rmobjective-invalid-args = Expected exactly 2 arguments.
+cmd-rmobjective-player-not-found = Can't find the playerdata.
+cmd-rmobjective-mind-not-found = Can't find the mind.
+cmd-rmobjective-success = Objective successfully removed!
+cmd-rmobjective-failed = Objective removing failed. Maybe the index is out of bounds? Check lsobjectives!
+cmd-rmobjective-invalid-index = Could not parse index { $index } as an integer.
+cmd-rmobjective-invalid-objective-info = INVALID
+
+cmd-rmobjective-player-completion = <Player>
+cmd-rmobjective-index-completion = <Index>


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Fixes #36391
and makes admin life easier

## Technical details
Make the query in `TryRemoveObjective` work correctly (no clue why the integration test did not catch that).
Turn the command into a `LocalizedEntityCommands` so it is localized and we can use dependencies.
Add a completion helper that gives you a preview of the selected objective, similar to the `lsobjectivescommand`

## Media
![Screenshot (386)](https://github.com/user-attachments/assets/6c1f4cb2-bcd3-41f8-b184-9262744efa14)
![Screenshot (387)](https://github.com/user-attachments/assets/9505adfe-4863-4176-9e63-4a8ee8a5371e)
![Screenshot (388)](https://github.com/user-attachments/assets/13dfc227-3c88-4714-a260-b66544f78317)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
ADMIN:
- fix: Fixed the rmobjective command.
- tweak: Added completion hints to the rmobjective command.
