### PR TITLE
add ability to return mail if there is no recipient in station records

### DIFF
--- a/Content.Server/Delivery/DeliverySystem.cs
+++ b/Content.Server/Delivery/DeliverySystem.cs
@@ -113,13 +113,13 @@ public sealed partial class DeliverySystem : SharedDeliverySystem
         {
             string messageDenied = Loc.GetString("delivery-insert-denied", ("mail", args.Used));
             _chat.TrySendInGameICMessage(args.Target.Value, messageDenied, InGameICChatType.Speak, hideChat: true);
-            _audio.PlayPvs(deliverySpawner.InsertAppoveSound, args.Target.Value);
+            _audio.PlayPvs(deliverySpawner.InsertDenySound, args.Target.Value);
             return;
         }
 
         string messageApproved = Loc.GetString("delivery-insert-approved", ("mail", args.Used));
         _chat.TrySendInGameICMessage(args.Target.Value, messageApproved, InGameICChatType.Speak, hideChat: true);
-        _audio.PlayPvs(deliverySpawner.InsertDenySound, args.Target.Value);
+        _audio.PlayPvs(deliverySpawner.InsertAppoveSound, args.Target.Value);
         QueueDel(args.Used);
     }
 

--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -289,6 +289,26 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
     }
 
     /// <summary>
+    /// Returns an id if a record with the same fingerprint exists.
+    /// </summary>
+    /// <remarks>
+    /// Linear search so O(n) time complexity.
+    /// </remarks>
+    public uint? GetRecordByFingerprint(EntityUid station, string fingerprint, StationRecordsComponent? records = null)
+    {
+        if (!Resolve(station, ref records, false))
+            return null;
+
+        foreach (var (id, record) in GetRecordsOfType<GeneralStationRecord>(station, records))
+        {
+            if (record.Fingerprint == fingerprint)
+                return id;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     ///     Gets all records of a specific type from a station.
     /// </summary>
     /// <param name="station">The station to get the records from.</param>

--- a/Content.Shared/Delivery/DeliverySpawnerComponent.cs
+++ b/Content.Shared/Delivery/DeliverySpawnerComponent.cs
@@ -40,4 +40,16 @@ public sealed partial class DeliverySpawnerComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier? OpenSound = new SoundCollectionSpecifier("storageRustle");
+
+    /// <summary>
+    /// The sound to play when a mail has been successfully revoked.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? InsertAppoveSound = new SoundPathSpecifier("/Audio/Effects/Cargo/ping.ogg");
+
+    /// <summary>
+    /// The sound to play when a mail has not been revoked.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? InsertDenySound = new SoundPathSpecifier("/Audio/Effects/Cargo/buzz_two.ogg");
 }

--- a/Resources/Locale/en-US/delivery/delivery-messages.ftl
+++ b/Resources/Locale/en-US/delivery/delivery-messages.ftl
@@ -2,3 +2,7 @@ delivery-penalty-default-reason = WARNING
 delivery-penalty-default-account-name = UNKNOWN ACCOUNT
 
 delivery-penalty-message = {$reason}! INVOKING A PENALTY OF {$spesos} SPESOS ON {$account}!
+
+delivery-insert-denied = There is still someone on the station capable of opening {THE($mail)}!
+delivery-insert-approved = {CAPITALIZE(THE($mail))} can't be opened by anyone on the station, it has been revoked.
+delivery-insert-no-station = No station with station records can be found!

--- a/Resources/Prototypes/Entities/Structures/Machines/mail_teleporter.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/mail_teleporter.yml
@@ -4,6 +4,7 @@
   name: mail teleporter
   description: Periodically teleports in mail to deliver across the station.
   components:
+  - type: Speech
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
1. you get a letter for Urist McCaptain
2. Urist McCaptain goes into cryo
3. "Oh! What should i do with this letter now?" (tho i've seen guys throwing it in disposals)

to get rid of this situation, you can try to return mail back via clicking with it on the teleporter
if there are no one in station records capable of opening this mail, it will be returned (no payment too) 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
so you can get rid of that mail of ssd guys

## Technical details
<!-- Summary of code changes for easier review. -->
wip

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
wip
![Screenshot_20250429_005922](https://github.com/user-attachments/assets/181e230b-5376-45b6-b21d-969c61e7bd7b)
![Screenshot_20250429_010053](https://github.com/user-attachments/assets/78e9ef58-a58f-4c90-8978-dd2d6339fbdf)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
i don't think so

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: If there are no one capable of opening mail, you can try to send it back via clicking with mail on the mail teleporter.