### PR TITLE
Replace obsolete Threading calls in RoundEndTest.

### DIFF
--- a/Content.IntegrationTests/Tests/RoundEndTest.cs
+++ b/Content.IntegrationTests/Tests/RoundEndTest.cs
@@ -128,8 +128,8 @@ namespace Content.IntegrationTests.Tests
             async Task WaitForEvent()
             {
                 var timeout = Task.Delay(TimeSpan.FromSeconds(10));
-                var currentCount = Thread.VolatileRead(ref sys.RoundCount);
-                while (currentCount == Thread.VolatileRead(ref sys.RoundCount) && !timeout.IsCompleted)
+                var currentCount = Volatile.Read(ref sys.RoundCount);
+                while (currentCount == Volatile.Read(ref sys.RoundCount) && !timeout.IsCompleted)
                 {
                     await pair.RunTicksSync(5);
                 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Another small one. Replaces the obsolete Threading.VolatileRead calls with Volatile.Read calls. As with the last one, if the tests fail, I'll close this. Just warning cleanup.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->