### PR TITLE
Fix FTL hyperspace slowdown

### DIFF
--- a/Content.Shared/Friction/TileFrictionController.cs
+++ b/Content.Shared/Friction/TileFrictionController.cs
@@ -5,6 +5,7 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Shuttles.Components;
 using JetBrains.Annotations;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
@@ -14,7 +15,6 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Controllers;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Systems;
-using Content.Shared.Shuttles.Components;
 
 namespace Content.Shared.Friction
 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a check for an FTLComponent in the TileFrictionController, blocking the angular and linear damping from being reset.

## Why / Balance
Any shuttle that started an FTL and was in hyperspace had a slowdown over time, bringing them to a complete stop after about 50 seconds. https://github.com/space-wizards/space-station-14/issues/37138

## Technical details
Added an EntityQuery for an FTLComponent to the TileFrictionController. Before updating the angular dampening or linear dampening, we check if the entity has an FTLComponent, and that FTL-ing entity is travelling. In the tick previous to this, the entity's linear and angular dampening was set to 0f, and this check keeps it at 0f. 

## Media
https://github.com/user-attachments/assets/1aea3fee-ab10-4283-af41-27689dc3d8c4

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Shuttles no longer slowdown during FTL.