### PR TITLE
Fix docks in shuttle UI not being shown at >100% UI scale

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -303,7 +303,7 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
         const float sqrt2 = 1.41421356f;
         const float dockRadius = DockScale * sqrt2;
         // Worst-case bounds used to cull a dock:
-        Box2 viewBounds = new Box2(-dockRadius, -dockRadius, Size.X + dockRadius, Size.Y + dockRadius);
+        Box2 viewBounds = new Box2(-dockRadius, -dockRadius, PixelSize.X + dockRadius, PixelSize.Y + dockRadius);
         if (_docks.TryGetValue(nent, out var docks))
         {
             foreach (var state in docks)


### PR DESCRIPTION
## About the PR

The existing culling code for removing the purple squares indicating docks in the shuttle piloting and mass scanner UIs does not account for UI scale, so they will not appear unless they are in the top left corner if the player has set their UI scale to more than 100% (common for high-res displays).

This patch changes the culling to use the scaled sizes instead, fixing the issue.

Ported from new-frontiers-14/frontier-station-14#2898, of which I am the author.

## Why / Balance

Not being able to see where you can dock most of the time is annoying. So is playing at 100% UI scale on a 4K display.

## Technical details

Change `ShuttleNavControl.xaml.cs` to use on `PixelSize` instead of `Size` for culling, which is scaled by the UI scale.

## Media

Currently, without patch:

![Screenshot_20250409_165932](https://github.com/user-attachments/assets/6697c3cf-d012-43d5-b8f0-d02fe45b016b)

With patch:

![Screenshot_20250409_170141](https://github.com/user-attachments/assets/0b176b34-5d13-41c1-9eb2-1dcafede928b)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- fix: Fix docks not always being visible in the shuttle UI when using UI scaling.

