### PR TITLE
Adding spesos values to chems

### DIFF
--- a/Content.Shared/Chemistry/Reagent/ReagentData.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentData.cs
@@ -41,4 +41,5 @@ public abstract partial class ReagentData : IEquatable<ReagentData>
     public abstract override int GetHashCode();
 
     public abstract ReagentData Clone();
+
 }

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -168,7 +168,7 @@ namespace Content.Shared.Chemistry.Reagent
         public float PricePerUnit => (ConsumesCatalyst ? 0.1f : 0.0f) + (FinalProduct ? 1.0f : 0.0f) + ChemComplexity * 0.1f;
 
         /// <summary>
-        /// add FinalProduct: true for the final desirable product in a chain, like advanced brutes, but not razorium
+        /// add FinalProduct: true for the final desirable product in a chain, like advanced brutes, but not chems like razorium
         /// </summary>
         [DataField]
         public bool FinalProduct = false;

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -18,6 +18,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
 using Robust.Shared.Utility;
+using YamlDotNet.Core.Tokens;
 
 namespace Content.Shared.Chemistry.Reagent
 {
@@ -158,8 +159,25 @@ namespace Content.Shared.Chemistry.Reagent
         [DataField("plantMetabolism", serverOnly: true)]
         public List<EntityEffect> PlantMetabolisms = new(0);
 
+        /// <summary>
+        /// ChemComplexity should be the amount of unique elements per chem added up, eg inaprov being 3 complexity, and bic being 4 even though inaprov uses carbon too
+        /// </summary>
         [DataField]
-        public float PricePerUnit;
+        public float ChemComplexity = 0;
+
+        public float PricePerUnit => (ConsumesCatalyst ? 0.1f : 0.0f) + (FinalProduct ? 1.0f : 0.0f) + ChemComplexity * 0.1f;
+
+        /// <summary>
+        /// add FinalProduct: true for the final desirable product in a chain, like advanced brutes, but not razorium
+        /// </summary>
+        [DataField]
+        public bool FinalProduct = false;
+
+        /// <summary>
+        /// if it consumes a chem thats used as a catalyst, like phlog eating the plasma, set to true, however chems like dex should be set to false
+        /// </summary>
+        [DataField]
+        public bool ConsumesCatalyst = false;
 
         [DataField]
         public SoundSpecifier FootstepSound = new SoundCollectionSpecifier("FootstepWater", AudioParams.Default.WithVolume(6));

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -16,7 +16,7 @@
     amount: 1.5
   - !type:PlantAdjustHealth
     amount: 0.75
-  pricePerUnit: 2
+    chemComplexity: 1
 
 - type: reagent
   id: Vitamin #Anything "healthy"
@@ -45,7 +45,7 @@
     amount: 0.5
   - !type:PlantAdjustHealth
     amount: 1.5
-  pricePerUnit: 2.5
+  chemComplexity: 1
 
 - type: reagent
   id: Protein #Meat and beans
@@ -66,7 +66,7 @@
       - !type:ModifyBloodLevel
         amount: 1 # weaker than iron but pretty good all things considered
       - !type:SatiateHunger
-  pricePerUnit: 3
+  chemComplexity: 1
 
 - type: reagent
   id: Sugar #Candy and grains

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -7,6 +7,7 @@
   physicalDesc: reagent-physical-desc-opaque
   flavor: nutriment
   color: "#24591F"
+  chemComplexity: 1
   metabolisms:
     Food:
       effects:
@@ -16,7 +17,6 @@
     amount: 1.5
   - !type:PlantAdjustHealth
     amount: 0.75
-    chemComplexity: 1
 
 - type: reagent
   id: Vitamin #Anything "healthy"
@@ -26,6 +26,7 @@
   physicalDesc: reagent-physical-desc-chalky
   flavor: vitamin
   color: "#D3D3D3"
+  chemComplexity: 1
   metabolisms:
     Food: #This makes it not compete with medicines, a large bonus for something that can heal
       effects:
@@ -45,7 +46,6 @@
     amount: 0.5
   - !type:PlantAdjustHealth
     amount: 1.5
-  chemComplexity: 1
 
 - type: reagent
   id: Protein #Meat and beans
@@ -55,6 +55,7 @@
   physicalDesc: reagent-physical-desc-clumpy
   flavor: protein
   color: "#FFFFE5"
+  chemComplexity: 1
   metabolisms:
     Food:
       effects:
@@ -66,7 +67,6 @@
       - !type:ModifyBloodLevel
         amount: 1 # weaker than iron but pretty good all things considered
       - !type:SatiateHunger
-  chemComplexity: 1
 
 - type: reagent
   id: Sugar #Candy and grains
@@ -77,6 +77,7 @@
   flavor: sweet
   color: white
   meltingPoint: 146.0
+  chemComplexity: 1
   metabolisms:
     Food:
       effects:

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -13,6 +13,7 @@
   metamorphicChangeColor: false
   recognizable: true
   physicalDesc: reagent-physical-desc-ferrous
+  chemComplexity: 1 # hope people don't start selling their blood with this one
   metabolisms:
     Drink:
       effects:
@@ -55,6 +56,7 @@
   color: "#808A51"
   recognizable: true
   physicalDesc: reagent-physical-desc-slimy
+  chemComplexity: 1
 
 - type: reagent
   id: Slime
@@ -66,6 +68,7 @@
   recognizable: true
   physicalDesc: reagent-physical-desc-viscous
   viscosity: 0.25
+  chemComplexity: 1
   tileReactions:
     - !type:SpillTileReaction
   metabolisms:
@@ -89,6 +92,7 @@
   recognizable: true
   physicalDesc: reagent-physical-desc-sticky
   viscosity: 0.10
+  chemComplexity: 1
   tileReactions:
     - !type:SpillTileReaction
   metabolisms:
@@ -114,6 +118,7 @@
   color: "#162581"
   recognizable: true
   physicalDesc: reagent-physical-desc-metallic
+  chemComplexity: 1
 
 - type: reagent
   parent: Blood
@@ -125,6 +130,7 @@
   color: "#7a8bf2"
   recognizable: true
   physicalDesc: reagent-physical-desc-pungent
+  chemComplexity: 1
 
 - type: reagent
   id: ZombieBlood
@@ -134,6 +140,7 @@
   physicalDesc: reagent-physical-desc-necrotic
   flavor: bitter
   color: "#2b0700"
+  chemComplexity: 1
   metabolisms:
     Drink:
       # Disgusting!
@@ -158,6 +165,8 @@
   flavor: metallic
   color: "#f4692e"
   recognizable: true
+  chemComplexity: 300 # it comes from a dragon, it has to be complex, also results in 620u spesos from grinding the 2 dragon flesh you get from killing one
+  finalProduct: true
   metabolisms:
     Drink:
       effects:
@@ -195,6 +204,7 @@
   flavor: terrible
   color: "#d8d8b0"
   physicalDesc: reagent-physical-desc-exotic-smelling
+  chemComplexity: 1
   footstepSound:
     collection: FootstepBlood
     params:
@@ -208,6 +218,7 @@
   flavor: terrible
   color: "#87ab08"
   physicalDesc: reagent-physical-desc-pungent
+  chemComplexity: 1
   slipData:
     requiredSlipSpeed: 4.0 #It's not as slippery as water
   friction: 0.4
@@ -232,6 +243,7 @@
   physicalDesc: reagent-physical-desc-neural
   flavor: mindful
   color: "#C584B8"
+  chemComplexity: 3
   metabolisms:
     Drink:
       effects:

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -218,7 +218,7 @@
   flavor: terrible
   color: "#87ab08"
   physicalDesc: reagent-physical-desc-pungent
-  chemComplexity: 1
+  chemComplexity: 1 # might need to change this?
   slipData:
     requiredSlipSpeed: 4.0 #It's not as slippery as water
   friction: 0.4

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -168,7 +168,7 @@
   flavor: bitter
   color: "#3CB371"
   physicalDesc: reagent-physical-desc-sickly
-  chemComplexity: 12
+  chemComplexity: 12 # i hate this chem
   finalProduct: true
   plantMetabolism:
     - !type:PlantAdjustHealth

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -6,6 +6,7 @@
   flavor: bitter
   color: "#664330"
   physicalDesc: reagent-physical-desc-thick
+  chemComplexity: 3
   plantMetabolism:
     - !type:PlantAdjustNutrition
       amount: 2
@@ -25,6 +26,8 @@
   flavor: bitter
   color: "#5b406c"
   physicalDesc: reagent-physical-desc-heterogeneous
+  chemComplexity: 4
+  finalProduct: true
   plantMetabolism:
     - !type:PlantAdjustNutrition
       amount: 1
@@ -80,6 +83,7 @@
   flavor: bitter
   color: "#49002E"
   physicalDesc: reagent-physical-desc-bubbling
+  chemComplexity: 2
   plantMetabolism:
     - !type:PlantAdjustToxins
       amount: 6
@@ -111,6 +115,7 @@
   flavor: bitter
   color: "#3e901c"
   physicalDesc: reagent-physical-desc-robust
+  chemComplexity: 6
   plantMetabolism:
     - !type:PlantAdjustNutrition
       amount: 0.05
@@ -163,6 +168,8 @@
   flavor: bitter
   color: "#3CB371"
   physicalDesc: reagent-physical-desc-sickly
+  chemComplexity: 12
+  finalProduct: true
   plantMetabolism:
     - !type:PlantAdjustHealth
       amount: -2
@@ -205,6 +212,7 @@
   color: "#77b58e"
   boilingPoint: -33.0
   meltingPoint: -77.7
+  chemComplexity: 2
   plantMetabolism:
   - !type:PlantAdjustNutrition
     amount: 1
@@ -284,6 +292,7 @@
   color: "#a1000b"
   boilingPoint: 55.5
   meltingPoint: -50.0
+  chemComplexity: 3
   plantMetabolism:
   - !type:PlantAdjustNutrition
     amount: 0.1

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -7,6 +7,7 @@
   color: "#AF14B7"
   boilingPoint: 55.5
   meltingPoint: -50.0
+  chemComplexity: 5
 
 - type: reagent
   id: Phenol
@@ -17,6 +18,7 @@
   color: "#E7EA91"
   boilingPoint: 55.5
   meltingPoint: -50.0
+  chemComplexity: 4
   metabolisms:
     Poison:
       effects:
@@ -34,6 +36,7 @@
   color: "#22282b"
   boilingPoint: 4200.0
   meltingPoint: 3550.0
+  chemComplexity: 5
   metabolisms:
     Medicine:
       effects:
@@ -50,6 +53,7 @@
   desc: reagent-desc-ash
   physicalDesc: reagent-physical-desc-powdery
   color: white
+  chemComplexity: 4
 
 - type: reagent
   id: SodiumCarbonate
@@ -57,6 +61,7 @@
   desc: reagent-desc-sodium-carbonate
   physicalDesc: reagent-physical-desc-powdery
   color: white
+  chemComplexity: 7
 
 - type: reagent
   id: Artifexium
@@ -65,6 +70,8 @@
   flavor: metallic
   physicalDesc: reagent-physical-desc-crystalline
   color: "#776291"
+  chemComplexity: 10 # hard to get+ comes from science only
+  finalProduct: true
   metabolisms:
     Poison:
       effects:
@@ -89,6 +96,7 @@
   color: "#E7EA91"
   boilingPoint: 353.2
   meltingPoint: 278.7
+  chemComplexity: 2
   metabolisms:
     Poison:
       effects:
@@ -105,6 +113,7 @@
   color: "white"
   boilingPoint: 1661.0
   meltingPoint: 596.0
+  chemComplexity: 2
 
 - type: reagent
   id: SodiumHydroxide
@@ -114,6 +123,7 @@
   color: "white"
   boilingPoint: 1661.0
   meltingPoint: 596.0
+  chemComplexity: 3
   metabolisms:
     Poison:
       effects:
@@ -138,6 +148,7 @@
   color: "#434b4d"
   boilingPoint: 2962.0
   meltingPoint: 1638.0
+  chemComplexity: 2
 
 - type: reagent
   id: SodiumPolyacrylate
@@ -146,6 +157,8 @@
   flavor: bitter
   physicalDesc: reagent-physical-desc-grainy
   color: "#F0F0F0"
+  chemComplexity: 3
+  finalProduct: true
   metabolisms:
     Poison:
       effects:
@@ -165,6 +178,7 @@
   flavor: bitter
   color: "#E6E6DA"
   physicalDesc: reagent-physical-desc-crystalline
+  chemComplexity: 1
 
 - type: reagent
   id: Rororium

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -53,7 +53,6 @@
   desc: reagent-desc-ash
   physicalDesc: reagent-physical-desc-powdery
   color: white
-  chemComplexity: 4
 
 - type: reagent
   id: SodiumCarbonate

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -7,7 +7,7 @@
   color: "#a1000b"
   boilingPoint: 111.0
   meltingPoint: -5.0
-  chemComplexity: 8 # i would add final product, but its used to make mustard... why?????
+  chemComplexity: 8 # i would add final product, but its used to make mustard... why????
   metabolisms:
     Poison:
       effects:

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -7,6 +7,7 @@
   color: "#a1000b"
   boilingPoint: 111.0
   meltingPoint: -5.0
+  chemComplexity: 8 # i would add final product, but its used to make mustard... why?????
   metabolisms:
     Poison:
       effects:
@@ -34,6 +35,7 @@
   recognizable: true
   boilingPoint: 147.0 # Made this up, loosely based on bleach
   meltingPoint: -11.0
+  chemComplexity: 3
   tileReactions:
     - !type:CleanTileReaction {}
     - !type:CleanDecalsReaction {}
@@ -77,6 +79,7 @@
   recognizable: true
   boilingPoint: 290.0 # Glycerin
   meltingPoint: 18.2
+  chemComplexity: 4
   tileReactions:
   - !type:SpillTileReaction
   friction: 0.0
@@ -90,6 +93,8 @@
   color: "#ffffff"
   boilingPoint: 250.0
   meltingPoint: 380.0
+  chemComplexity: 5
+  finalProduct: true
   tileReactions:
   - !type:SpillTileReaction
   viscosity: 0.5

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -121,7 +121,7 @@
   color: "#F7C430"
   boilingPoint: 2700.0
   meltingPoint: 1064.76
-  chemComplexity: 0 #gold can be solidified using frost oil, im not buffing botany into being even lazier
+  chemComplexity: 0 #gold can be solidified using frost oil, im not buffing botany into being even lazier.
 
 - type: reagent
   id: Hydrogen

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -8,6 +8,7 @@
   color: "#848789"
   boilingPoint: 2327.0
   meltingPoint: 660.0
+  chemComplexity: 1
 
 - type: reagent
   id: Carbon
@@ -19,6 +20,7 @@
   color: "#22282b"
   boilingPoint: 4200.0
   meltingPoint: 3550.0
+  chemComplexity: 1
 
 - type: reagent
   id: Chlorine
@@ -30,6 +32,7 @@
   color: "#a2ff00"
   meltingPoint: -101.5
   boilingPoint: -34.04
+  chemComplexity: 1
   plantMetabolism:
     - !type:PlantAdjustWater
       amount: -0.5
@@ -57,6 +60,7 @@
   color: "#b05b3c"
   boilingPoint: 2595.0
   meltingPoint: 1083.0
+  chemComplexity: 1
   metabolisms:
     Poison:
       metabolismRate: 0.1
@@ -88,6 +92,7 @@
   color: "#ba85cc"
   boilingPoint: -188.11
   meltingPoint: -219.67
+  chemComplexity: 1
   plantMetabolism:
     - !type:PlantAdjustWater
       amount: -0.5
@@ -105,6 +110,7 @@
           types:
             Caustic: 0.5
             Poison: 0.5
+
 - type: reagent
   id: Gold
   name: reagent-name-gold
@@ -115,6 +121,7 @@
   color: "#F7C430"
   boilingPoint: 2700.0
   meltingPoint: 1064.76
+  chemComplexity: 0 #gold can be solidified using frost oil, im not buffing botany into being even lazier
 
 - type: reagent
   id: Hydrogen
@@ -126,6 +133,7 @@
   color: "#cccccc"
   boilingPoint: -253.0
   meltingPoint: -259.2
+  chemComplexity: 1
 
 - type: reagent
   id: Iodine
@@ -137,6 +145,7 @@
   color: "#BC8A00"
   boilingPoint: 184.3
   meltingPoint: 113.7
+  chemComplexity: 1
 
 - type: reagent
   id: Iron
@@ -148,6 +157,7 @@
   color: "#434b4d"
   boilingPoint: 2862.0
   meltingPoint: 1538.0
+  chemComplexity: 1
   metabolisms:
     Poison:
       metabolismRate: 0.1
@@ -179,6 +189,7 @@
   color: "#d6c0a7"
   meltingPoint: 180.5
   boilingPoint: 1330.0
+  chemComplexity: 1
   metabolisms:
     Poison:
       metabolismRate: 0.1
@@ -206,6 +217,7 @@
   color: "#929296"
   meltingPoint: -38.83
   boilingPoint: 356.73
+  chemComplexity: 1
   metabolisms:
     Poison:
       effects:
@@ -227,6 +239,7 @@
   color: "#c6c8cc"
   meltingPoint: 65.5
   boilingPoint: 759.0
+  chemComplexity: 1
 
 - type: reagent
   id: Phosphorus
@@ -238,6 +251,7 @@
   color: "#f5da9a"
   meltingPoint: 44.2
   boilingPoint: 280.5
+  chemComplexity: 1
   plantMetabolism:
     - !type:PlantAdjustNutrition
       amount: 0.1
@@ -257,6 +271,7 @@
   color: "#00ff04"
   meltingPoint: 700.0
   boilingPoint: 1737.0
+  chemComplexity: 1
 
 - type: reagent
   id: Silicon
@@ -268,6 +283,7 @@
   color: "#364266"
   boilingPoint: 3265.0
   meltingPoint: 1414.0
+  chemComplexity: 1
   metabolisms:
     Poison:
       effects:
@@ -286,6 +302,7 @@
   color: "#d0d0d0"
   boilingPoint: 2212.0
   meltingPoint: 960.5
+  chemComplexity: 0 #can be solidified, no reason to make people sell it as a chem
 
 - type: reagent
   id: Sulfur
@@ -297,6 +314,7 @@
   color: "#fff385"
   boilingPoint: 445.0
   meltingPoint: 120.0
+  chemComplexity: 1
   metabolisms:
     Poison:
       effects:
@@ -315,6 +333,7 @@
   color: "#a7b3d6"
   meltingPoint: 97.8
   boilingPoint: 883.0
+  chemComplexity: 1
 
 - type: reagent
   id: Uranium
@@ -326,6 +345,7 @@
   color: "#8fa191"
   meltingPoint: 1133.0
   boilingPoint: 4131.0
+  chemComplexity: 2 #harder to get, and a byproduct of making radium if grinding uranium for maints chemistry
   plantMetabolism:
   - !type:PlantAdjustMutationLevel
     amount: 0.6
@@ -354,3 +374,4 @@
   color: "#bababa"
   meltingPoint: 419.5
   boilingPoint: 907.0
+  chemComplexity: 1

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -374,7 +374,7 @@
   physicalDesc: reagent-physical-desc-inversed
   flavor: hew
   color: "#a64dc5"
-  chemComplexity: 2
+  chemComplexity: 3 # rare
   metabolisms:
     Poison:
       metabolismRate: 0.25

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -35,7 +35,6 @@
   physicalDesc: reagent-physical-desc-fibrous
   flavor: fiber
   color: "#808080"
-  chemComplexity: 1
   metabolisms:
     Food:
       effects:

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -6,6 +6,7 @@
   physicalDesc: reagent-physical-desc-fibrous
   flavor: carpet
   color: "#800000"
+  chemComplexity: 4
   tileReactions:
   - !type:CreateEntityTileReaction
     entity: Carpet
@@ -34,6 +35,7 @@
   physicalDesc: reagent-physical-desc-fibrous
   flavor: fiber
   color: "#808080"
+  chemComplexity: 1
   metabolisms:
     Food:
       effects:
@@ -50,6 +52,8 @@
   physicalDesc: reagent-physical-desc-buzzy
   flavor: bee
   color: "#FFD35D"
+  chemComplexity: 7
+  finalProduct: true
   tileReactions:
   - !type:CreateEntityTileReaction
     entity: MobBee
@@ -143,6 +147,7 @@
   physicalDesc: reagent-physical-desc-bee-guts
   flavor: bee
   color: "#86530E"
+  chemComplexity: 1
 
 - type: reagent
   id: Saxoite
@@ -151,6 +156,7 @@
   physicalDesc: reagent-physical-desc-ground-brass
   flavor: sax
   color: "#B8A603"
+  chemComplexity: 1
 
 - type: reagent
   id: Licoxide
@@ -160,6 +166,8 @@
   physicalDesc: reagent-physical-desc-electric
   flavor: shocking
   color: "#FDD023"
+  chemComplexity: 2
+  finalProduct: true
   metabolisms:
     Poison:
       effects:
@@ -176,6 +184,7 @@
   physicalDesc: reagent-physical-desc-reflective
   flavor: sharp
   color: "#e3fffb"
+  chemComplexity: 2 # its higher, but you shouldn't get any kind of reward for making this
   reactiveEffects:
     Acidic:
       methods: [ Touch ]
@@ -216,6 +225,8 @@
   physicalDesc: reagent-physical-desc-frosty
   flavor: cold
   color: "#b3f1ff"
+  chemComplexity: 18 # lower, but this encourages atmos/chem interaction
+  finalProduct: true
   boilingPoint: 50.0
   meltingPoint: 45.0
   tileReactions:
@@ -307,6 +318,7 @@
   physicalDesc: reagent-physical-desc-funny
   flavor: funny
   color: "#FF4DD2"
+  chemComplexity: 8
   slipData:
     requiredSlipSpeed: 3.5 #clown juice gotta slip
   metabolisms:
@@ -329,6 +341,7 @@
   physicalDesc: reagent-physical-desc-vibrant
   flavor: weh
   color: "#59b23a"
+  chemComplexity: 1
   metabolisms:
     Poison:
       metabolismRate: 0.25
@@ -361,6 +374,7 @@
   physicalDesc: reagent-physical-desc-inversed
   flavor: hew
   color: "#a64dc5"
+  chemComplexity: 2
   metabolisms:
     Poison:
       metabolismRate: 0.25

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -6,6 +6,7 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: medicine
   color: "#081a80"
+  chemComplexity: 3
   metabolisms:
     Medicine:
       effects:
@@ -24,6 +25,7 @@
   physicalDesc: reagent-physical-desc-translucent
   flavor: medicine
   color: "#3a1d8a"
+  chemComplexity: 3
   metabolisms:
     Medicine:
       effects:
@@ -73,6 +75,8 @@
   physicalDesc: reagent-physical-desc-chalky
   flavor: medicine
   color: "#64ffe6"
+  chemComplexity: 9
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -102,6 +106,7 @@
   physicalDesc: reagent-physical-desc-opaque
   flavor: medicine
   color: "#2d5708"
+  chemComplexity: 5
   metabolisms:
     Medicine:
       effects:
@@ -122,6 +127,7 @@
   physicalDesc: reagent-physical-desc-cloudy
   flavor: medicine
   color: "#bd5902"
+  chemComplexity: 4
   metabolisms:
     Medicine:
       effects:
@@ -140,6 +146,7 @@
   physicalDesc: reagent-physical-desc-opaque
   flavor: medicine
   color: "#ffaa00"
+  chemComplexity: 4
   metabolisms:
     Medicine:
       effects:
@@ -174,6 +181,7 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: medicine
   color: "#0091ff"
+  chemComplexity: 4
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: -5
@@ -204,6 +212,7 @@
   physicalDesc: reagent-physical-desc-bubbling
   flavor: medicine
   color: "#32cd32"
+  chemComplexity: 7
   metabolisms:
     Medicine:
       effects:
@@ -223,6 +232,7 @@
   physicalDesc: reagent-physical-desc-translucent
   flavor: medicine
   color: "#215263"
+  chemComplexity: 4
   metabolisms:
     Medicine:
       effects:
@@ -255,6 +265,7 @@
   physicalDesc: reagent-physical-desc-opaque
   flavor: medicine
   color: "#0041a8"
+  chemComplexity: 2
   metabolisms:
     Medicine:
       effects:
@@ -280,6 +291,7 @@
   physicalDesc: reagent-physical-desc-cloudy
   flavor: medicine
   color: "#4da0bd"
+  chemComplexity: 4
   metabolisms:
     Medicine:
       effects:
@@ -313,6 +325,8 @@
   physicalDesc: reagent-physical-desc-odorless
   flavor: medicine
   color: "#d2fffa"
+  chemComplexity: 12
+  finalProduct: true #its used to make laughter, but that is absolutely not a desirable chem and is easily made by botany
   metabolisms:
     Medicine:
       effects:
@@ -378,6 +392,7 @@
   physicalDesc: reagent-physical-desc-cloudy
   flavor: medicine
   color: "#4cb580"
+  chemComplexity: 3
   metabolisms:
     Medicine:
       effects:
@@ -407,6 +422,8 @@
   physicalDesc: reagent-physical-desc-inky
   flavor: medicine
   color: "#422912"
+  chemComplexity: 4
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -424,6 +441,7 @@
   physicalDesc: reagent-physical-desc-opaque
   flavor: medicine
   color: "#731024"
+  chemComplexity: 3
   metabolisms:
     Medicine:
       metabolismRate: 0.1 # Smaller doses stabilize critical people for longer. Gives it a specific usecase as to not be entirely outclassed by dex+
@@ -447,6 +465,7 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: medicine
   color: "#bf3d19"
+  chemComplexity: 2
   metabolisms:
     Medicine:
       effects:
@@ -480,6 +499,7 @@
   physicalDesc: reagent-physical-desc-pungent
   flavor: medicine
   color: "#ff7db5"
+  chemComplexity: 4
   metabolisms:
     Medicine:
       effects:
@@ -514,6 +534,7 @@
   physicalDesc: reagent-physical-desc-viscous
   flavor: medicine
   color: "#ff867d"
+  chemComplexity: 0 #chem not currently used
   metabolisms:
     Medicine:
       effects:
@@ -558,6 +579,8 @@
   physicalDesc: reagent-physical-desc-acrid
   flavor: medicine
   color: "#c8ff75"
+  chemComplexity: 7
+  finalProduct: true
   plantMetabolism:
     - !type:PlantAdjustToxins
       amount: 6
@@ -599,6 +622,8 @@
   physicalDesc: reagent-physical-desc-pungent
   flavor: violets
   color: "#9423FF"
+  chemComplexity: 3 #requires a few mutations, niche chem and is useful
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -626,6 +651,7 @@
   physicalDesc: reagent-physical-desc-crisp
   flavor: medicine
   color: "#86caf7"
+  chemComplexity: 0 #this should NEVER be sold anyway
   metabolisms:
     Medicine:
       effects:
@@ -642,6 +668,7 @@
   physicalDesc: reagent-physical-desc-crisp
   flavor: medicine
   color: "#1274b5"
+  chemComplexity: 0 #should never be sold
   metabolisms:
     Medicine:
       effects:
@@ -659,6 +686,7 @@
   physicalDesc: reagent-physical-desc-pulpy
   flavor: medicine
   color: "#FFE774"
+  chemComplexity: 1
   metabolisms:
     Medicine:
       effects:
@@ -673,6 +701,8 @@
   physicalDesc: reagent-physical-desc-salty
   flavor: salty
   color: "#0064C8"
+  chemComplexity: 3
+  finalProduct: true
   metabolisms:
     Drink:
       effects:
@@ -689,6 +719,7 @@
   physicalDesc: reagent-physical-desc-milky
   flavor: medicine
   color: "#f4dab8"
+  chemComplexity: 2
   metabolisms:
     Medicine:
       effects:
@@ -705,6 +736,7 @@
   physicalDesc: reagent-physical-desc-starry
   flavor: medicine
   color: "#2b2f77"
+  chemComplexity: 1
   metabolisms:
     Medicine:
       effects:
@@ -728,6 +760,8 @@
   physicalDesc: reagent-physical-desc-pungent
   flavor: medicine
   color: "#d49a2f"
+  chemComplexity: 3
+  finalProduct: true #used to make pax, which isn't a poison but i don't think it should be counted as a desirable chem
   metabolisms:
     Poison:
       effects:
@@ -756,6 +790,7 @@
   physicalDesc: reagent-physical-desc-viscous
   flavor: medicine
   color: "#ba7d7d"
+  chemComplexity: 6
   metabolisms:
     Medicine:
       effects:
@@ -779,6 +814,8 @@
   physicalDesc: reagent-physical-desc-opaque
   flavor: medicine
   color: "#00e5ff"
+  chemComplexity: 5
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -803,6 +840,7 @@
   physicalDesc: reagent-physical-desc-oily
   flavor: medicine
   color: "#2690b5"
+  chemComplexity: 4
   metabolisms:
     Medicine:
       effects:
@@ -819,6 +857,7 @@
   physicalDesc: reagent-physical-desc-soothing
   flavor: medicine
   color: "#fcf7f9"
+  chemComplexity: 3 # rare ingredient, but mass produceable by a competent botany
   metabolisms:
     Medicine:
       effects:
@@ -838,6 +877,8 @@
   physicalDesc: reagent-physical-desc-thick-and-grainy
   flavor: medicine
   color: "#520e30"
+  chemComplexity: 3
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -881,6 +922,8 @@
   physicalDesc: reagent-physical-desc-translucent
   flavor: medicine
   color: "#404040"
+  chemComplexity: 5
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -894,6 +937,7 @@
   physicalDesc: reagent-physical-desc-enigmatic
   flavor: magical
   color: "#b50ee8"
+  chemComplexity: 10 # technically less, but requires either carps or koibeans so im increasing it
   metabolisms:
     Medicine:
       effects:
@@ -910,6 +954,8 @@
   physicalDesc: reagent-physical-desc-shiny
   flavor: medicine
   color: "#d5d5e4"
+  chemComplexity: 5
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -939,6 +985,8 @@
   physicalDesc: reagent-physical-desc-glowing
   flavor: medicine
   color: "#b0abaa"
+  chemComplexity: 19
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -964,6 +1012,8 @@
   physicalDesc: reagent-physical-desc-thick
   flavor: sweet
   color: "#e0a5b9"
+  chemComplexity: 11
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -1019,6 +1069,8 @@
   physicalDesc: reagent-physical-desc-viscous
   flavor: syrupy
   color: "#283332"
+  chemComplexity: 6
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -1042,6 +1094,8 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: fizzy
   color: "#b9bf93"
+  chemComplexity: 6
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -1066,6 +1120,8 @@
   physicalDesc: reagent-physical-desc-mucus-like
   flavor: sour
   color: "#ff3636"
+  chemComplexity: 6
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -1089,6 +1145,7 @@
   physicalDesc: reagent-physical-desc-holy
   flavor: holy
   color: "#91C3F7"
+  chemComplexity: 1
   metabolisms:
     Drink:
       effects:
@@ -1135,6 +1192,8 @@
   physicalDesc: reagent-physical-desc-thick
   flavor: syrupy
   color: "#aa4308"
+  chemComplexity: 9
+  finalProduct: true
   metabolisms:
     Medicine:
       metabolismRate: 0.1 # slow metabolism to not be a godly combat med, its for treating burn victims efficiently
@@ -1172,6 +1231,8 @@
   physicalDesc: reagent-physical-desc-frosty
   flavor: metallic
   color: "#8147ff"
+  chemComplexity: 7
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -1206,7 +1267,7 @@
         conditions:
         - !type:ReagentThreshold
           min: 12
-          
+
 - type: reagent
   id: Opporozidone #Name based of an altered version of the startreck chem "Opporozine"
   name: reagent-name-opporozidone
@@ -1215,6 +1276,8 @@
   physicalDesc: reagent-physical-desc-sickly
   flavor: acid
   color: "#b5e36d"
+  chemComplexity: 18
+  finalProduct: true
   worksOnTheDead: true
   metabolisms:
     Medicine:
@@ -1236,6 +1299,8 @@
   physicalDesc: reagent-physical-desc-necrotic
   flavor: medicine
   color: "#86a5bd"
+  chemComplexity: 8
+  finalProduct: true
   worksOnTheDead: true
   plantMetabolism:
   - !type:PlantAdjustToxins
@@ -1265,6 +1330,8 @@
   physicalDesc: reagent-physical-desc-soothing
   flavor: medicine
   color: "#89f77f"
+  chemComplexity: 16
+  finalProduct: true
   worksOnTheDead: true
   metabolisms:
     Medicine:
@@ -1287,6 +1354,7 @@
   physicalDesc: reagent-physical-desc-opaque
   flavor: sweet
   color: "#A0A0A0"
+  chemComplexity: 3
   metabolisms:
     Medicine:
       effects:
@@ -1307,6 +1375,8 @@
   physicalDesc: reagent-physical-desc-shiny
   flavor: bitter
   color: "#07E79E"
+  chemComplexity: 7
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:
@@ -1351,6 +1421,7 @@
   physicalDesc: reagent-physical-desc-grainy
   flavor: medicine
   color: "#baa15d"
+  chemComplexity: 2
   metabolisms:
     Medicine:
       effects:
@@ -1376,6 +1447,8 @@
   physicalDesc: reagent-physical-desc-crystalline
   flavor: medicine
   color: "#27870a"
+  chemComplexity: 8
+  finalProduct: true
   metabolisms:
     Medicine:
       effects:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1330,7 +1330,7 @@
   physicalDesc: reagent-physical-desc-soothing
   flavor: medicine
   color: "#89f77f"
-  chemComplexity: 16
+  chemComplexity: 16 # sigy is also finalProduct but thats fine i think
   finalProduct: true
   worksOnTheDead: true
   metabolisms:

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -439,7 +439,7 @@
   physicalDesc: reagent-physical-desc-soothing
   flavor: paintthinner
   color: "#EE35FF"
-  chemComplexity: # could be higher but easily made by botany
+  chemComplexity: 3
   metabolisms:
     Narcotic:
       effects:

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -8,6 +8,8 @@
   color: "#FAFAFA"
   boilingPoint: 212.0  # Dexosyephedrine vape when?
   meltingPoint: 170.0
+  chemComplexity: 11
+  finalProduct: true # might cause issues with botany being able to make it, but its a chem people will expect to be valuable
   metabolisms:
     Poison:
       effects:
@@ -65,6 +67,7 @@
   color: "#D2FFFA"
   boilingPoint: 255.0
   meltingPoint: 36.0
+  chemComplexity: 6
   metabolisms:
     Narcotic:
       effects:
@@ -118,6 +121,8 @@
   color: "#9A040E"
   boilingPoint: 212.0
   meltingPoint: 170.0
+  chemComplexity: 7
+  finalProduct: true
   metabolisms:
     Narcotic:
       metabolismRate: 1.0
@@ -190,6 +195,7 @@
   flavorMinimum: 0.05
   color: "#808080"
   physicalDesc: reagent-physical-desc-crystalline
+  chemComplexity: 1
   plantMetabolism:
   - !type:PlantAdjustNutrition
     amount: -5
@@ -226,6 +232,7 @@
   physicalDesc: reagent-physical-desc-acrid
   flavor: bitter
   color: "#215263"
+  chemComplexity: 3
   metabolisms:
     Narcotic:
       effects:
@@ -255,6 +262,8 @@
   physicalDesc: reagent-physical-desc-syrupy
   flavor: bitter
   color: "#63806e"
+  chemComplexity: 3
+  finalProduct: true
   metabolisms:
     Narcotic:
       effects:
@@ -273,6 +282,8 @@
   physicalDesc: reagent-physical-desc-powdery
   flavor: bitter
   color: "#ffff00"
+  chemComplexity: 8 # niche chem that nobody makes, should incentivise people to make it
+  finalProduct: true
   metabolisms:
     Narcotic:
       effects:
@@ -293,6 +304,8 @@
   color: "#128e80"
   boilingPoint: 444.0
   meltingPoint: 128.0
+  chemComplexity: 4
+  finalProduct: true
   metabolisms:
     Narcotic:
       effects:
@@ -315,6 +328,7 @@
   color: "#000000"
   boilingPoint: 255.0
   meltingPoint: 36.0
+  chemComplexity: 1 # can be made using chemistry, but nobody is going to do that
   metabolisms:
     Narcotic:
       effects:
@@ -335,6 +349,8 @@
   color: "#96a8b5"
   boilingPoint: 255.0
   meltingPoint: 36.0
+  chemComplexity: 8
+  finalProduct: true
   metabolisms:
     Narcotic:
       effects:
@@ -423,6 +439,7 @@
   physicalDesc: reagent-physical-desc-soothing
   flavor: paintthinner
   color: "#EE35FF"
+  chemComplexity: 1
   metabolisms:
     Narcotic:
       effects:

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -439,7 +439,7 @@
   physicalDesc: reagent-physical-desc-soothing
   flavor: paintthinner
   color: "#EE35FF"
-  chemComplexity: 1
+  chemComplexity: # could be higher but easily made by botany
   metabolisms:
     Narcotic:
       effects:

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -23,6 +23,8 @@
   color: "#757245"
   boilingPoint: 2977.0 # Aluminum oxide
   meltingPoint: 2030.0
+  chemComplexity: 3
+  finalProduct: true
   tileReactions:
   - !type:FlammableTileReaction
     temperatureMultiplier: 2
@@ -43,6 +45,7 @@
   physicalDesc: reagent-physical-desc-soapy
   flavor: bitter
   color: "#FA00AF"
+  chemComplexity: 5
   tileReactions:
   - !type:FlammableTileReaction
     temperatureMultiplier: 5
@@ -72,6 +75,9 @@
   physicalDesc: reagent-physical-desc-burning
   flavor: bitter
   color: "#D4872A"
+  chemComplexity: 5
+  consumesCatalyst: true
+  finalProduct: true
   metabolisms:
     Poison:
       effects:
@@ -140,6 +146,7 @@
   physicalDesc: reagent-physical-desc-foamy
   flavor: bitter
   color: "#215263"
+  chemComplexity: 2
   boilingPoint: 418.0 # I went with ammonium lauryl sulfate as the basis for this
   meltingPoint: 7.4 # I made this up
 
@@ -149,6 +156,7 @@
   parent: BasePyrotechnic
   desc: reagent-desc-welding-fuel
   physicalDesc: reagent-physical-desc-oily
+  chemComplexity: 1
   slipData:
     requiredSlipSpeed: 3.5
   flavor: bitter
@@ -178,5 +186,7 @@
   physicalDesc: reagent-physical-desc-opaque
   flavor: bitter
   color: "#9e6b38"
+  chemComplexity: 5
+  finalProduct: true
   boilingPoint: 190.0 # Perfluorooctanoic Acid.
   meltingPoint: 45.0

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -156,7 +156,7 @@
   parent: BasePyrotechnic
   desc: reagent-desc-welding-fuel
   physicalDesc: reagent-physical-desc-oily
-  chemComplexity: 1
+  chemComplexity: 1 # might be too high with how much you get from a chem tank
   slipData:
     requiredSlipSpeed: 3.5
   flavor: bitter

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -6,6 +6,7 @@
   flavor: bitter
   color: "#cf3600"
   physicalDesc: reagent-physical-desc-opaque
+  chemComplexity: 1
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: 10
@@ -27,6 +28,7 @@
   flavor: bitter
   color: "#e2a38c"
   physicalDesc: reagent-physical-desc-exotic-smelling
+  chemComplexity: 2
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: 10
@@ -53,6 +55,7 @@
   flavor: bitter
   color: "#000067"
   physicalDesc: reagent-physical-desc-nondescript
+  chemComplexity: 3
   metabolisms:
     Poison:
       effects:
@@ -86,6 +89,7 @@
   flavor: bitter
   color: "#acc91a"
   physicalDesc: reagent-physical-desc-putrid
+  chemComplexity: 1
   metabolisms:
     Poison:
       effects:
@@ -108,6 +112,7 @@
   color: "#8a9a5b"
   recognizable: true
   physicalDesc: reagent-physical-desc-fuzzy
+  chemComplexity: 2
   metabolisms:
     Poison:
       effects:
@@ -126,6 +131,9 @@
   color: "#a1000b"
   boilingPoint: 78.2 # This isn't a real chemical...
   meltingPoint: -19.4
+  chemComplexity: 5
+  consumesCatalyst: true
+  finalProduct: true
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: 20
@@ -194,6 +202,7 @@
   color: "#5050ff"
   boilingPoint: 165
   meltingPoint: -87
+  chemComplexity: 6
   reactiveEffects:
     Acidic:
       methods: [ Touch ]
@@ -235,6 +244,7 @@
   recognizable: true
   boilingPoint: 337.0
   meltingPoint: 10.31
+  chemComplexity: 3
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: 10
@@ -282,6 +292,7 @@
   color: "#00ff5f"
   boilingPoint: 340282300000000000000000000000000000000 # Ethidium bromide, which doesn't boil.
   meltingPoint: 261.0
+  chemComplexity: 3
   plantMetabolism:
   - !type:PlantAdjustMutationLevel
     amount: 1
@@ -300,6 +311,7 @@
   desc: reagent-desc-heartbreaker-toxin
   physicalDesc: reagent-physical-desc-strong-smelling
   color: "#5f959c"
+  chemComplexity: 10
   metabolisms:
     Poison:
       effects:
@@ -318,6 +330,9 @@
   desc: reagent-desc-lexorin
   physicalDesc: reagent-physical-desc-pungent
   color: "#6b0007"
+  chemComplexity: 12
+  consumesCatalyst: true
+  finalProduct: true
   metabolisms:
     Poison:
       effects:
@@ -334,6 +349,7 @@
   physicalDesc: reagent-physical-desc-opaque
   flavor: bitter
   color: "#77b58e"
+  chemComplexity: 5
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: 10
@@ -355,6 +371,7 @@
   desc: reagent-desc-histamine
   physicalDesc: reagent-physical-desc-abrasive
   color: "#FA6464"
+  chemComplexity: 1
   metabolisms:
     Poison:
       effects:
@@ -419,6 +436,7 @@
   desc: reagent-desc-amatoxin
   physicalDesc: reagent-physical-desc-nondescript
   color: "#D6CE7B"
+  chemComplexity: 1
   metabolisms:
     Poison:
       metabolismRate: 0.2
@@ -469,6 +487,7 @@
   physicalDesc: reagent-physical-desc-clumpy
   flavor: bitter
   color: "#FFFFE5"
+  chemComplexity: 1
   metabolisms:
     Food:
       effects:
@@ -511,6 +530,7 @@
   physicalDesc: reagent-physical-desc-pungent
   flavor: bitter
   color: "#F2E9D2"
+  chemComplexity: 1
   metabolisms:
     Poison:
       metabolismRate: 0.05
@@ -532,6 +552,7 @@
   desc: reagent-desc-pax
   physicalDesc: reagent-physical-desc-soothing
   color: "#AAAAAA"
+  chemComplexity: 5 # more complex but easily made by botany
   metabolisms:
     Poison:
       effects:
@@ -549,6 +570,7 @@
   physicalDesc: reagent-physical-desc-pungent
   flavor: bitter
   color: "#F2E9D2"
+  chemComplexity: 1
   metabolisms:
     Poison:
       metabolismRate: 0.05
@@ -576,6 +598,7 @@
   desc: reagent-desc-lead
   physicalDesc: reagent-physical-desc-metallic
   color: "#5C6274"
+  chemComplexity: 1
   metabolisms:
     Poison:
       metabolismRate: 0.03 # Effectively once every 30 seconds.
@@ -592,6 +615,7 @@
   desc: reagent-desc-bungotoxin
   physicalDesc: reagent-physical-desc-nondescript
   color: "#EBFF8E"
+  chemComplexity: 1
   metabolisms:
     Poison:
       metabolismRate: 0.2
@@ -609,6 +633,7 @@
   physicalDesc: reagent-physical-desc-shiny
   flavor: medicine
   color: "#435166"
+  chemComplexity: 1
   metabolisms:
     Poison:
       effects:
@@ -632,6 +657,7 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: shocking
   color: "#FDD023"
+  chemComplexity: 3
   metabolisms:
     Poison:
       effects:
@@ -646,6 +672,8 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: mothballs #why does weightloss juice taste like mothballs
   color: "#F0FFF0"
+  chemComplexity: 10
+  finalProduct: true
   metabolisms:
     Poison:
       effects:


### PR DESCRIPTION
## About the PR
Added a calculation for chem spesos values, and spesos values to chems

## Why / Balance
Currently medbay has no way to make money on their own except for fulfilling first aid kit bounties, this should solve that issue

## Technical details
Adds ChemComplexity (based on base chems used for each chem in a chain)
Adds FinalProduct (if the chem is the last desirable chem in a recipe chain)
Adds ConsumesCatalyst (if it consumes a chem that is normally a catalyst)
Adds a calculation for chem prices 
[public float PricePerUnit => (ConsumesCatalyst ? 0.1f : 0.0f) + (FinalProduct ? 1.0f : 0.0f) + ChemComplexity * 0.1f;]
adds tags to most chems for chemcomplexity and finalproduct/consumescatalyst

## Media
https://imgur.com/a/AW02XrN

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
Removed original pricePerUnit from reagentprototype.cs

**Changelog**
:cl:
- add: Added sell prices to most chems in the game

