### PR TITLE
Fixed Silo not accepting diamonds

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/silo.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/silo.yml
@@ -22,6 +22,7 @@
     whitelist:
       tags:
       - Sheet
+      - RawMaterial
       - Ingot
   - type: ActivatableUI
     key: enum.OreSiloUiKey.Key


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Silo now accepting diamonds, same way Protolathe does.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Protolathe accepts diamonds, Silo doesnt.

## Technical details
<!-- Summary of code changes for easier review. -->

Simple YAML change - added `RawMaterial` tag to the Silo mat whitelist. Not sure of other implications, I just took the tag from the Protlathe proto.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Silo can now accept diamonds. Shiny!
