### PR TITLE
Fix interaction popups

### DIFF
--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -953,7 +953,7 @@ namespace Content.Shared.Interaction
             if (!inRange && popup && _gameTiming.IsFirstTimePredicted)
             {
                 var message = Loc.GetString("interaction-system-user-interaction-cannot-reach");
-                _popupSystem.PopupEntity(message, origin, origin);
+                _popupSystem.PopupClient(message, origin, origin);
             }
 
             return inRange;

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -327,8 +327,8 @@ public class RCDSystem : EntitySystem
 
         // Exit if the target / target location is obstructed
         var unobstructed = (target == null)
-            ? _interaction.InRangeUnobstructed(user, _mapSystem.GridTileToWorld(mapGridData.GridUid, mapGridData.Component, mapGridData.Position), popup: popMsgs)
-            : _interaction.InRangeUnobstructed(user, target.Value, popup: popMsgs);
+            ? _interaction.InRangeUnobstructed(user, _mapSystem.GridTileToWorld(mapGridData.GridUid, mapGridData.Component, mapGridData.Position), popup: false)
+            : _interaction.InRangeUnobstructed(user, target.Value, popup: false);
 
         if (!unobstructed)
             return false;

--- a/Resources/Locale/en-US/interaction/interaction-system.ftl
+++ b/Resources/Locale/en-US/interaction/interaction-system.ftl
@@ -1,3 +1,2 @@
-shared-interaction-system-in-range-unobstructed-cannot-reach = You can't reach there!
 interaction-system-user-interaction-cannot-reach = You can't reach there!
 interaction-rate-limit-admin-announcement = Player { $player } breached interaction rate limits. They may be using macros, auto-clickers, or a modified client. Though they may just be spamming buttons or having network issues.


### PR DESCRIPTION
One IRU codepath was using popupentity not popupclient so it duplicated. RCD also manually checked this so you got this weird codepath where the interaction is considered a valid range but RCD does not consider it a valid range.

@chromiumboy 

Is it intended that RCD range is slightly smaller than interaction range? Seems like it would be easy to just skip the RCD range check to make it consistent even if the middle-of-tile-length is further.