### PR TITLE
Zombification resistance rework

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -178,16 +178,7 @@ public sealed partial class ZombieSystem
             _humanoidAppearance.SetBaseLayerId(target, HumanoidVisualLayers.Snout, zombiecomp.BaseLayerExternal, humanoid: huApComp);
 
             //This is done here because non-humanoids shouldn't get baller damage
-            //lord forgive me for the hardcoded damage
-            DamageSpecifier dspec = new()
-            {
-                DamageDict = new()
-                {
-                    { "Slash", 13 },
-                    { "Piercing", 7 },
-                    { "Structural", 10 }
-                }
-            };
+            DamageSpecifier dspec = zombiecomp.DamageOnBite;
             melee.Damage = dspec;
 
             // humanoid zombies get to pry open doors and shit

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -178,7 +178,16 @@ public sealed partial class ZombieSystem
             _humanoidAppearance.SetBaseLayerId(target, HumanoidVisualLayers.Snout, zombiecomp.BaseLayerExternal, humanoid: huApComp);
 
             //This is done here because non-humanoids shouldn't get baller damage
-            DamageSpecifier dspec = zombiecomp.DamageOnBite;
+            //lord forgive me for the hardcoded damage
+            DamageSpecifier dspec = new()
+            {
+                DamageDict = new()
+                {
+                    { "Slash", 13 },
+                    { "Piercing", 7 },
+                    { "Structural", 10 }
+                }
+            };
             melee.Damage = dspec;
 
             // humanoid zombies get to pry open doors and shit

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -77,8 +77,7 @@ namespace Content.Server.Zombies
             SubscribeLocalEvent<ZombifyOnDeathComponent, MobStateChangedEvent>(OnDamageChanged);
         }
 
-        private void OnBeforeRemoveAnomalyOnDeath(Entity<PendingZombieComponent> ent,
-            ref BeforeRemoveAnomalyOnDeathEvent args)
+        private void OnBeforeRemoveAnomalyOnDeath(Entity<PendingZombieComponent> ent, ref BeforeRemoveAnomalyOnDeathEvent args)
         {
             // Pending zombies (e.g. infected non-zombies) do not remove their hosted anomaly on death.
             // Current zombies DO remove the anomaly on death.

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -11,7 +11,6 @@ using Content.Shared.Armor;
 using Content.Shared.Bed.Sleep;
 using Content.Shared.Cloning.Events;
 using Content.Shared.Damage;
-using Content.Shared.FixedPoint;
 using Content.Shared.Humanoid;
 using Content.Shared.Inventory;
 using Content.Shared.Mind;
@@ -205,9 +204,6 @@ namespace Content.Server.Zombies
         {
             var chance = zombieComponent.BaseZombieInfectionChance;
 
-            if (!_inventory.TryGetContainerSlotEnumerator(uid, out var enumerator, ProtectiveSlots))
-                return chance;
-
             var armorEv = new CoefficientQueryEvent(ProtectiveSlots);
             RaiseLocalEvent(uid, armorEv);
             foreach (var resistanceEffectiveness in zombieComponent.ResistanceEffectiveness.DamageDict)
@@ -226,10 +222,7 @@ namespace Content.Server.Zombies
             RaiseLocalEvent(uid, zombificationResistanceEv);
             chance *= zombificationResistanceEv.TotalCoefficient;
 
-
-            var min = zombieComponent.MinZombieInfectionChance;
-            chance = MathF.Max(chance, min);
-            return chance;
+            return MathF.Max(chance, zombieComponent.MinZombieInfectionChance);
         }
 
         private void OnMeleeHit(EntityUid uid, ZombieComponent component, MeleeHitEvent args)
@@ -293,12 +286,10 @@ namespace Content.Server.Zombies
                 _humanoidAppearance.SetBaseLayerColor(target, layer, info.Color);
                 _humanoidAppearance.SetBaseLayerId(target, layer, info.Id);
             }
-
             if (TryComp<HumanoidAppearanceComponent>(target, out var appcomp))
             {
                 appcomp.EyeColor = zombiecomp.BeforeZombifiedEyeColor;
             }
-
             _humanoidAppearance.SetSkinColor(target, zombiecomp.BeforeZombifiedSkinColor, false);
             _bloodstream.ChangeBloodReagent(target, zombiecomp.BeforeZombifiedBloodReagent);
 

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -210,8 +210,7 @@ namespace Content.Server.Zombies
 
             var armorEv = new CoefficientQueryEvent(ProtectiveSlots);
             RaiseLocalEvent(uid, armorEv);
