### PR TITLE
dragons can now pry doors

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -159,6 +159,12 @@
     - NamesDragon
     - NamesDragonTitle
     nameFormat: name-format-dragon
+  - type: Prying
+    pryPowered: true
+    force: true
+    speedModifier: 2.5 # fast because dragon strong
+    useSound:
+      path: /Audio/Items/crowbar.ogg
 
 - type: entity
   parent: BaseMobDragon


### PR DESCRIPTION
## About the PR
gives dragons the ability to pry doors, with a speed modifier of 2.5 (tarantula prying speed is 1.5 for reference)

## Why / Balance
dragons have giant hands bigger than your face, makes sense that they could pry an airlock open pretty easily.
proper reason is airlocks are super annoying if you're a dragon, being able to pry them open quickly in the heat of battle lets them be more aggressive.
they can pry open bolted doors, but at that point they should just be eating it instead because it takes a bajillion years.

they're still encouraged to devour doors so their carp minions can follow them.

## Technical details
adds prying component to dragon

## Media
**powered door**
![dragondoor](https://github.com/user-attachments/assets/07fda1ff-9266-4db9-8259-ce81c3ee5419)
**airlock** (unpowered door is same speed)
![dragonfirelock](https://github.com/user-attachments/assets/35f13244-b0d3-4554-9171-300d94823110)
the "extra click" is just me focusing the window because it was focused on the gif recording software beforehand
[this PR doesn't mess with your inputs don't worry]

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Dragons can now pry open doors, including airlocks.