### PR TITLE
Allow shelves to be placed rotated when built by hand

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/shelfs.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/shelfs.yml
@@ -9,24 +9,21 @@
 # Normal
         - to: ShelfWood
           completed:
-            - !type:SnapToGrid
-              southRotation: true
+            - !type:SnapToGrid {}
           steps:
             - material: WoodPlank
               amount: 4
               doAfter: 2
         - to: ShelfMetal
           completed:
-            - !type:SnapToGrid
-              southRotation: true
+            - !type:SnapToGrid {}
           steps:
             - material: Steel
               amount: 5
               doAfter: 3
         - to: ShelfGlass
           completed:
-            - !type:SnapToGrid
-              southRotation: true
+            - !type:SnapToGrid {}
           steps:
             - material: Glass
               amount: 4
@@ -34,8 +31,7 @@
 # Reinforced
         - to: ShelfRWood
           completed:
-            - !type:SnapToGrid
-              southRotation: true
+            - !type:SnapToGrid {}
           steps:
             - material: WoodPlank
               amount: 8
@@ -45,8 +41,7 @@
               doAfter: 1
         - to: ShelfRMetal
           completed:
-            - !type:SnapToGrid
-              southRotation: true
+            - !type:SnapToGrid {}
           steps:
             - material: Plasteel
               amount: 5
@@ -59,8 +54,7 @@
               doAfter: 1
         - to: ShelfRGlass
           completed:
-            - !type:SnapToGrid
-              southRotation: true
+            - !type:SnapToGrid {}
           steps:
             - material: Plastic
               amount: 5
@@ -74,16 +68,14 @@
 # Departmental
         - to: ShelfBar
           completed:
-            - !type:SnapToGrid
-              southRotation: true
+            - !type:SnapToGrid {}
           steps:
             - material: WoodPlank
               amount: 6
               doAfter: 2
         - to: ShelfKitchen
           completed:
-            - !type:SnapToGrid
-              southRotation: true
+            - !type:SnapToGrid {}
           steps:
             - material: MetalRod
               amount: 2
@@ -95,8 +87,7 @@
               doAfter: 2
         - to: ShelfChemistry
           completed:
-            - !type:SnapToGrid
-              southRotation: true
+            - !type:SnapToGrid {}
           steps:
             - material: Plasteel
               amount: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Despite the construction ghost implying it's possible, shelves when built via the construction menu would always be placed so they were accessible from their south side. This makes them not do that.

(They always have been placeable via the entity spawn panel, and this PR does not affect that.)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Maints bar rebuilders rejoice.

## Technical details
<!-- Summary of code changes for easier review. -->
Their construction graph has had their SnapToGrid action set with the rotate south flag on which forces them to always rotate to face south. I'm not sure why this was turned on to begin with, but I don't see any odd behavior in testing.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/567a42a6-91b1-4954-b0c2-69ad9b62d32d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Shelves built from the construction menu can now be placed in all orientations.