### PR TITLE
Predict blocking examine + fix blocking breaking persistence

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -313,7 +313,7 @@ public sealed partial class BlockingSystem : EntitySystem
 
     private void OnVerbExamine(EntityUid uid, BlockingComponent component, GetVerbsEvent<ExamineVerb> args)
     {
-        if (!args.CanInteract || !args.CanAccess || !_net.IsServer)
+        if (!args.CanInteract || !args.CanAccess)
             return;
 
         var fraction = component.IsBlocking ? component.ActiveBlockFraction : component.PassiveBlockFraction;

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -156,52 +156,49 @@ public sealed partial class BlockingSystem : EntitySystem
         var msgUser = Loc.GetString("action-popup-blocking-user", ("shield", shieldName));
         var msgOther = Loc.GetString("action-popup-blocking-other", ("blockerName", blockerName), ("shield", shieldName));
 
-        if (component.BlockingToggleAction != null)
+        //Don't allow someone to block if they're not parented to a grid
+        if (xform.GridUid != xform.ParentUid)
         {
-            //Don't allow someone to block if they're not parented to a grid
-            if (xform.GridUid != xform.ParentUid)
-            {
-                CantBlockError(user);
-                return false;
-            }
+            CantBlockError(user);
+            return false;
+        }
 
-            // Don't allow someone to block if they're not holding the shield
-            if(!_handsSystem.IsHolding(user, item, out _))
-            {
-                CantBlockError(user);
-                return false;
-            }
+        // Don't allow someone to block if they're not holding the shield
+        if (!_handsSystem.IsHolding(user, item, out _))
+        {
+            CantBlockError(user);
+            return false;
+        }
 
-            //Don't allow someone to block if someone else is on the same tile
-            var playerTileRef = xform.Coordinates.GetTileRef();
-            if (playerTileRef != null)
+        //Don't allow someone to block if someone else is on the same tile
+        var playerTileRef = xform.Coordinates.GetTileRef();
+        if (playerTileRef != null)
+        {
+            var intersecting = _lookup.GetLocalEntitiesIntersecting(playerTileRef.Value, 0f);
+            var mobQuery = GetEntityQuery<MobStateComponent>();
+            foreach (var uid in intersecting)
             {
-                var intersecting = _lookup.GetLocalEntitiesIntersecting(playerTileRef.Value, 0f);
-                var mobQuery = GetEntityQuery<MobStateComponent>();
-                foreach (var uid in intersecting)
+                if (uid != user && mobQuery.HasComponent(uid))
                 {
-                    if (uid != user && mobQuery.HasComponent(uid))
-                    {
-                        TooCloseError(user);
-                        return false;
-                    }
+                    TooCloseError(user);
+                    return false;
                 }
             }
+        }
 
-            //Don't allow someone to block if they're somehow not anchored.
-            _transformSystem.AnchorEntity(user, xform);
-            if (!xform.Anchored)
-            {
-                CantBlockError(user);
-                return false;
-            }
-            _actionsSystem.SetToggled(component.BlockingToggleActionEntity, true);
-            if (_gameTiming.IsFirstTimePredicted)
-            {
-                _popupSystem.PopupEntity(msgOther, user, Filter.PvsExcept(user), true);
-                if(_gameTiming.InPrediction)
-                    _popupSystem.PopupEntity(msgUser, user, user);
-            }
+        //Don't allow someone to block if they're somehow not anchored.
+        _transformSystem.AnchorEntity(user, xform);
+        if (!xform.Anchored)
+        {
+            CantBlockError(user);
+            return false;
+        }
+        _actionsSystem.SetToggled(component.BlockingToggleActionEntity, true);
+        if (_gameTiming.IsFirstTimePredicted)
+        {
+            _popupSystem.PopupEntity(msgOther, user, Filter.PvsExcept(user), true);
+            if (_gameTiming.InPrediction)
+                _popupSystem.PopupEntity(msgUser, user, user);
         }
 
         if (TryComp<PhysicsComponent>(user, out var physicsComponent))
@@ -210,7 +207,7 @@ public sealed partial class BlockingSystem : EntitySystem
                 component.Shape,
                 BlockingComponent.BlockFixtureID,
                 hard: true,
-                collisionLayer: (int) CollisionGroup.WallLayer,
+                collisionLayer: (int)CollisionGroup.WallLayer,
                 body: physicsComponent);
         }
 
