### PR TITLE
Fix goliath tentacle exploit

### DIFF
--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared.StatusEffect;
 using Content.Shared.Throwing;
 using Content.Shared.Whitelist;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
@@ -31,6 +32,7 @@ public abstract class SharedStunSystem : EntitySystem
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifier = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly StandingStateSystem _standingState = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffect = default!;
 
@@ -116,8 +118,13 @@ public abstract class SharedStunSystem : EntitySystem
 
     private void OnStunOnContactStartup(Entity<StunOnContactComponent> ent, ref ComponentStartup args)
     {
-        if (TryComp<PhysicsComponent>(ent, out var body))
-            _broadphase.RegenerateContacts((ent, body));
+        if (!TryComp<PhysicsComponent>(ent, out var body) ||
+            !TryComp<FixturesComponent>(ent, out var manager))
+            return;
+
+        _physics.SetBodyType(ent, BodyType.Dynamic, manager: manager, body: body);
+        _physics.SetCanCollide(ent, true, manager: manager, body: body);
+        _broadphase.RegenerateContacts((ent, body));
     }
 
     private void OnStunOnContactCollide(Entity<StunOnContactComponent> ent, ref StartCollideEvent args)

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -158,8 +158,8 @@
   - type: Transform
     anchored: True
   - type: Physics
-    bodyType: Dynamic
-    canCollide: true
+    bodyType: Static
+    canCollide: false
   - type: Sprite
     sprite: Mobs/Aliens/Asteroid/goliath.rsi
   - type: InteractionOutline

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -119,10 +119,8 @@
   id: GoliathTentacle
   name: tentacle
   components:
-  - type: Transform
-    anchored: True
   - type: Physics
-    bodyType: Static
+    bodyType: Dynamic
     canCollide: true
   - type: InteractionOutline
   - type: Sprite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -158,8 +158,8 @@
   - type: Transform
     anchored: True
   - type: Physics
-    bodyType: Static
-    canCollide: false
+    bodyType: Dynamic
+    canCollide: true
   - type: Sprite
     sprite: Mobs/Aliens/Asteroid/goliath.rsi
   - type: InteractionOutline


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes goliath tentacles being unable to hit players if they stand still

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
obvious exploit lets people cheese goliaths with a minimum-effort strat.

## Technical details
<!-- Summary of code changes for easier review. -->
this is what beams do and i have no idea why. im so sorry, god.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Goliath tentacles no longer miss if you stand still.