### PR TITLE
Stealth Cardboard Box Destructible

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -59,7 +59,7 @@
 - type: entity
   id: StealthBox
   suffix: stealth
-  parent: BaseBigBox
+  parent: BigBox
   description: Kept ya waiting, huh?
   components:
     - type: Damageable

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -1,8 +1,7 @@
 ﻿- type: entity
-  id: BaseBigBox
+  id: BigBox
   name: cardboard box #it's still just a box
   description: Huh? Just a box...
-  abstract: true
   components:
     - type: Transform
       noRot: true
@@ -51,10 +50,19 @@
       tags:
         - DoorBumpOpener
     - type: Construction
-      graph: BaseBigBox
-      node: basebigbox
+      graph: BigBox
+      node: bigbox
       containers:
         - entity_storage
+    - type: InteractionOutline
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 15
+        behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 - type: entity
   id: StealthBox
@@ -71,21 +79,14 @@
     - type: StealthOnMove
       passiveVisibilityRate: -0.37
       movementVisibilityRate: 0.20
-
-- type: entity
-  id: BigBox
-  parent: BaseBigBox
-  components:
-  - type: InteractionOutline
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 15
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-
+    - type: Destructible                #The stealth box has significant structural integrity but is not indestructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 #For admin spawning only
 - type: entity

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/bigbox.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/bigbox.yml
@@ -1,15 +1,15 @@
 - type: constructionGraph
-  id: BaseBigBox
+  id: BigBox
   start: start
   graph:
     - node: start
       edges:
-        - to: basebigbox
+        - to: bigbox
           steps:
             - material: Cardboard
               amount: 5
               doAfter: 5
 
 
-    - node: basebigbox
+    - node: bigbox
       entity: BigBox

--- a/Resources/Prototypes/Recipes/Crafting/crates.yml
+++ b/Resources/Prototypes/Recipes/Crafting/crates.yml
@@ -40,9 +40,9 @@
 
 - type: construction
   id: BigBox
-  graph: BaseBigBox
+  graph: BigBox
   startNode: start
-  targetNode: basebigbox
+  targetNode: bigbox
   category: construction-category-storage
   objectType: Structure
 


### PR DESCRIPTION
## About the PR
This PR makes removes the `BaseBigBox` abstract entity, combining and replacing it with the `BigBox` entity (the large cardboard box), and makes it the parent of the `StealthBox` entity (the stealth cardboard box). The `StealthBox` entity is given a large base health pool of 300 but is no longer indestructible as it was previously

## Why / Balance
The `StealthBox` had an infinite capacity to absorb damage and projectiles, which was both inconsistent with all other storage objects and abusable in that it could be used as an infinite shield against projectiles. This was seen especially when tail-dragged by lizards with two handed weapons.
The Stealth Cardboard Box's functionality has not changed but it now has a moderate health pool (currently 300 before reductions.)

## Technical details
Removed the `BaseBigBox` abstract as it was deemed unnecessary.
Combined the the `BigBox` entity with the old `BaseBigBox` abstract to serve as the new parent entity for the `StealthBox`.
Gave the `StealthBox` entity a damage pool of 300 before being destroyed.
Changed references to `BaseBigBox` to `BigBox` in `big_boxes.yml`, `bigbox.yml`, and `crates.yml`.

## Media
**Before:**
https://github.com/user-attachments/assets/c478b94a-a3f8-4510-ae77-e7725eee76e7

**After:**
https://github.com/user-attachments/assets/39afea21-5550-4b83-9828-882c684cea32

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
`BaseBigBox` entity no longer exists as a parent abstract or crafting graph. 

**Changelog**
:cl:
- tweak: Stealth Cardboard Boxes no longer indestructible.