### PR TITLE
Restore `LimitedChargesComponent.MaxCharges` default value to 3

### DIFF
--- a/Content.Shared/Charges/Components/LimitedChargesComponent.cs
+++ b/Content.Shared/Charges/Components/LimitedChargesComponent.cs
@@ -17,7 +17,7 @@ public sealed partial class LimitedChargesComponent : Component
     ///     The max charges this action has.
     /// </summary>
     [DataField, AutoNetworkedField, Access(Other = AccessPermissions.Read)]
-    public int MaxCharges = 1;
+    public int MaxCharges = 3;
 
     /// <summary>
     /// Last time charges was changed. Used to derive current charges.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Returns the default value of the `MaxCharges` field of `LimitedChargesComponent` back to 3 (from 1).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The default value was changed from 3 to 1 as part of #33993. This was a breaking change and was not documented, and it altered the behavior of (at least) the authentication disruptor and the cryptographic sequencer unintentionally.

## Technical details
<!-- Summary of code changes for easier review. -->
1 -> 3

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
It's undoing an undocumented breaking change, so no?