### PR TITLE
Convert `NameIdentifier` to use `NameModifierSystem`

### DIFF
--- a/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
+++ b/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
@@ -1,6 +1,7 @@
 using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Controls;
 using Content.Shared.NameIdentifier;
+using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Preferences;
 using Content.Shared.Silicons.Borgs;
 using Content.Shared.Silicons.Borgs.Components;
@@ -15,6 +16,7 @@ namespace Content.Client.Silicons.Borgs;
 public sealed partial class BorgMenu : FancyWindow
 {
     [Dependency] private readonly IEntityManager _entity = default!;
+    private readonly NameModifierSystem _nameModifier;
 
     public Action? BrainButtonPressed;
     public Action? EjectBatteryButtonPressed;
@@ -31,6 +33,8 @@ public sealed partial class BorgMenu : FancyWindow
     {
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
+
+        _nameModifier = _entity.System<NameModifierSystem>();
 
         _lastValidName = NameLineEdit.Text;
 
@@ -54,9 +58,7 @@ public sealed partial class BorgMenu : FancyWindow
             NameIdentifierLabel.Visible = true;
             NameIdentifierLabel.Text = nameIdentifierComponent.FullIdentifier;
 
-            var fullName = _entity.GetComponent<MetaDataComponent>(Entity).EntityName;
-            var name = fullName.Substring(0, fullName.Length - nameIdentifierComponent.FullIdentifier.Length - 1);
-            NameLineEdit.Text = name;
+            NameLineEdit.Text = _nameModifier.GetBaseName(entity);
         }
         else
         {

--- a/Content.Server/Silicons/Borgs/BorgSystem.Ui.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Ui.cs
@@ -62,8 +62,6 @@ public sealed partial class BorgSystem
         }
 
         var name = args.Name.Trim();
-        if (TryComp<NameIdentifierComponent>(uid, out var identifier))
-            name = $"{name} {identifier.FullIdentifier}";
 
         var metaData = MetaData(uid);
 

--- a/Resources/Locale/en-US/name-identifier/name-identifier.ftl
+++ b/Resources/Locale/en-US/name-identifier/name-identifier.ftl
@@ -1,0 +1,2 @@
+name-identifier-format-append = {$baseName} {$identifier}
+name-identifier-format-full = {$identifier}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`NameIdentifier` now uses `NameModifierSystem` to add its identifier to the entity's name.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/36679.
This also makes it easier to add and remove identifiers from entities cleanly, and removes the need for some slightly-funky string manipulation in the borg UI.
This may make it possible to add an identifier to the AI as well, but I haven't actually tried that out.

## Technical details
<!-- Summary of code changes for easier review. -->
- `NameIdentifierSystem` no longer directly alters the name of the entity it's on. Instead, it subscribes to the `RefreshNameModifiers` event and adds the identifier as a modifier.
- The borg UI code was altered to get the borg's base name using `NameModifierSystem.GetBaseName` instead of trying to get it by taking a substring of the entity name (which could fail and throw an exception if the name had been made short enough).
- The logic for applying the identifier to the entity name now uses the localization system, because `NameModifierSystem` wants a LocId (and it's better that way anyway).

## Note to Admins
Due to this change, renaming an entity with an identifier will preserve the identifier in the name. For example, renaming "mouse (624)" to "Bubba the Great" will produce "Bubba the Great (624)". If you want to remove the identifier, simply remove the `NameIdentifier` component from the entity.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Borg UI functioning with a changed name:
<img width="656" alt="Screenshot 2025-04-19 at 12 38 16 PM" src="https://github.com/user-attachments/assets/ea517f9b-392a-4419-8586-25c4d3726472" />
<img width="656" alt="Screenshot 2025-04-19 at 12 38 31 PM" src="https://github.com/user-attachments/assets/31b7681e-cea1-4852-84f8-78ea5f557df9" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`NameIdentifier` is now applied as a name modifier. If you need to get an entity's base name (without the identifier), use `NameModifierSystem.GetBaseName`.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Not player-facing.