-            foreach (KeyValuePair<string, FixedPoint2> resistanceEffectiveness in zombieComponent
-                         .ResistanceEffectiveness)
+            foreach (var resistanceEffectiveness in zombieComponent.ResistanceEffectiveness.DamageDict)
             {
                 if (armorEv.DamageModifiers.Coefficients.TryGetValue(resistanceEffectiveness.Key, out var coefficient))
                 {

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -20,6 +20,7 @@ using Content.Shared.Strip.Components;
 using Content.Shared.Temperature;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Zombies;
 
 namespace Content.Shared.Inventory;
 
@@ -42,6 +43,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, SelfBeforeGunShotEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, SelfBeforeClimbEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, CoefficientQueryEvent>(RelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, ZombificationResistanceQueryEvent>(RelayInventoryEvent);
 
         // by-ref events
         SubscribeLocalEvent<InventoryComponent, GetExplosionResistanceEvent>(RefRelayInventoryEvent);

--- a/Content.Shared/Zombies/SharedZombieSystem.cs
+++ b/Content.Shared/Zombies/SharedZombieSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Movement.Systems;
+﻿using Content.Shared.Armor;
+using Content.Shared.Movement.Systems;
 using Content.Shared.NameModifier.EntitySystems;
 
 namespace Content.Shared.Zombies;
@@ -12,6 +13,18 @@ public abstract class SharedZombieSystem : EntitySystem
 
         SubscribeLocalEvent<ZombieComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshSpeed);
         SubscribeLocalEvent<ZombieComponent, RefreshNameModifiersEvent>(OnRefreshNameModifiers);
+        SubscribeLocalEvent<ZombificationResistanceComponent, ArmorExamineEvent>(OnArmorExamine);
+    }
+
+    private void OnArmorExamine(Entity<ZombificationResistanceComponent> ent, ref ArmorExamineEvent args)
+    {
+        var value = MathF.Round((1f - ent.Comp.ZombificationResistanceCoefficient) * 100, 1);
+
+        if (value == 0)
+            return;
+
+        args.Msg.PushNewline();
+        args.Msg.AddMarkupOrThrow(Loc.GetString(ent.Comp.Examine, ("value", value)));
     }
 
     private void OnRefreshSpeed(EntityUid uid, ZombieComponent component, RefreshMovementSpeedModifiersEvent args)

--- a/Content.Shared/Zombies/SharedZombieSystem.cs
+++ b/Content.Shared/Zombies/SharedZombieSystem.cs
@@ -22,6 +22,7 @@ public abstract class SharedZombieSystem : EntitySystem
     {
         query.Args.TotalCoefficient *= ent.Comp.ZombificationResistanceCoefficient;
     }
+
     private void OnArmorExamine(Entity<ZombificationResistanceComponent> ent, ref ArmorExamineEvent args)
     {
         var value = MathF.Round((1f - ent.Comp.ZombificationResistanceCoefficient) * 100, 1);

--- a/Content.Shared/Zombies/SharedZombieSystem.cs
+++ b/Content.Shared/Zombies/SharedZombieSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Armor;
+using Content.Shared.Inventory;
 using Content.Shared.Movement.Systems;
 using Content.Shared.NameModifier.EntitySystems;
 
@@ -14,8 +15,13 @@ public abstract class SharedZombieSystem : EntitySystem
         SubscribeLocalEvent<ZombieComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshSpeed);
         SubscribeLocalEvent<ZombieComponent, RefreshNameModifiersEvent>(OnRefreshNameModifiers);
         SubscribeLocalEvent<ZombificationResistanceComponent, ArmorExamineEvent>(OnArmorExamine);
+        SubscribeLocalEvent<ZombificationResistanceComponent, InventoryRelayedEvent<ZombificationResistanceQueryEvent>>(OnResistanceQuery);
     }
 
