### PR TITLE
Fix brains, borgs etc not counting as marooned

### DIFF
--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -46,9 +46,6 @@ public sealed class KillPersonConditionSystem : EntitySystem
             requireMaroon = false;
         }
 
-        Log.Debug(_emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value).ToString());
-        Log.Debug(_mind.IsCharacterUnrevivableIc(mind).ToString());
-
         if (requireDead && !targetDead)
             return 0f;
 

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -39,12 +39,15 @@ public sealed class KillPersonConditionSystem : EntitySystem
             return 1f;
 
         var targetDead = _mind.IsCharacterDeadIc(mind);
-        var targetOnShuttle = _emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value);
+        var targetMarooned = !_emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value) || _mind.IsCharacterUnrevivableIc(mind);
         if (!_config.GetCVar(CCVars.EmergencyShuttleEnabled) && requireMaroon)
         {
             requireDead = true;
             requireMaroon = false;
         }
+
+        Log.Debug(_emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value).ToString());
+        Log.Debug(_mind.IsCharacterUnrevivableIc(mind).ToString());
 
         if (requireDead && !targetDead)
             return 0f;
@@ -55,11 +58,11 @@ public sealed class KillPersonConditionSystem : EntitySystem
 
         // If the shuttle hasn't left, give 50% progress if the target isn't on the shuttle as a "almost there!"
         if (requireMaroon && !_emergencyShuttle.ShuttlesLeft)
-            return targetOnShuttle ? 0f : 0.5f;
+            return targetMarooned ? 0.5f : 0f;
 
         // If the shuttle has already left, and the target isn't on it, 100%
         if (requireMaroon && _emergencyShuttle.ShuttlesLeft)
-            return targetOnShuttle ? 0f : 1f;
+            return targetMarooned ? 1f : 0f;
 
         return 1f; // Good job you did it woohoo
     }

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -72,6 +72,7 @@ public sealed partial class BorgSystem : SharedBorgSystem
         SubscribeLocalEvent<BorgChassisComponent, PowerCellChangedEvent>(OnPowerCellChanged);
         SubscribeLocalEvent<BorgChassisComponent, PowerCellSlotEmptyEvent>(OnPowerCellSlotEmpty);
         SubscribeLocalEvent<BorgChassisComponent, GetCharactedDeadIcEvent>(OnGetDeadIC);
+        SubscribeLocalEvent<BorgChassisComponent, GetCharacterUnrevivableIcEvent>(OnGetUnrevivableIC);
         SubscribeLocalEvent<BorgChassisComponent, ItemToggledEvent>(OnToggled);
 
         SubscribeLocalEvent<BorgBrainComponent, MindAddedMessage>(OnBrainMindAdded);
@@ -216,6 +217,11 @@ public sealed partial class BorgSystem : SharedBorgSystem
     private void OnGetDeadIC(EntityUid uid, BorgChassisComponent component, ref GetCharactedDeadIcEvent args)
     {
         args.Dead = true;
+    }
+
+    private void OnGetUnrevivableIC(EntityUid uid, BorgChassisComponent component, ref GetCharacterUnrevivableIcEvent args)
+    {
+        args.Unrevivable = true;
     }
 
     private void OnToggled(Entity<BorgChassisComponent> ent, ref ItemToggledEvent args)

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -66,6 +66,7 @@ namespace Content.Server.Zombies
             SubscribeLocalEvent<ZombieComponent, CloningEvent>(OnZombieCloning);
             SubscribeLocalEvent<ZombieComponent, TryingToSleepEvent>(OnSleepAttempt);
             SubscribeLocalEvent<ZombieComponent, GetCharactedDeadIcEvent>(OnGetCharacterDeadIC);
+            SubscribeLocalEvent<ZombieComponent, GetCharacterUnrevivableIcEvent>(OnGetCharacterUnrevivableIC);
             SubscribeLocalEvent<ZombieComponent, MindAddedMessage>(OnMindAdded);
             SubscribeLocalEvent<ZombieComponent, MindRemovedMessage>(OnMindRemoved);
 
@@ -166,6 +167,11 @@ namespace Content.Server.Zombies
         private void OnGetCharacterDeadIC(EntityUid uid, ZombieComponent component, ref GetCharactedDeadIcEvent args)
         {
             args.Dead = true;
+        }
+
+        private void OnGetCharacterUnrevivableIC(EntityUid uid, ZombieComponent component, ref GetCharacterUnrevivableIcEvent args)
+        {
+            args.Unrevivable = true;
         }
 
         private void OnStartup(EntityUid uid, ZombieComponent component, ComponentStartup args)

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -266,6 +266,7 @@ public abstract partial class SharedMindSystem : EntitySystem
         if (!HasComp<MobStateComponent>(mind.OwnedEntity))
             return true;
 
