### PR TITLE
Smuggler follow up

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
@@ -28,8 +28,8 @@
     - !type:NestedSelector
       tableId: RandomSatchelTable6
 
-  #number after each group is potential max weight. If combined PMW is too high, it could result in an over-filled bag/error.
-  #number after each group is potential max inventory capacity. If combined PMIC is too high, it could result in an over-filled bag/error.
+
+  #number after each group inidcates potential max inventory fill. If all combined fills are too high, it could result in an over-filled bag/error.
 - type: entityTable
   id: RandomSatchelTable1
   table: !type:AllSelector

--- a/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
@@ -28,6 +28,8 @@
     - !type:NestedSelector
       tableId: RandomSatchelTable6
 
+  #number after each group is potential max weight. If combined PMW is too high, it could result in an over-filled bag/error.
+  #number after each group is potential max inventory capacity. If combined PMIC is too high, it could result in an over-filled bag/error.
 - type: entityTable
   id: RandomSatchelTable1
   table: !type:AllSelector

--- a/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
@@ -28,7 +28,7 @@
     - !type:NestedSelector
       tableId: RandomSatchelTable6
 
-  #number after each group inidcates potential max inventory fill. If all combined fills are too high, it could result in an over-filled bag/error.
+  #number after each group indicates potential max inventory fill. If all combined fills are too high, it could result in an over-filled bag/error.
 - type: entityTable
   id: RandomSatchelTable1
   table: !type:AllSelector

--- a/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
@@ -33,17 +33,17 @@
   table: !type:AllSelector
     children:
     - !type:NestedSelector
-      tableId: RandomSatchelGenericTable
+      tableId: RandomSatchelGenericTableSmallx2 #2x small
     - !type:NestedSelector
-      tableId: RandomSatchelFunnyTable
+      tableId: RandomSatchelFunnyTable #5x tiny
     - !type:NestedSelector
-      tableId: RandomSatchelClothingTable
+      tableId: RandomSatchelClothingTable #1x small
     - !type:NestedSelector
-      tableId: RandomSatchelCannabisTable
+      tableId: RandomSatchelCannabisTable #5x tiny
     - !type:NestedSelector
-      tableId: RandomSatchelGizmosTable
+      tableId: RandomSatchelGizmosTable #2x small
     - !type:NestedSelector
-      tableId: RandomSatchelChemsTable
+      tableId: RandomSatchelChemsTable #5x tiny
 
 - type: entityTable
   id: RandomSatchelFunnyTable
@@ -63,7 +63,7 @@
       amount: !type:RangeNumberSelector
         range: 1, 5
 
-- type: entityTable
+- type: entityTable #5x tiny
   id: RandomSatchelCannabisTable
   table: !type:GroupSelector
     children:
@@ -82,7 +82,7 @@
       amount: !type:RangeNumberSelector
         range: 1, 15
 
-- type: entityTable
+- type: entityTable #2x small
   id: RandomSatchelGizmosTable
   table: !type:GroupSelector
     children:
@@ -99,7 +99,7 @@
         range: 1, 2
     - id: ProximitySensor
 
-- type: entityTable
+- type: entityTable #5x tiny
   id: RandomSatchelChemsTable
   table: !type:GroupSelector
     children:
@@ -134,17 +134,17 @@
   table: !type:AllSelector
     children:
     - !type:NestedSelector
-      tableId: RandomSatchelTobaccoTable
+      tableId: RandomSatchelTobaccoTable #2x 2x3(12 slots)
     - !type:NestedSelector
-      tableId: RandomSatchelPartyTable
+      tableId: RandomSatchelPartyTable #5x small
     - !type:NestedSelector
-      tableId: RandomSatchelClothingTable
+      tableId: RandomSatchelClothingTable #1x small
     - !type:NestedSelector
-      tableId: RandomSatchelPayloadTable
+      tableId: RandomSatchelPayloadTable #2x small
     - !type:NestedSelector
-      tableId: RandomSatchelCircuitboardsTable
+      tableId: RandomSatchelCircuitboardsTable #1x small
 
