### PR TITLE
Add test of objective-related console commands

### DIFF
--- a/Content.IntegrationTests/Tests/Commands/ObjectiveCommandsTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/ObjectiveCommandsTest.cs
@@ -1,0 +1,74 @@
+#nullable enable
+using System.Linq;
+using Content.Server.Objectives;
+using Content.Shared.Mind;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Player;
+
+namespace Content.IntegrationTests.Tests.Commands;
+
+public sealed class ObjectiveCommandsTest
+{
+
+    private const string ObjectiveProtoId = "MindCommandsTestObjective";
+    private const string DummyUsername = "MindCommandsTestUser";
+
+    [TestPrototypes]
+    private const string Prototypes = $"""
+- type: entity
+  id: {ObjectiveProtoId}
+  components:
+  - type: Objective
+    difficulty: 1
+    issuer: test
+    icon:
+      sprite: error.rsi
+      state: error
+  - type: DieCondition
+""";
+
+    /// <summary>
+    /// Creates a dummy session, and assigns it a mind, then
+    /// tests using <c>addobjective</c>, <c>lsobjectives</c>,
+    /// and <c>rmobjective</c> on it.
+    /// </summary>
+    [Test]
+    public async Task AddListRemoveObjectiveTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var playerMan = server.ResolveDependency<ISharedPlayerManager>();
+        var mindSys = server.System<SharedMindSystem>();
+        var objectivesSystem = server.System<ObjectivesSystem>();
+
+        var mapData = await pair.CreateTestMap();
+
+        await server.AddDummySession(DummyUsername);
+        await server.WaitRunTicks(5);
+
+        var playerSession = playerMan.Sessions.Single();
+
+        Entity<MindComponent>? mindEnt = null;
+        await server.WaitPost(() =>
+        {
+            mindEnt = mindSys.CreateMind(playerSession.UserId);
+        });
+
+        Assert.That(mindEnt, Is.Not.Null);
+        var mindComp = mindEnt.Value.Comp;
+        Assert.That(mindComp.Objectives, Is.Empty, "Dummy player started with objectives.");
+
+        await pair.WaitCommand($"addobjective {playerSession.Name} {ObjectiveProtoId}");
+
+        Assert.That(mindComp.Objectives, Has.Count.EqualTo(1), "addobjective failed to increase Objectives count.");
+
+        await pair.WaitCommand($"lsobjectives {playerSession.Name}");
+
+        await pair.WaitCommand($"rmobjective {playerSession.Name} 0");
+
+        Assert.That(mindComp.Objectives, Is.Empty, "rmobjective failed to remove objective");
+
+        await pair.CleanReturnAsync();
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added an integration test that verifies that the `addobjective`, `lsobjectives`, and `rmobjective` console commands are functional.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Inspired by the fact that [rmobjective was broken](https://github.com/space-wizards/space-station-14/issues/36391). Wound up finding and fixing [an issue with lsobjectives](https://github.com/space-wizards/space-station-14/pull/36398) along the way.

## Technical details
<!-- Summary of code changes for easier review. -->
The test adds a dummy player session to the server and calls `SharedMindSystem.CreateMind` to assign it a mind entity.
After making sure that the mind has no objectives at first, the test adds an objective with `addobjective` and makes sure that one was added
It then uses `lsobjectives`, then uses `rmobjective` to remove it, verifying that the mind has no objectives again.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->