### PR TITLE
New Spawners, Modified Spawners, new Service/Theatre Airlock, and new Colorful Light Crate

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
@@ -29,6 +29,16 @@
   group: market
 
 - type: cargoProduct
+  id: ServiceLightsColorful
+  icon:
+    sprite: Objects/Power/light_bulb.rsi
+    state: normal
+  product: CrateServiceColorfulLights
+  cost: 800
+  category: cargoproduct-category-name-service
+  group: market
+
+- type: cargoProduct
   id: MousetrapBoxes
   icon:
     sprite: Objects/Devices/mousetrap.rsi
@@ -217,5 +227,3 @@
   cost: 500
   category: cargoproduct-category-name-service
   group: market
-
-

--- a/Resources/Prototypes/Catalog/Fills/Boxes/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/service.yml
@@ -38,3 +38,43 @@
     guides:
     - Botanical
     - Chemicals
+
+- type: entity
+  parent: BoxLightbulb
+  id: BoxLightbulbColorfulMixed
+  name: mixed colorful lightbulb box
+  components:
+  - type: StorageFill
+    contents:
+      - id: LightBulbCrystalCyan
+        amount: 2
+      - id: LightBulbCrystalBlue
+        amount: 2
+      - id: LightBulbCrystalGreen
+        amount: 2
+      - id: LightBulbCrystalPink
+        amount: 2
+      - id: LightBulbCrystalRed
+        amount: 2
+      - id: LightBulbCrystalOrange
+        amount: 2
+
+- type: entity
+  parent: BoxLighttube
+  id: BoxLighttubeColorfulMixed
+  name: mixed colorful lighttube box
+  components:
+  - type: StorageFill
+    contents:
+      - id: LightTubeCrystalCyan
+        amount: 2
+      - id: LightTubeCrystalBlue
+        amount: 2
+      - id: LightTubeCrystalGreen
+        amount: 2
+      - id: LightTubeCrystalPink
+        amount: 2
+      - id: LightTubeCrystalRed
+        amount: 2
+      - id: LightTubeCrystalOrange
+        amount: 2

--- a/Resources/Prototypes/Catalog/Fills/Boxes/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/service.yml
@@ -46,18 +46,18 @@
   components:
   - type: StorageFill
     contents:
-      - id: LightBulbCrystalCyan
-        amount: 2
-      - id: LightBulbCrystalBlue
-        amount: 2
-      - id: LightBulbCrystalGreen
-        amount: 2
-      - id: LightBulbCrystalPink
-        amount: 2
-      - id: LightBulbCrystalRed
-        amount: 2
-      - id: LightBulbCrystalOrange
-        amount: 2
+    - id: LightBulbCrystalCyan
+      amount: 2
+    - id: LightBulbCrystalBlue
+      amount: 2
+    - id: LightBulbCrystalGreen
+      amount: 2
+    - id: LightBulbCrystalPink
+      amount: 2
+    - id: LightBulbCrystalRed
+      amount: 2
+    - id: LightBulbCrystalOrange
+      amount: 2
 
 - type: entity
   parent: BoxLighttube
@@ -66,15 +66,15 @@
   components:
   - type: StorageFill
     contents:
-      - id: LightTubeCrystalCyan
-        amount: 2
-      - id: LightTubeCrystalBlue
-        amount: 2
-      - id: LightTubeCrystalGreen
-        amount: 2
-      - id: LightTubeCrystalPink
-        amount: 2
-      - id: LightTubeCrystalRed
-        amount: 2
-      - id: LightTubeCrystalOrange
-        amount: 2
+    - id: LightTubeCrystalCyan
+      amount: 2
+    - id: LightTubeCrystalBlue
+      amount: 2
+    - id: LightTubeCrystalGreen
+      amount: 2
+    - id: LightTubeCrystalPink
+      amount: 2
+    - id: LightTubeCrystalRed
+      amount: 2
+    - id: LightTubeCrystalOrange
+      amount: 2

--- a/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
@@ -228,6 +228,8 @@
     - id: SignalTimerElectronics
     - id: SMESMachineCircuitboard
     - id: SubstationMachineCircuitboard
+    - id: BorgChargerCircuitboard
+    - id: CellRechargerCircuitboard
     - id: SpaceVillainArcadeComputerCircuitboard
     - id: BlockGameArcadeComputerCircuitboard
 
