### PR TITLE
Theatre access to Service Request Computer

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1065,7 +1065,7 @@
   - type: PointLight
     color: "#afe837"
   - type: AccessReader
-    access: [["Service"]]
+    access: [["Service"], ["Theatre"]]
 
 - type: entity
   id: ComputerCargoBounty


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR gives those with Theatre access (clown/mime/musician) access to the Service Request Computer.

Fixes #36576 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

While they don't strictly have 'Service' access, Theatre workers are still part of the Service Department, and work to entertain the crew. They ought to be able to order supplies from the Service Request Computer that could aid their job, like instruments, art supplies, toys, etc.

It seems like this was just an oversight. If it was intentional (probably to prevent the clown from spending all the points on gorilla crates), then we could revert if it turns out to be an issue.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl:
- tweak: Theatre workers (clown/mime/musician) now have access to the Service Request Computer