### PR TITLE
Cleanup warnings in `GravitySystem`

### DIFF
--- a/Content.Client/Gravity/GravitySystem.cs
+++ b/Content.Client/Gravity/GravitySystem.cs
@@ -7,6 +7,8 @@ namespace Content.Client.Gravity;
 public sealed partial class GravitySystem : SharedGravitySystem
 {
     [Dependency] private readonly AppearanceSystem _appearanceSystem = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -26,34 +28,34 @@ public sealed partial class GravitySystem : SharedGravitySystem
         {
             if (comp.SpriteMap.TryGetValue(state, out var spriteState))
             {
-                var layer = args.Sprite.LayerMapGet(GravityGeneratorVisualLayers.Base);
-                args.Sprite.LayerSetState(layer, spriteState);
+                var layer = _sprite.LayerMapGet((uid, args.Sprite), GravityGeneratorVisualLayers.Base);
+                _sprite.LayerSetRsiState((uid, args.Sprite), layer, spriteState);
             }
         }
 
         if (_appearanceSystem.TryGetData<float>(uid, PowerChargeVisuals.Charge, out var charge, args.Component))
         {
-            var layer = args.Sprite.LayerMapGet(GravityGeneratorVisualLayers.Core);
+            var layer = _sprite.LayerMapGet((uid, args.Sprite), GravityGeneratorVisualLayers.Core);
             switch (charge)
             {
                 case < 0.2f:
-                    args.Sprite.LayerSetVisible(layer, false);
+                    _sprite.LayerSetVisible((uid, args.Sprite), layer, false);
                     break;
                 case >= 0.2f and < 0.4f:
-                    args.Sprite.LayerSetVisible(layer, true);
-                    args.Sprite.LayerSetState(layer, comp.CoreStartupState);
+                    _sprite.LayerSetVisible((uid, args.Sprite), layer, true);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), layer, comp.CoreStartupState);
                     break;
                 case >= 0.4f and < 0.6f:
-                    args.Sprite.LayerSetVisible(layer, true);
-                    args.Sprite.LayerSetState(layer, comp.CoreIdleState);
+                    _sprite.LayerSetVisible((uid, args.Sprite), layer, true);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), layer, comp.CoreIdleState);
                     break;
                 case >= 0.6f and < 0.8f:
-                    args.Sprite.LayerSetVisible(layer, true);
-                    args.Sprite.LayerSetState(layer, comp.CoreActivatingState);
+                    _sprite.LayerSetVisible((uid, args.Sprite), layer, true);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), layer, comp.CoreActivatingState);
                     break;
                 default:
-                    args.Sprite.LayerSetVisible(layer, true);
-                    args.Sprite.LayerSetState(layer, comp.CoreActivatedState);
+                    _sprite.LayerSetVisible((uid, args.Sprite), layer, true);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), layer, comp.CoreActivatedState);
                     break;
             }
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 12 warnings in (client) `GravitySystem`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods with `SpriteSystem` methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Clientside gravity visuals still working:

https://github.com/user-attachments/assets/e931d690-385f-45c7-a5c4-7dbbaaeb1a12

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->