### PR TITLE
Attributions checking in CI for PRs

### DIFF
--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -33,12 +33,7 @@ jobs:
     - name: Get changed files
       uses: tj-actions/changed-files@v45
       id: changed-files
-    - name: List all changed files
-      env:
-        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-      run: |
-        for file in ${ALL_CHANGED_FILES}; do
-          echo "$file" >> ${{ runner.temp }}/validate-rga-filter.txt
-        done
+      with:
+        write_output_files: true
     - name: Validate RGA attribution
-      run: python3 Tools/rga_check.py -i "" ${{ runner.temp }}/validate-rga-filter.txt
+      run: python3 Tools/rga_check.py -i "" cat .github/outputs/all_changed_and_modified_files.txt

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -1,14 +1,17 @@
-name: RGA schema validator
+name: RGA schema and attribution validator
 on:
   push:
     branches: [ master, staging, stable ]
   merge_group:
   pull_request:
-    types: [ opened, reopened, synchronize, ready_for_review ]
+    paths:
+      - 'Resources/**'
+      - 'Tools/rga_check.py'
+      - 'RobustToolbox/**'
 
 jobs:
   yaml-schema-validation:
-    name: YAML RGA schema validator
+    name: YAML RGA schema and attribution validator
     if: github.actor != 'PJBot' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
@@ -17,9 +20,25 @@ jobs:
       run: git submodule update --init
     - name: Pull engine updates
       uses: space-wizards/submodule-dependency@v0.1.5
-    - uses: PaulRitter/yaml-schema-validator@v1
+    - name: Validate RGA schema
+      uses: PaulRitter/yaml-schema-validator@v1
       with:
         schema: RobustToolbox/Schemas/rga.yml
         path_pattern: .*attributions.ya?ml$
         validators_path: RobustToolbox/Schemas/rga_validators.py
         validators_requirements: RobustToolbox/Schemas/rga_requirements.txt
+    - name: Install Python dependencies
+      run: |
+        pip3 install --ignore-installed --user pyyaml
+    - name: Get changed files
+      uses: tj-actions/changed-files@v45
+      id: changed-files
+    - name: List all changed files
+      env:
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+      run: |
+        for file in ${ALL_CHANGED_FILES}; do
+          echo "$file" >> ${{ runner.temp }}/validate-rga-filter.txt
+        done
+    - name: Validate RGA attribution
+      run: python3 Tools/rga_check.py -i "" ${{ runner.temp }}/validate-rga-filter.txt

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -35,5 +35,6 @@ jobs:
       id: changed-files
       with:
         write_output_files: true
+    # Does this include deleted files?
     - name: Validate RGA attribution
       run: python3 Tools/rga_check.py -i "" cat .github/outputs/all_changed_and_modified_files.txt

--- a/Resources/licensing.yml
+++ b/Resources/licensing.yml
@@ -1,0 +1,27 @@
+# Licensing configuration file
+
+# Used by `Tools/rga_check.py` for making sure that all assets have attribution, valid licenses,
+# that custom licenses have their files properly recorded, and various other asset compliance checks
+
+
+# Flag that designates the project as non-commercial and stops the script from screaming about license violation
+# Make sure to flip this off if you're unsure about commerciality of your project
+# This is purely for own checking of assets in your project
+project_is_non_commercial_and_not_for_profit: true
+
+
+# Checks to ignore for running the script without other parameters
+# Useful if you want to ensure linting in CI, but can't turn on full compliance checking yet
+# See ValidationFailure enum for values
+ignore_checks:
+- SOURCE_UNKNOWN
+- UNATTRIBUTED
+
+
+# If you want to make sure certain licenses are treated as invalid even though the project is non-commercial
+# invalid_licenses:
+# - "WTFPL" # Not actually allowed by the rga_validator check, but here as an example
+# - "CC-BY-NC-3.0"
+# - "CC-BY-NC-4.0"
+# - "CC-BY-NC-SA-3.0"
+# - "CC-BY-NC-SA-4.0"

--- a/Resources/licensing.yml
+++ b/Resources/licensing.yml
@@ -7,19 +7,92 @@
 # Flag that designates the project as non-commercial and stops the script from screaming about license violation
 # Make sure to flip this off if you're unsure about commerciality of your project
 # This is purely for own checking of assets in your project
-project_is_non_commercial_and_not_for_profit: true
+projectIsNonCommercial: true
 
 
 # Checks to ignore for running the script without other parameters
 # Useful if you want to ensure linting in CI, but can't turn on full compliance checking yet
 # See ValidationFailure enum for values
-ignore_checks:
+checksIgnored:
 - SOURCE_UNKNOWN
 - UNATTRIBUTED
+- FILE_ATTRIBUTIONS_MISSING
+- LICENSE_CUSTOM_UNCLARIFIED
 
