### PR TITLE
Predict GhostBoo

### DIFF
--- a/Content.Server/Ghost/GhostBooEvent.cs
+++ b/Content.Server/Ghost/GhostBooEvent.cs
@@ -1,7 +1,0 @@
-namespace Content.Server.Ghost
-{
-    public sealed class GhostBooEvent : HandledEntityEventArgs
-    {
-
-    }
-}

--- a/Content.Server/Ghost/SpookySpeakerSystem.cs
+++ b/Content.Server/Ghost/SpookySpeakerSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Chat.Systems;
 using Content.Server.Ghost.Components;
+using Content.Shared.Ghost;
 using Content.Shared.Random.Helpers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -2,7 +2,6 @@ using Content.Server.DeviceLinking.Systems;
 using Content.Server.DeviceNetwork;
 using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Emp;
-using Content.Server.Ghost;
 using Content.Server.Light.Components;
 using Content.Server.Power.Components;
 using Content.Shared.Audio;
@@ -20,6 +19,7 @@ using Robust.Shared.Audio.Systems;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Damage.Components;
 using Content.Shared.Power;
+using Content.Shared.Ghost;
 
 namespace Content.Server.Light.EntitySystems
 {

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAELightFlickerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAELightFlickerSystem.cs
@@ -1,6 +1,6 @@
-using Content.Server.Ghost;
 using Content.Server.Light.Components;
 using Content.Server.Xenoarchaeology.Artifact.XAE.Components;
+using Content.Shared.Ghost;
 using Content.Shared.Xenoarchaeology.Artifact;
 using Content.Shared.Xenoarchaeology.Artifact.XAE;
 using Robust.Shared.Random;
@@ -14,7 +14,7 @@ public sealed class XAELightFlickerSystem : BaseXAESystem<XAELightFlickerCompone
 {
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
-    [Dependency] private readonly GhostSystem _ghost = default!;
+    [Dependency] private readonly SharedGhostSystem _ghost = default!;
 
     private EntityQuery<PoweredLightComponent> _lights;
 

--- a/Content.Shared/Ghost/GhostBooEvent.cs
+++ b/Content.Shared/Ghost/GhostBooEvent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared.Ghost;
+
+[ByRefEvent]
+public record struct GhostBooEvent(bool Handled = false);

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -19,6 +19,8 @@ namespace Content.Shared.Ghost
         [Dependency] protected readonly EntityLookupSystem Lookup = default!;
         [Dependency] protected readonly IRobustRandom Random = default!;
 
+        private HashSet<EntityUid> _entitiesInRange = new();
+
         public override void Initialize()
         {
             base.Initialize();
@@ -47,12 +49,10 @@ namespace Content.Shared.Ghost
             if (args.Handled)
                 return;
 
-            var entities = Lookup.GetEntitiesInRange(args.Performer, component.BooRadius).ToList();
-            // Shuffle the possible targets so we don't favor any particular entities
-            Random.Shuffle(entities);
+            Lookup.GetEntitiesInRange(args.Performer, component.BooRadius, _entitiesInRange);
 
             var booCounter = 0;
-            foreach (var ent in entities)
+            foreach (var ent in _entitiesInRange)
             {
                 var handled = DoGhostBooEvent(ent);
 
@@ -64,7 +64,7 @@ namespace Content.Shared.Ghost
             }
 
             if (booCounter == 0)
-                Popup.PopupEntity(Loc.GetString("ghost-component-boo-action-failed"), uid, uid);
+                Popup.PopupPredicted(Loc.GetString("ghost-component-boo-action-failed"), uid, uid);
 
             args.Handled = true;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Predict GhostBoo. 
**Requires Chat refactor and #36541 - on hold until then.**

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolve #36540

## Technical details
<!-- Summary of code changes for easier review. -->
Move GhostBooEvent to Shared, make it a `record struct` and change the paths. Also pulled the Boo `OnActionPerform` listener method to Shared.
Could probably have moved other things too that use it but:
- SpookySpeaker has to be server still, uses Chat.
- Don't want to touch PoweredLight until #36541 is merged. Can keep this open and go back to it if necessary!
- XAE and revenant stuff needs the light flickering stuff pulled from ghost really

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
GhostBoo is now Shared.