-- type: entityTable
+- type: entityTable #2x 2x3(12 slots)
   id: RandomSatchelTobaccoTable
   table: !type:GroupSelector
     children:
@@ -164,7 +164,7 @@
       amount: !type:RangeNumberSelector
         range: 1, 2
 
-- type: entityTable
+- type: entityTable #5x small
   id: RandomSatchelPartyTable
   table: !type:GroupSelector
     children:
@@ -186,7 +186,7 @@
       amount: !type:RangeNumberSelector
         range: 1, 5
 
-- type: entityTable
+- type: entityTable #1x small
   id: RandomSatchelClothingTable
   table: !type:GroupSelector
     children:
@@ -200,7 +200,7 @@
     - id: ClothingHandsGlovesCombat
     - id: ClothingNeckScarfStripedSyndieRed
 
-- type: entityTable
+- type: entityTable #2x small
   id: RandomSatchelPayloadTable
   table: !type:GroupSelector
     children:
@@ -216,7 +216,7 @@
       amount: !type:RangeNumberSelector
         range: 1, 2
 
-- type: entityTable
+- type: entityTable #1x small
   id: RandomSatchelCircuitboardsTable
   table: !type:GroupSelector
     children:
@@ -245,19 +245,19 @@
   table: !type:AllSelector
     children:
     - !type:NestedSelector
-      tableId: RandomSatchelPresentsOrToysTable
+      tableId: RandomSatchelPresentsOrToysTable #3x small
     - !type:NestedSelector
-      tableId: RandomSatchelCashTable
+      tableId: RandomSatchelCashTable #1x small
     - !type:NestedSelector
-      tableId: RandomSatchelWeaponTable
+      tableId: RandomSatchelWeaponTable #5x small
     - !type:NestedSelector
-      tableId: RandomSatchelBurgerTable
+      tableId: RandomSatchelBurgerTable #5x small
     - !type:NestedSelector
-      tableId: RandomSatchelGenericTable
+      tableId: RandomSatchelGenericTableSmall #1x small
     - !type:NestedSelector
-      tableId: RandomSatchelKeysTable
+      tableId: RandomSatchelKeysTable #1x small
 
-- type: entityTable
+- type: entityTable #3x small
   id: RandomSatchelPresentsOrToysTable
   table: !type:GroupSelector
     children:
@@ -271,7 +271,7 @@
     - id: ToyFigurineQueen
     - id: ToyFigurineRatKing
 
-- type: entityTable
+- type: entityTable #1x small
   id: RandomSatchelCashTable
   table: !type:GroupSelector
     children:
@@ -301,7 +301,7 @@
       amount: !type:RangeNumberSelector
         range: 1, 10
 
-- type: entityTable
+- type: entityTable #5x small
   id: RandomSatchelWeaponTable
   table: !type:GroupSelector
     children:
@@ -312,7 +312,7 @@
       amount: !type:RangeNumberSelector
         range: 1, 5
 
-- type: entityTable
+- type: entityTable #5x small
   id: RandomSatchelBurgerTable
   table: !type:GroupSelector
     children:
@@ -331,8 +331,8 @@
       amount: !type:RangeNumberSelector
         range: 1, 5
 
-- type: entityTable
-  id: RandomSatchelGenericTable
+- type: entityTable #1x small
+  id: RandomSatchelGenericTableSmall
   table: !type:GroupSelector
     children:
     - id: SpaceCash100
@@ -342,6 +342,13 @@
     - id: WeaponFlareGun
     - id: ModularReceiver
     - id: RifleStock
+
+- type: entityTable #2x small
+  id: RandomSatchelGenericTableSmallx2
+  table: !type:GroupSelector
+    children:
+    - id: SpaceCash100
+      weight: 15
     - id: DrinkSpaceGlue
       amount: !type:RangeNumberSelector
         range: 1, 2
@@ -352,7 +359,7 @@
       amount: !type:RangeNumberSelector
         range: 1, 2
 
-- type: entityTable
+- type: entityTable #1x small
   id: RandomSatchelKeysTable
   table: !type:GroupSelector
     children:
