### PR TITLE
Fix warning CS8524 instances

### DIFF
--- a/Content.Client/CartridgeLoader/Cartridges/NanoTaskItemPopup.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/NanoTaskItemPopup.xaml.cs
@@ -90,10 +90,12 @@ public sealed partial class NanoTaskItemPopup : DefaultWindow
     {
         if (item is NanoTaskItem task)
         {
-            var button = task.Priority switch {
+            var button = task.Priority switch
+            {
                 NanoTaskPriority.High => HighButton,
                 NanoTaskPriority.Medium => MediumButton,
                 NanoTaskPriority.Low => LowButton,
+                _ => throw new ArgumentException("Invalid priority"),
             };
             button.Pressed = true;
             DescriptionInput.Text = task.Description;

--- a/Content.Client/CartridgeLoader/Cartridges/NanoTaskUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/NanoTaskUiFragment.xaml.cs
@@ -38,10 +38,12 @@ public sealed partial class NanoTaskUiFragment : BoxContainer
 
         foreach (var task in tasks)
         {
-            var container = task.Data.Priority switch {
+            var container = task.Data.Priority switch
+            {
                 NanoTaskPriority.High => HighContainer,
                 NanoTaskPriority.Medium => MediumContainer,
                 NanoTaskPriority.Low => LowContainer,
+                _ => throw new ArgumentException("Invalid priority"),
             };
             var control = new NanoTaskItemControl(task);
             container.AddChild(control);

--- a/Content.Client/Xenoarchaeology/Ui/NodeScannerDisplay.xaml.cs
+++ b/Content.Client/Xenoarchaeology/Ui/NodeScannerDisplay.xaml.cs
@@ -80,7 +80,8 @@ public sealed partial class NodeScannerDisplay : FancyWindow
             ArtifactState.None => "\u2800", // placeholder for line to not be squeezed
             ArtifactState.Ready => Loc.GetString("node-scanner-artifact-state-ready"),
             ArtifactState.Unlocking => Loc.GetString("node-scanner-artifact-state-unlocking"),
-            ArtifactState.Cooldown => Loc.GetString("node-scanner-artifact-state-cooldown")
+            ArtifactState.Cooldown => Loc.GetString("node-scanner-artifact-state-cooldown"),
+            _ => throw new ArgumentException("Invalid state"),
         };
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 3 instances of warning CS8524 (The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Added default cases to the switch expressions which just throw an `ArgumentException`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->