+
+# HTTP/HTTPS doesn't matter here
+# Use "url" or "urls" keys to add a single or multiple sources. Don't combine all similar sources together though
+# "reason" field - describes why the source should be accepted or rejected
+# Keep this list in order from least to most specific, as acceptance/rejection can be overridden by more specific source later
+sources:
+- url: https://github.com/space-wizards/space-station-14
+  reason: "Used as a catch-all for contributions"
+  licenses: [ "*" ]
+- url: https://freesound.org/
+  reason: "Well-known site that actively takes down license violating assets"
+  licenses: [ "*" ]
+- urls: [ https://youtube.com, https://youtu.be ]
+  reason: "Generally invalid as a source due to many channels uploading assets without license attached"
+  reject: true
+- url: https://github.com/goonstation/goonstation
+  reason: "Long running codebase, previously closed source, assumed to validate assets thoroughly"
+  licenses: [ CC-BY-NC-SA-3.0 ]
+
+mimetypesAsset:
+  - image/png
+  - image/webp
+  - image/svg+xml
+  - image/vnd.microsoft.icon
+  - audio/ogg
+  - audio/x-sf2 # Made up again
+  # These have actual license files lying nearby, and RGA should point at it
+  - font/otf
+  - font/ttf
+
+mimetypesIgnore:
+  - application/json
+  - application/toml
+  - text/xml
+  - text/markdown
+  - text/plain
+  # just making shit up here
+  - application/vnd.space-wizards.shader
+  - application/vnd.mozilla.fluent
+
+# YAML file is not orphaned if the first path fragment matches something in this array
+yamlPaths:
+  # Dirs
+  - "Changelog"
+  - "Credits"
+  - "IgnoredPrototypes"
+  - "Maps"
+  - "Prototypes"
+  # Files
+  - "clientCommandPerms.yml"
+  - "engineCommandPerms.yml"
+  - "keybinds.yml"
+  - "licensing.yml"
+  - "manifest.yml"
+  - "mapping_actions.yml"
+  - "migration.yml"
+  - "toolshedEngineCommandPerms.yml"
+
+mimetypes:
+  - type: application/yaml
+    extensions: [ .yaml, .yml ]
+    iana: true # Is it on https://www.iana.org/assignments/media-types/media-types.xhtml
+  - type: application/toml
+    extensions: [ .toml ]
+    iana: true
+  - type: application/vnd.mozilla.fluent
+    extensions: [ .ftl ]
+  - type: application/vnd.space-wizards.shader
+    extensions: [ .swsl ]
+  - type: audio/x-sf2
+    extensions: [ .sf2 ]
 
 # If you want to make sure certain licenses are treated as invalid even though the project is non-commercial
-# invalid_licenses:
+# licensesReject:
 # - "WTFPL" # Not actually allowed by the rga_validator check, but here as an example
 # - "CC-BY-NC-3.0"
 # - "CC-BY-NC-4.0"

--- a/Tools/rga_check.py
+++ b/Tools/rga_check.py
@@ -251,8 +251,16 @@ class LicensingScan:
     def filter(self, filter_list: set[str]):
         self.filtered = True
 
-        # This isn't great but it's hard to do a set intersect between entirely different types?
-        self.assets = [x for x in self.assets if str(x) in filter_list]
+        # Make sure we don't annoy people when they're adding files, but do annoy if they're working on attributions stuff
+        # Though, someone working on replacing files... well, they could run this manually? Hm.
+        if all(f.endswith("/attributions.yml") for f in filter_list):
+            attribution_files = [str(Path(x).parent) for x in filter_list if x.endswith("/attributions.yml")]
+
+            # This isn't great but it's hard to do a set intersect between entirely different types?
+            self.assets = [x for x in self.assets if str(x) in filter_list or str(x.parent) in attribution_files]
+        else:
+            self.assets = [x for x in self.assets if str(x) in filter_list]
+
         self.attributions = [x for x in self.attributions if str(x) in filter_list]
         return (len(self.assets), len(self.attributions))
 

--- a/Tools/rga_check.py
+++ b/Tools/rga_check.py
@@ -1,10 +1,10 @@
 import argparse
-from dataclasses import dataclass
 import mimetypes
 import sys
+import urllib.parse as urlparse
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any
 
 import yaml
 
@@ -14,36 +14,40 @@ class ValidationFailure(Enum):
     UNKNOWN = auto()
     # YAML files that exist outside of the dedicated directories, and don't seem to be associated with any data
     # Most likely just files that have a typo in their name
-    ORPHANED = auto()
+    FILE_ORPHANED_YAML = auto()
     ### attributions.yml failures
     # A value within `files` array is invalid in some way
-    INVALID_FILE_ENTRY = auto()
+    FILE_ENTRY_INVALID = auto()
     # License is set as "Custom" but has no clarification whether or not the assets can be used commercially
-    CUSTOM_LICENSE_UNCLARIFIED = auto()
+    LICENSE_CUSTOM_UNCLARIFIED = auto()
+    # TODO: License is "custom" and the custom license file is missing
+    LICENSE_CUSTOM_MISSING = auto()
     # License prohibits non-commercial use, but the licensing configuration or flags ask for checking that assets are okay to use
-    NON_COMMERCIAL_LICENSE_VIOLATION = auto()
+    LICENSE_VIOLATION_NON_COMMERCIAL = auto()
     # License was explicitly listed as invalid in the config
-    LICENSE_INVALID = auto()
+    LICENSE_REJECTED = auto()
     # Entry uses a source that's not been vetted as valid. Most applicable to audio files
     SOURCE_UNKNOWN = auto()
     # The source is known to use specific licenses, but the attribution entry uses another
     SOURCE_LICENSE_MISMATCH = auto()
+    # The source is known and is configured to reject
+    SOURCE_REJECTED = auto()
     # Attribution describes an asset that is missing. Most likely a typo, or reference to now deleted asset
     ASSET_MISSING = auto()
     # Asset has already been described by another entry. Most likely a failure to increment numbered files during copy-pasting
     ASSET_DUPLICATE_ATTRIBUTION = auto()
     ### Other validations
     # Asset exists but there's no attributions.yml file associated with it
-    ATTRIBUTIONS_YML_MISSING = auto()
+    FILE_ATTRIBUTIONS_MISSING = auto()
     ### The entire reason for this script to exist
     # Asset has no attribution on the record
     UNATTRIBUTED = auto()
 
-def validation_enum(validations: str):
+def string_to_enum(enum_class: Enum, value: str):
     try:
-        separated = set([ValidationFailure[v] for v in validations.split(",")])
+        separated = set([enum_class[v] for v in value.split(",")])
     except KeyError as ex:
-        raise argparse.ArgumentTypeError(f"Invalid validation enum value - \"{ex.args[0]}\"")
+        raise argparse.ArgumentTypeError(f"Invalid {enum_class.__name__} enum value - \"{ex.args[0]}\"")
     return separated
 
 def existing_path(path: str):
@@ -85,66 +89,6 @@ class SingleMetavarHelpFormatter(argparse.HelpFormatter):
 
         return (", ".join(action.option_strings) + nargs_desc).ljust(20)
 
-ignore_mimetypes = [
-    "application/json",
-    "application/toml",
-    "text/xml",
-    "text/markdown",
-    "text/plain",
-    # just making shit up here
-    "application/vnd.space-wizards.shader",
-    "application/vnd.mozilla.fluent",
-]
-
-asset_mimetypes = [
-    "image/png",
-    "image/webp",
-    "image/svg+xml",
-    "image/vnd.microsoft.icon",
-    "audio/ogg",
-    "audio/x-sf2", # Made up again
-    # (Some of) These have actual license files lying nearby, but... yeah
-    "font/otf",
-    "font/ttf",
-]
-
-yaml_paths = [
-    # Dirs
-    "Changelog",
-    "Credits",
-    "IgnoredPrototypes",
-    "Maps",
-    "Prototypes",
-    # Files
-    "clientCommandPerms.yml",
-    "engineCommandPerms.yml",
-    "keybinds.yml",
-    "licensing.yml",
-    "manifest.yml",
-    "mapping_actions.yml",
-    "migration.yml",
-    "toolshedEngineCommandPerms.yml",
-]
-
-# List them in a way that more specific paths is before the more general one
-
-source_validation = [
-    ("https://freesound.org/", [
-        "CC-BY-3.0",
-        "CC-BY-4.0",
-        "CC-BY-SA-3.0",
-        "CC-BY-SA-4.0",
-        "CC-BY-NC-3.0",
-        "CC-BY-NC-4.0",
-        "CC-BY-NC-SA-3.0",
-        "CC-BY-NC-SA-4.0",
-        "CC0-1.0",
-        "Custom" # because sampling was not added to list of valid licenses elsewhere yay
-    ]),
-    ("https://github.com/space-wizards/space-station-14", "*"),
-    ("https://github.com/goonstation/goonstation", "CC-BY-NC-SA-3.0")
-]
-
 # Should be a CLI flag
 list_unattributed_details = True
 
@@ -158,52 +102,134 @@ class ValidationFailureDetails:
         pass
 
     def __repr__(self):
-        return f"ValidationFailureDetails({self.affected_data}, {self.relevant_filepath})"
+        return f"ValidationFailureDetails(\"{self.affected_data}\", {self.relevant_filepath})"
 
     def __str__(self):
+        if " " in self.affected_data:
+            return f"{self.relevant_filepath}: \"{self.affected_data}\""
         return f"{self.relevant_filepath}: {self.affected_data}"
 
 validation_failure_names = {
     ValidationFailure.UNKNOWN: "Unknown files",
-    ValidationFailure.ORPHANED: "Orphaned YAML files",
-    ValidationFailure.INVALID_FILE_ENTRY: "Invalid file entries",
-    ValidationFailure.CUSTOM_LICENSE_UNCLARIFIED: "Assets with custom license without commercial use clarification flag",
-    ValidationFailure.NON_COMMERCIAL_LICENSE_VIOLATION: "VIOLATION OF A NON-COMMERCIAL LICENSE",
-    ValidationFailure.LICENSE_INVALID: "License configured as invalid",
+    ValidationFailure.FILE_ORPHANED_YAML: "Orphaned YAML files",
+    ValidationFailure.FILE_ENTRY_INVALID: "Invalid file entries",
+    ValidationFailure.LICENSE_CUSTOM_UNCLARIFIED: "Assets with custom license without commercial use clarification flag",
+    ValidationFailure.LICENSE_CUSTOM_MISSING: "Assets with custom license missing the license file",
+    ValidationFailure.LICENSE_VIOLATION_NON_COMMERCIAL: "VIOLATION OF A NON-COMMERCIAL LICENSE",
+    ValidationFailure.LICENSE_REJECTED: "License rejected as per configuration",
     ValidationFailure.SOURCE_UNKNOWN: "Source is not known to be valid",
     ValidationFailure.SOURCE_LICENSE_MISMATCH: "Source license usage doesn't match",
+    ValidationFailure.SOURCE_REJECTED: "Source rejected as per configuration",
     ValidationFailure.ASSET_MISSING: "Missing (or misspelt) assets",
-    ValidationFailure.ASSET_DUPLICATE_ATTRIBUTION: "Assets described by different attribution entries",
-    ValidationFailure.ATTRIBUTIONS_YML_MISSING: "Missing (or misspelt) attributions.yml files",
+    ValidationFailure.ASSET_DUPLICATE_ATTRIBUTION: "Assets described by multiple attribution entries",
+    ValidationFailure.FILE_ATTRIBUTIONS_MISSING: "Missing (or misspelt) attributions.yml files",
     ValidationFailure.UNATTRIBUTED: "Unattributed assets",
 }
 
-mimetypes.add_type("application/yaml", ".yaml")
-mimetypes.add_type("application/toml", ".toml")
-mimetypes.add_type("application/vnd.mozilla.fluent", ".ftl", False)
-mimetypes.add_type("application/vnd.space-wizards.shader", ".swsl", False)
-mimetypes.add_type("audio/x-sf2", ".sf2", False)
+class SourceStatus(Enum):
+    NOT_FOUND = auto()
+    # Aka "skip"
+    NOT_APPLICABLE = auto()
+    REJECTED = auto()
+    ACCEPTED = auto()
+    LICENSE_MISMATCH = auto()
+    # When the source is valid but the attribution format is wrong (not specific enough, etc)
+    MISFORMATTED = auto()
 
-mimetypes.suffix_map[".yml"] = ".yaml"
+class LicensingSource:
+    """Class for matching sources against and figuring out """
+
+    urls: list[urlparse.ParseResult]
+    licenses: list[str]
+    licenses_wildcard: bool = False
+    reject_source: bool = False
+
+    def __init__(self, yaml_data: dict[Any]):
+        if not isinstance(yaml_data, dict):
+            raise ValueError("Licensing source is not a dict")
+        yaml_urls: list[str] = yaml_data.get("urls", list())
+        yaml_urls.append(yaml_data.get("url", None))
+        if len(yaml_urls) == 0:
+            raise ValueError("Licensing source has no URLs defined")
+        self.urls = [ urlparse.urlparse(s) for s in yaml_urls ]
+        yaml_licenses: list[str] = [ x.strip() for x in yaml_data.get("licenses", list()) ]
+        if "*" in yaml_licenses:
+            self.licenses_wildcard = True
+        self.licenses = [ x for x in yaml_licenses if x != "*" ]
+        self.reject_source = yaml_data.get("reject", False)
+
+    def source_match(self, source: str) -> bool:
+        source_url = urlparse.urlparse(source)
+        for url in self.urls:
+            if source_url.netloc != url.netloc:
+                continue
+            if not source_url.path.startswith(url.path):
+                continue
+            return True
+        return False
+
+    def validate(self, attribution: dict[str]) -> SourceStatus:
+        if not self.source_match(attribution["source"]):
+            return SourceStatus.NOT_APPLICABLE
+        if self.reject_source:
+            return SourceStatus.REJECTED
+        if self.licenses_wildcard:
+            return SourceStatus.ACCEPTED
+        if attribution["license"] not in self.licenses:
+            return SourceStatus.LICENSE_MISMATCH
+        return SourceStatus.ACCEPTED
 
 class LicensingConfig:
     # Assume the worst and most strict case for this stuff always
-    non_commercial = False
+    non_commercial: bool = False
     ignored_validation: set[ValidationFailure]
-    invalid_licenses: list[str]
+    reject_licenses: list[str]
+
+    sources: list[LicensingSource] = []
+
+    mimetypes_ignore: list[str]
+    mimetypes_asset: list[str]
+    yaml_paths: list[str]
+
     list_unattributed_stats: bool = False
 
-    def __init__(self, config_data: dict[Any]):
-        if not isinstance(config_data, dict):
-            raise ValueError("Configuration file \"licensing.yml\" is invalid, check the syntax!")
-        self.non_commercial = config_data.get("project_is_non_commercial_and_not_for_profit", False)
-        ignoring = config_data.get("ignore_checks", list())
-        self.ignored_validation = set([ValidationFailure[v] for v in ignoring])
-        self.invalid_licenses = config_data.get("invalid_licenses", [])
+    def __init__(self, source: str  | Path | dict[str, Any]):
+        if isinstance(source, str):
+            source = Path(source)
+        if isinstance(source, Path):
+            if source.is_dir:
+                source = source / "licensing.yml"
+            if not source.exists:
+                raise ValueError(f"Configuration file does not exist at path \"{source}\"")
+            with source.open() as handle:
+                source = yaml.safe_load(handle)
+        if not isinstance(source, dict):
+            raise ValueError("Configuration file is invalid, check the syntax!")
 
+        self.non_commercial = source.get("projectIsNonCommercial", False)
+        ignoring = source.get("checksIgnored", list())
+        self.ignored_validation = set([ValidationFailure[v] for v in ignoring])
+        self.reject_licenses = source.get("licensesReject", [])
+
+        self.mimetypes_ignore = source.get("mimetypesIgnore", [])
+        self.mimetypes_asset = source.get("mimetypesAsset", [])
+        self.yaml_paths = source.get("yamlPaths", [])
+
+        for entry in source.get("mimetypes", {}):
+            extensions: list[str] = entry["extensions"]
+            first = extensions.pop(0)
+            mimetypes.add_type(entry["type"], first, entry.get("iana", False))
+            for ext in extensions:
+                mimetypes.suffix_map[ext] = first
+
+        for entry in source.get("sources", []):
+            self.sources.append(LicensingSource(entry))
 
 class LicensingScan:
     """Storage class for all files relevant to licensing that were found in a directory scan"""
+
+    config: LicensingConfig
+
     # Asset files
     assets: list[Path] = []
     # Attribution files, to be processed for matching with asset files
@@ -215,21 +241,33 @@ class LicensingScan:
 
     path: Path = None
 
-    def __init__(self, path: str | Path, ):
+    def __init__(self, path: str | Path, config: LicensingConfig):
         if isinstance(path, str):
             path = Path(path)
         self.path = path
+        self.config = config
+
+    def filter(self, filter: set[Path]):
+        self.assets = filter.intersection(self.assets)
 
     def run(self):
         for path in self.path.rglob("*"):
             if path.is_dir():
                 continue
 
+            if path.suffix == "":
+                print(path)
+
             if path.name == "attributions.yml":
                 self.attributions.append(path)
                 continue
 
             (ext_mime, _) = mimetypes.guess_type(path, False)
+
+            # RSI image files can have path like "blahblah.rsi/.png"
+            # Shrug
+            if path.name.startswith("."):
+                (ext_mime, _) = mimetypes.guess_type("empty" + path.name, False)
 
             if ext_mime is None and path.name.lower() == "readme":
                 ext_mime = "text/plain"
@@ -238,11 +276,11 @@ class LicensingScan:
                 self.unknown.append(path)
                 continue
 
-            if ext_mime in ignore_mimetypes:
+            if ext_mime in self.config.mimetypes_ignore:
                 continue
 
             if ext_mime == "application/yaml":
-                if path.parts[1] in yaml_paths:
+                if path.parts[1] in config.yaml_paths:
                     continue
                 # It's a semi-automatically generated file, or metadata for something
                 # TODO: make a better system for these
@@ -256,14 +294,16 @@ class LicensingScan:
             if path.name.endswith("dpi.png") and path.with_suffix("").with_suffix("").exists():
                 continue
 
-            if ext_mime not in asset_mimetypes:
+            if ext_mime not in self.config.mimetypes_asset:
                 print("UNKNOWN OR INVALID MIMETYPE: ", path, ext_mime)
 
-            # Ignore things that are gitignored
+            # Ignore things that are gitignored, yeah it's a hack
+            # Feel free to improve. BUT! licensing.yml should not have an easy "ignore path" entry
+            # That's too prone to abuse
             if path.parts[1] == "MapImages":
                 continue
 
-            # This is to be checked by a dedicated RSI validation script
+            # TODO: Checking RSI attribution (RGA too?)
             part_of_rsi = False
             for part in path.parts:
                 if (part.endswith(".rsi")):
@@ -289,27 +329,21 @@ class LicensingValidation:
 
     failures: dict[ValidationFailure, list[str | Path | ValidationFailureDetails]] = {}
 
-    def __init__(self, scan: LicensingScan):
+    def __init__(self, scan: LicensingScan, config: LicensingConfig):
         self.scan = scan
+        self.config = config
 
-        if (scan.path / "licensing.yml").exists():
-            with (scan.path / "licensing.yml").open() as handle:
-                licensing_config_data = yaml.safe_load(handle)
-                self.config = LicensingConfig(licensing_config_data)
-        else:
-            self.config = LicensingConfig({})
-
-    def record_failure(self, failure_type: ValidationFailure, files: list[str] | str, relevant_filepath: str = None):
+    def record_failure(self, failure_type: ValidationFailure, files: list[str | ValidationFailureDetails] | str, relevant_filepath: str = None):
         if not isinstance(files, list):
             files = [ files ]
 
         if relevant_filepath is not None:
-            detailed_files = []
+            detailed_files: list[ValidationFailureDetails] = []
             for item in files:
-                if not isinstance(files, ValidationFailureDetails):
-                    detailed_files.append(ValidationFailureDetails(item, relevant_filepath))
-                else:
+                if isinstance(files, ValidationFailureDetails):
                     detailed_files.append(item)
+                else:
+                    detailed_files.append(ValidationFailureDetails(item, relevant_filepath))
             files = detailed_files
 
         if isinstance(files, list):
@@ -317,77 +351,72 @@ class LicensingValidation:
         else:
             self.failures.setdefault(failure_type, []).append(files)
 
-    def process_attribution_data(self, filepath, data):
-        for attribution in data:
-            files = attribution["files"]
-            if len(files) == 0:
-                print(f"ATTRIBUTION ENTRY WITH NO FILES IN \"{filepath}\"")
-                self.record_failure(ValidationFailure.INVALID_FILE_ENTRY, filepath)
+    def process_attribution_data(self, filepath: Path, attribution):
+        files = attribution["files"]
+        if len(files) == 0:
+            self.record_failure(ValidationFailure.FILE_ENTRY_INVALID, "NO FILES IN THE ATTRIBUTION ENTRY", filepath)
 
+        if "Custom" == attribution["license"]:
+            if "commercialUseAllowed" not in attribution:
+                self.record_failure(ValidationFailure.LICENSE_CUSTOM_UNCLARIFIED, files, filepath)
+
+        non_commercial_asset_misuse = False
+        if not self.config.non_commercial:
+            if "-NC-" in attribution["license"]:
+                non_commercial_asset_misuse = True
             if "Custom" == attribution["license"]:
-                if "commercialUseAllowed" not in attribution:
-                    self.record_failure(ValidationFailure.CUSTOM_LICENSE_UNCLARIFIED, files, filepath)
+                # Let's err on the safe side here
+                non_commercial_asset_misuse = ("commercialUseAllowed" not in attribution) or (attribution["commercialUseAllowed"] == False)
 
-            non_commercial_asset_misuse = False
-            if not self.config.non_commercial:
-                if "-NC-" in attribution["license"]:
-                    non_commercial_asset_misuse = True
-                if "Custom" == attribution["license"]:
-                    # Let's err on the safe side here
-                    non_commercial_asset_misuse = ("commercialUseAllowed" not in attribution) or (attribution["commercialUseAllowed"] == False)
+        source_status = SourceStatus.NOT_FOUND
+        for source in self.config.sources:
+            status = source.validate(attribution)
+            match status:
+                case SourceStatus.NOT_APPLICABLE:
+                    continue
+                case SourceStatus.REJECTED:
+                    source_status = status
+                case SourceStatus.ACCEPTED:
+                    source_status = status
+                case SourceStatus.LICENSE_MISMATCH:
+                    source_status = status
+                case _:
+                    raise Exception(f"Unknown source validation value {status}")
 
-            license_invalid = False
-            if attribution["license"] in self.config.invalid_licenses:
-                license_invalid = True
+        if source_status == SourceStatus.NOT_FOUND:
+            self.record_failure(ValidationFailure.SOURCE_UNKNOWN, attribution["source"], filepath)
+        if source_status == SourceStatus.LICENSE_MISMATCH:
+            self.record_failure(ValidationFailure.SOURCE_LICENSE_MISMATCH, attribution["source"], filepath)
+        if source_status == SourceStatus.REJECTED:
+            self.record_failure(ValidationFailure.SOURCE_REJECTED, attribution["source"], filepath)
 
-            source_known_valid = False
-            for source in source_validation:
-                if source[0] in attribution["source"]:
-                    source_known_valid = True
-                    license_mismatch = True
-                    if isinstance(source[1], list):
-                        for license in source[1]:
-                            if license == attribution["license"]:
-                                license_mismatch = False
-                    elif source[1] == attribution["license"]:
-                        license_mismatch = False
-                    if source[1] == "*":
-                        license_mismatch = False
-                    if license_mismatch:
-                        self.record_failure(ValidationFailure.SOURCE_LICENSE_MISMATCH, attribution["source"], filepath)
-                        print(f"SOURCE LICENSE MISMATCH, PLEASE DOUBLE CHECK \"{filepath}\": \"{attribution["source"]}\" - \"{attribution["license"]}\", expected \"{source[1]}\"")
+        license_rejected = False
+        if attribution["license"] in self.config.reject_licenses:
+            license_rejected = True
 
-            if not source_known_valid:
-                self.record_failure(ValidationFailure.SOURCE_UNKNOWN, attribution["source"], filepath)
+        for file in files:
+            try:
+                attributed_asset = filepath.with_name(file)
 
-            for file in files:
-                try:
-                    attributed_asset = filepath.with_name(file)
-                    if non_commercial_asset_misuse:
-                        self.record_failure(ValidationFailure.NON_COMMERCIAL_LICENSE_VIOLATION, file, filepath)
-                    if license_invalid:
-                        self.record_failure(ValidationFailure.LICENSE_INVALID, file, filepath)
+                if not attributed_asset.exists():
+                    self.record_failure(ValidationFailure.ASSET_MISSING, file, filepath)
+                    continue
+                if non_commercial_asset_misuse:
+                    self.record_failure(ValidationFailure.LICENSE_VIOLATION_NON_COMMERCIAL, file, filepath)
+                if license_rejected:
+                    self.record_failure(ValidationFailure.LICENSE_REJECTED, file, filepath)
+                if attributed_asset in self.attribution_dict:
+                    self.record_failure(ValidationFailure.ASSET_DUPLICATE_ATTRIBUTION, file, filepath)
 
-                    if attributed_asset.exists():
-                        if attributed_asset in self.attribution_dict:
-                            self.record_failure(ValidationFailure.ASSET_DUPLICATE_ATTRIBUTION, file, filepath)
-
-                        self.attribution_dict[attributed_asset] = data
-                    else:
-                        self.record_failure(ValidationFailure.ASSET_MISSING, file, filepath)
-                except ValueError:
-                    self.record_failure(ValidationFailure.INVALID_FILE_ENTRY, file)
-                    if "/" in file or "\\" in file:
-                        print(f"Tried to attribute a file within a subdirectory path in \"{filepath}\": \"{file}\"")
-                    else:
-                        print(f"Invalid file entry in \"{filepath}\": \"{file}\"")
-                except OSError:
-                    self.record_failure(ValidationFailure.INVALID_FILE_ENTRY, file)
-                    print(f"Invalid file entry in \"{filepath}\": \"{file}\"")
+                self.attribution_dict[attributed_asset] = attribution
+            except ValueError:
+                self.record_failure(ValidationFailure.FILE_ENTRY_INVALID, file, filepath)
+            except OSError:
+                self.record_failure(ValidationFailure.FILE_ENTRY_INVALID, file, filepath)
 
     def check(self) -> bool:
         if len(self.scan.orphaned) > 0:
-            self.record_failure(ValidationFailure.ORPHANED, self.scan.orphaned)
+            self.record_failure(ValidationFailure.FILE_ORPHANED_YAML, self.scan.orphaned)
         if len(self.scan.unknown) > 0:
             self.record_failure(ValidationFailure.UNKNOWN, self.scan.unknown)
 
@@ -395,7 +424,8 @@ class LicensingValidation:
         for attribution_file in self.scan.attributions:
             with attribution_file.open() as handle:
                 data = yaml.safe_load(handle)
-                self.process_attribution_data(attribution_file, data)
+                for attribution in data:
+                    self.process_attribution_data(attribution_file, attribution)
 
         for asset in self.scan.assets:
             parent_path = asset.parent
@@ -415,7 +445,7 @@ class LicensingValidation:
                 have_attributions_yml = ""
                 if not (Path(path) / "attributions.yml").exists():
                     have_attributions_yml = " - no attributions.yml, shown later as !!!" if not printed_header else " !!!"
-                    self.record_failure(ValidationFailure.ATTRIBUTIONS_YML_MISSING, path)
+                    self.record_failure(ValidationFailure.FILE_ATTRIBUTIONS_MISSING, path)
 
                 if not self.config.list_unattributed_stats:
                     continue
@@ -424,9 +454,6 @@ class LicensingValidation:
                     print("Missing attributions per folder:")
                     printed_header = True
                 print(f"- {path}: {unatt_count}/{total_count} ({float(unatt_count) / float(total_count) * 100:.1f}%){have_attributions_yml}")
-
-            if not self.config.list_unattributed_stats:
-                print()
 
         return len(self.failures) == 0
 
@@ -438,8 +465,9 @@ if __name__ == "__main__":
         add_help=False
     )
     parser.add_argument("--help", "-h", action="help", help="Print this help message and exit")
