### PR TITLE
Cleanup warnings in `ApcVisualizerSystem`

### DIFF
--- a/Content.Client/Power/APC/ApcVisualizerSystem.cs
+++ b/Content.Client/Power/APC/ApcVisualizerSystem.cs
@@ -1,5 +1,4 @@
 using Content.Shared.APC;
-using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 
 namespace Content.Client.Power.APC;

--- a/Content.Client/Power/APC/ApcVisualizerSystem.cs
+++ b/Content.Client/Power/APC/ApcVisualizerSystem.cs
@@ -77,7 +77,7 @@ public sealed class ApcVisualizerSystem : VisualizerSystem<ApcVisualsComponent>
     }
 }
 
-enum ApcVisualLayers : byte
+public enum ApcVisualLayers : byte
 {
     /// <summary>
     /// The sprite layer used for the interface lock indicator light overlay.

--- a/Content.Client/Power/APC/ApcVisualizerSystem.cs
+++ b/Content.Client/Power/APC/ApcVisualizerSystem.cs
@@ -7,6 +7,7 @@ namespace Content.Client.Power.APC;
 public sealed class ApcVisualizerSystem : VisualizerSystem<ApcVisualsComponent>
 {
     [Dependency] private readonly SharedPointLightSystem _lights = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     protected override void OnAppearanceChange(EntityUid uid, ApcVisualsComponent comp, ref AppearanceChangeEvent args)
     {
@@ -14,38 +15,38 @@ public sealed class ApcVisualizerSystem : VisualizerSystem<ApcVisualsComponent>
             return;
 
         // get the mapped layer index of the first lock layer and the first channel layer
-        var lockIndicatorOverlayStart = args.Sprite.LayerMapGet(ApcVisualLayers.InterfaceLock);
-        var channelIndicatorOverlayStart = args.Sprite.LayerMapGet(ApcVisualLayers.Equipment);
+        var lockIndicatorOverlayStart = _sprite.LayerMapGet((uid, args.Sprite), ApcVisualLayers.InterfaceLock);
+        var channelIndicatorOverlayStart = _sprite.LayerMapGet((uid, args.Sprite), ApcVisualLayers.Equipment);
 
         // Handle APC screen overlay:
-        if(!AppearanceSystem.TryGetData<ApcChargeState>(uid, ApcVisuals.ChargeState, out var chargeState, args.Component))
+        if (!AppearanceSystem.TryGetData<ApcChargeState>(uid, ApcVisuals.ChargeState, out var chargeState, args.Component))
             chargeState = ApcChargeState.Lack;
 
         if (chargeState >= 0 && chargeState < ApcChargeState.NumStates)
         {
-            args.Sprite.LayerSetState(ApcVisualLayers.ChargeState, $"{comp.ScreenPrefix}-{comp.ScreenSuffixes[(sbyte)chargeState]}");
+            _sprite.LayerSetRsiState((uid, args.Sprite), ApcVisualLayers.ChargeState, $"{comp.ScreenPrefix}-{comp.ScreenSuffixes[(sbyte)chargeState]}");
 
             // LockState does nothing currently. The backend doesn't exist.
             if (AppearanceSystem.TryGetData<byte>(uid, ApcVisuals.LockState, out var lockStates, args.Component))
             {
-                for(var i = 0; i < comp.LockIndicators; ++i)
+                for (var i = 0; i < comp.LockIndicators; ++i)
                 {
-                    var layer = ((byte)lockIndicatorOverlayStart + i);
-                    sbyte lockState = (sbyte)((lockStates >> (i << (sbyte)ApcLockState.LogWidth)) & (sbyte)ApcLockState.All);
-                    args.Sprite.LayerSetState(layer, $"{comp.LockPrefix}{i}-{comp.LockSuffixes[lockState]}");
-                    args.Sprite.LayerSetVisible(layer, true);
+                    var layer = (byte)lockIndicatorOverlayStart + i;
+                    var lockState = (sbyte)((lockStates >> (i << (sbyte)ApcLockState.LogWidth)) & (sbyte)ApcLockState.All);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), layer, $"{comp.LockPrefix}{i}-{comp.LockSuffixes[lockState]}");
+                    _sprite.LayerSetVisible((uid, args.Sprite), layer, true);
                 }
             }
 
             // ChannelState does nothing currently. The backend doesn't exist.
             if (AppearanceSystem.TryGetData<byte>(uid, ApcVisuals.ChannelState, out var channelStates, args.Component))
             {
-                for(var i = 0; i < comp.ChannelIndicators; ++i)
+                for (var i = 0; i < comp.ChannelIndicators; ++i)
                 {
-                    var layer = ((byte)channelIndicatorOverlayStart + i);
-                    sbyte channelState = (sbyte)((channelStates >> (i << (sbyte)ApcChannelState.LogWidth)) & (sbyte)ApcChannelState.All);
-                    args.Sprite.LayerSetState(layer, $"{comp.ChannelPrefix}{i}-{comp.ChannelSuffixes[channelState]}");
-                    args.Sprite.LayerSetVisible(layer, true);
+                    var layer = (byte)channelIndicatorOverlayStart + i;
+                    var channelState = (sbyte)((channelStates >> (i << (sbyte)ApcChannelState.LogWidth)) & (sbyte)ApcChannelState.All);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), layer, $"{comp.ChannelPrefix}{i}-{comp.ChannelSuffixes[channelState]}");
+                    _sprite.LayerSetVisible((uid, args.Sprite), layer, true);
                 }
             }
 
@@ -57,16 +58,16 @@ public sealed class ApcVisualizerSystem : VisualizerSystem<ApcVisualsComponent>
         else
         {
             /// Overrides all of the lock and channel indicators.
-            args.Sprite.LayerSetState(ApcVisualLayers.ChargeState, comp.EmaggedScreenState);
-            for(var i = 0; i < comp.LockIndicators; ++i)
+            _sprite.LayerSetRsiState((uid, args.Sprite), ApcVisualLayers.ChargeState, comp.EmaggedScreenState);
+            for (var i = 0; i < comp.LockIndicators; ++i)
             {
-                var layer = ((byte)lockIndicatorOverlayStart + i);
-                args.Sprite.LayerSetVisible(layer, false);
+                var layer = (byte)lockIndicatorOverlayStart + i;
+                _sprite.LayerSetVisible((uid, args.Sprite), layer, false);
             }
-            for(var i = 0; i < comp.ChannelIndicators; ++i)
+            for (var i = 0; i < comp.ChannelIndicators; ++i)
             {
-                var layer = ((byte)channelIndicatorOverlayStart + i);
-                args.Sprite.LayerSetVisible(layer, false);
+                var layer = (byte)channelIndicatorOverlayStart + i;
+                _sprite.LayerSetVisible((uid, args.Sprite), layer, false);
             }
 
             if (TryComp<PointLightComponent>(uid, out var light))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 10 warnings in `ApcVisualizerSystem`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods with `SpriteSystem` methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
APC still visualizing:
<img width="264" alt="Screenshot 2025-05-12 at 7 36 10 PM" src="https://github.com/user-attachments/assets/58ff7bb1-6ec1-4f64-aa91-c659945e4bb5" />
<img width="264" alt="Screenshot 2025-05-12 at 7 35 52 PM" src="https://github.com/user-attachments/assets/e765f746-7b32-45fe-9029-b81c6eebf3a4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
