### PR TITLE
Revert "add material composition to some salv treasure"

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/base_clothinghands.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/base_clothinghands.yml
@@ -69,11 +69,8 @@
   abstract: true
   id: GoldRingBase
   components:
-    - type: PhysicalComposition
-      materialComposition:
-        Gold: 200 # 2 bars
-    - type: StaticPrice
-      price: 300
+  - type: StaticPrice
+    price: 300
 
 - type: entity
   abstract: true
@@ -81,8 +78,5 @@
   name: silver ring
   description: Looks slightly less valuable than a gold one.
   components:
-    - type: PhysicalComposition
-      materialComposition:
-        Silver: 200 # 2 bars
-    - type: StaticPrice
-      price: 275
+  - type: StaticPrice
+    price: 275

--- a/Resources/Prototypes/Entities/Objects/Misc/treasure.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/treasure.yml
@@ -83,11 +83,6 @@
     - state: cpu_super
   - type: Item
     size: Tiny
-  - type: PhysicalComposition
-    materialComposition: # big mats if you don't sell it
-      Steel: 500
-      Glass: 1000
-      Silver: 300
   - type: StaticPrice
     price: 750
 
@@ -155,9 +150,6 @@
     state: coin_iron
   - type: Item
     size: Tiny
-  - type: PhysicalComposition
-    materialComposition:
-      Steel: 300
   - type: StaticPrice
     price: 75
 
@@ -167,12 +159,8 @@
   components:
   - type: Sprite
     state: coin_silver
-  - type: PhysicalComposition
-    materialComposition:
-      Steel: 100 # coins are fake on the inside
-      Silver: 200
   - type: StaticPrice
-    price: 135
+    price: 125
 
 - type: entity
   parent: TreasureCoinIron
@@ -180,10 +168,6 @@
   components:
   - type: Sprite
     state: coin_gold
-  - type: PhysicalComposition
-    materialComposition:
-      Steel: 100
-      Gold: 200
   - type: StaticPrice
     price: 175
 
@@ -193,10 +177,6 @@
   components:
   - type: Sprite
     state: coin_adamantine
-  - type: PhysicalComposition
-    materialComposition:
-      Steel: 400
-      Diamond: 5
   - type: StaticPrice
     price: 250
 
@@ -206,10 +186,6 @@
   components:
   - type: Sprite
     state: coin_diamond
-  - type: PhysicalComposition
-    materialComposition:
-      Steel: 300
-      Diamond: 15
   - type: StaticPrice
     price: 500
 


### PR DESCRIPTION
# About this PR
Reverts space-wizards/space-station-14#31970

The original PR misses the point of treasure items, which is to have sellables. Making people able to turn them into mats is an absolute noob trap that just fucks over salvagers. Most of these items give you an unbelievably steep value lost with little purpose, so I don't even see a reason in having it. Most of these materials are trivially obtainable on wrecks or through scrap anyways.

Additionally removes materials from rings for the same reason

:cl:
- remove: You can no longer scrap coins and other salvaging treasures. They're simply too valuable to junk.