### PR TITLE
Add smart corgi prototype

### DIFF
--- a/Resources/Locale/en-US/datasets/names/corgi.ftl
+++ b/Resources/Locale/en-US/datasets/names/corgi.ftl
@@ -1,0 +1,9 @@
+names-corgi-1 = Ian but Smarter
+names-corgi-2 = Braindog
+names-corgi-3 = Speaks-In-Bork
+names-corgi-4 = Head of Pets
+names-corgi-5 = Hop's Best Friend
+names-corgi-6 = Super Corgi
+names-corgi-7 = Paws
+names-corgi-8 = Bingus
+names-corgi-9 = Bongus

--- a/Resources/Prototypes/Body/Parts/animal.yml
+++ b/Resources/Prototypes/Body/Parts/animal.yml
@@ -94,3 +94,28 @@
       - ReagentId: Blood
         Quantity: 20
 
+- type: entity
+  parent: PartAnimal
+  id: LeftHandSmartCorgi
+  name: corgi hand
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - state: l_hand
+  - type: BodyPart
+    partType: Hand
+    symmetry: Left
+
+- type: entity
+  parent: PartAnimal
+  id: RightHandSmartCorgi
+  name: corgi hand
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - state: r_hand
+  - type: BodyPart
+    partType: Hand
+    symmetry: Right

--- a/Resources/Prototypes/Body/Prototypes/Specific/smartcorgi.yml
+++ b/Resources/Prototypes/Body/Prototypes/Specific/smartcorgi.yml
@@ -1,0 +1,28 @@
+- type: body
+  id: smartcorgi
+  name: "corgi"
+  root: torso
+  slots:
+    torso:
+      part: TorsoAnimal
+      connections:
+      - righthand
+      - lefthand
+      - legs
+      organs:
+        brain: OrganHumanBrain # feels strange but it is what it is
+        lungs: OrganAnimalLungs
+        stomach: OrganAnimalStomach
+        liver: OrganAnimalLiver
+        heart: OrganAnimalHeart
+        kidneys: OrganAnimalKidneys
+    lefthand:
+      part: LeftHandSmartCorgi
+    righthand:
+      part: RightHandSmartCorgi
+    legs:
+      part: LegsAnimal
+      connections:
+      - feet
+    feet:
+      part: FeetAnimal

--- a/Resources/Prototypes/Datasets/Names/corgi.yml
+++ b/Resources/Prototypes/Datasets/Names/corgi.yml
@@ -1,0 +1,5 @@
+- type: localizedDataset
+  id: namescorgi
+  values:
+    prefix: names-corgi-
+    count: 9

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3633,3 +3633,90 @@
         Base: reindeer_doe_dead
       Dead:
         Base: reindeer_doe_dead
+
+- type: entity
+  parent: [SimpleMobBase, StripableInventoryBase]
+  id: MobSmartCorgi
+  name: smart corgi
+  description: An unusually smart dog.
+  components:
+  # Use corgi sprite, need to add handcuff layer
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Pets/corgi.rsi
+    layers:
+    - map: ["enum.DamageStateVisualLayers.Base"]
+      state: corgi
+    - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
+      color: "#ffffff"
+      sprite: Objects/Misc/handcuffs.rsi # Would do a custom dog handcuff sprite but unfortunately handcuffs have their overlay baked-in to the cuff itself so this is mostly filler
+      state: body-overlay-2
+      visible: false
+  - type: Physics
+  # Apply canine dog speech
+  - type: Speech
+    speechVerb: Canine
+    speechSounds: Dog
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.35
+        density: 50
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+  - type: UserInterface
+    interfaces:
+      enum.StrippingUiKey.Key:
+        type: StrippableBoundUserInterface
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+  # Custom inventory template
+  - type: Inventory
+    speciesId: dog
+    templateId: smartcorgi
+  - type: Hands # HANDS!
+  - type: Puller
+  - type: Cuffable # bad dog!
+  - type: BlockWriting # dogs can't write, paws unwieldy; mouth-writing is a myth
+  - type: Stripping
+  - type: ComplexInteraction
+  # Implement custom borgi body type
+  - type: Body
+    prototype: smartcorgi
+  - type: RotationVisuals
+    defaultRotation: 90
+    horizontalRotation: 180
+  - type: InteractionPopup
+    interactSuccessString: petting-success-dog
+    interactFailureString: petting-failure-generic
+    interactSuccessSpawn: EffectHearts
+    interactSuccessSound:
+      path: /Audio/Animals/small_dog_bark_happy.ogg
+  - type: Grammar
+    attributes:
+      gender: epicene # Gender neutral
+      proper: true
+  - type: SentienceTarget
+    flavorKind: station-event-random-sentience-flavor-corgi
+  - type: MobPrice
+    price: 200
+  - type: Tag
+    tags:
+    - VimPilot
+    - CanPilot
+    - AnomalyHost
+    - DoorBumpOpener
+  - type: Storage #Slime-type storage; probably replace if it's deemed sensible to let corgis wear regular bags, or if a custom 'dog bag' is made
+    clickInsert: false
+    grid:
+    - 0,0,3,3
+    maxItemSize: Huge
+  - type: StatusIcon # marks them as crew
+    bounds: -0.5,-0.5,0.5,0.5
+  - type: RandomMetadata
+    nameSegments:
+    - namescorgi

