### PR TITLE
Lumber Crate For Cargo

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -89,6 +89,16 @@
   group: market
 
 - type: cargoProduct
+  id: MaterialWood
+  icon:
+    sprite: Objects/Materials/materials.rsi
+    state: wood_3
+  product: CrateMaterialWood
+  cost: 1750
+  category: cargoproduct-category-name-materials
+  group: market
+
+- type: cargoProduct
   id: MaterialBasic
   icon:
     sprite: Objects/Materials/Sheets/other.rsi

--- a/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
@@ -46,12 +46,13 @@
 - type: entity
   id: CrateMaterialWood
   parent: CrateGenericSteel
-  name: wood crate
-  description: Bunch of wood planks.
+  name: lumber crate
+  description: 90 pieces of wood straight from the Lumber-Mill.
   components:
   - type: StorageFill
     contents:
       - id: MaterialWoodPlank
+        amount: 3
 
 - type: entity
   id: CrateMaterialBrass


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I added a new "lumber" crate for cargo, containing 90 pieces of wood, for 1750 spesos.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Tiders usually destroy the library for wood, and this provides a better alternate for obtaining wood.
## Technical details
<!-- Summary of code changes for easier review. -->
YML Changes
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/c470f853-89e8-4dc0-8b17-015a06a11389)
Media is outdated because right when I stopped testing I renamed it to lumber crate, incase a wooden material crate is added.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
**Changelog**
🆑 
- add: Cargo can now buy a lumber crate from cargo containing 90 wood.