### PR TITLE
Remove redundant fields from `MovementSpeedModifierComponent`

### DIFF
--- a/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
+++ b/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
@@ -32,28 +32,6 @@ namespace Content.Shared.Movement.Components
         [AutoNetworkedField, ViewVariables]
         public float SprintSpeedModifier = 1.0f;
 
-        [ViewVariables(VVAccess.ReadWrite)]
-        private float _baseWalkSpeedVV
-        {
-            get => BaseWalkSpeed;
-            set
-            {
-                BaseWalkSpeed = value;
-                Dirty();
-            }
-        }
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        private float _baseSprintSpeedVV
-        {
-            get => BaseSprintSpeed;
-            set
-            {
-                BaseSprintSpeed = value;
-                Dirty();
-            }
-        }
-
         /// <summary>
         /// Minimum speed a mob has to be moving before applying movement friction.
         /// </summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Deleted `_baseWalkSpeedVV` and `_baseSprintSpeedVV` from `MovementSpeedModifierComponent`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
They are outdated and pointless, and they produce compiler warnings.
Two more for [PZW](https://github.com/space-wizards/space-station-14/issues/33279).

## Technical details
<!-- Summary of code changes for easier review. -->
`BaseWalkSpeed` and `BaseSprintSpeed` can both be set using View Variables, and doing so will `Dirty` the field automatically (I have tested and verified this). These extra fields presumably come from a time before that was the case, but now they are redundant.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->