### PR TITLE
AlternateVerb toggle for APCs (Redo)

### DIFF
--- a/Content.Client/Power/APC/ApcVisualizerSystem.cs
+++ b/Content.Client/Power/APC/ApcVisualizerSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.APC;
+using Content.Shared.Silicons.StationAi;
 using Robust.Client.GameObjects;
 
 namespace Content.Client.Power.APC;
@@ -7,6 +8,19 @@ public sealed class ApcVisualizerSystem : VisualizerSystem<ApcVisualsComponent>
 {
     [Dependency] private readonly SharedPointLightSystem _lights = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
+    [Dependency] private readonly SharedStationAiSystem _stationAiSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ApcVisualsComponent, GetStationAiRadialEvent>(OnApcGetRadial);
+    }
+
+    private void OnApcGetRadial(Entity<ApcVisualsComponent> _, ref GetStationAiRadialEvent args)
+    {
+        _stationAiSystem.AddApcToggleMainBreakerAction(ref args);
+    }
 
     protected override void OnAppearanceChange(EntityUid uid, ApcVisualsComponent comp, ref AppearanceChangeEvent args)
     {

--- a/Content.Client/Silicons/StationAi/StationAiBoundUserInterface.cs
+++ b/Content.Client/Silicons/StationAi/StationAiBoundUserInterface.cs
@@ -19,7 +19,7 @@ public sealed class StationAiBoundUserInterface(EntityUid owner, Enum uiKey) : B
         _menu.Track(Owner);
         var buttonModels = ConvertToButtons(ev.Actions);
         _menu.SetButtons(buttonModels);
-        
+
         _menu.Open();
     }
 

--- a/Content.Client/Silicons/StationAi/StationAiSystem.Airlock.cs
+++ b/Content.Client/Silicons/StationAi/StationAiSystem.Airlock.cs
@@ -11,14 +11,18 @@ public sealed partial class StationAiSystem
 
     private void InitializeAirlock()
     {
-        SubscribeLocalEvent<AirlockComponent, GetStationAiRadialEvent>(OnAirlockGetRadial);
+        SubscribeLocalEvent<DoorComponent, GetStationAiRadialEvent>(OnDoorGetRadial);
     }
 
-    private void OnAirlockGetRadial(Entity<AirlockComponent> ent, ref GetStationAiRadialEvent args)
+    private void OnDoorGetRadial(Entity<DoorComponent> ent, ref GetStationAiRadialEvent args)
     {
-        GetRadialAirlockDoorBolt(ent, ref args);
-        GetRadialAirlockEmergencyAccess(ent, ref args);
-        GetRadialAirlockElectrified(ent, ref args);
+        if (TryComp<AirlockComponent>(ent.Owner, out var airlockComp)) {
+            var airlockEnt = (ent.Owner, airlockComp);
+
+            GetRadialAirlockDoorBolt(airlockEnt, ref args);
+            GetRadialAirlockEmergencyAccess(airlockEnt, ref args);
+            GetRadialAirlockElectrified(airlockEnt, ref args);
+        }
     }
 
     private void GetRadialAirlockDoorBolt(Entity<AirlockComponent> ent, ref GetStationAiRadialEvent args)

--- a/Content.Client/Silicons/StationAi/StationAiSystem.Airlock.cs
+++ b/Content.Client/Silicons/StationAi/StationAiSystem.Airlock.cs
@@ -11,63 +11,76 @@ public sealed partial class StationAiSystem
 
     private void InitializeAirlock()
     {
-        SubscribeLocalEvent<DoorBoltComponent, GetStationAiRadialEvent>(OnDoorBoltGetRadial);
-        SubscribeLocalEvent<AirlockComponent, GetStationAiRadialEvent>(OnEmergencyAccessGetRadial);
-        SubscribeLocalEvent<ElectrifiedComponent, GetStationAiRadialEvent>(OnDoorElectrifiedGetRadial);
+        SubscribeLocalEvent<AirlockComponent, GetStationAiRadialEvent>(OnAirlockGetRadial);
     }
 
