### PR TITLE
Add myself to mapping codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /Resources/ServerInfo/ @nikthechampiongr @crazybrain23
 /Resources/ServerInfo/Guidebook/ServerRules/ @nikthechampiongr @crazybrain23
 
-/Resources/Prototypes/Maps/** @Emisse
+/Resources/Prototypes/Maps/** @Emisse @ArtisticRoomba
 
 /Resources/Prototypes/Body/ @DrSmugleaf # suffering
 /Resources/Prototypes/Entities/Mobs/Player/ @DrSmugleaf


### PR DESCRIPTION
## About the PR
Adds myself as a codeowner to maps, because I'm a head mapper.

## Why / Balance
Oftentimes a map slips past me and waits for a bit when it should be merged mildly quickly and see playtesting. This happened with some genpop maps IIRC.

I didn't do this earlier because I wanted to concentrate on finals, but I'm done with that now.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
no cl no fun