### PR TITLE
Yellowtexting

### DIFF
--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -173,44 +173,42 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                     {
                         agentSummary.AppendLine(objectiveTitle);
                     }
+                    else if (progress > 0.99)
+                    {
+                        agentSummary.AppendLine(Loc.GetString(
+                            "objectives-objective-success",
+                            ("objective", objectiveTitle),
+                            ("progress", (int)(progress * 100)),
+                            ("markupColor", "green")
+                        ));
+                        completedObjectives++;
+                    }
+                    else if (progress <= 0.99 && progress >= 0.5)
+                    {
+                        agentSummary.AppendLine(Loc.GetString(
+                            "objectives-objective-partial-success",
+                            ("objective", objectiveTitle),
+                            ("progress", (int)(progress * 100)),
+                            ("markupColor", "orange")
+                        ));
+                    }
+                    else if (progress < 0.5 && progress > 0)
+                    {
+                        agentSummary.AppendLine(Loc.GetString(
+                            "objectives-objective-partial-failure",
+                            ("objective", objectiveTitle),
+                            ("progress", (int)(progress * 100)),
+                            ("markupColor", "#FF5349")
+                        ));
+                    }
                     else
                     {
-                        switch (progress)
-                        {
-                            case var percentage when percentage > 0.99:
-                                agentSummary.AppendLine(Loc.GetString(
-                                    "objectives-objective-success",
-                                    ("objective", objectiveTitle),
-                                    ("progress", (int)(progress * 100)),
-                                    ("markupColor", "green")
-                                ));
-                                completedObjectives++;
-                                break;
-                            case var percentage when percentage <= 0.99 && percentage >= 0.5:
-                                agentSummary.AppendLine(Loc.GetString(
-                                    "objectives-objective-partial-success",
-                                    ("objective", objectiveTitle),
-                                    ("progress", (int)(progress * 100)),
-                                    ("markupColor", "orange")
-                                ));
-                                break;
-                            case var percentage when percentage < 0.5 && percentage > 0:
-                                agentSummary.AppendLine(Loc.GetString(
-                                    "objectives-objective-partial-failure",
-                                    ("objective", objectiveTitle),
-                                    ("progress", (int)(progress * 100)),
-                                    ("markupColor", "#FF5349")
-                                ));
-                                break;
-                            case var percentage when percentage <= 0:
-                                agentSummary.AppendLine(Loc.GetString(
-                                    "objectives-objective-fail",
-                                    ("objective", objectiveTitle),
-                                    ("progress", (int)(progress * 100)),
-                                    ("markupColor", "red")
-                                ));
-                                break;
-                        }
+                        agentSummary.AppendLine(Loc.GetString(
+                            "objectives-objective-fail",
+                            ("objective", objectiveTitle),
+                            ("progress", (int)(progress * 100)),
+                            ("markupColor", "red")
+                        ));
                     }
                 }
             }

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -173,7 +173,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                     {
                         agentSummary.AppendLine(objectiveTitle);
                     }
-                    else if (progress > 0.99)
+                    else if (progress > 0.99f)
                     {
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-success",
@@ -183,7 +183,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                         ));
                         completedObjectives++;
                     }
-                    else if (progress <= 0.99 && progress >= 0.5)
+                    else if (progress <= 0.99f && progress >= 0.5f)
                     {
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-partial-success",
@@ -192,7 +192,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                             ("markupColor", "orange")
                         ));
                     }
-                    else if (progress < 0.5 && progress > 0)
+                    else if (progress < 0.5f && progress > 0f)
                     {
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-partial-failure",

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -178,8 +178,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-success",
                             ("objective", objectiveTitle),
-                            ("progress", (int)(progress * 100)),
-                            ("markupColor", "green")
+                            ("progress", (int)(progress * 100))
                         ));
                         completedObjectives++;
                     }
@@ -188,8 +187,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-partial-success",
                             ("objective", objectiveTitle),
-                            ("progress", (int)(progress * 100)),
-                            ("markupColor", "orange")
+                            ("progress", (int)(progress * 100))
                         ));
                     }
                     else if (progress < 0.5f && progress > 0f)
