### PR TITLE
make salv loot spawners only spawn crusher-named equipment, and add a new spawner identical to the old salv loot spawner

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/salvage.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/salvage.yml
@@ -65,8 +65,8 @@
   components:
   - type: Sprite
     layers:
-    - state: handdrill
     - state: red
+    - state: handdrill
       sprite: Objects/Tools/handdrill.rsi
   - type: RandomSpawner
     prototypes:


### PR DESCRIPTION
## About the PR
(fyi: salvage loot spawner refers to a specific spawner that used to spawn crusher daggers, crushers, and drills. spawners for literal salvage loot (e.g. materials, money, etc.) are unchanged)

changes original salvage loot spawner to have a 10% chance to spawn a crusher dagger, otherwise it spawns a normal crusher or crusher glaive (equal chance for either), and renamed it to the salvage crusher spawner.

also adds a new spawner, the salvage tool spawner, which has equal chances to spawn either a normal crusher, crusher glaive, crusher dagger or mining drill (the same as the old version of the salvage loot spawner).

## Why / Balance
Getting crushers should be easier by RNG (considering you can _only_ get them with RNG spawners/loot tables, such as on vgroid)

I doubt anyone will miss getting drills from these in specific (considering theyre not that difficult to get anyway), and daggers aren't completely useless but normal crushers are just much more preferable.

## Technical details
its only yaml and its just one file. new salv tool spawner gets icon of a mining drill

## Media
demonstration of spawn chances,
left: (newly added) tool spawner
right: crusher spawner (10% chance for dagger)
![image](https://github.com/user-attachments/assets/5d856d31-4622-4a40-b4d9-77c9502927f7)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Predetermined spawns for crushers will generally spawn normal crushers and crusher glaives much more frequently than they do crusher daggers.
- remove: Mining drills will no longer spawn on *predetermined* spawns for crushers; only leaving crushers/glaives and daggers. Doesn't affect random-location spawns.
