### PR TITLE
[DRAFT] Allow traitors to steal TC from locked uplinks

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -178,7 +178,7 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         Note[]? code = null;
 
         Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - Uplink add");
-        var uplinked = _uplink.AddUplink(traitor, startingBalance, pda, true);
+        var uplinked = _uplink.AddUplink(traitor, startingBalance, pda, true, true);
 
         if (pda is not null && uplinked)
         {

--- a/Content.Server/Traitor/Uplink/UplinkSystem.cs
+++ b/Content.Server/Traitor/Uplink/UplinkSystem.cs
@@ -34,12 +34,14 @@ public sealed class UplinkSystem : EntitySystem
     /// <param name="balance">The amount of currency on the uplink. If null, will just use the amount specified in the preset.</param>
     /// <param name="uplinkEntity">The entity that will actually have the uplink functionality. Defaults to the PDA if null.</param>
     /// <param name="giveDiscounts">Marker that enables discounts for uplink items.</param>
+    /// /// <param name="canSteal">Whether this store can steal currency from other stores with the StealableStore component.</param>
     /// <returns>Whether or not the uplink was added successfully</returns>
     public bool AddUplink(
         EntityUid user,
         FixedPoint2 balance,
         EntityUid? uplinkEntity = null,
-        bool giveDiscounts = false)
+        bool giveDiscounts = false,
+        bool canSteal = false)
     {
         // Try to find target item if none passed
 
@@ -49,6 +51,9 @@ public sealed class UplinkSystem : EntitySystem
             return ImplantUplink(user, balance, giveDiscounts);
 
         EnsureComp<UplinkComponent>(uplinkEntity.Value);
+
+        if (canSteal)
+            EnsureComp<StealableStoreComponent>(uplinkEntity.Value);
 
         SetUplink(user, uplinkEntity.Value, balance, giveDiscounts);
 

--- a/Content.Shared/Store/Components/StealableStoreComponent.cs
+++ b/Content.Shared/Store/Components/StealableStoreComponent.cs
@@ -1,0 +1,56 @@
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Store.Components;
+
+/// <summary>
+/// This component allows a store to steal, as well as get stolen from.
+/// This means that using this entity on another entity will transfer all currencies after the doAfter is complete.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class StealableStoreComponent : Component
+{
+    /// <summary>
+    /// How long will it take to steal the currencies from this store?
+    /// </summary>
+    [DataField]
+    public TimeSpan DoAfterDuration = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Whether this store can be stolen from by another store.
+    /// </summary>
+    [DataField]
+    public bool CanBeStolenFrom = true;
+
+    /// <summary>
+    /// Should the target store be unlocked to steal currency from it?
+    /// Used in PDA uplinks.
+    /// </summary>
+    [DataField]
+    public bool RequireTargetUnlocked = false;
+
+    /// <summary>
+    /// Should the used store be unlocked to allow to steal currency?
+    /// Used in PDA uplinks.
+    /// </summary>
+    [DataField]
+    public bool RequireUserUnlocked = true;
+
+    /// <summary>
+    /// Popup to show to the user when they begin stealing from another store.
+    /// </summary>
+    [DataField]
+    public LocId? SelfStealPopup = "store-steal-self-popup";
+
+    /// <summary>
+    /// Popup to show to everyone around once a store has been stolen from.
+    /// </summary>
+    [DataField]
+    public LocId? SuccessfulStealPopup = "store-steal-success-popup";
+
+    /// <summary>
+    /// The sound played around the player when currency has successfully been stolen.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier FinishStealingSound = new SoundPathSpecifier("/Audio/Effects/kaching.ogg");
+}

--- a/Content.Shared/Store/StealableStoreDoAfterEvent.cs
+++ b/Content.Shared/Store/StealableStoreDoAfterEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Store;
+
+[Serializable, NetSerializable]
+public sealed partial class StealableStoreDoAfterEvent : SimpleDoAfterEvent;

--- a/Resources/Locale/en-US/store/store.ftl
+++ b/Resources/Locale/en-US/store/store.ftl
@@ -13,3 +13,7 @@ store-not-account-owner = This {$store} is not bound to you!
 
 store-preset-name-uplink = Uplink
 store-preset-name-spellbook = Spellbook
+
+store-steal-self-popup = You press your uplink against {THE($target)}.
+store-steal-success-popup = Store currency transferred successfully.
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Traitors can now use their PDAs to extract TC from locked uplinks.
To do this you must have your uplink unlocked first.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently traitors have no reason to doubt eachother. This adds this tiny bit of uncertainty that just might be needed to make you decide "Hmmm... Maybe teaming up with this guy is not worth it..."

## Technical details
<!-- Summary of code changes for easier review. -->
StealableStoreComponent, some doAfter stuff. Not much to say.
Could probably be moved to its own system but I will wait for opinions first.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/35bb1282-b4b0-46f1-b955-14a2006ea0d8


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Traitors can now use their unlocked uplink on another uplink to siphon the TC inside.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
