### PR TITLE
fix: don't retroactively drain disabled batteries

### DIFF
--- a/Content.Server/PowerCell/PowerCellSystem.Draw.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.Draw.cs
@@ -20,10 +20,11 @@ public sealed partial class PowerCellSystem
             if (!comp.Enabled)
                 continue;
 
-            if (Timing.CurTime < comp.NextUpdateTime)
+            var now = Timing.CurTime;
+            if (now < comp.NextUpdateTime)
                 continue;
 
-            comp.NextUpdateTime += comp.Delay;
+            comp.NextUpdateTime = now + comp.Delay;
 
             if (!TryGetBatteryFromSlot(uid, out var batteryEnt, out var battery, slot))
                 continue;

--- a/Content.Server/PowerCell/PowerCellSystem.Draw.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.Draw.cs
@@ -20,11 +20,10 @@ public sealed partial class PowerCellSystem
             if (!comp.Enabled)
                 continue;
 
-            var now = Timing.CurTime;
-            if (now < comp.NextUpdateTime)
+            if (Timing.CurTime < comp.NextUpdateTime)
                 continue;
 
-            comp.NextUpdateTime = now + comp.Delay;
+            comp.NextUpdateTime += comp.Delay;
 
             if (!TryGetBatteryFromSlot(uid, out var batteryEnt, out var battery, slot))
                 continue;

--- a/Content.Shared/PowerCell/SharedPowerCellSystem.cs
+++ b/Content.Shared/PowerCell/SharedPowerCellSystem.cs
@@ -16,17 +16,10 @@ public abstract class SharedPowerCellSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<PowerCellDrawComponent, MapInitEvent>(OnMapInit);
-
         SubscribeLocalEvent<PowerCellSlotComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<PowerCellSlotComponent, EntInsertedIntoContainerMessage>(OnCellInserted);
         SubscribeLocalEvent<PowerCellSlotComponent, EntRemovedFromContainerMessage>(OnCellRemoved);
         SubscribeLocalEvent<PowerCellSlotComponent, ContainerIsInsertingAttemptEvent>(OnCellInsertAttempt);
-    }
-
-    private void OnMapInit(Entity<PowerCellDrawComponent> ent, ref MapInitEvent args)
-    {
-        QueueUpdate((ent, ent.Comp));
     }
 
     private void OnRejuvenate(EntityUid uid, PowerCellSlotComponent component, RejuvenateEvent args)
@@ -69,15 +62,6 @@ public abstract class SharedPowerCellSystem : EntitySystem
             return;
         _appearance.SetData(uid, PowerCellSlotVisuals.Enabled, false);
         RaiseLocalEvent(uid, new PowerCellChangedEvent(true), false);
-    }
-
-    /// <summary>
-    /// Makes the draw logic update in the next tick.
-    /// </summary>
-    public void QueueUpdate(Entity<PowerCellDrawComponent?> ent)
-    {
-        if (Resolve(ent, ref ent.Comp))
-            ent.Comp.NextUpdateTime = Timing.CurTime;
     }
 
     public void SetDrawEnabled(Entity<PowerCellDrawComponent?> ent, bool enabled)

--- a/Content.Shared/PowerCell/SharedPowerCellSystem.cs
+++ b/Content.Shared/PowerCell/SharedPowerCellSystem.cs
@@ -16,10 +16,17 @@ public abstract class SharedPowerCellSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<PowerCellDrawComponent, MapInitEvent>(OnMapInit);
+
         SubscribeLocalEvent<PowerCellSlotComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<PowerCellSlotComponent, EntInsertedIntoContainerMessage>(OnCellInserted);
         SubscribeLocalEvent<PowerCellSlotComponent, EntRemovedFromContainerMessage>(OnCellRemoved);
         SubscribeLocalEvent<PowerCellSlotComponent, ContainerIsInsertingAttemptEvent>(OnCellInsertAttempt);
+    }
+
+    private void OnMapInit(Entity<PowerCellDrawComponent> ent, ref MapInitEvent args)
+    {
+        ent.Comp.NextUpdateTime = Timing.CurTime + ent.Comp.Delay;
     }
 
     private void OnRejuvenate(EntityUid uid, PowerCellSlotComponent component, RejuvenateEvent args)
@@ -68,6 +75,9 @@ public abstract class SharedPowerCellSystem : EntitySystem
     {
         if (!Resolve(ent, ref ent.Comp, false) || ent.Comp.Enabled == enabled)
             return;
+
+        if (enabled)
+            ent.Comp.NextUpdateTime = Timing.CurTime;
 
         ent.Comp.Enabled = enabled;
         Dirty(ent, ent.Comp);

--- a/Content.Shared/PowerCell/ToggleCellDrawSystem.cs
+++ b/Content.Shared/PowerCell/ToggleCellDrawSystem.cs
@@ -38,7 +38,6 @@ public sealed class ToggleCellDrawSystem : EntitySystem
     {
         var uid = ent.Owner;
         var draw = Comp<PowerCellDrawComponent>(uid);
-        _cell.QueueUpdate((uid, draw));
         _cell.SetDrawEnabled((uid, draw), args.Activated);
     }
 


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
If something that used PowerCellDraw temporarily disabled said draw, once it became re-enabled the system would play catch-up trying to drain the battery for all the time since the component was disabled. This fixes that by setting our next update time to be in the future rather than possibly the past.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I like playing borg on long rounds.


## Technical details
<!-- Summary of code changes for easier review. -->


When `ToggleCellDrawSystem` was extracted in #31392, this issue was worked around for entities with both `ToggleCellDraw` and `PowerCellDraw` by adding a `QueueUpdate` method (which existed in a different form before that PR). Since `NextUpdateTime` should never need changed now, I've removed this, as well as the MapInit that was calling it too.

The issue I primarily was trying to address is that if a borg is being played, but has its mind remove causing its power draw to be disabled, upon return the battery—even if it's a microreactor—will be drained as its power draw is run on every tick, until `Update` catches back up.

I've tested this and everything seems to still work as expected. There's also an alternate solution of moving the `QueueUpdate` call to be within `SetDrawEnabled` but I feel like this makes more sense.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- `SharedPowerCellSystem.QueueUpdate` is removed and no longer needs to be called.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- fix: Borgs in certain circumstances will no-longer draw much more power than they should.