@@ -242,4 +244,4 @@
       entity_storage: !type:NestedSelector
         tableId: RandomTechBoardTable
         rolls: !type:RangeNumberSelector
-          range: 3, 7
+          range: 6, 8

--- a/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
@@ -149,9 +149,7 @@
       entity_storage: !type:NestedSelector
         tableId: RandomMaterialCrateTable
         rolls: !type:RangeNumberSelector
-          range: 1, 3
-          # for some reason, the selector here adds 1 to whatever value it generates,
-          # so this is actually 2-4
+          range: 2, 4
 
 - type: entity
   id: CrateMaterialSilo

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -370,5 +370,5 @@
   components:
   - type: StorageFill
     contents:
-      - id: BoxLightbulbColorfulMixed
-      - id: BoxLighttubeColorfulMixed
+    - id: BoxLightbulbColorfulMixed
+    - id: BoxLighttubeColorfulMixed

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -361,3 +361,14 @@
         amount: 2
       - id: BoxCandleSmall
         amount: 2
+
+- type: entity
+  parent: CrateGenericSteel
+  id: CrateServiceColorfulLights
+  name: colorful lights crate
+  description: It's not a party until it's hard to see, a little disorienting, and your ears hurt.
+  components:
+  - type: StorageFill
+    contents:
+      - id: BoxLightbulbColorfulMixed
+      - id: BoxLighttubeColorfulMixed

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/cables.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/cables.yml
@@ -1,0 +1,61 @@
+- type: entity
+  id: RandomCableHVSpawner
+  name: HV power cable spawner
+  parent: MarkerBase
+  suffix: 50%
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Structures/Power/Cables/hv_cable.rsi
+        state: hvcable_3
+      - sprite: Structures/Power/Cables/hv_cable.rsi
+        state: hvcable_12
+  - type: RandomSpawner
+    prototypes:
+      - CableHV
+    chance: 0.5
+
+- type: entity
+  id: RandomCableMVSpawner
+  name: MV power cable spawner
+  parent: MarkerBase
+  suffix: 50%
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Structures/Power/Cables/mv_cable.rsi
+        state: mvcable_3
+        color: Yellow
+      - sprite: Structures/Power/Cables/mv_cable.rsi
+        state: mvstripes_3
+      - sprite: Structures/Power/Cables/mv_cable.rsi
+        state: mvcable_12
+        color: Yellow
+      - sprite: Structures/Power/Cables/mv_cable.rsi
+        state: mvstripes_12
+  - type: RandomSpawner
+    prototypes:
+      - CableMV
+    chance: 0.5
+
+- type: entity
+  id: RandomCableApcExtensionSpawner
+  name: LV power cable spawner
+  parent: MarkerBase
+  suffix: 50%
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Structures/Power/Cables/lv_cable.rsi
+        state: lvcable_3
+        color: Green
+      - sprite: Structures/Power/Cables/lv_cable.rsi
+        state: lvcable_12
+        color: Green
+  - type: RandomSpawner
+    prototypes:
+      - CableApcExtension
+    chance: 0.5

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/cables.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/cables.yml
@@ -1,60 +1,60 @@
 - type: entity
+  parent: MarkerBase
   id: RandomCableHVSpawner
   name: HV power cable spawner
-  parent: MarkerBase
   suffix: 50%
   components:
   - type: Sprite
     layers:
-      - state: red
-      - sprite: Structures/Power/Cables/hv_cable.rsi
-        state: hvcable_3
-      - sprite: Structures/Power/Cables/hv_cable.rsi
-        state: hvcable_12
+    - state: red
+    - sprite: Structures/Power/Cables/hv_cable.rsi
+      state: hvcable_3
+    - sprite: Structures/Power/Cables/hv_cable.rsi
+      state: hvcable_12
   - type: RandomSpawner
     prototypes:
-      - CableHV
+    - CableHV
     chance: 0.5
 
 - type: entity
+  parent: MarkerBase
   id: RandomCableMVSpawner
   name: MV power cable spawner
-  parent: MarkerBase
   suffix: 50%
   components:
   - type: Sprite
     layers:
