### PR TITLE
Add EvenHealthChange effect

### DIFF
--- a/Content.Server/EntityEffects/Effects/EvenHealthChange.cs
+++ b/Content.Server/EntityEffects/Effects/EvenHealthChange.cs
@@ -1,0 +1,136 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.EntityEffects;
+using Content.Shared.FixedPoint;
+using Content.Shared.Localizations;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server.EntityEffects.Effects;
+
+/// <summary>
+/// Version of <see cref="HealthChange"/> that distributes the healing to groups
+/// </summary>
+[UsedImplicitly]
+public sealed partial class EvenHealthChange : EntityEffect
+{
+    /// <summary>
+    /// damage to heal, collected into entire damage groups
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<DamageGroupPrototype>, FixedPoint2> Damage;
+
+    /// <summary>
+    ///     Should this effect scale the damage by the amount of chemical in the solution?
+    ///     Useful for touch reactions, like styptic powder or acid.
+    ///     Only usable if the EntityEffectBaseArgs is an EntityEffectReagentArgs.
+    /// </summary>
+    [DataField]
+    public bool ScaleByQuantity;
+
+    [DataField]
+    public bool IgnoreResistances = true;
+
+    protected override string ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+    {
+        var damages = new List<string>();
+        var heals = false;
+        var deals = false;
+
+        var universalReagentDamageModifier = entSys.GetEntitySystem<DamageableSystem>().UniversalReagentDamageModifier;
+        var universalReagentHealModifier = entSys.GetEntitySystem<DamageableSystem>().UniversalReagentHealModifier;
+
+        foreach (var (group, amount) in Damage)
+        {
+            var groupProto = prototype.Index(group);
+
+            var sign = FixedPoint2.Sign(amount);
+            var mod = 1f;
+
+            if (sign < 0)
+            {
+                heals = true;
+                mod = universalReagentHealModifier;
+            }
+            else if (sign > 0)
+            {
+                deals = true;
+                mod = universalReagentDamageModifier;
+            }
+
+            damages.Add(
+                Loc.GetString("health-change-display",
+                    ("kind", groupProto.LocalizedName),
+                    ("amount", MathF.Abs(amount.Float() * mod)),
+                    ("deltasign", sign)
+                ));
+        }
+
+        var healsordeals = heals ? deals ? "both" : "heals" : deals ? "deals" : "none";
+        return Loc.GetString("reagent-effect-guidebook-even-health-change",
+            ("chance", Probability),
+            ("changes", ContentLocalizationManager.FormatList(damages)),
+            ("healsordeals", healsordeals));
+    }
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        if (!args.EntityManager.TryGetComponent<DamageableComponent>(args.TargetEntity, out var damageable))
+            return;
+        var protoMan = IoCManager.Resolve<IPrototypeManager>();
+
+        var scale = FixedPoint2.New(1);
+
+        if (args is EntityEffectReagentArgs reagentArgs)
+        {
+            scale = ScaleByQuantity ? reagentArgs.Quantity * reagentArgs.Scale : reagentArgs.Scale;
+        }
+
+        var universalReagentDamageModifier = args.EntityManager.System<DamageableSystem>().UniversalReagentDamageModifier;
+        var universalReagentHealModifier = args.EntityManager.System<DamageableSystem>().UniversalReagentHealModifier;
+
+        var dspec = new DamageSpecifier();
+
+        foreach (var (group, amount) in Damage)
+        {
+            var groupProto = protoMan.Index(group);
+            var groupDamage = new Dictionary<string, FixedPoint2>();
+            foreach (var damageId in groupProto.DamageTypes)
+            {
+                var damageAmount = damageable.Damage.DamageDict.GetValueOrDefault(damageId);
+                if (damageAmount != FixedPoint2.Zero)
+                    groupDamage.Add(damageId, damageAmount);
+            }
+
+            var sum = groupDamage.Values.Sum();
+            foreach (var (damageId, damageAmount) in groupDamage)
+            {
+                var existing = dspec.DamageDict.GetOrNew(damageId);
+                dspec.DamageDict[damageId] = existing + damageAmount / sum * amount;
+            }
+        }
+
+        if (universalReagentDamageModifier != 1 || universalReagentHealModifier != 1)
+        {
+            foreach (var (type, val) in dspec.DamageDict)
+            {
+                if (val < 0f)
+                {
+                    dspec.DamageDict[type] = val * universalReagentHealModifier;
+                }
+                if (val > 0f)
+                {
+                    dspec.DamageDict[type] = val * universalReagentDamageModifier;
+                }
+            }
+        }
+
+        args.EntityManager.System<DamageableSystem>()
+            .TryChangeDamage(
+                args.TargetEntity,
+                dspec * scale,
+                IgnoreResistances,
+                interruptsDoAfters: false);
+    }
+}

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -87,6 +87,21 @@ reagent-effect-guidebook-health-change =
                  }
     } { $changes }
 
+reagent-effect-guidebook-even-health-change =
+    { $chance ->
+        [1] { $healsordeals ->
+            [heals] Evenly heals
+            [deals] Evenly deals
+            *[both] Evenly modifies health by
+        }
+        *[other] { $healsordeals ->
+            [heals] evenly heal
+            [deals] evenly deal
+            *[both] evenly modify health by
+        }
+    } { $changes }
+
+
 reagent-effect-guidebook-status-effect =
     { $type ->
         [add]   { $chance ->

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -822,13 +822,12 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:HealthChange
+      - !type:EvenHealthChange
         damage:
-          groups:
-            Burn: -2
-            Toxin: -2
-            Airloss: -2
-            Brute: -2
+          Burn: -2
+          Toxin: -2
+          Airloss: -2
+          Brute: -2
 
 - type: reagent
   id: Ultravasculine
@@ -1206,7 +1205,7 @@
         conditions:
         - !type:ReagentThreshold
           min: 12
-          
+
 - type: reagent
   id: Opporozidone #Name based of an altered version of the startreck chem "Opporozine"
   name: reagent-name-opporozidone


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a new HealthChange effect that attempts to distribute damage more fairly when healing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

For the current system, if you have an effect that heals 3 brute, what you actually have is an effect that heals 1 blunt, 1 slash, and 1 piercing. This is not really what we want in a lot of cases, as it means that the effect is 1/3 as strong on single damage-type sources.

Ideally, we split it relative to the damages present. So if we have only 3 blunt damage, we heal all 3 blunt instead of only 1.

That is what this PR does.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Omnizine no longer "wastes" healing when administered to patients without even amounts of all damage types.
