### PR TITLE
Change colour tone of blue and green crayons

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -201,7 +201,7 @@
   - type: Item
     heldPrefix: blue
   - type: Crayon
-    color: lightblue
+    color: blue
   - type: Tag
     tags:
     - Write

--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -182,7 +182,7 @@
   - type: Item
     heldPrefix: green
   - type: Crayon
-    color: green
+    color: "#A8E61D"
   - type: Tag
     tags:
     - Write
@@ -201,7 +201,7 @@
   - type: Item
     heldPrefix: blue
   - type: Crayon
-    color: blue
+    color: "#00B7EF"
   - type: Tag
     tags:
     - Write


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Blue and green crayon drawings match colours of their sprites

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Light blue looked too grey. Green looked too dark.

Fixes #36522.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/280c9820-3ac7-44c8-afba-ffebf5c0839c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Drawings from blue and green crayons now match their colours.