### PR TITLE
Fix turnstile collision with firelocks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
@@ -22,7 +22,7 @@
         mask:
         - FullTileMask
         layer:
-        - AirlockLayer
+        - GlassAirlockLayer
       fix2:
         shape:
           !type:PhysShapeAabb
@@ -31,7 +31,7 @@
         mask:
         - FullTileMask
         layer:
-        - AirlockLayer
+        - GlassAirlockLayer
   - type: MeleeSound
     soundGroups:
       Brute:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR allows firelocks to close over turnstiles.

Fixes #36971 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

bugfix, don't want prisoners to suffocate.

## Technical details
<!-- Summary of code changes for easier review. -->

We simply move them to the glass airlock layer. This has the side-effect of allowing lasers to be shot through, but that's fairly intuitive anyway.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/a85a32b3-36f7-42e3-ae24-275fab3c5949

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Firelocks can now close over turnstiles
