### PR TITLE
For DamagedSiliconAccent use Destructible threshold for default "DamageAtMaxThreshold"

### DIFF
--- a/Content.Server/Speech/EntitySystems/DamagedSiliconAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/DamagedSiliconAccentSystem.cs
@@ -37,7 +37,7 @@ public sealed class DamagedSiliconAccentSystem : EntitySystem
             }
             currentChargeLevel = Math.Clamp(currentChargeLevel, 0.0f, 1.0f);
             // Corrupt due to low power (drops characters on longer messages)
-            args.Message = CorruptPower(args.Message, currentChargeLevel, ref ent.Comp);
+            args.Message = CorruptPower(args.Message, currentChargeLevel, ent.Comp);
         }
 
         if (ent.Comp.EnableDamageCorruption)
@@ -52,11 +52,11 @@ public sealed class DamagedSiliconAccentSystem : EntitySystem
                 damage = damageable.TotalDamage;
             }
             // Corrupt due to damage (drop, repeat, replace with symbols)
-            args.Message = CorruptDamage(args.Message, damage, ref ent);
+            args.Message = CorruptDamage(args.Message, damage, ent);
         }
     }
 
-    public string CorruptPower(string message, float chargeLevel, ref DamagedSiliconAccentComponent comp)
+    public string CorruptPower(string message, float chargeLevel, DamagedSiliconAccentComponent comp)
     {
         // The first idxMin characters are SAFE
         var idxMin = comp.StartPowerCorruptionAtCharIdx;
@@ -106,7 +106,7 @@ public sealed class DamagedSiliconAccentSystem : EntitySystem
         return outMsg.ToString();
     }
 
-    private string CorruptDamage(string message, FixedPoint2 totalDamage, ref Entity<DamagedSiliconAccentComponent> ent)
+    private string CorruptDamage(string message, FixedPoint2 totalDamage, Entity<DamagedSiliconAccentComponent> ent)
     {
         var outMsg = new StringBuilder();
 

--- a/Content.Server/Speech/EntitySystems/DamagedSiliconAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/DamagedSiliconAccentSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using Content.Server.Destructible;
 using Content.Server.PowerCell;
 using Content.Shared.Speech.Components;
 using Content.Shared.Damage;
@@ -11,6 +12,7 @@ public sealed class DamagedSiliconAccentSystem : EntitySystem
 {
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly PowerCellSystem _powerCell = default!;
+    [Dependency] private readonly DestructibleSystem _destructibleSystem = default!;
 
     public override void Initialize()
     {
@@ -50,7 +52,7 @@ public sealed class DamagedSiliconAccentSystem : EntitySystem
                 damage = damageable.TotalDamage;
             }
             // Corrupt due to damage (drop, repeat, replace with symbols)
-            args.Message = CorruptDamage(args.Message, damage, ref ent.Comp);
+            args.Message = CorruptDamage(args.Message, damage, ref ent);
         }
     }
 
@@ -104,12 +106,23 @@ public sealed class DamagedSiliconAccentSystem : EntitySystem
         return outMsg.ToString();
     }
 
-    private string CorruptDamage(string message, FixedPoint2 totalDamage, ref DamagedSiliconAccentComponent comp)
+    private string CorruptDamage(string message, FixedPoint2 totalDamage, ref Entity<DamagedSiliconAccentComponent> ent)
     {
         var outMsg = new StringBuilder();
+
+        // If this is not specified, use the Destructible threshold for destruction or breakage
+        var damageAtMaxCorruption = ent.Comp.DamageAtMaxCorruption;
+        if (damageAtMaxCorruption is null)
+        {
+            if (!TryComp<DestructibleComponent>(ent, out var destructible))
+                return message;
+
+            damageAtMaxCorruption = _destructibleSystem.DestroyedAt(ent, destructible);
+        }
+
         // Linear interpolation of character damage probability
-        var damagePercent = Math.Clamp((float)totalDamage / (float)comp.DamageAtMaxCorruption, 0, 1);
-        var chanceToCorruptLetter = damagePercent * comp.MaxDamageCorruption;
+        var damagePercent = Math.Clamp((float)totalDamage / (float)damageAtMaxCorruption, 0, 1);
+        var chanceToCorruptLetter = damagePercent * ent.Comp.MaxDamageCorruption;
         foreach (var letter in message)
         {
             if (_random.Prob(chanceToCorruptLetter)) // Corrupt!

--- a/Content.Shared/Speech/Components/DamagedSiliconAccentComponent.cs
+++ b/Content.Shared/Speech/Components/DamagedSiliconAccentComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class DamagedSiliconAccentComponent : Component
     ///     total damage is at or above this value.
     /// </summary>
     [DataField]
-    public FixedPoint2 DamageAtMaxCorruption = 300;
+    public FixedPoint2? DamageAtMaxCorruption;
 
     /// <summary>
     ///     Enable charge level corruption effects

--- a/Content.Shared/Speech/Components/DamagedSiliconAccentComponent.cs
+++ b/Content.Shared/Speech/Components/DamagedSiliconAccentComponent.cs
@@ -27,7 +27,8 @@ public sealed partial class DamagedSiliconAccentComponent : Component
 
     /// <summary>
     ///     Probability of character corruption will increase linearly to <see cref="MaxDamageCorruption" /> once until
-    ///     total damage is at or above this value.
+    ///     total damage is at or above this value. If null, it will use the value returned by
+    ///     DestructibleSystem.DestroyedAt, which is the damage threshold for destruction or breakage.
     /// </summary>
     [DataField]
     public FixedPoint2? DamageAtMaxCorruption;


### PR DESCRIPTION
## About the PR

Use a better default value for `DamagedSiliconAccent` `DamageAtMaxThreshold` field.

## Why / Balance

The default was previously 300 which is the value at which a standard borg will be destroyed. For different types of borgs, this should probably remain synchronized to the actual value at which the entity becomes destroyed.

This issue has presented itself in #36867 as @Samuka-C tweaks health values of xenoborgs, they need to remember to scale the speech corruption value with the total health of the borg.

## Technical details

Just uses `DestructibleSystem.DestroyedAt()` to get a default value if it's null.

## Media

negative

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

negative

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
