### PR TITLE
Contraband Fix - ZooKeeper - Double barrel shotgun

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -103,7 +103,7 @@
 
 - type: entity
   name: double-barreled shotgun
-  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseSecurityBartenderContraband]
+  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseSecurityBartenderZookeeperContraband]
   id: WeaponShotgunDoubleBarreled
   description: An immortal classic. Uses .50 shotgun shells.
   components:

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -172,7 +172,6 @@
     allowedDepartments: [ Security ]
     allowedJobs: [ Bartender ]
 
-# contraband restricted by job by some degree
 - type: entity
   id: BaseSecurityBartenderZookeeperContraband
   parent: BaseRestrictedContraband

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -172,6 +172,16 @@
     allowedDepartments: [ Security ]
     allowedJobs: [ Bartender ]
 
+# contraband restricted by job by some degree
+- type: entity
+  id: BaseSecurityBartenderZookeeperContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Security ]
+    allowedJobs: [ Bartender, Zookeeper ]
+
 - type: entity
   id: BaseSecurityLawyerContraband
   parent: BaseRestrictedContraband


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Put ZooKeep on the contra list for the double barrel shotgun

## Why / Balance
The Zookeeper starts with a double barrel shotgun with tranquilizer ammo, but sec will take it away because ZooKeeper is not in the contra list

## Technical details
Adds the New BaseSecurityBartenderZookeeperContraband Contraband type in
Resources/Prototypes/Entities/Objects/base_contraband.yml

Changes the Contraband parent in
Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml

## Media
![Screenshot 2025-04-15 164018](https://github.com/user-attachments/assets/7aca8f1e-12ab-420b-b4e8-d5a75071f3df)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed Zookeeper not being on the double barrel shotgun contraband list
