### PR TITLE
Fix grammar in latejoin announcement message

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -33,7 +33,7 @@ player-first-join-message = Player {$name} joined for the first time.
 # Displayed in chat to admins when a player leaves
 player-leave-message = Player {$name} left.
 
-latejoin-arrival-announcement = {$character} ({$job}) { CONJUGATE-HAVE($entity) } arrived at the station!
+latejoin-arrival-announcement = {$character} ({$job}) has arrived at the station!
 latejoin-arrival-announcement-special = {$job} {$character} on deck!
 latejoin-arrival-sender = Station
 latejoin-arrivals-direction = A shuttle transferring you to your station will arrive shortly.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The current latejoin arrival announcement conjugates the verb 'to have' based on the character's pronouns, resulting in the message saying "(Name) (job title) have arrived at the station!" for characters with they/them pronouns. This doesn't make sense grammatically, since their pronouns aren't used in the announcement text. This PR fixes that to always use 'has'.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Typo.

## Technical details
<!-- Summary of code changes for easier review. -->
One line ftl change.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:
![ek5Q3tw](https://github.com/user-attachments/assets/f884c2ed-c929-4fa9-ad05-30ba12a337af)
After:
![pInZSB9](https://github.com/user-attachments/assets/94093174-158c-449a-b491-33d91620fba8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
