### PR TITLE
Cleanup warnings in `TextScreenSystem`

### DIFF
--- a/Content.Client/TextScreen/TextScreenSystem.cs
+++ b/Content.Client/TextScreen/TextScreenSystem.cs
@@ -27,6 +27,7 @@ namespace Content.Client.TextScreen;
 public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsComponent>
 {
     [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     /// <summary>
     ///     Contains char/state Key/Value pairs. <br/>
@@ -89,11 +90,11 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
 
         for (var i = 0; i < screen.RowLength; i++)
         {
-            sprite.LayerMapReserveBlank(TimerMapKey + i);
+            _sprite.LayerMapReserve((uid, sprite), TimerMapKey + i);
             timer.LayerStatesToDraw.Add(TimerMapKey + i, null);
-            sprite.LayerSetRSI(TimerMapKey + i, new ResPath(TextPath));
-            sprite.LayerSetColor(TimerMapKey + i, screen.Color);
-            sprite.LayerSetState(TimerMapKey + i, DefaultState);
+            _sprite.LayerSetRsi((uid, sprite), TimerMapKey + i, new ResPath(TextPath));
+            _sprite.LayerSetColor((uid, sprite), TimerMapKey + i, screen.Color);
+            _sprite.LayerSetRsiState((uid, sprite), TimerMapKey + i, DefaultState);
         }
     }
 
@@ -110,24 +111,23 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
             return;
 
         if (args.AppearanceData.TryGetValue(TextScreenVisuals.Color, out var color) && color is Color)
-            component.Color = (Color) color;
+            component.Color = (Color)color;
 
         // DefaultText: fallback text e.g. broadcast updates from comms consoles
         if (args.AppearanceData.TryGetValue(TextScreenVisuals.DefaultText, out var newDefault) && newDefault is string)
-            component.Text = SegmentText((string) newDefault, component);
+            component.Text = SegmentText((string)newDefault, component);
 
         // ScreenText: currently rendered text e.g. the "ETA" accompanying shuttle timers
         if (args.AppearanceData.TryGetValue(TextScreenVisuals.ScreenText, out var text) && text is string)
         {
-            component.TextToDraw = SegmentText((string) text, component);
+            component.TextToDraw = SegmentText((string)text, component);
             ResetText(uid, component);
             BuildTextLayers(uid, component, args.Sprite);
             DrawLayers(uid, component.LayerStatesToDraw);
         }
 
-        if (args.AppearanceData.TryGetValue(TextScreenVisuals.TargetTime, out var time) && time is TimeSpan)
+        if (args.AppearanceData.TryGetValue(TextScreenVisuals.TargetTime, out var time) && time is TimeSpan target)
         {
-            var target = (TimeSpan) time;
             if (target > _gameTiming.CurTime)
             {
                 var timer = EnsureComp<TextScreenTimerComponent>(uid);
@@ -154,7 +154,7 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
             return;
 
         foreach (var key in timer.LayerStatesToDraw.Keys)
-            sprite.RemoveLayer(key);
+            _sprite.RemoveLayer((uid, sprite), key);
 
         RemComp<TextScreenTimerComponent>(uid);
 
@@ -190,7 +190,7 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
             return;
 
         foreach (var key in component.LayerStatesToDraw.Keys)
-            sprite.RemoveLayer(key);
+            _sprite.RemoveLayer((uid, sprite), key);
 
         component.LayerStatesToDraw.Clear();
 
@@ -198,11 +198,11 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
             for (var i = 0; i < component.RowLength; i++)
             {
                 var key = TextMapKey + row + i;
-                sprite.LayerMapReserveBlank(key);
+                _sprite.LayerMapReserve((uid, sprite), key);
                 component.LayerStatesToDraw.Add(key, null);
-                sprite.LayerSetRSI(key, new ResPath(TextPath));
-                sprite.LayerSetColor(key, component.Color);
-                sprite.LayerSetState(key, DefaultState);
+                _sprite.LayerSetRsi((uid, sprite), key, new ResPath(TextPath));
+                _sprite.LayerSetColor((uid, sprite), key, component.Color);
+                _sprite.LayerSetRsiState((uid, sprite), key, DefaultState);
             }
     }
 
@@ -228,7 +228,8 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
             for (var chr = 0; chr < min; chr++)
             {
                 component.LayerStatesToDraw[TextMapKey + rowIdx + chr] = GetStateFromChar(row[chr]);
-                sprite.LayerSetOffset(
+                _sprite.LayerSetOffset(
+                    (uid, sprite),
                     TextMapKey + rowIdx + chr,
                     Vector2.Multiply(
                         new Vector2((chr - min / 2f + 0.5f) * CharWidth, -rowIdx * component.RowOffset),
@@ -247,18 +248,19 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
         if (!TryComp<SpriteComponent>(uid, out var sprite))
             return;
 
-        string time = TimeToString(
+        var time = TimeToString(
             (_gameTiming.CurTime - timer.Target).Duration(),
             false,
             screen.HourFormat, screen.MinuteFormat, screen.SecondFormat
             );
 
-        int min = Math.Min(time.Length, screen.RowLength);
+        var min = Math.Min(time.Length, screen.RowLength);
 
-        for (int i = 0; i < min; i++)
+        for (var i = 0; i < min; i++)
         {
             timer.LayerStatesToDraw[TimerMapKey + i] = GetStateFromChar(time[i]);
-            sprite.LayerSetOffset(
+            _sprite.LayerSetOffset(
+                (uid, sprite),
                 TimerMapKey + i,
                 Vector2.Multiply(
                     new Vector2((i - min / 2f + 0.5f) * CharWidth, 0f),
@@ -277,7 +279,7 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
             return;
 
         foreach (var (key, state) in layerStates.Where(pairs => pairs.Value != null))
-            sprite.LayerSetState(key, state);
+            _sprite.LayerSetRsiState((uid, sprite), key, state);
     }
 
     public override void Update(float frameTime)
@@ -340,8 +342,8 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
             return null;
 
         // First checks if its one of our special characters
-        if (CharStatePairs.ContainsKey(character.Value))
-            return CharStatePairs[character.Value];
+        if (CharStatePairs.TryGetValue(character.Value, out var value))
+            return value;
 
         // Or else it checks if its a normal letter or digit
         if (char.IsLetterOrDigit(character.Value))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed 13 warnings in `TextScreenSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods with `SpriteSystem` methods.

Also cleaned up a few other (non-warning) things:
- Changed some explicitly-typed variables to `var`.
- Replaced a ContainsKey+Index double-lookup with a TryGetValue.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Text screen still displaying text on a screen:
<img width="351" alt="Screenshot 2025-05-12 at 2 51 48 PM" src="https://github.com/user-attachments/assets/f3bf4191-dce8-480d-b286-6f5b9d27ffd0" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->