### PR TITLE
Modernize `GhostComponent` & Ghost API

### DIFF
--- a/Content.Server/Administration/Commands/AGhostCommand.cs
+++ b/Content.Server/Administration/Commands/AGhostCommand.cs
@@ -117,6 +117,6 @@ public sealed class AGhostCommand : LocalizedCommands
         }
 
         var comp = _entities.GetComponent<GhostComponent>(ghost);
-        ghostSystem.SetCanReturnToBody(comp, canReturn);
+        ghostSystem.SetCanReturnToBody((ghost, comp), canReturn);
     }
 }

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -489,10 +489,10 @@ namespace Content.Server.Ghost
 
             if (mind.Comp.TimeOfDeath.HasValue)
             {
-                SetTimeOfDeath(ghost, mind.Comp.TimeOfDeath!.Value, ghostComponent);
+                SetTimeOfDeath((ghost, ghostComponent), mind.Comp.TimeOfDeath!.Value);
             }
 
-            SetCanReturnToBody(ghostComponent, canReturn);
+            SetCanReturnToBody((ghost, ghostComponent), canReturn);
 
             if (canReturn)
                 _minds.Visit(mind.Owner, ghost, mind.Comp);

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -62,7 +62,7 @@ public sealed class MindSystem : SharedMindSystem
         {
             TransferTo(mindId, visiting, mind: mind);
             if (TryComp(visiting, out GhostComponent? ghostComp))
-                _ghosts.SetCanReturnToBody(ghostComp, false);
+                _ghosts.SetCanReturnToBody((visiting, ghostComp), false);
             return;
         }
 
@@ -214,7 +214,7 @@ public sealed class MindSystem : SharedMindSystem
             entity = Spawn(GameTicker.ObserverPrototypeName, position);
             component = EnsureComp<MindContainerComponent>(entity.Value);
             var ghostComponent = Comp<GhostComponent>(entity.Value);
-            _ghosts.SetCanReturnToBody(ghostComponent, false);
+            _ghosts.SetCanReturnToBody((entity.Value, ghostComponent), false);
         }
 
         var oldEntity = mind.OwnedEntity;

--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -50,21 +50,8 @@ public sealed partial class GhostComponent : Component
     [DataField("booMaxTargets"), ViewVariables(VVAccess.ReadWrite)]
     public int BooMaxTargets = 3;
 
-    // TODO: instead of this funny stuff just give it access and update in system dirtying when needed
-    [ViewVariables(VVAccess.ReadWrite)]
-    public bool CanGhostInteract
-    {
-        get => _canGhostInteract;
-        set
-        {
-            if (_canGhostInteract == value) return;
-            _canGhostInteract = value;
-            Dirty();
-        }
-    }
-
     [DataField("canInteract"), AutoNetworkedField]
-    private bool _canGhostInteract;
+    public bool CanGhostInteract;
 
     /// <summary>
     /// Is this ghost player allowed to return to their original body?

--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -4,6 +4,10 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Ghost;
 
+/// <summary>
+/// Represents an observer ghost.
+/// Handles limiting interactions, using ghost abilities, ghost visibility, and ghost warping.
+/// </summary>
 [RegisterComponent, NetworkedComponent, Access(typeof(SharedGhostSystem))]
 [AutoGenerateComponentState(true), AutoGenerateComponentPause]
 public sealed partial class GhostComponent : Component

--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -41,13 +41,13 @@ public sealed partial class GhostComponent : Component
 
     // End actions
 
-    [ViewVariables(VVAccess.ReadWrite), DataField, AutoPausedField]
+    [DataField, AutoPausedField]
     public TimeSpan TimeOfDeath = TimeSpan.Zero;
 
