### PR TITLE
Cleanup warnings in ScreenshotHook

### DIFF
--- a/Content.Client/Screenshot/ScreenshotHook.cs
+++ b/Content.Client/Screenshot/ScreenshotHook.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using Content.Client.Viewport;
@@ -8,8 +7,6 @@ using Robust.Client.Input;
 using Robust.Client.State;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Input.Binding;
-using Robust.Shared.IoC;
-using Robust.Shared.Log;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -25,8 +22,13 @@ namespace Content.Client.Screenshot
         [Dependency] private readonly IResourceManager _resourceManager = default!;
         [Dependency] private readonly IStateManager _stateManager = default!;
 
+        private ISawmill _sawmill = default!;
+
         public void Initialize()
         {
+            _sawmill = Logger.GetSawmill("screenshot");
+            _sawmill.Level = LogLevel.Info;
+
             _inputManager.SetInputCommand(ContentKeyFunctions.TakeScreenshot, InputCmdHandler.FromDelegate(_ =>
             {
                 _clyde.Screenshot(ScreenshotType.Final, Take);
@@ -40,7 +42,7 @@ namespace Content.Client.Screenshot
                 }
                 else
                 {
-                    Logger.InfoS("screenshot", "Can't take no-UI screenshot: current state is not GameScreen");
+                    _sawmill.Info("Can't take no-UI screenshot: current state is not GameScreen");
                 }
             }));
         }
@@ -74,16 +76,16 @@ namespace Content.Client.Screenshot
                         screenshot.SaveAsPng(file);
                     });
 
-                    Logger.InfoS("screenshot", "Screenshot taken as {0}.png", filename);
+                    _sawmill.Info("Screenshot taken as {0}.png", filename);
                     return;
                 }
                 catch (IOException e)
                 {
-                    Logger.WarningS("screenshot", "Failed to save screenshot, retrying?:\n{0}", e);
+                    _sawmill.Warning("Failed to save screenshot, retrying?:\n{0}", e);
                 }
             }
 
-            Logger.ErrorS("screenshot", "Unable to save screenshot.");
+            _sawmill.Error("Unable to save screenshot.");
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 4 warnings in `ScreenshotHook.cs`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Instead of using the static logger, we get a Sawmill for screenshots and use that instead.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->