### PR TITLE
Add stamina damage resists to the bloodred raid/hard-suits (and ERT hardsuits).

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -130,8 +130,8 @@
         Caustic: 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.35
-  #- type: StaminaResistance
-  #  damageCoefficient: 0.45
+  - type: StaminaResistance
+    damageCoefficient: 0.45
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -540,8 +540,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  #- type: StaminaResistance
-  #  damageCoefficient: 0.75
+  - type: StaminaResistance
+    damageCoefficient: 0.75
   - type: Armor
     modifiers:
       coefficients:
@@ -602,8 +602,8 @@
     damageCoefficient: 0.2
   - type: FireProtection
     reduction: 0.8
-  #- type: StaminaResistance
-  #  damageCoefficient: 0.6
+  - type: StaminaResistance
+    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -638,8 +638,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  #- type: StaminaResistance
-  #  damageCoefficient: 0.6
+  - type: StaminaResistance
+    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -672,8 +672,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.3
-  #- type: StaminaResistance # Should not have stamina resistance, this is purely so people know it was not forgotten.
-  #  damageCoefficient: 0.99
+  - type: StaminaResistance # Should not have stamina resistance, this is purely so people know it was not forgotten.
+    damageCoefficient: 0.99
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
## About the PR
Uncomment the stamina damage resists that were added in [this PR](https://github.com/space-wizards/space-station-14/pull/35580).
Standard/Agent Bloodred: 25% (Standard ERT suits parent off of this)
Commander Bloodred: 40% (ERT Leader suit parents off of this)
Elite: 40%
Raidsuit: 55%
Juggernaut Suit: 1% (Basically 0, meant to show players that it is intentional the jugsuit does not help against stuns.)

## Why / Balance
Copypasted from the old PR, couple slight edits:
This has been debated for a while, and also implemented on several forks, heres my own reasoning:
Right now, nukies are the SS14 variant of highly armed and armored terrorists, however, when encountered by security, the most tactically correct decision is a disabler or stun baton, the SS14 variant of "TASE EM TASE EM"

Now I'm sorry but what the fuck? This should not be the optimal decision, not from a realism OR balance standpoint.
This PR aims to end the long-lived stun meta against nukies by adding stamina resists to their hardsuits.
Furthermore, this also means it is much less likely for any random tider to pick up a disabler/baton and become an immediate threat, possibly more of a threat than a security officer with a lecter in their hardsuit.

Now a brief explenation per suit, for those who cant read the chart below:
Standard/Agent/ERT: 25% is a good base, 4 hits with a baton, 5 with a disabler or 9 from the bolts fired by the SMG or EShotty.
Commander/Elitesuit/ERT Leader: 40% is a good upgrade for these slightly better suits, 5 hits with a baton, 6 with a disabler or 12 from the bolts fired by the SMG or EShotty.
Raidsuit: This suit has a major weakness due to not being space proof, but has improved armor to compensate, it should not be trivial to stun. 55% means you need 7 hits with a baton or disabler, or 15 with the light disabler bolts from smg or eshotty. This also means that this suit will be a very solid loneop option now, and since the raidsuit is not compatible with the china-lake's mass destruction and spacing, this change may also result in tactical/surgical lone-op strategies becoming more common instead of them just going in guns blazing.
Jugsuit: Jugsuit only gets 1%, which is primarily cosmetic so that on the player-facing side people know that it does not and should not resist stuns, this will prevent people PRing 70% stam resist on the jugsuit because "they probably just forgot".

## Media
![image](https://github.com/user-attachments/assets/33f9817a-cb5f-4e8d-89d9-3ee7d03571c1)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: BramvanZijp
- tweak: Added Stamina Damage resistance to the raid/hard-suits used by Nuclear Operatives and Emergency Response Teams.
