### PR TITLE
[HOTFIX] Ensure that mobs wake up when zombified

### DIFF
--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.StatusEffect;
 using Content.Shared.Stunnable;
 using Content.Shared.Traits.Assorted;
 using Content.Shared.Verbs;
+using Content.Shared.Zombies;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -51,6 +52,7 @@ public sealed partial class SleepingSystem : EntitySystem
         SubscribeLocalEvent<MobStateComponent, SleepActionEvent>(OnSleepAction);
 
         SubscribeLocalEvent<SleepingComponent, DamageChangedEvent>(OnDamageChanged);
+        SubscribeLocalEvent<SleepingComponent, EntityZombifiedEvent>(OnZombified);
         SubscribeLocalEvent<SleepingComponent, MobStateChangedEvent>(OnMobStateChanged);
         SubscribeLocalEvent<SleepingComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<SleepingComponent, SpeakAttemptEvent>(OnSpeakAttempt);
@@ -217,6 +219,16 @@ public sealed partial class SleepingSystem : EntitySystem
 
         if (args.DamageDelta.GetTotal() >= ent.Comp.WakeThreshold)
             TryWaking((ent, ent.Comp));
+    }
+
+    /// <summary>
+    /// Wake up on being zombified.
+    /// In some cases, zombification might theoretically occur without a mob state change or being damaged
+    /// </summary>
+    /// //TODO Perhaps a generic component should be introduced that guarantees that a mob will wake up immediately and can't go to sleep again
+    private void OnZombified(Entity<SleepingComponent> ent, ref EntityZombifiedEvent args)
+    {
+        TryWaking((ent, ent.Comp), true);
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
Ensure mobs wake up when zombified

## Why / Balance
SSD mobs asleep from #34039 will not wake up when bitten by zombies since their sleep is Forced. Thus they will still be asleep when they turn. The new zombie will then stay asleep and inert (no longer forced, they could press the action to wake up, but AI mobs dont do that) , when it should instead immediately become a threat. Zombies are not allowed to fall asleep, thus they should also not be able to _stay_ asleep when they turn. 

## Technical details
EntityZombifiedEvent now force-wakes the mob. While other, more general ways to fix this might be more proper (force-wake on crit, which is actually what a comment in SleepSystem claims is supposed to already happen), there is another, more rare scenario where this specific fix would be necessary. When antagcontrol is used to zombify someone, there is no health or state change. Thus, for that to wake up a sleeping now-zombie, zombification itself should cancel sleep, through some mechanism.

A more elegant and generic solution to do that would be to introduce a new component that prevents sleep and wakes the mob up when added, so we don't need to do checks for another new event when the next weird-conversion-thing-that can't-sleep gets added, but as a hotfix, this works and has minimal potential for breaking or breaking something else

## Media

https://github.com/user-attachments/assets/00176aac-7640-452d-ba72-23d7999ab4bb

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: Errant
- fix: Sleeping mobs now always wake up when zombified.