### PR TITLE
Allows disabler, practice disabler, disabler SMG, and practice laser rifle to be used by pacifists

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -228,6 +228,7 @@
     fireCost: 62.5
   - type: StaticPrice
     price: 300
+  - type: PacifismAllowedGun
 
 - type: entity
   name: laser rifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -472,6 +472,7 @@
     tags:
     - Taser
     - Sidearm
+  - type: PacifismAllowedGun
 
 - type: entity
   name: disabler
@@ -500,6 +501,7 @@
     guides:
     - Security
     - Antagonists
+  - type: PacifismAllowedGun
 
 - type: entity
   name: disabler SMG
@@ -538,6 +540,7 @@
   - type: Appearance
   - type: StaticPrice
     price: 260
+  - type: PacifismAllowedGun
 
 - type: entity
   name: taser


### PR DESCRIPTION
## About the PR
Allows pacifists to use the practice disabler, practice laser rifle, disabler, and disabler SMG.

## Why / Balance
As the disabler no longer deals anything but stamina damage, it stands to reason this is in-line with a pacifist's ability to use any other non-lethal tool. The practice laser rifle falls under this, as well.

## Technical details
Added PacifismAllowedGunComp to relevant YML lines.

## Media


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes


**Changelog**

:cl:

- tweak: Pacifists can now use the practice disabler, practice laser rifle, disabler, and disabler SMG.


