### PR TITLE
Add trailing whitespace check workflow

### DIFF
--- a/.github/workflows/check-trailing-whitespace.yml
+++ b/.github/workflows/check-trailing-whitespace.yml
@@ -1,0 +1,40 @@
+﻿name: Trailing Whitespace Check
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
+
+jobs:
+  build:
+    name: Trailing Whitespace Check
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.2.2
+    - name: Get changed text files
+      id: changed-files
+      uses: tj-actions/changed-files@v46.0.5
+       with:
+         files: |
+           **.cs
+           **.yml
+           **.swsl
+           **.json
+           **.py
+    - name: Check for trailing whitespace
+      env:
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+      run: |
+        has_trailing_whitespace=0
+        for file in ${ALL_CHANGED_FILES}; do
+          echo "Checking $file"
+          if grep -qP '[ \t]+$' "$file"; then
+            echo "::error file=$file::Trailing whitespace found"
+            has_trailing_whitespace=1
+          fi
+        done
+
+        if [ "$has_trailing_whitespace" -eq 1 ]; then
+          echo "Trailing whitespace detected. We recommend using an IDE to prevent this from happening."
+          exit 1
+        fi


### PR DESCRIPTION
## About the PR
Adds a new workflow checking for trailing whitespace in text files, similar to the CRLF check.
This workflow only checks files that have been edited in the corresponding PR, so we don't get one giant merge conflict but can clean it up over time without introducing new cases.

Do not merge until I did some more testing to make sure it works as intended.

## Why / Balance
A lot of contributors add trailing whitespace by accident because they don't use an IDE or use web edits. This usually automatically gets fixed once someone edits the file using an IDE, but each time it messes up the git history and potentially causes merge conflicts.
See https://github.com/space-wizards/space-station-14/pull/36022

## Technical details
Uses https://github.com/marketplace/actions/changed-files
and a simple bash script.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
no formating errors no fun
