### PR TITLE
Fix t-ray scanner exception spam

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/cable_terminal.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cable_terminal.yml
@@ -31,6 +31,7 @@
               acts: ["Destruction"]
     - type: Visibility
       layer: 1
+    - type: Appearance
     - type: SubFloorHide
       blockAmbience: false
       blockInteractions: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds the AppearanceComponent to cable terminal entities.

Fixes #37015 

While this PR was intended to just fix this exception, it looks like cable terminals were meant to be hidden below floor tiles this whole time, so this also fixes what was apparently a bug. (logging is important :godo:)

## Technical details
<!-- Summary of code changes for easier review. -->

Trying to get appearance data from an entity without the component will log an error. The t-ray client system hits this in an update() method, so it will cause a lot of spam. Cable terminals look to be the only entity with SubFloorHideComponent but without AppearanceComponent.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/c0a7113e-f0ed-4f6b-98d3-2c40a8e51313

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
🆑 
- fix: cable terminals are now visually layered below floors, like other cables