-    parser.add_argument("--ignore-flags", "-i", type=validation_enum, action=ExtendSetAction, nargs="?", help=f"Validation failures to ignore for the exit status, comma separated (Default: Empty): {", ".join([e._name_ for e in ValidationFailure])}")
-    parser.add_argument("--hide-details", "-d", type=validation_enum, action=ExtendSetAction, nargs="?", help="Hide details for specified validations, comma separated or empty for all")
+    parser.add_argument("--ignore-flags", "-i", type=lambda value: string_to_enum(ValidationFailure, value), action=ExtendSetAction, nargs="?", help=f"Validation failures to ignore for the exit status, comma separated (Default: Empty): {", ".join([e._name_ for e in ValidationFailure])}")
+    parser.add_argument("--hide-details", "-d", type=lambda value: string_to_enum(ValidationFailure, value), action=ExtendSetAction, nargs="?", help="Hide details for specified validations, comma separated or empty for all")
+    parser.add_argument("--show-details", "-D", type=lambda value: string_to_enum(ValidationFailure, value), action=ExtendSetAction, nargs="?", help="Only show details for specified validations, same format as others")
     parser.add_argument("--unattributed-stats", action="store_true", help="Treat non-commercial licenses as invalid", default=None)
     parser.add_argument("--commercial", action="store_true", help="Treat non-commercial licenses as invalid", default=False)
     parser.add_argument("--ignore-licensing-config", action="store_true", help="Ignore licensing.yml in the specified Resources directory", default=False)
