### PR TITLE
Adds muffin tins to dinnerware crate

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -84,6 +84,8 @@
       amount: 1
     - id: DrinkGlass
       amount: 4
+    - id: FoodPlateMuffinTin
+      amount: 4
     - id: FoodPlateTin
       amount: 4
     - id: Fork

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -88,10 +88,6 @@
       amount: 4
     - id: FoodPlateTin
       amount: 4
-    - id: Fork
-      amount: 2
-    - id: Spoon
-      amount: 2
 
 - type: entity
   id: CrateFoodBarSupply


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR replaces the 2 forks and 2 spoons in the Kitchen Dinnerware Crate with 4 muffin tins

## Why / Balance
The dinnerware crate currently adds bowls, skewers, and pie tins. Muffin tins are notably missing. The removal of forks and spoons are necessary because of the crate's item limit of 30. Muffin tins should be favored as they are more likely to be functionally useful to the chef.

In the future, forks and spoons can be re-added to the crate though the addition of a cardboard utensil box containing forks and spoons.


## Technical details
A simple addition to food.yml

## Media
![Muffin Tin](https://github.com/user-attachments/assets/09e911b9-5a74-4c16-b09a-e6b166f664e5)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Replaced forks and spoons in the Kitchen Dinnerware Crate with muffin tins.