### PR TITLE
XenoArch Rebalancing

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
@@ -68,13 +68,13 @@ public sealed partial class XenoArtifactComponent : Component
     /// By how much unlocking state should be prolonged for each node that was unlocked.
     /// </summary>
     [DataField]
-    public TimeSpan UnlockStateIncrementPerNode = TimeSpan.FromSeconds(5);
+    public TimeSpan UnlockStateIncrementPerNode = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// Minimum waiting time between unlock states.
     /// </summary>
     [DataField]
-    public TimeSpan UnlockStateRefractory = TimeSpan.FromSeconds(10);
+    public TimeSpan UnlockStateRefractory = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// When next unlock session can be triggered.

--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
@@ -64,7 +64,7 @@ public sealed partial class XenoArtifactNodeComponent : Component
     /// The amount of points a node is worth with no scaling
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float BasePointValue = 5000;
+    public float BasePointValue = 4000;
 
     /// <summary>
     /// Amount of points available currently for extracting.

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
@@ -394,6 +394,6 @@ public abstract partial class SharedXenoArtifactSystem
             : 1f + durabilityEffect;
 
         var predecessorNodes = GetPredecessorNodes((artifact, artifact), node);
-        nodeComponent.ResearchValue = (int)(Math.Pow(1.25, predecessorNodes.Count) * nodeComponent.BasePointValue * durabilityMultiplier);
+        nodeComponent.ResearchValue = (int)(Math.Pow(1.25, Math.Pow(predecessorNodes.Count, 1.5f)) * nodeComponent.BasePointValue * durabilityMultiplier);
     }
 }

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
@@ -73,6 +73,7 @@ public abstract partial class SharedXenoArtifactSystem
         if (TryGetNodeFromUnlockState(ent, out var node))
         {
             SetNodeUnlocked((ent, artifactComponent), node.Value);
+            ActivateNode((ent, ent), (node.Value, node.Value), null, null, Transform(ent).Coordinates, false);
             unlockAttemptResultMsg = "artifact-unlock-state-end-success";
 
             // as an experiment - unlocking node doesn't activate it, activation is left for player to decide.

--- a/Resources/Locale/en-US/paper/paper-misc.ftl
+++ b/Resources/Locale/en-US/paper/paper-misc.ftl
@@ -51,7 +51,7 @@ book-text-agrichemkit-manual = Thank you for choosing the safe-for-all-ages Nano
       
       Each individual plant responds to unstable mutagen differently, so you may want to use small doses on multiple crops and try to crossbreed the best traits from each of those. Applying multiple doses to one plant can stack multiple changes and make it harder to single out desirable traits.
       Unstable mutagen is entirely safe when used as a fertilizer, and NanoTrasen takes no responsibility for dead crops, excessive water bills, newly sentient plants asking existential questions, or flora-strangled farmhands that may coincidentally occur while using it.
-      Do not drink unstable mutagen. Wash your hands thoroughly after handing. Wash your eyes if you have looked at unstable mutagen for over 30 minutes in a 24 hour period. Store in a dark room between 293–295K. Do not use on corporate holidays. If you begin hearing voices telling you to drink unstable mutagen, please contact your doctor, head of personnel, or exorcist.
+      Do not drink unstable mutagen. Wash your hands thoroughly after handling. Wash your eyes if you have looked at unstable mutagen for over 30 minutes in a 24 hour period. Store in a dark room between 293–295K. Do not use on corporate holidays. If you begin hearing voices telling you to drink unstable mutagen, please contact your doctor, head of personnel, or exorcist.
 
 book-text-combat-bakery-kit = Thank you for choosing our combat bakery kit!
       Enclosed are two (2) CyberSun patented Throwing Croissants, and one (1) patent-pending Baguette Sword.

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/artifacts.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/artifacts.yml
@@ -10,16 +10,8 @@
           state: ano01
     - type: RandomSpawner
       prototypes:
-        - SimpleXenoArtifact
-        - MediumXenoArtifact
-        - MediumXenoArtifact
-        - MediumXenoArtifact
-        - MediumXenoArtifact
         - ComplexXenoArtifact
         - ComplexXenoArtifact
-        - ComplexXenoArtifact
-        - SimpleXenoArtifactItem
-        - MediumXenoArtifactItem
         - ComplexXenoArtifactItem
       chance: 1
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_xenoartifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_xenoartifacts.yml
@@ -64,43 +64,12 @@
 
 - type: entity
   parent: BaseXenoArtifactItem
-  id: SimpleXenoArtifactItem
-  suffix: hand-sized Simple
-  components:
-  - type: XenoArtifact
-    nodeCount:
-      min: 2
-      max: 5
-
-- type: entity
-  parent: BaseXenoArtifactItem
-  id: MediumXenoArtifactItem
-  suffix: hand-sized Medium
-  components:
-  - type: XenoArtifact
-    nodeCount:
-      min: 5
-      max: 9
-
-- type: entity
-  parent: BaseXenoArtifactItem
   id: ComplexXenoArtifactItem
-  suffix: hand-sized Complex
+  suffix: Hand-Sized
   components:
   - type: XenoArtifact
     nodeCount:
       min: 9
-      max: 13
-
-# this exists for crafting item artifacts so that the final result can be simple, medium, or complex.
-- type: entity
-  parent: BaseXenoArtifactItem
-  id: VariedXenoArtifactItem
-  suffix: hand-sized Varied
-  components:
-  - type: XenoArtifact
-    nodeCount:
-      min: 2
       max: 13
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_xenoartifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_xenoartifacts.yml
@@ -41,28 +41,7 @@
 
 - type: entity
   parent: BaseXenoArtifactStructure
-  id: SimpleXenoArtifact
-  suffix: Simple
-  components:
-  - type: XenoArtifact
-    nodeCount:
-      min: 2
-      max: 5
-
-- type: entity
-  parent: BaseXenoArtifactStructure
-  id: MediumXenoArtifact
-  suffix: Medium
-  components:
-  - type: XenoArtifact
-    nodeCount:
-      min: 5
-      max: 9
-
-- type: entity
-  parent: BaseXenoArtifactStructure
   id: ComplexXenoArtifact
-  suffix: Complex
   components:
   - type: XenoArtifact
     nodeCount:

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/artifact.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/artifact.yml
@@ -10,4 +10,4 @@
         amount: 4
         doAfter: 5
   - node: done
-    entity: VariedXenoArtifactItem
+    entity: ComplexXenoArtifactItem

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -1066,7 +1066,7 @@
   description: Creates anomaly
   components:
   - type: XenoArtifactNode
-    maxDurability: 2
+    maxDurability: 1
     maxDurabilityCanDecreaseBy:
       min: 0
       max: 1

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -1062,14 +1062,9 @@
 
 - type: entity
   id: XenoArtifactAnomalySpawn
-  parent: BaseXenoArtifactEffect
+  parent: BaseOneTimeXenoArtifactEffect
   description: Creates anomaly
   components:
-  - type: XenoArtifactNode
-    maxDurability: 1
-    maxDurabilityCanDecreaseBy:
-      min: 0
-      max: 1
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
     refreshOnReactivate: true

--- a/Resources/ServerInfo/Guidebook/Science/Xenoarchaeology.xml
+++ b/Resources/ServerInfo/Guidebook/Science/Xenoarchaeology.xml
@@ -9,7 +9,7 @@ By researching the unique things each artifact can do, you gain Research Points,
 ## Artifact Nodes
 <Box>
 <GuideEntityEmbed Entity="ComplexXenoArtifact" Caption=""/>
-<GuideEntityEmbed Entity="SimpleXenoArtifactItem" Caption=""/>
+<GuideEntityEmbed Entity="ComplexXenoArtifactItem" Caption=""/>
 </Box>
 Artifacts consist of a randomly-generated tree of nodes. These nodes have a "[color=#a4885c]depth[/color]", representing how dangerous the node is, and the number of other nodes connected to it, called "[color=#a4885c]edges[/color]",
 

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -592,3 +592,10 @@ MailAllAccessSpam: MailSpamLetter
 MailCentcommRetributionSpam: MailSpamLetter
 MailEvilLizardSpam: MailSpamLetter
 MailParentsNeedMoneySpam: MailSpamLetter
+
+# 2025-04-15
+SimpleXenoArtifact: ComplexXenoArtifact
+MediumXenoArtifact: ComplexXenoArtifact
+SimpleXenoArtifactItem: ComplexXenoArtifactItem
+MediumXenoArtifactItem: ComplexXenoArtifactItem
+VariedXenoArtifactItem: ComplexXenoArtifactItem


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A handful of balance tweaks in response to big xenoarcheology changes:
- Changed research output scaling to be more favorable to high-class nodes.
- Increased unlocking window 
- decreased post-unlock downtime
- Removed artifact variants with fewer nodes
- Made unlocking a node activate its effect.

apologies for mish-mash of changes; they are all relatively minor and stitched together.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In order:
- Previous scaling gave a largely linear reward for an exponentially more difficult challenge. This seeks to make it a bit more balanced. A 6-trigger node is significantly more difficult to unlock than 6 one-trigger nodes.
- The previous unlocking window was a bit too short for solo players to be able to do multiple triggers (especially those with doafters). Additionally, people had concerns about latency affecting their ability to do the triggers under such tight time pressure.
- The decently long downtime partially obscured the fact that certain triggers (gases, pressure, heat) were occurring continuously. A shorter downtime hopefully makes it more obvious that it's originating from a constant stimuli.
- With the new system, artifacts with few nodes (in the 2 to 9 range) often failed to create graph segments with interesting connections between nodes. This results in a large amount of class 1 and 2 nodes that have low research output and not much long-term interest.
- General feelings were that the removal of activation after unlocking made the process feel too safe. This was not something intended to be changed from the original design so it has been restored. I hate safety and love to see people injured. 

## Technical details
<!-- Summary of code changes for easier review. -->
n/a 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Artifact complexity variants (`SimpleXenoArtifact`, `MediumXenoArtifact`, `SimpleXenoArtifactItem`, `MediumXenoArtifactItem`, `VariedXenoArtifactItem`) have been remove and replaced with their default versions (`ComplexXenoArtifact` and `ComplexXenoArtifactItem`, respectively)

**Changelog**
:cl:
- add: When an artifact's node is unlocked, the effect will now also occur. Effects can still be triggered manually through interaction.
- tweak: Artifacts will now have more nodes on average.
- tweak: Higher-class artifact nodes now grant significantly more points.
