### PR TITLE
Fix effects of hosted anomaly when transform is parented

### DIFF
--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -372,7 +372,7 @@ public abstract class SharedAnomalySystem : EntitySystem
         // we're at the entity parented directly to the grid.
         while (source.Comp is { ParentUid.Valid: true } && source.Comp.ParentUid != source.Comp.GridUid)
         {
-            source = (source.Owner, Transform(source.Comp.ParentUid));
+            source = (source.Comp.ParentUid, Transform(source.Comp.ParentUid));
         }
 
         if (source.Comp is null)


### PR DESCRIPTION
## About the PR

If an anomaly entity is parented to something (chair, locker, container, etc), traverse the tree to get the location to spawn entities and tiles instead of using the local transform position (usually 0, 0)

Fixes #37165 

## Why / Balance

bugfix

## Technical details


## Media

Before:

https://github.com/user-attachments/assets/1f0513ba-f355-4b77-b4ad-cac5181cd8c9

After:

https://github.com/user-attachments/assets/01c22e07-35ec-4580-8dac-55c38599f126

dunno why the video is so deep fried but it shows it

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

none

**Changelog**

:cl:
- fix: Hosted anomaly effects not appearing at host when host is in container or buckled

