### PR TITLE
Add ability for Interaction tests to spawn a station entity

### DIFF
--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
@@ -26,6 +26,8 @@ using Robust.Shared.Timing;
 using Robust.UnitTesting;
 using Content.Shared.Item.ItemToggle;
 using Robust.Client.State;
+using Content.Server.Station.Systems;
+using Content.Server.Station;
 
 namespace Content.IntegrationTests.Tests.Interaction;
 
@@ -110,6 +112,7 @@ public abstract partial class InteractionTest
     protected SharedMapSystem MapSystem = default!;
     protected ISawmill SLogger = default!;
     protected SharedUserInterfaceSystem SUiSys = default!;
+    protected StationSystem StationSys = default!;
 
     // CLIENT dependencies
     protected IEntityManager CEntMan = default!;
@@ -128,6 +131,17 @@ public abstract partial class InteractionTest
     protected DoAfterComponent DoAfters = default!;
 
     public float TickPeriod => (float) STiming.TickPeriod.TotalSeconds;
+
+    /// <summary>
+    /// If not null, a station entity will be spawned using this prototype
+    /// and the test grid will be registered to it.
+    /// </summary>
+    protected virtual EntProtoId? StationPrototype => null;
+
+    /// <summary>
+    /// The station entity spawned if <see cref="StationPrototype"/> is not null.
+    /// </summary>
+    protected NetEntity? Station;
 
     // Simple mob that has one hand and can perform misc interactions.
     [TestPrototypes]
@@ -173,6 +187,7 @@ public abstract partial class InteractionTest
         STestSystem = SEntMan.System<InteractionTestSystem>();
         Stack = SEntMan.System<StackSystem>();
         SLogger = Server.ResolveDependency<ILogManager>().RootSawmill;
+        StationSys = SEntMan.System<StationSystem>();
         SUiSys = Client.System<SharedUserInterfaceSystem>();
 
         // client dependencies
@@ -193,6 +208,15 @@ public abstract partial class InteractionTest
         PlayerCoords = SEntMan.GetNetCoordinates(Transform.WithEntityId(MapData.GridCoords.Offset(new Vector2(0.5f, 0.5f)), MapData.MapUid));
         TargetCoords = SEntMan.GetNetCoordinates(Transform.WithEntityId(MapData.GridCoords.Offset(new Vector2(1.5f, 0.5f)), MapData.MapUid));
         await SetTile(Plating, grid: MapData.Grid);
+
+        if (StationPrototype is not null)
+        {
+            await Server.WaitPost(() =>
+            {
+                var station = StationSys.InitializeNewStation(new StationConfig() { StationPrototype = StationPrototype }, [MapData.Grid]);
+                Station = SEntMan.GetNetEntity(station);
+            });
+        }
 
         // Get player data
         var sPlayerMan = Server.ResolveDependency<Robust.Server.Player.IPlayerManager>();
@@ -261,6 +285,11 @@ public abstract partial class InteractionTest
     public async Task TearDownInternal()
     {
         await Server.WaitPost(() => MapSystem.DeleteMap(MapId));
+        // Clean up the station entity if we spawned one
+        if (SEntMan.TryGetEntity(Station, out var stationUid))
+        {
+            await Server.WaitPost(() => StationSys.DeleteStation(stationUid.Value));
+        }
         await Pair.CleanReturnAsync();
         await TearDown();
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the option for integration tests derived from `InteractionTest` to specify a station prototype that will be spawned and cleaned up automatically as part of the test.

This was separated from https://github.com/space-wizards/space-station-14/pull/36329 for easier review.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A bunch of systems rely on having a station and its associated data set up: station records, mail deliveries, salvage magnet stuff, etc.

This doesn't mean spawning in an actual station map; it just needs the nullspace entity that holds station-related data. These prototypes can be found in [Resources/Prototypes/Entities/Stations](https://github.com/space-wizards/space-station-14/tree/34f8be84b6989a49d614879be8db005864f310a4/Resources/Prototypes/Entities/Stations).

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a nullable, virtual `EntProtoId` `StationPrototype` to `InteractionTest`, defaulting to null.

During test setup, if `StationPrototype` is non-null, `StationSystem.InitializeNewStation` is called, passing in `StationPrototype` and the test grid. A reference to the station's `NetEntity` is stored in a protected field of `InteractionTest` for easy access by tests.

During test teardown, the station entity is deleted if it exists.

Adding this functionality into `InteractionTest` allows the station to be set up at the right time so that station systems can respond to the player being spawned (such as by adding them to the crew records). It also reduces code duplication by not making multiple tests reimplement this functionality.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->