### PR TITLE
Ghost friction fix

### DIFF
--- a/Content.Shared/Movement/Components/FrictionContactsComponent.cs
+++ b/Content.Shared/Movement/Components/FrictionContactsComponent.cs
@@ -9,23 +9,26 @@ namespace Content.Shared.Movement.Components;
 public sealed partial class FrictionContactsComponent : Component
 {
     /// <summary>
+    /// Should this affect airborne mobs?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool AffectAirborne;
+
+    /// <summary>
     /// Modified mob friction while on FrictionContactsComponent
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    [AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public float MobFriction = 0.05f;
 
     /// <summary>
     /// Modified mob friction without input while on FrictionContactsComponent
     /// </summary>
-    [AutoNetworkedField]
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoNetworkedField]
     public float? MobFrictionNoInput = 0.05f;
 
     /// <summary>
     /// Modified mob acceleration while on FrictionContactsComponent
     /// </summary>
-    [AutoNetworkedField]
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoNetworkedField]
     public float MobAcceleration = 0.1f;
 }

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -266,7 +266,8 @@ public abstract partial class SharedMoverController : VirtualController
         else
         {
             if (MapGridQuery.TryComp(xform.GridUid, out var gridComp)
-                && _mapSystem.TryGetTileRef(xform.GridUid.Value, gridComp, xform.Coordinates, out var tile))
+                && _mapSystem.TryGetTileRef(xform.GridUid.Value, gridComp, xform.Coordinates, out var tile)
+                && physicsComponent.BodyStatus == BodyStatus.OnGround)
                 tileDef = (ContentTileDefinition) _tileDefinitionManager[tile.Tile.TypeId];
 
             var walkSpeed = moveSpeedComponent?.CurrentWalkSpeed ?? MovementSpeedModifierComponent.DefaultBaseWalkSpeed;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ghosts and Air Movers no longer slide on ice.
Dragons and carp no longer slide on ice.

## Why / Balance
Half unintended behavior.

## Technical details
TileDef is now only taken if a mob is touching the ground preventing mobs in the air from being affected by tile friction.
Also added a bool to FrictionContacts to ignore in air entities so ice crust has parity with planet ice.

For help with review:
![image](https://github.com/user-attachments/assets/f52ad630-7d97-4c6c-abc4-fa9be2464a1d)
TileDef wasn't initially loaded for weightless and InAir mobs in the previous sharedMoverController

In the refactor weightless is properly checked before the game attempts to load the TileDef but I forgot to also check for physics body status (I assumed if they were in air they'd get caught by the weightless system, but some don't get caught because they ignore weightless movement and use tile movement while in the air)

Body Status currently only has two states: On Ground and InAir so there's no difference in the check there unless someone adds more physics body states in an engine PR.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
