### PR TITLE
Gyroscope throttling

### DIFF
--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Server.Shuttles.Systems;
 using Content.Shared.Damage;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
@@ -24,6 +25,24 @@ namespace Content.Server.Shuttles.Components
         // Need to serialize this because RefreshParts isn't called on Init and this will break post-mapinit maps!
         [ViewVariables(VVAccess.ReadWrite), DataField("thrust")]
         public float Thrust = 100f;
+
+        /// <summary>
+        /// Whether the thrust setting can be configured.
+        /// </summary>
+        [DataField]
+        public bool UseSetting = false;
+
+        /// <summary>
+        /// Scales down the maximum thrust. Useful for gyroscopes on small vessels.
+        /// </summary>
+        [DataField]
+        public ThrusterSetting SettingLevel = ThrusterSetting.Maximum;
+
+        /// <summary>
+        /// An optional sound that plays when the setting is changed.
+        /// </summary>
+        [DataField]
+        public SoundPathSpecifier? SettingSound;
 
         [DataField("thrusterType")]
         public ThrusterType Type = ThrusterType.Linear;
@@ -68,5 +87,13 @@ namespace Content.Server.Shuttles.Components
         Linear,
         // Angular meaning rotational.
         Angular,
+    }
+
+    public enum ThrusterSetting
+    {
+        Maximum,
+        High,
+        Medium,
+        Low
     }
 }

--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -18,6 +18,12 @@ namespace Content.Server.Shuttles.Components
         public bool Enabled { get; set; } = true;
 
         /// <summary>
+        /// Base power for the <see cref="ApcPowerReceiverComponent"/>, scaled by thruster setting.
+        /// </summary>
+        [DataField]
+        public float BasePowerLoad = 1500;
+
+        /// <summary>
         /// This determines whether the thruster is actually enabled for the purposes of thrust
         /// </summary>
         public bool IsOn;

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -53,7 +53,6 @@ public sealed class ThrusterSystem : EntitySystem
         SubscribeLocalEvent<ThrusterComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbsAlternate);
         SubscribeLocalEvent<ThrusterComponent, ComponentInit>(OnThrusterInit);
         SubscribeLocalEvent<ThrusterComponent, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<ThrusterComponent, ComponentStartup>(OnThrusterStartup);
         SubscribeLocalEvent<ThrusterComponent, ComponentShutdown>(OnThrusterShutdown);
         SubscribeLocalEvent<ThrusterComponent, PowerChangedEvent>(OnPowerChange);
         SubscribeLocalEvent<ThrusterComponent, AnchorStateChangedEvent>(OnAnchorChange);
@@ -336,11 +335,6 @@ public sealed class ThrusterSystem : EntitySystem
     private void OnMapInit(Entity<ThrusterComponent> ent, ref MapInitEvent args)
     {
         ent.Comp.NextFire = _timing.CurTime + ent.Comp.FireCooldown;
-    }
-
-    private void OnThrusterStartup(EntityUid uid, ThrusterComponent component, ref ComponentStartup args)
-    {
-        UpdatePowerLoad((uid, component));
     }
 
     private void OnThrusterShutdown(EntityUid uid, ThrusterComponent component, ref ComponentShutdown args)

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -196,9 +196,13 @@ public sealed class ThrusterSystem : EntitySystem
             return;
         }
 
-        SubtractThrust(ent.Owner, ent.Comp, shuttleComponent, xform);
+        if (ent.Comp.IsOn)
+            SubtractThrust(ent.Owner, ent.Comp, shuttleComponent, xform);
+
         ent.Comp.SettingLevel = setting;
-        AddThrust(ent.Owner, ent.Comp, shuttleComponent, xform);
+
+        if (ent.Comp.IsOn)
+            AddThrust(ent.Owner, ent.Comp, shuttleComponent, xform);
 
         _audio.PlayPvs(ent.Comp.SettingSound, ent.Owner);
         _popup.PopupEntity(Loc.GetString("thruster-switched-setting", ("setting", setting)), ent);
@@ -215,8 +219,8 @@ public sealed class ThrusterSystem : EntitySystem
         return component.Thrust * component.SettingLevel switch
         {
             ThrusterSetting.Maximum     => 1f,
-            ThrusterSetting.High        => 1f / 5f,
-            ThrusterSetting.Medium      => 1f / 10f,
+            ThrusterSetting.High        => 1f / 2f,
+            ThrusterSetting.Medium      => 1f / 5f,
             ThrusterSetting.Low         => 1f / 20f,
             _ => throw new ArgumentException(nameof(component.SettingLevel))
         };

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -53,6 +53,7 @@ public sealed class ThrusterSystem : EntitySystem
         SubscribeLocalEvent<ThrusterComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbsAlternate);
         SubscribeLocalEvent<ThrusterComponent, ComponentInit>(OnThrusterInit);
         SubscribeLocalEvent<ThrusterComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<ThrusterComponent, ComponentStartup>(OnThrusterStartup);
         SubscribeLocalEvent<ThrusterComponent, ComponentShutdown>(OnThrusterShutdown);
         SubscribeLocalEvent<ThrusterComponent, PowerChangedEvent>(OnPowerChange);
         SubscribeLocalEvent<ThrusterComponent, AnchorStateChangedEvent>(OnAnchorChange);
@@ -330,32 +331,35 @@ public sealed class ThrusterSystem : EntitySystem
         {
             EnableThruster(uid, component);
         }
-
-        UpdatePowerLoad((uid, component));
     }
 
     private void OnMapInit(Entity<ThrusterComponent> ent, ref MapInitEvent args)
     {
         ent.Comp.NextFire = _timing.CurTime + ent.Comp.FireCooldown;
-
-        UpdatePowerLoad(ent);
     }
 
