### PR TITLE
Fix solution visualization after drawing with a whitelist

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
@@ -369,7 +369,7 @@ public sealed class InjectorSystem : SharedInjectorSystem
         var removedSolution = SolutionContainers.Draw(target.Owner, targetSolution, realTransferAmount);
 
         // Add back non-whitelisted reagents to the target solution
-        applicableTargetSolution.AddSolution(temporarilyRemovedSolution, null);
+        SolutionContainers.TryAddSolution(targetSolution, temporarilyRemovedSolution);
 
         if (!SolutionContainers.TryAddSolution(soln.Value, removedSolution))
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
In the whitelisted case, the SCM is updated for the solution when removing the non-whitelisted chemicals, but not after they are re-added, resulting in the visualization being incorrect. Call into the SCM to re-add the non-whitelisted chemicals to avoid the desynchronization between actual state and last updated appearance.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