+    private void OnResistanceQuery(Entity<ZombificationResistanceComponent> ent, ref InventoryRelayedEvent<ZombificationResistanceQueryEvent> query)
+    {
+        query.Args.TotalCoefficient *= ent.Comp.ZombificationResistanceCoefficient;
+    }
     private void OnArmorExamine(Entity<ZombificationResistanceComponent> ent, ref ArmorExamineEvent args)
     {
         var value = MathF.Round((1f - ent.Comp.ZombificationResistanceCoefficient) * 100, 1);

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -17,17 +17,17 @@ namespace Content.Shared.Zombies;
 public sealed partial class ZombieComponent : Component
 {
     /// <summary>
-    /// The baseline infection chance you have if you are completely nude
+    /// The baseline infection chance you have if you have no protective gear
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float MaxZombieInfectionChance = 0.80f;
+    public float BaseZombieInfectionChance = 0.75f;
 
     /// <summary>
     /// The minimum infection chance possible. This is simply to prevent
-    /// being invincible by bundling up.
+    /// being overly protected by bundling up.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float MinZombieInfectionChance = 0.25f;
+    public float MinZombieInfectionChance = 0.05f;
 
     [ViewVariables(VVAccess.ReadWrite)]
     public float ZombieMovementSpeedDebuff = 0.70f;

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -34,7 +34,7 @@ public sealed partial class ZombieComponent : Component
     /// </summary>
     public Dictionary<string, FixedPoint2> ResistanceEffectiveness = new()
     {
-        {"Slash", 0.6},
+        {"Slash", 0.5},
         {"Piercing", 0.3},
         {"Blunt", 0.1},
     };
@@ -136,22 +136,6 @@ public sealed partial class ZombieComponent : Component
             { "Piercing", -2 }
         }
     };
-
-    /// <summary>
-    /// The damage dealt on bite, dehardcoded for your enjoyment
-    /// </summary>
-    [DataField]
-    public DamageSpecifier DamageOnBite = new()
-    {
-        DamageDict = new()
-        {
-            { "Slash", 13 },
-            { "Piercing", 7 },
-            { "Structural", 10 }
-        }
-    };
-
-
 
     /// <summary>
     ///     Path to antagonist alert sound.

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -1,7 +1,7 @@
-using Content.Shared.Antag;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
 using Content.Shared.Humanoid;
 using Content.Shared.Roles;
 using Content.Shared.StatusIcon;
@@ -28,6 +28,16 @@ public sealed partial class ZombieComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     public float MinZombieInfectionChance = 0.05f;
+
+    /// <summary>
+    /// How effective each resistance type on a piece of armor is.
+    /// </summary>
+    public Dictionary<string, FixedPoint2> ResistanceEffectiveness = new()
+    {
+        {"Slash", 0.6},
+        {"Piercing", 0.3},
+        {"Blunt", 0.1},
+    };
 
     [ViewVariables(VVAccess.ReadWrite)]
     public float ZombieMovementSpeedDebuff = 0.70f;
@@ -126,6 +136,22 @@ public sealed partial class ZombieComponent : Component
             { "Piercing", -2 }
         }
     };
+
+    /// <summary>
+    /// The damage dealt on bite, dehardcoded for your enjoyment
+    /// </summary>
+    [DataField]
+    public DamageSpecifier DamageOnBite = new()
+    {
+        DamageDict = new()
+        {
+            { "Slash", 13 },
+            { "Piercing", 7 },
+            { "Structural", 10 }
+        }
+    };
+
+
 
     /// <summary>
     ///     Path to antagonist alert sound.

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -30,13 +30,16 @@ public sealed partial class ZombieComponent : Component
     public float MinZombieInfectionChance = 0.05f;
 
     /// <summary>
-    /// How effective each resistance type on a piece of armor is.
+    /// How effective each resistance type on a piece of armor is. Using a damage specifier for this seems illegal.
     /// </summary>
-    public Dictionary<string, FixedPoint2> ResistanceEffectiveness = new()
+    public DamageSpecifier ResistanceEffectiveness = new()
     {
-        {"Slash", 0.5},
-        {"Piercing", 0.3},
-        {"Blunt", 0.1},
+        DamageDict = new ()
+        {
+            {"Slash", 0.5},
+            {"Piercing", 0.3},
+            {"Blunt", 0.1},
+        }
     };
 
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Zombies/ZombificationResistanceComponent.cs
+++ b/Content.Shared/Zombies/ZombificationResistanceComponent.cs
@@ -3,6 +3,10 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.Zombies;
 
