### PR TITLE
Changes suffix for always powered handhelds for clarity

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/station_map.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_map.yml
@@ -36,7 +36,7 @@
   parent:
   - BaseHandheldStationMap
   - BaseHandheldComputer
-  suffix: Handheld, Powered
+  suffix: Handheld
 
 - type: entity
   id: HandheldStationMapEmpty
@@ -51,4 +51,4 @@
 - type: entity
   id: HandheldStationMapUnpowered
   parent: BaseHandheldStationMap
-  suffix: Handheld, Unpowered
+  suffix: Handheld, Always Powered

--- a/Resources/Prototypes/Entities/Objects/Devices/station_map.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_map.yml
@@ -36,7 +36,7 @@
   parent:
   - BaseHandheldStationMap
   - BaseHandheldComputer
-  suffix: Handheld, Full
+  suffix: Handheld
 
 - type: entity
   id: HandheldStationMapEmpty

--- a/Resources/Prototypes/Entities/Objects/Devices/station_map.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_map.yml
@@ -36,7 +36,7 @@
   parent:
   - BaseHandheldStationMap
   - BaseHandheldComputer
-  suffix: Handheld
+  suffix: Handheld, Full
 
 - type: entity
   id: HandheldStationMapEmpty

--- a/Resources/Prototypes/Entities/Objects/Fun/spectral_locator.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/spectral_locator.yml
@@ -3,7 +3,7 @@
   parent: BaseItem
   name: spectral locator
   description: Appears to be a modified anomaly locator. Seems very old.
-  suffix: Unpowered
+  suffix: Always Powered
   components:
   - type: Sprite
     sprite: Objects/Fun/spectrallocator.rsi
@@ -39,7 +39,6 @@
 - type: entity
   id: SpectralLocator
   parent: [ SpectralLocatorUnpowered, PowerCellSlotSmallItem ]
-  suffix: Powered
   components:
   - type: PowerCellDraw
     drawRate: 1

--- a/Resources/Prototypes/Entities/Objects/Fun/spectral_locator.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/spectral_locator.yml
@@ -39,7 +39,7 @@
 - type: entity
   id: SpectralLocator
   parent: [ SpectralLocatorUnpowered, PowerCellSlotSmallItem ]
-  suffix: Full
+  suffix: ""
   components:
   - type: PowerCellDraw
     drawRate: 1

--- a/Resources/Prototypes/Entities/Objects/Fun/spectral_locator.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/spectral_locator.yml
@@ -39,6 +39,7 @@
 - type: entity
   id: SpectralLocator
   parent: [ SpectralLocatorUnpowered, PowerCellSlotSmallItem ]
+  suffix: Full
   components:
   - type: PowerCellDraw
     drawRate: 1

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -63,7 +63,7 @@
 - type: entity
   id: DefibrillatorOneHandedUnpowered
   parent: BaseDefibrillator
-  suffix: One-Handed, Unpowered
+  suffix: One-Handed, Always Powered
 
 - type: entity
   id: DefibrillatorCompact # This should be a research item at some point

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -44,7 +44,6 @@
 - type: entity
   id: Defibrillator
   parent: [ BaseDefibrillator, PowerCellSlotMediumItem ]
-  suffix: Full
   components:
   - type: MultiHandedItem
   - type: ToggleCellDraw

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -44,6 +44,7 @@
 - type: entity
   id: Defibrillator
   parent: [ BaseDefibrillator, PowerCellSlotMediumItem ]
+  suffix: Full
   components:
   - type: MultiHandedItem
   - type: ToggleCellDraw

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -45,6 +45,7 @@
 - type: entity
   id: HandheldHealthAnalyzer
   parent: [ HandheldHealthAnalyzerUnpowered, PowerCellSlotSmallItem]
+  suffix: Full
   components:
   - type: PowerCellDraw
     drawRate: 1.2 #Calculated for 5 minutes on a small cell

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -2,6 +2,7 @@
   id: HandheldHealthAnalyzerUnpowered
   parent: BaseItem
   name: health analyzer
+  suffix: Always Powered
   description: A hand-held body scanner capable of distinguishing vital signs of the subject.
   components:
   - type: Sprite
@@ -44,7 +45,6 @@
 - type: entity
   id: HandheldHealthAnalyzer
   parent: [ HandheldHealthAnalyzerUnpowered, PowerCellSlotSmallItem]
-  suffix: Powered
   components:
   - type: PowerCellDraw
     drawRate: 1.2 #Calculated for 5 minutes on a small cell

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -45,7 +45,7 @@
 - type: entity
   id: HandheldHealthAnalyzer
   parent: [ HandheldHealthAnalyzerUnpowered, PowerCellSlotSmallItem]
-  suffix: Full
+  suffix: ""
   components:
   - type: PowerCellDraw
     drawRate: 1.2 #Calculated for 5 minutes on a small cell

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -27,7 +27,7 @@
   parent: BaseItem
   name: anomaly locator
   description: A device designed to aid in the locating of anomalies. Did you check the gas miners?
-  suffix: Unpowered
+  suffix: Always Powered
   components:
   - type: Sprite
     sprite: Objects/Specific/Research/anomalylocator.rsi
