### PR TITLE
Emergency Food Changes.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -11,8 +11,8 @@
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: FireExtinguisherMini
+    - id: RadioHandheld
   - type: Sprite
     layers:
     - state: internals
@@ -29,8 +29,8 @@
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: FireExtinguisherMini
+    - id: RadioHandheld
   - type: Sprite
     layers:
     - state: internals
@@ -51,8 +51,8 @@
     - id: ExtendedEmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: FireExtinguisherMini
+    - id: RadioHandheld
   - type: Sprite
     layers:
     - state: internals
@@ -69,8 +69,8 @@
     - id: ExtendedEmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: FireExtinguisherMini
+    - id: RadioHandheld
   - type: Sprite
     layers:
     - state: internals
@@ -92,8 +92,8 @@
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: FireExtinguisherMini
+    - id: RadioHandheld
   - type: Sprite
     layers:
     - state: internals
@@ -110,8 +110,8 @@
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: FireExtinguisherMini
+    - id: RadioHandheld
   - type: Sprite
     layers:
     - state: internals
@@ -133,8 +133,8 @@
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: FireExtinguisherMini
+    - id: RadioHandheld
   - type: Sprite
     layers:
     - state: internals
@@ -151,8 +151,8 @@
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: FireExtinguisherMini
+    - id: RadioHandheld
   - type: Sprite
     layers:
     - state: internals
@@ -179,8 +179,8 @@
     - id: EmergencyFunnyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: FireExtinguisherMini
+    - id: RadioHandheld
   - type: Tag
     tags:
     - BoxHug
@@ -196,8 +196,8 @@
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
+    - id: FireExtinguisherMini
+    - id: RadioHandheld
   - type: Label
     currentLabel: reagent-name-nitrogen
 
@@ -213,7 +213,7 @@
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodBreadBaguette
-    - id: DrinkWaterBottleFull
+    - id: FireExtinguisherMini
 
 - type: entity
   parent: BoxSurvivalNitrogen
@@ -227,7 +227,7 @@
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodBreadBaguette
-    - id: DrinkWaterBottleFull
+    - id: FireExtinguisherMini
   - type: Sprite
     layers:
     - state: internals
@@ -247,8 +247,8 @@
     - id: ClothingMaskGasSyndicate
     - id: ExtendedEmergencyOxygenTankFilled
     - id: EmergencyMedipen
-    - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodSnackNutriBrick
+    - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
     - state: internals
@@ -264,8 +264,8 @@
     - id: ClothingMaskGasSyndicate
     - id: ExtendedEmergencyNitrogenTankFilled
     - id: EmergencyMedipen
-    - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodSnackNutriBrick
+    - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
     - state: internals

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -18,8 +18,6 @@
       - id: GlowstickBase
         orGroup: LightingItem
       # Low-chance items
-      - id: FoodSnackChocolate
-        prob: 0.15
       - id: HarmonicaInstrument
         prob: 0.15
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -31,8 +31,6 @@
       prob: 0.2
     - id: WeaponFlareGun
       prob: 0.1
-    - id: BoxMRE
-      prob: 0.1
 
 - type: entity
   id: ClosetEmergencyFilledRandom


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I replaced the nutribrick and water bottle in the survival boxes with a handheld fire extinguisher and a handheld radio, along with removing the MRI from emergency lockers and the chocolate from emergency toolboxes. (I also removed the flare from the syndicate boxes as it caused a bug)
## Why / Balance
my reasons for these changes are that, these items are hardly used for any actual emergencies, and are usually just consumed when a person is hungry/thirsty, another reason why I made these changes is because it discourages interacting with the station via water tanks, vending machines, bars, botany, and kitchens. (ALSO A MAINTAINER SAID IT WOULD BE A GOOD IDEA)
## Technical details
<!-- Summary of code changes for easier review. -->
Yaml changes
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
**Changelog**
🆑 
- tweak: the nutribrick and water bottle in the emergency boxes have been replaced with handheld fire extinguishers and handheld radios.
- removed: MRI's in emergency lockers and Chocolate in emergency toolboxes.
- removed: Flares from the syndicate survival boxes.