-      - state: red
-      - sprite: Structures/Power/Cables/mv_cable.rsi
-        state: mvcable_3
-        color: Yellow
-      - sprite: Structures/Power/Cables/mv_cable.rsi
-        state: mvstripes_3
-      - sprite: Structures/Power/Cables/mv_cable.rsi
-        state: mvcable_12
-        color: Yellow
-      - sprite: Structures/Power/Cables/mv_cable.rsi
-        state: mvstripes_12
+    - state: red
+    - sprite: Structures/Power/Cables/mv_cable.rsi
+      state: mvcable_3
+      color: Yellow
+    - sprite: Structures/Power/Cables/mv_cable.rsi
+      state: mvstripes_3
+    - sprite: Structures/Power/Cables/mv_cable.rsi
+      state: mvcable_12
+      color: Yellow
+    - sprite: Structures/Power/Cables/mv_cable.rsi
+      state: mvstripes_12
   - type: RandomSpawner
     prototypes:
-      - CableMV
+    - CableMV
     chance: 0.5
 
 - type: entity
+  parent: MarkerBase
   id: RandomCableApcExtensionSpawner
   name: LV power cable spawner
-  parent: MarkerBase
   suffix: 50%
   components:
   - type: Sprite
     layers:
-      - state: red
-      - sprite: Structures/Power/Cables/lv_cable.rsi
-        state: lvcable_3
-        color: Green
-      - sprite: Structures/Power/Cables/lv_cable.rsi
-        state: lvcable_12
-        color: Green
+    - state: red
+    - sprite: Structures/Power/Cables/lv_cable.rsi
+      state: lvcable_3
+      color: Green
+    - sprite: Structures/Power/Cables/lv_cable.rsi
+      state: lvcable_12
+      color: Green
   - type: RandomSpawner
     prototypes:
       - CableApcExtension

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/crates.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/crates.yml
@@ -24,6 +24,144 @@
     chance: 0.7
     offset: 0.0
 
+- type: entityTable
+  id: LowValueInstrumentCrateTable
+  table: !type:GroupSelector
+    children:
+    - id: CrateFunInstrumentsVariety
+    - id: CrateFunInstrumentsBrass
+    - id: CrateFunInstrumentsString
+    - id: CrateFunInstrumentsWoodwind
+    - id: CrateFunInstrumentsKeyedPercussion
+    - id: CrateFunInstrumentsSpecial
+      weight: 0.01
+    - id: CrateFunSadTromboneImplants
+      weight: 0.01
+
+- type: entityTable
+  id: LowValueFunCrateTable
+  table: !type:GroupSelector
+    children:
+    - id: CrateFunPlushie
+      weight: 2
+    - id: CrateFunLizardPlushieBulk
+    - id: CrateFunSharkPlushieBulk
+    - id: CrateCandles
+    - id: CrateFunArtSupplies
+    - id: CrateFunFoamGuns
+      weight: 0.01
+
+- type: entityTable
+  id: LowValueMaterialCrateTable
+  table: !type:GroupSelector
+    children:
+    - id: CrateMaterialGlass
+    - id: CrateMaterialSteel
+    - id: CrateMaterialPlastic
+    - id: CrateMaterialWood
+    - id: CrateMaterialPlasteel
+    - id: CrateMaterialBasicResource
+    - id: CrateMaterialRandom
+      weight: 4
+
+- type: entityTable
+  id: LowValueEmergencyCrateTable
+  table: !type:GroupSelector
+    children:
+    - id: CrateEmergencyFire
+    - id: CrateEmergencyInternals
+    - id: CrateEmergencyInflatablewall
+      weight: 0.2
+
+- type: entityTable
+  id: LowValueServiceCrateTable
+  table: !type:GroupSelector
+    children:
+    - id: CrateServiceColorfulLights
+    - id: CrateServiceReplacementLights
+    - id: CrateServiceBureaucracy
+    - id: PetCarrier
+    - id: CrateHydroponicsTools
+    - id: CrateHydroponicsSeeds
+    - id: CrateHydroponicsSeedsExotic
+      weight: 0.5
+    - id: CrateHydroponicsSeedsMedicinal
+      weight: 0.5
+    - id: CrateServiceJanitorialSupplies
+    - id: JanitorialTrolley
+      weight: 0.2
+
+- type: entityTable
+  id: LowValueEngineeringCrateTable
+  table: !type:GroupSelector
+    children:
+    - id: CrateEngineeringCableLV
+    - id: CrateEngineeringCableMV
+    - id: CrateEngineeringCableHV
+    - id: CrateEngineeringCableBulk
+    - id: CrateTechBoardRandom
+    - id: CrateEngineeringSpaceHeater
+    - id: StorageCanister
+      weight: 0.2
+
+- type: entityTable
+  id: LowValueMedicalCrateTable
+  table: !type:GroupSelector
+    children:
+    - id: CrateEmergencyBurnKit
+    - id: CrateEmergencyToxinKit
+    - id: CrateEmergencyBruteKit
+    - id: CrateEmergencyO2Kit
+    - id: CrateEmergencyRadiationKit
+    - id: CrateBodyBags
+    - id: CrateChemistrySupplies
+    - id: CrateChemistryP
+      weight: 0.2
+    - id: CrateChemistryS
+      weight: 0.2
+    - id: CrateChemistryD
+      weight: 0.2
+
+- type: entityTable
+  id: LowValueScienceCrateTable
+  table: !type:GroupSelector
+    children:
+    - id: CrateArtifactContainer
+    - id: HandheldArtifactContainer
+      weight: 0.2
+    - id: CrateMaterialPlasma
+      weight: 0.2
+
+- type: entityTable
+  id: LowValueCrateTable
+  table: !type:GroupSelector
+    children:
+    - !type:GroupSelector
+      children:
+      - !type:NestedSelector
+        tableId: LowValueFunCrateTable
+      - !type:NestedSelector
+        tableId: LowValueInstrumentCrateTable
+        weight: 0.2
+      - !type:NestedSelector
+        tableId: LowValueMaterialCrateTable
+        weight: 2
+      - !type:NestedSelector
+        tableId: LowValueEmergencyCrateTable
+      - !type:NestedSelector
+        tableId: LowValueServiceCrateTable
+      - !type:NestedSelector
+        tableId: LowValueEngineeringCrateTable
+      - !type:NestedSelector
+        tableId: LowValueMedicalCrateTable
+        weight: 0.2
+      - !type:NestedSelector
+        tableId: LowValueScienceCrateTable
+        weight: 0.2
+      weight: 80
+    - !type:NoneSelector
+      weight: 20
+
 - type: entity
   name: Filled Crate Spawner
   id: CrateFilledSpawner
