### PR TITLE
Fix skeletons spawning in folded body bags

### DIFF
--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -30,6 +30,7 @@ public sealed class FoldableSystem : EntitySystem
         SubscribeLocalEvent<FoldableComponent, ComponentInit>(OnFoldableInit);
         SubscribeLocalEvent<FoldableComponent, ContainerGettingInsertedAttemptEvent>(OnInsertEvent);
         SubscribeLocalEvent<FoldableComponent, StorageOpenAttemptEvent>(OnFoldableOpenAttempt);
+        SubscribeLocalEvent<FoldableComponent, EntityStorageInsertedIntoAttemptEvent>(OnEntityStorageAttemptInsert);
 
         SubscribeLocalEvent<FoldableComponent, StrapAttemptEvent>(OnStrapAttempt);
     }
@@ -53,6 +54,13 @@ public sealed class FoldableSystem : EntitySystem
     public void OnStrapAttempt(EntityUid uid, FoldableComponent comp, ref StrapAttemptEvent args)
     {
         if (comp.IsFolded)
+            args.Cancelled = true;
+    }
+
+    private void OnEntityStorageAttemptInsert(Entity<FoldableComponent> entity,
+        ref EntityStorageInsertedIntoAttemptEvent args)
+    {
+        if (entity.Comp.IsFolded)
             args.Cancelled = true;
     }
 

--- a/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
@@ -150,6 +150,9 @@ public sealed class EntityStorageComponentState : ComponentState
 public record struct InsertIntoEntityStorageAttemptEvent(EntityUid ItemToInsert, bool Cancelled = false);
 
 [ByRefEvent]
+public record struct EntityStorageInsertedIntoAttemptEvent(EntityUid ItemToInsert, bool Cancelled = false);
+
+[ByRefEvent]
 public record struct StorageOpenAttemptEvent(EntityUid User, bool Silent, bool Cancelled = false);
 
 [ByRefEvent]

--- a/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
@@ -146,9 +146,16 @@ public sealed class EntityStorageComponentState : ComponentState
     }
 }
 
+// Why does this even pass the entity being inserted if it's raised to the entity being inserted...
+/// <summary>
+/// Raised to the entity being inserted whenever checking if an entity can be inserted into a container.
+/// </summary>
 [ByRefEvent]
 public record struct InsertIntoEntityStorageAttemptEvent(EntityUid ItemToInsert, bool Cancelled = false);
 
+/// <summary>
+/// Raised to the container whenever checking if an entity can be inserted into it.
+/// </summary>
 [ByRefEvent]
 public record struct EntityStorageInsertedIntoAttemptEvent(EntityUid ItemToInsert, bool Cancelled = false);
 

--- a/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
@@ -146,15 +146,14 @@ public sealed class EntityStorageComponentState : ComponentState
     }
 }
 
-// Why does this even pass the entity being inserted if it's raised to the entity being inserted...
 /// <summary>
-/// Raised to the entity being inserted whenever checking if an entity can be inserted into a container.
+/// Raised on the entity being inserted whenever checking if an entity can be inserted into an entity storage.
 /// </summary>
 [ByRefEvent]
 public record struct InsertIntoEntityStorageAttemptEvent(EntityUid ItemToInsert, bool Cancelled = false);
 
 /// <summary>
-/// Raised to the container whenever checking if an entity can be inserted into it.
+/// Raised on the entity storage whenever checking if an entity can be inserted into it.
 /// </summary>
 [ByRefEvent]
 public record struct EntityStorageInsertedIntoAttemptEvent(EntityUid ItemToInsert, bool Cancelled = false);

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -343,6 +343,13 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (attemptEvent.Cancelled)
             return false;
 
+        // Allow other components on the container to prevent inserting the item: e.g. the container is folded
+        var containerAttemptEvent = new EntityStorageInsertedIntoAttemptEvent(toInsert);
+        RaiseLocalEvent(container, ref containerAttemptEvent);
+
+        if (containerAttemptEvent.Cancelled)
+            return false;
+
         // Consult the whitelist. The whitelist ignores the default assumption about how entity storage works.
         if (component.Whitelist != null)
             return _whitelistSystem.IsValid(component.Whitelist, toInsert);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR fixes skeletons spawning in folded body bags by making CanInsert check if the container is folded.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
If a skeleton spawns inside a folded body bag, it's impossible for them to escape without admin intervention. That is not good.

## Technical details
<!-- Summary of code changes for easier review. -->
The CanInsert function now raises a new `EntityStorageInsertedIntoAttemptEvent` to the container.
This event is cancelled by the foldable system if the container is folded.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/21642b91-2e3f-4e5e-8bc6-55a6c73d16a5


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Skeletons will no longer spawn inside of folded body bags.