### PR TITLE
Lobby duration is now 5 minutes on wizden

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -5,6 +5,7 @@
 desc             = "Official English Space Station 14 servers. Vanilla, roleplay ruleset."
 lobbyenabled     = true
 soft_max_players = 80
+lobbyduration    = 300 # 5 minutes lobby timer
 panic_bunker.enabled = true
 panic_bunker.min_overall_minutes = 120
 panic_bunker.disable_with_admins = true


### PR DESCRIPTION
The default value is 2 minutes 30 seconds, which was set many years ago. The game is different now, people need time to stretch their legs or get some water.

This was prompted by an internal discussion about unhealthy playing habits in the game.

:cl:
- tweak: Lobby time on Wizard's Den has been increased from 2 minute 30 seconds to 5 minutes.