### PR TITLE
Fix throwing prediction

### DIFF
--- a/Content.Shared/Throwing/LandEvent.cs
+++ b/Content.Shared/Throwing/LandEvent.cs
@@ -10,8 +10,5 @@ namespace Content.Shared.Throwing
     /// Raised when a thrown entity is no longer moving.
     /// </summary>
     [ByRefEvent]
-    public record struct StopThrowEvent
-    {
-        public EntityUid? User;
-    }
+    public record struct StopThrowEvent(EntityUid? User);
 }

--- a/Content.Shared/Throwing/LandEvent.cs
+++ b/Content.Shared/Throwing/LandEvent.cs
@@ -9,7 +9,8 @@ namespace Content.Shared.Throwing
     /// <summary>
     /// Raised when a thrown entity is no longer moving.
     /// </summary>
-    public sealed class StopThrowEvent : EntityEventArgs
+    [ByRefEvent]
+    public record struct StopThrowEvent
     {
         public EntityUid? User;
     }

--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -20,11 +20,6 @@ public sealed class ThrowingSystem : EntitySystem
 {
     public const float ThrowAngularImpulse = 5f;
 
-    /// <summary>
-    /// Speed cap on rotation in case of click-spam.
-    /// </summary>
-    public const float ThrowAngularCap = 3f * MathF.PI;
-
     public const float PushbackDefault = 2f;
 
     public const float FlyTimePercentage = 0.8f;

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Database;
 using Content.Shared.Gravity;
 using Content.Shared.Physics;
 using Content.Shared.Movement.Pulling.Events;
+using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
@@ -17,10 +18,11 @@ namespace Content.Shared.Throwing
     /// </summary>
     public sealed class ThrownItemSystem : EntitySystem
     {
-        [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
         [Dependency] private readonly IGameTiming _gameTiming = default!;
-        [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
+        [Dependency] private readonly INetManager _netMan = default!;
+        [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
         [Dependency] private readonly FixtureSystem _fixtures = default!;
+        [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
         [Dependency] private readonly SharedPhysicsSystem _physics = default!;
         [Dependency] private readonly SharedGravitySystem _gravity = default!;
 
@@ -108,8 +110,12 @@ namespace Content.Shared.Throwing
                 }
             }
 
-            EntityManager.EventBus.RaiseLocalEvent(uid, new StopThrowEvent { User = thrownItemComponent.Thrower }, true);
-            EntityManager.RemoveComponent<ThrownItemComponent>(uid);
+            var ev = new StopThrowEvent
+            {
+                User = thrownItemComponent.Thrower
+            };
+            RaiseLocalEvent(uid, ref ev);
+            RemComp<ThrownItemComponent>(uid);
         }
 
         public void LandComponent(EntityUid uid, ThrownItemComponent thrownItem, PhysicsComponent physics, bool playSound)
@@ -145,15 +151,13 @@ namespace Content.Shared.Throwing
         {
             base.Update(frameTime);
 
-            // TODO predicted throwing - remove this check
-            // We don't want to predict landing or stopping, since throwing isn't actually predicted.
-            // If we do, the landing/stop will occur prematurely on the client.
-            if (_gameTiming.InPrediction)
-                return;
-
             var query = EntityQueryEnumerator<ThrownItemComponent, PhysicsComponent>();
             while (query.MoveNext(out var uid, out var thrown, out var physics))
             {
+                // If you remove this check verify slipping for other entities is networked properly.
+                if (_netMan.IsClient && !physics.Predict)
+                    continue;
+
                 if (thrown.LandTime <= _gameTiming.CurTime)
                 {
                     LandComponent(uid, thrown, physics, thrown.PlayLandSound);

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -110,10 +110,7 @@ namespace Content.Shared.Throwing
                 }
             }
 
-            var ev = new StopThrowEvent
-            {
-                User = thrownItemComponent.Thrower
-            };
+            var ev = new StopThrowEvent(thrownItemComponent.Thrower);
             RaiseLocalEvent(uid, ref ev);
             RemComp<ThrownItemComponent>(uid);
         }


### PR DESCRIPTION
- Disposals is still janky but I think that's disposals in general not being predicted and the disposals throw not being predicted and short-lived.
- Would need to check RMC.
- Couldn't repro the underlying issues however thrown items don't slip anymore so (and we also don't predict their land / stopping anymore so).

Ref event breaking change on StopThrowEvent though nothing here uses it.

Probably fixes https://github.com/space-wizards/space-station-14/issues/37032

No one notices upstream so CL pointless.