### PR TITLE
Craftable Brass Tiles Changed from PlatingBrass turf to Plating

### DIFF
--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -194,7 +194,7 @@
   id: FloorBrassFilled
   name: tiles-brass-floor-filled
   sprite: /Textures/Tiles/Misc/clockwork/clockwork_floor_filled.png
-  baseTurf: PlatingBrass
+  baseTurf: Plating
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -206,7 +206,7 @@
   id: FloorBrassReebe
   name: tiles-brass-floor-reebe
   sprite: /Textures/Tiles/Misc/clockwork/reebe.png
-  baseTurf: PlatingBrass
+  baseTurf: Plating
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the baseTurf of the craftable brass floor tiles from PlatingBrass to Plating so that those floor tiles can be placed over top of hull plating tiles.

## Why / Balance
These plates are craftable from your inventory the same as the other floor tiles, but without any indication can only be placed on lattice. My understanding is that these tiles are for the as of now unimplemented clockwork cultist, but it is a tad confusing that these floor tiles work differently from the other tiles. I would like to either have these tiles behave the same as the others in the meantime, or update the item description to indicate that they must be placed on lattice.

## Technical details
Changes to floor.yml for tiles FloorBrassFilled and FloorBrassReebe.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

- tweak: Craftable brass floor tiles can now be placed on top of hull plating in addition to lattice.


