### PR TITLE
Remove update from DeviceLinkSystem

### DIFF
--- a/Content.Shared/DeviceLinking/DeviceLinkSinkComponent.cs
+++ b/Content.Shared/DeviceLinking/DeviceLinkSinkComponent.cs
@@ -1,6 +1,7 @@
 ﻿using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.DeviceLinking;
 
@@ -23,11 +24,20 @@ public sealed partial class DeviceLinkSinkComponent : Component
     public HashSet<EntityUid> LinkedSources = new();
 
     /// <summary>
-    /// Counts the amount of times a sink has been invoked for severing the link if this counter gets to high
-    /// The counter is counted down by one every tick if it's higher than 0
-    /// This is for preventing infinite loops
+    /// The tick <see cref="InvokeCounter"/> was set at. Used to calculate the real value for the current tick.
     /// </summary>
+    [Access(typeof(SharedDeviceLinkSystem), Other = AccessPermissions.None)]
+    public GameTick InvokeCounterTick;
+
+    /// <summary>
+    /// Counter used to throttle device invocations to avoid infinite loops.
+    /// </summary>
+    /// <remarks>
+    /// This is stored relative to <see cref="InvokeCounterTick"/>. For reading the real value,
+    /// <see cref="SharedDeviceLinkSystem.GetEffectiveInvokeCounter"/> should be used.
+    /// </remarks>
     [DataField]
+    [Access(typeof(SharedDeviceLinkSystem), Other = AccessPermissions.None)]
     public int InvokeCounter;
 
     /// <summary>


### PR DESCRIPTION
The tick updates were purely used to decrease the invoke counter once per tick. Now instead we just calculate the effective counter value with some trivial math on the tick number. This completely removes the need for an update function.

The relative tick is not stored to map files. If we really need this, we can add a TickOffsetSerializer (similar to TimeOffsetSerializer), but I doubt it matters.
