### PR TITLE
This is a mald PR - Remove rod wizard

### DIFF
--- a/Resources/Prototypes/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/Polymorphs/polymorph.yml
@@ -195,17 +195,17 @@
     revertOnDeath: true
     revertOnCrit: true
 
-- type: polymorph
-  id: WizardRod
-  configuration:
-    entity: ImmovableRodWizard #CLANG
-    transferName: true
-    transferDamage: false
-    inventory: None
-    duration: 1
-    forced: true
-    revertOnCrit: false
-    revertOnDeath: false
+# - type: polymorph
+#   id: WizardRod
+#   configuration:
+#     entity: ImmovableRodWizard #CLANG
+#     transferName: true
+#     transferDamage: false
+#     inventory: None
+#     duration: 1
+#     forced: true
+#     revertOnCrit: false
+#     revertOnDeath: false
 
 # Temporary Jaunt
 # Don't make permanent jaunts until action system can be reworked to allow do afters and cooldown pausing


### PR DESCRIPTION
Excuse me but EI NATH was comically broken on its own as is, and is *classically* broken. Why can wizards instantly delete people at range with only a 60 second cooldown? Hello????

:cl:
- remove: Wizards can no longer polymorph into immovable rods