### PR TITLE
Add `PopupPredictedCursor` and fix doubled popups on vending machines

### DIFF
--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -173,12 +173,12 @@ namespace Content.Client.Popups
                 PopupCursor(message, type);
         }
 
-        public override void PopupCursorPredicted(string? message, ICommonSession recipient, PopupType type = PopupType.Small)
+        public override void PopupPredictedCursor(string? message, ICommonSession recipient, PopupType type = PopupType.Small)
         {
             PopupCursor(message, recipient, type);
         }
 
-        public override void PopupCursorPredicted(string? message, EntityUid recipient, PopupType type = PopupType.Small)
+        public override void PopupPredictedCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small)
         {
             PopupCursor(message, recipient, type);
         }

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -173,6 +173,16 @@ namespace Content.Client.Popups
                 PopupCursor(message, type);
         }
 
+        public override void PopupCursorPredicted(string? message, ICommonSession recipient, PopupType type = PopupType.Small)
+        {
+            PopupCursor(message, recipient, type);
+        }
+
+        public override void PopupCursorPredicted(string? message, EntityUid recipient, PopupType type = PopupType.Small)
+        {
+            PopupCursor(message, recipient, type);
+        }
+
         public override void PopupCoordinates(string? message, EntityCoordinates coordinates, Filter filter, bool replayRecord, PopupType type = PopupType.Small)
         {
             PopupCoordinates(message, coordinates, type);

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -35,12 +35,12 @@ namespace Content.Server.Popups
                 RaiseNetworkEvent(new PopupCursorEvent(message, type), actor.PlayerSession);
         }
 
-        public override void PopupCursorPredicted(string? message, ICommonSession recipient, PopupType type = PopupType.Small)
+        public override void PopupPredictedCursor(string? message, ICommonSession recipient, PopupType type = PopupType.Small)
         {
             // Do nothing, since the client already predicted the popup.
         }
 
-        public override void PopupCursorPredicted(string? message, EntityUid recipient, PopupType type = PopupType.Small)
+        public override void PopupPredictedCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small)
         {
             // Do nothing, since the client already predicted the popup.
         }

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -35,6 +35,16 @@ namespace Content.Server.Popups
                 RaiseNetworkEvent(new PopupCursorEvent(message, type), actor.PlayerSession);
         }
 
+        public override void PopupCursorPredicted(string? message, ICommonSession recipient, PopupType type = PopupType.Small)
+        {
+            // Do nothing, since the client already predicted the popup.
+        }
+
+        public override void PopupCursorPredicted(string? message, EntityUid recipient, PopupType type = PopupType.Small)
+        {
+            // Do nothing, since the client already predicted the popup.
+        }
+
         public override void PopupCoordinates(string? message, EntityCoordinates coordinates, Filter filter, bool replayRecord, PopupType type = PopupType.Small)
         {
             if (message == null)

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -33,6 +33,18 @@ namespace Content.Shared.Popups
         public abstract void PopupCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small);
 
         /// <summary>
+        /// Variant of <see cref="PopupCursor(string?, ICommonSession, PopupType)"/> for use with prediction.
+        /// The local client will show the popup to the recipient. Does nothing on the server.
+        /// </summary>
+        public abstract void PopupCursorPredicted(string? message, ICommonSession recipient, PopupType type = PopupType.Small);
+
+        /// <summary>
+        /// Variant of <see cref="PopupCursor(string?, EntityUid, PopupType)"/> for use with prediction.
+        /// The local client will show the popup to the recipient. Does nothing on the server.
+        /// </summary>
+        public abstract void PopupCursorPredicted(string? message, EntityUid recipient, PopupType type = PopupType.Small);
+
+        /// <summary>
         ///     Shows a popup at a world location to every entity in PVS range.
         /// </summary>
         /// <param name="message">The message to display.</param>
@@ -60,7 +72,7 @@ namespace Content.Shared.Popups
 
         /// <summary>
         ///    Variant of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/> for use with prediction. The local client will
