### PR TITLE
Fix donuts tags breaking the bounty

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
@@ -22,6 +22,16 @@
   - type: Item
     sprite: Objects/Consumable/Food/Baked/donut.rsi
     size: Tiny
+
+- type: entity
+  abstract: true
+  parent: FoodDonutBase
+  id: FoodDonutFruitBase
+  components:
+  - type: Tag
+    tags:
+    - Donut
+    - Fruit
 # Tastes like donut.
 
 # The sprinkles are now an overlay, so you can put them on any donut! If we really
@@ -296,7 +306,7 @@
 
 - type: entity
   name: apple jelly-donut
-  parent: FoodDonutBase
+  parent: FoodDonutFruitBase
   id: FoodDonutJellyApple
   description: Goes great with a shot of cinnamon schnapps.
   components:
@@ -311,6 +321,7 @@
           Quantity: 3
         - ReagentId: Vitamin
           Quantity: 1
+
 # Tastes like jelly-donut, green apples.
 
 - type: entity
@@ -355,7 +366,7 @@
 
 - type: entity
   name: blue pumpkin jelly-donut
-  parent: FoodDonutBase
+  parent: FoodDonutFruitBase
   id: FoodDonutJellyBluePumpkin
   description: Goes great with a mug of soothing drunken blue pumpkin.
   components:
@@ -378,7 +389,7 @@
 
 - type: entity
   name: bungo jelly-donut
-  parent: FoodDonutBase
+  parent: FoodDonutFruitBase
   id: FoodDonutJellyBungo
   description: Goes great with a mason jar of hippie's delight.
   components:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
@@ -109,6 +109,7 @@
   - type: Tag
     tags:
     - Meat
+    - Donut
 # Tastes like meat.
 
 - type: entity
@@ -310,9 +311,6 @@
           Quantity: 3
         - ReagentId: Vitamin
           Quantity: 1
-  - type: Tag
-    tags:
-    - Fruit
 # Tastes like jelly-donut, green apples.
 
 - type: entity
@@ -376,9 +374,6 @@
           Quantity: 3
         - ReagentId: Vitamin
           Quantity: 1
-  - type: Tag
-    tags:
-    - Fruit
 # Tastes like jelly-donut, blue pumpkin.
 
 - type: entity
@@ -398,9 +393,6 @@
           Quantity: 3
         - ReagentId: Vitamin
           Quantity: 1
-  - type: Tag
-    tags:
-    - Fruit # Apparently this is a fruit. Huh.
 # Tastes like jelly-donut, tropical sweetness.
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR fixes the tags override for the donuts that made them not valid for the donut bounty.

## Why / Balance
Bugfix.

## Technical details
N/A

## Media

https://github.com/user-attachments/assets/4fea7539-e05e-4c9a-93d1-10c802bb9707


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed some donuts not counting towards the donuts bounty for cargo.
