### PR TITLE
ssd sleep time setting for dev

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -41,3 +41,4 @@ see_own_notes = true
 [ic]
 random_characters = true
 random_species_weights = ""
+ssd_sleep_time = 3600


### PR DESCRIPTION
## About the PR
Set the SSD sleep time delay on Dev to 60 minutes

**One possible reason to DENY this PR:** it will now be less likely to notice this feature failing. But it is very likely to be spotted on Live instead, and get reported

## Why / Balance
If anyone is testing something related to this, the default 10 minute will already be too long to tolerate, so they will cvar it down to seconds. They will not be impacted by this. On the other hand, I have been told that 10 minutes sometimes gets annoying when doing unrelated things.

## Technical details
Change a single server cvar for dev

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
Not player facing