-        ///    the popup to the recipient, and the server will show it to every other player in PVS range. If recipient is null, the local 
+        ///    the popup to the recipient, and the server will show it to every other player in PVS range. If recipient is null, the local
         //     client will do nothing and the server will show the message to every player in PVS range.
         /// </summary>
         public abstract void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small);

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -36,13 +36,13 @@ namespace Content.Shared.Popups
         /// Variant of <see cref="PopupCursor(string?, ICommonSession, PopupType)"/> for use with prediction.
         /// The local client will show the popup to the recipient. Does nothing on the server.
         /// </summary>
-        public abstract void PopupCursorPredicted(string? message, ICommonSession recipient, PopupType type = PopupType.Small);
+        public abstract void PopupPredictedCursor(string? message, ICommonSession recipient, PopupType type = PopupType.Small);
 
         /// <summary>
         /// Variant of <see cref="PopupCursor(string?, EntityUid, PopupType)"/> for use with prediction.
         /// The local client will show the popup to the recipient. Does nothing on the server.
         /// </summary>
-        public abstract void PopupCursorPredicted(string? message, EntityUid recipient, PopupType type = PopupType.Small);
+        public abstract void PopupPredictedCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small);
 
         /// <summary>
         ///     Shows a popup at a world location to every entity in PVS range.

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
@@ -17,7 +17,7 @@ public abstract partial class SharedVendingMachineSystem
     {
         if (!TryComp<WiresPanelComponent>(target, out var panel) || !panel.Open)
         {
-            Popup.PopupCursor(Loc.GetString("vending-machine-restock-needs-panel-open",
+            Popup.PopupCursorPredicted(Loc.GetString("vending-machine-restock-needs-panel-open",
                     ("this", uid),
                     ("user", user),
                     ("target", target)),
@@ -37,7 +37,7 @@ public abstract partial class SharedVendingMachineSystem
     {
         if (!component.CanRestock.Contains(machineComponent.PackPrototypeId))
         {
-            Popup.PopupCursor(Loc.GetString("vending-machine-restock-invalid-inventory", ("this", uid), ("user", user),
+            Popup.PopupCursorPredicted(Loc.GetString("vending-machine-restock-invalid-inventory", ("this", uid), ("user", user),
                 ("target", target)), user);
 
             return false;

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
@@ -17,7 +17,7 @@ public abstract partial class SharedVendingMachineSystem
     {
         if (!TryComp<WiresPanelComponent>(target, out var panel) || !panel.Open)
         {
-            Popup.PopupCursorPredicted(Loc.GetString("vending-machine-restock-needs-panel-open",
+            Popup.PopupPredictedCursor(Loc.GetString("vending-machine-restock-needs-panel-open",
                     ("this", uid),
                     ("user", user),
                     ("target", target)),
@@ -37,7 +37,7 @@ public abstract partial class SharedVendingMachineSystem
     {
         if (!component.CanRestock.Contains(machineComponent.PackPrototypeId))
         {
-            Popup.PopupCursorPredicted(Loc.GetString("vending-machine-restock-invalid-inventory", ("this", uid), ("user", user),
+            Popup.PopupPredictedCursor(Loc.GetString("vending-machine-restock-invalid-inventory", ("this", uid), ("user", user),
                 ("target", target)), user);
 
             return false;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a `PopupPredictedCursor` method to `SharedPopupSystem`.
Also uses the new method to fix a bug where the popup messages shown when unable to restock a vending machine were shown twice.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity with other popup methods - we have `PopupPredicted` for `PopupEntity` and `PopupPredictedCoordinates` for `PopupCoordinates`, so it makes sense to have `PopupPredictedCursor` for `PopupCursor`.

## Technical details
<!-- Summary of code changes for easier review. -->
Very simple implementation: because cursor popups can only be sent to a single player, the server does nothing in these methods and the client just calls its normal `PopupCursor` method.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:
<img width="561" alt="Screenshot 2025-04-17 at 12 36 58 PM" src="https://github.com/user-attachments/assets/a95818ef-5baf-47a9-ae74-6b237744e695" />

After:
<img width="561" alt="Screenshot 2025-04-17 at 12 35 08 PM" src="https://github.com/user-attachments/assets/f4759ef5-a13b-45de-a019-4f67f6c65bae" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->