### PR TITLE
Polymorph Improvements

### DIFF
--- a/Content.Server/Abilities/Mime/MimePowersSystem.cs
+++ b/Content.Server/Abilities/Mime/MimePowersSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Maps;
 using Content.Shared.Paper;
 using Content.Shared.Physics;
+using Content.Shared.Polymorph;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
@@ -32,6 +33,25 @@ namespace Content.Server.Abilities.Mime
 
             SubscribeLocalEvent<MimePowersComponent, BreakVowAlertEvent>(OnBreakVowAlert);
             SubscribeLocalEvent<MimePowersComponent, RetakeVowAlertEvent>(OnRetakeVowAlert);
+
+            SubscribeLocalEvent<MimePowersComponent, PolymorphedEvent>(OnPolymorphed);
+        }
+
+        private void OnPolymorphed(Entity<MimePowersComponent> ent, ref PolymorphedEvent args)
+        {
+            RemComp<MimePowersComponent>(args.NewEntity);
+            var newComp = CopyComp(ent, args.NewEntity, ent.Comp);
+
+            if (ent.Comp.VowBroken)
+            {
+                BreakVow(args.NewEntity);
+                newComp.VowRepentTime = ent.Comp.VowRepentTime;
+            }
+            else
+            {
+                RetakeVow(args.NewEntity);
+                newComp.InvisibleWallActionEntity = _actionsSystem.AddAction(args.NewEntity, ent.Comp.InvisibleWallAction);
+            }
         }
 
         public override void Update(float frameTime)

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -24,6 +24,7 @@ using Content.Shared.Toggleable;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.FixedPoint;
 using Content.Shared.Hands;
+using Content.Shared.Polymorph;
 using Robust.Server.Audio;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
@@ -74,6 +75,7 @@ namespace Content.Server.Atmos.EntitySystems
             SubscribeLocalEvent<FlammableComponent, TileFireEvent>(OnTileFire);
             SubscribeLocalEvent<FlammableComponent, RejuvenateEvent>(OnRejuvenate);
             SubscribeLocalEvent<FlammableComponent, ResistFireAlertEvent>(OnResistFireAlert);
+            SubscribeLocalEvent<FlammableComponent, PolymorphedEvent>(OnPolymorphed);
             Subs.SubscribeWithRelay<FlammableComponent, ExtinguishEvent>(OnExtinguishEvent);
 
             SubscribeLocalEvent<IgniteOnCollideComponent, StartCollideEvent>(IgniteOnCollide);
@@ -84,6 +86,13 @@ namespace Content.Server.Atmos.EntitySystems
             SubscribeLocalEvent<ExtinguishOnInteractComponent, ActivateInWorldEvent>(OnExtinguishActivateInWorld);
 
             SubscribeLocalEvent<IgniteOnHeatDamageComponent, DamageChangedEvent>(OnDamageChanged);
+        }
+
+        private void OnPolymorphed(Entity<FlammableComponent> ent, ref PolymorphedEvent args)
+        {
+            if (args.Configuration is { TransferDamage: false })
+                return;
+            SetFireStacks(args.NewEntity, ent.Comp.FireStacks, ignite: ent.Comp.OnFire);
         }
 
         private void OnExtinguishEvent(Entity<FlammableComponent> ent, ref ExtinguishEvent args)

--- a/Content.Server/Bible/BibleSystem.cs
+++ b/Content.Server/Bible/BibleSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Polymorph;
 using Content.Shared.Popups;
 using Content.Shared.Timing;
 using Content.Shared.Verbs;
@@ -39,11 +40,17 @@ namespace Content.Server.Bible
             base.Initialize();
 
             SubscribeLocalEvent<BibleComponent, AfterInteractEvent>(OnAfterInteract);
