### PR TITLE
Playtime commands improved time input format

### DIFF
--- a/Content.Server/Administration/Commands/PlayTimeCommands.cs
+++ b/Content.Server/Administration/Commands/PlayTimeCommands.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.Players.PlayTimeTracking;
 using Content.Shared.Administration;
+using Content.Shared.Localizations;
 using Content.Shared.Players.PlayTimeTracking;
 using Robust.Server.Player;
 using Robust.Shared.Console;
@@ -52,7 +53,7 @@ public sealed class PlayTimeAddOverallCommand : IConsoleCommand
         shell.WriteLine(Loc.GetString(
             "cmd-playtime_addoverall-succeed",
             ("username", args[0]),
-            ("time", overall)));
+            ("time", ContentLocalizationManager.FormatPlaytime(overall))));
     }
 
     public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
@@ -114,7 +115,7 @@ public sealed class PlayTimeAddRoleCommand : IConsoleCommand
         shell.WriteLine(Loc.GetString("cmd-playtime_addrole-succeed",
             ("username", userName),
             ("role", role),
-            ("time", overall)));
+            ("time", ContentLocalizationManager.FormatPlaytime(overall))));
     }
 
     public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
@@ -169,7 +170,7 @@ public sealed class PlayTimeGetOverallCommand : IConsoleCommand
         shell.WriteLine(Loc.GetString(
             "cmd-playtime_getoverall-success",
             ("username", userName),
-            ("time", value)));
+            ("time", ContentLocalizationManager.FormatPlaytime(value))));
     }
 
     public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
@@ -237,7 +238,7 @@ public sealed class PlayTimeGetRoleCommand : IConsoleCommand
 
             var time = _playTimeTracking.GetPlayTimeForTracker(session, args[1]);
             shell.WriteLine(Loc.GetString("cmd-playtime_getrole-succeed", ("username", session.Name),
-                ("time", time)));
+                ("time", ContentLocalizationManager.FormatPlaytime(time))));
         }
     }
 

--- a/Resources/Locale/en-US/players/play-time/play-time-commands.ftl
+++ b/Resources/Locale/en-US/players/play-time/play-time-commands.ftl
@@ -6,7 +6,7 @@ parse-session-fail = Did not find session for '{$username}'
 # - playtime_addoverall
 cmd-playtime_addoverall-desc = Adds the specified timespan to a player's overall playtime.
 cmd-playtime_addoverall-help = Usage: {$command} <user name> <brief alphanumeric timespan, such as "90m" or "1.5h">
-cmd-playtime_addoverall-succeed = Increased overall time for {$username} to {TOSTRING($time, "dddd\\:hh\\:mm")}
+cmd-playtime_addoverall-succeed = Increased overall time for {$username} to {$time}
 cmd-playtime_addoverall-arg-user = <user name>
 cmd-playtime_addoverall-arg-minutes = <brief alphanumeric timespan>
 cmd-playtime_addoverall-error-args = Expected exactly two arguments
@@ -14,7 +14,7 @@ cmd-playtime_addoverall-error-args = Expected exactly two arguments
 # - playtime_addrole
 cmd-playtime_addrole-desc = Adds the specified timespan to a player's role playtime
 cmd-playtime_addrole-help = Usage: {$command} <user name> <role> <brief alphanumeric timespan, such as "90m" or "1.5h">
-cmd-playtime_addrole-succeed = Increased role playtime for {$username} / \'{$role}\' to {TOSTRING($time, "dddd\\:hh\\:mm")}
+cmd-playtime_addrole-succeed = Increased role playtime for {$username} / \'{$role}\' to {$time}
 cmd-playtime_addrole-arg-user = <user name>
 cmd-playtime_addrole-arg-role = <role>
 cmd-playtime_addrole-arg-minutes = <brief alphanumeric timespan>
@@ -23,7 +23,7 @@ cmd-playtime_addrole-error-args = Expected exactly three arguments
 # - playtime_getoverall
 cmd-playtime_getoverall-desc = Gets the specified minutes for a player's overall playtime
 cmd-playtime_getoverall-help = Usage: {$command} <user name>
