### PR TITLE
fix so that the meat patty uses the meat patty sprite on custom burgers

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -1239,8 +1239,8 @@
     node: cooked meat patty
   - type: FoodSequenceElement
     entries:
-      Burger: MeatSteak
-      Taco: MeatSteak
+      Burger: MeatPatty
+      Taco: MeatPatty
 
 - type: entity
   name: boiled snail

--- a/Resources/Prototypes/Recipes/Cooking/food_sequence_element.yml
+++ b/Resources/Prototypes/Recipes/Cooking/food_sequence_element.yml
@@ -67,6 +67,17 @@
   - Cooked
   - Meat
 
+# Cooked Patty
+
+- type: foodSequenceElement
+  id: MeatPatty
+  sprites:
+  - sprite: Objects/Consumable/Food/meat.rsi
+    state: patty
+  tags:
+  - Cooked
+  - Meat
+
 # Dragon Steak
 
 - type: foodSequenceElement


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Currently, when putting a meat patty on a custom burger, it uses the steak sprite. This PR fixes it so it uses the meat patty sprite instead

## Why / Balance
Sprite fix

## Technical details
Added a meat patty entry to food_sequence_element.yml, changed code in meat.yml to use the patty sprite

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Meat patties](https://github.com/user-attachments/assets/b4c3dc4f-2075-43c1-807c-149d6d8ce86c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