@@ -377,17 +384,17 @@
   table: !type:AllSelector
     children:
     - !type:NestedSelector
-      tableId: RandomSatchelMaterialsTable
+      tableId: RandomSatchelMaterialsTable #1x medium
     - !type:NestedSelector
-      tableId: RandomSatchelImplantersTable
+      tableId: RandomSatchelImplantersTable #1x small
     - !type:NestedSelector
-      tableId: RandomSatchelCellsTable
+      tableId: RandomSatchelCellsTable #1x small
     - !type:NestedSelector
-      tableId: RandomSatchelSyndicateTable
+      tableId: RandomSatchelSyndicateTable #1x medium
     - !type:NestedSelector
-      tableId: RandomSatchelToolsTable
+      tableId: RandomSatchelToolsTable #1x small
 
-- type: entityTable
+- type: entityTable #1x medium
   id: RandomSatchelMaterialsTable
   table: !type:GroupSelector
     children:
@@ -424,7 +431,7 @@
         weight: 2
       - id: SheetUranium
 
-- type: entityTable
+- type: entityTable #1x small
   id: RandomSatchelImplantersTable
   table: !type:GroupSelector
     children:
@@ -434,7 +441,7 @@
     - id: BikeHornImplanter
     - id: SadTromboneImplanter
 
-- type: entityTable
+- type: entityTable #1x small
   id: RandomSatchelCellsTable
   table: !type:GroupSelector
     children:
@@ -444,7 +451,7 @@
     - id: PowerCellMicroreactor
     - id: PowerCellHigh
 
-- type: entityTable
+- type: entityTable #1x medium
   id: RandomSatchelSyndicateTable
   table: !type:GroupSelector
     children:
@@ -459,8 +466,9 @@
     - id: RadioJammer
     - id: SoapSyndie
     - id: SingularityToy
+    - id: DehydratedSpaceCarp
 
-- type: entityTable
+- type: entityTable #1x small
   id: RandomSatchelToolsTable
   table: !type:GroupSelector
     children:
@@ -477,15 +485,15 @@
   table: !type:AllSelector
     children:
     - !type:NestedSelector
-      tableId: RandomSatchelAlcoholTable
+      tableId: RandomSatchelAlcoholTable #3x medium
     - !type:NestedSelector
-      tableId: RandomSatchelInstrumentTable
+      tableId: RandomSatchelInstrumentTable #1x Medium
     - !type:NestedSelector
-      tableId: RandomSatchelMedsTable
+      tableId: RandomSatchelMedsTable #5x tiny
     - !type:NestedSelector
-      tableId: RandomSatchelMysteriesTable
+      tableId: RandomSatchelMysteriesTable #1x Medium
 
-- type: entityTable
+- type: entityTable #3x medium
   id: RandomSatchelAlcoholTable
   table: !type:GroupSelector
     children:
@@ -493,18 +501,18 @@
       weight: 5
     - id: DrinkCognacBottleFull
       amount: !type:RangeNumberSelector
-        range: 1, 4
+        range: 1, 3
     - id: DrinkGildlagerBottleFull
       amount: !type:RangeNumberSelector
-        range: 1, 4
+        range: 1, 3
     - id: DrinkPatronBottleFull
       amount: !type:RangeNumberSelector
-        range: 1, 4
+        range: 1, 3
     - id: DrinkRumBottleFull
       amount: !type:RangeNumberSelector
-        range: 1, 4
+        range: 1, 3
 
-- type: entityTable
+- type: entityTable #1x Medium
   id: RandomSatchelInstrumentTable
   table: !type:GroupSelector
     children:
@@ -517,7 +525,7 @@
     - id: RockGuitarInstrument
     - id: BassGuitarInstrument
 
-- type: entityTable
+- type: entityTable #5x tiny
   id: RandomSatchelMedsTable
   table: !type:GroupSelector
     children:
@@ -552,7 +560,7 @@
     - id: Stimpack
     - id: CombatMedipen
 
