### PR TITLE
Fix for vox dropping all bodyparts when gibbed

### DIFF
--- a/Resources/Prototypes/Body/Parts/vox.yml
+++ b/Resources/Prototypes/Body/Parts/vox.yml
@@ -1,197 +1,111 @@
 ﻿# TODO: Add descriptions (many)
 # TODO BODY: Part damage
 - type: entity
-  id: PartVox
-  parent: BaseItem
-  name: "vox body part"
   abstract: true
+  parent: [ BaseItem, BasePart ]
+  id: PartVox
+  name: "vox body part"
   components:
-  - type: Damageable
-    damageContainer: Biological
-  - type: BodyPart
-  - type: ContainerContainer
-    containers:
-      bodypart: !type:Container
-        ents: []
-  - type: StaticPrice
-    price: 100
-  - type: Tag
-    tags:
-      - Trash
+  - type: Sprite
+    sprite: Mobs/Species/Vox/parts.rsi
   - type: Extractable
     juiceSolution:
       reagents:
       - ReagentId: Fat
         Quantity: 3
-      - ReagentId: Blood
+      - ReagentId: AmmoniaBlood
         Quantity: 10
 
 - type: entity
+  parent: [PartVox, BaseTorso]
   id: TorsoVox
   name: "vox torso"
-  parent: PartVox
   components:
-    - type: Sprite
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "torso"
-    - type: Icon
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "torso"
-    - type: BodyPart
-      partType: Torso
-    - type: Extractable
-      juiceSolution:
-        reagents:
-        - ReagentId: Fat
-          Quantity: 3
-        - ReagentId: Blood
-          Quantity: 10
+  - type: Sprite
+    state: "torso"
+  - type: Extractable
+    juiceSolution:
+      reagents:
+      - ReagentId: Fat
+        Quantity: 10
+      - ReagentId: AmmoniaBlood
+        Quantity: 20
 
 - type: entity
+  parent: [ PartVox, BaseHead ]
   id: HeadVox
   name: "vox head"
-  parent: PartVox
   components:
-    - type: Sprite
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "head"
-    - type: Icon
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "head"
-    - type: BodyPart
-      partType: Head
-      vital: true
-    - type: Input
-      context: "ghost"
-    - type: Tag
-      tags:
-        - Head
-    - type: Extractable
-      juiceSolution:
-        reagents:
-        - ReagentId: Fat
-          Quantity: 5
-        - ReagentId: Blood
-          Quantity: 10
+  - type: Sprite
+    state: "head"
+  - type: Extractable
+    juiceSolution:
+      reagents:
+      - ReagentId: Fat
+        Quantity: 5
+      - ReagentId: AmmoniaBlood
+        Quantity: 10
 
 - type: entity
+  parent: [ PartVox, BaseLeftArm ]
   id: LeftArmVox
   name: "left vox arm"
-  parent: PartVox
   components:
-    - type: Sprite
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "l_arm"
-    - type: Icon
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "l_arm"
-    - type: BodyPart
-      partType: Arm
-      symmetry: Left
+  - type: Sprite
+    state: "l_arm"
 
 - type: entity
+  parent: [ PartVox, BaseRightArm ]
   id: RightArmVox
   name: "right vox arm"
-  parent: PartVox
   components:
-    - type: Sprite
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "r_arm"
-    - type: Icon
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "r_arm"
-    - type: BodyPart
-      partType: Arm
-      symmetry: Right
+  - type: Sprite
+    state: "r_arm"
 
 - type: entity
+  parent: [ PartVox, BaseLeftHand ]
   id: LeftHandVox
   name: "left vox hand"
-  parent: PartVox
   components:
-    - type: Sprite
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "l_hand"
-    - type: Icon
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "l_hand"
-    - type: BodyPart
-      partType: Hand
-      symmetry: Left
+  - type: Sprite
+    state: "l_hand"
 
 - type: entity
+  parent: [ PartVox, BaseRightHand ]
   id: RightHandVox
   name: "right vox hand"
-  parent: PartVox
   components:
-    - type: Sprite
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "r_hand"
-    - type: Icon
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "r_hand"
-    - type: BodyPart
-      partType: Hand
-      symmetry: Right
+  - type: Sprite
+    state: "r_hand"
 
 - type: entity
+  parent:  [ PartVox, BaseLeftLeg ]
   id: LeftLegVox
   name: "left vox leg"
-  parent: PartVox
   components:
-    - type: Sprite
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "l_leg"
-    - type: Icon
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "l_leg"
-    - type: BodyPart
-      partType: Leg
-      symmetry: Left
-    - type: MovementBodyPart
+  - type: Sprite
+    state: "l_leg"
 
 - type: entity
+  parent:  [ PartVox, BaseRightLeg ]
   id: RightLegVox
   name: "right vox leg"
-  parent: PartVox
   components:
-    - type: Sprite
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "r_leg"
-    - type: Icon
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "r_leg"
-    - type: BodyPart
-      partType: Leg
-      symmetry: Right
-    - type: MovementBodyPart
+  - type: Sprite
+    state: "r_leg"
 
 - type: entity
+  parent: [ PartVox, BaseLeftFoot ]
   id: LeftFootVox
   name: "left vox foot"
-  parent: PartVox
   components:
-    - type: Sprite
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "l_foot"
-    - type: Icon
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "l_foot"
-    - type: BodyPart
-      partType: Foot
-      symmetry: Left
+  - type: Sprite
+    state: "l_foot"
 
 - type: entity
+  parent: [ PartVox, BaseRightFoot ]
   id: RightFootVox
   name: "right vox foot"
-  parent: PartVox
   components:
-    - type: Sprite
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "r_foot"
-    - type: Icon
-      sprite: Mobs/Species/Vox/parts.rsi
-      state: "r_foot"
-    - type: BodyPart
-      partType: Foot
-      symmetry: Right
+  - type: Sprite
+    state: "r_foot"


### PR DESCRIPTION
## About the PR
Vox no longer drop head, torso, limbs etc parts when gibbed

## Why / Balance
Current behavior was inconsistent with all other species.
Fixes #32132

## Technical details
Bodypart prototypes were cleaned up to the format/standards of the other species

## Media
![image](https://github.com/user-attachments/assets/6cbade27-3795-431d-b2f1-02375be621d7)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: Errant
- fix: Vox now only drop their organs when gibbed, not all of their bodyparts.

