### PR TITLE
Advanced NT anti-syndicate technology

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -543,16 +543,6 @@ namespace Content.Server.Kitchen.EntitySystems
             // TODO use lists of Reagent quantities instead of reagent prototype ids.
             foreach (var item in component.Storage.ContainedEntities.ToArray())
             {
-                // special behavior when being microwaved ;)
-                var ev = new BeingMicrowavedEvent(uid, user);
-                RaiseLocalEvent(item, ev);
-
-                if (ev.Handled)
-                {
-                    UpdateUserInterfaceState(uid, component);
-                    return;
-                }
-
                 if (_tag.HasTag(item, MetalTag))
                 {
                     malfunctioning = true;
@@ -564,6 +554,19 @@ namespace Content.Server.Kitchen.EntitySystems
                     _container.Insert(junk, component.Storage);
                     Del(item);
                     continue;
+                }
+
+                if (!malfunctioning)
+                {
+                    // special behavior when being microwaved ;)
+                    var ev = new BeingMicrowavedEvent(uid, user);
+                    RaiseLocalEvent(item, ev);
+
+                    if (ev.Handled)
+                    {
+                        UpdateUserInterfaceState(uid, component);
+                        return;
+                    }
                 }
 
                 var microwavedComp = AddComp<ActivelyMicrowavedComponent>(item);

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -140,7 +140,7 @@
       - id: ClothingShoesClown
       - id: ClothingMaskClown
       - id: BikeHorn
-      - id: ClownPDA
+      - id: ClownPDAPlastic # no free ID for you
       - id: ClothingHeadsetService
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -368,6 +368,14 @@
 
 - type: entity
   parent: ClownPDA
+  id: ClownPDAPlastic
+  suffix: Plastic Card
+  components:
+  - type: Pda
+    id: ClownIDCardPlastic
+
+- type: entity
+  parent: ClownPDA
   id: VisitorClownPDA
   suffix: Visitor
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -257,6 +257,16 @@
     job: Clown
 
 - type: entity
+  parent: ClownIDCard
+  id: ClownIDCardPlastic
+  suffix: Plastic
+  components:
+  - type: Tag
+    tags: #override chameleon whitelist
+    - DoorBumpOpener
+    - Plastic
+
+- type: entity
   parent: IDCardStandard
   id: MimeIDCard
   name: mime ID card
@@ -601,6 +611,7 @@
   - type: Tag
     tags:
     - DoorBumpOpener
+    - Plastic
   - type: ChameleonClothing
     slot: [idcard]
     default: PassengerIDCard
@@ -648,6 +659,12 @@
     tags:
     - NuclearOperative
     - SyndicateAgent
+  - type: Tag
+    tags:
+    - DoorBumpOpener
+    - WhitelistChameleon
+    - WhitelistChameleonIdCard
+    - Plastic
 
 - type: entity
   parent: IDCardStandard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Common syndicate ID cards will now be melted inside of microwaves. this includes:
- agent ID
- syndicate ids (normal and nukie)
- clown ids from clown bundle

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Syndies and nukies constantly exploit microwave gambling to try and get access for free. Making it actually require stealing IDs at least presupposes some minor amount of brainpower, instead of being completely free.

## Technical details
<!-- Summary of code changes for easier review. -->
checks microwave tags _before_ the event handler so that they can cancel it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Superior Nanotrasen-made microwaves will now instantly melt puny Syndicate ID cards.
