### PR TITLE
Cnock spell

### DIFF
--- a/Resources/Locale/en-US/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/store/spellbook-catalog.ftl
@@ -8,6 +8,9 @@ spellbook-blink-desc = Don't blink or you'll miss yourself teleporting away.
 spellbook-voidapplause-name = Void Applause
 spellbook-voidapplause-desc = Swap places with the target, doesn't it make you want to do the boogie?
 
+spellbook-knock-name = Knock
+spellbook-knock-desc = Opens all airlocks, crates and lockers nearby.
+
 spellbook-force-wall-name = Force Wall
 spellbook-force-wall-desc = Make three walls of pure force that you can pass through, but others can't.
 

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -147,6 +147,19 @@
     stock: 1
 
 - type: listing
+  id: SpellbookKnock
+  name: spellbook-knock-name
+  description: spellbook-knock-desc
+  productAction: ActionKnock
+  cost:
+    WizCoin: 1
+  categories:
+  - SpellbookUtility
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
   id: SpellbookCharge
   name: spellbook-charge-name
   description: spellbook-charge-desc


### PR DESCRIPTION
## About the PR
Added the ability to purchase the knock spell through the wizard's grimoire.

## Why / Balance
It was always supposed to be there, but it was forgotten about.

## Media
No, I'm sorry

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: Golub
- add: Added the Knock spell to the wizard's grimoire
