### PR TITLE
Cleanup warning in `EmptyAllContainersBehaviour`

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/EmptyAllContainersBehaviour.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/EmptyAllContainersBehaviour.cs
@@ -13,7 +13,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
             if (!system.EntityManager.TryGetComponent<ContainerManagerComponent>(owner, out var containerManager))
                 return;
 
-            foreach (var container in containerManager.GetAllContainers())
+            foreach (var container in system.EntityManager.System<SharedContainerSystem>().GetAllContainers(owner, containerManager))
             {
                 system.ContainerSystem.EmptyContainer(container, true, system.EntityManager.GetComponent<TransformComponent>(owner).Coordinates);
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed one warning in `EmptyAllContainersBehaviour`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
**'ContainerManagerComponent.GetAllContainers()' is obsolete [CS0612](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0612))**
Replaced with `SharedContainerSystem.GetAllContainers`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->