### PR TITLE
Make 10u of "Atomic Bomb" drink instead of 11u

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -90,7 +90,7 @@
     Uranium:
       amount: 1
   products:
-    AtomicBomb: 11
+    AtomicBomb: 10
 
 - type: reaction
   id: B52


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Atomic Bomb recipe now gives 10u of cocktail instead of 11. Finally playable.

## Why / Balance
Consistency. All the other "rare" cocktails are made in 10 units,, but not this one for some reason. Also it just feels better to have even numbers.

## Technical details
Changed the folowing line: products: AtomicBomb: 11 to products: AtomicBomb: 10

## Media

Not needed.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None?.. If I understand this correctly. If I'm wrong - please tell me what to add here, sorry, first time trying to make a PR.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Atomic Bomb cocktail is now mixed in 10u instead of 11.
