### PR TITLE
Allow departments and jobs to be implicitly cleared to use job/department restricted items

### DIFF
--- a/Content.Shared/Contraband/ContrabandComponent.cs
+++ b/Content.Shared/Contraband/ContrabandComponent.cs
@@ -19,7 +19,6 @@ public sealed partial class ContrabandComponent : Component
 
     /// <summary>
     ///     Which departments is this item restricted to?
-    ///     By default, command and sec are assumed to be fine with contraband.
     ///     If null, no departments are allowed to use this.
     /// </summary>
     [DataField]
@@ -28,9 +27,25 @@ public sealed partial class ContrabandComponent : Component
 
     /// <summary>
     ///     Which jobs is this item restricted to?
-    ///     If empty, no jobs are allowed to use this beyond the allowed departments.
+    ///     If null, no jobs are allowed to use this beyond the allowed departments.
     /// </summary>
     [DataField]
     [AutoNetworkedField]
     public HashSet<ProtoId<JobPrototype>> AllowedJobs = new();
+
+    /// <summary>
+    ///     Departments allowed through this will not appear in the examine text.
+    ///     Useful for allowing departments like CentComm to be cleared for use without being explicilty stated.
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public HashSet<ProtoId<DepartmentPrototype>> ImplicitlyAllowedDepartments = new();
+
+    /// <summary>
+    ///     Jobs allowed through this will not appear in the examine text.
+    ///     Useful for allowing jobs like captain to be cleared for use without being explicilty stated.
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public HashSet<ProtoId<JobPrototype>> ImplicitlyAllowedJobs = new();
 }

--- a/Content.Shared/Contraband/ContrabandComponent.cs
+++ b/Content.Shared/Contraband/ContrabandComponent.cs
@@ -19,7 +19,7 @@ public sealed partial class ContrabandComponent : Component
 
     /// <summary>
     ///     Which departments is this item restricted to?
-    ///     If null, no departments are allowed to use this.
+    ///     If empty, no departments are allowed to use this.
     /// </summary>
     [DataField]
     [AutoNetworkedField]
@@ -27,7 +27,7 @@ public sealed partial class ContrabandComponent : Component
 
     /// <summary>
     ///     Which jobs is this item restricted to?
-    ///     If null, no jobs are allowed to use this beyond the allowed departments.
+    ///     If empty, no jobs are allowed to use this beyond the allowed departments.
     /// </summary>
     [DataField]
     [AutoNetworkedField]

--- a/Content.Shared/Contraband/ContrabandSystem.cs
+++ b/Content.Shared/Contraband/ContrabandSystem.cs
@@ -39,6 +39,8 @@ public sealed class ContrabandSystem : EntitySystem
         contraband.Severity = other.Severity;
         contraband.AllowedDepartments = other.AllowedDepartments;
         contraband.AllowedJobs = other.AllowedJobs;
+        contraband.ImplicitlyAllowedDepartments = other.ImplicitlyAllowedDepartments;
+        contraband.ImplicitlyAllowedJobs = other.ImplicitlyAllowedJobs;
         Dirty(uid, contraband);
     }
 
@@ -87,8 +89,11 @@ public sealed class ContrabandSystem : EntitySystem
         // if it is fully restricted, you're department-less, or your department isn't in the allowed list, you cannot carry it. Otherwise, you can.
         var carryingMessage = Loc.GetString("contraband-examine-text-avoid-carrying-around");
         var iconTexture = "/Textures/Interface/VerbIcons/lock-red.svg.192dpi.png";
