### PR TITLE
Make The Doctors Delight only heal when below 35 damage but heals faster

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -943,10 +943,10 @@
           max: 35
         damage:
           groups:
-            Burn: -.75
-            Toxin: -.75
-            Airloss: -.75
-            Brute: -.75
+            Burn: -1.5
+            Toxin: -1
+            Airloss: -1
+            Brute: -1.5
 
 
 - type: reagent


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The Doctors Delight drink now only works for when below 35 damage.
Healing properties upped from 1 brute, 1 heat, 1 toxin, and 1 airloss to 1.5 brute, 1.5 burn, 1 toxin, and 1 airloss

## Why / Balance
TDD being a budget omnizine is an interesting concept, but trivializes actually getting Omnizine. This makes in slightly better than Trico while under the 35 damage threshold.
The theory is to fill a slightly different niche that doesn't step on Omnizine or Trico.

## Technical details
Added the requirement that damage must be below 35 before it works. 

## Media
![image](https://github.com/user-attachments/assets/55b7e452-0cf9-437f-a8f1-69e9c3bda0e6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The Doctors Delight now only heals when below 35 damage.
- tweak: The Doctors Delight now heals 1.5 brute, 1.5 heat, 1 toxin, and 1 airloss
