### PR TITLE
Material Door rebalancing

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
@@ -51,7 +51,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 200
+        damage: 300
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -68,6 +68,8 @@
   components:
   - type: NavMapDoor
 
+### Metal doors ###
+
 - type: entity
   id: MetalDoor
   name: metal door
@@ -76,6 +78,183 @@
   - type: Construction
     graph: DoorGraph
     node: metalDoor
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 3
+            max: 5
+
+- type: entity
+  id: PlasmaDoor
+  name: plasma door
+  parent: BaseMaterialDoorNavMap
+  description: A door, where will it lead?
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/MineralDoors/plasma_door.rsi
+    layers:
+    - state: closed
+      map: ["enum.DoorVisualLayers.Base"]
+  - type: Construction
+    graph: DoorGraph
+    node: plasmaDoor
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetPlasma1:
+            min: 3
+            max: 5
+
+- type: entity
+  id: GoldDoor
+  name: gold door
+  parent: BaseMaterialDoorNavMap
+  description: A door, where will it lead?
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/MineralDoors/gold_door.rsi
+    layers:
+    - state: closed
+      map: ["enum.DoorVisualLayers.Base"]
+  - type: Construction
+    graph: DoorGraph
+    node: goldDoor
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          IngotGold1:
+            min: 3
+            max: 5
+
+- type: entity
+  id: SilverDoor
+  name: silver door
+  parent: BaseMaterialDoorNavMap
+  description: A door, where will it lead?
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/MineralDoors/silver_door.rsi
+    layers:
+    - state: closed
+      map: ["enum.DoorVisualLayers.Base"]
+  - type: Construction
+    graph: DoorGraph
+    node: silverDoor
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          IngotSilver1:
+            min: 3
+            max: 5
+
+- type: entity
+  id: BananiumDoor
+  name: bananium door
+  parent: BaseMaterialDoorNavMap
+  description: A door, where will it lead?
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/MineralDoors/bananium_door.rsi
+    layers:
+    - state: closed
+      map: ["enum.DoorVisualLayers.Base"]
+  - type: Door
+    openSound:
+      path: /Audio/Items/bikehorn.ogg
+    closeSound:
+      path: /Audio/Items/bikehorn.ogg
+  - type: Construction
+    graph: DoorGraph
+    node: bananiumDoor
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialBananium1:
+            min: 1
+            max: 2
+
+### Other doors ###
 
 - type: entity
   id: WoodDoor
@@ -99,6 +278,9 @@
       path: /Audio/Effects/door_open.ogg
     closeSound:
       path: /Audio/Effects/door_close.ogg
+  - type: Construction
+    graph: DoorGraph
+    node: woodDoor
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Wood
@@ -106,13 +288,24 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 150
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
-  - type: Construction
-    graph: DoorGraph
-    node: woodDoor
+    - trigger:
+        !type:DamageTrigger
+        damage: 75
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WoodDestroy
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialWoodPlank1:
+            min: 3
+            max: 5
 
 - type: entity
   id: PaperDoor
