### PR TITLE
Fix power cells/cages counting for laser weapon bounties

### DIFF
--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -529,6 +529,9 @@
     whitelist:
       components:
       - HitscanBatteryAmmoProvider
+    blacklist:
+      components:
+      - PowerCell
 
 - type: cargoBounty
   id: BountyFood


### PR DESCRIPTION
## About the PR
Fixes power cells or power cages counting for laser weapon bounties. You can no longer submit 6 small power cells for your laser weapon bounty.

## Why / Balance
It was a bug.

## Technical details
We explicitly blacklist items with a `PowerCell` component. This also checks for power cages because they share the same `PowerCell` component on the base `BasePowerCage` -> `BasePowerCell`.

No laser guns currently have a `PowerCell` component.

## Media
![Content Client_gVxLne1YxR](https://github.com/user-attachments/assets/ade1cb01-46d2-49dd-a097-428edd652d5d)
![Content Client_cirsNqB9UO](https://github.com/user-attachments/assets/5f966211-f54f-4565-a203-bfca3020a82d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed power cells and power cages counting for laser gun cargo bounties.