### PR TITLE
PlayerPanel username copy fix

### DIFF
--- a/Content.Client/Administration/UI/PlayerPanel/PlayerPanel.xaml.cs
+++ b/Content.Client/Administration/UI/PlayerPanel/PlayerPanel.xaml.cs
@@ -36,7 +36,7 @@ public sealed partial class PlayerPanel : FancyWindow
             RobustXamlLoader.Load(this);
             _adminManager = adminManager;
 
-            UsernameCopyButton.OnPressed += _ => OnUsernameCopy?.Invoke(PlayerName.Text ?? "");
+            UsernameCopyButton.OnPressed += _ => OnUsernameCopy?.Invoke(TargetUsername ?? "");
             BanButton.OnPressed += _ => OnOpenBanPanel?.Invoke(TargetPlayer);
             KickButton.OnPressed += _ => OnKick?.Invoke(TargetUsername);
             NotesButton.OnPressed += _ => OnOpenNotes?.Invoke(TargetPlayer);


### PR DESCRIPTION
## About the PR
The `Copy` button on the player panel now copies only the target username, not "Username: <username>"

## Why / Balance
Bug, the wrong value was targeted so it included the fluff text too.

## Media

![image](https://github.com/user-attachments/assets/28cbde4a-f1b0-493d-b8d9-1a718ada6f8b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl: Errant
ADMIN:
- fix: The Copy button on the PlayerPanel now copies only the target username, not the entire line.