+        var implicitJobs = component.ImplicitlyAllowedJobs.Select(p => _proto.Index(p).LocalizedName).ToArray();
         if (departments.Intersect(component.AllowedDepartments).Any()
-            || jobs.Contains(jobId))
+            || departments.Intersect(component.ImplicitlyAllowedDepartments).Any()
+            || jobs.Contains(jobId)
+            || implicitJobs.Contains(jobId))
         {
             carryingMessage = Loc.GetString("contraband-examine-text-in-the-clear");
             iconTexture = "/Textures/Interface/VerbIcons/unlock-green.svg.192dpi.png";

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -57,7 +57,7 @@
     - state: nano_label
 
 - type: entity
-  parent: [ EncryptionKey, BaseCentcommCommandContraband ]
+  parent: [ EncryptionKey, BaseCommandContraband ]
   id: EncryptionKeyStationMaster
   name: station master encryption key
   description: An encryption key used by station's bosses.

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -31,6 +31,8 @@
     severity: Major
 
 # base department restricted contraband, this should only be used as a parent for other contraband prototypes, not the restricted items themselves.
+# centcomm, captain, and hop are implicitly cleared for all departmental contraband
+# child prototypes can override this behavior by providing an empty set for these data fields
 - type: entity
   id: BaseRestrictedContraband
   abstract: true
@@ -39,6 +41,8 @@
     severity: Restricted
     allowedDepartments: [  ]
     allowedJobs: [  ]
+    implicitlyAllowedDepartments: [ CentralCommand ]
+    implicitlyAllowedJobs: [ Captain, HeadOfPersonnel ]
 
 # one department restricted contraband
 - type: entity
@@ -48,6 +52,8 @@
   components:
   - type: Contraband
     allowedDepartments: [ CentralCommand ]
+    implicitlyAllowedDepartments: [  ]
+    implicitlyAllowedJobs: [  ]
 
 - type: entity
   id: BaseCommandContraband
@@ -106,14 +112,6 @@
     allowedDepartments: [ Cargo ]
 
 # multiple departments restricted contraband
-- type: entity
-  id: BaseCentcommCommandContraband
-  parent: BaseRestrictedContraband
-  abstract: true
-  components:
-  - type: Contraband
-    allowedDepartments: [ CentralCommand, Command ]
-
 - type: entity
   id: BaseSecurityCommandContraband
   parent: BaseRestrictedContraband

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -31,7 +31,7 @@
     severity: Major
 
 # base department restricted contraband, this should only be used as a parent for other contraband prototypes, not the restricted items themselves.
-# centcomm, captain, and hop are implicitly cleared for all departmental contraband
+# centcomm and captain are implicitly cleared for all departmental contraband
 # child prototypes can override this behavior by providing an empty set for these data fields
 - type: entity
   id: BaseRestrictedContraband
@@ -42,7 +42,7 @@
     allowedDepartments: [  ]
     allowedJobs: [  ]
     implicitlyAllowedDepartments: [ CentralCommand ]
-    implicitlyAllowedJobs: [ Captain, HeadOfPersonnel ]
+    implicitlyAllowedJobs: [ Captain ]
 
 # one department restricted contraband
 - type: entity
@@ -169,6 +169,7 @@
   - type: Contraband
     allowedDepartments: [ Security ]
     allowedJobs: [ Bartender ]
+    implicitlyAllowedJobs: [ Captain, HeadOfPersonnel ]
 
 - type: entity
   id: BaseSecurityBartenderZookeeperContraband
@@ -178,6 +179,7 @@
   - type: Contraband
     allowedDepartments: [ Security ]
     allowedJobs: [ Bartender, Zookeeper ]
+    implicitlyAllowedJobs: [ Captain, HeadOfPersonnel ]
 
 - type: entity
   id: BaseSecurityLawyerContraband
@@ -187,6 +189,7 @@
   - type: Contraband
     allowedDepartments: [ Security ]
     allowedJobs: [ Lawyer ]
+    implicitlyAllowedJobs: [ Captain, HeadOfPersonnel ]
 
 - type: entity
   id: BaseJanitorContraband
@@ -195,6 +198,7 @@
   components:
   - type: Contraband
     allowedJobs: [ Janitor ]
+    implicitlyAllowedJobs: [ Captain, HeadOfPersonnel ]
 
 # for ~objective items
 - type: entity


### PR DESCRIPTION
## About the PR
This PR adds support to contraband to clear specific departments and jobs to use job/department restricted items without explicitly stating them in the examine text. This implicitly clears Central Command jobs and Captain to use all job and department restricted items and clears the Head of Personnel to use items that are restricted to service jobs by some degree.

This PR also removes the redundant BaseCentcommCommandContraband prototype, since all members of the CentComm department are already part of the Command department and it is only used for the station master encryption key entity.

## Why / Balance
Currently, if the Captain were to examine a contraband item that is not restricted to either the Captain job or the Command department (for example, a pair of galoshes), the examine text states they should probably avoid carrying this item without good reason, despite holding jurisdiction over all departments. This change gives the Captain positive feedback that they may use the restricted item without bloating the contraband examine text. This also lets heads of departments be cleared to use items that are restricted to specific jobs within their department, such as the Head of Personnel being cleared to use bartender-restricted items.

## Technical details
Adds the `ImplicitlyAllowedDepartments` and `ImplicitlyAllowedJobs` to `ContrabandComponent`. `ContrabandSystem` uses these to clear listed departments and jobs in the examine text using the same logic as it does for `AllowedDepartments` and `AllowedJobs`.

## Media
Before:
![Fq8xfvc](https://github.com/user-attachments/assets/45c0db87-9cb3-4703-8be7-b96edf2f8344)

After:
![JQ9bSO5](https://github.com/user-attachments/assets/884b51ca-3b44-4527-9a59-c6768eb93d6d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The BaseCentcommCommandContraband prototype has been removed and uses of it have been replaced with BaseCommandContraband.

**Changelog**
:cl:
- add: Captains will now be cleared to use job and department restricted items when examining them. HoPs will also be cleared to use items restricted to specific service jobs.
