### PR TITLE
Fix skeletons not becoming skulls on gib

### DIFF
--- a/Resources/Prototypes/Body/Parts/skeleton.yml
+++ b/Resources/Prototypes/Body/Parts/skeleton.yml
@@ -14,7 +14,6 @@
         ents: []
   - type: StaticPrice
     price: 20
-  - type: Gibbable
   - type: Tag
     tags:
       - Trash
@@ -37,7 +36,7 @@
   id: HeadSkeleton
   name: "skull"
   description: Alas poor Yorick...
-  parent: PartSkeleton
+  parent: [ PartSkeleton, BaseMob ]
   components:
     - type: Sprite
       sprite: Mobs/Species/Skeleton/parts.rsi
@@ -47,10 +46,12 @@
       state: "skull_icon"
     - type: BodyPart
       partType: Head
+    - type: BlockMovement
     - type: Input
       context: "human"
     - type: Speech
       speechVerb: Skeleton
+      speechSounds: Alto
     - type: SkeletonAccent
     - type: Actions
     - type: Vocal


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Skeletons on death are supposed to just become a sentient skull. This broke ages ago because someone stuck gibbable onto the limbs which means that they never got dropped.

I have come to correct this :godo:

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Incredibly funny.

## Technical details
<!-- Summary of code changes for easier review. -->
yaml work.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/8ca0bc63-6097-4cd1-a6ea-d287f24004cb)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Skeletons once again become living skulls on death.