@@ -125,98 +318,36 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
+  - type: Door
+    openSound:
+      path: /Audio/Effects/paperdoor_openclose.ogg
+    closeSound:
+      path: /Audio/Effects/paperdoor_openclose.ogg
+  - type: Construction
+    graph: DoorGraph
+    node: paperDoor
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Wood
   - type: Destructible
     thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
         damage: 50
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
-  - type: Construction
-    graph: DoorGraph
-    node: paperDoor
-  - type: Door
-    openSound:
-      path: /Audio/Effects/paperdoor_openclose.ogg
-    closeSound:
-      path: /Audio/Effects/paperdoor_openclose.ogg
-
-- type: entity
-  id: PlasmaDoor
-  name: plasma door
-  parent: BaseMaterialDoorNavMap
-  description: A door, where will it lead?
-  components:
-  - type: Sprite
-    sprite: Structures/Doors/MineralDoors/plasma_door.rsi
-    layers:
-    - state: closed
-      map: ["enum.DoorVisualLayers.Base"]
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallicStrong
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: Construction
-    graph: DoorGraph
-    node: plasmaDoor
-
-- type: entity
-  id: GoldDoor
-  name: gold door
-  parent: BaseMaterialDoorNavMap
-  description: A door, where will it lead?
-  components:
-  - type: Sprite
-    sprite: Structures/Doors/MineralDoors/gold_door.rsi
-    layers:
-    - state: closed
-      map: ["enum.DoorVisualLayers.Base"]
-  - type: Construction
-    graph: DoorGraph
-    node: goldDoor
-
-- type: entity
-  id: SilverDoor
-  name: silver door
-  parent: BaseMaterialDoorNavMap
-  description: A door, where will it lead?
-  components:
-  - type: Sprite
-    sprite: Structures/Doors/MineralDoors/silver_door.rsi
-    layers:
-    - state: closed
-      map: ["enum.DoorVisualLayers.Base"]
-  - type: Construction
-    graph: DoorGraph
-    node: silverDoor
-
-- type: entity
-  id: BananiumDoor
-  name: bananium door
-  parent: BaseMaterialDoorNavMap
-  description: A door, where will it lead?
-  components:
-  - type: Sprite
-    sprite: Structures/Doors/MineralDoors/bananium_door.rsi
-    layers:
-    - state: closed
-      map: ["enum.DoorVisualLayers.Base"]
-  - type: Construction
-    graph: DoorGraph
-    node: bananiumDoor
-  - type: Door
-    openSound:
-      path: /Audio/Items/bikehorn.ogg
-    closeSound:
-      path: /Audio/Items/bikehorn.ogg
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetPaper1:
+            min: 3
+            max: 5
 
 - type: entity
   id: WebDoor
@@ -229,11 +360,24 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
+  - type: Door
+    closeSound:
+      path: /Audio/Effects/rustle1.ogg
+    openSound:
+      path: /Audio/Effects/rustle2.ogg
   - type: Construction
     graph: WebStructures
     node: door
+  - type: Damageable
+    damageModifierSet: Web
   - type: Destructible
     thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
         damage: 50
@@ -245,13 +389,6 @@
           collection: WoodDestroy
       - !type:SpawnEntitiesBehavior
         spawn:
-          MaterialWebSilk:
-            min: 3
-            max: 5
-  - type: Damageable
-    damageModifierSet: Web
-  - type: Door
-    closeSound:
-      path: /Audio/Effects/rustle1.ogg
-    openSound:
-      path: /Audio/Effects/rustle2.ogg
+          MaterialWebSilk1:
+            min: 1
+            max: 2

--- a/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
@@ -341,6 +341,9 @@
         !type:DamageTrigger
         damage: 50
       behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Effects/poster_broken.ogg
       - !type:DoActsBehavior
         acts: ["Destruction"]
       - !type:SpawnEntitiesBehavior

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/doors.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/doors.yml
@@ -11,50 +11,50 @@
             - !type:SnapToGrid { }
           steps:
             - material: Steel
-              amount: 20
-              doAfter: 15
+              amount: 10
+              doAfter: 8
         - to: woodDoor
           completed:
             - !type:SnapToGrid { }
           steps:
             - material: WoodPlank
-              amount: 20
-              doAfter: 15
+              amount: 10
+              doAfter: 8
         - to: plasmaDoor
           completed:
             - !type:SnapToGrid { }
           steps:
             - material: Plasma
-              amount: 20
-              doAfter: 15
+              amount: 10
+              doAfter: 8
         - to: goldDoor
           completed:
             - !type:SnapToGrid { }
           steps:
             - material: Gold
-              amount: 20
-              doAfter: 15
+              amount: 10
+              doAfter: 8
         - to: silverDoor
           completed:
             - !type:SnapToGrid { }
           steps:
             - material: Silver
-              amount: 20
-              doAfter: 15
+              amount: 10
+              doAfter: 8
         - to: bananiumDoor
           completed:
             - !type:SnapToGrid { }
           steps:
             - material: Bananium
               amount: 5
