### PR TITLE
Prevent opening doors in map editor by accident

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -358,6 +358,9 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (!Resolve(uid, ref door))
             return;
 
+        if (Paused(uid))
+            return;
+
         var lastState = door.State;
 
         if (!SetState(uid, DoorState.Opening, door))
@@ -451,6 +454,9 @@ public abstract partial class SharedDoorSystem : EntitySystem
     public void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
     {
         if (!Resolve(uid, ref door))
+            return;
+
+        if (Paused(uid))
             return;
 
         if (!SetState(uid, DoorState.Closing, door))

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -330,6 +330,9 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (door.State == DoorState.Welded)
             return false;
 
+        if (Paused(uid))
+            return false;
+
         var ev = new BeforeDoorOpenedEvent() { User = user };
         RaiseLocalEvent(uid, ev);
         if (ev.Cancelled)
@@ -356,9 +359,6 @@ public abstract partial class SharedDoorSystem : EntitySystem
     public void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
     {
         if (!Resolve(uid, ref door))
-            return;
-
-        if (Paused(uid))
             return;
 
         var lastState = door.State;
@@ -440,6 +440,9 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (door.State is DoorState.Welded or DoorState.Closed)
             return false;
 
+        if (Paused(uid))
+            return false;
+
         var ev = new BeforeDoorClosedEvent(door.PerformCollisionCheck, partial);
         RaiseLocalEvent(uid, ev);
         if (ev.Cancelled)
@@ -454,9 +457,6 @@ public abstract partial class SharedDoorSystem : EntitySystem
     public void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
     {
         if (!Resolve(uid, ref door))
-            return;
-
-        if (Paused(uid))
             return;
 
         if (!SetState(uid, DoorState.Closing, door))


### PR DESCRIPTION
## About the PR
Less-controversial alternative to #33796.

Resolves #42835

## Why / Balance
At present if a map editor accidentally clicks a door, it invisibly enters the "Opening" state (or "Closing" for firelocks) and the door has to be erased and replaced or the YAML has to be manually edited or the door will open on roundstart.

## Technical details
Paused doors can't be opened or closed.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
