### PR TITLE
Add support for lattice removal prevention

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -507,7 +507,8 @@ public sealed partial class ExplosionSystem
         int maxTileBreak,
         bool canCreateVacuum,
         List<(Vector2i GridIndices, Tile Tile)> damagedTiles,
-        ExplosionPrototype type)
+        ExplosionPrototype type,
+        EntityUid gridUid)
     {
         if (_tileDefinitionManager[tileRef.Tile.TypeId] is not ContentTileDefinition tileDef
             || tileDef.Indestructible)
@@ -532,6 +533,11 @@ public sealed partial class ExplosionSystem
                 break;
 
             if (newDef.MapAtmosphere && !canCreateVacuum)
+                break;
+
+            var ev = new ReplaceTileAttempt(tileDef, newDef);
+            RaiseLocalEvent(gridUid, ref ev);
+            if (ev.Cancelled)
                 break;
 
             tileDef = newDef;
@@ -864,7 +870,7 @@ sealed class Explosion
 
                 // If the floor is not blocked by some dense object, damage the floor tiles.
                 if (canDamageFloor)
-                    _system.DamageFloorTile(tileRef, _currentIntensity * _tileBreakScale, _maxTileBreak, _canCreateVacuum, tileUpdateList, ExplosionType);
+                    _system.DamageFloorTile(tileRef, _currentIntensity * _tileBreakScale, _maxTileBreak, _canCreateVacuum, tileUpdateList, ExplosionType, _currentGrid.Owner);
             }
             else
             {

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -535,7 +535,7 @@ public sealed partial class ExplosionSystem
             if (newDef.MapAtmosphere && !canCreateVacuum)
                 break;
 
-            var ev = new ReplaceTileAttempt(tileDef, newDef);
+            var ev = new ReplaceTileAttemptEvent(tileDef, newDef);
             RaiseLocalEvent(gridUid, ref ev);
             if (ev.Cancelled)
                 break;

--- a/Content.Shared/Maps/BlockLatticeRemovalComponent.cs
+++ b/Content.Shared/Maps/BlockLatticeRemovalComponent.cs
@@ -1,0 +1,12 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Maps;
+
+/// <summary>
+/// Prevents lattice from being removed from the grid this component is attached to.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BlockLatticeRemovalComponent : Component
+{
+
+}

--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -135,6 +135,10 @@ public sealed class TileSystem : EntitySystem
         if (!Resolve(grid, ref component))
             return false;
 
+        var ev = new ReplaceTileAttemptEvent(tileref.Tile.GetContentTileDefinition(), replacementTile);
+        RaiseLocalEvent(grid, ref ev);
+        if (ev.Cancelled)
+            return false;
 
         var variant = PickVariant(replacementTile);
         var decals = _decal.GetDecalsInRange(tileref.GridUid, _turf.GetTileCenter(tileref).Position, 0.5f);

--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -28,13 +28,13 @@ public sealed class TileSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<BlockLatticeRemovalComponent, ReplaceTileAttempt>(OnReplaceTileAttempt);
+        SubscribeLocalEvent<BlockLatticeRemovalComponent, ReplaceTileAttemptEvent>(OnReplaceTileAttempt);
     }
 
-    public void OnReplaceTileAttempt(Entity<BlockLatticeRemovalComponent> entity, ref ReplaceTileAttempt replaceTileAttempt)
+    public void OnReplaceTileAttempt(Entity<BlockLatticeRemovalComponent> entity, ref ReplaceTileAttemptEvent args)
     {
-        if (replaceTileAttempt.OldTile.ID == BaseLatticeId && replaceTileAttempt.NewTile.ID == replaceTileAttempt.OldTile.BaseTurf)
-            replaceTileAttempt.Cancelled = true;
+        if (args.OldTile.ID == BaseLatticeId && args.NewTile.ID == args.OldTile.BaseTurf)
+            args.Cancelled = true;
     }
 
     /// <summary>
@@ -159,7 +159,7 @@ public sealed class TileSystem : EntitySystem
 
         var plating = (ContentTileDefinition) _tileDefinitionManager[tileDef.BaseTurf];
 
-        var ev = new ReplaceTileAttempt(tileDef, plating);
+        var ev = new ReplaceTileAttemptEvent(tileDef, plating);
         RaiseLocalEvent(tileRef.GridUid, ref ev);
         if (ev.Cancelled)
             return false;
@@ -196,4 +196,4 @@ public sealed class TileSystem : EntitySystem
 /// Raised on the grid whenever a tile is to be replaced by another.
 /// </summary>
 [ByRefEvent]
