### PR TITLE
Fix inflatable barriers finishing instantly if canceled!

### DIFF
--- a/Content.Shared/Engineering/Systems/DisassembleOnAltVerbSystem.cs
+++ b/Content.Shared/Engineering/Systems/DisassembleOnAltVerbSystem.cs
@@ -50,7 +50,7 @@ public sealed partial class DisassembleOnAltVerbSystem : EntitySystem
 
     private void OnDisassembleDoAfter(Entity<DisassembleOnAltVerbComponent> entity, ref DisassembleDoAfterEvent args)
     {
-        if (!_net.IsServer) // This is odd but it works :)
+        if (!_net.IsServer || args.Cancelled) // This is odd but it works :)
             return;
 
         if (TrySpawnNextTo(entity.Comp.PrototypeToSpawn, entity.Owner, out var spawnedEnt))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Caused by: #32420
Resolves: #36905

I didn't realize that doafters always trigger even if they aren't complete. Just added a simple check to ensure that it only deletes the wall if the doafter fully finishes!

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: archee1, Beck
- fix: Inflatable walls no longer instantly deconstruct if canceled.

