### PR TITLE
randomize names for mindshielded eventhumanoids

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -11,7 +11,6 @@
 - type: randomHumanoidSettings
   id: EventHumanoidMindShielded
   parent: EventHumanoid
-  randomizeName: false
   components:
     - type: MindShield
     - type: AntagImmune
@@ -19,6 +18,7 @@
 - type: randomHumanoidSettings
   id: EventHumanoidCentcomm
   parent: EventHumanoidMindShielded
+  randomizeName: false
   components:
   - type: AutoImplant
     implants:


### PR DESCRIPTION
## About the PR
Visitor Command, Visitor Security, DeathSquad, CBURN and ERT ghostroles once again get randomized names

CentComm Officials do not have their own nameset and have name generation still forced off so as to not get "inappropriately mundane" names. The spawning admin can just rename them as appropritate.

(Note that there is an unrelated event ordering issue, that causes any ghostroles that spawn with their face hidden, to not appear to others with their new name until their identity updates again such as if they toggle their helmet or drop and pick up their PDA. 
This is because Identitysystem gives them their name when they spawn, but their ID card is only renamed when their ghostrole is taken. That needs to also trigger an identity update )

## Why / Balance
Unintended change introduced by #28958

## Technical details
The above PR reorganized the eventhumanoid prototypes, but after the change the random names were turned off on the wrong prototype, so it turned off not just Centcomm Officials (who afaik never had individual names, so this is correct on them), but all of the above roles too

## Media
Before
![image](https://github.com/user-attachments/assets/452acee8-ff7a-4f5e-8ba6-93d666dfb933)

After
![image](https://github.com/user-attachments/assets/4f917fd2-ec9c-40c1-b5c1-6321ee878dfd)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Random name generation was turned on for all RandomHumanoidProfiles derived from `EventHumanoidMindShielded`, with the exception of `EventHumanoidCentcomm`

**Changelog**
:cl: Errant
- fix: Visiting Command and Security ghostroles, as well as some other rare centcomm ghostroles, now have their names properly randomized.