### PR TITLE
fix inspect mind verb

### DIFF
--- a/Content.Client/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Client/Administration/Systems/AdminVerbSystem.cs
@@ -37,21 +37,6 @@ namespace Content.Client.Administration.Systems
                     ClientExclusive = true // opening VV window is client-side. Don't ask server to run this verb.
                 };
                 args.Verbs.Add(verb);
-
-                // Inspect mind
-                if (TryComp<MindContainerComponent>(args.Target, out var mindContainer)
-                    && mindContainer.HasMind)
-                {
-                    Verb mindVerb = new()
-                    {
-                        Text = Loc.GetString("inspect-mind-verb-get-data-text"),
-                        Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/sentient.svg.192dpi.png")),
-                        Category = VerbCategory.Debug,
-                        Act = () => _clientConsoleHost.ExecuteCommand($"vv {GetNetEntity(mindContainer.Mind)}"),
-                        ClientExclusive = true
-                    };
-                    args.Verbs.Add(mindVerb);
-                }
             }
 
             if (!_admin.IsAdmin(args.User))

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -194,7 +194,7 @@ namespace Content.Server.Administration.Systems
                     });
                 }
 
-                if (_mindSystem.TryGetMind(args.Target, out _, out var mind) && mind.UserId != null)
+                if (_mindSystem.TryGetMind(args.Target, out var mindId, out var mindComp) && mindComp.UserId != null)
                 {
                     // Erase
                     args.Verbs.Add(new Verb
@@ -206,7 +206,7 @@ namespace Content.Server.Administration.Systems
                             new("/Textures/Interface/VerbIcons/delete_transparent.svg.192dpi.png")),
                         Act = () =>
                         {
-                            _adminSystem.Erase(mind.UserId.Value);
+                            _adminSystem.Erase(mindComp.UserId.Value);
                         },
                         Impact = LogImpact.Extreme,
                         ConfirmationPopup = true
@@ -219,10 +219,19 @@ namespace Content.Server.Administration.Systems
                         Category = VerbCategory.Admin,
                         Act = () =>
                         {
-                            _console.ExecuteCommand(player, $"respawn \"{mind.UserId}\"");
+                            _console.ExecuteCommand(player, $"respawn \"{mindComp.UserId}\"");
                         },
                         ConfirmationPopup = true,
                         // No logimpact as the command does it internally.
+                    });
+
+                    // Inspect mind
+                    args.Verbs.Add(new Verb
+                    {
+                        Text = Loc.GetString("inspect-mind-verb-get-data-text"),
+                        Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/sentient.svg.192dpi.png")),
+                        Category = VerbCategory.Debug,
+                        Act = () => _console.RemoteExecuteCommand(player, $"vv {GetNetEntity(mindId)}"),
                     });
                 }
 


### PR DESCRIPTION
## About the PR
It was only working for the local player.

## Why / Balance
bugfix

## Technical details
Move it to the server and execute the command remotely for the client since the vv command is client side only.
Mind entities are stored in nullspace, so they are not networked by default and the client was failing to get the net entity for the command.
It was only working for the local player's mind because that one has a PVS override.

## Media
![Screenshot (390)](https://github.com/user-attachments/assets/62ae2c3d-af13-4ef2-a919-1fde26e7db4f)
![Screenshot (391)](https://github.com/user-attachments/assets/f583838d-1a40-4aef-a5f9-8eb0b27de532)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
ADMIN:
- fix: Fixed the inspect mind command not working for other players.