### PR TITLE
Fix visitor mindshields

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/roles.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/roles.yml
@@ -13,9 +13,6 @@
       state: captain
     - type: RandomHumanoidSpawner
       settings: VisitorCaptain
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
 
 - type: entity
   id: RandomHumanoidVisitorCE
@@ -26,9 +23,7 @@
       state: ce
     - type: RandomHumanoidSpawner
       settings: VisitorCE
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidVisitorCMO
@@ -39,9 +34,7 @@
       state: cmo
     - type: RandomHumanoidSpawner
       settings: VisitorCMO
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidVisitorHOP
@@ -52,9 +45,7 @@
       state: hop
     - type: RandomHumanoidSpawner
       settings: VisitorHOP
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidVisitorHOS
@@ -65,9 +56,7 @@
       state: hos
     - type: RandomHumanoidSpawner
       settings: VisitorHOS
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidVisitorRD
@@ -78,9 +67,7 @@
       state: rd
     - type: RandomHumanoidSpawner
       settings: VisitorResearchDirector
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidVisitorQM
@@ -91,9 +78,7 @@
       state: qm
     - type: RandomHumanoidSpawner
       settings: VisitorQM
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 # Security
 
@@ -106,9 +91,7 @@
       state: security_cadet
     - type: RandomHumanoidSpawner
       settings: VisitorSecurityCadet
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidVisitorSecurityOfficer
@@ -119,9 +102,7 @@
       state: security_officer
     - type: RandomHumanoidSpawner
       settings: VisitorSecurityOfficer
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidVisitorDetective
@@ -132,9 +113,7 @@
       state: detective
     - type: RandomHumanoidSpawner
       settings: VisitorDetective
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidVisitorWarden
@@ -145,9 +124,7 @@
       state: warden
     - type: RandomHumanoidSpawner
       settings: VisitorWarden
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 # Cargo
 
@@ -504,9 +481,7 @@
       state: skull_icon
     - type: RandomHumanoidSpawner
       settings: ChallengeVictimCaptain
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidChallengeVictimCE
@@ -517,9 +492,7 @@
   components:
     - type: RandomHumanoidSpawner
       settings: ChallengeVictimChiefEngineer
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidChallengeVictimCMO
@@ -530,9 +503,7 @@
   components:
     - type: RandomHumanoidSpawner
       settings: ChallengeVictimCMO
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidChallengeVictimHOP
@@ -543,9 +514,7 @@
   components:
     - type: RandomHumanoidSpawner
       settings: ChallengeVictimHeadOfPersonnel
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidChallengeVictimHOS
@@ -556,9 +525,7 @@
   components:
     - type: RandomHumanoidSpawner
       settings: ChallengeVictimHeadOfSecurity
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidChallengeVictimRD
@@ -569,9 +536,7 @@
   components:
     - type: RandomHumanoidSpawner
       settings: ChallengeVictimResearchDirector
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 - type: entity
   id: RandomHumanoidChallengeVictimQM
@@ -582,9 +547,7 @@
   components:
     - type: RandomHumanoidSpawner
       settings: ChallengeVictimQuartermaster
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+
 
 # Security
 

--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -581,6 +581,7 @@
 
 - type: randomHumanoidSettings
   id: ChallengeVictimChiefEngineer
+  parent: EventHumanoidMindShielded
   randomizeName: false
   components:
     - type: GhostRole
@@ -601,6 +602,7 @@
 
 - type: randomHumanoidSettings
   id: ChallengeVictimCMO
+  parent: EventHumanoidMindShielded
   randomizeName: false
   components:
     - type: GhostRole
@@ -621,6 +623,7 @@
 
 - type: randomHumanoidSettings
   id: ChallengeVictimHeadOfPersonnel
+  parent: EventHumanoidMindShielded
   randomizeName: false
   components:
     - type: GhostRole
@@ -641,6 +644,7 @@
 
 - type: randomHumanoidSettings
   id: ChallengeVictimHeadOfSecurity
+  parent: EventHumanoidMindShielded
   randomizeName: false
   components:
     - type: GhostRole
@@ -661,6 +665,7 @@
 
 - type: randomHumanoidSettings
   id: ChallengeVictimResearchDirector
+  parent: EventHumanoidMindShielded
   randomizeName: false
   components:
     - type: GhostRole
@@ -681,6 +686,7 @@
 
 - type: randomHumanoidSettings
   id: ChallengeVictimQuartermaster
+  parent: EventHumanoidMindShielded
   randomizeName: false
   components:
     - type: GhostRole

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -11,7 +11,9 @@
   id: EventHumanoidMindShielded
   parent: EventHumanoid
   components:
-    - type: MindShield
+    - type: AutoImplant
+      implants:
+      - MindShieldImplant
     - type: AntagImmune
 
 - type: randomHumanoidSettings
@@ -20,6 +22,7 @@
   components:
   - type: AutoImplant
     implants:
+    - MindShieldImplant
     - DeathRattleImplantCentcomm
 
 ## Death Squad


### PR DESCRIPTION
## About the PR
Made the mindshields visitors get actually removeable, and gives mindshields to the disaster victim heads.

## Why / Balance
Makes no sense that visitors would have unremoveable mindshields, or that disaster victims would lose theirs.

## Technical details
YAML changes only 

Changed ```EventHumanoidMindShielded``` to use ```AutoImplant```, removed redundant ```AutoImplant``` components in children, and made disaster victims actually children of ```EventHumanoidMindShielded```

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- fix: You can now remove visitors mindshields.
- fix: Disaster victims now have mindshields as appropriate.