### PR TITLE
Welding locker loot, migrate to EntityTable

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -65,61 +65,41 @@
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
-        tableId: FillWelderSupplies
+      entity_storage: !type:AllSelector
+        children:
+        - !type:NestedSelector
+          tableId: FillWelderSupplies
+          rolls: !type:ConstantNumberSelector
+            value: 3
+        - !type:NestedSelector
+          tableId: FillWelderSuppliesMask
+          rolls: !type:ConstantNumberSelector
+            value: 3
 
 - type: entityTable
   id: FillWelderSupplies
-  table: !type:AllSelector
+  table: !type:GroupSelector
     children:
-    - !type:GroupSelector
-      children:
-      - id: ClothingHeadHatWelding
-      - id: ClothingHeadHatWeldingMaskFlame
-        weight: 0.25
-      - id: ClothingHeadHatWeldingMaskFlameBlue
-        weight: 0.25
-      - id: ClothingHeadHatWeldingMaskPainted
-        weight: 0.25
-    - !type:GroupSelector
-      children:
-      - id: ClothingHeadHatWelding
-      - id: ClothingHeadHatWeldingMaskFlame
-        weight: 0.25
-      - id: ClothingHeadHatWeldingMaskFlameBlue
-        weight: 0.25
-      - id: ClothingHeadHatWeldingMaskPainted
-        weight: 0.25
-    - !type:GroupSelector
-      children:
-      - id: ClothingHeadHatWelding
-      - id: ClothingHeadHatWeldingMaskFlame
-        weight: 0.25
-      - id: ClothingHeadHatWeldingMaskFlameBlue
-        weight: 0.25
-      - id: ClothingHeadHatWeldingMaskPainted
-        weight: 0.25
-    - !type:GroupSelector
-      children:
-      - id: Welder
-      - id: WelderIndustrial
-        weight: 0.25
-      - id: WelderIndustrialAdvanced
-        weight: 0.10
-    - !type:GroupSelector
-      children:
-      - id: Welder
-      - id: WelderIndustrial
-        weight: 0.25
-      - id: WelderIndustrialAdvanced
-        weight: 0.10
-    - !type:GroupSelector
-      children:
-      - id: Welder
-      - id: WelderIndustrial
-        weight: 0.25
-      - id: WelderIndustrialAdvanced
-        weight: 0.10
+    - id: ClothingHeadHatWelding
+    - id: ClothingHeadHatWeldingMaskFlame
+      weight: 0.25
+    - id: ClothingHeadHatWeldingMaskFlameBlue
+      weight: 0.25
+    - id: ClothingHeadHatWeldingMaskPainted
+      weight: 0.25
+    - id: ClothingMaskWeldingGas
+      weight: 0.05
+
+- type: entityTable
+  id: FillWelderSuppliesMask
+  table: !type:GroupSelector
+    children:
+    - id: WelderMini
+    - id: Welder
+    - id: WelderIndustrial
+      weight: 0.25
+    - id: WelderIndustrialAdvanced
+      weight: 0.05
 
 - type: entity
   id: LockerAtmosphericsFilledHardsuit

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -87,8 +87,8 @@
       weight: 0.25
     - id: ClothingHeadHatWeldingMaskPainted
       weight: 0.25
-    - id: ClothingMaskWeldingGas
-      weight: 0.05
+    - id: ClothingEyesGlassesMeson
+      weight: 0.25
 
 - type: entityTable
   id: FillWelderSuppliesMask

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -63,22 +63,63 @@
   suffix: Filled
   parent: LockerWeldingSupplies
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillWelderSupplies
+
+- type: entityTable
+  id: FillWelderSupplies
+  table: !type:AllSelector
+    children:
+    - !type:GroupSelector
+      children:
       - id: ClothingHeadHatWelding
+      - id: ClothingHeadHatWeldingMaskFlame
+        weight: 0.25
+      - id: ClothingHeadHatWeldingMaskFlameBlue
+        weight: 0.25
+      - id: ClothingHeadHatWeldingMaskPainted
+        weight: 0.25
+    - !type:GroupSelector
+      children:
       - id: ClothingHeadHatWelding
+      - id: ClothingHeadHatWeldingMaskFlame
+        weight: 0.25
+      - id: ClothingHeadHatWeldingMaskFlameBlue
+        weight: 0.25
+      - id: ClothingHeadHatWeldingMaskPainted
+        weight: 0.25
+    - !type:GroupSelector
+      children:
       - id: ClothingHeadHatWelding
-        prob: 0.5
+      - id: ClothingHeadHatWeldingMaskFlame
+        weight: 0.25
+      - id: ClothingHeadHatWeldingMaskFlameBlue
+        weight: 0.25
+      - id: ClothingHeadHatWeldingMaskPainted
+        weight: 0.25
+    - !type:GroupSelector
+      children:
       - id: Welder
-      - id: Welder
-      - id: WelderMini
-        orGroup: thirdWelder
-      - id: Welder
-        prob: 0.33
-        orGroup: thirdWelder
       - id: WelderIndustrial
-        prob: 0.33
-        orGroup: thirdWelder
+        weight: 0.25
+      - id: WelderIndustrialAdvanced
+        weight: 0.10
+    - !type:GroupSelector
+      children:
+      - id: Welder
+      - id: WelderIndustrial
+        weight: 0.25
+      - id: WelderIndustrialAdvanced
+        weight: 0.10
+    - !type:GroupSelector
+      children:
+      - id: Welder
+      - id: WelderIndustrial
+        weight: 0.25
+      - id: WelderIndustrialAdvanced
+        weight: 0.10
 
 - type: entity
   id: LockerAtmosphericsFilledHardsuit

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -87,8 +87,6 @@
       weight: 0.25
     - id: ClothingHeadHatWeldingMaskPainted
       weight: 0.25
-    - id: ClothingEyesGlassesMeson
-      weight: 0.25
 
 - type: entityTable
   id: FillWelderSuppliesMask


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Migrate welding supplies locker from StorageFill to EntityTableContainerFill
- Added industrial advanced welder and welding gas mask as potential loot inside welding supplies lockers

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Industrial advanced welders are only ever found on space debris or mapped. Adding that and engineering goggles should make welding lockers much more attractive to engies or tiders instead of just being props.

StorageFill is depreciated so I migrated to EntityTableContainerFill when adding new loot and adjusting RNG.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/ede7fda1-dbb4-4d21-ab23-5e0e61df4bf1)

Note: Out of thirty lockers, there are four industrial advanced welders and nine engineering goggles. Items were rearranged within each locker to appear more clearly.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Engineering goggles and industrial advanced welders may be found in welding supplies lockers.