--- a/Resources/Prototypes/InventoryTemplates/smartcorgi_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/smartcorgi_inventory_template.yml
@@ -1,0 +1,67 @@
+# Borgi Inventory Template
+- type: inventoryTemplate
+  id: smartcorgi
+  slots:
+  - name: ears
+    slotTexture: ears
+    slotFlags: EARS
+    stripTime: 3
+    uiWindowPos: 2,2
+    strippingWindowPos: 2,0
+    displayName: Ears
+  - name: mask
+    slotTexture: mask
+    slotFlags: MASK
+    uiWindowPos: 0,2
+    strippingWindowPos: 1,2
+    displayName: Mask
+    whitelist:
+      tags:
+        - PetWearable
+  - name: suitstorage
+    slotTexture: suit_storage
+    slotFlags: SUITSTORAGE
+    stripTime: 3
+    uiWindowPos: 0,1
+    strippingWindowPos: 2,5
+    displayName: Suit Storage
+    whitelist:
+      components:
+        - GasTank
+  - name: id
+    slotTexture: id
+    fullTextureName: template_small
+    slotFlags: IDCARD
+    slotGroup: SecondHotbar
+    stripTime: 2
+    uiWindowPos: 2,1
+    strippingWindowPos: 2,4
+    displayName: ID
+  - name: outerClothing
+    slotTexture: suit
+    slotFlags: OUTERCLOTHING
+    stripTime: 6
+    uiWindowPos: 1,1
+    strippingWindowPos: 1,3
+    displayName: Suit
+    whitelist:
+      tags:
+        - CorgiWearable
+  - name: eyes
+    slotTexture: glasses
+    slotFlags: EYES
+    uiWindowPos: 1,2
+    strippingWindowPos: 1,1
+    displayName: Eyes
+    whitelist:
+      tags:
+        - CorgiWearable
+  - name: head
+    slotTexture: head
+    slotFlags: HEAD
+    uiWindowPos: 1,3
+    strippingWindowPos: 1,0
+    displayName: Head
+    whitelist:
+      tags:
+        - CorgiWearable

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -347,6 +347,9 @@
 - type: Tag
   id: CoordinatesDisk
 
+- type: Tag
+  id: CorgiWearable
+
 - type: Tag #Ohioans die happy
   id: Corn
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the 'smart corgi' prototype.  This is a prototype used in the 'borgi' admeme but properly distributed in the code files rather than in a single .yml file.  It forms the basis of borgis, and is a targeted prototype for a polymorph reagent in the admeme.
This 'smart corgi' can speak normally, has hands (two) and an ID slot.  It has a custom inventory template to allow it to wear certain items, including the range of pet gear (i.e. masks, gas tanks), and communication headsets, hats, and outerwear.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is originating from an admeme and I'm working on partially merging some of that admeme into main.  The prototype being PR'ed today has no organic means of being placed into the game with this PR alone; rather it adds it in the entity spawner and serves as a foundation for later PRs to add things like a polymorph reagent, clothing/outfits, and borgi protos, if any or all of those are deemed acceptable for merging.
As far as them **having hands** goes, this is a key part of the 'smart corgi' admeme bit.  The larger vision here is that I would like to have a corgi that can 'soft replace' a crew member.  It wouldn't be as capable:  they cannot wear shoes or gloves, they always slip on things, and they get cold a lot faster than normal.  Also, corgis with guns is pretty funny.
The proto as-is would also be usable in a future PR, if approved, that would allow players to create a 'corgi juice' type reagent, like weh juice, that would polymorph them into this prototype.  The specifics of that reagent would be covered in that PR, but suffice it to say I would like to allow players to use this prototype for play, given effort; and not be completely disabled in so-doing.

## Technical details
<!-- Summary of code changes for easier review. -->
A new tag has been added:  CorgiWearable.  It isn't implemented on any items on THIS PR, but a future PR that adds various clothing options (and sprites) will use this tag.  This is also a tag that is implemented in another pending PR to add support for displacement-mapped clothing: #33737 
A new inventoryTemplate has been added: smartcorgi.   This will be applied to this prototype and, if through design docs and later iteration they are wanted, borgis and derivatives.
A localizedDataset for RandomMetadata name generation for these corgis has been added.
Body parts and a body prototype to support this creature have also been added.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/cefa6a58-9d5d-45e6-a8a7-6fb15234cc56



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No player-facing changes in this PR; just a new spawnable entity and support for iteration.
