### PR TITLE
Fix the component toggler

### DIFF
--- a/Content.Shared/Item/ItemToggle/ComponentTogglerSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ComponentTogglerSystem.cs
@@ -26,7 +26,10 @@ public sealed class ComponentTogglerSystem : EntitySystem
 
             EntityManager.AddComponents(target, ent.Comp.Components);
         } else {
-            var target = ent.Comp.Target;
+            if (ent.Comp.Target == null)
+            return;
+
+            var target = ent.Comp.Target.Value;
 
             if (TerminatingOrDeleted(target))
             return;

--- a/Content.Shared/Item/ItemToggle/ComponentTogglerSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ComponentTogglerSystem.cs
@@ -16,13 +16,22 @@ public sealed class ComponentTogglerSystem : EntitySystem
 
     private void OnToggled(Entity<ComponentTogglerComponent> ent, ref ItemToggledEvent args)
     {
-        var target = ent.Comp.Parent ? Transform(ent).ParentUid : ent.Owner;
-        if (TerminatingOrDeleted(target))
+        if (args.Activated) {
+            var target = ent.Comp.Parent ? Transform(ent).ParentUid : ent.Owner;
+
+            ent.Comp.Target = target;
+
+            if (TerminatingOrDeleted(target))
             return;
 
-        if (args.Activated)
             EntityManager.AddComponents(target, ent.Comp.Components);
-        else
+        } else {
+            var target = ent.Comp.Target;
+
+            if (TerminatingOrDeleted(target))
+            return;
+
             EntityManager.RemoveComponents(target, ent.Comp.RemoveComponents ?? ent.Comp.Components);
+        }
     }
 }

--- a/Content.Shared/Item/ItemToggle/Components/ComponentTogglerComponent.cs
+++ b/Content.Shared/Item/ItemToggle/Components/ComponentTogglerComponent.cs
@@ -29,4 +29,7 @@ public sealed partial class ComponentTogglerComponent : Component
     /// </summary>
     [DataField]
     public bool Parent;
+
+    [DataField]
+    public EntityUid? Target = null;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
It solves a issue from the component toggler
<!-- What did you change? -->

## Why / Balance
If you use a item with component toggler with parent true (that is, it will add components to the parent and not the actual thing with the component toggler) and the item changes parents (you drop it, put in your bag, or if is a item in a module, you change the module) then once it toggles back, it doesn't remove the components from the entity it gave to.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
I made so the component toggle component now remembers which entity it gave the components to and then it will try to remove the components from that entity and not their current parent.
<!-- Summary of code changes for easier review. -->

## Media
Doesn't need any
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
I don't think I need to make a fix changelog since the only thing affected by this bug were the cloaking device, that isn't available to players.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
