### PR TITLE
Tweak ND pin names and descriptions

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -191,8 +191,8 @@
 - type: entity
   parent: ClothingNeckPinBase
   id: ClothingNeckAutismPin
-  name: autism pin
-  description: Be autism do crime.
+  name: neurodivergent pin
+  description: Be neurodivergent do crime.
   components:
   - type: Sprite
     state: autism
@@ -202,8 +202,8 @@
 - type: entity
   parent: ClothingNeckPinBase
   id: ClothingNeckGoldAutismPin
-  name: golden autism pin
-  description: Be autism do warcrime.
+  name: autism pin
+  description: Be autism do crime.
   components:
   - type: Sprite
     state: goldautism

--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -192,7 +192,7 @@
   parent: ClothingNeckPinBase
   id: ClothingNeckAutismPin
   name: neurodivergent pin
-  description: Be neurodivergent do crime.
+  description: Be neurodivergent, do crime.
   components:
   - type: Sprite
     state: autism
@@ -203,7 +203,7 @@
   parent: ClothingNeckPinBase
   id: ClothingNeckGoldAutismPin
   name: autism pin
-  description: Be autism do crime.
+  description: Be autistic, do crime.
   components:
   - type: Sprite
     state: goldautism


### PR DESCRIPTION
## About the PR
Minor edits to the player-facing names and descriptions for two pins. Changes the rainbow infinity pin (currently named "autism pin") to a more generalized "neurodivergent pin" and the golden infinity pin (currently "golden autism pin") to just "autism pin". Descriptions are also edited to match.

## Why / Balance
This would generally be more correct considering what the corresponding symbols represent.

**The basic explanation is as follows:**
Neurodivergence -> diverse/spectrum -> rainbow
**Au**tism -> **Au** -> gold

## Technical details
Comically small PR, just a couple of YAML edits.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Changed the names of the neurodivergent pins to more accurately reflect their meanings.