### PR TITLE
Modified the T2/T3 laser recipies to (hopefully) see more than just xray cannons

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -221,7 +221,8 @@
   materials:
     Steel: 1500
     Glass: 1000
-    Gold: 850
+    Gold: 500
+    Uranium: 300
 
 - type: latheRecipe
   parent: BaseWeaponRecipeLong
@@ -230,7 +231,7 @@
   materials:
     Steel: 1250
     Plastic: 750
-    Gold: 500
+    Gold: 350
 
 - type: latheRecipe
   parent: BaseWeaponRecipeLong
@@ -240,7 +241,7 @@
     Steel: 1500
     Glass: 500
     Plastic: 250
-    Gold: 100
+    Gold: 250
 
 - type: latheRecipe
   parent: BaseWeaponRecipeLong


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Modified the recipies of the X-ray cannon, Laser cannon, and advanced laser pistol to bring the recipies more in line with each other.

X-ray Cannon: 1 Gold -> 2.5 Gold 

Laser Cannon: 5 Gold -> 3.5 Gold 

Advanced Laser Pistol: 8.5 Gold -> 5 Gold + 3 Uranium

## Why / Balance
One of the best things the crew can do against nukies is to print as many x-ray cannons as possible. This isn't because x-ray cannons do the most damage against nukies (the elite suit is practically immune to rads), but because you can print 5 times as many x-ray cannons as laser cannons and 8.5 times as many as you can Advanced Laser Pistols. 

In non-nukie rounds, it's rare for sec to get gold, even rarer for it to be a reliable supply so we see the same issue. 5 x-ray cannons will almost always be better to make than 1 laser cannon.

In any round where Advanced Laser Pistols are researched, making one uses up the majority of sec's gold reserves. Moving some of the gold required to uranium means that you don't completely cripple your ability to make the other 2 laser weapons, while also keeping it relatively expensive. Also the self-recharging cell using uranium makes sense in-universe.

## Technical details
Changed some numbers in `Resources\Prototypes\Recipes\Lathes\security.yml`

## Media
![Screenshot 2025-05-09 161305](https://github.com/user-attachments/assets/d2018d27-a523-4ee3-ada1-82d944bb900a)
![Screenshot 2025-05-09 161337](https://github.com/user-attachments/assets/4f5a833b-ec12-4e7b-a7b2-1204923067d4)
![Screenshot 2025-05-09 161352](https://github.com/user-attachments/assets/22d0ad12-4cbd-4bf8-b0b9-79e245796d68)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed the gold requirement for the recipies of the Laser Cannon, X-Ray Cannon, and Advanced Laser Pistol.
- tweak: The Advanced Laser Pistol now requires uranium to make.

