### PR TITLE
antag role placeholder loc text

### DIFF
--- a/Resources/Locale/en-US/character-info/components/character-info-component.ftl
+++ b/Resources/Locale/en-US/character-info/components/character-info-component.ftl
@@ -1,4 +1,4 @@
 character-info-title = Character
-character-info-roles-antagonist-text = Antagonist Roles
+character-info-roles-antagonist-text = You have no special Roles
 character-info-objectives-label = Objectives
 character-info-no-profession = No Profession


### PR DESCRIPTION
## About the PR
Changes the placeholder text in the character window for non-antagonists

## Why / Balance
Some new players reportedly find it confusing that the window seems to call them Antagonist, which is fair tbh

## Technical details
Replaces a single localization string

## Media
![antag](https://github.com/user-attachments/assets/c855759c-845a-4d40-b93b-3e37f4e579b3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
None