### PR TITLE
Cleanup warnings in `ExpendableLightSystem`

### DIFF
--- a/Content.Client/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Client/Light/EntitySystems/ExpendableLightSystem.cs
@@ -1,8 +1,6 @@
 using Content.Client.Light.Components;
 using Content.Shared.Light.Components;
 using Robust.Client.GameObjects;
-using Robust.Client.Graphics;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 
 namespace Content.Client.Light.EntitySystems;
@@ -12,6 +10,7 @@ public sealed class ExpendableLightSystem : VisualizerSystem<ExpendableLightComp
     [Dependency] private readonly PointLightSystem _pointLightSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly LightBehaviorSystem _lightBehavior = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -31,7 +30,7 @@ public sealed class ExpendableLightSystem : VisualizerSystem<ExpendableLightComp
             return;
 
         if (AppearanceSystem.TryGetData<string>(uid, ExpendableLightVisuals.Behavior, out var lightBehaviourID, args.Component)
-        &&  TryComp<LightBehaviourComponent>(uid, out var lightBehaviour))
+            && TryComp<LightBehaviourComponent>(uid, out var lightBehaviour))
         {
             _lightBehavior.StopLightBehaviour((uid, lightBehaviour));
 
@@ -55,37 +54,37 @@ public sealed class ExpendableLightSystem : VisualizerSystem<ExpendableLightComp
                 comp.PlayingStream = _audioSystem.PlayPvs(
                     comp.LoopedSound, uid)?.Entity;
 
-                if (args.Sprite.LayerMapTryGet(ExpendableLightVisualLayers.Overlay, out var layerIdx, true))
+                if (_sprite.LayerMapTryGet((uid, args.Sprite), ExpendableLightVisualLayers.Overlay, out var layerIdx, true))
                 {
                     if (!string.IsNullOrWhiteSpace(comp.IconStateLit))
-                        args.Sprite.LayerSetState(layerIdx, comp.IconStateLit);
+                        _sprite.LayerSetRsiState((uid, args.Sprite), layerIdx, comp.IconStateLit);
                     if (!string.IsNullOrWhiteSpace(comp.SpriteShaderLit))
                         args.Sprite.LayerSetShader(layerIdx, comp.SpriteShaderLit);
                     else
                         args.Sprite.LayerSetShader(layerIdx, null, null);
                     if (comp.GlowColorLit.HasValue)
-                        args.Sprite.LayerSetColor(layerIdx, comp.GlowColorLit.Value);
-                    args.Sprite.LayerSetVisible(layerIdx, true);
+                        _sprite.LayerSetColor((uid, args.Sprite), layerIdx, comp.GlowColorLit.Value);
+                    _sprite.LayerSetVisible((uid, args.Sprite), layerIdx, true);
                 }
 
                 if (comp.GlowColorLit.HasValue)
-                    args.Sprite.LayerSetColor(ExpendableLightVisualLayers.Glow, comp.GlowColorLit.Value);
-                args.Sprite.LayerSetVisible(ExpendableLightVisualLayers.Glow, true);
+                    _sprite.LayerSetColor((uid, args.Sprite), ExpendableLightVisualLayers.Glow, comp.GlowColorLit.Value);
+                _sprite.LayerSetVisible((uid, args.Sprite), ExpendableLightVisualLayers.Glow, true);
 
                 break;
             case ExpendableLightState.Dead:
                 comp.PlayingStream = _audioSystem.Stop(comp.PlayingStream);
-                if (args.Sprite.LayerMapTryGet(ExpendableLightVisualLayers.Overlay, out layerIdx, true))
+                if (_sprite.LayerMapTryGet((uid, args.Sprite), ExpendableLightVisualLayers.Overlay, out layerIdx, true))
                 {
                     if (!string.IsNullOrWhiteSpace(comp.IconStateSpent))
-                        args.Sprite.LayerSetState(layerIdx, comp.IconStateSpent);
+                        _sprite.LayerSetRsiState((uid, args.Sprite), layerIdx, comp.IconStateSpent);
                     if (!string.IsNullOrWhiteSpace(comp.SpriteShaderSpent))
                         args.Sprite.LayerSetShader(layerIdx, comp.SpriteShaderSpent);
                     else
                         args.Sprite.LayerSetShader(layerIdx, null, null);
                 }
 
-                args.Sprite.LayerSetVisible(ExpendableLightVisualLayers.Glow, false);
+                _sprite.LayerSetVisible((uid, args.Sprite), ExpendableLightVisualLayers.Glow, false);
                 break;
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 9 warnings in `ExpendableLightSystem.cs`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods with `SpriteSystem` methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Expendable lights still being expended:
<img width="264" alt="Screenshot 2025-05-13 at 11 12 02 AM" src="https://github.com/user-attachments/assets/f49407cf-33c6-45c9-8a09-a873d1e564d1" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->