### PR TITLE
Further Allocation Tweaks

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs
@@ -342,8 +342,8 @@ public sealed partial class CargoSystem
             {
                 distribution = new Dictionary<ProtoId<CargoAccountPrototype>, double>
                 {
-                    { sellComponent.OverrideAccount, bankAccount.PrimaryCut },
-                    { bankAccount.PrimaryAccount, 1.0 - bankAccount.PrimaryCut },
+                    { sellComponent.OverrideAccount, sellComponent.OverrideCut },
+                    { bankAccount.PrimaryAccount, 1.0 - sellComponent.OverrideCut },
                 };
             }
             else

--- a/Content.Shared/Cargo/Components/OverrideSellComponent.cs
+++ b/Content.Shared/Cargo/Components/OverrideSellComponent.cs
@@ -14,4 +14,10 @@ public sealed partial class OverrideSellComponent : Component
     /// </summary>
     [DataField(required: true)]
     public ProtoId<CargoAccountPrototype> OverrideAccount;
+
+    /// <summary>
+    /// The cut that the OverrideAccount will get from the price. The rest is given to the primary station account.
+    /// </summary>
+    [DataField]
+    public float OverrideCut = 0.75f;
 }

--- a/Content.Shared/Cargo/Components/StationBankAccountComponent.cs
+++ b/Content.Shared/Cargo/Components/StationBankAccountComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class StationBankAccountComponent : Component
     /// When giving funds to a particular account, the proportion of funds they should receive compared to remaining accounts.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public double PrimaryCut = 0.75;
+    public double PrimaryCut = 0.50;
 
     /// <summary>
     /// A dictionary corresponding to the money held by each cargo account.
@@ -44,11 +44,11 @@ public sealed partial class StationBankAccountComponent : Component
     public Dictionary<ProtoId<CargoAccountPrototype>, double> RevenueDistribution = new()
     {
         { "Cargo",       0.00 },
-        { "Engineering", 0.25 },
-        { "Medical",     0.25 },
-        { "Science",     0.15 },
+        { "Engineering", 0.20 },
+        { "Medical",     0.20 },
+        { "Science",     0.20 },
         { "Security",    0.20 },
-        { "Service",     0.15 },
+        { "Service",     0.20 },
     };
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Cargo now takes a 50% cut instead of 75% cut of all sales. Lockboxes remain unchanged.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently departments have no way to make money for themselves, and with the current split they earn close to no money at all. This should lead ot a more interesting split.
50% still makes sure cargo is the main manager for funds, however departments now actually earn enough to be able to order the more expensive things.

Also made the default allocations 20% across the board. I hate that it was different for some reason. This makes it more fair and HoP can still adjust if neccessary.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Default cargo split is now 50% instead of 75%. Lockboxes remain unchanged.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
