### PR TITLE
Changed soundGunshot for Pulse Pistol and Pulse Carbine from laser_cannon to laser3

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -267,7 +267,7 @@
     availableModes:
     - SemiAuto
     soundGunshot:
-      path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
+      path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: HitscanBatteryAmmoProvider
     proto: Pulse
     fireCost: 200
@@ -303,7 +303,7 @@
       - SemiAuto
       - FullAuto
     soundGunshot:
-      path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
+      path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: HitscanBatteryAmmoProvider
     proto: Pulse
     fireCost: 200


### PR DESCRIPTION
## About the PR
Changed soundGunshot for Pulse Pistol and Pulse Carbine from laser_cannon to laser3

## Why / Balance
The pulse weapon sounds didn't match. I was given the task by RedBookcase as a starting fix.

## Technical details
In battery_guns.yml soundGunshot file for Pulse Pistol and Pulse Carbine was set to laser_cannon, while Pulse Rifle was set to laser3. The sounds for Pulse Pistol and Pulse Carbine were changed to match Pulse Rifle.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Pulse Pistol, Pulse Carbine, and Pulse Rifle now share the same sound file.