@@ -255,8 +252,7 @@ public sealed partial class BlockingSystem : EntitySystem
         //If the component blocking toggle isn't null, grab the users SharedBlockingUserComponent and PhysicsComponent
         //then toggle the action to false, unanchor the user, remove the hard fixture
         //and set the users bodytype back to their original type
-        if (component.BlockingToggleAction != null && TryComp<BlockingUserComponent>(user, out var blockingUserComponent)
-                                                     && TryComp<PhysicsComponent>(user, out var physicsComponent))
+        if (TryComp<BlockingUserComponent>(user, out var blockingUserComponent) && TryComp<PhysicsComponent>(user, out var physicsComponent))
         {
             if (xform.Anchored)
                 _transformSystem.Unanchor(user, xform);
@@ -267,7 +263,7 @@ public sealed partial class BlockingSystem : EntitySystem
             if (_gameTiming.IsFirstTimePredicted)
             {
                 _popupSystem.PopupEntity(msgOther, user, Filter.PvsExcept(user), true);
-                if(_gameTiming.InPrediction)
+                if (_gameTiming.InPrediction)
                     _popupSystem.PopupEntity(msgUser, user, user);
             }
         }

--- a/Content.Shared/Blocking/Components/BlockingComponent.cs
+++ b/Content.Shared/Blocking/Components/BlockingComponent.cs
@@ -16,13 +16,13 @@ public sealed partial class BlockingComponent : Component
     /// <summary>
     /// The entity that's blocking
     /// </summary>
-    [ViewVariables, AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public EntityUid? User;
 
     /// <summary>
     /// Is it currently blocking?
     /// </summary>
-    [ViewVariables, AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public bool IsBlocking;
 
     /// <summary>
@@ -33,7 +33,7 @@ public sealed partial class BlockingComponent : Component
     /// <summary>
     /// The shape of the blocking fixture that will be dynamically spawned
     /// </summary>
-    [DataField("shape"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public IPhysShape Shape = new PhysShapeCircle(0.5f);
 
     /// <summary>
@@ -48,8 +48,8 @@ public sealed partial class BlockingComponent : Component
     [DataField("activeBlockModifier", required: true)]
     public DamageModifierSet ActiveBlockDamageModifier = default!;
 
-    [DataField("blockingToggleAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string BlockingToggleAction = "ActionToggleBlock";
+    [DataField]
+    public EntProtoId BlockingToggleAction = "ActionToggleBlock";
 
     [DataField, AutoNetworkedField]
     public EntityUid? BlockingToggleActionEntity;
@@ -57,7 +57,7 @@ public sealed partial class BlockingComponent : Component
     /// <summary>
     /// The sound to be played when you get hit while actively blocking
     /// </summary>
-    [DataField("blockSound")] public SoundSpecifier BlockSound =
+    [DataField] public SoundSpecifier BlockSound =
         new SoundPathSpecifier("/Audio/Weapons/block_metal1.ogg")
         {
             Params = AudioParams.Default.WithVariation(0.25f)
@@ -67,13 +67,13 @@ public sealed partial class BlockingComponent : Component
     /// Fraction of original damage shield will take instead of user
     /// when not blocking
     /// </summary>
-    [DataField("passiveBlockFraction"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float PassiveBlockFraction = 0.5f;
 
     /// <summary>
     /// Fraction of original damage shield will take instead of user
     /// when blocking
     /// </summary>
-    [DataField("activeBlockFraction"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float ActiveBlockFraction = 1.0f;
 }


### PR DESCRIPTION
No idea why these were like this.

technical:
- stateful data needs to be datafields or it breaks persistence.
- Never use .IsServer unless you have a very good reason.
- PopupPredicted