### PR TITLE
Made Nuclear Operatives spawn with Blood-red Magboots instead of combat boots.

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -48,7 +48,7 @@
     ears: ClothingHeadsetAltSyndicate
     gloves: ClothingHandsGlovesCombat
     outerClothing: ClothingOuterHardsuitSyndie
-    shoes: ClothingShoesBootsCombatFilled
+    shoes: ClothingShoesBootsMagSyndie
     id: SyndiPDA
     pocket2: PlushieCarp
     belt: ClothingBeltMilitaryWebbing


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Nuclear operative now round-start with Blood-red Magboots, instead of the combat boots.

## Why / Balance
I made this change for two reasons, 1. Drip, 2. It makes the BR Magboots actually worth using over the No-Slip shoes, instead of you get a slow speed reduction with a jetpack as your reward, instead of no-slips.

## Technical details
Changed the shoes line in nukeops.yml from ClothingShoesBootsCombatFilled to ClothingShoesBootsMagSyndie

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
![image](https://github.com/user-attachments/assets/c31a7594-e1db-4af1-9248-9f55bd8f5ad3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

Toast_Enjoyer
:cl:
- tweak: Made every nuclear operative spawn with blood-red magboots instead of only the agent.

