### PR TITLE
Remove fixture MachineLayer from pet carriers

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
@@ -1,12 +1,12 @@
 - type: entity
   id: PetCarrier
-  name: big pet carrier
+  name: pet carrier
   description: Allows large animals to be carried comfortably. It smells vaguely of toilet water and explosives.
   parent: BaseStructureDynamic
   components:
   - type: Sprite
     noRot: true
-    drawdepth: Objects
+    drawdepth: Items
     sprite: Objects/Storage/petcarrier.rsi
     layers:
     - state: pet_carrier_base
@@ -31,8 +31,6 @@
         density: 25
         mask:
         - ItemMask
-        layer:
-        - MachineLayer
   - type: EntityStorage
     capacity: 1
     airtight: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR removes the MachineLayer fixture from pet carriers and puts them on the "Items" drawdepth. This pet carriers no longer push players or lockers, and also draw on top of tables. 

Also changed the name from "big pet carrier" to "pet carrier" because big implies there being another size of pet carrier, and it can carry pets of any size regardless. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Pet carriers are the only item on the MachineLayer that is able to be picked up and thrown by players. This makes it possible to push other people by throwing the pet carrier, which can bring the target player up to speeds such that they can be slipped/"thrown" into disposal bins.

It also made them weirdly push away maintenance lockers they spawn in when opened.

## Technical details
<!-- Summary of code changes for easier review. -->

Removed the collision layer under fixture, changed the sprite drawdepth to Items, renamed the entity name.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Closed pet carriers no longer push players or lockers.
