### PR TITLE
Sentient Artifacts Can Self-Activate Again

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Actions;
 using Content.Shared.Destructible.Thresholds;
 using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.Xenoarchaeology.Artifact.Prototypes;
@@ -158,4 +159,15 @@ public sealed partial class XenoArtifactComponent : Component
             Variation = 0.1f
         }
     };
+
+    /// <summary>
+    /// Action that allows the artifact to self activate.
+    /// </summary>
+    [DataField]
+    public EntProtoId<InstantActionComponent> SelfActivateAction = "ActionArtifactActivate";
 }
+
+/// <summary>
+/// Event raised by sentient artifact to activate itself at no durability cost.
+/// </summary>
+public sealed partial class ArtifactSelfActivateEvent : InstantActionEvent;

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAE.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAE.cs
@@ -51,12 +51,14 @@ public abstract partial class SharedXenoArtifactSystem
     /// <param name="user">Character that attempted to activate artifact.</param>
     /// <param name="target">Target, on which artifact activation attempt was used (for hand-held artifact - it can be 'clicked' over someone).</param>
     /// <param name="coordinates">Coordinates of <paramref name="target"/> entity.</param>
+    /// <param name="consumeDurability">Whether this activation will deplete durability on the activated nodes.</param>
     /// <returns>True, if activation was successful, false otherwise.</returns>
     public bool TryActivateXenoArtifact(
         Entity<XenoArtifactComponent> artifact,
         EntityUid? user,
         EntityUid? target,
-        EntityCoordinates coordinates
+        EntityCoordinates coordinates,
+        bool consumeDurability = true
     )
     {
         XenoArtifactComponent xenoArtifactComponent = artifact;
@@ -69,7 +71,7 @@ public abstract partial class SharedXenoArtifactSystem
         var success = false;
         foreach (var node in GetActiveNodes(artifact))
         {
-            success |= ActivateNode(artifact, node, user, target, coordinates);
+            success |= ActivateNode(artifact, node, user, target, coordinates, consumeDurability: consumeDurability);
         }
 
         if (!success)

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/xenoartifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/xenoartifacts.yml
@@ -1,5 +1,6 @@
 - type: entity
   id: BaseXenoArtifact
+  parent: BaseMob # we use this since it can technically get inhabited
   name: artifact
   description: A strange artifact from time unknown. Looks like a good time.
   abstract: true
@@ -29,6 +30,9 @@
   - type: Actions
   - type: Physics
     bodyType: Dynamic
+  - type: MovementSpeedModifier
+    baseWalkSpeed: 0.25
+    baseSprintSpeed: 0.5
   - type: UseDelay
   - type: StealTarget
     stealGroup: XenoArtifact
@@ -41,3 +45,15 @@
   # These components are needed for certain triggers to work.
   - type: RadiationReceiver
   - type: Reactive
+
+- type: entity
+  id: ActionArtifactActivate
+  name: Activate Artifact
+  description: Activate yourself, causing chaos to those near you.
+  components:
+  - type: InstantAction
+    icon:
+      sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
+      state: ano29
+    useDelay: 300
+    event: !type:ArtifactSelfActivateEvent

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -363,9 +363,6 @@
       mindRoles:
       - MindRoleGhostRoleFreeAgent
     - type: GhostTakeoverAvailable
-    - type: MovementSpeedModifier
-      baseWalkSpeed: 0.25
-      baseSprintSpeed: 0.5
 
 - type: entity
   id: XenoArtifactOmnitool


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds back in the ability for sentient artifacts to self activate with a few major changes:
- Self-activation does not consume durability on the nodes.
- Self-activation has a longer cooldown (1 minute -> 5 minutes)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
self-activation is cool but we don't want to trivialize the durability or make it boring. hopefully this strikes a happy medium.

## Technical details
<!-- Summary of code changes for easier review. -->
n/a

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/f4ddaea4-985f-40ab-968d-eb92734fe52d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Sentient artifacts can once again activate themselves.
- tweak: Increased sentient artifact self activation cooldown.