+            SubscribeLocalEvent<BibleUserComponent, PolymorphedEvent>(OnBibleUserPolymorphed);
             SubscribeLocalEvent<SummonableComponent, GetVerbsEvent<AlternativeVerb>>(AddSummonVerb);
             SubscribeLocalEvent<SummonableComponent, GetItemActionsEvent>(GetSummonAction);
             SubscribeLocalEvent<SummonableComponent, SummonActionEvent>(OnSummon);
             SubscribeLocalEvent<FamiliarComponent, MobStateChangedEvent>(OnFamiliarDeath);
             SubscribeLocalEvent<FamiliarComponent, GhostRoleSpawnerUsedEvent>(OnSpawned);
+        }
+
+        private void OnBibleUserPolymorphed(Entity<BibleUserComponent> ent, ref PolymorphedEvent args)
+        {
+            EnsureComp<BibleUserComponent>(ent);
         }
 
         private readonly Queue<EntityUid> _addQueue = new();

--- a/Content.Server/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicsSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Forensics.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
+using Content.Shared.Polymorph;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Random;
 using Content.Shared.Verbs;
@@ -44,8 +45,18 @@ namespace Content.Server.Forensics
             SubscribeLocalEvent<CleansForensicsComponent, AfterInteractEvent>(OnAfterInteract, after: new[] { typeof(AbsorbentSystem) });
             SubscribeLocalEvent<ForensicsComponent, CleanForensicsDoAfterEvent>(OnCleanForensicsDoAfter);
             SubscribeLocalEvent<DnaComponent, TransferDnaEvent>(OnTransferDnaEvent);
+            SubscribeLocalEvent<DnaComponent, PolymorphedEvent>(OnPolymorphed);
             SubscribeLocalEvent<DnaSubstanceTraceComponent, SolutionContainerChangedEvent>(OnSolutionChanged);
             SubscribeLocalEvent<CleansForensicsComponent, GetVerbsEvent<UtilityVerb>>(OnUtilityVerb);
+        }
+
+        private void OnPolymorphed(Entity<DnaComponent> ent, ref PolymorphedEvent args)
+        {
+            if (args.Configuration == null || !args.Configuration.TransferIdentity)
+                return;
+            if (HasComp<DnaComponent>(args.NewEntity))
+                RemComp<DnaComponent>(args.NewEntity);
+            CopyComp(ent, args.NewEntity, ent.Comp);
         }
 
         private void OnSolutionChanged(Entity<DnaSubstanceTraceComponent> ent, ref SolutionContainerChangedEvent ev)

