### PR TITLE
ERT Backpack fill and hardsuit fixes.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -855,7 +855,7 @@
 
 #ERT Engineer Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitCBURN
+  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndieElite ]
   id: ClothingOuterHardsuitERTEngineer
   name: ERT engineer's hardsuit
   description: A protective hardsuit worn by the engineers of an emergency response team.
@@ -866,8 +866,6 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertengineer.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTEngineer
-  - type: FireProtection
-    reduction: 0.8
 
 #ERT Medic Hardsuit
 - type: entity
@@ -903,7 +901,7 @@
 
 #ERT Janitor Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitCBURN
+  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndieMedic ]
   id: ClothingOuterHardsuitERTJanitor
   name: ERT janitor's hardsuit
   description: A protective hardsuit worn by the janitors of an emergency response team.

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -127,16 +127,15 @@
     id: ERTChaplainPDA
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltStorageWaistbag
-    pocket1: Flare
+    pocket1: Bible
     pocket2: DrinkWaterBottleFull
+  inhand:
+  - BoxCandle
   storage:
     back:
-    - BoxCandle
     - BoxBodyBag
-    - DrinkWaterMelonJuiceJug
     - Lantern
     - Lantern
-    - Bible
     - CrowbarRed
     - FoodBakedBunHotX
     - FoodBakedBunHotX
@@ -158,16 +157,15 @@
     id: ERTChaplainPDA
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltStorageWaistbag
-    pocket1: Flare
+    pocket1: Bible
     pocket2: DrinkWaterBottleFull
+  inhand:
+  - BoxCandle
   storage:
     back:
-    - BoxCandle
     - BoxBodyBag
-    - DrinkWaterMelonJuiceJug
     - Lantern
     - Lantern
-    - Bible
     - CrowbarRed
     - FoodBakedBunHotX
     - FoodBakedBunHotX
@@ -207,20 +205,18 @@
     id: ERTEngineerPDA
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltChiefEngineerFilled
-    pocket1: Flare
-    pocket2: GasAnalyzer
+    pocket1: RCDAmmo
+    pocket2: RCDAmmo
+  inhand:
+  - RCD
   storage:
     back:
-    - trayScanner
-    - RCD
-    - RCDAmmo
-    - RCDAmmo
-    - CableMVStack
-    - CableHVStack
-    - CableApcStack
     - SheetPlasteel
     - SheetSteel
     - SheetGlass
+    - CableMVStack
+    - CableHVStack
+    - CableApcStack
 
 - type: startingGear
   id: ERTEngineerGearEVA
@@ -235,20 +231,18 @@
     id: ERTEngineerPDA
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltChiefEngineerFilled
-    pocket1: Flare
-    pocket2: GasAnalyzer
+    pocket1: RCDAmmo
+    pocket2: RCDAmmo
+  inhand:
+  - RCD
   storage:
     back:
-    - trayScanner
-    - RCD
-    - RCDAmmo
-    - RCDAmmo
-    - CableMVStack
-    - CableHVStack
-    - CableApcStack
     - SheetPlasteel
     - SheetSteel
     - SheetGlass
+    - CableMVStack
+    - CableHVStack
+    - CableApcStack
 
 # Security
 - type: job
@@ -441,15 +435,14 @@
     id: ERTJanitorPDA
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltJanitorFilled
-    pocket1: Flare
+    pocket1: Soap
+  inhand:
+  - AdvMopItem
   storage:
     back:
-    - LightReplacer
     - BoxLightMixed
     - BoxLightMixed
-    - Soap
     - CrowbarRed
-    - AdvMopItem
 
 - type: startingGear
   id: ERTJanitorGearEVA
@@ -463,12 +456,11 @@
     id: ERTJanitorPDA
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltJanitorFilled
-    pocket1: Flare
+    pocket1: Soap
+  inhand:
+  - AdvMopItem
   storage:
     back:
-    - LightReplacer
     - BoxLightMixed
     - BoxLightMixed
-    - Soap
     - CrowbarRed
-    - AdvMopItem


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Engineer and Janitor ERT hardsuits have been unparented from the CBURN hardsuit and re-parented to the Elite and Corpsman hardsuits, respectively. This is in line with other ERT gear, which is generally parented off of a similar syndicate item, and prevents parenting issues (Previously both suits were getting Zombie Infection resistance, for example).

- Fixes to various backpack fills for ERT agents. The Chaplain, Janitor, and Engineer roles had overflowing backpacks which caused their emergency kits to spawn at their feet. Items were rearranged or removed to prevent this from happening.

## Why / Balance
Cleans up ERT roles and removes the weird parenting the Engineer and Janitor suits had. 

## Technical details
.yml changes only.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
