### PR TITLE
Cleanup warnings in `CableSystem.Placer`

### DIFF
--- a/Content.Server/Power/EntitySystems/CableSystem.Placer.cs
+++ b/Content.Server/Power/EntitySystems/CableSystem.Placer.cs
@@ -32,13 +32,14 @@ public sealed partial class CableSystem
             return;
 
         var gridUid = _transform.GetGrid(args.ClickLocation)!.Value;
-        var snapPos = grid.TileIndicesFor(args.ClickLocation);
+        var snapPos = _map.TileIndicesFor((gridUid, grid), args.ClickLocation);
         var tileDef = (ContentTileDefinition) _tileManager[_map.GetTileRef(gridUid, grid,snapPos).Tile.TypeId];
 
         if (!tileDef.IsSubFloor || !tileDef.Sturdy)
             return;
 
-        foreach (var anchored in grid.GetAnchoredEntities(snapPos))
+
+        foreach (var anchored in _map.GetAnchoredEntities((gridUid, grid), snapPos))
         {
             if (TryComp<CableComponent>(anchored, out var wire) && wire.CableType == component.BlockingCableType)
                 return;
@@ -47,7 +48,7 @@ public sealed partial class CableSystem
         if (TryComp<StackComponent>(placer, out var stack) && !_stack.Use(placer, 1, stack))
             return;
 
-        var newCable = EntityManager.SpawnEntity(component.CablePrototypeId, grid.GridTileToLocal(snapPos));
+        var newCable = EntityManager.SpawnEntity(component.CablePrototypeId, _map.GridTileToLocal(gridUid, grid, snapPos));
         _adminLogger.Add(LogType.Construction, LogImpact.Low,
             $"{ToPrettyString(args.User):player} placed {ToPrettyString(newCable):cable} at {Transform(newCable).Coordinates}");
         args.Handled = true;

--- a/Content.Server/Power/EntitySystems/CableSystem.Placer.cs
+++ b/Content.Server/Power/EntitySystems/CableSystem.Placer.cs
@@ -28,12 +28,12 @@ public sealed partial class CableSystem
         if (component.CablePrototypeId == null)
             return;
 
-        if(!TryComp<MapGridComponent>(_transform.GetGrid(args.ClickLocation), out var grid))
+        if (!TryComp<MapGridComponent>(_transform.GetGrid(args.ClickLocation), out var grid))
             return;
 
         var gridUid = _transform.GetGrid(args.ClickLocation)!.Value;
         var snapPos = _map.TileIndicesFor((gridUid, grid), args.ClickLocation);
-        var tileDef = (ContentTileDefinition) _tileManager[_map.GetTileRef(gridUid, grid,snapPos).Tile.TypeId];
+        var tileDef = (ContentTileDefinition)_tileManager[_map.GetTileRef(gridUid, grid, snapPos).Tile.TypeId];
 
         if (!tileDef.IsSubFloor || !tileDef.Sturdy)
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 3 warnings in `CableSystem.Placer`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
**1x 'MapGridComponent.TileIndicesFor(EntityCoordinates)' is obsolete: 'Use the MapSystem method' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Replaced with `SharedMapSystem.TileIndicesFor`.

**1x 'MapGridComponent.GetAnchoredEntities(Vector2i)' is obsolete: 'Use the MapSystem method' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Replaced with `SharedMapSystem.GetAnchoredEntities`.

**1x 'MapGridComponent.GridTileToLocal(Vector2i)' is obsolete: 'Use the MapSystem method' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Replaced with `SharedMapSystem.GridTileToLocal`.

Also made some tiny formatting fixes in a separate commit.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->