--- a/Content.Server/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicsSystem.cs
@@ -52,7 +52,7 @@ namespace Content.Server.Forensics
 
         private void OnPolymorphed(Entity<DnaComponent> ent, ref PolymorphedEvent args)
         {
-            if (args.Configuration == null || !args.Configuration.TransferIdentity)
+            if (args.Configuration == null || !args.Configuration.TransferName)
                 return;
             if (HasComp<DnaComponent>(args.NewEntity))
                 RemComp<DnaComponent>(args.NewEntity);

--- a/Content.Server/IdentityManagement/IdentitySystem.cs
+++ b/Content.Server/IdentityManagement/IdentitySystem.cs
@@ -48,7 +48,7 @@ public sealed class IdentitySystem : SharedIdentitySystem
 
     private void OnPolymorphed(Entity<IdentityComponent> ent, ref PolymorphedEvent args)
     {
-        if (args.Configuration is { TransferIdentity: false } || !TryComp(ent, out MetaDataComponent? targetMeta))
+        if (args.Configuration is { TransferName: false } || !TryComp(ent, out MetaDataComponent? targetMeta))
             return;
         _metaData.SetEntityName(args.NewEntity, targetMeta.EntityName);
         if (TryComp<IdentityComponent>(ent, out var identity))

--- a/Content.Server/KillTracking/KillTrackingSystem.cs
+++ b/Content.Server/KillTracking/KillTrackingSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Polymorph;
 using Robust.Shared.Player;
 
 namespace Content.Server.KillTracking;
@@ -18,6 +19,14 @@ public sealed class KillTrackingSystem : EntitySystem
         // Add damage to LifetimeDamage before MobStateChangedEvent gets raised
         SubscribeLocalEvent<KillTrackerComponent, DamageChangedEvent>(OnDamageChanged, before: [ typeof(MobThresholdSystem) ]);
         SubscribeLocalEvent<KillTrackerComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<KillTrackerComponent, PolymorphedEvent>(OnPolymorph);
+    }
+
+    private void OnPolymorph(Entity<KillTrackerComponent> ent, ref PolymorphedEvent args)
+    {
+        var newComp = EnsureComp<KillTrackerComponent>(args.NewEntity);
+        newComp.KillState = ent.Comp.KillState;
+        newComp.LifetimeDamage = ent.Comp.LifetimeDamage;
     }
 
     private void OnDamageChanged(EntityUid uid, KillTrackerComponent component, DamageChangedEvent args)

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -224,15 +224,6 @@ public sealed partial class PolymorphSystem : EntitySystem
         if (_container.TryGetContainingContainer((uid, targetTransformComp, null), out var cont))
             _container.Insert(child, cont);
 
-        //Transfers all damage from the original to the new one
-        if (configuration.TransferDamage &&
-            TryComp<DamageableComponent>(child, out var damageParent) &&
-            _mobThreshold.GetScaledDamage(uid, child, out var damage) &&
-            damage != null)
-        {
-            _damageable.SetDamage(child, damageParent, damage);
-        }
-
         if (configuration.Inventory == PolymorphInventoryChange.Transfer)
         {
             _inventory.TransferEntityInventories(uid, child);
@@ -258,9 +249,6 @@ public sealed partial class PolymorphSystem : EntitySystem
             }
         }
 
-        if (configuration.TransferName && TryComp(uid, out MetaDataComponent? targetMeta))
-            _metaData.SetEntityName(child, targetMeta.EntityName);
-
         if (configuration.TransferHumanoidAppearance)
         {
             _humanoid.CloneAppearance(uid, child);
@@ -275,7 +263,7 @@ public sealed partial class PolymorphSystem : EntitySystem
             _transform.SetParent(uid, targetTransformComp, PausedMap.Value);
 
         // Raise an event to inform anything that wants to know about the entity swap
-        var ev = new PolymorphedEvent(uid, child, false);
+        var ev = new PolymorphedEvent(uid, child, false, configuration);
         RaiseLocalEvent(uid, ref ev);
 
         // visual effect spawn
@@ -355,7 +343,7 @@ public sealed partial class PolymorphSystem : EntitySystem
         _transform.AttachToGridOrMap(parent, parentXform);
 
         // Raise an event to inform anything that wants to know about the entity swap
-        var ev = new PolymorphedEvent(uid, parent, true);
+        var ev = new PolymorphedEvent(uid, parent, true, component.Configuration);
         RaiseLocalEvent(uid, ref ev);
 
         // visual effect spawn

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Atmos;
 using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.Inventory;
+using Content.Shared.Polymorph;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Temperature;
 using Robust.Shared.Physics.Components;
@@ -44,6 +45,7 @@ public sealed class TemperatureSystem : EntitySystem
         SubscribeLocalEvent<TemperatureComponent, OnTemperatureChangeEvent>(EnqueueDamage);
         SubscribeLocalEvent<TemperatureComponent, AtmosExposedUpdateEvent>(OnAtmosExposedUpdate);
         SubscribeLocalEvent<TemperatureComponent, RejuvenateEvent>(OnRejuvenate);
+        SubscribeLocalEvent<TemperatureComponent, PolymorphedEvent>(OnPolymorphed);
         SubscribeLocalEvent<AlertsComponent, OnTemperatureChangeEvent>(ServerAlert);
         SubscribeLocalEvent<TemperatureProtectionComponent, InventoryRelayedEvent<ModifyChangedTemperatureEvent>>(
             OnTemperatureChangeAttempt);
@@ -58,6 +60,13 @@ public sealed class TemperatureSystem : EntitySystem
             OnParentThresholdStartup);
         SubscribeLocalEvent<ContainerTemperatureDamageThresholdsComponent, ComponentShutdown>(
             OnParentThresholdShutdown);