-cmd-playtime_getoverall-success = Overall time for {$username} is {TOSTRING($time, "dddd\\:hh\\:mm")}.
+cmd-playtime_getoverall-success = Overall time for {$username} is {$time}
 cmd-playtime_getoverall-arg-user = <user name>
 cmd-playtime_getoverall-error-args = Expected exactly one argument
 
@@ -33,7 +33,7 @@ cmd-playtime_getrole-help = Usage: {$command} <user name> [role]
 cmd-playtime_getrole-no = Found no role timers
 cmd-playtime_getrole-role = Role: {$role}, Playtime: {$time}
 cmd-playtime_getrole-overall = Overall playtime is {$time}
-cmd-playtime_getrole-succeed = Playtime for {$username} is: {TOSTRING($time, "dddd\\:hh\\:mm")}.
+cmd-playtime_getrole-succeed = Playtime for {$username} is {$time}
 cmd-playtime_getrole-arg-user = <user name>
 cmd-playtime_getrole-arg-role = <role|'Overall'>
 cmd-playtime_getrole-error-args = Expected exactly one or two arguments

--- a/Resources/Locale/en-US/players/play-time/play-time-commands.ftl
+++ b/Resources/Locale/en-US/players/play-time/play-time-commands.ftl
@@ -1,23 +1,23 @@
-﻿parse-minutes-fail = Unable to parse '{$minutes}' as minutes
+﻿parse-time-fail = Unable to parse '{$time}' as time
 parse-session-fail = Did not find session for '{$username}'
 
 ## Role Timer Commands
 
 # - playtime_addoverall
-cmd-playtime_addoverall-desc = Adds the specified minutes to a player's overall playtime
-cmd-playtime_addoverall-help = Usage: {$command} <user name> <minutes>
+cmd-playtime_addoverall-desc = Adds the specified timespan to a player's overall playtime.
+cmd-playtime_addoverall-help = Usage: {$command} <user name> <brief alphanumeric timespan, such as "90m" or "1.5h">
 cmd-playtime_addoverall-succeed = Increased overall time for {$username} to {TOSTRING($time, "dddd\\:hh\\:mm")}
 cmd-playtime_addoverall-arg-user = <user name>
-cmd-playtime_addoverall-arg-minutes = <minutes>
+cmd-playtime_addoverall-arg-minutes = <brief alphanumeric timespan>
 cmd-playtime_addoverall-error-args = Expected exactly two arguments
 
 # - playtime_addrole
-cmd-playtime_addrole-desc = Adds the specified minutes to a player's role playtime
-cmd-playtime_addrole-help = Usage: {$command} <user name> <role> <minutes>
+cmd-playtime_addrole-desc = Adds the specified timespan to a player's role playtime
+cmd-playtime_addrole-help = Usage: {$command} <user name> <role> <brief alphanumeric timespan, such as "90m" or "1.5h">
 cmd-playtime_addrole-succeed = Increased role playtime for {$username} / \'{$role}\' to {TOSTRING($time, "dddd\\:hh\\:mm")}
 cmd-playtime_addrole-arg-user = <user name>
 cmd-playtime_addrole-arg-role = <role>
-cmd-playtime_addrole-arg-minutes = <minutes>
+cmd-playtime_addrole-arg-minutes = <brief alphanumeric timespan>
 cmd-playtime_addrole-error-args = Expected exactly three arguments
 
 # - playtime_getoverall


### PR DESCRIPTION
## About the PR
The 'playtime_' commands can now take time specified as the new brief alphanumeric timespans, such as "1.5h" for 90 minutes. (seconds and minutes can also be specified, technically, but are not likely to be used). A number input without time unit will be read as minutes, so there is no incompatibility with the old method.
The time displayed in the console feedback messages is now also formatted the same as the times in the playtime stat window.

PR is done and works, but only with engine update.
Requires [#5910](https://github.com/space-wizards/RobustToolbox/pull/5910)

## Why / Balance
Entering playtimes as minutes is inconvenient, when we probably typically allocate them by hours.
The old format for the command's output was very ambiguous about the time units being shown, now its consistent with other showcases of playtime.

## Media
![image](https://github.com/user-attachments/assets/680da729-810e-47f2-ba31-d3dd9410be0e)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: Errant
ADMIN:
- tweak: The 'playtime_' commands can now take time specified as brief alphanumeric timespan, such as "1.5h" for 90 minutes.
