### PR TITLE
CMO Hardsuit: Zombification Resistance tweak

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -403,6 +403,8 @@
     modifiers:
       coefficients:
         Caustic: 0.1
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.4
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.95


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gives the CMO's hardsuit infection resistance equal to roughly halfway between a winter coat and a generic bio suit

## Why / Balance
Emisse told me to do it this way.
As for the value, this makes it desirable as a zeds protection item but fills its own niche (because hardsuit) instead of being strictly better than a bio suit.

## Technical details
YAML component addition

## Media
None needed

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None
**Changelog**
:cl: UpAndLeaves
- tweak: The CMO's hardsuit has been redesigned with extra durathread to withstand zombie bites more effectively.