+    }
+
+    private void OnPolymorphed(Entity<TemperatureComponent> ent, ref PolymorphedEvent args)
+    {
+        if (args.Configuration is { TransferDamage: false })
+            return;
+        ForceChangeTemperature(args.NewEntity, ent.Comp.CurrentTemperature);
     }
 
     public override void Update(float frameTime)

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Polymorph;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
 using Content.Shared.Weapons.Melee.Events;
@@ -61,6 +62,14 @@ namespace Content.Server.Zombies
             SubscribeLocalEvent<ZombieComponent, EmoteEvent>(OnEmote, before:
                 new[] { typeof(VocalSystem), typeof(BodyEmotesSystem) });
 
+            SubscribeLocalEvent<ZombieComponent, PolymorphedEvent>(OnPolymorphed);
+            SubscribeLocalEvent<InitialInfectedComponent, PolymorphedEvent>(OnPolymorphed);
+            SubscribeLocalEvent<IncurableZombieComponent, PolymorphedEvent>(OnPolymorphed);
+            SubscribeLocalEvent<NonSpreaderZombieComponent, PolymorphedEvent>(OnPolymorphed);
+            SubscribeLocalEvent<PendingZombieComponent, PolymorphedEvent>(OnPolymorphed);
+            SubscribeLocalEvent<ZombieImmuneComponent, PolymorphedEvent>(OnPolymorphed);
+            SubscribeLocalEvent<ZombifyOnDeathComponent, PolymorphedEvent>(OnPolymorphed);
+
             SubscribeLocalEvent<ZombieComponent, MeleeHitEvent>(OnMeleeHit);
             SubscribeLocalEvent<ZombieComponent, MobStateChangedEvent>(OnMobState);
             SubscribeLocalEvent<ZombieComponent, CloningEvent>(OnZombieCloning);
@@ -76,6 +85,42 @@ namespace Content.Server.Zombies
             SubscribeLocalEvent<IncurableZombieComponent, MapInitEvent>(OnPendingMapInit);
 
             SubscribeLocalEvent<ZombifyOnDeathComponent, MobStateChangedEvent>(OnDamageChanged);
+        }
+
+        private void OnPolymorphed(Entity<ZombieComponent> ent, ref PolymorphedEvent args)
+        {
+            ZombifyEntity(args.NewEntity);
+        }
+
+        private void OnPolymorphed(Entity<InitialInfectedComponent> ent, ref PolymorphedEvent args)
+        {
+            CopyComp(ent, args.NewEntity, ent.Comp);
+        }
+
+        private void OnPolymorphed(Entity<IncurableZombieComponent> ent, ref PolymorphedEvent args)
+        {
+            var newComp = CopyComp(ent, args.NewEntity, ent.Comp);
+            _actions.AddAction(args.NewEntity, ref newComp.Action, newComp.ZombifySelfActionPrototype);
+        }
+
+        private void OnPolymorphed(Entity<NonSpreaderZombieComponent> ent, ref PolymorphedEvent args)
+        {
+            CopyComp(ent, args.NewEntity, ent.Comp);
+        }
+
+        private void OnPolymorphed(Entity<PendingZombieComponent> ent, ref PolymorphedEvent args)
+        {
+             CopyComp(ent, args.NewEntity, ent.Comp);
+        }
+
+        private void OnPolymorphed(Entity<ZombieImmuneComponent> ent, ref PolymorphedEvent args)
+        {
+            CopyComp(ent, args.NewEntity, ent.Comp);
+        }
+
+        private void OnPolymorphed(Entity<ZombifyOnDeathComponent> ent, ref PolymorphedEvent args)
+        {
+            CopyComp(ent, args.NewEntity, ent.Comp);
         }
 
         private void OnBeforeRemoveAnomalyOnDeath(Entity<PendingZombieComponent> ent, ref BeforeRemoveAnomalyOnDeathEvent args)

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Polymorph;
 using Content.Shared.Radiation.Events;
 using Content.Shared.Rejuvenate;
 using Robust.Shared.Configuration;