@@ -35,34 +173,9 @@
     - state: red
     - sprite: Structures/Storage/Crates/o2.rsi
       state: icon
-  - type: RandomSpawner
-    prototypes:
-    - CrateServiceReplacementLights
-    - CrateServiceBureaucracy
-    - CrateChemistrySupplies
-    - CrateMaterialGlass
-    - CrateMaterialSteel
-    - CrateMaterialPlastic
-    - CrateMaterialWood
-    - CrateMaterialPlasteel
-    - CrateMaterialRandom
-    - CrateFunArtSupplies
-    - CrateEngineeringCableLV
-    - CrateEngineeringCableMV
-    - CrateEngineeringCableHV
-    - CrateEngineeringCableBulk
-    - CrateTechBoardRandom
-    - CrateEmergencyFire
-    - CrateEmergencyInternals
-    - CrateEmergencyInflatablewall
-    - CrateHydroponicsTools
-    - CrateHydroponicsSeeds
-    - PetCarrier
-    chance: 0.7
-    rarePrototypes:
-    - CrateMaterialPlasma
-    - CrateHydroponicsSeedsExotic
-    rareChance: 0.1
+  - type: EntityTableSpawner
+    table: !type:NestedSelector
+      tableId: LowValueCrateTable
     offset: 0.0
 
 - type: entity
@@ -138,4 +251,31 @@
     - CrateEmergencyExplosive
     - CrateSecurityBiosuit
     chance: 0.9
+    offset: 0.0
+
+- type: entityTable
+  id: LockboxTable
+  table: !type:GroupSelector
+    children:
+    - id: CrateLockBoxEngineering
+    - id: CrateLockBoxMedical
+    - id: CrateLockBoxSecurity
+    - id: CrateLockBoxScience
+    - id: CrateLockBoxService
+    - !type:NoneSelector
+
+- type: entity
+  name: random lockbox spawner
+  id: LootSpawnerRandomLockbox
+  parent: MarkerBase
+  suffix: 90%
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures/Storage/Crates/lockbox.rsi
+      state: icon
+  - type: EntityTableSpawner
+    table: !type:NestedSelector
+      tableId: LockboxTable
     offset: 0.0

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/crates.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/crates.yml
@@ -71,7 +71,7 @@
     - id: CrateEmergencyFire
     - id: CrateEmergencyInternals
     - id: CrateEmergencyInflatablewall
