### PR TITLE
Fix `ComponentTogglerSystem` deletion error

### DIFF
--- a/Content.Shared/Item/ItemToggle/ComponentTogglerSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ComponentTogglerSystem.cs
@@ -17,6 +17,8 @@ public sealed class ComponentTogglerSystem : EntitySystem
     private void OnToggled(Entity<ComponentTogglerComponent> ent, ref ItemToggledEvent args)
     {
         var target = ent.Comp.Parent ? Transform(ent).ParentUid : ent.Owner;
+        if (TerminatingOrDeleted(target))
+            return;
 
         if (args.Activated)
             EntityManager.AddComponents(target, ent.Comp.Components);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a bug where `ComponentTogglerSystem` could try to add or remove components while the target entity (self or parent) was terminating.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/37187.

## Technical details
<!-- Summary of code changes for easier review. -->
Simply check if the `target` is `TerminatingOrDeleted` in `OnToggled`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->