### PR TITLE
Dragon Direction Briefing Fixed

### DIFF
--- a/Content.Server/GameTicking/Rules/DragonRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DragonRuleSystem.cs
@@ -27,7 +27,7 @@ public sealed class DragonRuleSystem : GameRuleSystem<DragonRuleComponent>
         SubscribeLocalEvent<DragonRoleComponent, GetBriefingEvent>(UpdateBriefing);
     }
 
-    private void UpdateBriefing(EntityUid uid, DragonRoleComponent comp, GetBriefingEvent args)
+    private void UpdateBriefing(Entity<DragonRuleComponent> entity, ref GetBriefingEvent args)
     {
         var ent = args.Mind.Comp.OwnedEntity;
 

--- a/Content.Server/GameTicking/Rules/DragonRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DragonRuleSystem.cs
@@ -1,7 +1,11 @@
 using Content.Server.Antag;
+using Content.Server.Dragon;
 using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Mind;
+using Content.Server.Roles;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
+using Content.Shared.CharacterInfo;
 using Content.Shared.Localizations;
 using Robust.Server.GameObjects;
 
@@ -12,16 +16,38 @@ public sealed class DragonRuleSystem : GameRuleSystem<DragonRuleComponent>
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
     [Dependency] private readonly StationSystem _station = default!;
+    [Dependency] private readonly ILogManager _logManager = default!;
+    [Dependency] private readonly RoleSystem _roleSystem = default!;
+    [Dependency] private readonly MindSystem _mind = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<DragonRuleComponent, AfterAntagEntitySelectedEvent>(AfterAntagEntitySelected);
+        SubscribeLocalEvent<DragonRoleComponent, GetBriefingEvent>(UpdateBriefing);
+    }
+
+    private void UpdateBriefing(EntityUid uid, DragonRoleComponent comp, GetBriefingEvent args)
+    {
+        var ent = args.Mind.Comp.OwnedEntity;
+
+        if(ent is null)
+            return;
+
+        args.Append(MakeBriefing(ent.Value));
     }
 
     private void AfterAntagEntitySelected(Entity<DragonRuleComponent> ent, ref AfterAntagEntitySelectedEvent args)
     {
+        if (!_mind.TryGetMind(args.EntityUid, out var mindId, out var mind))
+            return;
+
+        _roleSystem.MindHasRole<DragonRoleComponent>(mindId, out var dragonRole);
+
+        if(dragonRole is null)
+            return;
+
         _antag.SendBriefing(args.EntityUid, MakeBriefing(args.EntityUid), null, null);
     }
 

--- a/Content.Server/GameTicking/Rules/DragonRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DragonRuleSystem.cs
@@ -27,7 +27,7 @@ public sealed class DragonRuleSystem : GameRuleSystem<DragonRuleComponent>
         SubscribeLocalEvent<DragonRoleComponent, GetBriefingEvent>(UpdateBriefing);
     }
 
-    private void UpdateBriefing(Entity<DragonRuleComponent> entity, ref GetBriefingEvent args)
+    private void UpdateBriefing(Entity<DragonRoleComponent> entity, ref GetBriefingEvent args)
     {
         var ent = args.Mind.Comp.OwnedEntity;
 

--- a/Content.Server/GameTicking/Rules/DragonRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DragonRuleSystem.cs
@@ -16,7 +16,6 @@ public sealed class DragonRuleSystem : GameRuleSystem<DragonRuleComponent>
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
     [Dependency] private readonly StationSystem _station = default!;
-    [Dependency] private readonly ILogManager _logManager = default!;
     [Dependency] private readonly RoleSystem _roleSystem = default!;
     [Dependency] private readonly MindSystem _mind = default!;
 

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -144,8 +144,6 @@
     subtype: role-subtype-dragon
     exclusiveAntag: true
   - type: DragonRole
-  - type: RoleBriefing
-    briefing: dragon-role-briefing
 
 # Ninja
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The Space Dragon antag briefing now correctly shows the accurate direction to the station

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It was broken and is now fixed

## Technical details
<!-- Summary of code changes for easier review. -->
The direction is now calculated on GetBriefingEvent, and the DragonRoleComponent is now properly added

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/f3afccd9-3726-408f-ada6-c7723cff4005


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: gorillagaming
- fix: The space dragon briefing now shows the correct direction to the station

