### PR TITLE
Fix explosion visuals

### DIFF
--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -1,5 +1,11 @@
 #  Does not currently support prototype hot-reloading. See comments in c# file.
 
+# Note that for every explosion type you define, explosions & nukes will start performing worse
+# You should only define a new explopsion type if you really need to
+#
+# If you just want to modify properties other than `damagePerIntensity`, it'd be better to
+# split off explosion damage & explosion visuals/effects into their own separate prototypes.
+
 - type: explosion
   id: Default
   damagePerIntensity:
@@ -43,7 +49,7 @@
   intensityPerState: 20
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
-  fireStates: 6
+  fireStates: 3
 
 - type: explosion
   id: Radioactive
@@ -100,7 +106,7 @@
   intensityPerState: 20
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
-  fireStates: 6
+  fireStates: 3
 
 - type: explosion
   id: HardBomb
@@ -116,7 +122,7 @@
   intensityPerState: 20
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
-  fireStates: 6
+  fireStates: 3
 
 - type: explosion
   id: FireBomb
@@ -127,7 +133,7 @@
       Piercing: 3
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
-  fireStates: 6
+  fireStates: 3
   fireStacks: 2
 
 # STOP


### PR DESCRIPTION
## About the PR
Several explosion prototypes use an incorrect `fireStates` value, leading to broken visuals.

## Technical details
`fire.rsi` contains both atmos/tile fires states and some other related states. Explosions should only use the actual tile fire states to draw the overlay. The `fireStates` field is a somewhat hacky field that limits explosions to only using the first `n` states in the RSI for drawing the explosion. If you use the wrong value, you end up getting stuff like this:

![Content Client_TvJ51PlcK3](https://github.com/user-attachments/assets/2aa7604f-e25a-4661-b9d8-fede98bdcd5f)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl:
- fix: Fixed some intense explosion types using incorrect overlay sprites.
