### PR TITLE
Add implant names to implanters

### DIFF
--- a/Resources/Locale/en-US/tips.ftl
+++ b/Resources/Locale/en-US/tips.ftl
@@ -136,3 +136,4 @@ tips-dataset-135 = Instead of picking it up, you can alt-click food to eat it. T
 tips-dataset-136 = If you're trapped behind an electrified door, disable the APC or throw your ID at the door to avoid getting shocked!
 tips-dataset-137 = If the AI electrifies a door and you have insulated gloves, snip and mend the power wire to reset their electrification!
 tips-dataset-138 = If you want to stop your prisoner from escaping from the cell right after being uncuffed, turn on combat mode while uncuffing - this will shove the prisoner down.
+tips-dataset-139 = Make sure to clean your illegal implanters with a soap or a damp rag after you use them! Detectives can scan used implanters for incriminating DNA evidence, but not if they've been wiped clean.

--- a/Resources/Prototypes/Datasets/tips.yml
+++ b/Resources/Prototypes/Datasets/tips.yml
@@ -2,4 +2,4 @@
   id: Tips
   values:
     prefix: tips-dataset-
-    count: 137
+    count: 139

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -157,7 +157,7 @@
 
 - type: entity
   id: SadTromboneImplanter
-  suffix: sad trombone
+  name: sad trombone implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -165,7 +165,7 @@
 
 - type: entity
   id: LightImplanter
-  suffix: light
+  name: light implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -173,7 +173,7 @@
 
 - type: entity
   id: BikeHornImplanter
-  suffix: bike horn
+  name: bike horn implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -183,7 +183,7 @@
 
 - type: entity
   id: TrackingImplanter
-  suffix: tracking
+  name: tracking implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -193,7 +193,7 @@
 
 - type: entity
   id: StorageImplanter
-  suffix: storage
+  name: storage implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -201,7 +201,7 @@
 
 - type: entity
   id: FreedomImplanter
-  suffix: freedom
+  name: freedom implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -209,7 +209,7 @@
 
 - type: entity
   id: RadioImplanter
-  suffix: radio Syndicate
+  name: syndicate radio implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -217,7 +217,7 @@
 
 - type: entity
   id: UplinkImplanter
-  suffix: uplink
+  name: uplink implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -225,7 +225,7 @@
 
 - type: entity
   id: EmpImplanter
-  suffix: EMP
+  name: EMP implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -233,7 +233,7 @@
 
 - type: entity
   id: ScramImplanter
-  suffix: scram
+  name: scram implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -241,7 +241,7 @@
 
 - type: entity
   id: DnaScramblerImplanter
-  suffix: DNA scrambler
+  name: DNA scrambler implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -251,7 +251,7 @@
 
 - type: entity
   id: MicroBombImplanter
-  suffix: micro-bomb
+  name: micro-bomb implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -259,7 +259,7 @@
 
 - type: entity
   id: MacroBombImplanter
-  suffix: macro-bomb
+  name: macro-bomb implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -267,7 +267,7 @@
 
 - type: entity
   id: DeathRattleImplanter
-  suffix: death rattle
+  name: death rattle implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -275,7 +275,7 @@
 
 - type: entity
   id: DeathAcidifierImplanter
-  suffix: death acidifier
+  name: death acidifier implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -283,7 +283,7 @@
 
 - type: entity
   id: FakeMindShieldImplanter
-  suffix: fake mindshield
+  name: fake mindshield implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -293,7 +293,7 @@
 
 - type: entity
   id: MindShieldImplanter
-  suffix: mindshield
+  name: mindshield implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -303,7 +303,7 @@
 
 - type: entity
   id: RadioImplanterCentcomm
-  suffix: radio Centcomm
+  name: centcomm radio implanter
   parent: BaseImplantOnlyImplanter
   components:
   - type: Implanter
@@ -311,7 +311,7 @@
 
 - type: entity
   id: DeathRattleImplanterCentcomm
-  suffix: centcomm death rattle
+  name: centcomm death rattle implanter
   parent: BaseImplantOnlyImplanter
   components:
   - type: Implanter

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -2,7 +2,6 @@
 
 - type: entity
   name: implanter
-  description: A syringe exclusively designed for the injection and extraction of subdermal implants. Use care when extracting implants, as incorrect draw settings may injure the user.
   id: BaseImplanter
   parent: BaseItem
   abstract: true
@@ -125,7 +124,7 @@
   id: BaseImplantOnlyImplanterSyndi
   parent: [BaseImplantOnlyImplanter, BaseSyndicateContraband]
   name: syndicate implanter
-  description: A compact disposable syringe exclusively designed for the injection of subdermal implants.
+  description: A compact disposable syringe exclusively designed for the injection of subdermal implants. Make sure to scrub it with soap or a rag to remove residual DNA after use!
   abstract: true
   components:
     - type: Item


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR (re)introduces implant names to implanters, allowing them to be identified by the entity name even when no longer containing the implant.

It also gives tips in the implanter description and as a gameplay tip that you should wipe the implanter after use.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Back when I made the PR that changed implanters and their extraction, a goal was to keep a balance between antags and Security where Sec are strongly discouraged from doing outright guesswork when it comes to implant checking, yet have no barriers if they are certain they are correct.
The PR was also intended to allow Security to do educated guesses - using deductive reasoning to extract a suspected implant, but still preventing randomly guessing.

I think these goals were met. However, since we were uncertain of if removing the metashield would impact balance in Sec's favor, we decided to be conservative via keeping labels off to see the effects, even with concerns raised by contributors. 

This has resulted in a situation that isn't an issue from a rules-perspective, but simply put is unfun. And that is Security finding an implanter, figuring out who used it (via DNA or other evidence), and then being unable to act on it. While Sec use this to mark them as suspicious or bring them in for the crime of using syndie contra, it leaves a bad taste where Sec managed to secure easily hideable evidence yet don't get anything from it. An antag can drop off an implanter at Sec's doorstep and suffer no consequence.

---

Labels on implanters would throw Security a bone in this regard. The main concern here is that it would bring back some semblance of random implant checking, in that after Sec finds a scrubbed implant, they will just start implant checking anyone they arrest for that implant. There is also an impact on people who fail to scrub their implant (likely due to being new, but can also be stress/arrogance) who can now have their implant removed.

While these are undoubtedly antag nerfs, I think they allow for some more round dynamicity and also makes hiding the implant actually important. I also don't think the first concern is going to be prevalent; under the old implanter system for sure, but the cost of guessing wrong is high now, even if you know the implant you're looking for. It's also a system players are familiar with, helps new Sec players know what implants to look out for, and further mellows out popular implants by making them indirectly more at risk.

---

The description tip is needed to help new players who have not played Detective know the importance of cleaning your implanter, something that isn't very evident otherwise. 

There have been discussions to allow recyclers to be able to destroy implanters again, though this PR will be added first, with a later evaluation seeing if the recycler change is desirable. 

## Technical details
<!-- Summary of code changes for easier review. -->

Reverts some of the changes in #31045 in regards to implant names.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Implanters are now named after the implant they contained, even after the implanter has been used.
- add: Syndicate implanters now remind you to scrub them in the item description.
