### PR TITLE
Fix ore silo clients showing up when out of range

### DIFF
--- a/Content.Server/Materials/OreSiloSystem.cs
+++ b/Content.Server/Materials/OreSiloSystem.cs
@@ -39,6 +39,10 @@ public sealed class OreSiloSystem : SharedOreSiloSystem
             if (client.Comp.Silo is not null)
                 continue;
 
+            // Don't show clients on the screen if we can't link them.
+            if (!CanTransmitMaterials((ent, ent, xform), client))
+                continue;
+
             var netEnt = GetNetEntity(client);
             var name = Identity.Name(client, EntityManager);
             var beacon = _navMap.GetNearestBeaconString(client.Owner, onlyName: true);
@@ -58,7 +62,7 @@ public sealed class OreSiloSystem : SharedOreSiloSystem
             var netEnt = GetNetEntity(client);
             var name = Identity.Name(client, EntityManager);
             var beacon = _navMap.GetNearestBeaconString(client, onlyName: true);
-            var inRange = CanTransmitMaterials((ent, ent), client);
+            var inRange = CanTransmitMaterials((ent, ent, xform), client);
 
             var txt = Loc.GetString("ore-silo-ui-itemlist-entry",
                 ("name", name),

--- a/Content.Shared/Materials/OreSilo/SharedOreSiloSystem.cs
+++ b/Content.Shared/Materials/OreSilo/SharedOreSiloSystem.cs
@@ -149,9 +149,9 @@ public abstract class SharedOreSiloSystem : EntitySystem
     /// Checks if a given client fulfills the criteria to link/receive materials from an ore silo.
     /// </summary>
     [PublicAPI]
-    public bool CanTransmitMaterials(Entity<OreSiloComponent?> silo, EntityUid client)
+    public bool CanTransmitMaterials(Entity<OreSiloComponent?, TransformComponent?> silo, EntityUid client)
     {
-        if (!Resolve(silo, ref silo.Comp))
+        if (!Resolve(silo, ref silo.Comp1, ref silo.Comp2))
             return false;
 
         if (!_powerReceiver.IsPowered(silo.Owner))
@@ -160,7 +160,7 @@ public abstract class SharedOreSiloSystem : EntitySystem
         if (_transform.GetGrid(client) != _transform.GetGrid(silo.Owner))
             return false;
 
-        if (!_transform.InRange(silo.Owner, client, silo.Comp.Range))
+        if (!_transform.InRange((silo.Owner, silo.Comp2), client, silo.Comp1.Range))
             return false;
 
         return true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
fixes micro bug where the lookup grabs something slightly out of range.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
n/a
## Technical details
<!-- Summary of code changes for easier review. -->
n/a
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun