### PR TITLE
Allow Pacifists to Use Bola

### DIFF
--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -52,7 +52,6 @@ public abstract class SharedEnsnareableSystem : EntitySystem
         SubscribeLocalEvent<EnsnaringComponent, StepTriggerAttemptEvent>(AttemptStepTrigger);
         SubscribeLocalEvent<EnsnaringComponent, StepTriggeredOffEvent>(OnStepTrigger);
         SubscribeLocalEvent<EnsnaringComponent, ThrowDoHitEvent>(OnThrowHit);
-        SubscribeLocalEvent<EnsnaringComponent, AttemptPacifiedThrowEvent>(OnAttemptPacifiedThrow);
     }
 
     protected virtual void OnEnsnareInit(Entity<EnsnareableComponent> ent, ref ComponentInit args)
@@ -185,11 +184,6 @@ public abstract class SharedEnsnareableSystem : EntitySystem
             TryFree(uid, args.Actor, entity, ensnaring);
             return;
         }
-    }
-
-    private void OnAttemptPacifiedThrow(Entity<EnsnaringComponent> ent, ref AttemptPacifiedThrowEvent args)
-    {
-        args.Cancel("pacified-cannot-throw-snare");
     }
 
     private void OnRemoveEnsnareAlert(Entity<EnsnareableComponent> ent, ref RemoveEnsnareAlertEvent args)

--- a/Resources/Locale/en-US/pacified/pacified.ftl
+++ b/Resources/Locale/en-US/pacified/pacified.ftl
@@ -7,8 +7,6 @@ pacified-cannot-throw = I can't bring myself to throw { THE($projectile) }, that
 pacified-cannot-throw-embed = No way I could throw { THE($projectile) }, that could get lodged inside someone!
 # With liquid-spilling projectiles:
 pacified-cannot-throw-spill = I can't possibly throw { THE($projectile) }, that could spill nasty stuff on someone!
-# With bolas and snares:
-pacified-cannot-throw-snare = I can't throw { THE($projectile) }, what if someone trips?!
 
 pacified-cannot-harm-directly = I can't bring myself to hurt { THE($entity) }!
 pacified-cannot-harm-indirect = I can't damage { THE($entity) }, it could hurt someone!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Lets pacifits use bola
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Talked about in #37164 
## Technical details
<!-- Summary of code changes for easier review. -->
Removes the AttemptPacifiedThrowEvent cancel in the SharedEnsnarableSystem
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/e969828e-0972-485b-a314-bce76fb6a7c5

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
The AttemptPacifiedThrowEvent is no longer referenced in the SharedEnsnarableSystem

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Pacifists can now throw bola

