### PR TITLE
Remove non-functional ninja exemption from `SpawnAndDeleteEntityCountTest`

### DIFF
--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -277,11 +277,6 @@ namespace Content.IntegrationTests.Tests
             {
                 foreach (var protoId in protoIds)
                 {
-                    // TODO fix ninja
-                    // Currently ninja fails to equip their own loadout.
-                    if (protoId == "MobHumanSpaceNinja")
-                        continue;
-
                     var count = Count(server.EntMan);
                     var clientCount = Count(client.EntMan);
                     var serverEntities = new HashSet<EntityUid>(Entities(server.EntMan));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removes a chunk of code that tried to make the space ninja entity exempt from `SpawnAndDeleteEntityCountTest` (but actually did nothing).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It does nothing, and it has a TODO comment saying to fix it.

## Technical details
<!-- Summary of code changes for easier review. -->
The deleted code checks each ProtoId in the loop to see if it matches "MobHumanSpaceNinja" so it can be skipped by the test.

But there is no entity prototype with the ID "MobHumanSpaceNinja", so it does nothing.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->