### PR TITLE
Fix listcontainer constantly disposing children

### DIFF
--- a/Content.Client/UserInterface/Controls/ListContainer.cs
+++ b/Content.Client/UserInterface/Controls/ListContainer.cs
@@ -264,12 +264,6 @@ public class ListContainer : Control
             _updateChildren = false;
 
             var toRemove = new Dictionary<ListData, ListContainerButton>(_buttons);
-            foreach (var child in Children.ToArray())
-            {
-                if (child == _vScrollBar)
-                    continue;
-                RemoveChild(child);
-            }
 
             if (_data.Count > 0)
             {
@@ -292,8 +286,9 @@ public class ListContainer : Control
 
                         if (Toggle && data == _selected)
                             button.Pressed = true;
+                        AddChild(button);
                     }
-                    AddChild(button);
+                    button.SetPositionInParent(i - _topIndex);
                     button.Measure(finalSize);
                 }
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Modifies ListContainer so that it stops disposing and readding its children literally every time ArrangeOverride is called.

This is bad because it spams the everloving shit out of `ExitedTree`, which we use nowadays for control disposal behavior. This is most noticable with something like `EntityPrototypeView`, where constantly disposing and readding the controls causes them to flicker like crazy.

## Technical details
<!-- Summary of code changes for easier review. -->
Instead of disposing all the children, we simply reorder them manually and add new ones into tree. the existing logic already takes care of everything else.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no hog.