### PR TITLE
Minor fix to give Lone Operatives the correct roletype

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -555,7 +555,7 @@
         factions:
         - Syndicate
       mindRoles:
-      - MindRoleNukeops
+      - MindRoleLoneops
 
 - type: entity
   parent: BaseTraitorRule

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -170,6 +170,14 @@
 
 # Nukies
 - type: entity
+  parent: MindRoleNukeops
+  id: MindRoleLoneops
+  name: Loneops Operative Role
+  components:
+  - type: MindRole
+    roleType: SoloAntagonist
+
+- type: entity
   parent: BaseMindRoleAntag
   id: MindRoleNukeops
   name: Nukeops Operative Role


### PR DESCRIPTION
## About the PR
Lone Operatives are officially a Solo Antagonist. But because they use the same mindrole as nukeops their roletype is marked Team Antagonist when you join as them. This minor fix will now show players the correct roletype ingame.

## Why / Balance
To give them the correct roletype

## Technical details
Gave the Loneops their own mindrole with the roletype SoloAntagonist that still has MindRoleNukeops as their parent.

## Media
![soloantag](https://github.com/user-attachments/assets/676aef90-37f3-47ef-be83-e501a144fe44)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Lone Operative is now assigned the Solo Antagonist role ingame instead of the Team Antagonist role.