### PR TITLE
Reptilians Can Eat Orange Creamsicles

### DIFF
--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -564,7 +564,8 @@
       - Cake
       - Pie
       - Bread
-      - Pistachios  
+      - Pistachios
+      - Creamsicle
 
 - type: cargoBounty
   id: BountyVegetable

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -90,6 +90,9 @@
   - type: Food
     trash: 
     - FoodFrozenPopsicleTrash
+  - type: Tag
+    tags:
+    - Fruit
 
 - type: entity
   name: berry creamsicle

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -93,6 +93,7 @@
   - type: Tag
     tags:
     - Fruit
+    - Creamsicle
 
 - type: entity
   name: berry creamsicle
@@ -112,6 +113,7 @@
   - type: Tag
     tags:
     - Fruit
+    - Creamsicle
 
 - type: entity
   name: jumbo ice-cream

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -387,6 +387,9 @@
   id: CrayonYellow
 
 - type: Tag
+  id: Creamsicle
+
+- type: Tag
   id: Crowbar
 
 - type: Tag


### PR DESCRIPTION
## About the PR
I've added a fruit tag to the orange creamsicle entity in frozen.yml to bring it in line with Reptilian dietary restrictions, and therefore make it edible to the species.

## Why / Balance
Reptilians are able to consume foods with meat and fruit tags. Otherwise inedible foods, such as cakes, are made edible when fruit flavoured (for instance, Reptilians can eat orange cake, but not normal cake, or carrot cake). On top of that, the berry creamsicle entity already had a fruit tag to make it edible to Reptilians.

This was a relatively rare entity before, but now with the [Ice Cream Delivery](https://github.com/space-wizards/space-station-14/pull/33286) crate now available from cargo, they will become a much more common item. This change gives Reptilians two options to pick from the freezer, all while staying in line with their established dietary habits.

## Technical details
Added the "fruit" tag to orange creamsicle, matching what is already there for berry creamsicle in frozen.yml.

## Media
![image](https://github.com/user-attachments/assets/c2c30f9a-858f-4224-94b6-ed74cc016a28)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl: AgentSmithRadio
- tweak: Reptilians can now eat orange creamsicles.
- fix: Berry creamsicles can no longer be used in cargo's generic fruit bounty.