-      weight: 0.2
+      weight: 0.5
 
 - type: entityTable
   id: LowValueServiceCrateTable
@@ -102,7 +102,7 @@
     - id: CrateTechBoardRandom
     - id: CrateEngineeringSpaceHeater
     - id: StorageCanister
-      weight: 0.2
+      weight: 0.5
 
 - type: entityTable
   id: LowValueMedicalCrateTable
@@ -116,11 +116,11 @@
     - id: CrateBodyBags
     - id: CrateChemistrySupplies
     - id: CrateChemistryP
-      weight: 0.2
+      weight: 0.5
     - id: CrateChemistryS
-      weight: 0.2
+      weight: 0.5
     - id: CrateChemistryD
-      weight: 0.2
+      weight: 0.5
 
 - type: entityTable
   id: LowValueScienceCrateTable
@@ -130,7 +130,6 @@
     - id: HandheldArtifactContainer
       weight: 0.2
     - id: CrateMaterialPlasma
-      weight: 0.2
 
 - type: entityTable
   id: LowValueCrateTable

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/crates.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/crates.yml
@@ -135,31 +135,26 @@
   id: LowValueCrateTable
   table: !type:GroupSelector
     children:
-    - !type:GroupSelector
-      children:
-      - !type:NestedSelector
-        tableId: LowValueFunCrateTable
-      - !type:NestedSelector
-        tableId: LowValueInstrumentCrateTable
-        weight: 0.2
-      - !type:NestedSelector
-        tableId: LowValueMaterialCrateTable
-        weight: 2
-      - !type:NestedSelector
-        tableId: LowValueEmergencyCrateTable
-      - !type:NestedSelector
-        tableId: LowValueServiceCrateTable
-      - !type:NestedSelector
-        tableId: LowValueEngineeringCrateTable
-      - !type:NestedSelector
-        tableId: LowValueMedicalCrateTable
-        weight: 0.2
-      - !type:NestedSelector
-        tableId: LowValueScienceCrateTable
-        weight: 0.2
-      weight: 80
-    - !type:NoneSelector
-      weight: 20
+    - !type:NestedSelector
+      tableId: LowValueFunCrateTable
+    - !type:NestedSelector
+      tableId: LowValueInstrumentCrateTable
+      weight: 0.2
+    - !type:NestedSelector
+      tableId: LowValueMaterialCrateTable
+      weight: 2
+    - !type:NestedSelector
+      tableId: LowValueEmergencyCrateTable
+    - !type:NestedSelector
+      tableId: LowValueServiceCrateTable
+    - !type:NestedSelector
+      tableId: LowValueEngineeringCrateTable
+    - !type:NestedSelector
+      tableId: LowValueMedicalCrateTable
+      weight: 0.2
+    - !type:NestedSelector
+      tableId: LowValueScienceCrateTable
+      weight: 0.2
 
 - type: entity
   name: Filled Crate Spawner
@@ -175,6 +170,7 @@
   - type: EntityTableSpawner
     table: !type:NestedSelector
       tableId: LowValueCrateTable
+      prob: 0.8
     offset: 0.0
 
 - type: entity
@@ -261,7 +257,6 @@
     - id: CrateLockBoxSecurity
     - id: CrateLockBoxScience
     - id: CrateLockBoxService
-    - !type:NoneSelector
 
 - type: entity
   name: random lockbox spawner
@@ -277,4 +272,5 @@
   - type: EntityTableSpawner
     table: !type:NestedSelector
       tableId: LockboxTable
+      prob: 0.9
     offset: 0.0

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
@@ -104,6 +104,14 @@
   - type: AccessReader
     access: [["Service"]]
 
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsServiceTheatre
+  suffix: Service, Theatre, Locked
+  components:
+  - type: AccessReader
+    access: [["Service"], ["Theatre"]]
+
 # Cargo
 - type: entity
   parent: DoorElectronics

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -30,6 +30,15 @@
 
 - type: entity
   parent: AirlockServiceLocked
