### PR TITLE
Fix chairs deleting players

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -458,7 +458,7 @@ public abstract partial class SharedBuckleSystem
         var buckleXform = Transform(buckle);
         var oldBuckledXform = Transform(strap);
 
-        if (buckleXform.ParentUid == strap.Owner && !Terminating(buckleXform.ParentUid))
+        if (buckleXform.ParentUid == strap.Owner && !Terminating(oldBuckledXform.ParentUid))
         {
             _transform.PlaceNextTo((buckle, buckleXform), (strap.Owner, oldBuckledXform));
             buckleXform.ActivelyLerping = false;

--- a/Content.Shared/Buckle/SharedBuckleSystem.Strap.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Strap.cs
@@ -14,6 +14,7 @@ public abstract partial class SharedBuckleSystem
     {
         SubscribeLocalEvent<StrapComponent, ComponentStartup>(OnStrapStartup);
         SubscribeLocalEvent<StrapComponent, ComponentShutdown>(OnStrapShutdown);
+        SubscribeLocalEvent<StrapComponent, EntityTerminatingEvent>(OnStrapTerminating);
         SubscribeLocalEvent<StrapComponent, ComponentRemove>((e, c, _) => StrapRemoveAll(e, c));
 
         SubscribeLocalEvent<StrapComponent, ContainerGettingInsertedAttemptEvent>(OnStrapContainerGettingInsertedAttempt);
@@ -33,6 +34,11 @@ public abstract partial class SharedBuckleSystem
     {
         if (!TerminatingOrDeleted(uid))
             StrapRemoveAll(uid, component);
+    }
+
+    private void OnStrapTerminating(Entity<StrapComponent> entity, ref EntityTerminatingEvent args)
+    {
+        StrapRemoveAll(entity, entity.Comp);
     }
 
     private void OnStrapContainerGettingInsertedAttempt(EntityUid uid, StrapComponent component, ContainerGettingInsertedAttemptEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Chairs no longer delete everything buckled to them when they are deleted (by admin action, destruction, deconstruction, etc.)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/36886.
Fixes https://github.com/space-wizards/space-station-14/issues/33600.
Fixes https://github.com/space-wizards/space-station-14/issues/29526.

## Technical details
<!-- Summary of code changes for easier review. -->
- `StrapComponent` subscribes to `EntityTerminatingEvent` and responds by unbuckling everything buckled to it.
- Fixed logic in `Unbuckle` intended to stop errors on round end/server shutdown. Now it checks and cancels the reparenting if the chair's parent transform is terminating instead of checking the mob's parent transform (which definitely is terminating).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->