### PR TITLE
Give Nukies No-Slips and Agent ID for Free

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -48,12 +48,13 @@
     ears: ClothingHeadsetAltSyndicate
     gloves: ClothingHandsGlovesCombat
     outerClothing: ClothingOuterHardsuitSyndie
-    shoes: ClothingShoesBootsCombatFilled
+    shoes: ClothingShoesBootsCombat
     id: SyndiPDA
     pocket2: PlushieCarp
     belt: ClothingBeltMilitaryWebbing
   storage:
     back:
+    - CombatKnife
     - WeaponPistolViper
     - PinpointerSyndicateNuclear
     - DeathAcidifierImplanter
@@ -64,6 +65,9 @@
   parent: SyndicateOperativeGearFullNoUplink
   equipment:
     pocket2: BaseUplinkRadio40TC
+    shoes: ClothingShoesChameleonNoSlips
+  inhand:
+  - AgentIDCard
 
 #Nuclear Operative Commander Gear
 - type: startingGear
@@ -75,6 +79,7 @@
   inhand:
   - NukeOpsDeclarationOfWar
 
+
 #Nuclear Operative Medic Gear
 - type: startingGear
   id: SyndicateOperativeMedicFull
@@ -82,7 +87,6 @@
   equipment:
     eyes: ClothingEyesHudSyndicateAgent
     outerClothing: ClothingOuterHardsuitSyndieMedic
-    shoes: ClothingShoesBootsMagSyndie
     id: SyndiAgentPDA
     belt: ClothingBeltMilitaryWebbingMedFilled
   storage:


### PR DESCRIPTION
## About the PR
All Nukies now spawn with No-Slips and an Agent ID. Forum discussion mirror is [here](https://forum.spacestation14.com/t/give-nukies-the-always-buy-items-for-free/19921/27).

## Why / Balance
I expect a lot of pushback on this one, but hear me out here.

For NukeOps, No-Slips and Agent ID are easily the most bought items. See the following top 10 purchases from the Nukie uplink within the past 20 days (as of May 3):

"item","item_count"
**Agent ID Card,806**
**No-slip Shoes,618**
Energy Sword,610
SMG magazine (.35 auto),457
C-4,302
EMP Implanter,301
SyndiCat Teleporter,263
Access Breaker,235
Jaws Of Life,233
Pistol Magazine (.35 auto),213

And I bet if we looked historically, they would probably be top 5 for the past several months, maybe even more.

Why not just give Nukies these items for free, and enable a tiny bit more build options? I'm of the opinion that if something is a must-have, it should just be included in the base kit anyways, or re-worked to not be a must-have. I don't expect No-Slips to be reworked, nor do I expect the slipping system to be re-worked, so this is what I am suggesting.

No-Slips are practically required, considering how powerful slipping is. Hitting the station without No-Slips or Bloodred Mags is a total **noob-trap** and will quickly get you killed. I think Bloodred Mags have enough added utility to still be useful, such as greater space mobility and the option to hit gravity and still have full maneuverability, so I do not think this change invalidates the Bloodred Mags. There is a reason no one wants to roll Diona Nukie or Ninja. As user [Tao7891](https://forum.spacestation14.com/u/Tao7891) states in my discussion on the forums, slip protection is mechanically pretty close to flash protection, which Nukies get for free already. This is a 2 TC buff that stops Newkies (and forgetful veterans) from falling for the trap of forgetting to buy No-Slips.

Agent ID is even more bought than No-Slips, probably because the Agent already spawns with Bloodred Mags, maybe because some Nukies buy the Bloodred Mags for the reasons I stated above. This is an item that's not nearly as necessary, but is definitely a big QOL buy for Nukies. Instead of having to juggle IDs over and over, you just upgrade as you go. This is not something I am as inclined to give for free, but it's more bought than even the No-Slips so I figured I would include it in the scope of this PR. As user [Nancok](https://forum.spacestation14.com/u/Nancok) pointed out, Agent ID actually doesn't give you anything until you find some other ID to copy (or buy the Clown Bundle I guess) so I could see an argument for it being more balanced than the free No-Slips.

Now I understand that this is an impactful buff, but currently most Nukies on average are spending 12.5% of their budget on these items. Here are some balance levers to consider:

- I would happily change this so it's either one or the other. A 2 or 3 TC buff is not going to break Nukies all of a sudden. Even grouped together, I don't think the TC buff is that crazy.
- Perhaps some other Nukie round start equipment is removed, such as the Viper. I think everyone can agree that the No-Slips are more impactful than the Viper.
- Remove some items that spawn at the Nukie outpost, such as C4, Cobra, or the EMP grenades.

Very open to discussion and feedback. I'm mostly aiming for more QOL and options here.

## Technical details

- Replaced Nukie Operative, Lone-Op, and Commander combat boots with No-Slips.
- Replaced Nukie Agent Bloodred Mags with No-Slips.
- Nukie Operative, Lone-Op, Agent, and Commander now spawn with Agent ID in-hand.
- Moved the combat knife normally found in the combat boots to bag inventory.
- Nukie Reinforcement is unchanged.

## Media
<img width="1420" alt="Operative" src="https://github.com/user-attachments/assets/f60d05d4-84ee-436e-8153-47de0c5a009a" />
<img width="1422" alt="Agent" src="https://github.com/user-attachments/assets/dd83afe5-5448-4489-94c3-014ca554af9b" />
<img width="1419" alt="Commander" src="https://github.com/user-attachments/assets/4e97af6a-d377-43ed-a564-620147967fd6" />

I forgot to spawn in as a Lone Op but it's a yaml only change so it should work.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Nukie Operative, Lone-Op, Agent, and Commander now spawn with No-Slips and Agent ID.
- remove: Agent no longer gets free Bloodred Mags.
- tweak: Combat knife from the original combat boot has been moved to inventory.
