### PR TITLE
Lowered PKA upgrade prices.

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/salvage.yml
+++ b/Resources/Prototypes/Recipes/Lathes/salvage.yml
@@ -76,9 +76,9 @@
   - Weapons
   completetime: 5
   materials:
-    Steel: 1500
-    Gold: 500
-    Silver: 500
+    Steel: 500
+    Gold: 100
+    Silver: 100
 
 - type: latheRecipe
   id: PKAUpgradeRange
@@ -87,9 +87,9 @@
   - Weapons
   completetime: 5
   materials:
-    Steel: 1500
-    Gold: 500
-    Silver: 500
+    Steel: 500
+    Gold: 100
+    Silver: 100
 
 - type: latheRecipe
   id: PKAUpgradeFireRate
@@ -98,7 +98,7 @@
   - Weapons
   completetime: 5
   materials:
-    Steel: 1500
-    Gold: 500
-    Silver: 500
+    Steel: 500
+    Gold: 100
+    Silver: 100
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
New PKA Upgrades are cool! The prices to make them are not.

As implemented making a single PKA modkit upgrade cost 15 Steel, 5 Gold, and 5 Silver. This is more expensive than the price to make a new PKA. Can you imagine the look on Science's face when the salvage team comes up to them and asks them to spend 3 stacks of steel and a stack of silver and gold just to get their guns upgraded? I can, and it's not a happy look. 

Prices have been lowered across the board. PKA modkits now cost 5 steel, one silver, and one gold, which should be much more managable and will prevent the upgrades from being such a massive tax on Science.

## Why / Balance
Save science from being the poverty department.

## Technical details
a dozen or so lines of yaml to cut the prices down.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
