### PR TITLE
Fix clientsided alerts being overwritten by server

### DIFF
--- a/Content.Client/Alerts/ClientAlertsSystem.cs
+++ b/Content.Client/Alerts/ClientAlertsSystem.cs
@@ -52,7 +52,23 @@ public sealed class ClientAlertsSystem : AlertsSystem
         if (args.Current is not AlertComponentState cast)
             return;
 
+        // Save all client-sided alerts to later put back in
+        var clientAlerts = new Dictionary<AlertKey, AlertState>();
+        foreach (var alert in alerts.Comp.Alerts)
+        {
+            if (alert.Key.AlertType != null && TryGet(alert.Key.AlertType.Value, out var alertProto))
+            {
+                if (alertProto.ClientHandled)
+                    clientAlerts[alert.Key] = alert.Value;
+            }
+        }
+
         alerts.Comp.Alerts = new(cast.Alerts);
+
+        foreach (var alert in clientAlerts)
+        {
+            alerts.Comp.Alerts[alert.Key] = alert.Value;
+        }
 
         UpdateHud(alerts);
     }

--- a/Content.Shared/Alert/AlertPrototype.cs
+++ b/Content.Shared/Alert/AlertPrototype.cs
@@ -76,6 +76,12 @@ public sealed partial class AlertPrototype : IPrototype
     public bool SupportsSeverity => MaxSeverity != -1;
 
     /// <summary>
+    /// If true, this alert is being handled by the client and will not be overwritten when handling server -> client states.
+    /// </summary>
+    [DataField]
+    public bool ClientHandled = false;
+
+    /// <summary>
     /// Event raised on the user when they click on this alert.
     /// Can be null.
     /// </summary>

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -134,6 +134,7 @@
     state: walking
   name: alerts-walking-name
   description: alerts-walking-desc
+  clientHandled: true
 
 - type: alert
   id: Stun


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Clientsided alerts (which is really only the walking toggle alert) are handled by the client, but due to Sloth fixing the jank I originally coded in, they broke! The component state removed the clientsided alert since they weren't present on the server. This PR fixes that.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bugfix!

## Technical details
<!-- Summary of code changes for easier review. -->

Alert prototypes now have a property that marks them as "client handled". If an alert has that set to true, it will save and reapply the alert on the client whenever the component state gets updated. 

I have noted that there is a separate bug where the walking state is reset when detaching from an entity and then reattaching, but that seems tied to the walking toggle in general since it requires two taps of the key to reactivate walking. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: The "Toggle Walk" alert no longer gets removed when it shouldn't.