@@ -448,9 +476,26 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    scan = LicensingScan(args.resources)
+    config: LicensingConfig | None = None
+
+    if (args.resources / "licensing.yml").exists():
+        config = LicensingConfig(args.resources)
+    else:
+        print("USING EMPTY LICENSING CONFIG")
+        config = LicensingConfig({})
+
+    scan = LicensingScan(args.resources, config)
     scan.run()
-    validation = LicensingValidation(scan)
+
+    if args.filelist:
+        with open(args.filelist) as file:
+            lines = file.readlines()
+            scan.filter(set(lines))
+
+    validation = LicensingValidation(scan, config)
+    if args.show_details is not None and args.hide_details is not None:
+        print("Flags --hide-details (-d) and --show-details (-D) can not be used simultaneously")
+        sys.exit(1)
     if args.ignore_flags is not None:
         validation.config.ignored_validation = args.ignore_flags
     if args.unattributed_stats is not None:
@@ -465,17 +510,21 @@ if __name__ == "__main__":
         fail_exit = False
         print("Assets attribution validation failed!")
         if len(validation.config.ignored_validation) > 0:
-            print(f"Some checks have been ignored: {", ".join([e._name_ for e in validation.config.ignored_validation])}")
+            print(f"Some checks have been ignored: {", ".join([e._name_ for e in sorted(validation.config.ignored_validation, key=lambda e: e.value)])}")
         print()
 
         for failure_type in ValidationFailure:
             if failure_type not in validation.failures:
                 continue
             ignored = ""