+/// <summary>
+/// An armor-esque component for clothing that grants "resistance" (lowers the chance) against getting infected.
+/// It works on a coefficient system, so 0.3 is better than 0.9, 1 is no resistance, and 0 is full resistance.
+/// </summary>
 [NetworkedComponent, RegisterComponent]
 public sealed partial class ZombificationResistanceComponent : Component
 {
@@ -16,9 +20,13 @@ public sealed partial class ZombificationResistanceComponent : Component
     /// Examine string for the zombification resistance.
     /// Passed <c>value</c> from 0 to 100.
     /// </summary>
+    [DataField]
     public LocId Examine = "zombification-resistance-coefficient-value";
 }
 
+/// <summary>
+/// Gets the total resistance from the ZombificationResistanceComponent, i.e. just all of them multiplied together.
+/// </summary>
 public sealed class ZombificationResistanceQueryEvent : EntityEventArgs, IInventoryRelayEvent
 {
     /// <summary>

--- a/Content.Shared/Zombies/ZombificationResistanceComponent.cs
+++ b/Content.Shared/Zombies/ZombificationResistanceComponent.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Damage;
 using Content.Shared.Inventory;
 using Robust.Shared.GameStates;
 
@@ -25,12 +24,12 @@ public sealed class ZombificationResistanceQueryEvent : EntityEventArgs, IInvent
     /// <summary>
     /// All slots to relay to
     /// </summary>
-    public SlotFlags TargetSlots { get; set; }
+    public SlotFlags TargetSlots { get; }
 
     /// <summary>
     /// The Total of all Coefficients.
     /// </summary>
-    public float TotalCoefficient { get; set; } = 1.0f;
+    public float TotalCoefficient = 1.0f;
 
     public ZombificationResistanceQueryEvent(SlotFlags slots)
     {

--- a/Content.Shared/Zombies/ZombificationResistanceComponent.cs
+++ b/Content.Shared/Zombies/ZombificationResistanceComponent.cs
@@ -1,0 +1,20 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Zombies;
+
+[NetworkedComponent, RegisterComponent]
+public sealed partial class ZombificationResistanceComponent : Component
+{
+    /// <summary>
+    ///  The multiplier that will by applied to the cha
+    /// </summary>
+    [DataField("coefficient")]
+    public float ZombificationResistanceCoefficient = 1;
+
+    /// <summary>
+    /// Examine string for the zombification resistance.
+    /// Passed <c>value</c> from 0 to 100.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public LocId Examine = "zombification-resistance-coefficient-value";
+}

--- a/Content.Shared/Zombies/ZombificationResistanceComponent.cs
+++ b/Content.Shared/Zombies/ZombificationResistanceComponent.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Damage;
+using Content.Shared.Inventory;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Zombies;
@@ -6,15 +8,32 @@ namespace Content.Shared.Zombies;
 public sealed partial class ZombificationResistanceComponent : Component
 {
     /// <summary>
-    ///  The multiplier that will by applied to the cha
+    ///  The multiplier that will by applied to the zombification chance.
     /// </summary>
-    [DataField("coefficient")]
+    [DataField]
     public float ZombificationResistanceCoefficient = 1;
 
     /// <summary>
     /// Examine string for the zombification resistance.
     /// Passed <c>value</c> from 0 to 100.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public LocId Examine = "zombification-resistance-coefficient-value";
+}
+
+public sealed class ZombificationResistanceQueryEvent : EntityEventArgs, IInventoryRelayEvent
+{
+    /// <summary>
+    /// All slots to relay to
+    /// </summary>
+    public SlotFlags TargetSlots { get; set; }
+
+    /// <summary>
+    /// The Total of all Coefficients.
+    /// </summary>
+    public float TotalCoefficient { get; set; } = 1.0f;
+
+    public ZombificationResistanceQueryEvent(SlotFlags slots)
+    {
+        TargetSlots = slots;
+    }
 }

--- a/Resources/Locale/en-US/zombies/zombie.ftl
+++ b/Resources/Locale/en-US/zombies/zombie.ftl
@@ -8,4 +8,4 @@ zombie-role-rules = You are a [color={role-type-team-antagonist-color}][bold]{ro
 
 zombie-permadeath = This time, you're dead for real.
 
-zombification-resistance-coefficient-value = - [color=violet]Infection[/color] chance reduced by [color=lightblue]{$value}%[/color]
+zombification-resistance-coefficient-value = - [color=violet]Infection[/color] chance reduced by [color=lightblue]{$value}%[/color].

--- a/Resources/Locale/en-US/zombies/zombie.ftl
+++ b/Resources/Locale/en-US/zombies/zombie.ftl
@@ -7,3 +7,5 @@ zombie-role-desc =  A malevolent creature of the dead.
 zombie-role-rules = You are a [color={role-type-team-antagonist-color}][bold]{role-type-team-antagonist-name}[/bold][/color]. Search out the living and bite them in order to infect them and turn them into zombies. Work together with the other zombies and remaining initial infected to overtake the station.
 
 zombie-permadeath = This time, you're dead for real.
+
+zombification-resistance-coefficient-value = - [color=violet]Infection[/color] chance reduced by [color=lightblue]{$value}%[/color]

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -249,6 +249,11 @@
   - type: TemperatureProtection
     heatingCoefficient: 1.05
     coolingCoefficient: 0.7
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.90
+  - type: Armor # so zombification resistance shows up
+    modifiers:
+      coefficients: { }
   - type: GroupExamine
   - type: HideLayerClothing
     slots:

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -738,6 +738,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.75
 
 #Deathsquad Hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -269,8 +269,6 @@
     sprite: Clothing/Head/Hoods/Coat/hooddefault.rsi
   - type: Clothing
     sprite: Clothing/Head/Hoods/Coat/hooddefault.rsi
-  - type: ZombificationResistance
-    zombificationResistanceCoefficient: 0.95
 
 - type: entity
   parent: ClothingHeadHatHoodWinterBase

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -11,6 +11,8 @@
     sprite: Clothing/Head/Hoods/Bio/general.rsi
   - type: BreathMask
   - type: IngestionBlocker
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.9
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -33,6 +35,8 @@
     sprite: Clothing/Head/Hoods/Bio/cmo.rsi
   - type: Clothing
     sprite: Clothing/Head/Hoods/Bio/cmo.rsi
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.8
 
 - type: entity
   parent: ClothingHeadHatHoodBioGeneral
@@ -78,13 +82,15 @@
   id: ClothingHeadHatHoodBioVirology
   name: bio hood
   suffix: Virology
-  description: A hood that protects the head and face from biological contaminants.
+  description: A hood that strongly protects the head and face from biological contaminants.
   components:
   - type: IdentityBlocker
   - type: Sprite
     sprite: Clothing/Head/Hoods/Bio/virology.rsi
   - type: Clothing
     sprite: Clothing/Head/Hoods/Bio/virology.rsi
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.8
 
 - type: entity
   parent: ClothingHeadBase
@@ -260,6 +266,8 @@
     sprite: Clothing/Head/Hoods/Coat/hooddefault.rsi
   - type: Clothing
     sprite: Clothing/Head/Hoods/Coat/hooddefault.rsi
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.95
 
 - type: entity
   parent: ClothingHeadHatHoodWinterBase

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -11,6 +11,9 @@
     sprite: Clothing/Head/Hoods/Bio/general.rsi
   - type: BreathMask
   - type: IngestionBlocker
+  - type: GroupExamine
+  - type: Armor
+    modifiers: { }
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.9
   - type: Tag

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -25,19 +25,12 @@
   id: ClothingOuterBioCmo
   name: bio suit
   suffix: CMO
-  description: An advanced suit that protects against biological contamination, specially made with armor for the CMO.
+  description: An advanced suit that protects against biological contamination, in CMO colors.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Bio/cmo.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Bio/cmo.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Caustic: 0.5
-        Slash: 0.75
-  - type: ZombificationResistance
-    zombificationResistanceCoefficient: 0.3
 
 - type: entity
   parent: ClothingOuterBioGeneral
@@ -86,7 +79,6 @@
         Piercing: 0.8
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.4
-
 
 - type: entity
   parent: ClothingOuterBioGeneral

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -12,31 +12,44 @@
   - type: Armor
     modifiers:
       coefficients:
-        Caustic: 0.5
+        Caustic: 0.75
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.35
 
 - type: entity
   parent: ClothingOuterBioGeneral
   id: ClothingOuterBioCmo
   name: bio suit
   suffix: CMO
-  description: An advanced suit that protects against biological contamination, in CMO colors.
+  description: An advanced suit that protects against biological contamination, specially made with armor for the CMO.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Bio/cmo.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Bio/cmo.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Caustic: 0.5
+        Slash: 0.75
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.3
 
 - type: entity
   parent: ClothingOuterBioGeneral
   id: ClothingOuterBioJanitor
   name: bio suit
   suffix: Janitor
-  description: A suit that protects against biological contamination, in Janitor colors.
+  description: A suit that protects against biological contamination and caustic spills.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Bio/janitor.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Bio/janitor.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Caustic: 0.4
 
 - type: entity
   parent: ClothingOuterBioGeneral
@@ -51,25 +64,36 @@
     sprite: Clothing/OuterClothing/Bio/scientist.rsi
 
 - type: entity
-  parent: ClothingOuterBioGeneral
+  parent: [ClothingOuterBioGeneral, BaseSecurityContraband]
   id: ClothingOuterBioSecurity
   name: bio suit
   suffix: Security
-  description: A suit that protects against biological contamination, in Security colors.
+  description: A suit that protects against biological contamination, kitted out with additional armor.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Bio/security.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Bio/security.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Caustic: 0.8
+        Slash: 0.6
+        Piercing: 0.8
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.4
+
 
 - type: entity
   parent: ClothingOuterBioGeneral
   id: ClothingOuterBioVirology
   name: bio suit
   suffix: Virology
-  description: A suit that protects against biological contamination, in Virology colors.
+  description: A suit that strongly protects against biological contamination.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Bio/virology.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Bio/virology.rsi
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.25

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -15,6 +15,10 @@
         Caustic: 0.75
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.35
+  - type: GroupExamine
+  - type: ClothingSpeedModifier
+    walkModifier: 1
+    sprintModifier: 0.95
 
 - type: entity
   parent: ClothingOuterBioGeneral

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -958,6 +958,8 @@
         Shock: 0.1
         Radiation: 0.1
         Caustic: 0.1
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.25
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -18,9 +18,9 @@
       coefficients:
         Slash: 0.95
         Heat: 0.90
+    priceMultiplier: 0
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.45
-    priceMultiplier: 0
   - type: Food
     requiresSpecialDigestion: true
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -20,7 +20,7 @@
         Heat: 0.90
     priceMultiplier: 0
   - type: ZombificationResistance
-    zombificationResistanceCoefficient: 0.45
+    zombificationResistanceCoefficient: 0.55
   - type: Food
     requiresSpecialDigestion: true
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -18,6 +18,8 @@
       coefficients:
         Slash: 0.95
         Heat: 0.90
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.45
     priceMultiplier: 0
   - type: Food
     requiresSpecialDigestion: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Zombification resistance has been reworked to no longer be based upon merely the number of items of clothing you are wearing. Instead, it is calculated based off a combination of your armour's resistances and any clothing's ZombificationResistance component.

**Balance changes:**
In general, bio suits got caust resist nerfed but now get a strong zombification resist. (all bio suits also got a 5% speed increase)
Jani suits got a caust resist buff.
Sec suits got an armour buff at the cost of some zombification resistance, providing a middle ground between riot suits and general bio suits.
Viro suits got even better zombification resistance.

Winter coats and hoods got mediocre zombification resistance.

CBURN suits + helmets got resistance similar to the viro suit.

## Why / Balance
The wonderous pride pin that provides 10% resistance no longer, sadge. Also @beck-thompson asked me to do it this way.

Here is the wonderous balance excel sheet:
![image](https://github.com/user-attachments/assets/2a20c3f1-b731-40e4-b128-8d29aeefd5ea)


## Technical details
Implements the ZombificationResistanceComponent in Content.Shared and adds an examine message detailing the infection value.
Reworks the GetZombieInfectionChance function to be based off ArmorComponents and ZombificationResistanceComponents.

## Media
The examine message for ZombificationResistanceComponent:
![image](https://github.com/user-attachments/assets/33b126a1-b596-4ddb-bd56-1593a9f9642b)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
MaxZombieInfectionChance in ZombieComponent has been renamed to BaseZombieInfectionChance to more accurately reflect its usage

**Changelog**
:cl: UpAndLeaves
- tweak: Most clothing will no longer provide protection against zombification
- tweak: Blunt/Slash/Piercing resistance will now provide weak protection against zombification.
- tweak: Winter coats are now moderately effective against zombification.
- tweak: Bio suits are now very effective against zombification.
- tweak: Security bio suits are now lightly armored.
- tweak: Bio suits now only have 5% slowdown.