### PR TITLE
Hotfix: Fix item toggling crashing the client for slimes

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -347,6 +347,7 @@ public abstract class SharedStorageSystem : EntitySystem
         storage = null;
 
         if (!ContainerSystem.TryGetContainingContainer(itemEnt, out container) ||
+            container.ID != StorageComponent.ContainerId ||
             !TryComp(container.Owner, out storage) ||
             !_itemQuery.Resolve(itemEnt, ref itemEnt.Comp, false))
         {


### PR DESCRIPTION
## About the PR
Fixes #37052

## Why / Balance
Bugfix

## Technical details
This method was newly added in #36533
It gets the container entity of an item, checks if it has the `StorageComponent` and gives you the location the item is stored at.
However it was missing a check to see the container is actually the corresponding storage container.
If a slime holds an item (for example an e-sword or welder) and toggles it, then the container of the item is the hand, but the slime person also has the `StorageComponent` for internal storage. The dictionary lookup trying to find the hand item in the storage container then fails, causing a crash.

## Media
![example](https://github.com/user-attachments/assets/db87bb77-3cab-4401-a3c8-eebf8e6f4e78)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
nope
