### PR TITLE
Move random species selection earlier in player spawning logic

### DIFF
--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -9,6 +9,7 @@ using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Preferences.Managers;
 using Content.Server.ServerUpdates;
 using Content.Server.Station.Systems;
+using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.GameTicking;
 using Content.Shared.Mind;
@@ -72,6 +73,8 @@ namespace Content.Server.GameTicking
 
         private ISawmill _sawmill = default!;
 
+        private bool _randomizeCharacters;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -81,6 +84,8 @@ namespace Content.Server.GameTicking
 
             _sawmill = _logManager.GetSawmill("ticker");
             _sawmillReplays = _logManager.GetSawmill("ticker.replays");
+
+            Subs.CVar(_cfg, CCVars.ICRandomCharacters, e => _randomizeCharacters = e, true);
 
             // Initialize the other parts of the game ticker.
             InitializeStatusShell();

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -89,10 +89,9 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
                         roundStart.Add(proto.ID);
                 }
 
-                if (roundStart.Count == 0)
-                    speciesId = SharedHumanoidAppearanceSystem.DefaultSpecies;
-                else
-                    speciesId = _random.Pick(roundStart);
+                speciesId = roundStart.Count == 0
+                    ? SharedHumanoidAppearanceSystem.DefaultSpecies
+                    : _random.Pick(roundStart);
             }
             else
             {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Moved code around in `StationSpawningSystem` and `GameTicker` so that the logic for selecting a random species for the player (used in the dev environment) happens earlier in the process. This allows it to override the player's profile so they spawn with species-appropriate equipment and have the correct information in the station records.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/37214.
Fixes https://github.com/space-wizards/space-station-14/issues/37244.

## Technical details
<!-- Summary of code changes for easier review. -->
The current random species selection logic waits until just before spawning the player entity before picking a random species. Notably, this means that the profile used for determining loadout and entered into the station records isn't updated with the random character, but instead uses the player's selected profile. There are probably more bugs caused by this too; for example, I believe that the random selection will ignore any species restrictions on jobs (not used on WizDen, but relevant to downstreams).

To fix these issues, the random species selection logic was moved from `StationSpawningSystem` to `GameTicker.Spawning`. The random profile now replaces the selected profile before being sent out with spawning events and method calls, so it will be used consistently.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
A randomly-selected moth character showing up correctly in the station records:
<img width="744" alt="mothman finally caught on record" src="https://github.com/user-attachments/assets/2f991443-30cc-438f-9749-d8dab900f1ce" />

A randomly-selected vox character with the appropriate species loadout.
<img width="846" alt="vox with nitrogen" src="https://github.com/user-attachments/assets/f2607c5d-7620-4e4e-a754-01fc315a4f70" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`StationSpawningSystem.SpawnPlayerMob` no longer handles the random species selection from the `ic.random_characters` CVar. This logic is now handled in `GameTicker`. If you're directly calling `SpawnPlayerMob` and using `ic.random_characters`, you may need to add additional logic to handle it.