### PR TITLE
Fix dough rolling

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
@@ -41,6 +41,9 @@ public sealed class SliceableFoodSystem : EntitySystem
         if (args.Handled)
             return;
 
+        if (!TryComp<UtensilComponent>(args.Used, out var utensil) || (utensil.Types & UtensilType.Knife) == 0)
+            return;
+
         var doAfterArgs = new DoAfterArgs(EntityManager,
             args.User,
             entity.Comp.SliceTime,


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes being unable to roll dough flat.

I noticed this myself on Vulture, and it was mentioned in discord chat as well.

## Technical details
<!-- Summary of code changes for easier review. -->

Caused by me from #37105 (oops)

We never checked for what tool you use until the doafter completes, at which point we were saying it was already handled.

This meant that even before my previous PR, you could also just click on dough with any object and make a doafter appear, which might've confused people ("why isn't it slicing/rolling?").

Dough is a unique case that can be eaten, sliced, or rolled. Now we have the expected behavior in all three circumstances.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/b65e13f0-ce4e-4c51-9556-bb55b060431b

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed being unable to roll dough flat
