### PR TITLE
Increase thief to player ratio

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -202,7 +202,7 @@
     selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Traitor ]
-      max: 8
+      max: 6
       playerRatio: 10
       blacklist:
         components:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -202,7 +202,7 @@
     selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Traitor ]
-      max: 6
+      max: 8
       playerRatio: 10
       blacklist:
         components:

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -20,7 +20,7 @@
     definitions:
     - prefRoles: [ Thief ]
       max: 3
-      playerRatio: 15
+      playerRatio: 20
       lateJoinAdditional: true
       allowNonHumans: true
       multiAntagSetting: NotExclusive


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Increase player to thief ratio from 15 to 20

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

### Preamble

Anecdotal observation suggests 11 to 15 antags per shift for 80 players for a 1 hour Traitor gamemode shift.

Guaranteed:
- 8 traitors
- 3 thieves

At least one of the following:
- 2 sleeper agents
- 1 paradox clone
- 1 space ninja
- 1 revenant (guaranteed with space ninja hack)
- 1 space dragon (guaranteed with space ninja hack)
- 1 loneop (usually has reinforcements)
- 1 wizard
- 3 syndicate shuttle crew
- 1 rat king
- 3 initial infected (extremely rare)
- Various vent critters
- Sentient exploding artifact
- Shitters
- People caught doing crimes like trespassing or fighting

LRP servers on Wizden operates with 3 or 4 security at most (assuming half the department hasn't cryo'd). More antags being added has increased the possible number of antags in a shift, making players less likely to join security due to workload.

### Balance

Max number of thieves hasn't been changed, as thieves pose little threat to overall station safety. Ratio has been increased so you don't end up with 3 thieves for 45 crew (which usually has 2 or 3 sec at most). Max number remains the same to keep security on their toes.

~~Max number of traitors has been reduced given the existence of sleeper agents and typically low number of security per shift.~~ Will be handled by future PR.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Increased ratio of crew to thieves from 15 to 20.