### PR TITLE
Cleanup warnings in `SolutionContainerVisualsSystem`

### DIFF
--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -16,6 +16,7 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly ItemSystem _itemSystem = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -49,7 +50,7 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
         if (args.Sprite == null)
             return;
 
-        if (!args.Sprite.LayerMapTryGet(component.Layer, out var fillLayer))
+        if (!_sprite.LayerMapTryGet((uid, args.Sprite), component.Layer, out var fillLayer, false))
             return;
 
         var maxFillLevels = component.MaxFillLevels;
@@ -67,9 +68,9 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
         }
         if (component.Metamorphic)
         {
-            if (args.Sprite.LayerMapTryGet(component.BaseLayer, out var baseLayer))
+            if (_sprite.LayerMapTryGet((uid, args.Sprite), component.BaseLayer, out var baseLayer, false))
             {
-                var hasOverlay = args.Sprite.LayerMapTryGet(component.OverlayLayer, out var overlayLayer);
+                var hasOverlay = _sprite.LayerMapTryGet((uid, args.Sprite), component.OverlayLayer, out var overlayLayer, false);
 
                 if (AppearanceSystem.TryGetData<string>(uid, SolutionContainerVisuals.BaseOverride,
                         out var baseOverride,
@@ -79,35 +80,35 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
 
                     if (reagentProto?.MetamorphicSprite is { } sprite)
                     {
-                        args.Sprite.LayerSetSprite(baseLayer, sprite);
+                        _sprite.LayerSetSprite((uid, args.Sprite), baseLayer, sprite);
                         if (reagentProto.MetamorphicMaxFillLevels > 0)
                         {
-                            args.Sprite.LayerSetVisible(fillLayer, true);
+                            _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, true);
                             maxFillLevels = reagentProto.MetamorphicMaxFillLevels;
                             fillBaseName = reagentProto.MetamorphicFillBaseName;
                             changeColor = reagentProto.MetamorphicChangeColor;
                             fillSprite = sprite;
                         }
                         else
-                            args.Sprite.LayerSetVisible(fillLayer, false);
+                            _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, false);
 
                         if (hasOverlay)
-                            args.Sprite.LayerSetVisible(overlayLayer, false);
+                            _sprite.LayerSetVisible((uid, args.Sprite), overlayLayer, false);
                     }
                     else
                     {
-                        args.Sprite.LayerSetVisible(fillLayer, true);
+                        _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, true);
                         if (hasOverlay)
-                            args.Sprite.LayerSetVisible(overlayLayer, true);
+                            _sprite.LayerSetVisible((uid, args.Sprite), overlayLayer, true);
                         if (component.MetamorphicDefaultSprite != null)
-                            args.Sprite.LayerSetSprite(baseLayer, component.MetamorphicDefaultSprite);
+                            _sprite.LayerSetSprite((uid, args.Sprite), baseLayer, component.MetamorphicDefaultSprite);
                     }
                 }
             }
         }
         else
         {
-            args.Sprite.LayerSetVisible(fillLayer, true);
+            _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, true);
         }
 
         var closestFillSprite = ContentHelpers.RoundToLevels(fraction, 1, maxFillLevels + 1);
@@ -119,25 +120,25 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
 
             var stateName = fillBaseName + closestFillSprite;
             if (fillSprite != null)
-                args.Sprite.LayerSetSprite(fillLayer, fillSprite);
-            args.Sprite.LayerSetState(fillLayer, stateName);
+                _sprite.LayerSetSprite((uid, args.Sprite), fillLayer, fillSprite);
+            _sprite.LayerSetRsiState((uid, args.Sprite), fillLayer, stateName);
 
             if (changeColor && AppearanceSystem.TryGetData<Color>(uid, SolutionContainerVisuals.Color, out var color, args.Component))
-                args.Sprite.LayerSetColor(fillLayer, color);
+                _sprite.LayerSetColor((uid, args.Sprite), fillLayer, color);
             else
-                args.Sprite.LayerSetColor(fillLayer, Color.White);
+                _sprite.LayerSetColor((uid, args.Sprite), fillLayer, Color.White);
         }
         else
         {
             if (component.EmptySpriteName == null)
-                args.Sprite.LayerSetVisible(fillLayer, false);
+                _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, false);
             else
             {
-                args.Sprite.LayerSetState(fillLayer, component.EmptySpriteName);
+                _sprite.LayerSetRsiState((uid, args.Sprite), fillLayer, component.EmptySpriteName);
                 if (changeColor)
-                    args.Sprite.LayerSetColor(fillLayer, component.EmptySpriteColor);
+                    _sprite.LayerSetColor((uid, args.Sprite), fillLayer, component.EmptySpriteColor);
                 else
-                    args.Sprite.LayerSetColor(fillLayer, Color.White);
+                    _sprite.LayerSetColor((uid, args.Sprite), fillLayer, Color.White);
             }
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 19 warnings in `SolutionContainerVisualsSystem`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced obsolete `SpriteComponent` methods with `SpriteSystem` methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Visual solution containers, still containing solutions visually:
<img width="263" alt="Screenshot 2025-05-12 at 1 12 29 PM" src="https://github.com/user-attachments/assets/84d00d78-c66c-44be-a32b-7848d0ce218c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->