### PR TITLE
Fix RoundToEqualLevels for max = levels case

### DIFF
--- a/Content.Shared/Rounding/ContentHelpers.cs
+++ b/Content.Shared/Rounding/ContentHelpers.cs
@@ -110,7 +110,11 @@
                 return 0;
             }
 
-            return (int) Math.Round(actual / max * levels, MidpointRounding.ToZero);
+            // This is necessary if the stack size is the same as the number of levels.
+            // If this doesn't happen, it starts at 1 instead of 0 and will skip the first state.
+            var mod = levels == (int) max ? 1 : 0;
+
+            return (int) Math.Round(actual / max * levels, MidpointRounding.ToZero) - mod;
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
There was odd behavior when the levels were equal to the max amount of items. This resolves the issue by just doing a specific check for the case of the levels equaling the max! There isn't really another easy fix, this is the cleanest I could think of.

See #35697 (This PR fixes the issue. Checkout the cone pr and make the cone levels normal to test this pr!)
See #35698 (Another approach)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

`RoundToEqualLevels` in `ContentHelper.cs` now properly sets the states when the levels are equal to the maximum value.
