### PR TITLE
air alarm panic wire snipping forces panic mode

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
@@ -74,7 +74,13 @@
         <!-- Mode buttons -->
         <BoxContainer Orientation="Horizontal">
             <Label Text="{Loc 'air-alarm-ui-window-mode-label'}" Margin="0 0 2 0" />
-            <OptionButton Name="CModeButton" HorizontalExpand="True" />
+            <BoxContainer Orientation="Vertical" HorizontalExpand="True">
+                <OptionButton Name="CModeButton" HorizontalExpand="True" />
+                <ui:StripeBack Name="CModeSelectLocked">
+                    <RichTextLabel Text="{Loc 'air-alarm-ui-window-mode-select-locked-label'}"
+                                   HorizontalAlignment="Center" />
+                </ui:StripeBack>
+            </BoxContainer>
             <CheckBox Name="AutoModeCheckBox" Text="{Loc 'air-alarm-ui-window-auto-mode-label'}" />
         </BoxContainer>
     </BoxContainer>

--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
@@ -74,13 +74,13 @@
         <!-- Mode buttons -->
         <BoxContainer Orientation="Horizontal">
             <Label Text="{Loc 'air-alarm-ui-window-mode-label'}" Margin="0 0 2 0" />
-            <BoxContainer Orientation="Vertical" HorizontalExpand="True">
+            <Control HorizontalExpand="True">
                 <OptionButton Name="CModeButton" HorizontalExpand="True" />
                 <ui:StripeBack Name="CModeSelectLocked">
                     <RichTextLabel Text="{Loc 'air-alarm-ui-window-mode-select-locked-label'}"
                                    HorizontalAlignment="Center" />
                 </ui:StripeBack>
-            </BoxContainer>
+            </Control>
             <CheckBox Name="AutoModeCheckBox" Text="{Loc 'air-alarm-ui-window-auto-mode-label'}" />
         </BoxContainer>
     </BoxContainer>

--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
@@ -75,7 +75,7 @@
         <BoxContainer Orientation="Horizontal">
             <Label Text="{Loc 'air-alarm-ui-window-mode-label'}" Margin="0 0 2 0" />
             <Control HorizontalExpand="True">
-                <OptionButton Name="CModeButton" HorizontalExpand="True" />
+                <OptionButton Name="CModeButton" />
                 <ui:StripeBack Name="CModeSelectLocked">
                     <RichTextLabel Text="{Loc 'air-alarm-ui-window-mode-select-locked-label'}"
                                    HorizontalAlignment="Center" />

--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -110,6 +110,7 @@ public sealed partial class AirAlarmWindow : FancyWindow
         {
             UpdateDeviceData(addr, dev);
         }
+        _modes.Disabled = state.PanicWireCut;
     }
 
     public void UpdateModeSelector(AirAlarmMode mode)

--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -110,7 +110,8 @@ public sealed partial class AirAlarmWindow : FancyWindow
         {
             UpdateDeviceData(addr, dev);
         }
-        _modes.Disabled = state.PanicWireCut;
+        _modes.Visible = !state.PanicWireCut;
+        CModeSelectLocked.Visible = state.PanicWireCut;
     }
 
     public void UpdateModeSelector(AirAlarmMode mode)

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
@@ -71,6 +71,7 @@ public sealed partial class ScrubberControl : BoxContainer
             _data.PumpDirection = (ScrubberPumpDirection) args.Id;
             ScrubberDataChanged?.Invoke(_address, _data);
         };
+        _pumpDirection.Disabled = data.AirAlarmPanicWireCut;
 
         _copySettings.OnPressed += _ =>
         {
@@ -109,6 +110,7 @@ public sealed partial class ScrubberControl : BoxContainer
 
         _data.PumpDirection = data.PumpDirection;
         _pumpDirection.Select((int) _data.PumpDirection);
+        _pumpDirection.Disabled = data.AirAlarmPanicWireCut;
 
         _data.VolumeRate = data.VolumeRate;
         _volumeRate.Value = _data.VolumeRate;

--- a/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
+++ b/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
@@ -47,4 +47,7 @@ public sealed partial class AirAlarmComponent : Component
     /// </summary>
     [DataField("normalPort", customTypeSerializer: typeof(PrototypeIdSerializer<SourcePortPrototype>))]
     public string NormalPort = "AirNormal";
+
+    [ViewVariables]
+    public AirAlarmMode? ForcedMode;
 }

--- a/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
+++ b/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
@@ -52,6 +52,6 @@ public sealed partial class AirAlarmComponent : Component
     /// If not null, this mode will be forced and any attempts to change it will be ignored.
     /// E.g., if the panic wire is cut, this will be set to panic.
     /// </summary>
-    [ViewVariables]
+    [DataField, ViewVariables]
     public AirAlarmMode? ForcedMode;
 }

