### PR TITLE
Allow handless mobs to exit containers, make ResistLocker respect OpenOnMove

### DIFF
--- a/Content.Server/Resist/ResistLockerSystem.cs
+++ b/Content.Server/Resist/ResistLockerSystem.cs
@@ -33,7 +33,7 @@ public sealed partial class ResistLockerSystem : EntitySystem
         if (component.IsResisting)
             return;
 
-        if (!TryComp(uid, out EntityStorageComponent? storageComponent))
+        if (!TryComp(uid, out EntityStorageComponent? storageComponent) || !storageComponent.OpenOnMove)
             return;
 
         if (!_actionBlocker.CanMove(args.Entity))
@@ -65,30 +65,34 @@ public sealed partial class ResistLockerSystem : EntitySystem
         _popupSystem.PopupEntity(Loc.GetString("resist-locker-component-start-resisting"), user, user, PopupType.Large);
     }
 
+    // TODO: Convert to DoAfterAttemptEvent
     private void OnDoAfter(EntityUid uid, ResistLockerComponent component, DoAfterEvent args)
     {
-        if (args.Cancelled)
-        {
-            component.IsResisting = false;
-            _popupSystem.PopupEntity(Loc.GetString("resist-locker-component-resist-interrupted"), args.Args.User, args.Args.User, PopupType.Medium);
-            return;
-        }
-
-        if (args.Handled || args.Args.Target == null)
+        if (args.Handled)
             return;
 
         component.IsResisting = false;
 
-        if (HasComp<EntityStorageComponent>(uid))
+        if (args.Target != uid)
+            return;
+
+        if (args.Cancelled)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("resist-locker-component-resist-interrupted"), args.User, args.User, PopupType.Medium);
+            return;
+        }
+
+        if (TryComp(uid, out EntityStorageComponent? storageComponent))
         {
             WeldableComponent? weldable = null;
             if (_weldable.IsWelded(uid, weldable))
                 _weldable.SetWeldedState(uid, false, weldable);
 
-            if (TryComp<LockComponent>(args.Args.Target.Value, out var lockComponent))
-                _lockSystem.Unlock(uid, args.Args.User, lockComponent);
+            if (TryComp<LockComponent>(uid, out var lockComponent))
+                _lockSystem.Unlock(uid, args.User, lockComponent);
 
-            _entityStorage.TryOpenStorage(args.Args.User, uid);
+            if (storageComponent.OpenOnMove)
+                _entityStorage.TryOpenStorage(args.User, uid);
         }
 
         args.Handled = true;

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -115,7 +115,8 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
 
     private void OnRelayMovement(EntityUid uid, EntityStorageComponent component, ref ContainerRelayMovementEntityEvent args)
     {
-        if (!HasComp<HandsComponent>(args.Entity))
+        if (!component.Contents.Contains(args.Entity) &&
+            !HasComp<HandsComponent>(args.Entity))
             return;
 
         if (!_actionBlocker.CanMove(args.Entity))
@@ -415,7 +416,8 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
         if (!Resolve(target, ref component))
             return false;
 
-        if (!HasComp<HandsComponent>(user))
+        if (!component.Contents.Contains(user) &&
+            !HasComp<HandsComponent>(user))
             return false;
 
         if (_weldable.IsWelded(target))


### PR DESCRIPTION
## About the PR
Title. Mice in containers are no longer trapped forever, despite being able to force open their locks.
#35128

## Why / Balance
Response to: #37246
Prevents griefing dragon players by stuffing them in a locker.
Respecting `OpenOnMove` allows containers that move (cardboard box) to have resistible locks, just incase somebody wants that.

## Technical details
See breaking changes.

## Media
![vlc_UB77eYu8c2](https://github.com/user-attachments/assets/ef30cb75-336e-4e8f-9c7a-bb33d587c1d9)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
`SharedEntityStorageSystem` no longer requires hands to open if the user is contained within.
`ResistLockerSystem` now respects the container's `OpenOnMove` parameter.

**Changelog**
:cl:
- fix: Mobs that don't have hands can once again exit closed containers.
