### PR TITLE
Mob pull spin fix

### DIFF
--- a/Content.Shared/Friction/TileFrictionController.cs
+++ b/Content.Shared/Friction/TileFrictionController.cs
@@ -118,8 +118,11 @@ namespace Content.Shared.Friction
                 // You may think you can just pass the body.LinearVelocity to the Friction function and edit it there!
                 // But doing so is unpredicted! And you will doom yourself to 1000 years of rubber banding!
                 var velocity = body.LinearVelocity;
+                var angVelocity = body.AngularVelocity;
                 _mover.Friction(0f, frameTime, friction, ref velocity);
+                _mover.Friction(0f, frameTime, friction, ref angVelocity);
                 PhysicsSystem.SetLinearVelocity(uid, velocity, body: body);
+                PhysicsSystem.SetAngularVelocity(uid, angVelocity, body: body);
             }
         }
 

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -412,6 +412,17 @@ public abstract partial class SharedMoverController : VirtualController
 
     }
 
+    public void Friction(float minimumFrictionSpeed, float frameTime, float friction, ref float velocity)
+    {
+        if (velocity < minimumFrictionSpeed)
+            return;
+
+        // This equation is lifted from the Physics Island solver.
+        // We re-use it here because Kinematic Controllers can't/shouldn't use the Physics Friction
+        velocity *= Math.Clamp(1.0f - frameTime * friction, 0.0f, 1.0f);
+
+    }
+
     /// <summary>
     /// Adjusts the current velocity to the target velocity based on the specified acceleration.
     /// </summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Mobs no longer spin as if they had 0 friction when being pulled (because they had 0 friction before oops)

## Why / Balance
Unintended change. Bugfix.

## Technical details
Angular Velocity now has friction applied to it through the same method as Linear Velocity and only for Kinematic Controllers.
This is how it worked before.

Added a version of the Friction method that takes a float instead of a Vector2 for Angular Velocity

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
