### PR TITLE
Update power load for thrusters when enabled/disabled

### DIFF
--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -21,6 +21,18 @@ namespace Content.Server.Shuttles.Components
         /// </summary>
         public bool IsOn;
 
+        /// <summary>
+        /// Baseline power that this thruster consumes.
+        /// </summary>
+        [DataField("idlePower")]
+        public float IdlePowerUse { get; set; }
+
+        /// <summary>
+        /// Power consumed when the thruster is enabled.
+        /// </summary>
+        [DataField("activePower")]
+        public float ActivePowerUse { get; set; }
+
         // Need to serialize this because RefreshParts isn't called on Init and this will break post-mapinit maps!
         [ViewVariables(VVAccess.ReadWrite), DataField("thrust")]
         public float Thrust = 100f;

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -324,6 +324,11 @@ public sealed class ThrusterSystem : EntitySystem
             _light.SetEnabled(uid, true, pointLightComponent);
         }
 
+        if (EntityManager.TryGetComponent(uid, out ApcPowerReceiverComponent? powerReceiver))
+        {
+            powerReceiver.Load = component.ActivePowerUse;
+        }
+
         _ambient.SetAmbience(uid, true);
         RefreshCenter(uid, shuttleComponent);
     }
@@ -410,6 +415,11 @@ public sealed class ThrusterSystem : EntitySystem
         if (_light.TryGetLight(uid, out var pointLightComponent))
         {
             _light.SetEnabled(uid, false, pointLightComponent);
+        }
+
+        if (EntityManager.TryGetComponent(uid, out ApcPowerReceiverComponent? powerReceiver))
+        {
+            powerReceiver.Load = component.IdlePowerUse;
         }
 
         _ambient.SetAmbience(uid, false);

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -32,12 +32,13 @@
       damage:
         types:
           Heat: 40
+      idlePower: 0
+      activePower: 1500
     - type: InteractionOutline
     - type: Sprite
     - type: Appearance
     - type: ThrusterVisuals
     - type: ApcPowerReceiver
-      powerLoad: 1500
     - type: ExtensionCableReceiver
     - type: Damageable
       damageContainer: StructuralInorganic


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Modified thruster objects to dynamically update their power load depending on if they are enabled or not.

## Why / Balance
Discussion in #36277

## Technical details
Added `activePower` / `idlePower` similar to PowerCharge component.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Thrusters and gyroscopes no longer consume power when disabled
