### PR TITLE
Remove invalid error logging in HideLayerClothingSystem

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/HideLayerClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/HideLayerClothingSystem.cs
@@ -45,7 +45,8 @@ public sealed class HideLayerClothingSystem : EntitySystem
         if (!Resolve(clothing.Owner, ref clothing.Comp1, ref clothing.Comp2))
             return;
 
-        if (!Resolve(user.Owner, ref user.Comp))
+        // logMissing: false, as this clothing might be getting equipped by a non-human.
+        if (!Resolve(user.Owner, ref user.Comp, false))
             return;
 
         hideLayers &= IsEnabled(clothing!);


### PR DESCRIPTION
## About the PR
Stops `HideLayerClothingSystem.SetLayerVisibility()` from incorrectly logging an error when an entity doesn't have the a `HumanoidAppearanceComponent`. Fixes #36230

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->