### PR TITLE
Change ambuzol plus guidebook entry to match recipe.

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -59,7 +59,7 @@ reagent-name-ambuzol = ambuzol
 reagent-desc-ambuzol = A highly engineered substance able to halt the progression of a zombie infection.
 
 reagent-name-ambuzol-plus = ambuzol plus
-reagent-desc-ambuzol-plus = Further engineered with the blood of the infected, inoculates the living against the infection.
+reagent-desc-ambuzol-plus = Further engineered with omnizine, inoculates the living against the infection.
 
 reagent-name-pulped-banana-peel = pulped banana peel
 reagent-desc-pulped-banana-peel = Pulped banana peels have some effectiveness against bleeding.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the description of ambuzol plus to match the recipe needing omnizine instead of zombie blood. I am not sure if just "omnizine" fits well or if I should add more flavor similar to it previously mentioning "the blood of the infected".

## Why / Balance
The guidebook entry was inaccurate to the new recipe.

## Technical details
None

## Media
![image](https://github.com/user-attachments/assets/317d23b7-3268-4729-981d-35957648f83e)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**