### PR TITLE
Make research clients grid-local

### DIFF
--- a/Content.Server/Research/Systems/ResearchSystem.Client.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Client.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Research.Components;
 
@@ -12,6 +13,7 @@ public sealed partial class ResearchSystem
         SubscribeLocalEvent<ResearchClientComponent, ComponentShutdown>(OnClientShutdown);
         SubscribeLocalEvent<ResearchClientComponent, BoundUIOpenedEvent>(OnClientUIOpen);
         SubscribeLocalEvent<ResearchClientComponent, ConsoleServerSelectionMessage>(OnConsoleSelect);
+        SubscribeLocalEvent<ResearchClientComponent, AnchorStateChangedEvent>(OnClientAnchorStateChanged);
 
         SubscribeLocalEvent<ResearchClientComponent, ResearchClientSyncMessage>(OnClientSyncMessage);
         SubscribeLocalEvent<ResearchClientComponent, ResearchClientServerSelectedMessage>(OnClientSelected);
@@ -23,7 +25,11 @@ public sealed partial class ResearchSystem
 
     private void OnClientSelected(EntityUid uid, ResearchClientComponent component, ResearchClientServerSelectedMessage args)
     {
-        if (!TryGetServerById(args.ServerId, out var serveruid, out var serverComponent))
+        if (!TryGetServerById(uid, args.ServerId, out var serveruid, out var serverComponent))
+            return;
+
+        // Validate that we can access this server.
+        if (!GetServers(uid).Contains((serveruid.Value, serverComponent)))
             return;
 
         UnregisterClient(uid, component);
@@ -56,12 +62,7 @@ public sealed partial class ResearchSystem
 
     private void OnClientMapInit(EntityUid uid, ResearchClientComponent component, MapInitEvent args)
     {
-        var allServers = new List<Entity<ResearchServerComponent>>();
-        var query = AllEntityQuery<ResearchServerComponent>();
-        while (query.MoveNext(out var serverUid, out var serverComp))
-        {
-            allServers.Add((serverUid, serverComp));
-        }
+        var allServers = GetServers(uid).ToList();
 
         if (allServers.Count > 0)
             RegisterClient(uid, allServers[0], component, allServers[0]);
@@ -77,6 +78,24 @@ public sealed partial class ResearchSystem
         UpdateClientInterface(uid, component);
     }
 
+    private void OnClientAnchorStateChanged(Entity<ResearchClientComponent> ent, ref AnchorStateChangedEvent args)
+    {
+        if (args.Anchored)
+        {
+            if (ent.Comp.Server is not null)
+                return;
+
+            var allServers = GetServers(ent).ToList();
+
+            if (allServers.Count > 0)
+                RegisterClient(ent, allServers[0], ent, allServers[0]);
+        }
+        else
+        {
+            UnregisterClient(ent, ent.Comp);
+        }
+    }
+
     private void UpdateClientInterface(EntityUid uid, ResearchClientComponent? component = null)
     {
         if (!Resolve(uid, ref component, false))
@@ -84,9 +103,12 @@ public sealed partial class ResearchSystem
 
         TryGetClientServer(uid, out _, out var serverComponent, component);
 
-        var names = GetServerNames();
-        var state = new ResearchClientBoundInterfaceState(names.Length, names,
-            GetServerIds(), serverComponent?.Id ?? -1);
+        var names = GetServerNames(uid);
+        var state = new ResearchClientBoundInterfaceState(
+            names.Length,
+            names,
+            GetServerIds(uid),
+            serverComponent?.Id ?? -1);
 
         _uiSystem.SetUiState(uid, ResearchClientUiKey.Key, state);
     }

--- a/Content.Server/Research/Systems/ResearchSystem.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.cs
@@ -34,19 +34,20 @@ namespace Content.Server.Research.Systems
         }
 
         /// <summary>
-        /// Gets a server based on it's unique numeric id.
+        /// Gets a server based on its unique numeric id.
         /// </summary>
+        /// <param name="client"></param>
         /// <param name="id"></param>
         /// <param name="serverUid"></param>
         /// <param name="serverComponent"></param>
         /// <returns></returns>
-        public bool TryGetServerById(int id, [NotNullWhen(true)] out EntityUid? serverUid, [NotNullWhen(true)] out ResearchServerComponent? serverComponent)
+        public bool TryGetServerById(EntityUid client, int id, [NotNullWhen(true)] out EntityUid? serverUid, [NotNullWhen(true)] out ResearchServerComponent? serverComponent)
         {
             serverUid = null;
             serverComponent = null;
 
-            var query = EntityQueryEnumerator<ResearchServerComponent>();
-            while (query.MoveNext(out var uid, out var server))
+            var query = GetServers(client).ToList();
+            foreach (var (uid, server) in query)
             {
                 if (server.Id != id)
                     continue;
@@ -61,14 +62,14 @@ namespace Content.Server.Research.Systems
         /// Gets the names of all the servers.
         /// </summary>
         /// <returns></returns>
-        public string[] GetServerNames()
+        public string[] GetServerNames(EntityUid client)
         {
-            var allServers = EntityQuery<ResearchServerComponent>(true).ToArray();
+            var allServers = GetServers(client).ToArray();
             var list = new string[allServers.Length];
 
             for (var i = 0; i < allServers.Length; i++)
             {
-                list[i] = allServers[i].ServerName;
+                list[i] = allServers[i].Comp.ServerName;
             }
 
             return list;
@@ -78,17 +79,30 @@ namespace Content.Server.Research.Systems
         /// Gets the ids of all the servers
         /// </summary>
         /// <returns></returns>
-        public int[] GetServerIds()
+        public int[] GetServerIds(EntityUid client)
         {
-            var allServers = EntityQuery<ResearchServerComponent>(true).ToArray();
+            var allServers = GetServers(client).ToArray();
             var list = new int[allServers.Length];
 
             for (var i = 0; i < allServers.Length; i++)
             {
-                list[i] = allServers[i].Id;
+                list[i] = allServers[i].Comp.Id;
             }
 
             return list;
+        }
+
+        public IEnumerable<Entity<ResearchServerComponent>> GetServers(EntityUid client)
+        {
+            var clientXform = Transform(client);
+            var query = AllEntityQuery<ResearchServerComponent, TransformComponent>();
+            while (query.MoveNext(out var uid, out var comp, out var xform))
+            {
+                if (xform.GridUid != clientXform.GridUid)
+                    continue;
+
+                yield return (uid, comp);
+            }
         }
 
         public override void Update(float frameTime)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Prevents research clients from being able to access servers on different grids

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, RD servers have global range. This means that basically anyone, including entities that don't interact with or aren't positively affiliated with the station can access any tech that is researched.

Forcing people to at least be on the same grid ensures that at least some level of interaction is required for them to make good use of the science system. This prevents things like antags accessing science's unlocks and off-station salvagers being able to set up factories in shuttles and such.

## Technical details
<!-- Summary of code changes for easier review. -->
changes research code to use a shared method for accessing servers.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`GetServerIds`, `GetServerNames`, and `TryGetServerById` in Server.ResearchSystem all now have an additional parameter for the research client.
 
**Changelog**
:cl:
- tweak: Lathes can no longer connect to research servers on separate grids

