### PR TITLE
Normalize turnstile construction to be more like airlocks -- use door electronics for access configuration

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
@@ -244,6 +244,22 @@
   - type: AccessReader
     access: [["Brig"]]
 
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsGenpopEnter
+  suffix: Genpop Enter, Locked
+  components:
+  - type: AccessReader
+    access: [["GenpopEnter"], ["Security"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsGenpopLeave
+  suffix: Genpop Leave, Locked
+  components:
+  - type: AccessReader
+    access: [["GenpopLeave"], ["Security"]]
+
 # Medical
 - type: entity
   parent: DoorElectronics

--- a/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
@@ -1,4 +1,47 @@
 - type: entity
+  id: TurnstileAssembly
+  name: turnstile assembly
+  description: A mechanical door that permits one-way access and prevents tailgating.
+  components:
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/basic.rsi
+    state: "assembly"
+  - type: Physics
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.45"
+        density: 110
+        mask:
+        - FullTileMask
+        layer:
+        - HumanoidBlockLayer
+  - type: Anchorable
+    delay: 2
+  - type: Pullable
+  - type: Transform
+    anchored: true
+    noRot: true
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallicStrong
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 500
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: Construction
+    graph: Turnstile
+    node: assembly
+
+- type: entity
   id: Turnstile
   parent: BaseStructure
   name: turnstile
@@ -55,7 +98,14 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronics ]
   - type: AccessReader
+    containerAccessProvider: board
   - type: Construction
     graph: Turnstile
     node: turnstile
@@ -84,13 +134,15 @@
   parent: Turnstile
   suffix: Genpop Enter
   components:
-  - type: AccessReader
-    access: [["GenpopEnter"], ["Security"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsGenpopEnter ]
 
 - type: entity
   id: TurnstileGenpopLeave
   parent: Turnstile
   suffix: Genpop Leave
   components:
-  - type: AccessReader
-    access: [["GenpopLeave"], ["Security"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsGenpopLeave ]

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/turnstile.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/turnstile.yml
@@ -3,12 +3,11 @@
   start: start
   graph:
   - node: start
-    actions:
-    - !type:DeleteEntity { }
     edges:
-    - to: turnstile
+    - to: assembly
       completed:
-      - !type:SnapToGrid
+      - !type:SetAnchor
+        value: false
       steps:
       - material: MetalRod
         amount: 4
@@ -17,17 +16,87 @@
         amount: 1
         doAfter: 2
 
-  - node: turnstile
-    entity: Turnstile
+  - node: assembly
+    entity: TurnstileAssembly
+    actions:
+    - !type:SnapToGrid {}
+    - !type:SetAnchor {}
     edges:
+    - to: wired
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: Cable
+        amount: 5
+        doAfter: 2.5
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: PartRodMetal1
         amount: 4
-      - !type:DeleteEntity
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 1
+      - !type:DeleteEntity {}
       steps:
       - tool: Welding
-        doAfter: 4.0
+        doAfter: 3
+
+  - node: wired
+    entity: TurnstileAssembly
+    edges:
+    - to: electronics
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - component: DoorElectronics
+        store: board
+        name: construction-graph-component-door-electronics-circuit-board
+        icon:
+          sprite: "Objects/Misc/module.rsi"
+          state: "door_electronics"
+        doAfter: 3
+    - to: assembly
+      completed:
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 5
+      steps:
       - tool: Cutting
-        doAfter: 2.0
+        doAfter: 2.5
+
+  - node: electronics
+    edges:
+    - to: turnstile
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - tool: Screwing
+        doAfter: 2.5
+    - to: wired
+      conditions:
+      - !type:EntityAnchored {}
+      completed:
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
+      steps:
+      - tool: Prying
+        doAfter: 5
+  - node: turnstile
+    entity: Turnstile
+    edges:
+    - to: wired
+      conditions:
+      - !type:EntityAnchored {}
+      completed:
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
+      steps:
+      - tool: Prying
+        doAfter: 5
+


### PR DESCRIPTION
## About the PR

Make the turnstile construction more like doors.

- Metal sheet + Metal rod -> Turnstile assembly
- Anchor the assembly
- Add LV wire -> wired node
- Add door electronics -> electronics node
- Use a screwdriver -> Turnstile (finished) node

## Why / Balance

In the same vein of normalizing machine and computer construction, I believe that turnstiles should be as similar as possible to airlock construction. This also solves the problem (#37225) of re-configuring genpop turnstile access after they have been destroyed or deconstructed, as the door electronics can provide access configuration.

This also increases the effort to deconstruct a turnstyle as they now require a crowbar to pull out the board.

## Technical details

- Turnstile assembly entity has been added, mirroring what has been done with airlock assemblies
- DoorElectronicsGenpop(Enter|Leave) prototypes have been added with accesses pre-configured into door electronics
- Turnstile components have been added to allow a board slot with the access reader
- TurnstileGenpop(Enter|Leave) entities have been changed to contain the proper board in its fill

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

None anticipated, previously mapped `TurnstileGenpopEnter` and `TurnstileGenpopLeave` should work as expected.

**Changelog**
:cl:
- add: Turnstiles now require board electronics, which means access can be configured

