### PR TITLE
Wizard Helmet in the Magic Vend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/magivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/magivend.yml
@@ -8,6 +8,7 @@
     ClothingOuterWizardRed: 3
     ClothingHeadHatVioletwizard: 3
     ClothingOuterWizardViolet: 3
+    ClothingHeadHelmetWizardHelm: 3
     ClothingShoesWizard: 9
     #TODO:
     #only missing staff


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I added the wizard helmet to the magic vend.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Its like the only wizard related vanity item not in the magicvend.
## Technical details
<!-- Summary of code changes for easier review. -->
YAML changes.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
🆑 
- tweak: The Wizard Helmet is now obtainable from the magic vend.