### PR TITLE
Fire damage system fixes

### DIFF
--- a/Content.Shared/Atmos/GetFireProtectionEvent.cs
+++ b/Content.Shared/Atmos/GetFireProtectionEvent.cs
@@ -29,5 +29,6 @@ public sealed class GetFireProtectionEvent : EntityEventArgs, IInventoryRelayEve
     public void Reduce(float by)
     {
         Multiplier -= by;
+        Multiplier = MathF.Max(Multiplier, 0f);
     }
 }

--- a/Content.Shared/Clothing/EntitySystems/FireProtectionSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/FireProtectionSystem.cs
@@ -25,7 +25,7 @@ public sealed class FireProtectionSystem : EntitySystem
 
     private void OnArmorExamine(Entity<FireProtectionComponent> ent, ref ArmorExamineEvent args)
     {
-        var value = MathF.Round((1f - ent.Comp.Reduction) * 100, 1);
+        var value = MathF.Round(ent.Comp.Reduction * 100, 1);
 
         if (value == 0)
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
1. Having greater than 100% fire protection no longer heals burn damage (possible with Elite Web Suit + Atmos Fire Helmet according to @RedBookcase )
2. Examine text is fixed, no longer will the CE helmet say it has 80% Fire resistance (it has 20%)
## Why / Balance
Bugs

## Technical details
MathF.Min and removing a "1f -"

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl: UpAndLeaves
- fix: wearing an elite web vest and an atmos fire helmet will no longer heal your burn damage when on fire.