-    [DataField("booRadius"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float BooRadius = 3;
 
-    [DataField("booMaxTargets"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public int BooMaxTargets = 3;
 
     [DataField("canInteract"), AutoNetworkedField]

--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -41,15 +41,36 @@ public sealed partial class GhostComponent : Component
 
     // End actions
 
+    /// <summary>
+    /// Time at which the player died and created this ghost.
+    /// Used to determine votekick eligibility.
+    /// </summary>
+    /// <remarks>
+    /// May not reflect actual time of death if this entity has been paused,
+    /// but will give an accurate length of time <i>since</i> death.
+    /// </remarks>
     [DataField, AutoPausedField]
     public TimeSpan TimeOfDeath = TimeSpan.Zero;
 
+    /// <summary>
+    /// Range of the Boo action.
+    /// </summary>
     [DataField]
     public float BooRadius = 3;
 
+    /// <summary>
+    /// Maximum number of entities that can affected by the Boo action.
+    /// </summary>
     [DataField]
     public int BooMaxTargets = 3;
 
+    /// <summary>
+    /// Is this ghost allowed to interact with entities?
+    /// </summary>
+    /// <remarks>
+    /// Used to allow admins ghosts to interact with the world.
+    /// Changed by <see cref="SharedGhostSystem.SetCanGhostInteract"/>.
+    /// </remarks>
     [DataField("canInteract"), AutoNetworkedField]
     public bool CanGhostInteract;
 
@@ -57,7 +78,7 @@ public sealed partial class GhostComponent : Component
     /// Is this ghost player allowed to return to their original body?
     /// </summary>
     /// <remarks>
-    /// Changed by <see cref="SharedGhostSystem.SetCanReturnToBody"/>
+    /// Changed by <see cref="SharedGhostSystem.SetCanReturnToBody"/>.
     /// </remarks>
     [DataField, AutoNetworkedField]
     public bool CanReturnToBody;

--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -67,20 +67,13 @@ public sealed partial class GhostComponent : Component
     private bool _canGhostInteract;
 
     /// <summary>
-    ///     Changed by <see cref="SharedGhostSystem.SetCanReturnToBody"/>
+    /// Is this ghost player allowed to return to their original body?
     /// </summary>
-    // TODO MIRROR change this to use friend classes when thats merged
-    [ViewVariables(VVAccess.ReadWrite)]
-    public bool CanReturnToBody
-    {
-        get => _canReturnToBody;
-        set
-        {
-            if (_canReturnToBody == value) return;
-            _canReturnToBody = value;
-            Dirty();
-        }
-    }
+    /// <remarks>
+    /// Changed by <see cref="SharedGhostSystem.SetCanReturnToBody"/>
+    /// </remarks>
+    [DataField, AutoNetworkedField]
+    public bool CanReturnToBody;
 
     /// <summary>
     /// Ghost color
@@ -88,9 +81,6 @@ public sealed partial class GhostComponent : Component
     /// <remarks>Used to allow admins to change ghost colors. Should be removed if the capability to edit existing sprite colors is ever added back.</remarks>
     [DataField, AutoNetworkedField]
     public Color Color = Color.White;
-
-    [DataField("canReturnToBody"), AutoNetworkedField]
-    private bool _canReturnToBody;
 }
 
 public sealed partial class ToggleFoVActionEvent : InstantActionEvent { }

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -37,6 +37,9 @@ namespace Content.Shared.Ghost
                 args.Cancel();
         }
 
+        /// <summary>
+        /// Sets the ghost's time of death.
+        /// </summary>
         public void SetTimeOfDeath(Entity<GhostComponent?> entity, TimeSpan value)
         {
             if (!Resolve(entity, ref entity.Comp))
@@ -55,6 +58,9 @@ namespace Content.Shared.Ghost
             SetTimeOfDeath((uid, component), value);
         }
 
+        /// <summary>
+        /// Sets whether or not the ghost player is allowed to return to their original body.
+        /// </summary>
         public void SetCanReturnToBody(Entity<GhostComponent?> entity, bool value)
         {
             if (!Resolve(entity, ref entity.Comp))
@@ -79,6 +85,10 @@ namespace Content.Shared.Ghost
             SetCanReturnToBody((component.Owner, component), value);
         }
 
+
+        /// <summary>
+        /// Sets whether the ghost is allowed to interact with other entities.
+        /// </summary>
         public void SetCanGhostInteract(Entity<GhostComponent?> entity, bool value)
         {
             if (!Resolve(entity, ref entity.Comp))

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -68,6 +68,18 @@ namespace Content.Shared.Ghost
         {
             SetCanReturnToBody((component.Owner, component), value);
         }
+
+        public void SetCanGhostInteract(Entity<GhostComponent?> entity, bool value)
+        {
+            if (!Resolve(entity, ref entity.Comp))
+                return;
+
+            if (entity.Comp.CanGhostInteract == value)
+                return;
+
+            entity.Comp.CanGhostInteract = value;
+            Dirty(entity);
+        }
     }
 
     /// <summary>

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -37,12 +37,22 @@ namespace Content.Shared.Ghost
                 args.Cancel();
         }
 
-        public void SetTimeOfDeath(EntityUid uid, TimeSpan value, GhostComponent? component)
+        public void SetTimeOfDeath(Entity<GhostComponent?> entity, TimeSpan value)
         {
-            if (!Resolve(uid, ref component))
+            if (!Resolve(entity, ref entity.Comp))
                 return;
 
-            component.TimeOfDeath = value;
+            if (entity.Comp.TimeOfDeath == value)
+                return;
+
+            entity.Comp.TimeOfDeath = value;
+            Dirty(entity);
+        }
+
+        [Obsolete("Use the Entity<GhostComponent?> overload")]
+        public void SetTimeOfDeath(EntityUid uid, TimeSpan value, GhostComponent? component)
+        {
+            SetTimeOfDeath((uid, component), value);
         }
 
         public void SetCanReturnToBody(Entity<GhostComponent?> entity, bool value)

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -45,17 +45,28 @@ namespace Content.Shared.Ghost
             component.TimeOfDeath = value;
         }
 
