### PR TITLE
Bluespace lights

### DIFF
--- a/Content.Server/Light/Components/PoweredLightComponent.cs
+++ b/Content.Server/Light/Components/PoweredLightComponent.cs
@@ -76,5 +76,7 @@ namespace Content.Server.Light.Components
         /// </summary>
         [DataField("unarmedHitStun")]
         public TimeSpan UnarmedHitStun = TimeSpan.FromSeconds(5);
+
+        public const string PayloadSlotName = "payloadSlot";
     }
 }

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -214,6 +214,7 @@ namespace Content.Server.Light.EntitySystems
 
         private void ActivatePayload(EntityUid uid, PoweredLightComponent? light = null)
         {
+            //Bunch of checks to make sure we have valid bluespace lightbulb
             if (!Resolve(uid, ref light))
                 return;
             if (GetBulb(uid, light) is not { Valid: true } bulb)
@@ -225,12 +226,15 @@ namespace Content.Server.Light.EntitySystems
                 var payloadItem = _itemSlots.GetItemOrNull(bulb, PoweredLightComponent.PayloadSlotName);
                 if (payloadItem == null)
                     return;
+                // check for already active timer trigger in the payload
                 if (HasComp<ActiveTimerTriggerComponent>(payloadItem))
                 {
+                    //eject payload
                     _itemSlots.TryEject(uid, itemSlot, user: null, out var item);
                 }
                 else
                 {
+                    // check if there is timer trigger
                     if (TryComp<OnUseTimerTriggerComponent>(payloadItem, out var timerTrigger))
                     {
                         _trigger.HandleTimerTrigger(
@@ -243,6 +247,7 @@ namespace Content.Server.Light.EntitySystems
                     }
                     else
                     {
+                        //eject payload
                         _itemSlots.TryEject(uid, itemSlot, user: null, out var item);
                     }
                 }
@@ -401,10 +406,9 @@ namespace Content.Server.Light.EntitySystems
                 SetState(uid, false, component);
             else if (args.Port == component.OnPort)
             {
+                // check if light is already on, if yes, try to work with possible bluespace payload
                 if (component.On)
-                {
                     ActivatePayload(uid, component);
-                }
                 SetState(uid, true, component);
             }
 

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -466,3 +466,6 @@ uplink-fake-mindshield-desc = A togglable implant capable of mimicking the same 
 
 uplink-smuggler-satchel-name = Smuggler's Satchel
 uplink-smuggler-satchel-desc = A handy, suspicious looking satchel. Just flat enough to fit underneath floor tiles.
+
+uplink-bluespace-light-name = Bluespace Mixed Lights Box
+uplink-bluespace-light-desc = A science project that never found reasonable use has become the go to covert explosive installation method. These lights can be filled with small payload that can be activated from excessive 'On' signal of the fixture. Payloads with already active timer or no timer at all will be ejected.

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -477,3 +477,19 @@
     contents:
       - id: Envelope
         amount: 9
+
+- type: entity
+  name: mixed bluespace lights box
+  parent: BoxLightbulb
+  id: BoxBluespaceLightMixed
+  components:
+  - type: Sprite
+    layers:
+      - state: box
+      - state: lightmixed
+  - type: StorageFill
+    contents:
+      - id: BluespaceLightTube
+        amount: 6
+      - id: BluespaceLightBulb
+        amount: 6

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -2178,4 +2178,6 @@
   - !type:BuyerJobCondition
     whitelist:
     - Janitor
-    - Engineer
+    - StationEngineer
+    - TechnicalAssistant
+    - AtmosphericTechnician

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -2161,3 +2161,21 @@
     Telecrystal: 2
   categories:
   - UplinkDeception
+
+- type: listing
+  id: uplinkBluespaceLight
+  name: uplink-bluespace-light-name
+  description: uplink-bluespace-light-desc
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 1
+  productEntity: BoxBluespaceLightMixed
+  cost:
+    Telecrystal: 2
+  categories:
+  - UplinkJob
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist:
+    - Janitor
+    - Engineer

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -579,3 +579,70 @@
     refineResult:
     - id: SheetGlass1
     - id: ShardCrystalGreen
+
+- type: entity
+  parent: BaseLightTube
+  name: bluespace light tube
+  description: A high power high energy bulb.
+  id: BluespaceLightTube
+  components:
+  - type: LightBulb
+    color: "#EEEEFF"
+    lightEnergy: 1
+    lightRadius: 15
+    lightSoftness: 0.9
+    BurningTemperature: 350
+    PowerUse: 12
+  - type: ContainerContainer
+    containers:
+      payloadSlot: !type:ContainerSlot
+  - type: ItemSlots
+    slots:
+      payloadSlot:
+        whitelist:
+          sizes:
+            - Tiny
+            - Small
+        insertSound:
+          path: /Audio/Weapons/Guns/Empty/empty.ogg
+        ejectSound:
+          path: /Audio/Weapons/Guns/Empty/empty.ogg
+        swap: false
+        disableEject: true
+        ejectOnBreak: true
+
+- type: entity
+  parent: BaseLightbulb
+  name: bluespace light bulb
+  id: BluespaceLightBulb
+  description: A power efficient light bulb.
+  components:
+  - type: LightBulb
+    bulb: Bulb
+    color: "#EEEEFF"
+    lightEnergy: 1
+    lightRadius: 8
+    lightSoftness: 1
+    BurningTemperature: 350 #LEDs are colder than incandescent bulbs
+    PowerUse: 6 #LEDs are more power efficient than incandescent bulbs
+  - type: Tag
+    tags:
+      - LightBulb
+      - Trash
+  - type: ContainerContainer
+    containers:
+      payloadSlot: !type:ContainerSlot
+  - type: ItemSlots
+    slots:
+      payloadSlot:
+        whitelist:
+          sizes:
+            - Tiny
+            - Small
+        insertSound:
+          path: /Audio/Weapons/Guns/Empty/empty.ogg
+        ejectSound:
+          path: /Audio/Weapons/Guns/Empty/empty.ogg
+        swap: false
+        disableEject: true
+        ejectOnBreak: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added new syndicate item for janitors and engineers. Bluespace light tubes and bulbs. These let you hide tiny and small items inside the tube. If the item has timer trigger (most explosives do) then the payload can be activated.
How it works:
You can insert any tiny/small item into the tube or bulb.
After installed on a fixture, if the light is **On** and it receives additional **On** signal it will do one of following:
- if the item has **OnUseTimerTrigger** Component and it is not already active, trigger it.
- else eject the item from the slot dropping it in-front of the fixture.
This prevents accidental triggering of the mechanism.

Light tube's content can be ejected also by breaking the tube.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Janitors especially need more love in their syndicate roles. Also I am sure someone figures out other inventive uses for the mechanism. I am already thinking complicated traps involving logic relays bolting doors and trapping someone with bunch of C4 lights.

## Technical details
<!-- Summary of code changes for easier review. -->
Added `ActivatePayload` to `PoweredLightSystem` that handles triggering the payload in bluepsace bulbs and ejecting the contents. Logic to call this function is at `OnSignalReceived` where we check excess 'On' signals to the light fixture.
Also added constant of `PayloadSlotName` to `PoweredLightComponent`

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/3c35dc8e-0aa1-4140-93b7-78c383e78804)
[Screencast from 04-13-2025 04:13:21 PM.webm](https://github.com/user-attachments/assets/daca464f-7545-4232-89cc-f4008379d2ff)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
There should be no breaking changes.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: DrTeaSpoon
- add: Bluespace Light Tubes and Bulbs mixed light box as Janitor and Engineer syndicate item.
