### PR TITLE
Revert ringer text entry changes

### DIFF
--- a/Content.Client/PDA/Ringer/RingtoneMenu.xaml.cs
+++ b/Content.Client/PDA/Ringer/RingtoneMenu.xaml.cs
@@ -50,27 +50,14 @@ namespace Content.Client.PDA.Ringer
                     input.CursorPosition = input.Text.Length; // Resets caret position to the end of the typed input
                 };
 
-                input.OnTextChanged += args =>
+                input.OnTextChanged += _ =>
                 {
-                    // Convert to uppercase
-                    var upperText = args.Text.ToUpper();
+                    input.Text = input.Text.ToUpper();
 
-                    // Filter to only valid notes
-                    var newText = upperText;
-                    if (!IsNote(newText))
-                    {
-                        newText = PreviousNoteInputs[index];
+                    if (!IsNote(input.Text))
                         input.AddStyleClass("Caution");
-                    }
                     else
-                    {
-                        PreviousNoteInputs[index] = newText;
                         input.RemoveStyleClass("Caution");
-                    }
-
-                    // Only update if there's a change
-                    if (newText != input.Text)
-                        input.Text = newText;
                 };
             }
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Small revert to exactly how text is entered in the PDA ringer.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

For a bit of context, there are broadly two ways to edit your ringer:
1. highlight and replace a note
2. backspace and enter a new note

Prior to #35907, both options were possible. After it, only option 1 works, and option 2 no longer works. This seems to be because an empty text box is "invalid" and reverted to the previous note, as though a bad note were entered.

We use Wizden master changes pretty quickly after they get merged down on [Moffstation](https://github.com/moff-station/moff-station-14), so we ran into this as a useability issue, specifically for traitors who use entry option 2, who reported this as a hard bug which prevented their access to their uplinks.

As far as I can tell, there are no downsides to this revert, and it just works like it used to while keeping all of the predictive benefits of the refactor.

## Technical details
<!-- Summary of code changes for easier review. -->
Reverted `RingtoneMenu`'s `input.OnTextChanged` callback changes from #35907 .

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/43f15ac9-a5e6-4156-8c49-9a2da0401047

<details>
  <summary>Ringtone behavior prior to #35907</summary>
https://github.com/user-attachments/assets/81a9fcf7-edf8-4ef8-9c7f-2fdde4d9b5ea
</details>

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Shouldn't be any.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
N/A