### PR TITLE
Species are now picked at random in the developer environment!

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -140,8 +140,29 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
         if (_randomizeCharacters)
         {
             var weightId = _configurationManager.GetCVar(CCVars.ICRandomSpeciesWeights);
-            var weights = _prototypeManager.Index<WeightedRandomSpeciesPrototype>(weightId);
-            speciesId = weights.Pick(_random);
+
+            // If blank, choose a round start species.
+            if (string.IsNullOrEmpty(weightId))
+            {
+                var roundStart = new List<ProtoId<SpeciesPrototype>>();
+
+                var speciesPrototypes = _prototypeManager.EnumeratePrototypes<SpeciesPrototype>();
+                foreach (var proto in speciesPrototypes)
+                {
+                    if (proto.RoundStart)
+                        roundStart.Add(proto.ID);
+                }
+
+                if (roundStart.Count == 0)
+                    speciesId = SharedHumanoidAppearanceSystem.DefaultSpecies;
+                else
+                    speciesId = _random.Pick(roundStart);
+            }
+            else
+            {
+                var weights = _prototypeManager.Index<WeightedRandomSpeciesPrototype>(weightId);
+                speciesId = weights.Pick(_random);
+            }
         }
         else if (profile != null)
         {

--- a/Content.Shared/CCVar/CCVars.Ic.cs
+++ b/Content.Shared/CCVar/CCVars.Ic.cs
@@ -36,6 +36,7 @@ public sealed partial class CCVars
 
     /// <summary>
     ///     A weighted random prototype used to determine the species selected for random characters.
+    ///     If blank, will use a round start species picked at random.
     /// </summary>
     public static readonly CVarDef<string> ICRandomSpeciesWeights =
         CVarDef.Create("ic.random_species_weights", "SpeciesWeights", CVar.SERVER);

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -37,3 +37,7 @@ preload_grids = false
 
 [admin]
 see_own_notes = true
+
+[ic]
+random_characters = true
+random_species_weights = ""

--- a/Resources/Prototypes/Species/species_weights.yml
+++ b/Resources/Prototypes/Species/species_weights.yml
@@ -2,11 +2,7 @@
 - type: weightedRandomSpecies
   id: SpeciesWeights
   weights:
-    Dwarf: 1
-    Moth: 1
-    Reptilian: 1
-    Human: 1
-    Archnid: 1
-    SlimePerson: 1
-    Diona: 1
-    Vox: 1
+    Human: 5
+    Reptilian: 4
+    SlimePerson: 4
+    Diona: 2

--- a/Resources/Prototypes/Species/species_weights.yml
+++ b/Resources/Prototypes/Species/species_weights.yml
@@ -2,7 +2,11 @@
 - type: weightedRandomSpecies
   id: SpeciesWeights
   weights:
-    Human: 5
-    Reptilian: 4
-    SlimePerson: 4
-    Diona: 2
+    Dwarf: 1
+    Moth: 1
+    Reptilian: 1
+    Human: 1
+    Archnid: 1
+    SlimePerson: 1
+    Diona: 1
+    Vox: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title! Species are now chosen at random round start when in dev mode.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
There are many many species specific bugs that come up (See #37054 for a recent example). A lot of the time this is due to the dev environments character just not being one that fully tests all edge cases. Having them be random allows for easier testing of features with a wide variety of species! This wont catch all bugs, but it hopefully will reduce this issue by at little bit.

## Technical details
<!-- Summary of code changes for easier review. -->
Just enabled the CCvar in dev mode and also added some additional logic so it will just randomly choose a round start species instead of something from a specific table if `ICRandomSpeciesWeights` is left blank.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Species are now picked at random when in development mode! If you don't want this feature, turn `random_characters` to `false` in the `development.toml` config file.