### PR TITLE
move SignalState to shared

### DIFF
--- a/Content.Server/DeviceLinking/Components/LogicGateComponent.cs
+++ b/Content.Server/DeviceLinking/Components/LogicGateComponent.cs
@@ -49,7 +49,7 @@ public sealed partial class LogicGateComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public ProtoId<SourcePortPrototype> OutputPort = "Output";
 
-    // Initial state
+    // Initial state, used to not spam invoke ports
     [DataField]
     public SignalState StateA = SignalState.Low;
 
@@ -58,14 +58,4 @@ public sealed partial class LogicGateComponent : Component
 
     [DataField]
     public bool LastOutput;
-}
-
-/// <summary>
-/// Last state of a signal port, used to not spam invoking ports.
-/// </summary>
-public enum SignalState : byte
-{
-    Momentary, // Instantaneous pulse high, compatibility behavior
-    Low,
-    High
 }

--- a/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.DeviceLinking.Components;
 using Content.Server.DeviceNetwork;
 using Content.Server.Doors.Systems;
+using Content.Shared.DeviceLinking;
 using Content.Shared.DeviceLinking.Events;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.Doors.Components;

--- a/Content.Server/DeviceLinking/Systems/EdgeDetectorSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/EdgeDetectorSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.DeviceLinking.Components;
+using Content.Shared.DeviceLinking;
 using Content.Shared.DeviceLinking.Events;
 using Content.Shared.DeviceNetwork;
 

--- a/Content.Shared/DeviceLinking/SharedLogicGate.cs
+++ b/Content.Shared/DeviceLinking/SharedLogicGate.cs
@@ -40,3 +40,15 @@ public enum LogicGateLayers : byte
     InputB,
     Output
 }
+
+/// <summary>
+/// The possible states of a logic-capable signal.
+/// Stored in network payload data of device network messages.
+/// </summary>
+[Serializable, NetSerializable]
+public enum SignalState : byte
+{
+    Momentary, // Instantaneous pulse high, compatibility behavior
+    Low,
+    High
+}


### PR DESCRIPTION
## About the PR
title and made comment better

## Why / Balance
its 2025

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
SignalState enum was moved into `Content.Shared.DeviceLinking` import it if you used it
