### PR TITLE
Improve LocalizedDataset test to check for low Count

### DIFF
--- a/Content.IntegrationTests/Tests/Localization/LocalizedDatasetPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Localization/LocalizedDatasetPrototypeTest.cs
@@ -30,6 +30,10 @@ public sealed class LocalizedDatasetPrototypeTest
                     // Make sure the localization manager has a string for the LocId
                     Assert.That(localizationMan.HasString(locId), $"LocalizedDataset {proto.ID} with prefix \"{proto.Values.Prefix}\" specifies {proto.Values.Count} entries, but no localized string was found matching {locId}!");
                 }
+
+                // Check that count isn't set too low
+                var nextId = proto.Values.Prefix + (proto.Values.Count + 1);
+                Assert.That(localizationMan.HasString(nextId), Is.False, $"LocalizedDataset {proto.ID} with prefix \"{proto.Values.Prefix}\" specifies {proto.Values.Count} entries, but a localized string exists with ID {nextId}! Does count need to be raised?");
             }
         });
 

--- a/Resources/Prototypes/Datasets/figurines.yml
+++ b/Resources/Prototypes/Datasets/figurines.yml
@@ -212,7 +212,7 @@
   id: FigurinesFootsoldier
   values:
     prefix: figurines-footsoldier-
-    count: 2
+    count: 5
 
 - type: localizedDataset
   id: FigurinesWizard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added logic to `LocalizedDatasetPrototypeTest` to check if a LocId exists using the dataset's Count + 1.

Also, proves its worth by fixing the Count being set too low for the `FigurinesFootsoldier` dataset.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This will catch instances where the Count has been set too low. Requested [here](https://github.com/space-wizards/space-station-14/pull/36846#issuecomment-2822852702).

## Technical details
<!-- Summary of code changes for easier review. -->
Added an additional check for each prototype that generates the next LocId that would be used and checks if a localized string is registered with that ID. If it is, the test fails with a message suggesting that Count should be raised.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->