### PR TITLE
Fragile Deliveries

### DIFF
--- a/Content.Shared/Delivery/DeliveryFragileComponent.cs
+++ b/Content.Shared/Delivery/DeliveryFragileComponent.cs
@@ -15,13 +15,13 @@ public sealed partial class DeliveryFragileComponent : Component
     /// Multiplier to use when the delivery is intact.
     /// </summary>
     [DataField]
-    public float IntactMultiplierOffset = 0.1f;
+    public float IntactMultiplierOffset = 0.15f;
 
     /// <summary>
     /// Multiplier to use when the delivery is broken.
     /// </summary>
     [DataField]
-    public float BrokenMultiplierOffset = -0.1f;
+    public float BrokenMultiplierOffset = -0.33f;
 
     /// <summary>
     /// Whether this priority has already been broken or not.

--- a/Content.Shared/Delivery/DeliveryFragileComponent.cs
+++ b/Content.Shared/Delivery/DeliveryFragileComponent.cs
@@ -1,0 +1,31 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Delivery;
+
+/// <summary>
+/// Component given to deliveries.
+/// Allows the delivery to be broken.
+/// If intact, applies a small multiplier, otherwise substracts it.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(DeliveryModifierSystem))]
+public sealed partial class DeliveryFragileComponent : Component
+{
+    /// <summary>
+    /// Multiplier to use when the delivery is intact.
+    /// </summary>
+    [DataField]
+    public float IntactMultiplierOffset = 0.1f;
+
+    /// <summary>
+    /// Multiplier to use when the delivery is broken.
+    /// </summary>
+    [DataField]
+    public float BrokenMultiplierOffset = -0.1f;
+
+    /// <summary>
+    /// Whether this priority has already been broken or not.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Broken;
+}

--- a/Content.Shared/Delivery/DeliveryPriorityComponent.cs
+++ b/Content.Shared/Delivery/DeliveryPriorityComponent.cs
@@ -12,13 +12,13 @@ namespace Content.Shared.Delivery;
 public sealed partial class DeliveryPriorityComponent : Component
 {
     /// <summary>
-    /// The highest the random multiplier can go.
+    /// The multiplier to apply when delivered in time.
     /// </summary>
     [DataField]
     public float InTimeMultiplierOffset = 0.2f;
 
     /// <summary>
-    /// The lowest the random multiplier can go.
+    /// The multiplier to apply when delivered late.
     /// </summary>
     [DataField]
     public float ExpiredMultiplierOffset = -0.1f;

--- a/Content.Shared/Delivery/SharedDeliverySystem.cs
+++ b/Content.Shared/Delivery/SharedDeliverySystem.cs
@@ -231,6 +231,7 @@ public abstract class SharedDeliverySystem : EntitySystem
         }
     }
 
+    #region Visual Updates
     // TODO: generic updateVisuals from component data
     private void UpdateAntiTamperVisuals(EntityUid uid, bool isLocked)
     {
@@ -252,10 +253,17 @@ public abstract class SharedDeliverySystem : EntitySystem
         }
     }
 
+    public void UpdateBrokenVisuals(Entity<DeliveryFragileComponent> ent, bool isFragile)
+    {
+        _appearance.SetData(ent, DeliveryVisuals.IsBroken, ent.Comp.Broken);
+        _appearance.SetData(ent, DeliveryVisuals.IsFragile, isFragile);
+    }
+
     protected void UpdateDeliverySpawnerVisuals(EntityUid uid, int contents)
     {
         _appearance.SetData(uid, DeliverySpawnerVisuals.Contents, contents > 0);
     }
+    #endregion
 
     /// <summary>
     /// Gathers the total multiplier for a delivery.

--- a/Resources/Locale/en-US/delivery/delivery-component.ftl
+++ b/Resources/Locale/en-US/delivery/delivery-component.ftl
@@ -25,3 +25,6 @@ delivery-teleporter-empty-verb = Take mail
 # modifiers
 delivery-priority-examine = This is a [color=orange]priority {$type}[/color]. You have [color=orange]{$time}[/color] left to deliver it to get a bonus.
 delivery-priority-expired-examine = This is a [color=orange]priority {$type}[/color]. It seems you ran out of time.
+
+delivery-fragile-examine = This is a [color=red]fragile {$type}[/color]. Deliver it intact for a bonus.
+delivery-fragile-broken-examine = This is a [color=red]fragile {$type}[/color]. It looks badly damaged.

--- a/Resources/Prototypes/Entities/Objects/Deliveries/deliveries.yml
+++ b/Resources/Prototypes/Entities/Objects/Deliveries/deliveries.yml
@@ -137,6 +137,8 @@
     children:
     - id: DeliveryModifierPriority
       prob: 0.25
+    - id: DeliveryModifierFragile
+      prob: 0.25
 
 - type: entity
   id: DeliveryModifierPriority
@@ -144,3 +146,34 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: DeliveryPriority
+
+- type: entity
+  id: DeliveryModifierFragile
+  description: Components to add when a delivery is rolled as fragile.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: DeliveryFragile
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: DamageOnHighSpeedImpact
+    minimumSpeed: 0.1
+    damage:
+      types:
+        Blunt: 1
+    soundHit:
+      collection: WeakHit
+  - type: DamageOnLand
+    damage:
+      types:
+        Blunt: 1
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: DeliveryOpenSounds
+      - !type:DoActsBehavior
+        acts: [ "Breakage" ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Deliveries now have a 25% chance to spawn as a fragile delivery.
Fragile deliveries get 10% more profit, but lose 10% on being broken. (Either by tripping, throwing, etc)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Missing feature from the design doc, and wanted by players. Also adds a little more flavor to cargo itself.

## Technical details
<!-- Summary of code changes for easier review. -->
DeliveryFragileComponent, stores the "Broken" state. Subscribes to BreakageEventArgs to decide when it should break.
It also gets all neccessary components from the ComponentTable (damage on impact, etc)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/0e74eab7-627b-43a1-9ccf-3acf50079ee6)
![image](https://github.com/user-attachments/assets/82d0d46e-99a9-4afe-bd35-f6450046c80f)
![image](https://github.com/user-attachments/assets/a020d9cd-b80f-461b-8f32-e0a8c77cdc0f)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Deliveries can now spawn as fragile-type! Deliver them intact to earn a minor speso bonus.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
