### PR TITLE
Fix `lsobjectives` target player logic

### DIFF
--- a/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
+++ b/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
@@ -18,8 +18,8 @@ namespace Content.Server.Objectives.Commands
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            var player = shell.Player;
-            if (player == null || !_players.TryGetSessionByUsername(args[0], out player))
+            var player = (args.Length > 0 && _players.TryGetSessionByUsername(args[0], out var passedPlayer)) ? passedPlayer : shell.Player;
+            if (player == null)
             {
                 shell.WriteError(LocalizationManager.GetString("shell-target-player-does-not-exist"));
                 return;

--- a/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
+++ b/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
@@ -5,6 +5,7 @@ using Content.Shared.Mind;
 using Content.Shared.Objectives.Systems;
 using Robust.Server.Player;
 using Robust.Shared.Console;
+using Robust.Shared.Player;
 
 namespace Content.Server.Objectives.Commands
 {
@@ -18,7 +19,12 @@ namespace Content.Server.Objectives.Commands
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            var player = (args.Length > 0 && _players.TryGetSessionByUsername(args[0], out var passedPlayer)) ? passedPlayer : shell.Player;
+            ICommonSession? player;
+            if (args.Length > 0)
+                _players.TryGetSessionByUsername(args[0], out player);
+            else
+                player = shell.Player;
+
             if (player == null)
             {
                 shell.WriteError(LocalizationManager.GetString("shell-target-player-does-not-exist"));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The `lsobjectives` command no longer requires that the executing client has a player session.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is preventing the command from working from the server console and in integration tests.

## Technical details
<!-- Summary of code changes for easier review. -->
Small, sneaky logic error in the old code.
```
var player = shell.Player;
if (player == null || !_players.TryGetSessionByUsername(args[0], out player))
```
That null check will cause the command to always fail if `shell.Player` is null. Presumably the intention was to fall back to the local shell's player if the `TryGetSessionByUsername` call fails, and only if neither works, report a failure.

The logic is now: if an argument was passed, try to find a player with that username. If no arguments were passed, used the local shell's player instead. If that still didn't work, report an error.

This is a slight change in behavior from before: Previously, if the specified player was not found, the command would instead report the objectives for the local player. However, that behavior is kinda weird, and probably not intended, so it has been changed to report that the target player was not found instead.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->