### PR TITLE
Add a toggle to silicon laws to prevent accidental stating

### DIFF
--- a/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml
+++ b/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml
@@ -6,8 +6,10 @@
                       HorizontalExpand="True"
                       VerticalExpand="True"
                       Margin="5 5 5 5">
-            <RichTextLabel Name="LawNumberLabel" StyleClasses="LabelKeyText"/>
-            <Button Name="AllowStatingLaws" Text="{Loc 'laws-ui-stating-toggle'}" ToggleMode="True" Pressed="True"/>
+            <GridContainer Columns="2">
+                <RichTextLabel Name="LawNumberLabel" StyleClasses="LabelKeyText" HorizontalExpand="False"/>
+                <Button Name="AllowStatingLaws" Text="{Loc 'laws-ui-stating-toggle'}" ToggleMode="True" Pressed="True" HorizontalExpand="False" HorizontalAlignment="Right"/>
+            </GridContainer>
             <customControls:HSeparator Margin="0 5 0 5"/>
             <RichTextLabel Name="LawLabel"/>
             <BoxContainer Name="LawAnnouncementButtons" Orientation="Horizontal" HorizontalExpand="True" Margin="0 5 0 0">

--- a/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml
+++ b/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml
@@ -7,6 +7,7 @@
                       VerticalExpand="True"
                       Margin="5 5 5 5">
             <RichTextLabel Name="LawNumberLabel" StyleClasses="LabelKeyText"/>
+            <Button Name="AllowStatingLaws" Text="{Loc 'laws-ui-stating-toggle'}" ToggleMode="True" Pressed="True"/>
             <customControls:HSeparator Margin="0 5 0 5"/>
             <RichTextLabel Name="LawLabel"/>
             <BoxContainer Name="LawAnnouncementButtons" Orientation="Horizontal" HorizontalExpand="True" Margin="0 5 0 0">

--- a/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml.cs
+++ b/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml.cs
@@ -105,7 +105,7 @@ public sealed partial class LawDisplay : Control
         var curTime = _timing.CurTime;
         foreach (var (button, nextPress) in _nextAllowedPress)
         {
-            button.Disabled = curTime < nextPress;
+            button.Disabled = curTime < nextPress || !AllowStatingLaws.Pressed;
         }
     }
 }

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -95,6 +95,7 @@ law-emag-cannot-emag-self = You cannot use the EMAG on yourself.
 laws-ui-menu-title = Laws
 laws-ui-law-header = Law {$id}
 laws-ui-state-law = State law:
+laws-ui-stating-toggle = Enable stating
 
 laws-notify = You are bound to silicon laws, which you can view via the action menu. You are required to always follow your laws.
 laws-update-notify = Your laws have been updated. You can view the changes via the action menu.


### PR DESCRIPTION
## About the PR
Added a toggle to each silicon law that disables the state law buttons

## Why / Balance
This would make it much easier to avoid accidentally revealing that you are emaged as a borg. (As it stands it's pretty easy to reveal the emaged laws out of muscle memory)

## Technical details
Adds a single toggle button to the law display UI element, and disables any channel button depending on its state

## Media


https://github.com/user-attachments/assets/f79f2eda-198f-49e6-b246-f95fc4b0f0f7




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added a simple toggle to prevent accidentally stating certain laws
