### PR TITLE
Changed misleading line in the Traitors guidebook

### DIFF
--- a/Resources/ServerInfo/Guidebook/Antagonist/Traitors.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Traitors.xml
@@ -26,7 +26,7 @@
     <GuideEntityEmbed Entity="BaseUplinkRadio" Caption="Uplink Implant"/>
   </Box>
 
-  [bold]Make sure to close your PDA uplink to prevent anyone else from seeing it.[/bold] You don't want [color=#cb0000]Security[/color] to get their hands on this premium selection of contraband!
+  [bold]Make sure to close your PDA uplink to prevent anyone else from seeing it.[/bold] You don't want [color=#cb0000]Security[/color] to notice you have it and confiscate it from you!
 
   Implanted uplinks are not normally accessible to other people, so they do not have any security measures. They can, however, be removed from you with an empty implanter.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed a line in the Traitors guidebook entry.
It used to say "You don't want Security to get their hands on this premium selection of contraband!"
It now says "You don't want Security to notice you have it and confiscate it from you!"

## Why / Balance
The previous line was misleading and suggested that Security are allowed to purchase contraband from a Syndicate uplink, which they are not.
The main reason to lock uplinks isn't to prevent Security from getting their hands on stuff like blood-reds, Syndie encryption keys and the like, because they are forbidden by rules from purchasing items from the uplink anyway. The main reason is that if Security finds you with an unlocked uplink:
- They know for a fact Syndies are on-board, and that you are one of them.
- They know uplinks are hidden in PDAs and are heavily incentivised to PDA check anyone they arrest. (The wiki also states it allows them to confiscate the PDAs of anyone found with Syndie contraband; I don't know if this is true.)
- You are not getting your uplink back.

## Technical details
Edited line 29 of Resources/ServerInfo/Guidebook/Antagonist/Traitors.xml to change the line "You don't want Security to get their hands on this premium selection of contraband!" to "You don't want Security to notice you have it and confiscate it from you!"

## Media
![image](https://github.com/user-attachments/assets/dcb8f076-85ab-47b0-b65c-c43f6b1c2355)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
