### PR TITLE
Dragons no longer round remove cyborgs when devouring them

### DIFF
--- a/Content.Server/Devour/DevourSystem.cs
+++ b/Content.Server/Devour/DevourSystem.cs
@@ -4,12 +4,14 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Devour;
 using Content.Shared.Devour.Components;
 using Content.Shared.Humanoid;
+using Content.Shared.Silicons.Borgs.Components;
 
 namespace Content.Server.Devour;
 
 public sealed class DevourSystem : SharedDevourSystem
 {
     [Dependency] private readonly BloodstreamSystem _bloodstreamSystem = default!;
+    [Dependency] private readonly BodySystem _body = default!;
 
     public override void Initialize()
     {
@@ -19,31 +21,55 @@ public sealed class DevourSystem : SharedDevourSystem
         SubscribeLocalEvent<DevourerComponent, BeingGibbedEvent>(OnGibContents);
     }
 
-    private void OnDoAfter(EntityUid uid, DevourerComponent component, DevourDoAfterEvent args)
+    private void OnDoAfter(Entity<DevourerComponent> entity, ref DevourDoAfterEvent args)
     {
         if (args.Handled || args.Cancelled)
             return;
 
-        var ichorInjection = new Solution(component.Chemical, component.HealRate);
-
-        if (component.FoodPreference == FoodPreference.All ||
-            (component.FoodPreference == FoodPreference.Humanoid && HasComp<HumanoidAppearanceComponent>(args.Args.Target)))
+        // Heal the devourer if the target is one of its favored foods.
+        if (entity.Comp.FoodPreference == FoodPreference.All ||
+            (entity.Comp.FoodPreference == FoodPreference.Humanoid &&
+             HasComp<HumanoidAppearanceComponent>(args.Args.Target)))
         {
-            if (component.ShouldStoreDevoured && args.Args.Target is not null)
+            var ichorInjection = new Solution(entity.Comp.Chemical, entity.Comp.HealRate);
+            _bloodstreamSystem.TryAddToChemicals(entity, ichorInjection);
+        }
+
+        // Either put the entity into the devourer's stomach or delete it.
+        if (args.Args.Target is { } target)
+        {
+            InsertEntityToDevourerStomachOrDelete(entity, target);
+        }
+
+        _audioSystem.PlayPvs(entity.Comp.SoundDevour, entity);
+    }
+
+    private void InsertEntityToDevourerStomachOrDelete(DevourerComponent devourer, EntityUid target)
+    {
+        if (devourer.ShouldStoreDevoured)
+        {
+            // Humanoids go into the stomach entirely
+            if (HasComp<HumanoidAppearanceComponent>(target))
             {
-                ContainerSystem.Insert(args.Args.Target.Value, component.Stomach);
+                ContainerSystem.Insert(target, devourer.Stomach);
+                return;
             }
-            _bloodstreamSystem.TryAddToChemicals(uid, ichorInjection);
+
+            // Borgs get gibbed and their brain goes in the stomach
+            if (TryComp<BorgChassisComponent>(target, out var borg))
+            {
+                if (borg.BrainEntity is { } brain)
+                {
+                    ContainerSystem.Insert(brain, devourer.Stomach);
+                }
+                _body.GibBody(target);
+
+                return;
+            }
         }
 
-        //TODO: Figure out a better way of removing structures via devour that still entails standing still and waiting for a DoAfter. Somehow.
-        //If it's not human, it must be a structure
-        else if (args.Args.Target != null)
-        {
-            QueueDel(args.Args.Target.Value);
-        }
-
-        _audioSystem.PlayPvs(component.SoundDevour, uid);
+        // Everything else gets deleted.
+        QueueDel(target);
     }
 
     private void OnGibContents(EntityUid uid, DevourerComponent component, ref BeingGibbedEvent args)
@@ -56,4 +82,3 @@ public sealed class DevourSystem : SharedDevourSystem
         ContainerSystem.EmptyContainer(component.Stomach);
     }
 }
-


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Dragons no longer round remove cyborgs when devouring them, because now the cyborg body gets gibbed and the brain goes in the dragon

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The number of times I have been round removed because a dragon ate me is greater than four, and my poor cyborgsonas deserve better.

## Technical details
<!-- Summary of code changes for easier review. -->
More or less just added a special case to devouring for borgs.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Small, so I didn't record anything, but lemme know if you want proof and I can provide it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Cyborgs are no longer literally deleted when devoured by a dragon, round-removing the cyborg player. Instead, their chassis is destroyed and their brain goes in the dragon's stomach.
