### PR TITLE
Implement BreakOnContainerChange for DoAfter

### DIFF
--- a/Content.Shared/DoAfter/DoAfter.cs
+++ b/Content.Shared/DoAfter/DoAfter.cs
@@ -63,6 +63,12 @@ public sealed partial class DoAfter
     public string? InitialHand;
 
     /// <summary>
+    ///     If <see cref="DoAfterArgs.BreakOnContainerChange"/> is true, this is the container ID for the event target entity when the doafter started.
+    /// </summary>
+    [DataField("initialContainer")]
+    public string? InitialContainerID;
+
+    /// <summary>
     ///     If <see cref="NeedHand"/> is true, this is the entity that was in the active hand when the doafter started.
     /// </summary>
     [NonSerialized]
@@ -96,6 +102,7 @@ public sealed partial class DoAfter
         UserPosition = other.UserPosition;
         TargetDistance = other.TargetDistance;
         InitialHand = other.InitialHand;
+        InitialContainerID = other.InitialContainerID;
         InitialItem = other.InitialItem;
 
         NetUserPosition = other.NetUserPosition;

--- a/Content.Shared/DoAfter/DoAfterArgs.cs
+++ b/Content.Shared/DoAfter/DoAfterArgs.cs
@@ -92,6 +92,12 @@ public sealed partial class DoAfterArgs
     public bool BreakOnHandChange = true;
 
     /// <summary>
+    ///     Whether the do-after should get interrupted if the event target entity changes containers.
+    /// </summary>
+    [DataField]
+    public bool BreakOnContainerChange = true;
+
+    /// <summary>
     ///     Whether the do-after should get interrupted if we drop the
     ///     active item we started the do-after with
     ///     This does nothing if <see cref="NeedHand"/> is false.

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -3,6 +3,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Physics;
+using Robust.Shared.Containers;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.DoAfter;
@@ -235,6 +236,15 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             // If the user changes which hand is active at all, interrupt the do-after
             if (args.BreakOnHandChange && hands.ActiveHand?.Name != doAfter.InitialHand)
                 return true;
+        }
+
+        if (args.BreakOnContainerChange && args.EventTarget != null)
+        {
+            _container.TryGetContainingContainer((args.EventTarget.Value, null, null), out var container);
+            if (container == null || container.ID != doAfter.InitialContainerID)
+            {
+                return true;
+            }
         }
 
         if (args.RequireCanInteract && !_actionBlocker.CanInteract(args.User, args.Target))

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Damage;
 using Content.Shared.Hands.Components;
 using Content.Shared.Tag;
+using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -16,6 +17,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
 {
     [Dependency] protected readonly IGameTiming GameTiming = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly TagSystem _tag = default!;
 
@@ -223,6 +225,14 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
 
             doAfter.InitialHand = handsComponent.ActiveHand?.Name;
             doAfter.InitialItem = handsComponent.ActiveHandEntity;
+        }
+
+        if (args.BreakOnContainerChange && args.EventTarget != null)
+        {
+            if (_container.TryGetContainingContainer((args.EventTarget.Value, null, null), out var container))
+            {
+                doAfter.InitialContainerID = container.ID;
+            }
         }
 
         doAfter.NetInitialItem = GetNetEntity(doAfter.InitialItem);

--- a/Content.Shared/Medical/Stethoscope/StethoscopeSystem.cs
+++ b/Content.Shared/Medical/Stethoscope/StethoscopeSystem.cs
@@ -73,6 +73,7 @@ public sealed class StethoscopeSystem : EntitySystem
             BreakOnMove = true,
             Hidden = true,
             BreakOnHandChange = false,
+            BreakOnContainerChange = true,
         });
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Add `BreakOnContainerChange` option to DoAfter, application is for stethoscope to be interrupted when unequipping it

## Why / Balance
See #36223

## Technical details
DoAfter checks the container ID on start and on update to compare. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fix a bug where stethoscope wasn't interrupted on unequip.
-->
