### PR TITLE
Add self message variants for starting/finishing vending machine restocking

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Damage;
 using Content.Shared.Destructible;
 using Content.Shared.DoAfter;
 using Content.Shared.Emp;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Popups;
 using Content.Shared.Power;
 using Content.Shared.Throwing;
@@ -144,7 +145,7 @@ namespace Content.Server.VendingMachines
 
             Popup.PopupEntity(Loc.GetString("vending-machine-restock-done-self", ("target", uid)), args.Args.User, args.Args.User, PopupType.Medium);
             var othersFilter = Filter.PvsExcept(args.Args.User);
-            Popup.PopupEntity(Loc.GetString("vending-machine-restock-done-others", ("user", args.Args.User), ("target", uid)), args.Args.User, othersFilter, true, PopupType.Medium);
+            Popup.PopupEntity(Loc.GetString("vending-machine-restock-done-others", ("user", Identity.Entity(args.User, EntityManager)), ("target", uid)), args.Args.User, othersFilter, true, PopupType.Medium);
 
             Audio.PlayPvs(restockComponent.SoundRestockDone, uid, AudioParams.Default.WithVolume(-2f).WithVariation(0.2f));
 

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.UserInterface;
 using Content.Shared.VendingMachines;
 using Content.Shared.Wall;
 using Robust.Shared.Audio;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -141,7 +142,9 @@ namespace Content.Server.VendingMachines
 
             TryRestockInventory(uid, component);
 
-            Popup.PopupEntity(Loc.GetString("vending-machine-restock-done", ("this", args.Args.Used), ("user", args.Args.User), ("target", uid)), args.Args.User, PopupType.Medium);
+            Popup.PopupEntity(Loc.GetString("vending-machine-restock-done-self", ("target", uid)), args.Args.User, args.Args.User, PopupType.Medium);
+            var othersFilter = Filter.PvsExcept(args.Args.User);
+            Popup.PopupEntity(Loc.GetString("vending-machine-restock-done-others", ("user", args.Args.User), ("target", uid)), args.Args.User, othersFilter, true, PopupType.Medium);
 
             Audio.PlayPvs(restockComponent.SoundRestockDone, uid, AudioParams.Default.WithVolume(-2f).WithVariation(0.2f));
 

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
@@ -1,4 +1,5 @@
 using Content.Shared.DoAfter;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Wires;
@@ -73,7 +74,7 @@ public abstract partial class SharedVendingMachineSystem
             return;
 
         var selfMessage = Loc.GetString("vending-machine-restock-start-self", ("target", target));
-        var othersMessage = Loc.GetString("vending-machine-restock-start-others", ("user", args.User), ("target", target));
+        var othersMessage = Loc.GetString("vending-machine-restock-start-others", ("user", Identity.Entity(args.User, EntityManager)), ("target", target));
         Popup.PopupPredicted(selfMessage,
             othersMessage,
             uid,

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
@@ -72,8 +72,10 @@ public abstract partial class SharedVendingMachineSystem
         if (!_doAfter.TryStartDoAfter(doAfterArgs))
             return;
 
-        Popup.PopupPredicted(Loc.GetString("vending-machine-restock-start", ("this", uid), ("user", args.User),
-                ("target", target)),
+        var selfMessage = Loc.GetString("vending-machine-restock-start-self", ("target", target));
+        var othersMessage = Loc.GetString("vending-machine-restock-start-others", ("user", args.User), ("target", target));
+        Popup.PopupPredicted(selfMessage,
+            othersMessage,
             uid,
             args.User,
             PopupType.Medium);

--- a/Resources/Locale/en-US/vending-machines/vending-machine-restock-component.ftl
+++ b/Resources/Locale/en-US/vending-machines/vending-machine-restock-component.ftl
@@ -1,4 +1,6 @@
 vending-machine-restock-invalid-inventory = { CAPITALIZE(THE($this)) } isn't the right package to restock { THE($target) }.
-vending-machine-restock-needs-panel-open = { CAPITALIZE($target) } needs { POSS-ADJ($target) } maintenance panel opened first.
-vending-machine-restock-start = { $user } starts restocking { $target }.
-vending-machine-restock-done = { $user } finishes restocking { $target }.
+vending-machine-restock-needs-panel-open = { CAPITALIZE(THE($target)) } needs { POSS-ADJ($target) } maintenance panel opened first.
+vending-machine-restock-start-self = You start restocking { THE($target) }.
+vending-machine-restock-start-others = { CAPITALIZE(THE($user)) } starts restocking { THE($target) }.
+vending-machine-restock-done-self = You finish restocking { THE($target) }.
+vending-machine-restock-done-others = { CAPITALIZE(THE($user)) } finishes restocking { THE($target) }.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A player restocking a vending machine now sees a second-person popup message ("You start restocking the NanoMed Plus") instead of a third-person popup message ("Urist McHands starts restocking the NanoMed Plus"). Other players still see the third-person popup.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Popups should refer to the local player in the second person. Third person is weird.

## Technical details
<!-- Summary of code changes for easier review. -->
- Added new loc strings to the ftl file.
- Use the two-message overload of `PopupPredicted` for the started message.
- Use the single-recipient and filtered overloads of `PopupEntity` for the finished message.
- Also made a few fixes to the loc strings for better formating (a few missing `CAPITALIZE` and `THE`s).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:
<img width="561" alt="Screenshot 2025-04-16 at 3 40 55 PM" src="https://github.com/user-attachments/assets/42e20e2f-3cd2-4d6d-a6f2-b21159a57c47" />
<img width="561" alt="Screenshot 2025-04-16 at 3 41 00 PM" src="https://github.com/user-attachments/assets/484a21e8-3ad0-4e1e-a1c9-eaa825d66080" />

After:
<img width="561" alt="Screenshot 2025-04-16 at 3 55 15 PM" src="https://github.com/user-attachments/assets/8f1cf71c-5ae4-4c14-bffb-641927401700" />
<img width="561" alt="Screenshot 2025-04-16 at 3 55 20 PM" src="https://github.com/user-attachments/assets/c6526a73-bc0c-48f6-ae35-475a67c075c6" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->