-              doAfter: 15
+              doAfter: 8
         - to: paperDoor
           completed:
             - !type:SnapToGrid { }
           steps:
             - material: Paper
-              amount: 20
-              doAfter: 15
+              amount: 10
+              doAfter: 8
     - node: metalDoor
       entity: MetalDoor
       edges:
@@ -62,10 +62,10 @@
           completed:
             - !type:SpawnPrototype
               prototype: SheetSteel1
-              amount: 20
+              amount: 10
           steps:
             - tool: Anchoring
-              doAfter: 15
+              doAfter: 8
     - node: woodDoor
       entity: WoodDoor
       edges:
@@ -73,10 +73,10 @@
           completed:
             - !type:SpawnPrototype
               prototype: MaterialWoodPlank1
-              amount: 20
+              amount: 10
           steps:
             - tool: Anchoring
-              doAfter: 15
+              doAfter: 8
     - node: plasmaDoor
       entity: PlasmaDoor
       edges:
@@ -84,10 +84,10 @@
           completed:
             - !type:SpawnPrototype
               prototype: SheetPlasma
-              amount: 20
+              amount: 10
           steps:
             - tool: Anchoring
-              doAfter: 15
+              doAfter: 8
     - node: goldDoor
       entity: GoldDoor
       edges:
@@ -95,10 +95,10 @@
           completed:
             - !type:SpawnPrototype
               prototype: IngotGold1
-              amount: 20
+              amount: 10
           steps:
             - tool: Anchoring
-              doAfter: 15
+              doAfter: 8
     - node: silverDoor
       entity: SilverDoor
       edges:
@@ -106,10 +106,10 @@
           completed:
             - !type:SpawnPrototype
               prototype: IngotSilver1
-              amount: 20
+              amount: 10
           steps:
             - tool: Anchoring
-              doAfter: 15
+              doAfter: 8
     - node: paperDoor
       entity: PaperDoor
       edges:
@@ -117,10 +117,10 @@
           completed:
             - !type:SpawnPrototype
               prototype: SheetPaper1
-              amount: 20
+              amount: 10
           steps:
             - tool: Anchoring
-              doAfter: 15
+              doAfter: 8
     - node: bananiumDoor
       entity: BananiumDoor
       edges:
@@ -131,4 +131,4 @@
               amount: 5
           steps:
             - tool: Anchoring
-              doAfter: 15
+              doAfter: 8


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR targets material doors (not airlocks or firelocks)
Aims to tweak constructible material doors to encourage their use.

- Changes the de/construction time for all of them from 15s -> 8s
- halves their material costs from 20 -> 10
- destroying them returns a small portion of the materials put in
- lowers their overall health and resistances
- adds sounds when destroying them

## Why / Balance
For the most part these material doors are rarely built or mapped into stations, hopefully this should encourage them to be used at the cheaper cost and be a better alternative when needing a low security door for a construction project.

Paper doors are difficult enough already to get the materials to craft, mostly only being built when a stack of 30 paper is mapped on a station by default (bagel), then disappointingly only creates 1 door leaving 10 paper left over with no use.

Lowering their resistances and health across the board make sense given more doors being buildable out of the same amount of surplus materials, their previous resistances also didn't make much sense given they can be crafted by hand with no tools.

## Technical details
destructible threshold on metal doors lowered from 200 to 150 (also lowers the wood/paper/web doors slightly)
added thresholds for nuke-level damage to destroy doors without dropping materials
changes the damageModifierSet from StructuralMetallicStrong -> StrongMetallic
Reduces construction recipes by half (most cases 20 -> 10) and all doafter times from 15s -> 8s
Adds break sounds to all doors (except web, It uses foliage rustle for opening its kind of an outlier to the other doors)
*also shifts around some of the prototype/component orders

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Material doors now have destruction sounds and will drop a portion of their construction materials when destroyed.
- tweak: Material doors now have reduced health, resistances, construction time, and construction costs

