### PR TITLE
Made wizard take 15 hours of gameplay to play the wizard antagonist.

### DIFF
--- a/Resources/Prototypes/Roles/Antags/wizard.yml
+++ b/Resources/Prototypes/Roles/Antags/wizard.yml
@@ -13,7 +13,7 @@
   objective: roles-antag-wizard-objective # TODO: maybe give random objs and stationary ones from AntagObjectives and AntagRandomObjectives
   requirements: # I hate time locked roles but this should be enough time for someone to be acclimated
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
+    time: 54000 # 15h
   guides: [ Wizard ]
 
 # See wizard_startinggear for wiz start gear options


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made the wizard antagonist require 15 hours of overall gameplay to roll wizard.

## Why / Balance
I have seen a lot of wizards die due to not knowing the basic mechanics of the game. This PR should hopefully mitigate the amount of wizards that die before they reach the station.

## Technical details
Changed the 18000 to 56000 in the Wizard.yml file.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Tweaked the wizard time requirements: Now it requires atleast 15 hours of overall playtime.

