### PR TITLE
cleanup RingerSystem

### DIFF
--- a/Content.Client/PDA/Ringer/RingerSystem.cs
+++ b/Content.Client/PDA/Ringer/RingerSystem.cs
@@ -33,24 +33,4 @@ public sealed class RingerSystem : SharedRingerSystem
             bui.Update();
         }
     }
-
-    /// <inheritdoc/>
-    public override bool TryToggleUplink(EntityUid uid, Note[] ringtone, EntityUid? user = null)
-    {
-        if (!TryComp<RingerUplinkComponent>(uid, out var uplink))
-            return false;
-
-        if (!HasComp<StoreComponent>(uid))
-            return false;
-
-        // Special case for client-side prediction:
-        // Since we can't expose the uplink code to clients for security reasons,
-        // we assume if an antagonist is trying to set a ringtone, it's to unlock the uplink.
-        // The server will properly verify the code and correct if needed.
-        if (IsAntagonist(user))
-            return ToggleUplinkInternal((uid, uplink));
-
-        // Non-antagonists never get to toggle the uplink on the client
-        return false;
-    }
 }

--- a/Content.Shared/PDA/SharedRingerSystem.cs
+++ b/Content.Shared/PDA/SharedRingerSystem.cs
@@ -145,16 +145,18 @@ public abstract class SharedRingerSystem : EntitySystem
 
     /// <summary>
     /// Attempts to unlock or lock the uplink by checking the provided ringtone against the uplink code.
-    /// On the client side, for antagonists, the code check is skipped to support prediction.
-    /// On the server side, the code is always verified.
+    /// On the client side, it does nothing since the client cannot know the code in advance.
+    /// On the server side, the code is verified.
     /// </summary>
     /// <param name="uid">The entity with the RingerUplinkComponent.</param>
     /// <param name="ringtone">The ringtone to check against the uplink code.</param>
-    /// <param name="user">The entity attempting to toggle the uplink. If the user is an antagonist,
-    /// the ringtone code check will be skipped on the client to allow prediction.</param>
+    /// <param name="user">The entity attempting to toggle the uplink.</param>
     /// <returns>True if the uplink state was toggled, false otherwise.</returns>
     [PublicAPI]
-    public abstract bool TryToggleUplink(EntityUid uid, Note[] ringtone, EntityUid? user = null);
+    public virtual bool TryToggleUplink(EntityUid uid, Note[] ringtone, EntityUid? user = null)
+    {
+        return false;
+    }
 
     #endregion
 


### PR DESCRIPTION
## About the PR
Follow up to https://github.com/space-wizards/space-station-14/pull/35907
Milon ignored my review and self-merged 😢 

## Why / Balance
cleanup

## Technical details
The old code was predicting unlocking the uplink clientside depending on if you were a traitor or not:
- It didn't even check the ringtone combination (which the client doesn't know)
- it didn't even check the type of antag, so it will mispredict if any antagonist sets the ringtone
I would rather have it not predicted at all than unintentionally to show the uplink in weird mispredicts like this.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
none
