### PR TITLE
Prevent AI from interacting with objects on other grids

### DIFF
--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Held.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Held.cs
@@ -160,6 +160,10 @@ public abstract partial class SharedStationAiSystem
         if (!_uiSystem.HasUi(args.Target, AiUi.Key))
             return;
 
+        // No cross-grid
+        if (Transform(args.Target).GridUid != Transform(args.User).GridUid)
+            return;
+
         if (!args.CanComplexInteract
             || !HasComp<StationAiHeldComponent>(args.User)
             || !args.CanInteract)


### PR DESCRIPTION
## About the PR
AI should not be able to interact with objects on other grids, but the interaction menu still opened via Alt+ click.

## Why / Balance
Players could abuse this and bolt the airlocks on the shuttles.

## Media
_No need_

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: AI can no longer interact with objects on other grids using hotkeys.