-        public void SetCanReturnToBody(EntityUid uid, bool value, GhostComponent? component = null)
+        public void SetCanReturnToBody(Entity<GhostComponent?> entity, bool value)
         {
-            if (!Resolve(uid, ref component))
+            if (!Resolve(entity, ref entity.Comp))
                 return;
 
-            component.CanReturnToBody = value;
+            if (entity.Comp.CanReturnToBody == value)
+                return;
+
+            entity.Comp.CanReturnToBody = value;
+            Dirty(entity);
         }
 
+        [Obsolete("Use the Entity<GhostComponent?> overload")]
+        public void SetCanReturnToBody(EntityUid uid, bool value, GhostComponent? component = null)
+        {
+            SetCanReturnToBody((uid, component), value);
+        }
+
+        [Obsolete("Use the Entity<GhostComponent?> overload")]
         public void SetCanReturnToBody(GhostComponent component, bool value)
         {
-            component.CanReturnToBody = value;
+            SetCanReturnToBody((component.Owner, component), value);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Brought `GhostComponent` and `SharedGhostSystem` more in line with current coding conventions.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This started out as wanting to kill the obsolete warnings for `Dirty` in `GhostComponent`, but the best way to do that was to convert the getter/setter properties into system methods, as expected for ECS. Some additional cleanup happened along the way.

## Technical details
<!-- Summary of code changes for easier review. -->
- Converted the `CanGhostInteract` and `CanReturnToBody` properties of `GhostComponent` into simple fields.
- Added a public `SetCanGhostInteract` method to `SharedGhostSystem`.
- Added an overload of `SetCanReturnToBody` that takes an `Entity<GhostComponent?>`.
- Obsoleted old versions of `SetCanReturnToBody`.
- Added an overload of `SetTimeOfDeath` that takes an `Entity<GhostComponent?>`.
- Obsoleted the old version of `SetTimeOfDeath`.
- Cleaned up code in other places that was calling the now-obsolete methods.
- Added xmldocs to `GhostComponent`, most `GhostComponent` datafields, and `SharedGhostSystem` public methods.
- Verified that ghost tests still pass and ghosts appear to function as expected.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Non-breaking, just obsoleted, but still:

The following `SharedGhostSystem` methods are now obsolete:
- `SetCanReturnToBody(GhostComponent, bool)`
- `SetCanReturnToBody(EntityUid, bool, GhostComponent?)`
- `SetTimeOfDeath(EntityUid, TimeSpan, GhostComponent?)`

Please update your code to use the `Entity<GhostComponent?>` overloads.