### PR TITLE
Nuke DoesCustomBoundsIntersectWithFixture

### DIFF
--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -446,11 +446,6 @@ public sealed class RCDSystem : EntitySystem
                     if (!fixture.Hard || fixture.CollisionLayer <= 0 || (fixture.CollisionLayer & (int) prototype.CollisionMask) == 0)
                         continue;
 
-                    // Continue if our custom collision bounds are not intersected
-                    if (prototype.CollisionPolygon != null &&
-                        !DoesCustomBoundsIntersectWithFixture(prototype.CollisionPolygon, component.ConstructionTransform, ent, fixture))
-                        continue;
-
                     // Collision was detected
                     if (popMsgs)
                         _popup.PopupClient(Loc.GetString("rcd-component-cannot-build-on-occupied-tile-message"), uid, user);
@@ -572,18 +567,6 @@ public sealed class RCDSystem : EntitySystem
 
                 break;
         }
-    }
-
-    #endregion
-
-    #region Utility functions
-
-    private bool DoesCustomBoundsIntersectWithFixture(PolygonShape boundingPolygon, Transform boundingTransform, EntityUid fixtureOwner, Fixture fixture)
-    {
-        var entXformComp = Transform(fixtureOwner);
-        var entXform = new Transform(new(), entXformComp.LocalRotation);
-
-        return boundingPolygon.ComputeAABB(boundingTransform, 0).Intersects(fixture.Shape.ComputeAABB(entXform, 0));
     }
 
     #endregion


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Takes the request quite literally.

Resolves #36665

## Technical details
I took DoesCustomBoundsIntersectWithFixture around back and beat it to death with a shovel.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

I don't believe so. The only use for this was just above in a collision check that seemed to do nothing most tile items won't collide anyway and items like wall lights will happily collide regardless.
