### PR TITLE
ChemMaster UI Reset Fix

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterBoundUserInterface.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterBoundUserInterface.cs
@@ -42,10 +42,10 @@ namespace Content.Client.Chemistry.UI
                 new ChemMasterSetModeMessage(ChemMasterMode.Discard));
             _window.CreatePillButton.OnPressed += _ => SendMessage(
                 new ChemMasterCreatePillsMessage(
-                    (uint) _window.PillDosage.Value, (uint) _window.PillNumber.Value, _window.LabelLine));
+                    (uint)_window.PillDosage.Value, (uint)_window.PillNumber.Value, _window.LabelLine));
             _window.CreateBottleButton.OnPressed += _ => SendMessage(
                 new ChemMasterOutputToBottleMessage(
-                    (uint) _window.BottleDosage.Value, _window.LabelLine));
+                    (uint)_window.BottleDosage.Value, _window.LabelLine));
             _window.BufferSortButton.OnPressed += _ => SendMessage(
                     new ChemMasterSortingTypeCycleMessage());
 
@@ -69,7 +69,7 @@ namespace Content.Client.Chemistry.UI
         {
             base.UpdateState(state);
 
-            var castState = (ChemMasterBoundUserInterfaceState) state;
+            var castState = (ChemMasterBoundUserInterfaceState)state;
 
             _window?.UpdateState(castState); // Update window state
         }

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -171,6 +171,8 @@ namespace Content.Client.Chemistry.UI
 
             PillTypeButtons[castState.SelectedPillType].Pressed = true;
 
+            PillNumber.Value = (int)castState.SelectedPillNumber;
+            PillDosage.Value = (int)castState.SelectedPillDosage;
             PillNumber.IsValid = x => x >= 0 && x <= pillNumberMax;
             PillDosage.IsValid = x => x > 0 && x <= castState.PillDosageLimit;
             BottleDosage.IsValid = x => x >= 0 && x <= bottleAmountMax;
@@ -181,13 +183,9 @@ namespace Content.Client.Chemistry.UI
                 BottleDosage.Value = bottleAmountMax;
 
             // Avoid division by zero
-            if (PillDosage.Value > 0)
+            if (PillDosage.Value > 0 && PillNumber.Value == 0)
             {
                 PillNumber.Value = Math.Min(bufferVolume / PillDosage.Value, pillNumberMax);
-            }
-            else
-            {
-                PillNumber.Value = 0;
             }
 
             BottleDosage.Value = Math.Min(bottleAmountMax, bufferVolume);
@@ -263,7 +261,7 @@ namespace Content.Client.Chemistry.UI
                 _prototypeManager.TryIndex(reagentId.Prototype, out ReagentPrototype? proto);
                 var name = proto?.LocalizedName ?? Loc.GetString("chem-master-window-unknown-reagent-text");
                 var reagentColor = proto?.SubstanceColor ?? default(Color);
-                reagentList.Add(new (reagentId, name, reagentColor, quantity));
+                reagentList.Add(new(reagentId, name, reagentColor, quantity));
             }
 
             // We sort here since we need sorted list to be filled first.
@@ -356,7 +354,7 @@ namespace Content.Client.Chemistry.UI
             var rowColor1 = Color.FromHex("#1B1B1E");
             var rowColor2 = Color.FromHex("#202025");
             var currentRowColor = (rowCount % 2 == 1) ? rowColor1 : rowColor2;
-            if ((reagentColor == default(Color))|(!addReagentButtons))
+            if ((reagentColor == default(Color)) | (!addReagentButtons))
             {
                 reagentColor = currentRowColor;
             }

--- a/Content.Server/Chemistry/Components/ChemMasterComponent.cs
+++ b/Content.Server/Chemistry/Components/ChemMasterComponent.cs
@@ -15,6 +15,12 @@ namespace Content.Server.Chemistry.Components
         [DataField("pillType"), ViewVariables(VVAccess.ReadWrite)]
         public uint PillType = 0;
 
+        [DataField("pillNumber"), ViewVariables(VVAccess.ReadWrite)]
+        public uint PillNumber = 0;
+
+        [DataField("pillDosage"), ViewVariables(VVAccess.ReadWrite)]
+        public uint PillDosage = 20;
+
         [DataField("mode"), ViewVariables(VVAccess.ReadWrite)]
         public ChemMasterMode Mode = ChemMasterMode.Transfer;
 

--- a/Content.Shared/Chemistry/SharedChemMaster.cs
+++ b/Content.Shared/Chemistry/SharedChemMaster.cs
@@ -176,6 +176,8 @@ namespace Content.Shared.Chemistry
 
         public readonly FixedPoint2? BufferCurrentVolume;
         public readonly uint SelectedPillType;
+        public readonly uint SelectedPillNumber;
+        public readonly uint SelectedPillDosage;
 
         public readonly uint PillDosageLimit;
 
@@ -184,7 +186,7 @@ namespace Content.Shared.Chemistry
         public ChemMasterBoundUserInterfaceState(
             ChemMasterMode mode, ChemMasterSortingType sortingType, ContainerInfo? inputContainerInfo, ContainerInfo? outputContainerInfo,
             IReadOnlyList<ReagentQuantity> bufferReagents, FixedPoint2 bufferCurrentVolume,
-            uint selectedPillType, uint pillDosageLimit, bool updateLabel)
+            uint selectedPillType, uint selectedPillNumber, uint selectedPillDosage, uint pillDosageLimit, bool updateLabel)
         {
             InputContainerInfo = inputContainerInfo;
             OutputContainerInfo = outputContainerInfo;
@@ -193,6 +195,8 @@ namespace Content.Shared.Chemistry
             SortingType = sortingType;
             BufferCurrentVolume = bufferCurrentVolume;
             SelectedPillType = selectedPillType;
+            SelectedPillNumber = selectedPillNumber;
+            SelectedPillDosage = selectedPillDosage;
             PillDosageLimit = pillDosageLimit;
             UpdateLabel = updateLabel;
         }


### PR DESCRIPTION
## About the PR
This makes it so the ChemMaster pill number and dosage do not reset back to their default values after creating a pill.

## Why / Balance
Addressing #36906 . The ChemMaster would wipe the pill number and dosage settings upon creating a pill, making it an arduous process to re-use the same settings multiple times in a row.

## Technical details
This makes pill number and pill dosage a shared value by the client and server, which is updated by the server when a pill is created. It adds SelectedPillNumber and SelectedPillDosage fields to ChemMasterBoundUserInterfaceState and updates them in ChemMasterSystem>OnCreatePillsMessage. Finally, it changes ChemMasterWindow>UpdateDosageFields to only use a default value when the shared pill number is zero.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Added two fields to ChemMasterBoundUserInterfaceState: SelectedPillNumber and SelectedPillDosage

**Changelog**
:cl:
- tweak: ChemMaster pill number and dosage no longer resets after creating a pill.
