### PR TITLE
Fix meteors deceleration

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -43,6 +43,8 @@
     maxIntensity: 100
     maxTileBreak: 1
     tileBreakScale: 2
+  - type: TileFrictionModifier
+    modifier: 0
 
 
 - type: entity


### PR DESCRIPTION
## About the PR
Meteors no longer slow down during flight

## Why / Balance
It's strange to look at a rotating meteor frozen in the middle of the station

## Media
_Definitely not necessary, it just works_

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Meteors no longer slow down during flight.
