### PR TITLE
Cleanup warnings in `EntityStorageVisualizerSystem`

### DIFF
--- a/Content.Client/Storage/Visualizers/EntityStorageVisualizerSystem.cs
+++ b/Content.Client/Storage/Visualizers/EntityStorageVisualizerSystem.cs
@@ -5,6 +5,8 @@ namespace Content.Client.Storage.Visualizers;
 
 public sealed class EntityStorageVisualizerSystem : VisualizerSystem<EntityStorageVisualsComponent>
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -23,7 +25,7 @@ public sealed class EntityStorageVisualizerSystem : VisualizerSystem<EntityStora
         if (!TryComp<SpriteComponent>(uid, out var sprite))
             return;
 
-        sprite.LayerSetState(StorageVisualLayers.Base, comp.StateBaseClosed);
+        _sprite.LayerSetRsiState((uid, sprite), StorageVisualLayers.Base, comp.StateBaseClosed);
     }
 
     protected override void OnAppearanceChange(EntityUid uid, EntityStorageVisualsComponent comp, ref AppearanceChangeEvent args)
@@ -33,41 +35,41 @@ public sealed class EntityStorageVisualizerSystem : VisualizerSystem<EntityStora
             return;
 
         // Open/Closed state for the storage entity.
-        if (args.Sprite.LayerMapTryGet(StorageVisualLayers.Door, out _))
+        if (_sprite.LayerMapTryGet((uid, args.Sprite), StorageVisualLayers.Door, out _, false))
         {
             if (open)
             {
                 if (comp.OpenDrawDepth != null)
-                    args.Sprite.DrawDepth = comp.OpenDrawDepth.Value;
+                    _sprite.SetDrawDepth((uid, args.Sprite), comp.OpenDrawDepth.Value);
 
                 if (comp.StateDoorOpen != null)
                 {
-                    args.Sprite.LayerSetState(StorageVisualLayers.Door, comp.StateDoorOpen);
-                    args.Sprite.LayerSetVisible(StorageVisualLayers.Door, true);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), StorageVisualLayers.Door, comp.StateDoorOpen);
+                    _sprite.LayerSetVisible((uid, args.Sprite), StorageVisualLayers.Door, true);
                 }
                 else
                 {
-                    args.Sprite.LayerSetVisible(StorageVisualLayers.Door, false);
+                    _sprite.LayerSetVisible((uid, args.Sprite), StorageVisualLayers.Door, false);
                 }
 
                 if (comp.StateBaseOpen != null)
-                    args.Sprite.LayerSetState(StorageVisualLayers.Base, comp.StateBaseOpen);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), StorageVisualLayers.Base, comp.StateBaseOpen);
             }
             else
             {
                 if (comp.ClosedDrawDepth != null)
-                    args.Sprite.DrawDepth = comp.ClosedDrawDepth.Value;
+                    _sprite.SetDrawDepth((uid, args.Sprite), comp.ClosedDrawDepth.Value);
 
                 if (comp.StateDoorClosed != null)
                 {
-                    args.Sprite.LayerSetState(StorageVisualLayers.Door, comp.StateDoorClosed);
-                    args.Sprite.LayerSetVisible(StorageVisualLayers.Door, true);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), StorageVisualLayers.Door, comp.StateDoorClosed);
+                    _sprite.LayerSetVisible((uid, args.Sprite), StorageVisualLayers.Door, true);
                 }
                 else
-                    args.Sprite.LayerSetVisible(StorageVisualLayers.Door, false);
+                    _sprite.LayerSetVisible((uid, args.Sprite), StorageVisualLayers.Door, false);
 
                 if (comp.StateBaseClosed != null)
-                    args.Sprite.LayerSetState(StorageVisualLayers.Base, comp.StateBaseClosed);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), StorageVisualLayers.Base, comp.StateBaseClosed);
             }
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 12 warnings in `EntityStorageVisualizerSystem.cs`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods and properties with `SpriteSystem` methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Entity storage visualizers still visually storing entities:
<img width="214" alt="Screenshot 2025-05-12 at 4 59 22 PM" src="https://github.com/user-attachments/assets/2b0a87dd-3b35-4e20-a821-1a3bed87b3fd" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->