### PR TITLE
fix clone appearance

### DIFF
--- a/Content.Server/IdentityManagement/IdentitySystem.cs
+++ b/Content.Server/IdentityManagement/IdentitySystem.cs
@@ -72,7 +72,7 @@ public sealed class IdentitySystem : SharedIdentitySystem
     /// <summary>
     ///     Queues an identity update to the start of the next tick.
     /// </summary>
-    public void QueueIdentityUpdate(EntityUid uid)
+    public override void QueueIdentityUpdate(EntityUid uid)
     {
         _queuedIdentityUpdates.Add(uid);
     }

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -39,6 +39,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
     [Dependency] private readonly ISerializationManager _serManager = default!;
     [Dependency] private readonly MarkingManager _markingManager = default!;
     [Dependency] private readonly GrammarSystem _grammarSystem = default!;
+    [Dependency] private readonly SharedIdentitySystem _identity = default!;
 
     [ValidatePrototypeId<SpeciesPrototype>]
     public const string DefaultSpecies = "Human";
@@ -161,6 +162,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
         if (TryComp<GrammarComponent>(target, out var grammar))
             _grammarSystem.SetGender((target, grammar), sourceHumanoid.Gender);
 
+        _identity.QueueIdentityUpdate(target);
         Dirty(target, targetHumanoid);
     }
 

--- a/Content.Shared/IdentityManagement/SharedIdentitySystem.cs
+++ b/Content.Shared/IdentityManagement/SharedIdentitySystem.cs
@@ -39,6 +39,11 @@ public abstract class SharedIdentitySystem : EntitySystem
     {
         ent.Comp.Enabled = !args.Mask.Comp.IsToggled;
     }
+
+    /// <summary>
+    /// Queues an identity update to the start of the next tick.
+    /// </summary>
+    public virtual void QueueIdentityUpdate(EntityUid uid) { }
 }
 /// <summary>
 ///     Gets called whenever an entity changes their identity.


### PR DESCRIPTION
## About the PR
Fixes a small bug in the `CloneAppearance` method.
Needed for https://github.com/space-wizards/space-station-14/pull/34002

## Why / Balance
bugfix

## Technical details
The `CloneAppearance` method was missing an identity update, which caused the target's identity to not receive any changes to the grammar component, for example the gender.
Added a virtual method for `QueueIdentityUpdate` with an override on the server so it can be called from shared.
This bug was currently not noticed because the only code using `CloneAppearance` is cloning code, which already forces the identity update when the clone's entity name is changed afterwards by raising an event.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
no gameplay impact
