### PR TITLE
AI Listening Channel

### DIFF
--- a/Resources/Locale/en-US/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/headset/headset-component.ftl
@@ -19,3 +19,4 @@ chat-radio-freelance = Freelance
 # not headset but whatever
 chat-radio-handheld = Handheld
 chat-radio-binary = Binary
+chat-radio-ailistening = AI listening

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -31,6 +31,7 @@
     inherentRadioChannels:
     - Common
     - Binary
+    - AIlistening
 
 - type: entity
   id: BorgChassisGeneric

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -223,6 +223,7 @@
   - type: EncryptionKey
     channels:
     - Binary
+    - AIlistening
     defaultChannel: Binary
   - type: Sprite
     layers:
@@ -238,6 +239,7 @@
   - type: EncryptionKey
     channels:
     - Binary
+    - AIlistening
     defaultChannel: Binary
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -22,10 +22,12 @@
   - type: IntrinsicRadioTransmitter
     channels:
     - Binary
+    - AIlistening
   - type: ActiveRadio
     channels:
     - Binary
     - Common
+    - AIlistening
   - type: NameIdentifier
     group: MMI
   - type: DoAfter
@@ -103,10 +105,12 @@
     - type: IntrinsicRadioTransmitter
       channels:
       - Binary
+      - AIlistening
     - type: ActiveRadio
       channels:
       - Binary
       - Common
+      - AIlistening
     - type: NameIdentifier
       group: PositronicBrain
     - type: DoAfter

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/intercom.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/intercom.yml
@@ -235,6 +235,7 @@
       - IntercomElectronics
       key_slots:
       - EncryptionKeyCommon
+      - EncryptionKeyBinary
 
 - type: entity
   id: IntercomCommand
@@ -249,6 +250,7 @@
       key_slots:
       - EncryptionKeyCommon
       - EncryptionKeyCommand
+      - EncryptionKeyBinary
 
 - type: entity
   id: IntercomEngineering
@@ -262,6 +264,7 @@
       key_slots:
       - EncryptionKeyCommon
       - EncryptionKeyEngineering
+      - EncryptionKeyBinary
 
 - type: entity
   id: IntercomMedical
@@ -275,6 +278,7 @@
       key_slots:
       - EncryptionKeyCommon
       - EncryptionKeyMedical
+      - EncryptionKeyBinary
 
 - type: entity
   id: IntercomScience
@@ -288,6 +292,7 @@
       key_slots:
       - EncryptionKeyCommon
       - EncryptionKeyScience
+      - EncryptionKeyBinary
 
 - type: entity
   id: IntercomSecurity
@@ -302,6 +307,7 @@
       key_slots:
       - EncryptionKeyCommon
       - EncryptionKeySecurity
+      - EncryptionKeyBinary
 
 - type: entity
   id: IntercomService
@@ -315,6 +321,7 @@
       key_slots:
       - EncryptionKeyCommon
       - EncryptionKeyService
+      - EncryptionKeyBinary
 
 - type: entity
   id: IntercomSupply
@@ -328,6 +335,7 @@
       key_slots:
       - EncryptionKeyCommon
       - EncryptionKeyCargo
+      - EncryptionKeyBinary
 
 - type: entity
   id: IntercomAll
@@ -341,6 +349,7 @@
       key_slots:
       - EncryptionKeyCommon
       - EncryptionKeyStationMaster
+      - EncryptionKeyBinary
 
 - type: entity
   id: IntercomFreelance

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -95,3 +95,10 @@
   color: "#f6ce64"
   # long range since otherwise it'd defeat the point of a handheld radio independent of telecomms
   longRange: true
+
+- type: radioChannel
+  id: AIlistening
+  name: chat-radio-ailistening
+  keycode: 'p'
+  frequency: 1447
+  color: "#E6089C"


### PR DESCRIPTION

## About the PR
Adds the AI Listening radio channel, along with the configurations to have cyborgs, MMI/Posi brain, and Binary Translator keys to access it.
## Why / Balance
Inspiration from SS13 with it's private AI channel to let the AI listen to conversations without needing to flood a public channel with conversations
## Technical details
Added the AIlistening channel to radio channels.yml
Added the AIlistening channel to the Binary radio key in radio keys.yml
Added the AIlistening channel to MMI/Cyborg/Positronic brain.
## Media
![image](https://github.com/user-attachments/assets/d7fd9acc-e577-441e-bb08-cfc243889e2b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
I cannot think of any, apart from my workaround of needing to add a binary key to all the intercoms, which means theoretically anyone with tools could yank them out of the intercom...
**Changelog**
:cl:
- add: The AI now has a radio channel to listen to conversations.


Drafting because of me not knowing why the radio is not displayed in chat despite having an encryption key inserted, the media displayed is from speaking into an intercom, whereas headsets do not actually transmit to the channel itself

Would anyone know why that is?