### PR TITLE
Add Aluminum Source (Cans)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -20,7 +20,6 @@
           Quantity: 4
         - ReagentId: Iron
           Quantity: 1
-        maxVol: 5
   - type: MixableSolution
     solution: drink
   - type: SolutionTransfer

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -14,11 +14,20 @@
         - ReagentId: Cola
           Quantity: 30
         maxVol: 30
+      grindable:
+        reagents: # 5u -> 1/2 steel sheet (10u)
+        - ReagentId: Aluminium # Fun fact: soda can makeup is approx. 75% aluminium and 25% tin/iron.
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
+        maxVol: 5
   - type: MixableSolution
     solution: drink
   - type: SolutionTransfer
     canChangeTransferAmount: true
     maxTransferAmount: 15
+  - type: Extractable
+    grindableSolutionName: grindable
   - type: UserInterface
     interfaces:
       enum.TransferAmountUiKey.Key:
@@ -81,6 +90,12 @@
         reagents:
         - ReagentId: Cola
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Tag
     tags:
     - Cola
@@ -101,6 +116,12 @@
     solutions:
       drink:
         maxVol: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Openable
     opened: true
   - type: Sprite
@@ -129,6 +150,12 @@
         reagents:
         - ReagentId: IcedTea
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Sprite
     sprite: Objects/Consumable/Drinks/ice_tea_can.rsi
   - type: Item
@@ -147,6 +174,12 @@
         reagents:
         - ReagentId: LemonLime
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Sprite
     sprite: Objects/Consumable/Drinks/lemon-lime.rsi
   - type: Item
@@ -165,6 +198,12 @@
         reagents:
         - ReagentId: LemonLimeCranberry
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Sprite
     sprite: Objects/Consumable/Drinks/lemon-lime-cranberry.rsi
   - type: Item
@@ -216,6 +255,12 @@
         reagents:
         - ReagentId: GrapeSoda
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Sprite
     sprite: Objects/Consumable/Drinks/purple_can.rsi
   - type: Item
@@ -234,6 +279,12 @@
         reagents:
         - ReagentId: RootBeer
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Sprite
     sprite: Objects/Consumable/Drinks/rootbeer.rsi
   - type: Item
@@ -255,6 +306,12 @@
         reagents:
         - ReagentId: SodaWater
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/sodawater.rsi
@@ -272,6 +329,12 @@
         reagents:
         - ReagentId: SpaceMountainWind
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Sprite
     sprite: Objects/Consumable/Drinks/space_mountain_wind.rsi
   - type: Item
@@ -290,6 +353,12 @@
         reagents:
         - ReagentId: SpaceUp
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Sprite
     sprite: Objects/Consumable/Drinks/space-up.rsi
   - type: Item
@@ -308,6 +377,12 @@
         reagents:
         - ReagentId: SolDry
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Sprite
     sprite: Objects/Consumable/Drinks/sol_dry.rsi
   - type: Item
@@ -326,6 +401,12 @@
         reagents:
         - ReagentId: Starkist
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Sprite
     sprite: Objects/Consumable/Drinks/starkist.rsi
   - type: Item
@@ -344,6 +425,12 @@
         reagents:
         - ReagentId: TonicWater
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/tonic.rsi
@@ -361,6 +448,12 @@
         reagents:
         - ReagentId: FourteenLoko
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Sprite
     sprite: Objects/Consumable/Drinks/fourteen_loko.rsi
   - type: Item
@@ -379,6 +472,12 @@
         reagents:
         - ReagentId: ChangelingSting
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/changelingsting.rsi
@@ -398,6 +497,12 @@
         reagents:
         - ReagentId: DrGibb
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/dr_gibb.rsi
@@ -421,6 +526,12 @@
           Quantity: 20
         - ReagentId: Ice
           Quantity: 5
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Tag
     tags:
     - DrinkCan
@@ -443,6 +554,12 @@
         reagents:
         - ReagentId: EnergyDrink
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/energy_drink.rsi
@@ -515,6 +632,12 @@
         reagents:
         - ReagentId: ShamblersJuice
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/shamblersjuice.rsi
@@ -534,6 +657,12 @@
         reagents:
         - ReagentId: PwrGame
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/pwrgame.rsi
@@ -553,6 +682,12 @@
         reagents:
         - ReagentId: Beer
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/beer_can.rsi
@@ -575,6 +710,12 @@
         reagents:
         - ReagentId: Wine
           Quantity: 30
+      grindable:
+        reagents:
+        - ReagentId: Aluminium
+          Quantity: 4
+        - ReagentId: Iron
+          Quantity: 1
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/wine_can.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes aluminum obtainable through grinding soda cans.

inshallah the copy paste is no good

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Aluminum is a fairly common element in chem that doesn't have any non-cargo sources. This limits the ability for non-chem players to use the fairly interesting reactions that it has.

Grinding cans is a bit of a funny source and can serve as an interesting 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/95af61dc-7027-4a7d-8d82-297f3ce10e79)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Grinding soda cans now gives a small amount of Aluminum.