### PR TITLE
Fix construction orientation being ignored for some objects

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/fence_metal.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/fence_metal.yml
@@ -7,29 +7,21 @@
     - !type:DeleteEntity { }
     edges:
     - to: straight
-      completed:
-      - !type:SnapToGrid
       steps:
       - material: MetalRod
         amount: 5
         doAfter: 6
     - to: corner
-      completed:
-      - !type:SnapToGrid
       steps:
       - material: MetalRod
         amount: 5
         doAfter: 6
     - to: end
-      completed:
-      - !type:SnapToGrid
       steps:
       - material: MetalRod
         amount: 5
         doAfter: 6
     - to: gate
-      completed:
-      - !type:SnapToGrid
       steps:
       - material: MetalRod
         amount: 5

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/fence_metal.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/fence_metal.yml
@@ -9,7 +9,6 @@
     - to: straight
       completed:
       - !type:SnapToGrid
-        southRotation: true
       steps:
       - material: MetalRod
         amount: 5
@@ -17,7 +16,6 @@
     - to: corner
       completed:
       - !type:SnapToGrid
-        southRotation: true
       steps:
       - material: MetalRod
         amount: 5
@@ -25,7 +23,6 @@
     - to: end
       completed:
       - !type:SnapToGrid
-        southRotation: true
       steps:
       - material: MetalRod
         amount: 5
@@ -33,7 +30,6 @@
     - to: gate
       completed:
       - !type:SnapToGrid
-        southRotation: true
       steps:
       - material: MetalRod
         amount: 5

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -306,7 +306,6 @@
         - to: diagonalshuttleWall
           completed:
             - !type:SnapToGrid
-              southRotation: false
           conditions:
             - !type:EntityAnchored { }
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -304,8 +304,6 @@
               doAfter: 1
 
         - to: diagonalshuttleWall
-          completed:
-            - !type:SnapToGrid
           conditions:
             - !type:EntityAnchored { }
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/grille_diagonal.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/grille_diagonal.yml
@@ -7,7 +7,6 @@
         - to: grilleDiagonal
           completed:
             - !type:SnapToGrid
-              southRotation: true
           steps:
             - material: MetalRod
               amount: 2
@@ -16,7 +15,6 @@
         - to: clockworkGrilleDiagonal
           completed:
             - !type:SnapToGrid
-              southRotation: true
           steps:
             - material: MetalRod
               amount: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/grille_diagonal.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/grille_diagonal.yml
@@ -5,16 +5,12 @@
     - node: start
       edges:
         - to: grilleDiagonal
-          completed:
-            - !type:SnapToGrid
           steps:
             - material: MetalRod
               amount: 2
               doAfter: 1
               
         - to: clockworkGrilleDiagonal
-          completed:
-            - !type:SnapToGrid
           steps:
             - material: MetalRod
               amount: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
For some objects, such as diagonal grilles and metal fences, rotation of the construction ghost was ignored, resulting in same rotation for all built objects.

I believe this is not an issue for mappers because they can just select the desired rotation, it doesn't involve construction (tested with entities spawn menu).

Exhaustive list of all fixed objects:
- diagonal grille
- clockwork diagonal grille
- diagonal shuttle wall
- metal fence
- metal fence corner
- metal fence end piece
- metal fence gate

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Annoying.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed `southRotation` from a few construction graph's `SnapToGrid`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before (ex. grilles; top - construction ghost, bottom - what's built)

![grille before](https://github.com/user-attachments/assets/97651486-1f29-4a1e-9902-91cc5980d6d6)

After

![grille after](https://github.com/user-attachments/assets/c76fcaba-1626-4329-b31b-e8c9a6871bf1)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Building orientation on fences, diagonal grilles and the diagonal shuttle wall is now respected.