--- a/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
+++ b/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
@@ -49,9 +49,8 @@ public sealed partial class AirAlarmComponent : Component
     public string NormalPort = "AirNormal";
 
     /// <summary>
-    /// If not null, this mode will be forced and any attempts to change it will be ignored.
-    /// E.g., if the panic wire is cut, this will be set to panic.
+    /// Whether the panic wire is cut, forcing the alarm into panic mode.
     /// </summary>
     [DataField, ViewVariables]
-    public AirAlarmMode? ForcedMode;
+    public bool PanicWireCut;
 }

--- a/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
+++ b/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
@@ -48,6 +48,10 @@ public sealed partial class AirAlarmComponent : Component
     [DataField("normalPort", customTypeSerializer: typeof(PrototypeIdSerializer<SourcePortPrototype>))]
     public string NormalPort = "AirNormal";
 
+    /// <summary>
+    /// If not null, this mode will be forced and any attempts to change it will be ignored.
+    /// E.g., if the panic wire is cut, this will be set to panic.
+    /// </summary>
     [ViewVariables]
     public AirAlarmMode? ForcedMode;
 }

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -478,11 +478,6 @@ public sealed class AirAlarmSystem : EntitySystem
             mode = AirAlarmMode.Panic;
         }
 
-        if (controller.CurrentMode == mode)
-        {
-            return;
-        }
-
         controller.CurrentMode = mode;
 
         // setting it to UI only means we don't have
@@ -681,7 +676,7 @@ public sealed class AirAlarmSystem : EntitySystem
         _ui.SetUiState(
             uid,
             SharedAirAlarmInterfaceKey.Key,
-            new AirAlarmUIState(devNet.Address, deviceCount, pressure, temperature, dataToSend, alarm.CurrentMode, highestAlarm.Value, alarm.AutoMode));
+            new AirAlarmUIState(devNet.Address, deviceCount, pressure, temperature, dataToSend, alarm.CurrentMode, highestAlarm.Value, alarm.AutoMode, alarm.PanicWireCut));
     }
 
     private const float Delay = 8f;

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -468,7 +468,17 @@ public sealed class AirAlarmSystem : EntitySystem
     /// <param name="uiOnly">Whether this change is for the UI only, or if it changes the air alarm's operating mode. Defaults to true.</param>
     public void SetMode(EntityUid uid, string origin, AirAlarmMode mode, bool uiOnly = true, AirAlarmComponent? controller = null)
     {
-        if (!Resolve(uid, ref controller) || controller.CurrentMode == mode)
+        if (!Resolve(uid, ref controller))
+        {
+            return;
+        }
+
+        if (controller.ForcedMode is not null)
+        {
+            mode = controller.ForcedMode.Value;
+        }
+
+        if (controller.CurrentMode == mode)
         {
             return;
         }

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -659,6 +659,7 @@ public sealed class AirAlarmSystem : EntitySystem
         }
         foreach (var (addr, data) in alarm.ScrubberData)
         {
+            data.AirAlarmPanicWireCut = alarm.PanicWireCut;
             dataToSend.Add((addr, data));
         }
         foreach (var (addr, data) in alarm.SensorData)

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -473,9 +473,9 @@ public sealed class AirAlarmSystem : EntitySystem
             return;
         }
 
-        if (controller.ForcedMode is not null)
+        if (controller.PanicWireCut)
         {
-            mode = controller.ForcedMode.Value;
+            mode = AirAlarmMode.Panic;
         }
 
         if (controller.CurrentMode == mode)

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -478,6 +478,9 @@ public sealed class AirAlarmSystem : EntitySystem
             mode = AirAlarmMode.Panic;
         }
 
+        if (controller.CurrentMode == mode)
+            return;
+
         controller.CurrentMode = mode;
 
         // setting it to UI only means we don't have

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -478,8 +478,6 @@ public sealed class AirAlarmSystem : EntitySystem
             mode = AirAlarmMode.Panic;
         }
 
-        if (controller.CurrentMode == mode)
-            return;
 
         controller.CurrentMode = mode;
 

