### PR TITLE
Added salvage expeditions computer board to shuttlecraft research

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -125,3 +125,4 @@
   - ThrusterMachineCircuitboard
   - GyroscopeMachineCircuitboard
   - MiniGravityGeneratorCircuitboard
+  - SalvageExpeditionsComputerCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -604,3 +604,8 @@
   parent: BaseCircuitboardRecipe
   id: HolopadMachineCircuitboard
   result: HolopadMachineCircuitboard
+
+- type: latheRecipe
+  parent: BaseGoldCircuitboardRecipe
+  id: SalvageExpeditionsComputerCircuitboard
+  result: SalvageExpeditionsComputerCircuitboard

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -135,6 +135,7 @@
   - ThrusterMachineCircuitboard
   - GyroscopeMachineCircuitboard
   - MiniGravityGeneratorCircuitboard
+  - SalvageExpeditionsComputerCircuitboard
 
 - type: technology
   id: AdvancedAtmospherics


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the salvage expeditions computer board to shuttlecraft research, with the intention to make salvage no longer start with an expeditions console.

## Why / Balance
Moving the expeditions console to a research reduces the incentive for salvage to build shuttles early, and shifts their focus towards making sure science and other departments have the resources they need to work if they want to eventually do expeditions.  Putting the board in shuttlecraft specifically also makes science a better source of shuttle parts for salvage than just ordering them.

## Technical details
-added a lathe recipe for the salvage expeditions computer that needs gold
-added the salvage expeditions board to the "ShuttleBoards" recipe pack

## Media
![image](https://github.com/user-attachments/assets/9b6704ae-8e6f-4a57-b418-35d291122cf8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- The salvage expeditions computer board can now be researched under shuttlecraft and made by science.
-->