@@ -48,6 +49,7 @@ namespace Content.Shared.Damage
             SubscribeLocalEvent<DamageableComponent, ComponentHandleState>(DamageableHandleState);
             SubscribeLocalEvent<DamageableComponent, ComponentGetState>(DamageableGetState);
             SubscribeLocalEvent<DamageableComponent, OnIrradiatedEvent>(OnIrradiated);
+            SubscribeLocalEvent<DamageableComponent, PolymorphedEvent>(OnPolymorphed);
             SubscribeLocalEvent<DamageableComponent, RejuvenateEvent>(OnRejuvenate);
 
             _appearanceQuery = GetEntityQuery<AppearanceComponent>();
@@ -84,6 +86,18 @@ namespace Content.Shared.Damage
             Subs.CVar(_config, CCVars.PlaytestThrownDamageModifier, value => UniversalThrownDamageModifier = value, true);
             Subs.CVar(_config, CCVars.PlaytestTopicalsHealModifier, value => UniversalTopicalsHealModifier = value, true);
             Subs.CVar(_config, CCVars.PlaytestMobDamageModifier, value => UniversalMobDamageModifier = value, true);
+        }
+
+        private void OnPolymorphed(Entity<DamageableComponent> ent, ref PolymorphedEvent args)
+        {
+            //Transfers all damage from the original to the new one
+            if (args.Configuration is { TransferDamage: true } &&
+                TryComp<DamageableComponent>(args.NewEntity, out var damageParent) &&
+                _mobThreshold.GetScaledDamage(ent, args.NewEntity, out var damage) &&
+                damage != null)
+            {
+                SetDamage(args.NewEntity, damageParent, damage);
+            }
         }
 
         /// <summary>

--- a/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Inventory;
+using Content.Shared.Polymorph;
 using Content.Shared.Rejuvenate;
 using JetBrains.Annotations;
 
@@ -13,8 +14,17 @@ public sealed class BlindableSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
+        SubscribeLocalEvent<BlindableComponent, PolymorphedEvent>(OnPolymorphed);
         SubscribeLocalEvent<BlindableComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<BlindableComponent, EyeDamageChangedEvent>(OnDamageChanged);
+    }
+
+    private void OnPolymorphed(Entity<BlindableComponent> ent, ref PolymorphedEvent args)
+    {
+        if (args.Configuration is { TransferStatusEffects: false })
+            return;
+        EnsureComp<BlindableComponent>(args.NewEntity);
+        AdjustEyeDamage(args.NewEntity, ent.Comp.EyeDamage);
     }
 
     private void OnRejuvenate(Entity<BlindableComponent> ent, ref RejuvenateEvent args)

--- a/Content.Shared/Polymorph/PolymorphEvents.cs
+++ b/Content.Shared/Polymorph/PolymorphEvents.cs
@@ -7,4 +7,8 @@ namespace Content.Shared.Polymorph;
 /// <param name="NewEntity">EntityUid of the entity after the polymorph</param>
 /// <param name="IsRevert">Whether this polymorph event was a revert back to the original entity</param>
 [ByRefEvent]
-public record struct PolymorphedEvent(EntityUid OldEntity, EntityUid NewEntity, bool IsRevert);
+public record struct PolymorphedEvent(
+    EntityUid OldEntity,
+    EntityUid NewEntity,
+    bool IsRevert,
+    PolymorphConfiguration? Configuration = null);

--- a/Content.Shared/Polymorph/PolymorphPrototype.cs
+++ b/Content.Shared/Polymorph/PolymorphPrototype.cs
@@ -70,16 +70,29 @@ public sealed partial record PolymorphConfiguration
     public bool Forced;
 
     /// <summary>