-            if not failure_type in validation.config.ignored_validation:
+            if failure_type not in validation.config.ignored_validation:
                 fail_exit = True
             else:
+                if args.hide_details is None and args.show_details is None:
+                    continue
                 ignored = " - IGNORED!"
+            if args.show_details is not None and failure_type not in args.show_details:
+                continue
             if args.hide_details is not None and failure_type in args.hide_details:
                 continue
             failures = validation.failures[failure_type]

--- a/Tools/rga_check.py
+++ b/Tools/rga_check.py
@@ -1,0 +1,499 @@
+import argparse
+from dataclasses import dataclass
+import mimetypes
+import sys
+from enum import Enum, auto
+from pathlib import Path
+from typing import Any, Sequence
+
+import yaml
+
+class ValidationFailure(Enum):
+    ### Scan failures
+    # Could not determine the file mimetype from its full name. Likely something got lost or misnamed
+    UNKNOWN = auto()
+    # YAML files that exist outside of the dedicated directories, and don't seem to be associated with any data
+    # Most likely just files that have a typo in their name
+    ORPHANED = auto()
+    ### attributions.yml failures
+    # A value within `files` array is invalid in some way
+    INVALID_FILE_ENTRY = auto()
+    # License is set as "Custom" but has no clarification whether or not the assets can be used commercially
+    CUSTOM_LICENSE_UNCLARIFIED = auto()
+    # License prohibits non-commercial use, but the licensing configuration or flags ask for checking that assets are okay to use
+    NON_COMMERCIAL_LICENSE_VIOLATION = auto()
+    # License was explicitly listed as invalid in the config
+    LICENSE_INVALID = auto()
+    # Entry uses a source that's not been vetted as valid. Most applicable to audio files
+    SOURCE_UNKNOWN = auto()
+    # The source is known to use specific licenses, but the attribution entry uses another
+    SOURCE_LICENSE_MISMATCH = auto()
+    # Attribution describes an asset that is missing. Most likely a typo, or reference to now deleted asset
+    ASSET_MISSING = auto()
+    # Asset has already been described by another entry. Most likely a failure to increment numbered files during copy-pasting
+    ASSET_DUPLICATE_ATTRIBUTION = auto()
+    ### Other validations
+    # Asset exists but there's no attributions.yml file associated with it
+    ATTRIBUTIONS_YML_MISSING = auto()
+    ### The entire reason for this script to exist
+    # Asset has no attribution on the record
+    UNATTRIBUTED = auto()
+
+def validation_enum(validations: str):
+    try:
+        separated = set([ValidationFailure[v] for v in validations.split(",")])
+    except KeyError as ex:
+        raise argparse.ArgumentTypeError(f"Invalid validation enum value - \"{ex.args[0]}\"")
+    return separated
+
+def existing_path(path: str):
+    try:
+        path = Path(path)
+    except:
+        raise argparse.ArgumentTypeError(f"Invalid path - \"{path}\"")
+    if not path.exists():
+        raise argparse.ArgumentTypeError(f"Path does not exist - \"{path}\"")
+    return path
+
+class ExtendSetAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string) -> None:
+        previous: set[ValidationFailure] | None = getattr(namespace, self.dest)
+        if previous is None:
+            previous = set()
+        if values is None:
+            values = set(ValidationFailure)
+
+        setattr(namespace, self.dest, previous.union(values))
+
+class SingleMetavarHelpFormatter(argparse.HelpFormatter):
+    def _format_action_invocation(self, action: argparse.Action) -> str:
+        metavar = action.metavar or action.dest
+        nargs_desc = ""
+        flaglikes = len(action.option_strings)
+
+        if action.nargs == "?" and flaglikes > 0:
+            nargs_desc = f"({metavar})"
+        elif action.nargs == "?" and flaglikes == 0:
+            nargs_desc = f"{metavar}"
+        elif action.nargs == "*":
+            nargs_desc = f"{metavar}..."
+        elif isinstance(action.nargs, int) or action.nargs:
+            nargs_desc = f"{" ".join([metavar] * action.nargs)}"
+
+        if len(action.option_strings) > 0:
+            nargs_desc = " " + nargs_desc
+
+        return (", ".join(action.option_strings) + nargs_desc).ljust(20)
+
+ignore_mimetypes = [
+    "application/json",
+    "application/toml",
+    "text/xml",
+    "text/markdown",
+    "text/plain",
+    # just making shit up here
+    "application/vnd.space-wizards.shader",
+    "application/vnd.mozilla.fluent",
+]
+
+asset_mimetypes = [
+    "image/png",
+    "image/webp",
+    "image/svg+xml",
+    "image/vnd.microsoft.icon",
+    "audio/ogg",
+    "audio/x-sf2", # Made up again
+    # (Some of) These have actual license files lying nearby, but... yeah
+    "font/otf",
+    "font/ttf",
+]
+
+yaml_paths = [
+    # Dirs
+    "Changelog",
+    "Credits",
+    "IgnoredPrototypes",
+    "Maps",
+    "Prototypes",
+    # Files
+    "clientCommandPerms.yml",
+    "engineCommandPerms.yml",
+    "keybinds.yml",
+    "licensing.yml",
+    "manifest.yml",
+    "mapping_actions.yml",
+    "migration.yml",
+    "toolshedEngineCommandPerms.yml",
+]
+
+# List them in a way that more specific paths is before the more general one
+
+source_validation = [
+    ("https://freesound.org/", [
+        "CC-BY-3.0",
+        "CC-BY-4.0",
+        "CC-BY-SA-3.0",
+        "CC-BY-SA-4.0",
+        "CC-BY-NC-3.0",
+        "CC-BY-NC-4.0",
+        "CC-BY-NC-SA-3.0",
+        "CC-BY-NC-SA-4.0",
+        "CC0-1.0",
+        "Custom" # because sampling was not added to list of valid licenses elsewhere yay
+    ]),
+    ("https://github.com/space-wizards/space-station-14", "*"),
+    ("https://github.com/goonstation/goonstation", "CC-BY-NC-SA-3.0")
+]
+
+# Should be a CLI flag
+list_unattributed_details = True
+
+class ValidationFailureDetails:
+    affected_data: str = None
+    relevant_filepath: object = None
+
+    def __init__(self, affected_data, relevant_filepath):
+        self.affected_data = affected_data
+        self.relevant_filepath = relevant_filepath
+        pass
+
+    def __repr__(self):
+        return f"ValidationFailureDetails({self.affected_data}, {self.relevant_filepath})"
+
+    def __str__(self):
+        return f"{self.relevant_filepath}: {self.affected_data}"
+
+validation_failure_names = {
+    ValidationFailure.UNKNOWN: "Unknown files",
+    ValidationFailure.ORPHANED: "Orphaned YAML files",
+    ValidationFailure.INVALID_FILE_ENTRY: "Invalid file entries",
+    ValidationFailure.CUSTOM_LICENSE_UNCLARIFIED: "Assets with custom license without commercial use clarification flag",
+    ValidationFailure.NON_COMMERCIAL_LICENSE_VIOLATION: "VIOLATION OF A NON-COMMERCIAL LICENSE",
+    ValidationFailure.LICENSE_INVALID: "License configured as invalid",
+    ValidationFailure.SOURCE_UNKNOWN: "Source is not known to be valid",
+    ValidationFailure.SOURCE_LICENSE_MISMATCH: "Source license usage doesn't match",
+    ValidationFailure.ASSET_MISSING: "Missing (or misspelt) assets",
+    ValidationFailure.ASSET_DUPLICATE_ATTRIBUTION: "Assets described by different attribution entries",
+    ValidationFailure.ATTRIBUTIONS_YML_MISSING: "Missing (or misspelt) attributions.yml files",
+    ValidationFailure.UNATTRIBUTED: "Unattributed assets",
+}
+
+mimetypes.add_type("application/yaml", ".yaml")
+mimetypes.add_type("application/toml", ".toml")
+mimetypes.add_type("application/vnd.mozilla.fluent", ".ftl", False)
+mimetypes.add_type("application/vnd.space-wizards.shader", ".swsl", False)
+mimetypes.add_type("audio/x-sf2", ".sf2", False)
+
+mimetypes.suffix_map[".yml"] = ".yaml"
+
+class LicensingConfig:
+    # Assume the worst and most strict case for this stuff always
+    non_commercial = False
+    ignored_validation: set[ValidationFailure]
+    invalid_licenses: list[str]
+    list_unattributed_stats: bool = False
+
+    def __init__(self, config_data: dict[Any]):
+        if not isinstance(config_data, dict):
+            raise ValueError("Configuration file \"licensing.yml\" is invalid, check the syntax!")
+        self.non_commercial = config_data.get("project_is_non_commercial_and_not_for_profit", False)
+        ignoring = config_data.get("ignore_checks", list())
+        self.ignored_validation = set([ValidationFailure[v] for v in ignoring])
+        self.invalid_licenses = config_data.get("invalid_licenses", [])
+
+
+class LicensingScan:
+    """Storage class for all files relevant to licensing that were found in a directory scan"""
+    # Asset files
+    assets: list[Path] = []
+    # Attribution files, to be processed for matching with asset files
+    attributions: list[Path] = []
+    # YAML files outside of known path, not an attributions file and does not have associated image file
+    orphaned: list[Path] = []
+    # Shrug
+    unknown: list[Path] = []
+
+    path: Path = None
+
+    def __init__(self, path: str | Path, ):
+        if isinstance(path, str):
+            path = Path(path)
+        self.path = path
+
+    def run(self):
+        for path in self.path.rglob("*"):
+            if path.is_dir():
+                continue
+
+            if path.name == "attributions.yml":
+                self.attributions.append(path)
+                continue
+
+            (ext_mime, _) = mimetypes.guess_type(path, False)
+
+            if ext_mime is None and path.name.lower() == "readme":
+                ext_mime = "text/plain"
+
+            if ext_mime is None:
+                self.unknown.append(path)
+                continue
+
+            if ext_mime in ignore_mimetypes:
+                continue
+
+            if ext_mime == "application/yaml":
+                if path.parts[1] in yaml_paths:
+                    continue
+                # It's a semi-automatically generated file, or metadata for something
+                # TODO: make a better system for these
+                if path.with_suffix("").exists():
+                    continue
+
+                self.orphaned.append(path)
+                continue
+
+            # Similar, and very related, to above yaml thing
+            if path.name.endswith("dpi.png") and path.with_suffix("").with_suffix("").exists():
+                continue
+
+            if ext_mime not in asset_mimetypes:
+                print("UNKNOWN OR INVALID MIMETYPE: ", path, ext_mime)
+
+            # Ignore things that are gitignored
+            if path.parts[1] == "MapImages":
+                continue
+
+            # This is to be checked by a dedicated RSI validation script
+            part_of_rsi = False
+            for part in path.parts:
+                if (part.endswith(".rsi")):
+                    part_of_rsi = True
+            if part_of_rsi:
+                continue
+
+            self.assets.append(path)
+
+class LicensingValidation:
+    """A class for drawing conclusions about a directory scan"""
+
+    scan: LicensingScan
+    config: LicensingConfig
+
+    # Dictionary of the attribution objects for a given file
+    attribution_dict: dict[str, object] = {}
+    # List of assets that have no associated attribution file
+    unattributed_assets = []
+    # Per-folder count of total assets found and unattributed assets
+    asset_folders_count: dict[str, int] = {}
+    unattributed_folders_count: dict[str, int] = {}
+
+    failures: dict[ValidationFailure, list[str | Path | ValidationFailureDetails]] = {}
+
+    def __init__(self, scan: LicensingScan):
+        self.scan = scan
+
+        if (scan.path / "licensing.yml").exists():
+            with (scan.path / "licensing.yml").open() as handle:
+                licensing_config_data = yaml.safe_load(handle)
+                self.config = LicensingConfig(licensing_config_data)
+        else:
+            self.config = LicensingConfig({})
+
+    def record_failure(self, failure_type: ValidationFailure, files: list[str] | str, relevant_filepath: str = None):
+        if not isinstance(files, list):
+            files = [ files ]
+
+        if relevant_filepath is not None:
+            detailed_files = []
+            for item in files:
+                if not isinstance(files, ValidationFailureDetails):
+                    detailed_files.append(ValidationFailureDetails(item, relevant_filepath))
+                else:
+                    detailed_files.append(item)
+            files = detailed_files
+
+        if isinstance(files, list):
+            self.failures.setdefault(failure_type, []).extend(files)
+        else:
+            self.failures.setdefault(failure_type, []).append(files)
+
+    def process_attribution_data(self, filepath, data):
+        for attribution in data:
+            files = attribution["files"]
+            if len(files) == 0:
+                print(f"ATTRIBUTION ENTRY WITH NO FILES IN \"{filepath}\"")
+                self.record_failure(ValidationFailure.INVALID_FILE_ENTRY, filepath)
+
+            if "Custom" == attribution["license"]:
+                if "commercialUseAllowed" not in attribution:
+                    self.record_failure(ValidationFailure.CUSTOM_LICENSE_UNCLARIFIED, files, filepath)
+
+            non_commercial_asset_misuse = False
+            if not self.config.non_commercial:
+                if "-NC-" in attribution["license"]:
+                    non_commercial_asset_misuse = True
+                if "Custom" == attribution["license"]:
+                    # Let's err on the safe side here
+                    non_commercial_asset_misuse = ("commercialUseAllowed" not in attribution) or (attribution["commercialUseAllowed"] == False)
+
+            license_invalid = False
+            if attribution["license"] in self.config.invalid_licenses:
+                license_invalid = True
+
+            source_known_valid = False
+            for source in source_validation:
+                if source[0] in attribution["source"]:
+                    source_known_valid = True
+                    license_mismatch = True
+                    if isinstance(source[1], list):
+                        for license in source[1]:
+                            if license == attribution["license"]:
+                                license_mismatch = False
+                    elif source[1] == attribution["license"]:
+                        license_mismatch = False
+                    if source[1] == "*":
+                        license_mismatch = False
+                    if license_mismatch:
+                        self.record_failure(ValidationFailure.SOURCE_LICENSE_MISMATCH, attribution["source"], filepath)
+                        print(f"SOURCE LICENSE MISMATCH, PLEASE DOUBLE CHECK \"{filepath}\": \"{attribution["source"]}\" - \"{attribution["license"]}\", expected \"{source[1]}\"")
+
+            if not source_known_valid:
+                self.record_failure(ValidationFailure.SOURCE_UNKNOWN, attribution["source"], filepath)
+
+            for file in files:
+                try:
+                    attributed_asset = filepath.with_name(file)
+                    if non_commercial_asset_misuse:
+                        self.record_failure(ValidationFailure.NON_COMMERCIAL_LICENSE_VIOLATION, file, filepath)
+                    if license_invalid:
+                        self.record_failure(ValidationFailure.LICENSE_INVALID, file, filepath)
+
+                    if attributed_asset.exists():
+                        if attributed_asset in self.attribution_dict:
+                            self.record_failure(ValidationFailure.ASSET_DUPLICATE_ATTRIBUTION, file, filepath)
+
+                        self.attribution_dict[attributed_asset] = data
+                    else:
+                        self.record_failure(ValidationFailure.ASSET_MISSING, file, filepath)
+                except ValueError:
+                    self.record_failure(ValidationFailure.INVALID_FILE_ENTRY, file)
+                    if "/" in file or "\\" in file:
+                        print(f"Tried to attribute a file within a subdirectory path in \"{filepath}\": \"{file}\"")
+                    else:
+                        print(f"Invalid file entry in \"{filepath}\": \"{file}\"")
+                except OSError:
+                    self.record_failure(ValidationFailure.INVALID_FILE_ENTRY, file)
+                    print(f"Invalid file entry in \"{filepath}\": \"{file}\"")
+
+    def check(self) -> bool:
+        if len(self.scan.orphaned) > 0:
+            self.record_failure(ValidationFailure.ORPHANED, self.scan.orphaned)
+        if len(self.scan.unknown) > 0:
+            self.record_failure(ValidationFailure.UNKNOWN, self.scan.unknown)
+
+        # Process attribution files, and all files mentioned in them
+        for attribution_file in self.scan.attributions:
+            with attribution_file.open() as handle:
+                data = yaml.safe_load(handle)
+                self.process_attribution_data(attribution_file, data)
+
+        for asset in self.scan.assets:
+            parent_path = asset.parent
+            self.asset_folders_count[parent_path] = self.asset_folders_count.get(parent_path, 0) + 1
+            if asset in self.attribution_dict:
+                continue
+            self.unattributed_folders_count[parent_path] = self.unattributed_folders_count.get(parent_path, 0) + 1
+            self.unattributed_assets.append(asset)
+
+        if len(self.unattributed_assets) > 0:
+            self.record_failure(ValidationFailure.UNATTRIBUTED, self.unattributed_assets)
+
+            printed_header = False
+            for path, unatt_count in self.unattributed_folders_count.items():
+                total_count = self.asset_folders_count[path]
+
+                have_attributions_yml = ""
+                if not (Path(path) / "attributions.yml").exists():
+                    have_attributions_yml = " - no attributions.yml, shown later as !!!" if not printed_header else " !!!"
+                    self.record_failure(ValidationFailure.ATTRIBUTIONS_YML_MISSING, path)
+
+                if not self.config.list_unattributed_stats:
+                    continue
+
+                if not printed_header:
+                    print("Missing attributions per folder:")
+                    printed_header = True
+                print(f"- {path}: {unatt_count}/{total_count} ({float(unatt_count) / float(total_count) * 100:.1f}%){have_attributions_yml}")
+
+            if not self.config.list_unattributed_stats:
+                print()
+
+        return len(self.failures) == 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="A tool for checking license compliance of a project that uses Robust General Attribution files",
+        formatter_class=SingleMetavarHelpFormatter,
+        add_help=False
+    )
+    parser.add_argument("--help", "-h", action="help", help="Print this help message and exit")
+    parser.add_argument("--ignore-flags", "-i", type=validation_enum, action=ExtendSetAction, nargs="?", help=f"Validation failures to ignore for the exit status, comma separated (Default: Empty): {", ".join([e._name_ for e in ValidationFailure])}")
+    parser.add_argument("--hide-details", "-d", type=validation_enum, action=ExtendSetAction, nargs="?", help="Hide details for specified validations, comma separated or empty for all")
+    parser.add_argument("--unattributed-stats", action="store_true", help="Treat non-commercial licenses as invalid", default=None)
+    parser.add_argument("--commercial", action="store_true", help="Treat non-commercial licenses as invalid", default=False)
+    parser.add_argument("--ignore-licensing-config", action="store_true", help="Ignore licensing.yml in the specified Resources directory", default=False)
+    parser.add_argument("--resources", type=existing_path, help="Resource directory to scan (Default: ./Resources/)", default=Path("Resources"))
+    parser.add_argument("filelist", type=existing_path, nargs="?", help="Path to a file containing a list of files to check. Everything else is ignored", default=None)
+
+    args = parser.parse_args()
+
+    scan = LicensingScan(args.resources)
+    scan.run()
+    validation = LicensingValidation(scan)
+    if args.ignore_flags is not None:
+        validation.config.ignored_validation = args.ignore_flags
+    if args.unattributed_stats is not None:
+        validation.config.list_unattributed_stats = args.unattributed_stats
+
+    validation.check()
+
+    print(f"Found {len(validation.scan.assets)} assets, described by {len(validation.scan.attributions)} attributions.yml files")
+    print()
+
+    if len(validation.failures) > 0:
+        fail_exit = False
+        print("Assets attribution validation failed!")
+        if len(validation.config.ignored_validation) > 0:
+            print(f"Some checks have been ignored: {", ".join([e._name_ for e in validation.config.ignored_validation])}")
+        print()
+
+        for failure_type in ValidationFailure:
+            if failure_type not in validation.failures:
+                continue
+            ignored = ""
+            if not failure_type in validation.config.ignored_validation:
+                fail_exit = True
+            else:
+                ignored = " - IGNORED!"
+            if args.hide_details is not None and failure_type in args.hide_details:
+                continue
+            failures = validation.failures[failure_type]
+
+            print(f"{validation_failure_names.get(failure_type, str(failure_type))} ({len(failures)}){ignored}:")
+            for entry in failures:
+                print(f"- {entry}")
+            print()
+
+        print("Summary:")
+        for failure_type in ValidationFailure:
+            if failure_type not in validation.failures:
+                continue
+            failures = validation.failures[failure_type]
+            ignored = "" if failure_type not in validation.config.ignored_validation else " - IGNORED!"
+            print(f"- {validation_failure_names.get(failure_type, str(failure_type))}: {len(failures)}{ignored}")
+
+        if fail_exit:
+            sys.exit(1)
+    else:
+        print("Assets attribution validation ok!")


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a script to check for attribution issues that can run in CI and fail the build if any are found