-    private void OnDoorBoltGetRadial(Entity<DoorBoltComponent> ent, ref GetStationAiRadialEvent args)
+    private void OnAirlockGetRadial(Entity<AirlockComponent> ent, ref GetStationAiRadialEvent args)
     {
+        GetRadialAirlockDoorBolt(ent, ref args);
+        GetRadialAirlockEmergencyAccess(ent, ref args);
+        GetRadialAirlockElectrified(ent, ref args);
+    }
+
+    private void GetRadialAirlockDoorBolt(Entity<AirlockComponent> ent, ref GetStationAiRadialEvent args)
+    {
+        if (!TryComp<DoorBoltComponent>(ent, out var doorBolt))
+            return;
+
         args.Actions.Add(
             new StationAiRadial
             {
-                Sprite = ent.Comp.BoltsDown
+                Sprite = doorBolt.BoltsDown
                     ? new SpriteSpecifier.Rsi(_aiActionsRsi, "unbolt_door")
                     : new SpriteSpecifier.Rsi(_aiActionsRsi, "bolt_door"),
-                Tooltip = ent.Comp.BoltsDown
+                Tooltip = doorBolt.BoltsDown
                     ? Loc.GetString("bolt-open")
                     : Loc.GetString("bolt-close"),
                 Event = new StationAiBoltEvent
                 {
-                    Bolted = !ent.Comp.BoltsDown,
+                    Bolted = !doorBolt.BoltsDown,
                 }
             }
         );
     }
 
-    private void OnEmergencyAccessGetRadial(Entity<AirlockComponent> ent, ref GetStationAiRadialEvent args)
+    private void GetRadialAirlockEmergencyAccess(Entity<AirlockComponent> ent, ref GetStationAiRadialEvent args)
     {
+        var airlock = ent.Comp;
+
         args.Actions.Add(
             new StationAiRadial
             {
-                Sprite = ent.Comp.EmergencyAccess
+                Sprite = airlock.EmergencyAccess
                     ? new SpriteSpecifier.Rsi(_aiActionsRsi, "emergency_off")
                     : new SpriteSpecifier.Rsi(_aiActionsRsi, "emergency_on"),
-                Tooltip = ent.Comp.EmergencyAccess
+                Tooltip = airlock.EmergencyAccess
                     ? Loc.GetString("emergency-access-off")
                     : Loc.GetString("emergency-access-on"),
                 Event = new StationAiEmergencyAccessEvent
                 {
-                    EmergencyAccess = !ent.Comp.EmergencyAccess,
+                    EmergencyAccess = !airlock.EmergencyAccess,
                 }
             }
         );
     }
 
