### PR TITLE
Rebalance magnet debris, update worldgen

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -54,9 +54,6 @@ allow_multi_server_play = false
 [atmos]
 max_explosion_range = 5
 
-[worldgen]
-enabled = true
-
 [status]
 privacy_policy_link = "https://spacestation14.com/about/privacy/#game-server-privacy-policy"
 privacy_policy_identifier = "wizden"

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -266,16 +266,16 @@
       children:
       - !type:NestedSelector
         tableId: SalvageEquipmentCommon
-        weight: 50
+        weight: 20
       - !type:NestedSelector
         tableId: SalvageEquipmentUncommon
         weight: 35
       - !type:NestedSelector
         tableId: SalvageEquipmentRare
-        weight: 14
+        weight: 35
       - !type:NestedSelector
         tableId: SalvageEquipmentLegendary
-        weight: 1
+        weight: 10
     # 5% chance of decent-ish treasure
     - !type:GroupSelector
       weight: 5
@@ -325,16 +325,16 @@
       children:
       - !type:NestedSelector
         tableId: SalvageEquipmentCommon
-        weight: 15
+        weight: 5
       - !type:NestedSelector
         tableId: SalvageEquipmentUncommon
-        weight: 40
+        weight: 25
       - !type:NestedSelector
         tableId: SalvageEquipmentRare
-        weight: 35
+        weight: 45
       - !type:NestedSelector
         tableId: SalvageEquipmentLegendary
-        weight: 10
+        weight: 25
     # 5% chance of decent-ish treasure
     - !type:GroupSelector
       weight: 5
@@ -407,20 +407,36 @@
   id: SalvageMagnetMobTable
   table: !type:GroupSelector
     children:
-    - id: MobCarpSalvage
-      weight: 80
-    - id: MobCarpSalvage
-      weight: 15
-      amount: !type:RangeNumberSelector
-        range: 1, 3
-    - !type:AllSelector
+    - !type:GroupSelector # normal theats
+      weight: 95
+      children:
+      - id: MobCarpSalvage
+        weight: 2
+      - !type:AllSelector
+        weight: 1
+        children:
+        - id: LandMineExplosive
+        - !type:NestedSelector # what's that thing underneath the scrap?
+          prob: 0.33
+          tableId: SalvageScrapSpawnerCommon
+    - !type:GroupSelector # scary monsters
       weight: 5
       children:
-      - id: MobSharkSalvage
-      - id: MobCarpSalvage
-        amount: !type:ConstantNumberSelector
-          value: 2
-    # - id: MobHivebot (solo hivebot spawn)
+      - !type:AllSelector
+        children:
+        - id: MobSharkSalvage
+        - id: MobCarpSalvage
+          amount: !type:ConstantNumberSelector
+            value: 2
+        - !type:NestedSelector
+          rolls: !type:RangeNumberSelector
+            range: 1, 3
+          tableId: SalvageTreasureSpawnerValuable
+        - !type:NestedSelector
+          rolls: !type:RangeNumberSelector
+            range: 7, 10
+          tableId: TreasureCoinPileRare
+      #- id: MobHivebot (solo hivebot spawn)
 
 - type: entity
   parent: MarkerBase
@@ -457,6 +473,42 @@
     table: !type:NestedSelector
       prob: 1.0
       tableId: SalvageMagnetMobTable
+
+- type: entity
+  parent: MarkerBase
+  id: SalvageSpawnerStructuresVarious
+  name: Space Debris Structure Spawner
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - sprite: Structures/Storage/tanks.rsi
+      state: fueltank-2
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - id: WeldingFuelTankFull
+        weight: 0.5
+      - !type:GroupSelector
+        children:
+        - id: Table
+          weight: 2
+        - id: TableFrame
+      - id: SalvageCanisterSpawner
+      - id: Rack
+      - !type:NestedSelector
+        weight: 0.5
+        tableId: LowValueCrateTable
+      - id: ComputerBroken
+        weight: 0.1
+      - id: CrateGeneric
+        weight: 0.25
+      - id: ClosetMaintenanceFilledRandom
+        weight: 2
+      - !type:GroupSelector
+        children:
+        - id: Thruster
+        - id: Gyroscope
 
 - type: entity
   parent: MarkerBase

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -80,6 +80,25 @@
           - /Maps/Ruins/whiteship_ancient.yml
           - /Maps/Ruins/whiteship_bluespacejumper.yml
           - /Maps/Ruins/wrecklaimer.yml
