### PR TITLE
Mark the spider clan explosive as major contraband

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/spider.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/spider.yml
@@ -2,7 +2,7 @@
   name: spider clan charge
   description: A modified C-4 charge supplied to you by the Spider Clan. Its explosive power has been juiced up, but only works in one specific area.
   # not actually modified C-4! oh the horror!
-  parent: BaseItem
+  parent: [ BaseItem, BaseMajorContraband ]
   id: SpiderCharge
   components:
   - type: Sprite


### PR DESCRIPTION

## About the PR

Mark the spider clan explosive that the ninja starts off with as major contraband.

## Why / Balance

Most other ninja gear is contraband. It's an unsanctioned explosive and antagonist gear.

## Technical details

Add `BaseMajorContraband` to the parents of the spider clan charge.

## Media

Currently, without patch, fun allowed:

![Screenshot_20250409_172358](https://github.com/user-attachments/assets/a61d7c34-9d60-43df-83f2-4585b3fee9e1)

With this patch, no fun allowed:

![Screenshot_20250409_172519](https://github.com/user-attachments/assets/87c84790-cdcc-45f1-b78a-92d01359d33d)

![Screenshot_20250409_172527](https://github.com/user-attachments/assets/d3b1a985-8f83-45b5-ba28-841a0038b0ae)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Spider clan charges are now marked as contraband
