### PR TITLE
Cleanup warnings in `SharedCryostorageSystem`

### DIFF
--- a/Content.Shared/Bed/Cryostorage/SharedCryostorageSystem.cs
+++ b/Content.Shared/Bed/Cryostorage/SharedCryostorageSystem.cs
@@ -21,6 +21,7 @@ public abstract class SharedCryostorageSystem : EntitySystem
     [Dependency] private   readonly IConfigurationManager _configuration = default!;
     [Dependency] private   readonly IMapManager _mapManager = default!;
     [Dependency] private   readonly ISharedPlayerManager _player = default!;
+    [Dependency] private   readonly SharedMapSystem _map = default!;
     [Dependency] private   readonly MobStateSystem _mobState = default!;
     [Dependency] private   readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] protected readonly IGameTiming Timing = default!;
@@ -168,9 +169,8 @@ public abstract class SharedCryostorageSystem : EntitySystem
         if (PausedMap != null && Exists(PausedMap))
             return;
 
-        var map = _mapManager.CreateMap();
-        _mapManager.SetMapPaused(map, true);
-        PausedMap = _mapManager.GetMapEntityId(map);
+        PausedMap = _map.CreateMap();
+        _map.SetPaused(PausedMap.Value, true);
     }
 
     public bool IsInPausedMap(Entity<TransformComponent?> entity)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed 3 warnings in `SharedCryostorageSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Added `SharedMapSystem` as a dependency and replaced obsolete `MapManager` methods with `SharedMapSystem` methods. Code structure was changed slightly because `SharedMapSystem.CreateMap` returns the map EntityUid instead of a MapId, so it was no longer necessary to get the map's uid.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->