### PR TITLE
Add interaction with SMES and substation to AI

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -97,6 +97,7 @@
       - PowerStorage
       - VoltageNetworks
       - Power
+    - type: StationAiWhitelist
 
     # Interface
     - type: BatteryInterface

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -25,6 +25,7 @@
     supplyRampTolerance: 5000
     supplyRampRate: 1000
   - type: StationInfiniteBatteryTarget
+  - type: StationAiWhitelist
 
   # Interface
   - type: BatteryInterface


### PR DESCRIPTION
## About the PR
[https://github.com/space-wizards/space-station-14/pull/36386](https://github.com/space-wizards/space-station-14/pull/36386) adds UI for substation and SMES, why not let the AI use this interface.

## Why / Balance
Good feature

## Media
_No need_

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
_Not that important_
