### PR TITLE
More filters for station records

### DIFF
--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -393,6 +393,10 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         {
             StationRecordFilterType.Name =>
                 !someRecord.Name.ToLower().Contains(filterLowerCaseValue),
+            StationRecordFilterType.Job =>
+                !someRecord.JobTitle.ToLower().Contains(filterLowerCaseValue),
+            StationRecordFilterType.Species =>
+                !someRecord.Species.ToLower().Contains(filterLowerCaseValue),
             StationRecordFilterType.Prints => someRecord.Fingerprint != null
                 && IsFilterWithSomeCodeValue(someRecord.Fingerprint, filterLowerCaseValue),
             StationRecordFilterType.DNA => someRecord.DNA != null

--- a/Content.Shared/StationRecords/StationRecordsFilter.cs
+++ b/Content.Shared/StationRecords/StationRecordsFilter.cs
@@ -39,6 +39,8 @@ public sealed class SetStationRecordFilter : BoundUserInterfaceMessage
 public enum StationRecordFilterType : byte
 {
     Name,
+    Job,
+    Species,
     Prints,
     DNA,
 }

--- a/Resources/Locale/en-US/station-records/general-station-records.ftl
+++ b/Resources/Locale/en-US/station-records/general-station-records.ftl
@@ -12,6 +12,8 @@ general-station-record-console-record-dna = DNA: {$dna}
 
 general-station-record-for-filter-line-placeholder = Input text and press "Enter"
 general-station-record-name-filter = Name of person
+general-station-record-job-filter = Job
+general-station-record-species-filter = Species
 general-station-record-prints-filter = Fingerprints
 general-station-record-dna-filter = DNA
 general-station-record-console-search-records = Search


### PR DESCRIPTION
## About the PR
Adds two new filters for the station records console:

- Job
- Species

## Why / Balance
Just a useful feature.

## Media
_No need_

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
- add: Added a search by profession and species in station records.
