### PR TITLE
Move guardian sounds to component

### DIFF
--- a/Content.Server/Guardian/GuardianComponent.cs
+++ b/Content.Server/Guardian/GuardianComponent.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Audio;
+
 namespace Content.Server.Guardian
 {
     /// <summary>
@@ -29,6 +31,24 @@ namespace Content.Server.Guardian
         /// </summary>
         [DataField]
         public bool GuardianLoose;
+
+        /// <summary>
+        /// Sound played when a mob starts hosting the guardian.
+        /// </summary>
+        [DataField]
+        public SoundSpecifier InjectSound = new SoundPathSpecifier("/Audio/Effects/guardian_inject.ogg");
+
+        /// <summary>
+        /// Sound played when the guardian enters critical state.
+        /// </summary>
+        [DataField]
+        public SoundSpecifier CriticalSound = new SoundPathSpecifier("/Audio/Effects/guardian_warn.ogg");
+
+        /// <summary>
+        /// Sound played when the guardian dies.
+        /// </summary>
+        [DataField]
+        public SoundSpecifier DeathSound = new SoundPathSpecifier("/Audio/Voice/Human/malescream_guardian.ogg", AudioParams.Default.WithVariation(0.2f));
 
     }
 }

--- a/Content.Server/Guardian/GuardianSystem.cs
+++ b/Content.Server/Guardian/GuardianSystem.cs
@@ -1,7 +1,6 @@
 using Content.Server.Body.Systems;
 using Content.Server.Popups;
 using Content.Shared.Actions;
-using Content.Shared.Audio;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -13,8 +12,6 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs;
 using Content.Shared.Popups;
-using Robust.Server.GameObjects;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
@@ -224,7 +221,7 @@ namespace Content.Server.Guardian
             if (TryComp<GuardianComponent>(guardian, out var guardianComp))
             {
                 guardianComp.Host = args.Args.Target.Value;
-                _audio.PlayPvs("/Audio/Effects/guardian_inject.ogg", args.Args.Target.Value);
+                _audio.PlayPvs(guardianComp.InjectSound, args.Args.Target.Value);
                 _popupSystem.PopupEntity(Loc.GetString("guardian-created"), args.Args.Target.Value, args.Args.Target.Value);
                 // Exhaust the activator
                 component.Used = true;
@@ -246,15 +243,18 @@ namespace Content.Server.Guardian
             if (component.HostedGuardian == null)
                 return;
 
+            TryComp<GuardianComponent>(component.HostedGuardian, out var guardianComp);
+
             if (args.NewMobState == MobState.Critical)
             {
                 _popupSystem.PopupEntity(Loc.GetString("guardian-host-critical-warn"), component.HostedGuardian.Value, component.HostedGuardian.Value);
-                _audio.PlayPvs("/Audio/Effects/guardian_warn.ogg", component.HostedGuardian.Value);
+                if (guardianComp != null)
+                    _audio.PlayPvs(guardianComp.CriticalSound, component.HostedGuardian.Value);
             }
             else if (args.NewMobState == MobState.Dead)
             {
-                //TODO: Replace WithVariation with datafield
-                _audio.PlayPvs("/Audio/Voice/Human/malescream_guardian.ogg", uid, AudioParams.Default.WithVariation(0.20f));
+                if (guardianComp != null)
+                    _audio.PlayPvs(guardianComp.DeathSound, uid);
                 RemComp<GuardianHostComponent>(uid);
             }
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Moved the inject, host critical, and death sounds so they are no longer hardcoded into `GuardianSystem` and can be configured on `GuardianComponent`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Using string literals for sounds is deprecated, and I wanted to fix the resulting warnings. Rather than switch to a different way of hardcoding the sound specifiers into the system, I opted to make them configurable as part of `GuardianComponent`, so different types of guardians can now use different sounds if desired.
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Added three new datafields to `GuardianComponent`: SoundSpecifiers for inject, critical, and death sounds. `GuardianSystem` now looks up the sound specifiers on the guardian's component and uses them.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->