+    /// Whether or not the entity transfers its bloodstream between forms.
+    /// </summary>
+    [DataField(serverOnly: true)]
+    public bool TransferBloodstream = true;
+
+    /// <summary>
     /// Whether or not the entity transfers its damage between forms.
     /// </summary>
     [DataField(serverOnly: true)]
     public bool TransferDamage = true;
 
     /// <summary>
-    /// Whether or not the entity transfers its name between forms.
+    /// Whether or not the entity transfers status effects between forms.
     /// </summary>
     [DataField(serverOnly: true)]
-    public bool TransferName;
+    public bool TransferStatusEffects = true;
+
+    /// <summary>
+    /// Whether or not the entity transfers its identity between forms. Includes name and DNA.
+    /// </summary>
+    [DataField(serverOnly: true)]
+    public bool TransferIdentity;
+
 
     /// <summary>
     /// Whether or not the entity transfers its hair, skin color, hair color, etc.

--- a/Content.Shared/Polymorph/PolymorphPrototype.cs
+++ b/Content.Shared/Polymorph/PolymorphPrototype.cs
@@ -91,7 +91,7 @@ public sealed partial record PolymorphConfiguration
     /// Whether or not the entity transfers its identity between forms. Includes name and DNA.
     /// </summary>
     [DataField(serverOnly: true)]
-    public bool TransferIdentity;
+    public bool TransferName;
 
 
     /// <summary>

--- a/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
+++ b/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.IdentityManagement;
+using Content.Shared.Polymorph;
 using Robust.Shared.Network;
 
 namespace Content.Shared.Traits.Assorted;
@@ -17,8 +18,16 @@ public sealed class PermanentBlindnessSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<PermanentBlindnessComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<PermanentBlindnessComponent, PolymorphedEvent>(OnPolymorphed);
         SubscribeLocalEvent<PermanentBlindnessComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<PermanentBlindnessComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnPolymorphed(Entity<PermanentBlindnessComponent> ent, ref PolymorphedEvent args)
+    {
+        if (args.Configuration is { TransferStatusEffects: false })
+            return;
+        CopyComp(ent, args.NewEntity, ent.Comp);
     }
 
     private void OnExamined(Entity<PermanentBlindnessComponent> blindness, ref ExaminedEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Uses polymorphed event to transfer most needed components.

always
- Injected anoms die and drop core to prevent continued point generation from paused anomaly
- Bible user transfers
- Kill tracking transfers
- Temperature transfers

Transfer Status Effects
- Eye damage is transferred
- Status Effects transfer

Damage Transfer
- flame stacks transfer
Transfer Bloodstream
- bloodstream and reagents transfer

Identity
- Name transfers
- Criminal records transfer
- DNA transfers

Vow
- Mime vow transfers

Code ported from: https://github.com/space-wizards/space-station-14/pull/28941

## Why / Balance
Polymorphs are becoming more frequent with wizard and downstream systems. This allows polymorphs to transfer components such as zombification that could persist between forms.

Fixes https://github.com/DeltaV-Station/Delta-v/issues/3522 , https://github.com/DeltaV-Station/Delta-v/issues/3603

## Technical details
More changes to come as https://github.com/space-wizards/RobustToolbox/pull/5854 gets merged.
An extra anomaly core is spawned when an entity with an injected anomaly is polymorphed.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: SolStar, Vermidia
- tweak: Injected anomalies die when an injected person is polymorphed.
- tweak: Identity and DNA transferred along with name if polymorph transfers name.
- tweak: Flame stacks now transfer if polymorph transfers damage.
- tweak: Polymorphs may now transfer bloodstream.
- tweak: Polymorphs may now transfer status effects.
- tweak: Polymorphs may now transfer mime vows.
- fix: Tempature persists between polymorphs
- fix: Bible users retain their ability to use bibles through polymorphs.