### PR TITLE
Adjust entityTableContainerFill to work better with Storage

### DIFF
--- a/Content.Shared/Containers/ContainerFillSystem.cs
+++ b/Content.Shared/Containers/ContainerFillSystem.cs
@@ -1,15 +1,22 @@
 using System.Linq;
 using System.Numerics;
 using Content.Shared.EntityTable;
+using Content.Shared.Item;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Containers;
 
 public sealed class ContainerFillSystem : EntitySystem
 {
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
     [Dependency] private readonly EntityTableSystem _entityTable = default!;
+    [Dependency] private readonly SharedItemSystem _item = default!;
+    [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
@@ -57,6 +64,9 @@ public sealed class ContainerFillSystem : EntitySystem
         if (TerminatingOrDeleted(ent) || !Exists(ent))
             return;
 
+        // we include special behavior for storage due to stack merging and other things that it handles.
+        var storageComp = CompOrNull<StorageComponent>(ent);
+
         var xform = Transform(ent);
         var coords = new EntityCoordinates(ent, Vector2.Zero);
 
@@ -68,11 +78,20 @@ public sealed class ContainerFillSystem : EntitySystem
                 continue;
             }
 
-            var spawns = _entityTable.GetSpawns(table);
+            var spawns = _entityTable.GetSpawns(table)
+                .OrderByDescending(p => _prototype.Index(p).TryGetComponent<ItemComponent>(out var item, EntityManager.ComponentFactory)
+                    ? _item.GetItemShape(item).GetArea()
+                    : int.MaxValue);
+
             foreach (var proto in spawns)
             {
                 var spawn = Spawn(proto, coords);
-                if (!_containerSystem.Insert(spawn, container, containerXform: xform))
+
+                var success = storageComp != null && containerId == StorageComponent.ContainerId
+                    ? _storage.Insert(ent, spawn, out _, storageComp: storageComp, playSound: false)
+                    : _containerSystem.Insert(spawn, container, containerXform: xform);
+
+                if (!success)
                 {
                     var alreadyContained = container.ContainedEntities.Count > 0 ? string.Join("\n", container.ContainedEntities.Select(e => $"\t - {EntityManager.ToPrettyString(e)}")) : "< empty >";
                     Log.Error($"Entity {ToPrettyString(ent)} with a {nameof(EntityTableContainerFillComponent)} failed to insert an entity: {ToPrettyString(spawn)}.\nCurrent contents:\n{alreadyContained}");


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds in some custom handling for storage since it has some unique handling logic that doesnt get called on typical insert events.
also adds in the size-based sorting that StorageFill does.

the goal is better parity with storageFill as we start to decommission it. problem is that not using the StorageSystem insert function would cause the stack merging logic to skip which sucks.

apologies if this isn't comprehensible its nearly 2 am

## Technical details
<!-- Summary of code changes for easier review. -->
container fill now prioritizes larger items first so things have the lowest chance of conflicts.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun