### PR TITLE
fix unremovable items used in construction

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -8,8 +8,10 @@ using Content.Shared.Construction.EntitySystems;
 using Content.Shared.Construction.Steps;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Components;
 using Content.Shared.Prying.Systems;
 using Content.Shared.Radio.EntitySystems;
+using Content.Shared.Stacks;
 using Content.Shared.Temperature;
 using Content.Shared.Tools.Systems;
 using Robust.Shared.Containers;
@@ -272,6 +274,10 @@ namespace Content.Server.Construction
                     // Since many things inherit this step, we delegate the "is this entity valid?" logic to them.
                     // While this is very OOP and I find it icky, I must admit that it simplifies the code here a lot.
                     if(!insertStep.EntityValid(insert, EntityManager, _factory))
+                        return HandleResult.False;
+
+                    // Unremovable items can't be inserted, unless they are a lingering stack
+                    if(HasComp<UnremoveableComponent>(insert) && (!TryComp<StackComponent>(insert, out var comp) || !comp.Lingering))
                         return HandleResult.False;
 
                     // If we're only testing whether this step would be handled by the given event, then we're done.


### PR DESCRIPTION
## About the PR
Unremovable items can no longer be used in a construction step, most prominently this means that borgs can no longer use up/lose their tools

## Why / Balance
Unremovable items should not be removable

## Technical details
Any items that have the Unremovable component can no longer be used in construction steps. Since this would also prevent borgs from using their steel stack and such, an exception is made for items that have StackComponent.Lingering, since that should be specifically indicating that this item was in fact meant to be used up, and will not disappear once the stack is empty.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: Errant
- fix: Borgs can no longer craft items using up their tools as an ingredient, losing them forever.