### PR TITLE
Add one word to the dragon summon announcement

### DIFF
--- a/Resources/Locale/en-US/communications/terror.ftl
+++ b/Resources/Locale/en-US/communications/terror.ftl
@@ -1,2 +1,2 @@
-terror-dragon = Attention crew, it appears that someone on your station has made an unexpected communication with a strange fish in nearby space.
+terror-dragon = Attention crew, it appears that someone on your station has made an unexpected communication with a strange man-eating fish in nearby space.
 terror-revenant = Attention crew, it appears that someone on your station has made an unexpected communication with an otherworldly energy in nearby space.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I added "Man-eating" to the the message that is announced when a dragon is summoned, so its now "Attention crew, it appears that someone on your station has made an unexpected communication with a strange man-eating fish in nearby space.".

## Why / Balance
The announcement always reacted to by people yelling DRAGON!!!!! or ARM UP!!!, but it doesn't feel fitting to do so based on the vague "strange fish" that is announced. I think just adding man-eating keeps it vague and makes it threatening, and also the idea of a man-eating fish is funny. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
no cl!!!
