### PR TITLE
Replace GetEntitiesInTile with EntityLookupSystem equivalent

### DIFF
--- a/Content.Shared/Construction/Conditions/EmptyOrWindowValidInTile.cs
+++ b/Content.Shared/Construction/Conditions/EmptyOrWindowValidInTile.cs
@@ -14,8 +14,7 @@ namespace Content.Shared.Construction.Conditions
         public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
         {
             var entManager = IoCManager.Resolve<IEntityManager>();
-            var sysMan = entManager.EntitySysManager;
-            var lookupSys = sysMan.GetEntitySystem<EntityLookupSystem>();
+            var lookupSys = entManager.System<EntityLookupSystem>();
 
             var result = false;
 

--- a/Content.Shared/Construction/Conditions/EmptyOrWindowValidInTile.cs
+++ b/Content.Shared/Construction/Conditions/EmptyOrWindowValidInTile.cs
@@ -13,9 +13,14 @@ namespace Content.Shared.Construction.Conditions
 
         public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
         {
+            var entManager = IoCManager.Resolve<IEntityManager>();
+            var sysMan = entManager.EntitySysManager;
+            var lookupSys = sysMan.GetEntitySystem<EntityLookupSystem>();
+
             var result = false;
 
-            foreach (var entity in location.GetEntitiesInTile(LookupFlags.Approximate | LookupFlags.Static))
+
+            foreach (var entity in lookupSys.GetEntitiesIntersecting(location, LookupFlags.Approximate | LookupFlags.Static))
             {
                 if (IoCManager.Resolve<IEntityManager>().HasComponent<SharedCanBuildWindowOnTopComponent>(entity))
                     result = true;

--- a/Content.Shared/Construction/Conditions/NoWindowsInTile.cs
+++ b/Content.Shared/Construction/Conditions/NoWindowsInTile.cs
@@ -17,8 +17,9 @@ namespace Content.Shared.Construction.Conditions
             var entManager = IoCManager.Resolve<IEntityManager>();
             var sysMan = entManager.EntitySysManager;
             var tagSystem = sysMan.GetEntitySystem<TagSystem>();
+            var lookupSys = sysMan.GetEntitySystem<EntityLookupSystem>();
 
-            foreach (var entity in location.GetEntitiesInTile(LookupFlags.Static))
+            foreach (var entity in lookupSys.GetEntitiesIntersecting(location, LookupFlags.Static))
             {
                 if (tagSystem.HasTag(entity, WindowTag))
                     return false;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Minor warnings cleanup. Replaces calls to TurfHelpers.GetEntitiesInTile with EntityLookupSystem.GetEntitiesIntersecting. I wasn't sure if there was a better way to get EntityLookupSystem into these conditions so I followed how TagSystem was brought in.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->