### PR TITLE
Fixes battery weapons changing firemode on wield

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
@@ -82,6 +82,10 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
 
     private void OnUseInHandEvent(EntityUid uid, BatteryWeaponFireModesComponent component, UseInHandEvent args)
     {
+        if(args.Handled)
+            return;
+
+        args.Handled = true;
         TryCycleFireMode(uid, component, args.User);
     }
 

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -44,7 +44,7 @@ public abstract class SharedWieldableSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<WieldableComponent, UseInHandEvent>(OnUseInHand, before: [typeof(SharedGunSystem)]);
+        SubscribeLocalEvent<WieldableComponent, UseInHandEvent>(OnUseInHand, before: [typeof(SharedGunSystem), typeof(BatteryWeaponFireModesSystem)]);
         SubscribeLocalEvent<WieldableComponent, ItemUnwieldedEvent>(OnItemUnwielded);
         SubscribeLocalEvent<WieldableComponent, GotUnequippedHandEvent>(OnItemLeaveHand);
         SubscribeLocalEvent<WieldableComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes a behavior with wielding energy weapons that have multiple fire modes changing fire mode when wielded.

## Why / Balance
The previous behavior could result in frustrating interactions as a weapon a player had previously set in a desired fire-mode suddenly changes directly before it is needed. (IE, HoS setting their energy shotgun to disable, only to have it suddenly switch to lethal rounds when wielded and injuring a crew member)

## Technical details
Adds a missing handled check to the OnUseInHand event that keeps the TryCycleFireMode function from being called if we are not wielding the weapon. Original implementation by Happyrobot33 at https://github.com/ss14Starlight/space-station-14/pull/547

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Battery weapons with multiple fire-modes (Energy Shotgun, Temperature Gun) will no longer change their fire-modes when wielded by activating them in your hand.

