### PR TITLE
Fix artifact point extraction going into negatives

### DIFF
--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -39,7 +39,8 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
             sumResearch += research;
         }
 
-        if (sumResearch == 0)
+        // 4-16-25: It's a sad day when a scientist makes negative 5k research
+        if (sumResearch <= 0)
             return;
 
         _research.ModifyServerPoints(server.Value, sumResearch, serverComponent);

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
@@ -163,7 +163,7 @@ public abstract partial class SharedXenoArtifactSystem
         if (ent.Comp.Locked)
             return 0;
 
-        return ent.Comp.ResearchValue - ent.Comp.ConsumedResearchValue;
+        return Math.Max(0, ent.Comp.ResearchValue - ent.Comp.ConsumedResearchValue);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a bug where the research value of an artifact could be negative. In such a case, you could lose points by extracting an artifact.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
n/a

## Technical details
<!-- Summary of code changes for easier review. -->
Adds two basic checks to ensure the research value is [0, R)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed artifacts sometimes having negative research values.
