### PR TITLE
Truncate lathe announcement lists

### DIFF
--- a/Content.Server/Lathe/Components/LatheAnnouncingComponent.cs
+++ b/Content.Server/Lathe/Components/LatheAnnouncingComponent.cs
@@ -14,4 +14,10 @@ public sealed partial class LatheAnnouncingComponent : Component
     /// </summary>
     [DataField(required: true)]
     public List<ProtoId<RadioChannelPrototype>> Channels = new();
+
+    /// <summary>
+    /// How many items should be announced in a message before it truncates
+    /// </summary>
+    [DataField]
+    public int MaximumItems = 5;
 }

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -385,10 +385,17 @@ namespace Content.Server.Lathe
             if (recipeNames.Count == 0)
                 return;
 
-            var message = Loc.GetString(
-                "lathe-unlock-recipe-radio-broadcast",
-                ("items", ContentLocalizationManager.FormatList(recipeNames))
-            );
+            var message =
+                recipeNames.Count > ent.Comp.MaximumItems ?
+                    Loc.GetString(
+                        "lathe-unlock-recipe-radio-broadcast-overflow",
+                        ("items", ContentLocalizationManager.FormatList(recipeNames.GetRange(0, ent.Comp.MaximumItems))),
+                        ("count", recipeNames.Count)
+                    ) :
+                    Loc.GetString(
+                        "lathe-unlock-recipe-radio-broadcast",
+                        ("items", ContentLocalizationManager.FormatList(recipeNames))
+                    );
 
             foreach (var channel in ent.Comp.Channels)
             {

--- a/Resources/Locale/en-US/lathe/lathesystem.ftl
+++ b/Resources/Locale/en-US/lathe/lathesystem.ftl
@@ -1,3 +1,4 @@
 lathe-popup-material-not-used = This material is not used in this machine.
 lathe-unlock-recipe-radio-broadcast = This lathe is now capable of producing the following recipes: {$items}
+lathe-unlock-recipe-radio-broadcast-overflow = This lathe is now capable of producing {$count} new recipes, including: {$items}
 lathe-unlock-recipe-radio-broadcast-item = [bold]{$item}[/bold]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR 
Lathe announcements now have an upper cap on the amount of recipes they'll announce at once

## Why / Balance
![grafik](https://github.com/user-attachments/assets/971186a4-681c-40f3-8d7a-39426d77d689)

## Media
![grafik](https://github.com/user-attachments/assets/1e0a884e-25eb-4688-9b08-0eb21be3a462)

## Technical details
- new datafield on the lathe announcing component & a new message

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Medical and security techfab will no longer announce more than five recipes at once, avoiding chat flooding

<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
