### PR TITLE
Fix absurd volume in gas filters

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -60,8 +60,8 @@
           type: GasFilterBoundUserInterface
     - type: GasFilter
       enabled: false
-      transferRate: 1000
-      maxTransferRate: 1000
+      transferRate: 200
+      maxTransferRate: 200
     - type: Flippable
       mirrorEntity: GasFilterFlipped
     - type: Construction


### PR DESCRIPTION
## About the PR
Decreased transfer rate in gas filter

## Why / Balance
Zero reasons for filter to be x5 more efficient than volumetric pump. Bug.

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Gas filters now have accurate transfer rate.
