### PR TITLE
Set default lighting option to low

### DIFF
--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
@@ -171,7 +171,7 @@ public sealed partial class GraphicsTab : Control
             if (val <= 0.125)
                 return QualityVeryLow;
 
-            if (val <= 0.5 && !soft)
+            if (val <= 0.3 && !soft)
                 return QualityLow;
 
             if (val <= 0.5)

--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
@@ -97,7 +97,7 @@ public sealed partial class GraphicsTab : Control
         private const int QualityMedium = 2;
         private const int QualityHigh = 3;
 
-        private const int QualityDefault = QualityMedium;
+        private const int QualityDefault = QualityLow;
 
         public OptionLightingQuality(OptionsTabControlRow controller, IConfigurationManager cfg, OptionDropDown dropDown) : base(controller)
         {
@@ -131,12 +131,12 @@ public sealed partial class GraphicsTab : Control
                     _cfg.SetCVar(CVars.LightSoftShadows, false);
                     _cfg.SetCVar(CVars.LightBlur, false);
                     break;
-                case QualityLow:
-                    _cfg.SetCVar(CVars.LightResolutionScale, 0.5f);
+                default: // = QualityLow
+                    _cfg.SetCVar(CVars.LightResolutionScale, 0.3f);
                     _cfg.SetCVar(CVars.LightSoftShadows, false);
                     _cfg.SetCVar(CVars.LightBlur, true);
                     break;
-                default: // = QualityMedium
+                case QualityMedium:
                     _cfg.SetCVar(CVars.LightResolutionScale, 0.5f);
                     _cfg.SetCVar(CVars.LightSoftShadows, true);
                     _cfg.SetCVar(CVars.LightBlur, true);
@@ -171,7 +171,7 @@ public sealed partial class GraphicsTab : Control
             if (val <= 0.125)
                 return QualityVeryLow;
 
-            if ((val <= 0.5) && !soft)
+            if (val <= 0.5 && !soft)
                 return QualityLow;
 
             if (val <= 0.5)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Lowers the default light settings to "low" and reduces low to 0.3 res scale

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Lighting in 14 is pretty heavy, however i am bearly able to tell a difrrence between low and medium. And the switch to low saves quite a bit of gpu power.

Requires https://github.com/space-wizards/RobustToolbox/pull/5819

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Myra
- tweak: The new default lighting option is "Low". This lowers GPU usage quite a bit without (noticeably) reducing lighting quality.