+        // Could use checks for the amount of damage they have, but with chemistry you can never tell what damage means someone is truly "unrevivable".
         return false;
     }
 
@@ -576,8 +577,8 @@ public abstract partial class SharedMindSystem : EntitySystem
     ///     True if this Mind is 'sufficiently unrevivable' IC (Objectives, EndText).
     ///     Note that this is *IC logic*, it's not necessarily tied to any specific truth.
     ///     "If administrators decide that zombies are unrevivable, this returns true for zombies."
-    ///     Alternative IsCharacterDeadIC that checks for whether they will be able to inherit their original body again.
-    ///     Cases when they must be given a new body to live (cloning, borging, being a brain, etc) should count as "unrevivable".
+    ///     Alternative IsCharacterDeadIC that checks for whether they will be able to inherit their body again.
+    ///     State in which they must be given a new body to "live" (borging, being a brain, etc) should count as "unrevivable".
     /// </summary>
     public bool IsCharacterUnrevivableIc(MindComponent mind)
     {

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -253,6 +253,22 @@ public abstract partial class SharedMindSystem : EntitySystem
         return _mobState.IsDead(mind.OwnedEntity.Value, targetMobState);
     }
 
+    /// <summary>
+    ///     True if the OwnedEntity of this mind is physically unrevivable.
+    ///     This is mainly to check whether a mind is able to inherit their "original" character again without the need for creating a new one.
+    ///     In cases of being a brain, being borged or a zombie they are "unrevivable"
+    /// </summary>
+    public bool IsCharacterUnrevivablePhysically(MindComponent mind)
+    {
+        if (mind.OwnedEntity == null)
+            return true;
+
+        if (!HasComp<MobStateComponent>(mind.OwnedEntity))
+            return true;
+
+        return false;
+    }
+
     public virtual void Visit(EntityUid mindId, EntityUid entity, MindComponent? mind = null)
     {
     }
@@ -557,6 +573,27 @@ public abstract partial class SharedMindSystem : EntitySystem
     }
 
     /// <summary>
+    ///     True if this Mind is 'sufficiently unrevivable' IC (Objectives, EndText).
+    ///     Note that this is *IC logic*, it's not necessarily tied to any specific truth.
+    ///     "If administrators decide that zombies are unrevivable, this returns true for zombies."
+    ///     Alternative IsCharacterDeadIC that checks for whether they will be able to inherit their original body again.
+    ///     Cases when they must be given a new body to live (cloning, borging, being a brain, etc) should count as "unrevivable".
+    /// </summary>
+    public bool IsCharacterUnrevivableIc(MindComponent mind)
+    {
+        if (mind.OwnedEntity is { } owned)
+        {
+            var ev = new GetCharacterUnrevivableIcEvent(null);
+            RaiseLocalEvent(owned, ref ev);
+
+            if (ev.Unrevivable != null)
+                return ev.Unrevivable.Value;
+        }
+
+        return IsCharacterUnrevivablePhysically(mind);
+    }
+
+    /// <summary>
     ///     A string to represent the mind for logging
     /// </summary>
     public string MindOwnerLoggingString(MindComponent mind)
@@ -602,3 +639,11 @@ public abstract partial class SharedMindSystem : EntitySystem
 /// <param name="Dead"></param>
 [ByRefEvent]
 public record struct GetCharactedDeadIcEvent(bool? Dead);
+
+/// <summary>
+/// Raised on an entity to determine whether or not they are "unrevivable" in IC-logic.
+/// Used to check for things such as being borged or a zombie.
+/// </summary>
+/// <param name="Unrevivable"></param>
+[ByRefEvent]
+public record struct GetCharacterUnrevivableIcEvent(bool? Unrevivable);

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -263,6 +263,7 @@ public abstract partial class SharedMindSystem : EntitySystem
         if (mind.OwnedEntity == null)
             return true;
 
+        // This entity cannot be dead, alive or crit, so it makes sense it cannot be revived to begin with.
         if (!HasComp<MobStateComponent>(mind.OwnedEntity))
             return true;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Borgs and brains now correctly count as marooned even while on the evac shuttle.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Unintentional change that was made along with the new maroon objective. This results in people having to dispose of the brains instead of letting them get borged and stuff, which is just a dick thing to do.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new GetCharacterUnrevivableIcEvent which serves a similiar purpose to GetCharacterDeadIcEvent. However the main differance is it is supposed to check whether the character must receive a new body to be considered alive. (Brains are unrevivable as the body is gone, borgs are unrevivable as the orginal body cannot be revived anymore, being a zombie is considered unrevivable as you must be cloned, aka given a new body)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Borgs, brains, zombies and similiar now correctly count as "marooned" even while on the evac shuttle.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
