### PR TITLE
Forcing people to open mail

### DIFF
--- a/Content.Shared/Delivery/DeliveryComponent.cs
+++ b/Content.Shared/Delivery/DeliveryComponent.cs
@@ -70,6 +70,20 @@ public sealed partial class DeliveryComponent : Component
     public bool WasPenalized;
 
     /// <summary>
+    /// Whether you can force another entity to open this letter.
+    /// This is done via interaction.
+    /// </summary>
+    [DataField]
+    public bool CanForceDeliver = true;
+
+    /// <summary>
+    /// Whether this delivery has already received a penalty.
+    /// Used to avoid getting penalized several times.
+    /// </summary>
+    [DataField]
+    public TimeSpan ForceDeliverTime = TimeSpan.FromSeconds(5);
+
+    /// <summary>
     /// The sound to play when the delivery is unlocked.
     /// </summary>
     [DataField]

--- a/Content.Shared/FingerprintReader/FingerprintReaderSystem.cs
+++ b/Content.Shared/FingerprintReader/FingerprintReaderSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Forensics.Components;
+using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Popups;
 using JetBrains.Annotations;
@@ -23,6 +24,9 @@ public sealed class FingerprintReaderSystem : EntitySystem
     {
         if (!Resolve(target, ref target.Comp, false))
             return true;
+
+        if (!HasComp<FingerprintReaderComponent>(target))
+            return false;
 
         if (target.Comp.AllowedFingerprints.Count == 0)
             return true;

--- a/Resources/Locale/en-US/delivery/delivery-component.ftl
+++ b/Resources/Locale/en-US/delivery/delivery-component.ftl
@@ -9,6 +9,10 @@ delivery-opened-self = You open the {$delivery}.
 delivery-unlocked-others = {CAPITALIZE($recipient)} unlocked the {$delivery} with {POSS-ADJ($possadj)} fingerprint.
 delivery-opened-others = {CAPITALIZE($recipient)} opened the {$delivery}.
 
+delivery-force-popup-target = {$identity} is trying to scan your fingerprint!
+delivery-force-popup-self = You try to force {$identity} to open the {$type}.
+delivery-force-popup-self-fail = {$identity} cannot unlock this {$type}.
+
 delivery-unlock-verb = Unlock
 delivery-open-verb = Open
 delivery-slice-verb = Slice open


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
You can now force people to open deliveries.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Frequently requested due to the inability to deliver to dead or SSD players. Now you can do it if you find their corpse!

## Technical details
<!-- Summary of code changes for easier review. -->
AfterInteract event for deliveries. Runs a doafter on an entity when interacted with using mail.
Only checks if they are able to open it after the doAfter to discourage identity-checking. (Their face is covered but the doAfter started? They must be this person)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/bff73bfd-f4b7-4b74-85ad-afa6bd159bae

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Using mail on another player will now try to forcefully deliver it to them.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
