### PR TITLE
Fix vending machine manager wire error

### DIFF
--- a/Content.Client/VendingMachines/UI/VendingMachineMenu.xaml.cs
+++ b/Content.Client/VendingMachines/UI/VendingMachineMenu.xaml.cs
@@ -10,6 +10,7 @@ using Robust.Client.UserInterface;
 using Content.Client.UserInterface.Controls;
 using Content.Shared.IdentityManagement;
 using Robust.Client.Graphics;
+using Robust.Shared.Utility;
 
 namespace Content.Client.VendingMachines.UI
 {
@@ -162,7 +163,9 @@ namespace Content.Client.VendingMachines.UI
                     continue;
 
                 var dummy = _dummies[proto];
-                var amount = cachedInventory.First(o => o.ID == proto).Amount;
+                if (!cachedInventory.TryFirstOrDefault(o => o.ID == proto, out var entry))
+                    continue;
+                var amount = entry.Amount;
                 // Could be better? Problem is all inventory entries get squashed.
                 var text = GetItemText(dummy, amount);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed a bug where mending the manager wire on a vending machine while the vending UI was open could cause an error and force the game world to reload.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/36925.

## Technical details
<!-- Summary of code changes for easier review. -->
The vending machine UI keeps a dictionary of clientside entities used to represent the items in the list - this is used to get the correct names for the items.

Cutting the manager wire grants access to the contraband items in the vending machine. If the UI is opened after cutting the wire, the the contraband items are displayed in the list. This causes them to get dummy entities too.

Mending the wire removes the contraband items from the vending machine's inventory. The dummies are not removed. The code for updating the current amounts of each item iterates over the dummies and tries to update the amount for each one's displayed entry - but it can't find the amount for the contraband items, since they are no longer accessible. This causes the `First` method to fail and throw an exception.

To fix it, we switch from blindly using `First` to using `TryFirstOrDefault` and skipping the current entry if it fails.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

On a related note, it would be better if cutting/mending the manager wire affected the UI if it's currently open. I'm not great with UI stuff, so I'll leave that for someone to do in another PR and just fix the bug here.