### PR TITLE
MapManager warning cleanup client edition

### DIFF
--- a/Content.Client/Administration/UI/SpawnExplosion/SpawnExplosionWindow.xaml.cs
+++ b/Content.Client/Administration/UI/SpawnExplosion/SpawnExplosionWindow.xaml.cs
@@ -22,6 +22,7 @@ public sealed partial class SpawnExplosionWindow : DefaultWindow
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IEntityManager _entMan = default!;
+    
     private readonly SharedMapSystem _mapSystem;
     private readonly SharedTransformSystem _transform = default!;
 

--- a/Content.Client/Administration/UI/SpawnExplosion/SpawnExplosionWindow.xaml.cs
+++ b/Content.Client/Administration/UI/SpawnExplosion/SpawnExplosionWindow.xaml.cs
@@ -22,7 +22,7 @@ public sealed partial class SpawnExplosionWindow : DefaultWindow
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IEntityManager _entMan = default!;
-    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    private readonly SharedMapSystem _mapSystem;
     private readonly SharedTransformSystem _transform = default!;
 
     private readonly SpawnExplosionEui _eui;
@@ -38,6 +38,7 @@ public sealed partial class SpawnExplosionWindow : DefaultWindow
     {
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
+        _mapSystem = _entMan.System<MapSystem>();
         _transform = _entMan.System<TransformSystem>();
         _eui = eui;
 

--- a/Content.Client/Administration/UI/SpawnExplosion/SpawnExplosionWindow.xaml.cs
+++ b/Content.Client/Administration/UI/SpawnExplosion/SpawnExplosionWindow.xaml.cs
@@ -38,7 +38,7 @@ public sealed partial class SpawnExplosionWindow : DefaultWindow
     {
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
-        _mapSystem = _entMan.System<MapSystem>();
+        _mapSystem = _entMan.System<SharedMapSystem>();
         _transform = _entMan.System<TransformSystem>();
         _eui = eui;
 

--- a/Content.Client/Administration/UI/SpawnExplosion/SpawnExplosionWindow.xaml.cs
+++ b/Content.Client/Administration/UI/SpawnExplosion/SpawnExplosionWindow.xaml.cs
@@ -19,10 +19,10 @@ namespace Content.Client.Administration.UI.SpawnExplosion;
 public sealed partial class SpawnExplosionWindow : DefaultWindow
 {
     [Dependency] private readonly IClientConsoleHost _conHost = default!;
-    [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IEntityManager _entMan = default!;
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     private readonly SharedTransformSystem _transform = default!;
 
     private readonly SpawnExplosionEui _eui;
@@ -87,7 +87,7 @@ public sealed partial class SpawnExplosionWindow : DefaultWindow
     {
         _mapData.Clear();
         MapOptions.Clear();
-        foreach (var map in _mapManager.GetAllMapIds())
+        foreach (var map in _mapSystem.GetAllMapIds())
         {
             _mapData.Add(map);
             MapOptions.AddItem(map.ToString());

--- a/Content.Client/Administration/UI/SpawnExplosion/SpawnExplosionWindow.xaml.cs
+++ b/Content.Client/Administration/UI/SpawnExplosion/SpawnExplosionWindow.xaml.cs
@@ -22,7 +22,6 @@ public sealed partial class SpawnExplosionWindow : DefaultWindow
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IEntityManager _entMan = default!;
-    
     private readonly SharedMapSystem _mapSystem;
     private readonly SharedTransformSystem _transform = default!;
 

--- a/Content.Client/Administration/UI/Tabs/AdminbusTab/LoadBlueprintsWindow.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/AdminbusTab/LoadBlueprintsWindow.xaml.cs
@@ -14,6 +14,9 @@ namespace Content.Client.Administration.UI.Tabs.AdminbusTab
     [UsedImplicitly]
     public sealed partial class LoadBlueprintsWindow : DefaultWindow
     {
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IPlayerManager _playerManager = default!;
+
         public LoadBlueprintsWindow()
         {
             RobustXamlLoader.Load(this);
@@ -21,8 +24,7 @@ namespace Content.Client.Administration.UI.Tabs.AdminbusTab
 
         protected override void EnteredTree()
         {
-            var entManager = IoCManager.Resolve<IEntityManager>();
-            var mapSystem = entManager.System<SharedMapSystem>();
+            var mapSystem = _entityManager.System<SharedMapSystem>();
 
             foreach (var mapId in mapSystem.GetAllMapIds())
             {
@@ -40,21 +42,19 @@ namespace Content.Client.Administration.UI.Tabs.AdminbusTab
 
         private void Reset()
         {
-            var entManager = IoCManager.Resolve<IEntityManager>();
-            var xformSystem = entManager.System<SharedTransformSystem>();
-            var playerManager = IoCManager.Resolve<IPlayerManager>();
-            var player = playerManager.LocalEntity;
+            var xformSystem = _entityManager.System<SharedTransformSystem>();
+            var player = _playerManager.LocalEntity;
 
             var currentMap = MapId.Nullspace;
             var position = Vector2.Zero;
             var rotation = Angle.Zero;
 
-            if (entManager.TryGetComponent<TransformComponent>(player, out var xform))
+            if (_entityManager.TryGetComponent<TransformComponent>(player, out var xform))
             {
                 currentMap = xform.MapID;
                 position = xformSystem.GetWorldPosition(xform);
 
-                if (entManager.TryGetComponent<TransformComponent>(xform.GridUid, out var gridXform))
+                if (_entityManager.TryGetComponent<TransformComponent>(xform.GridUid, out var gridXform))
                 {
                     rotation = xformSystem.GetWorldRotation(gridXform);
                 }

--- a/Content.Client/Administration/UI/Tabs/AdminbusTab/LoadBlueprintsWindow.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/AdminbusTab/LoadBlueprintsWindow.xaml.cs
@@ -21,9 +21,10 @@ namespace Content.Client.Administration.UI.Tabs.AdminbusTab
 
         protected override void EnteredTree()
         {
-            var mapManager = IoCManager.Resolve<IMapManager>();
+            var entManager = IoCManager.Resolve<IEntityManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
 
-            foreach (var mapId in mapManager.GetAllMapIds())
+            foreach (var mapId in mapSystem.GetAllMapIds())
             {
                 MapOptions.AddItem(mapId.ToString(), (int) mapId);
             }

--- a/Content.Client/Atmos/Overlays/GasTileOverlay.cs
+++ b/Content.Client/Atmos/Overlays/GasTileOverlay.cs
@@ -21,6 +21,7 @@ namespace Content.Client.Atmos.Overlays
     {
         private readonly IEntityManager _entManager;
         private readonly IMapManager _mapManager;
+        private readonly SharedMapSystem _mapSystem;
         private readonly SharedTransformSystem _xformSys;
 
         public override OverlaySpace Space => OverlaySpace.WorldSpaceEntities | OverlaySpace.WorldSpaceBelowWorld;
@@ -51,6 +52,7 @@ namespace Content.Client.Atmos.Overlays
         {
             _entManager = entManager;
             _mapManager = IoCManager.Resolve<IMapManager>();
+            _mapSystem = entManager.System<SharedMapSystem>();
             _xformSys = xformSys;
             _shader = protoMan.Index<ShaderPrototype>("unshaded").Instance();
             ZIndex = GasOverlayZIndex;
@@ -163,7 +165,7 @@ namespace Content.Client.Atmos.Overlays
                 xformQuery,
                 _xformSys);
 
-            var mapUid = _mapManager.GetMapEntityId(args.MapId);
+            var mapUid = _mapSystem.GetMap(args.MapId);
 
             if (_entManager.TryGetComponent<MapAtmosphereComponent>(mapUid, out var atmos))
                 DrawMapOverlay(drawHandle, args, mapUid, atmos);

--- a/Content.Client/Atmos/Overlays/GasTileOverlay.cs
+++ b/Content.Client/Atmos/Overlays/GasTileOverlay.cs
@@ -165,7 +165,7 @@ namespace Content.Client.Atmos.Overlays
                 xformQuery,
                 _xformSys);
 
-            var mapUid = _mapSystem.GetMap(args.MapId);
+            var mapUid = _mapSystem.GetMapOrInvalid(args.MapId);
 
             if (_entManager.TryGetComponent<MapAtmosphereComponent>(mapUid, out var atmos))
                 DrawMapOverlay(drawHandle, args, mapUid, atmos);

--- a/Content.Client/Explosion/ExplosionOverlaySystem.cs
+++ b/Content.Client/Explosion/ExplosionOverlaySystem.cs
@@ -19,7 +19,7 @@ public sealed class ExplosionOverlaySystem : EntitySystem
     [Dependency] private readonly IResourceCache _resCache = default!;
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
     [Dependency] private readonly SharedPointLightSystem _lights = default!;
-    [Dependency] private readonly IMapManager _mapMan = default!;
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 
     public override void Initialize()
@@ -69,7 +69,7 @@ public sealed class ExplosionOverlaySystem : EntitySystem
         }
 
         // Map may have been deleted.
-        if (_mapMan.MapExists(component.Epicenter.MapId))
+        if (_mapSystem.MapExists(component.Epicenter.MapId))
         {
             // spawn in a client-side light source at the epicenter
             var lightEntity = Spawn("ExplosionLight", component.Epicenter);

--- a/Content.Client/Explosion/ExplosionOverlaySystem.cs
+++ b/Content.Client/Explosion/ExplosionOverlaySystem.cs
@@ -4,7 +4,6 @@ using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Shared.GameStates;
 using Robust.Shared.Graphics.RSI;
-using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client.Explosion;

--- a/Content.Client/Overlays/StencilOverlay.cs
+++ b/Content.Client/Overlays/StencilOverlay.cs
@@ -48,7 +48,7 @@ public sealed partial class StencilOverlay : Overlay
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        var mapUid = _mapManager.GetMapEntityId(args.MapId);
+        var mapUid = _map.GetMap(args.MapId);
         var invMatrix = args.Viewport.GetWorldToLocalMatrix();
 
         if (_blep?.Texture.Size != args.Viewport.Size)

--- a/Content.Client/Overlays/StencilOverlay.cs
+++ b/Content.Client/Overlays/StencilOverlay.cs
@@ -48,7 +48,7 @@ public sealed partial class StencilOverlay : Overlay
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        var mapUid = _map.GetMap(args.MapId);
+        var mapUid = _map.GetMapOrInvalid(args.MapId);
         var invMatrix = args.Viewport.GetWorldToLocalMatrix();
 
         if (_blep?.Texture.Size != args.Viewport.Size)

--- a/Content.Client/Parallax/BiomeDebugOverlay.cs
+++ b/Content.Client/Parallax/BiomeDebugOverlay.cs
@@ -17,7 +17,6 @@ public sealed class BiomeDebugOverlay : Overlay
     [Dependency] private readonly IEntityManager _entManager = default!;
     [Dependency] private readonly IEyeManager _eyeManager = default!;
     [Dependency] private readonly IInputManager _inputManager = default!;
-    [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IResourceCache _cache = default!;
     [Dependency] private readonly ITileDefinitionManager _tileDefManager = default!;
 
@@ -38,7 +37,7 @@ public sealed class BiomeDebugOverlay : Overlay
 
     protected override bool BeforeDraw(in OverlayDrawArgs args)
     {
-        var mapUid = _mapManager.GetMapEntityId(args.MapId);
+        var mapUid = _maps.GetMap(args.MapId);
 
         return _entManager.HasComponent<BiomeComponent>(mapUid);
     }
@@ -51,7 +50,7 @@ public sealed class BiomeDebugOverlay : Overlay
         if (mousePos.MapId == MapId.Nullspace || mousePos.MapId != args.MapId)
             return;
 
-        var mapUid = _mapManager.GetMapEntityId(args.MapId);
+        var mapUid = _maps.GetMap(args.MapId);
 
         if (!_entManager.TryGetComponent(mapUid, out BiomeComponent? biomeComp) || !_entManager.TryGetComponent(mapUid, out MapGridComponent? grid))
             return;

--- a/Content.Client/Parallax/BiomeDebugOverlay.cs
+++ b/Content.Client/Parallax/BiomeDebugOverlay.cs
@@ -37,7 +37,7 @@ public sealed class BiomeDebugOverlay : Overlay
 
     protected override bool BeforeDraw(in OverlayDrawArgs args)
     {
-        var mapUid = _maps.GetMap(args.MapId);
+        var mapUid = _maps.GetMapOrInvalid(args.MapId);
 
         return _entManager.HasComponent<BiomeComponent>(mapUid);
     }

--- a/Content.Client/Parallax/BiomeDebugOverlay.cs
+++ b/Content.Client/Parallax/BiomeDebugOverlay.cs
@@ -50,7 +50,7 @@ public sealed class BiomeDebugOverlay : Overlay
         if (mousePos.MapId == MapId.Nullspace || mousePos.MapId != args.MapId)
             return;
 
-        var mapUid = _maps.GetMap(args.MapId);
+        var mapUid = _maps.GetMapOrInvalid(args.MapId);
 
         if (!_entManager.TryGetComponent(mapUid, out BiomeComponent? biomeComp) || !_entManager.TryGetComponent(mapUid, out MapGridComponent? grid))
             return;

--- a/Content.Client/Parallax/ParallaxOverlay.cs
+++ b/Content.Client/Parallax/ParallaxOverlay.cs
@@ -28,7 +28,7 @@ public sealed class ParallaxOverlay : Overlay
     {
         ZIndex = ParallaxSystem.ParallaxZIndex;
         IoCManager.InjectDependencies(this);
-        _mapSystem = _entManager.System<MapSystem>();
+        _mapSystem = _entManager.System<SharedMapSystem>();
         _parallax = _entManager.System<ParallaxSystem>();
     }
 

--- a/Content.Client/Parallax/ParallaxOverlay.cs
+++ b/Content.Client/Parallax/ParallaxOverlay.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Client.Parallax.Managers;
 using Content.Shared.CCVar;
 using Content.Shared.Parallax.Biomes;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
@@ -17,8 +18,8 @@ public sealed class ParallaxOverlay : Overlay
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
-    [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IParallaxManager _manager = default!;
+    private readonly SharedMapSystem _mapSystem;
     private readonly ParallaxSystem _parallax;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowWorld;
@@ -27,12 +28,13 @@ public sealed class ParallaxOverlay : Overlay
     {
         ZIndex = ParallaxSystem.ParallaxZIndex;
         IoCManager.InjectDependencies(this);
+        _mapSystem = _entManager.System<MapSystem>();
         _parallax = _entManager.System<ParallaxSystem>();
     }
 
     protected override bool BeforeDraw(in OverlayDrawArgs args)
     {
-        if (args.MapId == MapId.Nullspace || _entManager.HasComponent<BiomeComponent>(_mapManager.GetMapEntityId(args.MapId)))
+        if (args.MapId == MapId.Nullspace || _entManager.HasComponent<BiomeComponent>(_mapSystem.GetMap(args.MapId)))
             return false;
 
         return true;

--- a/Content.Client/Parallax/ParallaxOverlay.cs
+++ b/Content.Client/Parallax/ParallaxOverlay.cs
@@ -34,7 +34,7 @@ public sealed class ParallaxOverlay : Overlay
 
     protected override bool BeforeDraw(in OverlayDrawArgs args)
     {
-        if (args.MapId == MapId.Nullspace || _entManager.HasComponent<BiomeComponent>(_mapSystem.GetMap(args.MapId)))
+        if (args.MapId == MapId.Nullspace || _entManager.HasComponent<BiomeComponent>(_mapSystem.GetMapOrInvalid(args.MapId)))
             return false;
 
         return true;

--- a/Content.Client/Parallax/ParallaxSystem.cs
+++ b/Content.Client/Parallax/ParallaxSystem.cs
@@ -10,9 +10,9 @@ namespace Content.Client.Parallax;
 
 public sealed class ParallaxSystem : SharedParallaxSystem
 {
-    [Dependency] private readonly IMapManager _map = default!;
     [Dependency] private readonly IOverlayManager _overlay = default!;
     [Dependency] private readonly IParallaxManager _parallax = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!;
 
     [ValidatePrototypeId<ParallaxPrototype>]
     private const string Fallback = "Default";
@@ -58,12 +58,12 @@ public sealed class ParallaxSystem : SharedParallaxSystem
 
     public ParallaxLayerPrepared[] GetParallaxLayers(MapId mapId)
     {
-        return _parallax.GetParallaxLayers(GetParallax(_map.GetMapEntityId(mapId)));
+        return _parallax.GetParallaxLayers(GetParallax(_map.GetMap(mapId)));
     }
 
     public string GetParallax(MapId mapId)
     {
-        return GetParallax(_map.GetMapEntityId(mapId));
+        return GetParallax(_map.GetMap(mapId));
     }
 
     public string GetParallax(EntityUid mapUid)

--- a/Content.Client/Parallax/ParallaxSystem.cs
+++ b/Content.Client/Parallax/ParallaxSystem.cs
@@ -58,7 +58,7 @@ public sealed class ParallaxSystem : SharedParallaxSystem
 
     public ParallaxLayerPrepared[] GetParallaxLayers(MapId mapId)
     {
-        return _parallax.GetParallaxLayers(GetParallax(_map.GetMap(mapId)));
+        return _parallax.GetParallaxLayers(GetParallax(_map.GetMapOrInvalid(mapId)));
     }
 
     public string GetParallax(MapId mapId)

--- a/Content.Client/Parallax/ParallaxSystem.cs
+++ b/Content.Client/Parallax/ParallaxSystem.cs
@@ -63,7 +63,7 @@ public sealed class ParallaxSystem : SharedParallaxSystem
 
     public string GetParallax(MapId mapId)
     {
-        return GetParallax(_map.GetMap(mapId));
+        return GetParallax(_map.GetMapOrInvalid(mapId));
     }
 
     public string GetParallax(EntityUid mapUid)

--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IInputManager _inputs = default!;
-    [Dependency] private readonly IMapManager _mapManager = default!;
+    private readonly SharedMapSystem _mapSystem;
     private readonly ShuttleSystem _shuttles;
     private readonly SharedTransformSystem _xformSystem;
 
@@ -73,6 +73,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
     public ShuttleMapControl() : base(256f, 512f, 512f)
     {
         RobustXamlLoader.Load(this);
+        _mapSystem = EntManager.System<SharedMapSystem>();
         _shuttles = EntManager.System<ShuttleSystem>();
         _xformSystem = EntManager.System<SharedTransformSystem>();
         var cache = IoCManager.Resolve<IResourceCache>();
@@ -109,7 +110,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
         {
             if (args.Function == EngineKeyFunctions.UIClick)
             {
-                var mapUid = _mapManager.GetMapEntityId(ViewingMap);
+                var mapUid = _mapSystem.GetMap(ViewingMap);
 
                 var beaconsOnly = EntManager.TryGetComponent(mapUid, out FTLDestinationComponent? destComp) &&
                                   destComp.BeaconsOnly;
@@ -249,7 +250,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
 
         DrawParallax(handle);
 
-        var viewedMapUid = _mapManager.GetMapEntityId(ViewingMap);
+        var viewedMapUid = _mapSystem.GetMap(ViewingMap);
         var matty = Matrix3Helpers.CreateInverseTransform(Offset, Angle.Zero);
         var realTime = _timing.RealTime;
         var viewBox = new Box2(Offset - WorldRangeVector, Offset + WorldRangeVector);

--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -110,7 +110,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
         {
             if (args.Function == EngineKeyFunctions.UIClick)
             {
-                var mapUid = _mapSystem.GetMap(ViewingMap);
+                var mapUid = _mapSystem.GetMapOrInvalid(ViewingMap);
 
                 var beaconsOnly = EntManager.TryGetComponent(mapUid, out FTLDestinationComponent? destComp) &&
                                   destComp.BeaconsOnly;

--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -250,7 +250,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
 
         DrawParallax(handle);
 
-        var viewedMapUid = _mapSystem.GetMap(ViewingMap);
+        var viewedMapUid = _mapSystem.GetMapOrInvalid(ViewingMap);
         var matty = Matrix3Helpers.CreateInverseTransform(Offset, Angle.Zero);
         var realTime = _timing.RealTime;
         var viewBox = new Box2(Offset - WorldRangeVector, Offset + WorldRangeVector);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Cleans up all warnings where obsolete MapManager calls were made in place of SharedMapSystem. Also removes any unused MapManager imports/dependencies where applicable. I haven't replaced FindGridsIntersecting as I haven't yet figured out how to do so. See also #36781 #36795

I've been gutting parts of the template when I feel the description adequately meets all requirements. Please do smite me if I've oversimplified things.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->