### PR TITLE
add subtype to admin notice

### DIFF
--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -330,7 +330,12 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
                 var cachedInfo = adminSys.GetCachedPlayerInfo(new NetUserId(id));
                 if (cachedInfo != null && cachedInfo.Antag)
                 {
-                    logMessage += " [ANTAG: " + cachedInfo.CharacterName + "]";
+                    var subtype = Loc.GetString(cachedInfo.Subtype ?? cachedInfo.RoleProto.Name);
+                    logMessage = Loc.GetString(
+                        "admin-alert-antag-label",
+                        ("message", logMessage),
+                        ("name", cachedInfo.CharacterName),
+                        ("subtype", subtype));
                 }
             }
 

--- a/Resources/Locale/en-US/administration/admin-alerts.ftl
+++ b/Resources/Locale/en-US/administration/admin-alerts.ftl
@@ -1,3 +1,4 @@
 ﻿admin-alert-shared-connection = {$player} is sharing a connection with {$otherCount} connected player(s): {$otherList}
 admin-alert-ipintel-blocked = {$player} was rejected from joining due to their IP having a {TOSTRING($percent, "P2")} confidence of being a VPN/Datacenter.
 admin-alert-ipintel-warning = {$player} IP has a {TOSTRING($percent, "P2")} confidence of being a VPN/Datacenter. Please watch them.
+admin-alert-antag-label = {$message} [ANTAG: {$name}, {$subtype}]


### PR DESCRIPTION
## About the PR
add subtype info to admin notices. 
Localize the antag label on admin notices

## Why / Balance
Makes antag identities more clear on the notice

## Technical details
The notice already uses PlayerInfo data, so we simply add Subtype from it to the notice. If subtype is missing, role type is listed instead, as is usual for UIs that show subtype.

## Media
![image](https://github.com/user-attachments/assets/93c6435d-54c1-49a5-a7f3-adf8664adcf1)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: Errant
ADMIN:
- tweak: Antag tags on admin notices now show exactly what kind of antag that mob is.