### PR TITLE
Fix deliveries disappearing when opened in a container

### DIFF
--- a/Content.Shared/Delivery/SharedDeliverySystem.cs
+++ b/Content.Shared/Delivery/SharedDeliverySystem.cs
@@ -180,7 +180,7 @@ public abstract class SharedDeliverySystem : EntitySystem
         if (!_container.TryGetContainer(ent, ent.Comp.Container, out var container))
             return;
 
-        if (attemptPickup)
+        if (attemptPickup || _container.IsEntityInContainer(ent))
         {
             foreach (var entity in container.ContainedEntities.ToArray())
             {

--- a/Content.Shared/Delivery/SharedDeliverySystem.cs
+++ b/Content.Shared/Delivery/SharedDeliverySystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Map;
 
 namespace Content.Shared.Delivery;
 
@@ -180,7 +181,7 @@ public abstract class SharedDeliverySystem : EntitySystem
         if (!_container.TryGetContainer(ent, ent.Comp.Container, out var container))
             return;
 
-        if (attemptPickup || _container.IsEntityInContainer(ent))
+        if (attemptPickup)
         {
             foreach (var entity in container.ContainedEntities.ToArray())
             {
@@ -189,7 +190,8 @@ public abstract class SharedDeliverySystem : EntitySystem
         }
         else
         {
-            _container.EmptyContainer(container, true, Transform(ent.Owner).Coordinates);
+            EntityCoordinates? coords = _container.IsEntityInContainer(ent) ? null : Transform(ent).Coordinates;
+            _container.EmptyContainer(container, true, coords);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I saw a discord message about items not spawning properly when you open a delivery inside your bag. So I fixed it!
Not sure if there's a github issue for this one

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Items were disappearing, it's a bug and confusing for players. Also, lost mail :(

## Technical details
<!-- Summary of code changes for easier review. -->
`EmptyContainer` -> `Remove` doesn't actually reach the "Set Parent" bit of code if there's a coordinate destination to empty the items to. So we don't set the coordinates if the delivery is in a container so it just drops it in the container instead.

## Media
Not shown in the video, but if the container is full and you open it, the delivery drops onto the floor under the container (you if your bag)

https://github.com/user-attachments/assets/75ae32aa-e476-4bad-9990-790f718b6954

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 fix: Deliveries opened in a container now drop the item in the container.
