### PR TITLE
Fix for anomaly double explosion sound and sprite scaling flicker before removal

### DIFF
--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -356,7 +356,7 @@ public abstract class SharedAnomalySystem : EntitySystem
             if (Timing.CurTime <= super.EndTime)
                 continue;
             DoAnomalySupercriticalEvent(ent, anom);
-            RemComp(ent, super);
+            // Removal of the supercritical component is handled by DoAnomalySupercriticalEvent
         }
     }
 

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -153,10 +153,11 @@ public abstract class SharedAnomalySystem : EntitySystem
         if (!Timing.IsFirstTimePredicted)
             return;
 
-        Audio.PlayPvs(component.SupercriticalSound, Transform(uid).Coordinates);
-
         if (_net.IsServer)
+        {
+            Audio.PlayPvs(component.SupercriticalSound, Transform(uid).Coordinates);
             Log.Info($"Raising supercritical event. Entity: {ToPrettyString(uid)}");
+        }
 
         var powerMod = 1f;
         if (component.CurrentBehavior != null)


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

## Why / Balance
bugfix, better visuals

## Technical details

Two changes:

1. Only play `component.SupercriticalSound` on server, as the server is the authority on whether the anomaly actually went critical
2. Don't force remove the SupercriticalComponent in the Update loop, `DoAnomalySupercriticalEvent` calls `EndAnomaly` which calls `RemCompDeferred`...

## Media

before:

https://github.com/user-attachments/assets/fb897e58-a315-4f45-837e-476c77033498

after:

https://github.com/user-attachments/assets/4b02f1b4-541c-4e74-9605-ee27be134b7b

proof that it happens on master too I just had video of my other branch:

https://github.com/user-attachments/assets/2c8a730c-f979-4afe-afc6-4ed27c4cd236


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Supercrit anomaly playing explosion sound twice
