### PR TITLE
Use CompTree for TileEmission

### DIFF
--- a/Content.Client/Light/Components/TileEmissionTreeComponent.cs
+++ b/Content.Client/Light/Components/TileEmissionTreeComponent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Light.Components;
+using Robust.Shared.ComponentTrees;
+using Robust.Shared.Physics;
+
+namespace Content.Client.Light.Components;
+
+[RegisterComponent]
+public sealed partial class TileEmissionTreeComponent : Component, IComponentTreeComponent<TileEmissionComponent>
+{
+    public DynamicTree<ComponentTreeEntry<TileEmissionComponent>> Tree { get; set; }
+}

--- a/Content.Client/Light/EntitySystems/TileEmissionSystem.cs
+++ b/Content.Client/Light/EntitySystems/TileEmissionSystem.cs
@@ -1,0 +1,19 @@
+using System.Numerics;
+using Content.Client.Light.Components;
+using Content.Shared.Light.Components;
+using Robust.Shared.ComponentTrees;
+using Robust.Shared.Physics;
+
+namespace Content.Client.Light.EntitySystems;
+
+public sealed class TileEmissionSystem : ComponentTreeSystem<TileEmissionTreeComponent, TileEmissionComponent>
+{
+    protected override bool DoFrameUpdate => true;
+    protected override bool DoTickUpdate => true;
+    protected override bool Recursive => false;
+    protected override Box2 ExtractAabb(in ComponentTreeEntry<TileEmissionComponent> entry, Vector2 pos, Angle rot)
+    {
+        var boxR = new Box2Rotated(Box2.CenteredAround(pos, new Vector2(entry.Component.Range)), rot);
+        return boxR.CalcBoundingBox();
+    }
+}

--- a/Content.Shared/Light/Components/TileEmissionComponent.cs
+++ b/Content.Shared/Light/Components/TileEmissionComponent.cs
@@ -1,4 +1,7 @@
+using Content.Shared.Audio;
+using Robust.Shared.ComponentTrees;
 using Robust.Shared.GameStates;
+using Robust.Shared.Physics;
 
 namespace Content.Shared.Light.Components;
 
@@ -6,11 +9,16 @@ namespace Content.Shared.Light.Components;
 /// Will draw lighting in a range around the tile.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class TileEmissionComponent : Component
+public sealed partial class TileEmissionComponent : Component, IComponentTreeEntry<TileEmissionComponent>
 {
     [DataField, AutoNetworkedField]
     public float Range = 0.25f;
 
     [DataField(required: true), AutoNetworkedField]
     public Color Color = Color.Transparent;
+
+    public EntityUid? TreeUid { get; set; }
+    public DynamicTree<ComponentTreeEntry<TileEmissionComponent>>? Tree { get; set; }
+    public bool AddToTree => Range > 0f && !Color.Equals(Color.Transparent);
+    public bool TreeUpdateQueued { get; set; }
 }


### PR DESCRIPTION
Was like 8.5% of full-station render, mostly just helps with bigger viewports though with the engine light query PR this will also help for that as we can quickly check particular points.

Might need to move the tree comp to shared at some point if the engine pr gets merged.

Resolves https://github.com/space-wizards/space-station-14/issues/36536