### PR TITLE
nuke borg soap

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -488,7 +488,6 @@
     - LightReplacer
     - BorgTrashBag
     - Plunger
-    - SoapNT
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: light-replacer-module }
 


### PR DESCRIPTION
## About the PR
Removes the soap bar janitorial borgs get.

## Why / Balance
There was a bug where if you fully consumed the soap (feeding it to someone, draining it by mixing it with water), you're left with an empty hand which can be used to pick up objects and interact with the world.

I would have fixed this by giving the borgs a soapbar that isn't able to be consumed, however:
- While doing this, I realized that borgs don't even clean things properly (I was trying to give it custom residue). The doafter for `CleanForensicsDoAfterEvent` fires but it's never received and the logic in `OnCleanForensicsDoAfter` never happens.
- I am not experienced enough in events to fix this so I am opting for a removal. After this, it's basically going to be the same.
- Borgs don't really need to clean stuff anyways so it's not like people are missing out on crazy gameplay (though it would be cool and complete to have it).

If someone else makes a fix then this PR can be closed and the fix merged.

## Technical details
Goodbye soap entry

## Media
Nah

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- remove: Soap has been removed from the borg custodial module pending a fix. It was able to be exploited to gain a hand slot as a borg, and it never actually cleaned scrubbed boxes anyways.
