### PR TITLE
Borg Hands is Kill

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -98,6 +98,21 @@
 
 - type: entity
   name: soap
+  id: SoapBorg # Intended for borg internals
+  parent: SoapNT
+  description: A Nanotrasen brand bar of soap. Smells of plasma and machines.
+  components:
+  - type: DeleteOnSolutionEmpty #This overrides the DeleteOnSolutionEmpty component from the parent of the parent, Soap, which prevents this item from being consumed
+    solution: none
+  - type: SolutionRegeneration #Slowly regenerates so a borg isn't stuck with a sad crust of soap if they use it up, the rate may be lowered.
+    solution: soap
+    generated:
+      reagents:
+      - ReagentId: SoapReagent
+        Quantity: 1
+
+- type: entity
+  name: soap
   id: SoapDeluxe
   parent: Soap
   description: A deluxe Waffle Co. brand bar of soap. Smells of strawberries.

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -98,18 +98,25 @@
 
 - type: entity
   name: soap
-  id: SoapBorg # Intended for borg internals
-  parent: SoapNT
+  id: SoapBorg # Intended for borg internals, not slippery or food, not a container for soap reagent
+  parent: BaseItem
   description: A Nanotrasen brand bar of soap. Smells of plasma and machines.
   components:
-  - type: DeleteOnSolutionEmpty #This overrides the DeleteOnSolutionEmpty component from the parent of the parent, Soap, which prevents this item from being consumed
-    solution: none
-  - type: SolutionRegeneration #Slowly regenerates so a borg isn't stuck with a sad crust of soap if they use it up, the rate may be lowered.
-    solution: soap
-    generated:
-      reagents:
-      - ReagentId: SoapReagent
-        Quantity: 1
+  - type: Tag
+    tags:
+    - Soap
+  - type: Sprite
+    sprite: Objects/Specific/Janitorial/soap.rsi
+    layers:
+    - state: nt-4
+  - type: Appearance
+  - type: Item
+    sprite: Objects/Specific/Janitorial/soap.rsi
+    storedRotation: -90
+  - type: CleansForensics
+  - type: Residue
+    residueAdjective: residue-slippery
+    residueColor: residue-grey
 
 - type: entity
   name: soap

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -254,8 +254,6 @@
   - type: Residue
     residueAdjective: residue-slippery
     residueColor: residue-grey
-    residueAdjective: residue-slippery
-    residueColor: residue-blue
   - type: Tag
     tags:
     - Soap

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -98,28 +98,6 @@
 
 - type: entity
   name: soap
-  id: SoapBorg # Intended for borg internals, not slippery or food, not a container for soap reagent
-  parent: BaseItem
-  description: A Nanotrasen brand bar of soap. Smells of plasma and machines.
-  components:
-  - type: Tag
-    tags:
-    - Soap
-  - type: Sprite
-    sprite: Objects/Specific/Janitorial/soap.rsi
-    layers:
-    - state: nt-4
-  - type: Appearance
-  - type: Item
-    sprite: Objects/Specific/Janitorial/soap.rsi
-    storedRotation: -90
-  - type: CleansForensics
-  - type: Residue
-    residueAdjective: residue-slippery
-    residueColor: residue-grey
-
-- type: entity
-  name: soap
   id: SoapDeluxe
   parent: Soap
   description: A deluxe Waffle Co. brand bar of soap. Smells of strawberries.
@@ -255,5 +233,27 @@
         - ReagentId: SoapReagent
           Quantity: 240
   - type: Residue
+
+- type: entity
+  name: soap
+  id: SoapBorg # Intended for borg internals, not slippery or food, not a container for soap reagent
+  parent: BaseItem
+  description: A Nanotrasen brand bar of soap. Smells of plasma and machines.
+  components:
+  - type: Tag
+    tags:
+    - Soap
+  - type: Sprite
+    sprite: Objects/Specific/Janitorial/soap.rsi
+    layers:
+    - state: nt-4
+  - type: Appearance
+  - type: Item
+    sprite: Objects/Specific/Janitorial/soap.rsi
+    storedRotation: -90
+  - type: CleansForensics
+  - type: Residue
+    residueAdjective: residue-slippery
+    residueColor: residue-grey
     residueAdjective: residue-slippery
     residueColor: residue-blue

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -233,6 +233,8 @@
         - ReagentId: SoapReagent
           Quantity: 240
   - type: Residue
+    residueAdjective: residue-slippery
+    residueColor: residue-blue
 
 - type: entity
   name: soap
@@ -240,9 +242,6 @@
   parent: BaseItem
   description: A Nanotrasen brand bar of soap. Smells of plasma and machines.
   components:
-  - type: Tag
-    tags:
-    - Soap
   - type: Sprite
     sprite: Objects/Specific/Janitorial/soap.rsi
     layers:
@@ -257,3 +256,6 @@
     residueColor: residue-grey
     residueAdjective: residue-slippery
     residueColor: residue-blue
+  - type: Tag
+    tags:
+    - Soap

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -488,7 +488,7 @@
     - LightReplacer
     - BorgTrashBag
     - Plunger
-    - SoapNT
+    - SoapBorg
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: light-replacer-module }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Created new soap for borgs, SoapBorg. This does not inherent the solution container features of the normal soaps nor is it a food. 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Prevents a bug where a janiborg could use up their soap and then have a free hand. 

Fixes https://github.com/space-wizards/space-station-14/issues/36927.
## Technical details
<!-- Summary of code changes for easier review. -->
The parent of all soaps, Soap, has the component DeleteOnSolutionEmpty with solution: soap. To resolve the issue, I reparent from BaseItem to get rid of this and other unneeded components.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. 

https://github.com/user-attachments/assets/471705a3-5c4f-48ec-af42-05161844edbc -->


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed a bug which allowed Janitor borgs to delete a held item and acquire an empty hand.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