--- a/Content.Server/Atmos/Monitor/WireActions/AirAlarmPanicWire.cs
+++ b/Content.Server/Atmos/Monitor/WireActions/AirAlarmPanicWire.cs
@@ -30,6 +30,7 @@ public sealed partial class AirAlarmPanicWire : ComponentWireAction<AirAlarmComp
 
     public override bool Cut(EntityUid user, Wire wire, AirAlarmComponent comp)
     {
+        comp.ForcedMode = AirAlarmMode.Panic;
         if (EntityManager.TryGetComponent<DeviceNetworkComponent>(wire.Owner, out var devNet))
         {
             _airAlarmSystem.SetMode(wire.Owner, devNet.Address, AirAlarmMode.Panic, false);
@@ -40,6 +41,7 @@ public sealed partial class AirAlarmPanicWire : ComponentWireAction<AirAlarmComp
 
     public override bool Mend(EntityUid user, Wire wire, AirAlarmComponent alarm)
     {
+        alarm.ForcedMode = null;
         if (EntityManager.TryGetComponent<DeviceNetworkComponent>(wire.Owner, out var devNet)
             && alarm.CurrentMode == AirAlarmMode.Panic)
         {

--- a/Content.Server/Atmos/Monitor/WireActions/AirAlarmPanicWire.cs
+++ b/Content.Server/Atmos/Monitor/WireActions/AirAlarmPanicWire.cs
@@ -30,7 +30,7 @@ public sealed partial class AirAlarmPanicWire : ComponentWireAction<AirAlarmComp
 
     public override bool Cut(EntityUid user, Wire wire, AirAlarmComponent comp)
     {
-        comp.ForcedMode = AirAlarmMode.Panic;
+        comp.PanicWireCut = true;
         if (EntityManager.TryGetComponent<DeviceNetworkComponent>(wire.Owner, out var devNet))
         {
             _airAlarmSystem.SetMode(wire.Owner, devNet.Address, AirAlarmMode.Panic, false);
@@ -41,7 +41,7 @@ public sealed partial class AirAlarmPanicWire : ComponentWireAction<AirAlarmComp
 
     public override bool Mend(EntityUid user, Wire wire, AirAlarmComponent alarm)
     {
-        alarm.ForcedMode = null;
+        alarm.PanicWireCut = false;
         if (EntityManager.TryGetComponent<DeviceNetworkComponent>(wire.Owner, out var devNet)
             && alarm.CurrentMode == AirAlarmMode.Panic)
         {

--- a/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
+++ b/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
@@ -37,7 +37,7 @@ public interface IAtmosDeviceData
 [Serializable, NetSerializable]
 public sealed class AirAlarmUIState : BoundUserInterfaceState
 {
-    public AirAlarmUIState(string address, int deviceCount, float pressureAverage, float temperatureAverage, List<(string, IAtmosDeviceData)> deviceData, AirAlarmMode mode, AtmosAlarmType alarmType, bool autoMode)
+    public AirAlarmUIState(string address, int deviceCount, float pressureAverage, float temperatureAverage, List<(string, IAtmosDeviceData)> deviceData, AirAlarmMode mode, AtmosAlarmType alarmType, bool autoMode, bool panicWireCut)
     {
         Address = address;
         DeviceCount = deviceCount;
@@ -47,6 +47,7 @@ public sealed class AirAlarmUIState : BoundUserInterfaceState
         Mode = mode;
         AlarmType = alarmType;
         AutoMode = autoMode;
+        PanicWireCut = panicWireCut;
     }
 
     public string Address { get; }
@@ -64,6 +65,7 @@ public sealed class AirAlarmUIState : BoundUserInterfaceState
     public AirAlarmMode Mode { get; }
     public AtmosAlarmType AlarmType { get; }
     public bool AutoMode { get; }
+    public bool PanicWireCut { get; }
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -13,6 +13,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
         public ScrubberPumpDirection PumpDirection { get; set; } = ScrubberPumpDirection.Scrubbing;
         public float VolumeRate { get; set; } = 200f;
         public bool WideNet { get; set; } = false;
+        public bool AirAlarmPanicWireCut { get; set; }
 
         public static HashSet<Gas> DefaultFilterGases = new()
         {

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -13,6 +13,7 @@ air-alarm-ui-window-device-count-label = Total Devices
 air-alarm-ui-window-resync-devices-label = Resync
 
 air-alarm-ui-window-mode-label = Mode
+air-alarm-ui-window-mode-select-locked-label = [bold][color=red] Mode selector failure! [/color][/bold]
 air-alarm-ui-window-auto-mode-label = Auto mode
 
 -air-alarm-state-name = { $state ->


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Snipping the air alarm panic wire forces panic mode until the wire is mended. When the wire is snipped, the mode change drop-down menus for the air alarm and for individual scrubbbers are disabled.

Before, the panic wire just changed the mode to siphon but allowed anyone to change it back normally in the alarm UI.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Before this change, the panic wire was useless. If you had access, you could just switch the mode to panic normally. If you didn't have access, you were better off snipping the access wire, giving you control to change the mode to panic and also any other.

This wire is now more dangerous when snipped, giving agents the ability to cause localized atmospheric hazards that are slightly harder to fix by Atmos and impossible to fix by the station AI, while remaining easy to spot (red siphoning animation on all scrubbers).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


<!--https://github.com/user-attachments/assets/9ccc73bc-6fb8-4162-be6f-9b190f18fa1d-->



**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Snipping the panic wire in an air alarm now forces panic mode until the wire is mended.
