### PR TITLE
fixing spessman getting teleported inside artifact

### DIFF
--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPortalSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPortalSystem.cs
@@ -1,13 +1,15 @@
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Teleportation.Systems;
+using Content.Shared.Xenoarchaeology.Artifact;
+using Content.Shared.Xenoarchaeology.Artifact.XAE;
 using Content.Shared.Xenoarchaeology.Artifact.XAE.Components;
 using Robust.Shared.Collections;
 using Robust.Shared.Containers;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
-namespace Content.Shared.Xenoarchaeology.Artifact.XAE;
+namespace Content.Server.Xenoarchaeology.Artifact.XAE;
 
 /// <summary>
 /// System for xeno artifact effect that creates temporary portal between places on station.
@@ -41,16 +43,14 @@ public sealed class XAEPortalSystem : BaseXAESystem<XAEPortalComponent>
         if (validMinds.Count == 0)
             return;
 
-        var offset = _random.NextVector2(2, 3);
-        var originWithOffset = args.Coordinates.Offset(offset);
-        var firstPortal = Spawn(ent.Comp.PortalProto, originWithOffset);
+        var firstPortal = Spawn(ent.Comp.PortalProto, args.Coordinates);
 
         var target = _random.Pick(validMinds);
-
-        var secondPortal = Spawn(ent.Comp.PortalProto, _transform.GetMapCoordinates(target));
+        var targetCoordinates = _transform.GetMapCoordinates(target);
+        var secondPortal = Spawn(ent.Comp.PortalProto, targetCoordinates);
 
         // Manual position swapping, because the portal that opens doesn't trigger a collision, and doesn't teleport targets the first time.
-        _transform.SwapPositions(target, ent.Owner);
+        _transform.SwapPositions(target, args.Artifact.Owner);
 
         _link.TryLink(firstPortal, secondPortal, true);
     }

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/Components/XAEPortalComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/Components/XAEPortalComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Xenoarchaeology.Artifact.XAE.Components;
 /// <summary>
 ///     When activated artifact will spawn a pair of portals. First - right in artifact, Second - at random point of station.
 /// </summary>
-[RegisterComponent, Access(typeof(XAEPortalSystem)), NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class XAEPortalComponent : Component
 {
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Xeno artifact effect of teleport should swap places of spessman and artifact, not spessman and artifact node.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfix

## Technical details
<!-- Summary of code changes for easier review. -->
code is self explainin

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Fildrance
- fix: fixed spessman getting stuck after unlocking portal node