+        wrecks: !type:DungeonSpawnGroup
+          minimumDistance: 150
+          maximumDistance: 300
+          stationGrid: false
+          minCount: 12
+          maxCount: 16
+          addComponents:
+          - type: Gravity
+            enabled: true
+            inherent: true
+          - type: IFF
+            flags: HideLabel
+            color: "#88b0d1"
+          protos:
+          - ChunkDebrisSmall
+          - ChunkDebrisSmall
+          - ChunkDebrisSmall
+          - ChunkDebrisSmall
+          - ChunkDebris
         vgroid: !type:DungeonSpawnGroup
           minimumDistance: 300
           maximumDistance: 350
@@ -89,6 +108,9 @@
           - type: Gravity
             enabled: true
             inherent: true
+          - type: IFF
+            flags: HideLabel
+            color: "#d67e27"
           protos:
           - VGRoid
 

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -87,9 +87,6 @@
           minCount: 12
           maxCount: 16
           addComponents:
-          - type: Gravity
-            enabled: true
-            inherent: true
           - type: IFF
             flags: HideLabel
             color: "#88b0d1"

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -87,6 +87,9 @@
           minCount: 12
           maxCount: 16
           addComponents:
+          - type: Gravity
+            enabled: true
+            inherent: true
           - type: IFF
             flags: HideLabel
             color: "#88b0d1"

--- a/Resources/Prototypes/Procedural/Magnet/space_debris.yml
+++ b/Resources/Prototypes/Procedural/Magnet/space_debris.yml
@@ -38,3 +38,44 @@
     # Generate biome
     - !type:BiomeDunGen
       biomeTemplate: SpaceDebris
+
+- type: dungeonConfig
+  id: ChunkDebrisSmall
+  # Floor generation
+  layers:
+  - !type:NoiseDunGen
+    tileCap: 150
+    capStd: 32
+    iterations: 3
+    layers:
+    - tile: FloorSteel
+      threshold: 0.50
+      noise:
+        frequency: 0.05
+        noiseType: OpenSimplex2
+        fractalType: FBm
+        octaves: 3
+        lacunarity: 3
+        gain: 0.5
+    - tile: Plating
+      threshold: 0.35
+      noise:
+        frequency: 0.05
+        noiseType: OpenSimplex2
+        fractalType: FBm
+        octaves: 3
+        lacunarity: 3
+        gain: 0.3
+    - tile: Lattice
+      threshold: 0.25
+      noise:
+        frequency: 0.05
+        noiseType: OpenSimplex2
+        fractalType: FBm
+        octaves: 3
+        lacunarity: 3
+        gain: 0.5
+
+  # Generate biome
+  - !type:BiomeDunGen
+    biomeTemplate: SpaceDebris

--- a/Resources/Prototypes/Procedural/Magnet/space_debris_templates.yml
+++ b/Resources/Prototypes/Procedural/Magnet/space_debris_templates.yml
@@ -70,12 +70,7 @@
     - Plating
     - FloorSteel
     entities:
-    - WeldingFuelTankFull
-    - Table
-    - SalvageCanisterSpawner
-    - Rack
-    - ClosetMaintenanceFilledRandom
-    - ClosetMaintenanceFilledRandom
+    - SalvageSpawnerStructuresVarious
   - !type:BiomeEntityLayer
     allowedTiles:
     - FloorSteel
@@ -108,7 +103,8 @@
   - !type:BiomeEntityLayer
     allowedTiles:
     - FloorSteel
-    threshold: 0.90
+    - Plating
+    threshold: 0.925
     noise:
       seed: 1
       frequency: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Rebalances procgen debris from space magnet:
- equipment is generally better: fewer worthless tools
- added explosive mines as a threat alternative to just carp
- added more structures and crates into the generation table

Additionally, opts to disable the dynamic worldgen in favor of pre-spawning a few magnet debris roundstart.

The main reason for this is just that the old system has bitrotted. It's completely unsupported and unused in the codebase and has been entirely supplanted by the biome procgen. As such, all the new generation stuff is incompatible with it and, frankly, it's unsuitable for use. The asteroids in particular just had to go because they're pretty much worthless when compared to vgroid or magnet asteroids.

I've tried to mimic the same style because the core idea is fine; the system itself is what sucks. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Salvagers have been taking it too hard. They deserve some nicer things that are less deadly.

## Technical details
<!-- Summary of code changes for easier review. -->
disabled worldgen cvar on default wizden config.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
:cl:
- add: Space debris now have a chance for landmines to spawn on them.
- tweak: Adjusted the loot table on space debris to have more useful equipment and items.
- tweak: Round-start space debris now better mimics what the salvage magnet can pull in.
- remove: Removed round-start space asteroids.
