### PR TITLE
kill filing cabinet heisentests

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/filing_cabinets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/filing_cabinets.yml
@@ -29,7 +29,7 @@
       children:
       - !type:AllSelector
         weight: 0.2
-        children: 
+        children:
         - id: RubberStampApproved
         - id: RubberStampDenied
       - id: RubberStampGreytide
@@ -131,9 +131,6 @@
   id: filingCabinetDrawer
   description: A small drawer for all your filing needs, Now with wheels!
   components:
-  - type: Storage
-    grid:
-    - 0,0,7,2
   - type: Sprite
     state: chestdrawer
     layers:


### PR DESCRIPTION
## About the PR
Gives the large filing cabinet the same inventory as all of the other filing cabinets to stop the heisentest it causes

## Why / Balance
We have enough heisentests going around already and I genuinely do not want to put thought into creating creative inventories for them right now.

If any contrib wants to, they can make the storagegrids of these cabinets much more interesting. They should be.

## Technical details
Removes storagecomp so they inherit storage params from parent

## Media
Reused my shitty test from the last time we went through this

![image](https://github.com/user-attachments/assets/c8780a8c-941e-4e55-899d-5b55cfaa07d3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: Filing cabinet drawers have the same internal storage size as tall filing cabinets.

