### PR TITLE
Fix action ent prediction

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -202,6 +202,7 @@ namespace Content.Client.Actions
                 return;
 
             OnActionAdded?.Invoke(actionId);
+            ActionsUpdated?.Invoke();
         }
 
         protected override void ActionRemoved(EntityUid performer, EntityUid actionId, ActionsComponent comp, BaseActionComponent action)
@@ -210,6 +211,7 @@ namespace Content.Client.Actions
                 return;
 
             OnActionRemoved?.Invoke(actionId);
+            ActionsUpdated?.Invoke();
         }
 
         public IEnumerable<(EntityUid Id, BaseActionComponent Comp)> GetClientActions()


### PR DESCRIPTION
Buttons don't get created in the predicted methods only on state handler.

Fixes https://github.com/space-wizards/space-station-14/issues/37075

**Changelog**
:cl:
- fix: Fix action additions / removals sometimes not being predicted.
