### PR TITLE
Tranexamic Metabolism Buff

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -758,11 +758,12 @@
   color: "#ba7d7d"
   metabolisms:
     Medicine:
+      metabolismRate: 0.2 # makes it viable for pre-combat rather than a burst post-combat
       effects:
       # Medium-large quantities can hurt you instead,
-      # but still technically stop your bleeding.
+      # but still stop your bleeding.
       - !type:ModifyBleedAmount
-        amount: -1.5
+        amount: -0.6
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -1206,7 +1207,7 @@
         conditions:
         - !type:ReagentThreshold
           min: 12
-          
+
 - type: reagent
   id: Opporozidone #Name based of an altered version of the startreck chem "Opporozine"
   name: reagent-name-opporozidone

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -770,7 +770,7 @@
           min: 15
         damage:
           types:
-            Bloodloss: 3
+            Bloodloss: 1.5
 
 - type: reagent
   id: Tricordrazine


### PR DESCRIPTION
## About the PR
Makes Tranexamic-Acid last 2.5x longer and lowers its bleed-reduction and overdose to compensate

## Why / Balance
Currently tranexamic acid is rarely used, aside from the small amount in an emergency-medipen the use of the chem is almost non existent (aside making sutures).

This change should allow you to use a syringe of tranex before a gunfight and leave it without being pale, or dying due to making poor decisions by rushing to gain any value while its metabolising (due to it only lasting 30s)
With the nature of most gunfights or red alert situations you typically don't have the time to inject yourself with a syringe and it then typically only sees use post-fight in places where a single gauze would be doing its job better.

## Technical details
yaml changes
adds metabolism rate of 0.2 (from 0.5) making it last 2.5x longer
lowers bleed-rate to 0.6 (from 1.5) making it 2.5x slower (in testing this is still enough to prevent going pale after being shot from 0-100 pierce)
lowers overdose bloodloss damage to 1.5 (from 3.0) to compensate for lasting longer in metabolism

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Tranexamic Acid now metabolizes and clots blood slower, with a less harsh overdose.