-- type: entityTable
+- type: entityTable #1x Medium
   id: RandomSatchelMysteriesTable
   table: !type:GroupSelector
     children:
@@ -597,13 +605,13 @@
   table: !type:AllSelector
     children:
     - !type:NestedSelector
-      tableId: RandomSatchelGearTable
+      tableId: RandomSatchelGearTable #1x Huge
     - !type:NestedSelector
-      tableId: RandomSatchelGadgetsTable
+      tableId: RandomSatchelGadgetsTable #2x small
     - !type:NestedSelector
-      tableId: CubeTable
+      tableId: CubeTable #10x tiny
 
-- type: entityTable
+- type: entityTable #1x Huge
   id: RandomSatchelGearTable
   table: !type:GroupSelector
     children:
@@ -615,7 +623,7 @@
     - id: HandheldStationMap
     - id: PinpointerStation
 
-- type: entityTable
+- type: entityTable #2x small
   id: RandomSatchelGadgetsTable
   table: !type:GroupSelector
     children:
@@ -633,7 +641,7 @@
     - id: ChameleonProjector
       weight: 0.25
 
-- type: entityTable
+- type: entityTable #10x tiny
   id: CubeTable
   table: !type:GroupSelector
     children:

--- a/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
@@ -158,12 +158,8 @@
     - id: CigCartonGreen
     - id: CigCartonBlack
     - id: CigarCase
-      amount: !type:RangeNumberSelector
-        range: 1, 2
     - id: CigarGoldCase
       weight: 0.25
-      amount: !type:RangeNumberSelector
-        range: 1, 2
 
 - type: entityTable #5x small
   id: RandomSatchelPartyTable
@@ -486,7 +482,7 @@
   table: !type:AllSelector
     children:
     - !type:NestedSelector
-      tableId: RandomSatchelAlcoholTable #3x medium
+      tableId: RandomSatchelAlcoholTable #2x medium
     - !type:NestedSelector
       tableId: RandomSatchelInstrumentTable #1x Medium
     - !type:NestedSelector
@@ -494,7 +490,7 @@
     - !type:NestedSelector
       tableId: RandomSatchelMysteriesTable #1x Medium
 
-- type: entityTable #3x medium
+- type: entityTable #2x medium
   id: RandomSatchelAlcoholTable
   table: !type:GroupSelector
     children:
@@ -502,16 +498,16 @@
       weight: 5
     - id: DrinkCognacBottleFull
       amount: !type:RangeNumberSelector
-        range: 1, 3
+        range: 1, 2
     - id: DrinkGildlagerBottleFull
       amount: !type:RangeNumberSelector
-        range: 1, 3
+        range: 1, 2
     - id: DrinkPatronBottleFull
       amount: !type:RangeNumberSelector
-        range: 1, 3
+        range: 1, 2
     - id: DrinkRumBottleFull
       amount: !type:RangeNumberSelector
-        range: 1, 3
+        range: 1, 2
 
 - type: entityTable #1x Medium
   id: RandomSatchelInstrumentTable

--- a/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
@@ -28,7 +28,6 @@
     - !type:NestedSelector
       tableId: RandomSatchelTable6
 
-
   #number after each group inidcates potential max inventory fill. If all combined fills are too high, it could result in an over-filled bag/error.
 - type: entityTable
   id: RandomSatchelTable1


### PR DESCRIPTION
## About the PR
Fixes the smuggler satchels overfilling with minimal changes. 
- Adds notes on fill sizes
- Reduces the alcohol bottle fill range 4->2
- Reduces cigar cases range 2->1
- Splits the generic category 
- <details><summary>🐟</summary>Sneaks in a dehydrated carp</details>  

Alternate fix to [36146](https://github.com/space-wizards/space-station-14/pull/36146)
No shade just trying to do it with less changes. I went through each of the groups to determine which were the offenders and changed those, opposed to blanket culling a bunch of things. 


## Why / Balance
Was breaking tests making people go crazy.

## Technical details
~~Depends on [36155](https://github.com/space-wizards/space-station-14/pull/36155)~~

## Media
n/a

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
n/a

**Changelog**
n/a
