### PR TITLE
Changes the name of the Detectives suitskirts from "... suit" to "... suitskirt"

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -561,8 +561,8 @@
 - type: entity
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtLawyerRed
-  name: red lawyer 
-  description: A flashy red  worn by lawyers and show-offs.
+  name: red lawyer suitskirt
+  description: A flashy red suitskirt worn by lawyers and show-offs.
   components:
     - type: Sprite
       sprite: Clothing/Uniforms/Jumpskirt/lawyerred.rsi

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -133,7 +133,7 @@
 - type: entity
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtDetective
-  name: hard-worn suit
+  name: hard-worn suitskirt
   description: Someone who wears this means business.
   components:
     - type: Sprite
@@ -144,7 +144,7 @@
 - type: entity
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtDetectiveGrey
-  name: noir suit
+  name: noir suitskirt
   description: A hard-boiled private investigator's grey suit, complete with tie clip.
   components:
     - type: Sprite
@@ -561,8 +561,8 @@
 - type: entity
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtLawyerRed
-  name: red lawyer suitskirt
-  description: A flashy red suitskirt worn by lawyers and show-offs.
+  name: red lawyer 
+  description: A flashy red  worn by lawyers and show-offs.
   components:
     - type: Sprite
       sprite: Clothing/Uniforms/Jumpskirt/lawyerred.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Appends "skirt" to the Detectives suitskirts

## Why / Balance
The Detectives skirts just feel out of place with a regular name. All of the lawyer ones are called "suitskirt", and it feels inconsistent

## Technical details
This is a two line yml file change

## Media
Not needed

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.