### PR TITLE
Remove egg-plant from MegaSeed Servitor

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
@@ -15,7 +15,6 @@
     CornSeeds: 5
     CottonSeeds: 5
     EggplantSeeds: 5
-    EggySeeds: 5
     GalaxythistleSeeds: 3
     GarlicSeeds: 3
     GrapeSeeds: 5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Removed egg-plant from MegaSeed Servitor
  - Egg-plant can still be obtained by mutating eggplant or exotic seed crate

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Egg-plant seems out of place in the MegaSeed Servitor, especially as an exotic and mutant plant.

Follows tg station and goonstation convention where egg-plant seeds are only obtainable by mutation or exotic seed.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- remove: Removed egg-plant from MegaSeed Servitor. (Egg-plant seeds can still be obtained by mutation or exotic seed crate.)