### PR TITLE
Add checks for various complex interactions

### DIFF
--- a/Content.Server/Resist/ResistLockerSystem.cs
+++ b/Content.Server/Resist/ResistLockerSystem.cs
@@ -50,6 +50,9 @@ public sealed class ResistLockerSystem : EntitySystem
         if (!Resolve(target, ref storageComponent, ref resistLockerComponent))
             return;
 
+        if (!_actionBlocker.CanComplexInteract(user))
+            return;
+
         var doAfterEventArgs = new DoAfterArgs(EntityManager, user, resistLockerComponent.ResistTime, new ResistLockerDoAfterEvent(), target, target: target)
         {
             BreakOnMove = true,

--- a/Content.Server/Resist/ResistLockerSystem.cs
+++ b/Content.Server/Resist/ResistLockerSystem.cs
@@ -50,9 +50,6 @@ public sealed class ResistLockerSystem : EntitySystem
         if (!Resolve(target, ref storageComponent, ref resistLockerComponent))
             return;
 
-        if (!_actionBlocker.CanComplexInteract(user))
-            return;
-
         var doAfterEventArgs = new DoAfterArgs(EntityManager, user, resistLockerComponent.ResistTime, new ResistLockerDoAfterEvent(), target, target: target)
         {
             BreakOnMove = true,

--- a/Content.Server/Rotatable/RotatableSystem.cs
+++ b/Content.Server/Rotatable/RotatableSystem.cs
@@ -37,7 +37,9 @@ namespace Content.Server.Rotatable
 
         private void AddFlipVerb(EntityUid uid, FlippableComponent component, GetVerbsEvent<Verb> args)
         {
-            if (!args.CanAccess || !args.CanInteract)
+            if (!args.CanAccess
+                || !args.CanInteract
+                || !args.CanComplexInteract)
                 return;
 
             // Check if the object is anchored.
@@ -60,6 +62,7 @@ namespace Content.Server.Rotatable
         {
             if (!args.CanAccess
                 || !args.CanInteract
+                || !args.CanComplexInteract
                 || Transform(uid).NoLocalRotation) // Good ol prototype inheritance, eh?
                 return;
 
@@ -125,7 +128,9 @@ namespace Content.Server.Rotatable
             if (!TryComp<RotatableComponent>(entity, out var rotatableComp))
                 return false;
 
-            if (!_actionBlocker.CanInteract(player, entity) || !_interaction.InRangeAndAccessible(player, entity))
+            if (!_actionBlocker.CanInteract(player, entity)
+                || !_actionBlocker.CanComplexInteract(player)
+                || !_interaction.InRangeAndAccessible(player, entity))
                 return false;
 
             // Check if the object is anchored, and whether we are still allowed to rotate it.
@@ -148,7 +153,9 @@ namespace Content.Server.Rotatable
             if (!TryComp<RotatableComponent>(entity, out var rotatableComp))
                 return false;
 
-            if (!_actionBlocker.CanInteract(player, entity) || !_interaction.InRangeAndAccessible(player, entity))
+            if (!_actionBlocker.CanInteract(player, entity)
+                || !_actionBlocker.CanComplexInteract(player)
+                || !_interaction.InRangeAndAccessible(player, entity))
                 return false;
 
             // Check if the object is anchored, and whether we are still allowed to rotate it.
@@ -171,7 +178,9 @@ namespace Content.Server.Rotatable
             if (!TryComp<FlippableComponent>(entity, out var flippableComp))
                 return false;
 
-            if (!_actionBlocker.CanInteract(player, entity) || !_interaction.InRangeAndAccessible(player, entity))
+            if (!_actionBlocker.CanInteract(player, entity)
+                || !_actionBlocker.CanComplexInteract(player)
+                || !_interaction.InRangeAndAccessible(player, entity))
                 return false;
 
             // Check if the object is anchored.

--- a/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
@@ -62,7 +62,7 @@ namespace Content.Server.Singularity.EntitySystems
 
         private void OnActivate(EntityUid uid, EmitterComponent component, ActivateInWorldEvent args)
         {
-            if (args.Handled)
+            if (args.Handled || !args.Complex)
                 return;
 
             if (TryComp(uid, out LockComponent? lockComp) && lockComp.Locked)
@@ -101,7 +101,7 @@ namespace Content.Server.Singularity.EntitySystems
 
         private void OnGetVerb(EntityUid uid, EmitterComponent component, GetVerbsEvent<Verb> args)
         {
-            if (!args.CanAccess || !args.CanInteract || args.Hands == null)
+            if (!args.CanAccess || !args.CanInteract || !args.CanComplexInteract || args.Hands == null)
                 return;
 
             if (TryComp<LockComponent>(uid, out var lockComp) && lockComp.Locked)

--- a/Content.Server/Singularity/EntitySystems/RadiationCollectorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/RadiationCollectorSystem.cs
@@ -68,6 +68,9 @@ public sealed class RadiationCollectorSystem : EntitySystem
 
     private void OnActivate(EntityUid uid, RadiationCollectorComponent component, ActivateInWorldEvent args)
     {
+        if (!args.Complex)
+            return;
+
         if (TryComp(uid, out UseDelayComponent? useDelay) && !_useDelay.TryResetDelay((uid, useDelay), true))
             return;
 

--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -25,7 +25,6 @@ namespace Content.Server.Stunnable.Systems
             SubscribeLocalEvent<StunbatonComponent, ExaminedEvent>(OnExamined);
             SubscribeLocalEvent<StunbatonComponent, SolutionContainerChangedEvent>(OnSolutionChange);
             SubscribeLocalEvent<StunbatonComponent, StaminaDamageOnHitAttemptEvent>(OnStaminaHitAttempt);
-            SubscribeLocalEvent<StunbatonComponent, ItemToggleActivateAttemptEvent>(TryTurnOn);
             SubscribeLocalEvent<StunbatonComponent, ChargeChangedEvent>(OnChargeChanged);
         }
 
@@ -52,8 +51,10 @@ namespace Content.Server.Stunnable.Systems
             }
         }
 
-        private void TryTurnOn(Entity<StunbatonComponent> entity, ref ItemToggleActivateAttemptEvent args)
+        protected override void TryTurnOn(Entity<StunbatonComponent> entity, ref ItemToggleActivateAttemptEvent args)
         {
+            base.TryTurnOn(entity, ref args);
+
             if (!TryComp<BatteryComponent>(entity, out var battery) || battery.CurrentCharge < entity.Comp.EnergyPerUse)
             {
                 args.Cancelled = true;

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraRouterSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraRouterSystem.cs
@@ -92,7 +92,7 @@ public sealed class SurveillanceCameraRouterSystem : EntitySystem
 
     private void AddVerbs(EntityUid uid, SurveillanceCameraRouterComponent component, GetVerbsEvent<AlternativeVerb> verbs)
     {
-        if (!_actionBlocker.CanInteract(verbs.User, uid))
+        if (!_actionBlocker.CanInteract(verbs.User, uid) || !_actionBlocker.CanComplexInteract(verbs.User))
         {
             return;
         }

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSystem.cs
@@ -129,7 +129,7 @@ public sealed class SurveillanceCameraSystem : EntitySystem
 
     private void AddVerbs(EntityUid uid, SurveillanceCameraComponent component, GetVerbsEvent<AlternativeVerb> verbs)
     {
-        if (!_actionBlocker.CanInteract(verbs.User, uid))
+        if (!_actionBlocker.CanInteract(verbs.User, uid) || !_actionBlocker.CanComplexInteract(verbs.User))
         {
             return;
         }

--- a/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
@@ -43,6 +43,10 @@ public abstract partial class SharedBuckleSystem
         }
         else
         {
+            if (!TryComp(args.Dragged, out BuckleComponent? buckle) ||
+                !CanBuckle(args.Dragged, args.User, uid, true, out var _, buckle))
+                return;
+
             var doAfterArgs = new DoAfterArgs(EntityManager, args.User, component.BuckleDoafterTime, new BuckleDoAfterEvent(), args.Dragged, args.Dragged, uid)
             {
                 BreakOnMove = true,

--- a/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
@@ -204,6 +204,9 @@ public abstract partial class SharedBuckleSystem
         if (!args.CanAccess || !args.CanInteract || !component.Buckled)
             return;
 
+        if (!CanUnbuckle((uid, component), args.User, false))
+            return;
+
         InteractionVerb verb = new()
         {
             Act = () => TryUnbuckle(uid, args.User, buckleComp: component),

--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -282,7 +282,7 @@ public sealed class LockSystem : EntitySystem
 
     private void AddToggleLockVerb(EntityUid uid, LockComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract)
+        if (!args.CanAccess || !args.CanInteract || !args.CanComplexInteract)
             return;
 
         AlternativeVerb verb = new()

--- a/Content.Shared/Stunnable/SharedStunbatonSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunbatonSystem.cs
@@ -1,9 +1,33 @@
+using Content.Shared.ActionBlocker;
+using Content.Shared.Item.ItemToggle.Components;
+
 namespace Content.Shared.Stunnable;
 
 public abstract class SharedStunbatonSystem : EntitySystem
 {
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+
     public override void Initialize()
     {
         base.Initialize();
+
+        SubscribeLocalEvent<StunbatonComponent, ItemToggleActivateAttemptEvent>(TryTurnOn);
+        SubscribeLocalEvent<StunbatonComponent, ItemToggleDeactivateAttemptEvent>(TryTurnOff);
+    }
+
+    protected virtual void TryTurnOn(Entity<StunbatonComponent> entity, ref ItemToggleActivateAttemptEvent args)
+    {
+        if (args.User != null && !_actionBlocker.CanComplexInteract(args.User.Value)) {
+            args.Cancelled = true;
+            return;
+        }
+    }
+
+    protected virtual void TryTurnOff(Entity<StunbatonComponent> entity, ref ItemToggleDeactivateAttemptEvent args)
+    {
+        if (args.User != null && !_actionBlocker.CanComplexInteract(args.User.Value)) {
+            args.Cancelled = true;
+            return;
+        }
     }
 }

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
@@ -1,3 +1,4 @@
+using Content.Shared.ActionBlocker;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Database;
@@ -12,6 +13,8 @@ namespace Content.Shared.Tools.Systems;
 
 public abstract partial class SharedToolSystem
 {
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+
     public void InitializeWelder()
     {
         SubscribeLocalEvent<WelderComponent, ExaminedEvent>(OnWelderExamine);
@@ -27,6 +30,7 @@ public abstract partial class SharedToolSystem
 
         SubscribeLocalEvent<WelderComponent, ItemToggledEvent>(OnToggle);
         SubscribeLocalEvent<WelderComponent, ItemToggleActivateAttemptEvent>(OnActivateAttempt);
+        SubscribeLocalEvent<WelderComponent, ItemToggleDeactivateAttemptEvent>(OnDeactivateAttempt);
     }
 
     public virtual void TurnOn(Entity<WelderComponent> entity, EntityUid? user)
@@ -165,6 +169,11 @@ public abstract partial class SharedToolSystem
 
     private void OnActivateAttempt(Entity<WelderComponent> entity, ref ItemToggleActivateAttemptEvent args)
     {
+        if (args.User != null && !_actionBlocker.CanComplexInteract(args.User.Value)) {
+            args.Cancelled = true;
+            return;
+        }
+
         if (!SolutionContainerSystem.TryGetSolution(entity.Owner, entity.Comp.FuelSolutionName, out _, out var solution))
         {
             args.Cancelled = true;
@@ -177,6 +186,14 @@ public abstract partial class SharedToolSystem
         {
             args.Popup = Loc.GetString("welder-component-no-fuel-message");
             args.Cancelled = true;
+        }
+    }
+
+    private void OnDeactivateAttempt(Entity<WelderComponent> entity, ref ItemToggleDeactivateAttemptEvent args)
+    {
+        if (args.User != null && !_actionBlocker.CanComplexInteract(args.User.Value)) {
+            args.Cancelled = true;
+            return;
         }
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -78,7 +78,7 @@ public abstract partial class SharedGunSystem
     /// </summary>
     private void OnChamberActivationVerb(EntityUid uid, ChamberMagazineAmmoProviderComponent component, GetVerbsEvent<ActivationVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract || component.BoltClosed == null || !component.CanRack)
+        if (!args.CanAccess || !args.CanInteract || !args.CanComplexInteract || args.Hands == null || component.BoltClosed == null || !component.CanRack)
             return;
 
         args.Verbs.Add(new ActivationVerb()
@@ -131,7 +131,7 @@ public abstract partial class SharedGunSystem
     /// </summary>
     private void OnChamberInteractionVerb(EntityUid uid, ChamberMagazineAmmoProviderComponent component, GetVerbsEvent<InteractionVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract || component.BoltClosed == null)
+        if (!args.CanAccess || !args.CanInteract || !args.CanComplexInteract || args.Hands == null || component.BoltClosed == null)
             return;
 
         args.Verbs.Add(new InteractionVerb()

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -30,7 +30,7 @@ public abstract partial class SharedGunSystem
 
     private void OnAltVerb(EntityUid uid, GunComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract || component.SelectedMode == component.AvailableModes)
+        if (!args.CanAccess || !args.CanInteract || !args.CanComplexInteract || args.Hands == null || component.SelectedMode == component.AvailableModes)
             return;
 
         var nextMode = GetNextMode(component);


### PR DESCRIPTION
## About the PR
Prevents abuse/weirdness by considering the following actions complex:
- Switching gun modes, open/closing gun bolts, racking guns
- Toggling radiation collectors, emitters, welders & stun batons
- Unbuckling others (can still unbuckle yourself)
- Setting up cameras and camera routers
- Rotating and flipping objects
- ~Resisting locks~

Also ensures the following actions require hands:
- Switching gun modes, open/closing gun bolts, racking guns

Additionally, unbuckling cannot occur even if the user (ex: a dragon) tries to pull the target off. I can tackle this if necessary.

https://discord.com/channels/310555209753690112/1369481928893534409
~#35128~
#28097
#10666 (1 & 2, not 3)

## Why / Balance
Radiation collectors, cameras, camera routers and guns should obviously require humanoid-level intellect.
For everything else, a more fleshed out solution might consider the relative size of the user and target, if necessary.

## Media

https://github.com/user-attachments/assets/216f3e24-afdd-44df-a497-c7702694bd40

![Content Client_zh2jGnx5XK](https://github.com/user-attachments/assets/627ccd9a-d72c-445a-8725-6f04471a4ae2)
![Content Client_UrILTNGzAX](https://github.com/user-attachments/assets/a235205f-5163-4eeb-80e4-3e7797834009)
![Content Client_aBdbjpqSio](https://github.com/user-attachments/assets/e8f3c250-9f0c-4d66-bf53-7b83f34bc4cb)
![image](https://github.com/user-attachments/assets/9728c063-d9aa-42d8-a3be-ccd59ccf8fa9)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
`SharedBuckleSystem.Interaction:OnStrapDragDropTarget()` now checks `CanBuckle()` to exit early, skipping the doafter.
`SharedBuckleSystem.Interaction:AddUnbuckleVerb()` also checks `CanUnbuckle()` to prevent the verb.
`StunBatonSystem:TryTurnOn()` is now a protected override method.

**Changelog**
:cl:
- fix: Animals can no longer fiddle with guns, radiation collectors, emitters, welders, stun batons, cameras and camera routers.
- fix: Animals can no longer rotate and flip buildings or unbuckle others.
