### PR TITLE
Genpop closet cargo orders

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -81,8 +81,8 @@
 - type: cargoProduct
   id: SecurityGenPopCloset
   icon:
-    sprite: Objects/Misc/id_cards.rsi
-    state: orange
+    sprite: Structures/Storage/closet.rsi
+    state: genpop
   product: LockerPrisoner
   cost: 250
   category: cargoproduct-category-name-security

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -77,3 +77,13 @@
   cost: 2500
   category: cargoproduct-category-name-security
   group: market
+
+- type: cargoProduct
+  id: SecurityGenPopCloset
+  icon:
+    sprite: Objects/Misc/id_cards.rsi
+    state: orange
+  product: LockerPrisoner
+  cost: 250
+  category: cargoproduct-category-name-security
+  group: market


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR allows the new gen pop lockers to be ordered from cargo.

The sprites for the replacements will all show #&NoBreak;1, but that is a limitation until we can spray paint lockers, like in #31328.
(The prisoner's name will still appear on the locker upon examine.)

Closes #37218 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

These need to be replaceable if they are destroyed or unanchored/stolen.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/3baaf0d4-46ab-482a-9059-e80b6f6597ef

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Genpop prisoner closets can be ordered from cargo