-    private void OnThrusterShutdown(EntityUid uid, ThrusterComponent component, ComponentShutdown args)
+    private void OnThrusterStartup(EntityUid uid, ThrusterComponent component, ref ComponentStartup args)
+    {
+        UpdatePowerLoad((uid, component));
+    }
+
+    private void OnThrusterShutdown(EntityUid uid, ThrusterComponent component, ref ComponentShutdown args)
     {
         DisableThruster(uid, component);
     }
 
-    private void OnPowerChange(EntityUid uid, ThrusterComponent component, ref PowerChangedEvent args)
+    private void OnPowerChange(Entity<ThrusterComponent> ent, ref PowerChangedEvent args)
     {
-        if (args.Powered && CanEnable(uid, component))
+        if (args.Powered && CanEnable(ent.Owner, ent.Comp))
         {
-            EnableThruster(uid, component);
+            EnableThruster(ent.Owner, ent.Comp);
         }
         else
         {
-            DisableThruster(uid, component);
+            DisableThruster(ent.Owner, ent.Comp);
         }
+
+        UpdatePowerLoad(ent);
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/shuttles/thruster.ftl
+++ b/Resources/Locale/en-US/shuttles/thruster.ftl
@@ -3,3 +3,23 @@ thruster-comp-disabled = The thruster is turned [color=red]off[/color].
 thruster-comp-nozzle-direction = The nozzle is facing [color=yellow]{$direction}[/color].
 thruster-comp-nozzle-exposed = The nozzle [color=green]exposed[/color] to space.
 thruster-comp-nozzle-not-exposed = The nozzle [color=red]is not exposed[/color] to space.
+
+-thruster-setting-name =
+    { $setting ->
+        [maximum] maximum
+        [high] high
+        [medium] medium
+        [low] low
+       *[other] unknown
+    }
+
+thruster-examined = It is set to { $setting ->
+    [maximum] [color=green]{ -thruster-setting-name(setting: "maximum") }[/color]
+    [high] [color=yellow]{ -thruster-setting-name(setting: "high") }[/color]
+    [medium] [color=orange]{ -thruster-setting-name(setting: "medium") }[/color]
+    [low] [color=red]{ -thruster-setting-name(setting: "low") }[/color]
+   *[other] [color=purple]{ -thruster-setting-name(setting: "other") }[/color]
+}.
+thruster-switch-setting = Switch to { -thruster-setting-name(setting: $setting) }
+thruster-switched-setting = Switched to { -thruster-setting-name(setting: $setting) }.
+

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -29,6 +29,7 @@
     - type: Rotatable
       rotateWhileAnchored: true
     - type: Thruster
+      basePowerLoad: 1500
       damage:
         types:
           Heat: 40
@@ -37,7 +38,6 @@
     - type: Appearance
     - type: ThrusterVisuals
     - type: ApcPowerReceiver
-      powerLoad: 1500
     - type: ExtensionCableReceiver
     - type: Damageable
       damageContainer: StructuralInorganic
@@ -118,10 +118,10 @@
   suffix: DEBUG
   components:
   - type: Thruster
+    basePowerLoad: 0
     requireSpace: false
   - type: ApcPowerReceiver
     needsPower: false
-    powerLoad: 0
   - type: Sprite
     sprite: Structures/Shuttles/thruster.rsi
     layers:
@@ -222,6 +222,7 @@
   suffix: DEBUG
   components:
   - type: Thruster
+    basePowerLoad: 0
     thrusterType: Angular
     useSetting: true
     settingSound:
@@ -232,7 +233,6 @@
     thrust: 2000
   - type: ApcPowerReceiver
     needsPower: false
-    powerLoad: 0
   - type: Sprite
     sprite: Structures/Shuttles/gyroscope.rsi
     snapCardinals: true

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -145,6 +145,11 @@
   components:
   - type: Thruster
     thrusterType: Angular
+    useSetting: true
+    settingSound:
+      path: /Audio/Weapons/click.ogg
+      params:
+        volume: -6
     requireSpace: false
     thrust: 2000
     machinePartThrust: Manipulator
@@ -218,8 +223,13 @@
   components:
   - type: Thruster
     thrusterType: Angular
+    useSetting: true
+    settingSound:
+      path: /Audio/Weapons/click.ogg
+      params:
+        volume: -6
     requireSpace: false
-    thrust: 100
+    thrust: 2000
   - type: ApcPowerReceiver
     needsPower: false
     powerLoad: 0


### PR DESCRIPTION
## About the PR
Allows players to reduce a thruster's influence to one of four predefined modes. Currently only enabled on gyroscopes.
Maximum: 100%
High: 50%
Medium: 20%
Low: 5%

## Why / Balance
Makes it easier to fly shittles since gyroscopes are so powerful by default.

## Technical details
Same code, sound and examine text from the electric grill, along with a fix for `IsOn` behavior if the `TryGet<ShuttleComponent>` fails.

## Media
https://github.com/user-attachments/assets/61cb7db1-9f7e-45d3-85b9-f4612a332d68

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
`ThrusterSystem:Enable/DisableThruster()` no longer set IsOn if the `TryGet<ShuttleComponent>` fails. Make sure you are not relying on this behavior.
`ThrusterComponent` now controls the power output of the `ApcPowerReceiver`. Copy the `powerLoad` field to `basePowerLoad` for anything inheriting `BaseThruster`. See `thrusters.yml`.
.
**Changelog**
:cl:
- add: Gyroscopes can now be alt-clicked to reduce their influence. Great for personal shuttles!
