### PR TITLE
Fix ninja battery drain debug assertion

### DIFF
--- a/Content.Server/Ninja/Systems/BatteryDrainerSystem.cs
+++ b/Content.Server/Ninja/Systems/BatteryDrainerSystem.cs
@@ -106,6 +106,6 @@ public sealed class BatteryDrainerSystem : SharedBatteryDrainerSystem
         _popup.PopupEntity(Loc.GetString("battery-drainer-success", ("battery", target)), uid, uid);
 
         // repeat the doafter until battery is full
-        return !_battery.IsFull(ent, battery);
+        return !_battery.IsFull(comp.BatteryUid.Value, battery);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed a debug assert that would occur when a ninja drained power from a device.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/36454.

## Technical details
<!-- Summary of code changes for easier review. -->
The end of `BatteryDrainerSystem.TryDrainPower` calls `BatterySystem.IsFull` to check if the ninja's battery is full, but it accidentally passes in the ninja itself as the UID instead of the ninja's battery entity. This trips the debug assertion in `IsFull`'s `Resolve` call when it checks that the `BatteryComponent` belongs to the passed UID.

Fixed by simply passing in the right UID - the `BatteryUid` field from the `BatteryDrainerComponent`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->