### PR TITLE
fix atmos grid markers

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
@@ -69,8 +69,8 @@ public sealed partial class AtmosphereSystem
        mixtures[7].AdjustMoles(Gas.Nitrogen, Atmospherics.MolesCellStandard);
 
        // 8: Air (GM)
-       mixtures[8].AdjustMoles(Gas.Oxygen, Atmospherics.MolesCellGasMiner);
-       mixtures[8].AdjustMoles(Gas.Nitrogen, Atmospherics.MolesCellGasMiner);
+       mixtures[8].AdjustMoles(Gas.Oxygen, Atmospherics.OxygenMolesGasMiner);
+       mixtures[8].AdjustMoles(Gas.Nitrogen, Atmospherics.NitrogenMolesGasMiner);
 
        foreach (var arg in args)
        {

--- a/Resources/Changelog/Maps.yml
+++ b/Resources/Changelog/Maps.yml
@@ -67,18 +67,11 @@
   id: 9
   time: '2025-04-30T14:49:36.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/36653
-- author: K-Dynamic
-  changes:
-  - message: Atmos air (6500 kPa) markers are available for mapping.
-    type: Add
-  id: 10
-  time: '2025-05-01T22:03:47.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37061
 - author: Southbridge
   changes:
   - message: 'New salvage ruin: Atmos Interchange'
     type: Add
-  id: 11
+  id: 10
   time: '2025-05-02T15:45:46.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37115
 Order: 1


### PR DESCRIPTION
## About the PR
Fixes the atmos grid markers to properly fill air holding tiles to their correct pressure.

## Why / Balance
Incorrect constants were used when they were made so it basically doubled the pressure of the tile.

## Technical details
Uses the correct constants

## Media
![image](https://github.com/user-attachments/assets/b4b5a954-f105-4d6e-a66c-216c0010f2f4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->