### PR TITLE
Prevent certain foldable items from being unfolded on structures

### DIFF
--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -277,7 +277,10 @@ public sealed partial class AnchorableSystem : EntitySystem
         return !attempt.Cancelled;
     }
 
-    private bool TileFree(EntityCoordinates coordinates, PhysicsComponent anchorBody)
+    /// <summary>
+    /// Returns true if no hard anchored entities exist on the coordinate tile that would collide with the provided physics body.
+    /// </summary>
+    public bool TileFree(EntityCoordinates coordinates, PhysicsComponent anchorBody)
     {
         // Probably ignore CanCollide on the anchoring body?
         var gridUid = _transformSystem.GetGrid(coordinates);

--- a/Content.Shared/Foldable/DeployFoldableSystem.cs
+++ b/Content.Shared/Foldable/DeployFoldableSystem.cs
@@ -1,7 +1,10 @@
+using Content.Shared.Construction.EntitySystems;
 using Content.Shared.DragDrop;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Robust.Shared.Physics.Components;
 
 namespace Content.Shared.Foldable;
 
@@ -9,6 +12,8 @@ public sealed class DeployFoldableSystem : EntitySystem
 {
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly FoldableSystem _foldable = default!;
+    [Dependency] private readonly AnchorableSystem _anchorable = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
@@ -56,6 +61,13 @@ public sealed class DeployFoldableSystem : EntitySystem
 
         if (!TryComp<FoldableComponent>(ent, out var foldable))
             return;
+
+        if (!TryComp(ent.Owner, out PhysicsComponent? anchorBody)
+            || !_anchorable.TileFree(args.ClickLocation, anchorBody))
+        {
+            _popup.PopupPredicted(Loc.GetString("foldable-deploy-fail", ("object", ent)), ent, args.User);
+            return;
+        }
 
         if (!TryComp(args.User, out HandsComponent? hands)
             || !_hands.TryDrop(args.User, args.Used, targetDropLocation: args.ClickLocation, handsComp: hands))

--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -1,9 +1,11 @@
-using Content.Shared.Body.Components;
 using Content.Shared.Buckle;
 using Content.Shared.Buckle.Components;
+using Content.Shared.Construction.EntitySystems;
+using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
@@ -15,6 +17,8 @@ public sealed class FoldableSystem : EntitySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedBuckleSystem _buckle = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly AnchorableSystem _anchorable = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
@@ -83,9 +87,17 @@ public sealed class FoldableSystem : EntitySystem
             args.Cancel();
     }
 
-    public bool TryToggleFold(EntityUid uid, FoldableComponent comp)
+    public bool TryToggleFold(EntityUid uid, FoldableComponent comp, EntityUid? folder = null)
     {
-        return TrySetFolded(uid, comp, !comp.IsFolded);
+        var result = TrySetFolded(uid, comp, !comp.IsFolded);
+        if (!result && folder != null)
+        {
+            if (comp.IsFolded)
+                _popup.PopupPredicted(Loc.GetString("foldable-unfold-fail", ("object", uid)), uid, folder.Value);
+            else
+                _popup.PopupPredicted(Loc.GetString("foldable-fold-fail", ("object", uid)), uid, folder.Value);
+        }
+        return result;
     }
 
     public bool CanToggleFold(EntityUid uid, FoldableComponent? fold = null)
@@ -95,6 +107,10 @@ public sealed class FoldableSystem : EntitySystem
 
         // Can't un-fold in any container unless enabled (locker, hands, inventory, whatever).
         if (_container.IsEntityInContainer(uid) && !fold.CanFoldInsideContainer)
+            return false;
+
+        if (!TryComp(uid, out PhysicsComponent? body) ||
+            !_anchorable.TileFree(Transform(uid).Coordinates, body))
             return false;
 
         var ev = new FoldAttemptEvent(fold);
@@ -121,12 +137,12 @@ public sealed class FoldableSystem : EntitySystem
 
     private void AddFoldVerb(EntityUid uid, FoldableComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract || args.Hands == null || !CanToggleFold(uid, component))
+        if (!args.CanAccess || !args.CanInteract || args.Hands == null)
             return;
 
         AlternativeVerb verb = new()
         {
-            Act = () => TryToggleFold(uid, component),
+            Act = () => TryToggleFold(uid, component, args.User),
             Text = component.IsFolded ? Loc.GetString(component.UnfoldVerbText) : Loc.GetString(component.FoldVerbText),
             Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/fold.svg.192dpi.png")),
 

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -855,7 +855,7 @@ namespace Content.Shared.Interaction
             {
                 // If the target is an item, we ignore any colliding entities. Currently done so that if items get stuck
                 // inside of walls, users can still pick them up.
-                ignored.UnionWith(_broadphase.GetEntitiesIntersectingBody(target, (int) collisionMask, false, physics));
+                ignored.UnionWith(_broadphase.GetEntitiesIntersectingBody(target, (int) collisionMask, false, physics)); // Note: This also bypasses items underneath doors, which may be problematic if it'd cause undesirable behavior.
             }
             else if (_wallMountQuery.TryComp(target, out var wallMount))
             {

--- a/Resources/Locale/en-US/foldable/components/foldable-component.ftl
+++ b/Resources/Locale/en-US/foldable/components/foldable-component.ftl
@@ -1,5 +1,8 @@
 # Foldable
 
+foldable-fold-fail = You can't fold the {$object} here.
+foldable-unfold-fail = You can't unfold the {$object} here.
+
 foldable-deploy-fail = You can't deploy the {$object} here.
 fold-verb = Fold
 unfold-verb = Unfold


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR prevents foldables from being deployed if it would cause physics collisions, relevant for foldable chairs, rollerbeds, bodybags etc.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This has some potential for abuse so it makes it harder.

Note that, like anchoring lockers, this makes it not possible to deploy on tiles with thin windows.

## Technical details
<!-- Summary of code changes for easier review. -->

Uses the check for anchored entities on the tile and checks if it would cause a physics collision. Also some pop-ups.

Ideally FoldableSystem should be refactored to be able to be used more generally, but that's a whole other can of beans.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Testing
1. Spawn a folding chair
2. Try to deploy it on a machine via leftclicking; it should not work
3. Drop it (Q) between two machines and try to unfold; you should get a pop-up that it does not work.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

No CL, pretty minor bugfix.