### PR TITLE
Gave damage resistances to the bucket & warning cone when worn

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -150,6 +150,10 @@
     sprite: Clothing/Head/Misc/cone.rsi
   - type: Item
     storedRotation: 0
+  - type: Armor
+    modifiers:
+        coefficients:
+          Piercing: 0.95
   - type: PhysicalComposition #you can't just pass up some free plastic!
     materialComposition:
       Plastic: 100

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -22,6 +22,10 @@
     slots:
     - HEAD
     quickEquip: false
+  - type: Armor
+    modifiers:
+         coefficients:
+          Slash: 0.95
   - type: SolutionContainerManager
     solutions:
       bucket:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I changed buckets and traffic cones to give, respectively; a 5% slash resistance, and a 5% pierce resistance when worn.

## Why / Balance
There's a critical lack of non-contraband, minorly protective armours, *especially* helmets, and it's always felt weird that these two iconic hats don't give *any* protection, so I asked around and the idea seemed popular, so I made my first PR.

## Technical details
Added a 5% slash armour/resistance value to the bucket helmet, added a 5% pierce armour/resistance value to the warning cone helmet.

## Media

Cone Evidence
![Cone Evidence](https://github.com/user-attachments/assets/cf5cc752-0a0a-4274-acbb-a89caa8412b8)

Bucket Evidence
![Bucket Evidence](https://github.com/user-attachments/assets/cc31047b-0fad-4a29-9934-fe0919f96760)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
:cl:
- tweak: Added Slight damage resistances to the bucket and traffic cone when worn as hats!
