### PR TITLE
Make escape pods fail the "Maroon Target" objective

### DIFF
--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -51,7 +51,7 @@ public sealed class KillPersonConditionSystem : EntitySystem
             return 0f;
 
         // target is escaping so you fail
-        if (_emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value))
+        if (_emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value, false))
             return 0f;
 
         // evac has left without the target, greentext since the target is afk in space with a full oxygen tank and coordinates off.

--- a/Content.Server/Shuttles/Components/EscapePodComponent.cs
+++ b/Content.Server/Shuttles/Components/EscapePodComponent.cs
@@ -12,4 +12,10 @@ public sealed partial class EscapePodComponent : Component
     [DataField(customTypeSerializer:typeof(TimeOffsetSerializer))]
     [AutoPausedField]
     public TimeSpan? LaunchTime;
+
+    /// <summary>
+    /// Whether the pod has launched to CentComm or not.
+    /// </summary>
+    [DataField]
+    public bool Launched;
 }

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -191,7 +191,8 @@ public sealed partial class EmergencyShuttleSystem
             // Stagger launches coz funny
             while (podQuery.MoveNext(out _, out var pod))
             {
-                pod.LaunchTime = _timing.CurTime + TimeSpan.FromSeconds(_random.NextFloat(0.05f, 0.75f));
+                if (!pod.Launched)
+                    pod.LaunchTime = _timing.CurTime + TimeSpan.FromSeconds(_random.NextFloat(0.05f, 0.75f));
             }
         }
 
@@ -211,7 +212,7 @@ public sealed partial class EmergencyShuttleSystem
 
             // Don't dock them. If you do end up doing this then stagger launch.
             _shuttle.FTLToDock(uid, shuttle, centcomm.Entity.Value, hyperspaceTime: TransitTime);
-            RemCompDeferred<EscapePodComponent>(uid);
+            pod.Launched = true;
         }
 
         // Departed

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -642,7 +642,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
     /// <summary>
     /// Returns whether a target is escaping on the emergency shuttle, but only if evac has arrived.
     /// </summary>
-    public bool IsTargetEscaping(EntityUid target)
+    public bool IsTargetEscaping(EntityUid target, bool evacShuttleOnly = true)
     {
         // if evac isn't here then sitting in a pod doesn't return true
         if (!EmergencyShuttleArrived)
@@ -658,6 +658,18 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
             if (IsOnGrid(xform, stationData.EmergencyShuttle.Value))
             {
                 return true;
+            }
+        }
+
+        if (!evacShuttleOnly)
+        {
+            var query = AllEntityQuery<EscapePodComponent>();
+            while (query.MoveNext(out var podUid, out var _))
+            {
+                if (IsOnGrid(xform, podUid))
+                {
+                    return true;
+                }
             }
         }
 

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -661,10 +661,19 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
             }
         }
 
+        // check if they're on CentComm
+        var centcomms = GetCentcommMaps();
+        if (xform.MapUid != null && centcomms.Contains(xform.MapUid.Value))
+        {
+            return true;
+        }
+
+        // check if they're on a pod, if need be
         if (!evacShuttleOnly)
         {
-            var query = AllEntityQuery<EscapePodComponent>();
-            while (query.MoveNext(out var podUid, out var _))
+            var podQuery = AllEntityQuery<EscapePodComponent>();
+
+            while (podQuery.MoveNext(out var podUid, out var _))
             {
                 if (IsOnGrid(xform, podUid))
                 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR makes being on the escape pod *as a target* fail the maroon target objective for antags, in which you must kill or maroon your target.

Being on CentComm also counts as surviving - this doesn't change the roundend text, but keeps the objectives consistent post roundend.

Note! The escape pod does *not* count for the "Survive to CentComm" objective in this PR.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This should (hopefully) push players a bit more towards doing objectives on-station, as waiting for the evac shuttle and blindly throwing bombs into it is no longer going to be as reliable since the target may be on a pod instead. 

This PR doesn't change the survive objective for antags because that has a larger impact on how antags and Sec have to play during the end of the round and that requires extra design work, i.e. out of scope for this PR.

## Technical details
<!-- Summary of code changes for easier review. -->

Added a query for all entities with the `EscapePodComponent`, simple as that.

Previously the EscapePodComponent was removed upon launch (to prevent pods launching more than once somehow?), so now instead the component tracks if it has been launched or not.

## Steps to test

1. Spawn 3 clients on a station map with at least one escape pod
2. Make one traitor and give it `KillPersonObjective` until it has an objective for both other clients
3. Make one client go to an escape pod
4. Call evac with `dockemergencyshuttle` and launch it with `launchemergencyshuttle`
5. The objective for the client on the pod should count as failed, while the client remaining on the station should count as successful.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/4893ed29-2ff2-4a98-af3d-049985a1b45b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The "Kill/Maroon" objective now fails if the target is on an escape pod. 
- fix: Being at CentComm now counts as surviving post-roundend.