## Why / Balance
A lot of the times people forget to add appropriate `attributions.yml` entry when contributing assets. This should prevent that.

## Technical details
Added the `Tools/rga_check.py`, which checks that all the assets have appropriate `attributions.yml` entry, and that said entry passes source checks as defined in `Resources/licensing.yml`. The script needs to run in the root dir of the repository. There's a lot of flags that control the verbosity of it, too.

The info about the checks done and what they represent can be seen in the comments for `ValidationFailure` enum. Feedback about unclear wording or needing a better description will be VERY appreciated, especially for `validation_failure_names` list!

The script when running in CI will only output info relevant to the files changed by the PR. So in attributions files it will only validate entries of files that have been added/changed. However if the changeset is ONLY modifying attributions files, the script will validate all the asset files in same directory.

Still on todo/wishlist: making the source check properly aware of github users existing, and handling the relevant URLs appropriately. Another wishlist thing is making it aware of SS13 repos, and having it parse paths out, so that we can check if paths are known to be valid or invalid according to another configurable list. The asset ecosystem of SS13 is complex, and SS14 is inheriting a lot of this complexity due to using assets from these repositories, so I think we would benefit a lot from this.

Additionally source links pointing at SS13 repositories are inconsistent, and can point to either a repo overall, a commit, or a specific file blob. Having the script also check for this being in some specific format (I am leaning to commit specific file blob URLs) would be nice.

The source list is *INCOMPLETE* and needs a lot of help in making sure that it will not annoy ever single person who contributes some asset. We don't want them to dive into the `licensing.yml` file unless it's particularly necessary.

Needs someone to test it with the lists of changed files from PRs that modified assets.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Added CI script for checking attributions, please make sure `Resources/licensing.yml` is set up appropriately