### PR TITLE
Add test that mob damage thresholds have alerts

### DIFF
--- a/Content.IntegrationTests/Tests/Damageable/MobThresholdsTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/MobThresholdsTest.cs
@@ -1,0 +1,35 @@
+using Content.Shared.Mobs.Components;
+
+namespace Content.IntegrationTests.Tests.Damageable;
+
+public sealed class MobThresholdsTest
+{
+    [Test]
+    public async Task ValidateMobThresholds()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.EntMan;
+        var protoMan = server.ProtoMan;
+
+        var protos = pair.GetPrototypesWithComponent<MobThresholdsComponent>();
+
+        Assert.Multiple(() =>
+        {
+            foreach (var (proto, comp) in protos)
+            {
+                // See which mob states are mapped to alerts
+                var alertStates = comp.StateAlertDict.Keys;
+                // Check each mob state that this mob can be in
+                foreach (var (_, state) in comp.Thresholds)
+                {
+                    // Make sure that an alert exists for each possible mob state
+                    Assert.That(alertStates, Does.Contain(state), $"{proto.ID} does not have an alert state for mob state {state}");
+                }
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/Damageable/MobThresholdsTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/MobThresholdsTest.cs
@@ -1,9 +1,14 @@
+using Content.Shared.Alert;
 using Content.Shared.Mobs.Components;
 
 namespace Content.IntegrationTests.Tests.Damageable;
 
 public sealed class MobThresholdsTest
 {
+    /// <summary>
+    /// Inspects every entity prototype with a <see cref="MobThresholdsComponent"/> and makes
+    /// sure that every possible mob state is mapped to an <see cref="AlertPrototype"/>.
+    /// </summary>
     [Test]
     public async Task ValidateMobThresholds()
     {

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -62,6 +62,7 @@
       120: Dead
     stateAlertDict:
       Alive: BorgHealth
+      Dead: BorgDead
     showOverlays: false
   - type: Stamina
     critThreshold: 120


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds an integration test that checks every entity prototype with a `MobThresholdsComponent` and makes sure that each possible state for the mob is mapped to an `AlertPrototype` in the component's `StateAlertDict`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I'm working on an integration test for setting off the station's nuke, and ran into [an error](https://github.com/space-wizards/space-station-14/blob/394b5e71f6c75032714cfa9583ec764d9ab372c9/Content.Shared/Mobs/Systems/MobThresholdSystem.cs#L382) for the cleanbot, honkbot, and other non-cyborg silicons that get killed by the explosion.

This test lets us catch this error and others like it without having to encounter it at runtime.

## Technical details
<!-- Summary of code changes for easier review. -->
Iterates through all entity prototypes with a `MobThresholdsComponent`, and looks at the `Thresholds` DataField to find all of the states the mob can be in. The `StateAlertDict` DataField is then inspected to make sure that an entry exists for each state.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->