-    private void OnDoorElectrifiedGetRadial(Entity<ElectrifiedComponent> ent, ref GetStationAiRadialEvent args)
+    private void GetRadialAirlockElectrified(Entity<AirlockComponent> ent, ref GetStationAiRadialEvent args)
     {
+        if (!TryComp<ElectrifiedComponent>(ent, out var electrified))
+            return;
+
         args.Actions.Add(
             new StationAiRadial
             {
-                Sprite = ent.Comp.Enabled
+                Sprite = electrified.Enabled
                     ? new SpriteSpecifier.Rsi(_aiActionsRsi, "door_overcharge_off")
                     : new SpriteSpecifier.Rsi(_aiActionsRsi, "door_overcharge_on"),
-                Tooltip = ent.Comp.Enabled
+                Tooltip = electrified.Enabled
                     ? Loc.GetString("electrify-door-off")
                     : Loc.GetString("electrify-door-on"),
                 Event = new StationAiElectrifiedEvent
                 {
-                    Electrified = !ent.Comp.Enabled,
+                    Electrified = !electrified.Enabled,
                 }
             }
         );

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Apc.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Apc.cs
@@ -1,0 +1,24 @@
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Silicons.StationAi;
+
+public abstract partial class SharedStationAiSystem
+{
+    public void AddApcToggleMainBreakerAction(ref GetStationAiRadialEvent args)
+    {
+        args.Actions.Add(new StationAiRadial()
+            {
+                Sprite = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png")),
+                Tooltip = Loc.GetString("apc-component-verb-text-alternative"),
+                Event = new StationAiApcToggleMainBreakerEvent()
+            }
+        );
+    }
+}
+
+/// <summary> Event for StationAI attempt at toggling an APC's main breaker. </summary>
+[Serializable, NetSerializable]
+public sealed class StationAiApcToggleMainBreakerEvent : BaseStationAiAction
+{
+}

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Held.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Held.cs
@@ -171,6 +171,17 @@ public abstract partial class SharedStationAiSystem
 
         var target = args.Target;
 
+        var ev = new GetStationAiRadialEvent();
+        RaiseLocalEvent(target, ref ev);
+
+        var actions = ev.Actions;
+
+        // Pass through if there is only one action ex. APC main breaker
+        if (actions.Count == 1) {
+            RaiseLocalEvent(target, actions[0].Event);
+            return;
+        }
+
         var isOpen = _uiSystem.IsUiOpen(target, AiUi.Key, user);
 
         var verb = new AlternativeVerb

--- a/Resources/Locale/en-US/apc/components/apc-component.ftl
+++ b/Resources/Locale/en-US/apc/components/apc-component.ftl
@@ -2,3 +2,4 @@ apc-component-insufficient-access = Insufficient access!
 apc-component-on-examine-panel-open = The [color=lightgray]APC electronics panel[/color] is [color=red]open[/color].
 apc-component-on-examine-panel-closed = The [color=lightgray]APC electronics panel[/color] is [color=darkgreen]closed[/color].
 apc-component-on-toggle-cancel = It does nothing!
+apc-component-verb-text-alternative = Toggle Breaker

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -87,6 +87,8 @@
   - type: ExtensionCableProvider
   - type: UserInterface
     interfaces:
+      enum.AiUi.Key:
+        type: StationAiBoundUserInterface
       enum.ApcUiKey.Key:
         type: ApcBoundUserInterface
   - type: ActivatableUI


### PR DESCRIPTION
## About the PR
Enables alt+click for APCs to toggle their main breaker.
Works for AI and skips the radial menu since there is only one action.

Downstream / future APCs with multiple actions will still spawn the menu.

## Why / Balance
A handy shortcut. Reduces the click spam when playing AI during a power outage, antimov lawset, what have you.

## Technical details
`GetVerbsEvent<AlternateVerb>` should be self explanatory for the humanoid interactions.

For the AI, the following assumes that APCs are setup with an `ApcComponent` / `ApcVisualsComponent` on the server / client respectively. There is no shared `ApcComponent`, it inherits `BaseApcNetComponent` so I couldn't just copy-paste the pattern from airlocks.

- `apc.yml`: BaseAPC prototype now has a key for StationAiBoundUserInterface
- `SharedStationAISystem.Apc`: Defines `StationAiApcToggleMainBreakerEvent` and `AddApcToggleMainBreakerAction()`
- (Client)`StationAISystem.Airlock` no longer subscribes to `DoorBoltComponent` and `ElectrifiedComponent`, but checks for them on airlocks instead
- (Client)`ApcVisualizerSystem` & (Server)`ApcSystem`: Respond to `GetStationAiRadialEvent()` to add a radial action for `StationAiApcToggleMainBreakerEvent`
- `SharedStationAiSystem.Held`: `OnTargetVerbs()` raises `GetStationAiRadialEvent` early, looks for a single action and if so, raises that action's event immediately, skipping the menu
- (Server)`ApcSystem`: Responds to `GetVerbsEvent<AlternativeVerb>`, `ApcToggleMainBreakerMessage` and `StationAiApcToggleMainBreakerEvent` to join all paths into `OnToggleMainBreaker()`

## Media
![unknown_2025 05 02-09 28](https://github.com/user-attachments/assets/c96f9822-3b81-4181-8149-6d6d0c056f03)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
In `ApcSystem`, the behavior of `OnToggleMainBreakerMessage()` was moved down to join multiple paths. `OnToggleMainBreaker()` takes the actor's ID directly.
`StationAISystem.Airlock` no longer subscribes to `DoorBoltComponent` and `ElectrifiedComponent`, but checks for them on airlocks instead.
In `StationAISystem.Airlock` a few `OnXGetRadial()` functions have been renamed for clarity.

**Changelog**
:cl:
- add: APCs can now be alt-clicked to quickly toggle their main breaker.