-public record struct ReplaceTileAttempt(ContentTileDefinition OldTile, ContentTileDefinition NewTile, bool Cancelled = false);
+public record struct ReplaceTileAttemptEvent(ContentTileDefinition OldTile, ContentTileDefinition NewTile, bool Cancelled = false);

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -531,6 +531,12 @@ public sealed class RCDSystem : EntitySystem
         switch (prototype.Mode)
         {
             case RcdMode.ConstructTile:
+
+                var evConstruct = new ReplaceTileAttemptEvent(tile.Tile.GetContentTileDefinition(), (ContentTileDefinition) _tileDefMan[prototype.Prototype]);
+                RaiseLocalEvent(gridUid, ref evConstruct);
+                if (evConstruct.Cancelled)
+                    break;
+
                 _mapSystem.SetTile(gridUid, mapGrid, position, new Tile(_tileDefMan[prototype.Prototype].TileId));
                 _adminLogger.Add(LogType.RCD, LogImpact.High, $"{ToPrettyString(user):user} used RCD to set grid: {gridUid} {position} to {prototype.Prototype}");
                 break;
@@ -561,9 +567,9 @@ public sealed class RCDSystem : EntitySystem
                     // Deconstruct tile (either converts the tile to lattice, or removes lattice)
                     var tileDef = (tile.Tile.GetContentTileDefinition().ID != "Lattice") ? new Tile(_tileDefMan["Lattice"].TileId) : Tile.Empty;
 
-                    var ev = new ReplaceTileAttemptEvent(tile.Tile.GetContentTileDefinition(), tileDef.GetContentTileDefinition());
-                    RaiseLocalEvent(gridUid, ref ev);
-                    if (ev.Cancelled)
+                    var evDeconstruct = new ReplaceTileAttemptEvent(tile.Tile.GetContentTileDefinition(), tileDef.GetContentTileDefinition());
+                    RaiseLocalEvent(gridUid, ref evDeconstruct);
+                    if (evDeconstruct.Cancelled)
                         break;
 
                     _mapSystem.SetTile(gridUid, mapGrid, position, tileDef);

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -560,6 +560,12 @@ public sealed class RCDSystem : EntitySystem
                 {
                     // Deconstruct tile (either converts the tile to lattice, or removes lattice)
                     var tileDef = (tile.Tile.GetContentTileDefinition().ID != "Lattice") ? new Tile(_tileDefMan["Lattice"].TileId) : Tile.Empty;
+
+                    var ev = new ReplaceTileAttempt(tile.Tile.GetContentTileDefinition(), tileDef.GetContentTileDefinition());
+                    RaiseLocalEvent(gridUid, ref ev);
+                    if (ev.Cancelled)
+                        break;
+
                     _mapSystem.SetTile(gridUid, mapGrid, position, tileDef);
                     _adminLogger.Add(LogType.RCD, LogImpact.High, $"{ToPrettyString(user):user} used RCD to set grid: {gridUid} tile: {position} open to space");
                 }

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -561,7 +561,7 @@ public sealed class RCDSystem : EntitySystem
                     // Deconstruct tile (either converts the tile to lattice, or removes lattice)
                     var tileDef = (tile.Tile.GetContentTileDefinition().ID != "Lattice") ? new Tile(_tileDefMan["Lattice"].TileId) : Tile.Empty;
 
-                    var ev = new ReplaceTileAttempt(tile.Tile.GetContentTileDefinition(), tileDef.GetContentTileDefinition());
+                    var ev = new ReplaceTileAttemptEvent(tile.Tile.GetContentTileDefinition(), tileDef.GetContentTileDefinition());
                     RaiseLocalEvent(gridUid, ref ev);
                     if (ev.Cancelled)
                         break;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds support for the `BlockLatticeRemovalComponent`, which makes it impossible to remove the lattice of a grid. 

This does not update any shuttles; that has to be done in separate PRs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This component is intended for Evac shuttles. Evac shuttles has a bit of a strange issue:

1. We can't allow extending the Evac shuttle grid, as that could make it possible to block docking by building new lattice along its sides.
2. We want to make it repairable in the event of a bombing.
3. Strong bombs can remove lattice.

These combined aren't possible since when the lattice is removed, that space is considered "not-grid" and can therefore not be repaired. So the solution this PR proposes is to keep the lattice on Evac; this still allows for it to space the environment, but crew are also able to quickly patch the hole.

## Technical details
<!-- Summary of code changes for easier review. -->

Added the `ReplaceTileAttemptEvent` event, which is raised whenever a tile should be replaced by another. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No CL
