### PR TITLE
Fix warning CS9107

### DIFF
--- a/Content.Client/Xenoarchaeology/Ui/AnalysisConsoleBoundUserInterface.cs
+++ b/Content.Client/Xenoarchaeology/Ui/AnalysisConsoleBoundUserInterface.cs
@@ -21,7 +21,7 @@ public sealed class AnalysisConsoleBoundUserInterface(EntityUid owner, Enum uiKe
         base.Open();
 
         _consoleMenu = this.CreateWindow<AnalysisConsoleMenu>();
-        _consoleMenu.SetOwner(owner);
+        _consoleMenu.SetOwner(Owner);
 
         _consoleMenu.OnClose += Close;
         _consoleMenu.OpenCentered();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes an instance of warning CS9107 ("Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor. The value might be captured by the base class as well") in `AnalysisConsoleBoundUserInterface.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Capitalized an o.

Actual explanation: using `owner` from the primary constructor in `AnalysisConsoleBoundUserInterface.Open` causes this warning, since it is both being used locally and being passed to the base constructor. The base constructor (in `BoundUserInterface`) captures the value in the `Owner` field, so we can just use that instead.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->