### PR TITLE
Remove a redundant trycomp from TileAnomalySystem

### DIFF
--- a/Content.Server/Anomaly/Effects/TileAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/TileAnomalySystem.cs
@@ -84,11 +84,8 @@ public sealed class TileAnomalySystem : SharedTileAnomalySystem
 
     private void SpawnTiles(Entity<TileSpawnAnomalyComponent> anomaly, TileSpawnSettingsEntry entry, float stability, float severity, float powerMod)
     {
-        var xform = Transform(anomaly);
-        if (!TryComp<MapGridComponent>(xform.GridUid, out var grid))
-            return;
-
         var tiles = _anomaly.GetSpawningPoints(anomaly, stability, severity, entry.Settings, powerMod);
+
         if (tiles == null)
             return;
 

--- a/Content.Server/Anomaly/Effects/TileAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/TileAnomalySystem.cs
@@ -85,7 +85,6 @@ public sealed class TileAnomalySystem : SharedTileAnomalySystem
     private void SpawnTiles(Entity<TileSpawnAnomalyComponent> anomaly, TileSpawnSettingsEntry entry, float stability, float severity, float powerMod)
     {
         var tiles = _anomaly.GetSpawningPoints(anomaly, stability, severity, entry.Settings, powerMod);
-
         if (tiles == null)
             return;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes a redundant TryComp from TileAnomalySystem. This may well be pointless as I couldn't remember if there was any performance impact from TryComp. Essentially, this trycomp is repeated within GetSpawningPoints which will return null which immediately ends the function. Thinking here being this check can just be skipped as it'll be ran in the next function. I may very well be smooth brain though so. I figured I'd shoot it out there and see what happens.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->