@@ -197,8 +195,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-partial-failure",
                             ("objective", objectiveTitle),
-                            ("progress", (int)(progress * 100)),
-                            ("markupColor", "#FF5349")
+                            ("progress", (int)(progress * 100))
                         ));
                     }
                     else
@@ -206,8 +203,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-fail",
                             ("objective", objectiveTitle),
-                            ("progress", (int)(progress * 100)),
-                            ("markupColor", "red")
+                            ("progress", (int)(progress * 100))
                         ));
                     }
                 }

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -178,7 +178,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-success",
                             ("objective", objectiveTitle),
-                            ("progress", (int)(progress * 100))
+                            ("progress", progress)
                         ));
                         completedObjectives++;
                     }
@@ -187,7 +187,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-partial-success",
                             ("objective", objectiveTitle),
-                            ("progress", (int)(progress * 100))
+                            ("progress", progress)
                         ));
                     }
                     else if (progress < 0.5f && progress > 0f)
@@ -195,7 +195,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-partial-failure",
                             ("objective", objectiveTitle),
-                            ("progress", (int)(progress * 100))
+                            ("progress", progress)
                         ));
                     }
                     else
@@ -203,7 +203,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-fail",
                             ("objective", objectiveTitle),
-                            ("progress", (int)(progress * 100))
+                            ("progress", progress)
                         ));
                     }
                 }

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -173,23 +173,44 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                     {
                         agentSummary.AppendLine(objectiveTitle);
                     }
-                    else if (progress > 0.99f)
-                    {
-                        agentSummary.AppendLine(Loc.GetString(
-                            "objectives-objective-success",
-                            ("objective", objectiveTitle),
-                            ("markupColor", "green")
-                        ));
-                        completedObjectives++;
-                    }
                     else
                     {
-                        agentSummary.AppendLine(Loc.GetString(
-                            "objectives-objective-fail",
-                            ("objective", objectiveTitle),
-                            ("progress", (int) (progress * 100)),
-                            ("markupColor", "red")
-                        ));
+                        switch (progress)
+                        {
+                            case var percentage when percentage > 0.99:
+                                agentSummary.AppendLine(Loc.GetString(
+                                    "objectives-objective-success",
+                                    ("objective", objectiveTitle),
+                                    ("progress", (int)(progress * 100)),
+                                    ("markupColor", "green")
+                                ));
+                                completedObjectives++;
+                                break;
+                            case var percentage when percentage <= 0.99 && percentage >= 0.5:
+                                agentSummary.AppendLine(Loc.GetString(
+                                    "objectives-objective-partial-success",
+                                    ("objective", objectiveTitle),
+                                    ("progress", (int)(progress * 100)),
+                                    ("markupColor", "orange")
+                                ));
+                                break;
+                            case var percentage when percentage < 0.5 && percentage > 0:
+                                agentSummary.AppendLine(Loc.GetString(
+                                    "objectives-objective-partial-failure",
+                                    ("objective", objectiveTitle),
+                                    ("progress", (int)(progress * 100)),
+                                    ("markupColor", "#FF5349")
+                                ));
+                                break;
+                            case var percentage when percentage <= 0:
+                                agentSummary.AppendLine(Loc.GetString(
+                                    "objectives-objective-fail",
+                                    ("objective", objectiveTitle),
+                                    ("progress", (int)(progress * 100)),
+                                    ("markupColor", "red")
+                                ));
+                                break;
+                        }
                     }
                 }
             }

--- a/Resources/Locale/en-US/objectives/round-end.ftl
+++ b/Resources/Locale/en-US/objectives/round-end.ftl
@@ -11,9 +11,9 @@ objectives-player-named = [color=White]{$name}[/color]
 objectives-no-objectives = {$custody}{$title} was a {$agent}.
 objectives-with-objectives = {$custody}{$title} was a {$agent} who had the following objectives:
 