@@ -63,7 +63,6 @@
 - type: entity
   id: AnomalyLocator
   parent: [ AnomalyLocatorUnpowered, PowerCellSlotSmallItem ]
-  suffix: Powered
   components:
   - type: PowerCellDraw
     drawRate: 1
@@ -85,7 +84,7 @@
   parent: AnomalyLocatorUnpowered
   name: wide-spectrum anomaly locator
   description: A device that looks for anomalies from an extended distance, but has no way to determine the distance to them.
-  suffix: Unpowered
+  suffix: Always Powered
   components:
   - type: Sprite
     sprite: Objects/Specific/Research/anomalylocatorwide.rsi
@@ -94,10 +93,10 @@
     maxBeepInterval: 0.5
   - type: ProximityDetector
     range: 40
+
 - type: entity
   id: AnomalyLocatorWide
   parent: [ AnomalyLocatorWideUnpowered, PowerCellSlotSmallItem ]
-  suffix: Powered
   components:
   - type: PowerCellDraw
     drawRate: 1

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -63,6 +63,7 @@
 - type: entity
   id: AnomalyLocator
   parent: [ AnomalyLocatorUnpowered, PowerCellSlotSmallItem ]
+  suffix: Full
   components:
   - type: PowerCellDraw
     drawRate: 1
@@ -97,6 +98,7 @@
 - type: entity
   id: AnomalyLocatorWide
   parent: [ AnomalyLocatorWideUnpowered, PowerCellSlotSmallItem ]
+  suffix: Full
   components:
   - type: PowerCellDraw
     drawRate: 1

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -63,7 +63,7 @@
 - type: entity
   id: AnomalyLocator
   parent: [ AnomalyLocatorUnpowered, PowerCellSlotSmallItem ]
-  suffix: Full
+  suffix: ""
   components:
   - type: PowerCellDraw
     drawRate: 1
@@ -98,7 +98,7 @@
 - type: entity
   id: AnomalyLocatorWide
   parent: [ AnomalyLocatorWideUnpowered, PowerCellSlotSmallItem ]
-  suffix: Full
+  suffix: ""
   components:
   - type: PowerCellDraw
     drawRate: 1

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/scanner.yml
@@ -3,7 +3,7 @@
   parent: BaseItem
   name: mineral scanner
   description: A scanner that checks surrounding rock for useful minerals. It must be in your hand or pocket to work.
-  suffix: Unpowered
+  suffix: Always Powered
   components:
   - type: Sprite
     sprite: Objects/Specific/Mining/mineral_scanner.rsi
@@ -36,7 +36,6 @@
 - type: entity
   id: MineralScanner
   parent: [ MineralScannerUnpowered, PowerCellSlotMediumItem ]
-  suffix: Powered
   components:
   - type: ToggleCellDraw
   - type: PowerCellDraw
@@ -58,7 +57,7 @@
   parent: MineralScannerUnpowered
   name: advanced mineral scanner
   description: A scanner that checks surrounding rock for useful minerals. It must be in your hand or pocket to work. This one has an extended range.
-  suffix: Unpowered
+  suffix: Always Powered
   components:
   - type: Sprite
     layers:
@@ -75,7 +74,6 @@
 - type: entity
   id: AdvancedMineralScanner
   parent: [ AdvancedMineralScannerUnpowered, PowerCellSlotMediumItem ]
-  suffix: Powered
   components:
   - type: ToggleCellDraw
   - type: PowerCellDraw

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/scanner.yml
@@ -36,7 +36,7 @@
 - type: entity
   id: MineralScanner
   parent: [ MineralScannerUnpowered, PowerCellSlotMediumItem ]
-  suffix: Full
+  suffix: ""
   components:
   - type: ToggleCellDraw
   - type: PowerCellDraw
@@ -75,7 +75,7 @@
 - type: entity
   id: AdvancedMineralScanner
   parent: [ AdvancedMineralScannerUnpowered, PowerCellSlotMediumItem ]
-  suffix: Full
+  suffix: ""
   components:
   - type: ToggleCellDraw
   - type: PowerCellDraw

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/scanner.yml
@@ -36,6 +36,7 @@
 - type: entity
   id: MineralScanner
   parent: [ MineralScannerUnpowered, PowerCellSlotMediumItem ]
+  suffix: Full
   components:
   - type: ToggleCellDraw
   - type: PowerCellDraw
@@ -74,6 +75,7 @@
 - type: entity
   id: AdvancedMineralScanner
   parent: [ AdvancedMineralScannerUnpowered, PowerCellSlotMediumItem ]
+  suffix: Full
   components:
   - type: ToggleCellDraw
   - type: PowerCellDraw


### PR DESCRIPTION
## About the PR
Suffixes for handheld devices were "Powered" "Unpowered" and "Empty"
This confuses a lot of mappers, including myself. I changed it to follow the same standard that lights use, "Always Powered" ~~and changes "Powered" to "Full"~~
- Also removes "Powered" suffix as that isn't needed any more.

## Why / Balance
Qol for mappers

## Technical details
n/a

## Media
Example:
![image](https://github.com/user-attachments/assets/ead7e615-d0e8-4b27-b245-64f311ad34c3)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
n/a
