### PR TITLE
Fixed holy water metabolism rate

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1094,19 +1094,18 @@
       effects:
       - !type:SatiateThirst
         factor: 3
-    Medicine:
-      effects:
       - !type:HealthChange
-        conditions:
-        - !type:TotalDamage
-          max: 50
-        damage:
-          types:
+         conditions:
+         - !type:TotalDamage
+           max: 50
+         damage:
+           types:
             Blunt: -0.2
             Poison: -0.2
             Heat: -0.2
             Shock: -0.2
             Cold: -0.2
+
   reactiveEffects:
     Extinguish:
       methods: [ Touch ]
@@ -1206,7 +1205,7 @@
         conditions:
         - !type:ReagentThreshold
           min: 12
-          
+
 - type: reagent
   id: Opporozidone #Name based of an altered version of the startreck chem "Opporozine"
   name: reagent-name-opporozidone

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1095,11 +1095,11 @@
       - !type:SatiateThirst
         factor: 3
       - !type:HealthChange
-         conditions:
-         - !type:TotalDamage
-           max: 50
-         damage:
-           types:
+        conditions:
+        - !type:TotalDamage
+          max: 50
+        damage:
+          types:
             Blunt: -0.2
             Poison: -0.2
             Heat: -0.2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed Holy water metabolizing at 1u a second rather than .5u a second. This is to bring it in the same way that TDD was changed in PR #32297 

## Why / Balance
Similar to the above PR, having it metabolize twice led to the unintentional effect of if being used up twice as fast as it should.

## Technical details
Moved the healing properties into one singular category to avoid "double dipping" when metabolizing.

## Media
![image](https://github.com/user-attachments/assets/bc97c46d-7f5d-493c-80bf-2ecefba4738b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Holy water now correctly metabolizes at .5 unites per second