-objectives-objective-success = {$objective} | [color={$markupColor}]Success![/color] ({$progress}%)
-objectives-objective-partial-success = {$objective} | [color={$markupColor}]Partial Success![/color] ({$progress}%)
-objectives-objective-partial-failure = {$objective} | [color={$markupColor}]Partial Failure![/color] ({$progress}%)
-objectives-objective-fail = {$objective} | [color={$markupColor}]Failure![/color] ({$progress}%)
+objectives-objective-success = {$objective} | [color=green]Success![/color] ({$progress}%)
+objectives-objective-partial-success = {$objective} | [color=yellow]Partial Success![/color] ({$progress}%)
+objectives-objective-partial-failure = {$objective} | [color=orange]Partial Failure![/color] ({$progress}%)
+objectives-objective-fail = {$objective} | [color=red]Failure![/color] ({$progress}%)
 
 objectives-in-custody = [bold][color=red]| IN CUSTODY | [/color][/bold]

--- a/Resources/Locale/en-US/objectives/round-end.ftl
+++ b/Resources/Locale/en-US/objectives/round-end.ftl
@@ -11,7 +11,9 @@ objectives-player-named = [color=White]{$name}[/color]
 objectives-no-objectives = {$custody}{$title} was a {$agent}.
 objectives-with-objectives = {$custody}{$title} was a {$agent} who had the following objectives:
 
-objectives-objective-success = {$objective} | [color={$markupColor}]Success![/color]
+objectives-objective-success = {$objective} | [color={$markupColor}]Success![/color] ({$progress}%)
+objectives-objective-partial-success = {$objective} | [color={$markupColor}]Partial Success![/color] ({$progress}%)
+objectives-objective-partial-failure = {$objective} | [color={$markupColor}]Partial Failure![/color] ({$progress}%)
 objectives-objective-fail = {$objective} | [color={$markupColor}]Failure![/color] ({$progress}%)
 
 objectives-in-custody = [bold][color=red]| IN CUSTODY | [/color][/bold]

--- a/Resources/Locale/en-US/objectives/round-end.ftl
+++ b/Resources/Locale/en-US/objectives/round-end.ftl
@@ -11,9 +11,9 @@ objectives-player-named = [color=White]{$name}[/color]
 objectives-no-objectives = {$custody}{$title} was a {$agent}.
 objectives-with-objectives = {$custody}{$title} was a {$agent} who had the following objectives:
 
-objectives-objective-success = {$objective} | [color=green]Success![/color] ({$progress}%)
-objectives-objective-partial-success = {$objective} | [color=yellow]Partial Success![/color] ({$progress}%)
-objectives-objective-partial-failure = {$objective} | [color=orange]Partial Failure![/color] ({$progress}%)
-objectives-objective-fail = {$objective} | [color=red]Failure![/color] ({$progress}%)
+objectives-objective-success = {$objective} | [color=green]Success![/color] ({TOSTRING($progress, "P0")})
+objectives-objective-partial-success = {$objective} | [color=yellow]Partial Success![/color] ({TOSTRING($progress, "P0")})
+objectives-objective-partial-failure = {$objective} | [color=orange]Partial Failure![/color] ({TOSTRING($progress, "P0")})
+objectives-objective-fail = {$objective} | [color=red]Failure![/color] ({TOSTRING($progress, "P0")})
 
 objectives-in-custody = [bold][color=red]| IN CUSTODY | [/color][/bold]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the ability to "yellowtext" when you don't quite complete your objectives but don't fail them either.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Redtexting is seen as a big negative thing in the game. You don't max out your objective, you redtext, you feel bad. Seeing the big red screen is quite a sad sight.
The idea of yellowtexting is meant to improve on that a little. You see more positive feedback, even if you mess up your objective. This also lets you make objectives have more "partial" states (such as Kill and Maroon being 50% when you maroon your target but they stay alive)

## Technical details
<!-- Summary of code changes for easier review. -->
ObjectivesSystem displays Partial Success and Partial Failure based on the progress. Done this via adding 2 more else ifs (was a switch statement but with very sus syntax before).
If anyone knows a better way to do this, do tell.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/c033d7e0-33cb-4c6c-9dcd-958ad367ee9c)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added "Yellowtexting" for when you don't quite complete your objectives.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
