### PR TITLE
Make universal access config better

### DIFF
--- a/Content.Server/Access/Systems/AccessOverriderSystem.cs
+++ b/Content.Server/Access/Systems/AccessOverriderSystem.cs
@@ -201,7 +201,7 @@ public sealed class AccessOverriderSystem : SharedAccessOverriderSystem
         if (!PrivilegedIdIsAuthorized(uid, component))
             return;
 
-        if (!_tagSystem.HasTag(player, BypassInteractionRangeChecksTag) && !_interactionSystem.InRangeUnobstructed(uid, component.TargetAccessReaderId))
+        if (!_interactionSystem.InRangeUnobstructed(player, component.TargetAccessReaderId))
         {
             _popupSystem.PopupEntity(Loc.GetString("access-overrider-out-of-range"), player, player);
 

--- a/Content.Server/Access/Systems/AccessOverriderSystem.cs
+++ b/Content.Server/Access/Systems/AccessOverriderSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Access;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Administration.Logs;
-using Content.Shared.Tag;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
@@ -26,12 +25,9 @@ public sealed class AccessOverriderSystem : SharedAccessOverriderSystem
     [Dependency] private readonly AccessReaderSystem _accessReader = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
-    [Dependency] private readonly TagSystem _tagSystem = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
-
-    private static readonly ProtoId<TagPrototype> BypassInteractionRangeChecksTag = "BypassInteractionRangeChecks";
 
     public override void Initialize()
     {

--- a/Content.Server/Access/Systems/AccessOverriderSystem.cs
+++ b/Content.Server/Access/Systems/AccessOverriderSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Access;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Administration.Logs;
+using Content.Shared.Tag;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
@@ -25,9 +26,12 @@ public sealed class AccessOverriderSystem : SharedAccessOverriderSystem
     [Dependency] private readonly AccessReaderSystem _accessReader = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+    [Dependency] private readonly TagSystem _tagSystem = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
+
+    private static readonly ProtoId<TagPrototype> BypassInteractionRangeChecksTag = "BypassInteractionRangeChecks";
 
     public override void Initialize()
     {
@@ -197,7 +201,7 @@ public sealed class AccessOverriderSystem : SharedAccessOverriderSystem
         if (!PrivilegedIdIsAuthorized(uid, component))
             return;
 
-        if (!component.infiniteRange && !_interactionSystem.InRangeUnobstructed(uid, component.TargetAccessReaderId))
+        if (!_tagSystem.HasTag(player, BypassInteractionRangeChecksTag) && !_interactionSystem.InRangeUnobstructed(uid, component.TargetAccessReaderId))
         {
             _popupSystem.PopupEntity(Loc.GetString("access-overrider-out-of-range"), player, player);
 

--- a/Content.Server/Access/Systems/AccessOverriderSystem.cs
+++ b/Content.Server/Access/Systems/AccessOverriderSystem.cs
@@ -197,7 +197,7 @@ public sealed class AccessOverriderSystem : SharedAccessOverriderSystem
         if (!PrivilegedIdIsAuthorized(uid, component))
             return;
 
-        if (!_interactionSystem.InRangeUnobstructed(uid, component.TargetAccessReaderId))
+        if (!component.infiniteRange && !_interactionSystem.InRangeUnobstructed(uid, component.TargetAccessReaderId))
         {
             _popupSystem.PopupEntity(Loc.GetString("access-overrider-out-of-range"), player, player);
 

--- a/Content.Shared/Access/Components/AccessOverriderComponent.cs
+++ b/Content.Shared/Access/Components/AccessOverriderComponent.cs
@@ -14,6 +14,9 @@ public sealed partial class AccessOverriderComponent : Component
     public static string PrivilegedIdCardSlotId = "AccessOverrider-privilegedId";
 
     [DataField]
+    public bool infiniteRange = false;
+
+    [DataField]
     public ItemSlot PrivilegedIdSlot = new();
 
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Access/Components/AccessOverriderComponent.cs
+++ b/Content.Shared/Access/Components/AccessOverriderComponent.cs
@@ -14,9 +14,6 @@ public sealed partial class AccessOverriderComponent : Component
     public static string PrivilegedIdCardSlotId = "AccessOverrider-privilegedId";
 
     [DataField]
-    public bool infiniteRange = false;
-
-    [DataField]
     public ItemSlot PrivilegedIdSlot = new();
 
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -86,7 +86,6 @@
   - type: Clothing
     sprite: Objects/Tools/universal_access_configurator.rsi
   - type: AccessOverrider
-    infiniteRange: true
     accessLevels:
     - Armory
     - Atmospherics

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -130,6 +130,7 @@
     - GenpopLeave
     privilegedIdSlot:
       name: id-card-console-privileged-id
+      startingItem: UniversalIDCard
       ejectSound: /Audio/Machines/id_swipe.ogg
       insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
       ejectOnBreak: true

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -69,6 +69,7 @@
       requiresComplex: true
       requireActiveHand: false
       singleUser: true
+      inHandsOnly: true
     - type: ItemSlots
     - type: ContainerContainer
       containers:

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -86,6 +86,7 @@
   - type: Clothing
     sprite: Objects/Tools/universal_access_configurator.rsi
   - type: AccessOverrider
+    infiniteRange: true
     accessLevels:
     - Armory
     - Atmospherics


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Universal access config now starts with a universal ID and now has infinite range
<!-- What did you change? -->

## Why / Balance
As a admin is very annoying either having to spawn a universal ID to use in the universal access config or having to remove the universal ID from your PDA, also, is annoying having to be physically close to the stuff to use the universal access config
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Some yml edit to add the universal ID to the universal access config and fixed a bug with the AccessOverrider system
<!-- Summary of code changes for easier review. -->

## Media

https://github.com/user-attachments/assets/7fef6105-dbd0-41b7-af35-9389efa73ea9

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
🆑 Samuka 
ADMIN:
- tweak: universal access config now starts with a universal ID
- fix: admins can now use any access config from any range
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
