### PR TITLE
Rod Mald PR #2

### DIFF
--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Popups;
 using Content.Shared.Body.Components;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
+using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
@@ -100,6 +101,9 @@ public sealed class ImmovableRodSystem : EntitySystem
 
             return;
         }
+
+        if (!HasComp<DamageableComponent>(ent) && !component.ShouldGib)
+            return;
 
         // dont delete/hurt self if polymoprhed into a rod
         if (TryComp<PolymorphedEntityComponent>(uid, out var polymorphed))

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -4,7 +4,6 @@ using Content.Server.Popups;
 using Content.Shared.Body.Components;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
-using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -14,6 +14,8 @@
   - type: Physics
     bodyType: Dynamic
     linearDamping: 0
+  - type: TileFrictionModifier
+    modifier: 0
   - type: PointLight
     radius: 3
     color: red
@@ -72,7 +74,7 @@
     shouldGib: false
     damage:
       types:
-        Blunt: 190
+        Piercing: 50
   - type: MovementIgnoreGravity
     gravityState: true
   - type: InputMover
@@ -82,6 +84,17 @@
     weightlessFriction: 0
     friction: 0
     frictionNoInput: 0
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.5
+        density: 1
+        hard: false
+        layer:
+        - Impassable
+        - Opaque
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
   - type: NoSlip

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -68,13 +68,13 @@
   suffix: Wizard
   components:
   - type: ImmovableRod
-    maxSpeed: 25
+    maxSpeed: 15
     destroyTiles: false
     randomizeVelocity: false
     shouldGib: false
     damage:
       types:
-        Piercing: 50
+        Piercing: 40 # applies damage twice so it's actually half what it should be
   - type: MovementIgnoreGravity
     gravityState: true
   - type: InputMover
@@ -84,20 +84,12 @@
     weightlessFriction: 0
     friction: 0
     frictionNoInput: 0
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.5
-        density: 1
-        hard: false
-        layer:
-        - Impassable
-        - Opaque
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
   - type: NoSlip
+  - type: StunOnCollide
+    stunAmount: 1
+    knockdownAmount: 1
 
 - type: entity
   parent: ImmovableRodKeepTiles


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Nerfed the Wizard's Rod to hotfix gibbing -> deletion combo

## Why / Balance
Basically a better Ei'Nath currently and it shouldn't be because it's already very strong.

## Technical details
Rod now does 80 piercing damage instead of 190 blunt.
Rods can no longer delete undamagable items if they have "ShouldGib" false.
Rods now stun for 1 second upon hitting something.

## Media
![image](https://github.com/user-attachments/assets/6d891d04-38fa-46df-ab70-80c1877ee7b8)

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Removed fun!
- tweak: Wizard Rod now does less damage and can't delete unbreakable items
- fix: Wizard Rod can no longer delete bodies

