### PR TITLE
Removed the emergency crowbar from the chef's closet

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -34,7 +34,6 @@
   components:
   - type: StorageFill
     contents:
-      - id: CrowbarRed
       - id: VariantCubeBox
       - id: BoxMousetrap
         amount: 2

--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -37,6 +37,7 @@
       - id: VariantCubeBox
       - id: BoxMousetrap
         amount: 2
+      - id: SprayBottleWater
       - id: ReagentContainerFlour
         amount: 2
       - id: FoodBoxCloth

--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -37,7 +37,6 @@
       - id: VariantCubeBox
       - id: BoxMousetrap
         amount: 2
-      - id: SprayBottleWater
       - id: ReagentContainerFlour
         amount: 2
       - id: FoodBoxCloth


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
## About the PR
<!-- What did you change? -->
The chef's closet no longer contains an emergency crowbar.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Maintainer discussion has recently come to the conclusion that job lockers should "be relegated strictly to the most relevant job-related equipment". (See [here](https://github.com/space-wizards/space-station-14/pull/37375#issuecomment-2874123196).) The Chef has no more need for a crowbar than most other members of the station, so one spawning in the same closet as their various cooking ingredients seems out of place.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed one line of code from Resources\Prototypes\Catalog\Fills\Lockers\service.yml.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![MyServer - Space Station 14 5_12_2025 10_34_12 PM](https://github.com/user-attachments/assets/7a2a49f9-c8e5-4272-a1c3-b3ce9a3aeab4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: The chef's closet no longer contains an emergency crowbar.