### PR TITLE
Add Nuclear explosion type [Redo]

### DIFF
--- a/Content.Shared/Explosion/ExplosionPrototype.cs
+++ b/Content.Shared/Explosion/ExplosionPrototype.cs
@@ -110,6 +110,21 @@ public sealed partial class ExplosionPrototype : IPrototype
     [DataField("fireStates")]
     public int FireStates = 3;
 
+    [DataField]
+    public HashSet<ProtoId<EntityPrototype>> DeleteComponents = new();
+
+    [DataField]
+    public HashSet<ProtoId<EntityPrototype>> BlacklistedComponents = new();
+
+    [NonSerialized]
+    public HashSet<Type> CachedDeleteComponents = new();
+
+    [NonSerialized]
+    public HashSet<Type> CachedBlacklistedComponents = new();
+
+    [NonSerialized]
+    public bool ComponentsCached = false;
+
     /// <summary>
     ///     Basic function for linear interpolation of the _tileBreakChance and _tileBreakIntensity arrays
     /// </summary>

--- a/Content.Shared/Explosion/ExplosionPrototype.cs
+++ b/Content.Shared/Explosion/ExplosionPrototype.cs
@@ -111,10 +111,10 @@ public sealed partial class ExplosionPrototype : IPrototype
     public int FireStates = 3;
 
     [DataField]
-    public HashSet<ProtoId<EntityPrototype>> DeleteComponents = new();
+    public HashSet<string> DeleteComponents = new();
 
     [DataField]
-    public HashSet<ProtoId<EntityPrototype>> BlacklistedComponents = new();
+    public HashSet<string> BlacklistedComponents = new();
 
     [NonSerialized]
     public HashSet<Type> CachedDeleteComponents = new();

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -75,7 +75,7 @@
     enabled: false
   - type: NukeLabel
   - type: Nuke
-    explosionType: Default
+    explosionType: Nuclear
     maxIntensity: 100
     intensitySlope: 5
     totalIntensity: 5000000

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -136,6 +136,28 @@
   fireStates: 3
   fireStacks: 2
 
+- type: explosion
+  id: Nuclear
+  deleteComponents:
+    - "Item"
+    - "Cable"
+    - "DisposalTube"
+    - "WallMount"
+    - "GasMiner"
+  blacklistedComponents: []
+  damagePerIntensity:
+    types:
+      Heat: 5
+      Blunt: 5
+      Piercing: 5
+      Radiation: 2
+  tileBreakChance: [0, 0.5, 1]
+  tileBreakIntensity: [0, 30, 50]
+  tileBreakRerollReduction: 20
+  lightColor: Orange
+  texturePath: /Textures/Effects/fire.rsi
+  fireStates: 3
+
 # STOP
 # BEFORE YOU ADD MORE EXPLOSION TYPES CONSIDER IF AN EXISTING ONE IS SUITABLE
 # ADDING NEW ONES IS PROHIBITIVELY EXPENSIVE


### PR DESCRIPTION
## About the PR
_This is the second attempt due to problems with the old branch and bad code in general_

Adds new `Nuclear` type of explosion, which is now used by a nuclear warhead. It deletes some objects (see the technical part).
Unlike the default one, it additionally deals 2 radiation damage:
```
  damagePerIntensity:
    types:
      Heat: 5
      Blunt: 5
      Piercing: 5
      Radiation: 2
```


## Why / Balance

- It is quite logical that a nuclear explosion should cause radiation damage.
- Removes a large number of objects that the default type of explosion cannot handle. A nuclear explosion ends the round in 99.99% of cases, so the balance will not be affected by removing items. But the server will not lag so much, especially if someone decides to fly through the remnants of the station on a shuttle.

## Technical details
The deletion is based on the matching of the components. 

A white and black list of components has been added to the yml file (they can also be added to other types of explosions and everything will work fine.):
```
- type: explosion
  id: Nuclear
  deleteComponents:
    - "Item"
    - "Cable"
    - "DisposalTube"
    - "WallMount"
    - "GasMiner"
  blacklistedComponents: []
```

String component IDs (e.g. "Item") are converted to `Type` via `IComponentFactory`. This also eliminates invalid components derived from yml, which is a fork-friendly method.

**Caching:**
On first use, component lists (`DeleteComponents`, `BlacklistedComponents`) are cached into `HashSet<Type>`, eliminating repeated string conversions. Cache is also marked as `[NonSerialized]`.

**Explosion Processing:**
- Entities with `BlacklistedComponents` are skipped (but they are still can take damage from the explosion).
- Entities with `DeleteComponents` are deleted if not in a container.
- The processed entities are added to a separate `HashSet`, which does not allow them to be processed again, which prevents errors and improves performance.

In terms of performance, of course, the new checks have an impact, but they do not take up more than 50% of the entity processing time. Also, the optimization benefit gained from removing such a huge number of objects on the map will significantly exceed the disadvantages of some additional load on the server during the explosion.

## Media
Default:
![image](https://github.com/user-attachments/assets/f622e35b-6d22-4de2-8fdc-d2a9303e2f7a)

Nuclear:
![image](https://github.com/user-attachments/assets/a6829f1e-2887-4c01-83a6-b50244034583)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Nuclear explosion now destroys items, cables, pipes, and the like.