+  id: AirlockServiceTheatreLocked
+  suffix: Service, Theatre, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsServiceTheatre ]
+
+- type: entity
+  parent: AirlockServiceLocked
   id: AirlockChapelLocked
   suffix: Chapel, Locked
   components:
@@ -469,6 +478,15 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsTheatre ]
+
+- type: entity
+  parent: AirlockServiceGlassLocked
+  id: AirlockServiceTheatreGlassLocked
+  suffix: Service, Theatre, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsServiceTheatre ]
 
 - type: entity
   parent: AirlockServiceGlassLocked
@@ -987,6 +1005,15 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsTheatre ]
+
+- type: entity
+  parent: AirlockMaintServiceLocked
+  id: AirlockMaintServiceTheatreLocked
+  suffix: Service, Theatre, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsServiceTheatre ]
 
 - type: entity
   parent: AirlockMaintServiceLocked


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

- Reworked the Low Value crate spawner to use multiple entity tables 
- Also added way more options to the Low Value crate spawner.
- Added Lockbox spawner
- Added spawners for roundstart LV, MV, and HV cables, for more roundstart variation.
- Added a new airlock electronics prototype and respective airlocks for dual Service and Theatre access. 
- Added box fills, crate fill, and cargo request for colorful lights. Costs the same as the holiday lights crate since that's also a crate with two boxes of colorful lights. 
- Since the `RangeNumberSelector` has been modified to be inclusive on both ends, the `CrateMaterialRandom` crate has been updated.
- `CrateTechBoardRandom` has also been updated and now includes the possibility of a Borg recharger or Cell recharger circuit board.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

- Low Value crate spawner didn't have a wide list of things it could spawn, this changes that, allowing for more variety among round start crate spawns. Also there's been a lot added since it was last modified that I felt could be appropriate to include.
- Lockbox spawner has been requested since the lockboxes were added.
- LV, MV, HV cable spawners are mostly for solars variation on maps so it's less predictable. The rest are useful in maints for some more fun variation.
  - The sprites are made up of the north-south and east-west sprites layered on top of each other, I felt like those looked better than the 4-way sprites since a lot of those rely on nearby sprites to look good. Plus these are spawners so they won't be player-facing.
- Service/Theatre access has been requested for the service ordering room on Amber and I need these to make it happen. I'd rather include them here so it's not a single, tiny PR.
- Colorful lights crate with boxes is popular on the downstream places I've implemented it and so I wanted to upstream it here.

## Technical details

All yaml changes

## Media

### Modified Low Value Crates
![image](https://github.com/user-attachments/assets/9a7df582-5d19-4cce-bd53-18f3b0dd7f8e)
Sample of the types of things that can be rolled now.

### Lockbox spawner
![image](https://github.com/user-attachments/assets/2b0a6436-aab6-4377-9382-3db8e368590c)
![image](https://github.com/user-attachments/assets/e576cdd6-d8b0-4a48-a6b7-d6889453c01f)

### Cable Spawners
![image](https://github.com/user-attachments/assets/13477f20-d256-406e-bb47-87e1dd42dc9e)
![image](https://github.com/user-attachments/assets/dbcb4d3f-023e-4972-84c2-f043d8c7482c)
![image](https://github.com/user-attachments/assets/b99ef173-db19-4526-aa6e-0339945152b4)
![image](https://github.com/user-attachments/assets/d6cef7f1-38c1-4177-83ff-aba7688a26f6)
![image](https://github.com/user-attachments/assets/5f2c9bec-7145-418b-a7eb-f5d99e34dd18)

### Colorful Lights crate
![image](https://github.com/user-attachments/assets/f8858354-6515-4f5a-8982-30afaf354b84)
![image](https://github.com/user-attachments/assets/d5b4a032-c035-463b-ad3f-cc31a201b02f)
![image](https://github.com/user-attachments/assets/498edb43-01e2-4901-ac32-b5d8c412ea66)
![image](https://github.com/user-attachments/assets/61b669e2-35b3-4142-a242-8f12c3573c63)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

Unlikely, although the changes to the low value crate spawner may cause some issues.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Southbridge
- add: Colorful Light Crates have been added and can be ordered.
