### PR TITLE
Fix borg chassis gibbing not dropping items

### DIFF
--- a/Content.Server/Silicons/Borgs/BorgSystem.Ui.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Ui.cs
@@ -40,15 +40,8 @@ public sealed partial class BorgSystem
 
     private void OnEjectBatteryBuiMessage(EntityUid uid, BorgChassisComponent component, BorgEjectBatteryBuiMessage args)
     {
-        if (!TryComp<PowerCellSlotComponent>(uid, out var slotComp) ||
-            !Container.TryGetContainer(uid, slotComp.CellSlotId, out var container) ||
-            !container.ContainedEntities.Any())
-        {
-            return;
-        }
-
-        var ents = Container.EmptyContainer(container);
-        _hands.TryPickupAnyHand(args.Actor, ents.First());
+        if (TryEjectPowerCell(uid, component, out var ents))
+            _hands.TryPickupAnyHand(args.Actor, ents.First());
     }
 
     private void OnSetNameBuiMessage(EntityUid uid, BorgChassisComponent component, BorgSetNameBuiMessage args)


### PR DESCRIPTION
## About the PR
#37137

## Why / Balance
Fixes direct gibbing like wizard smite, emagged recycler, artifact crusher etc.

## Technical details
Subscribes to `BeingGibbedEvent` to eject the brain, battery and module containers before the chassis is deleted.

## Media
![image](https://github.com/user-attachments/assets/3f025b21-3125-4849-a28d-7d3d8efb2ea2)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Cyborg chassis now properly drop their contents when gibbed.
