### PR TITLE
Nerf science magboots

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -67,13 +67,21 @@
     stealGroup: ClothingShoesBootsMagAdv
 
 - type: entity
-  parent: [ClothingShoesBootsMagBase]
+  parent: [ClothingShoesBootsMagBase, PowerCellSlotMediumItem]
   id: ClothingShoesBootsMagSci
+  name: experimental magboots
+  description: Not every experiment is a success...
   components:
   - type: Sprite
     sprite: Clothing/Shoes/Boots/magboots-science.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-science.rsi
+  - type: PowerCellDraw
+    drawRate: 6
+  - type: ClothingSpeedModifier
+    walkModifier: 0.75
+    sprintModifier: 0.7
+  - type: ToggleCellDraw
 
 - type: entity
   parent: ClothingShoesBootsMagBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Science magboots are a research item that makes what is supposed to be a limited piece of job equipment into a common station item. The fact that basically everyone can get a set of magboots that are on-par with engineer's and salvager's equipment is a really nasty piece of power creep.

This PR adds a battery charge system to the science magboots to make them less overpowered and not just an infinitely printable version of normal magboots.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
If the whole appeal of science magboots is being mass-printable, they shouldn't simultaneously be equal to rare roundstart magboots without any further investment.

## Technical details
<!-- Summary of code changes for easier review. -->
n/a
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Magboots printed in science now require power-cells to function.
