### PR TITLE
Cleanup warnings in `HolopadSystem`

### DIFF
--- a/Content.Client/Holopad/HolopadSystem.cs
+++ b/Content.Client/Holopad/HolopadSystem.cs
@@ -13,6 +13,7 @@ public sealed class HolopadSystem : SharedHolopadSystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -58,8 +59,8 @@ public sealed class HolopadSystem : SharedHolopadSystem
             return;
 
         // Remove all sprite layers
-        for (int i = hologramSprite.AllLayers.Count() - 1; i >= 0; i--)
-            hologramSprite.RemoveLayer(i);
+        for (var i = hologramSprite.AllLayers.Count() - 1; i >= 0; i--)
+            _sprite.RemoveLayer((hologram, hologramSprite), i);
 
         if (TryComp<SpriteComponent>(target, out var targetSprite))
         {
@@ -67,17 +68,16 @@ public sealed class HolopadSystem : SharedHolopadSystem
             if (TryComp<HolographicAvatarComponent>(target, out var targetAvatar) &&
                 targetAvatar.LayerData != null)
             {
-                for (int i = 0; i < targetAvatar.LayerData.Length; i++)
+                for (var i = 0; i < targetAvatar.LayerData.Length; i++)
                 {
-                    var layer = targetAvatar.LayerData[i];
-                    hologramSprite.AddLayer(targetAvatar.LayerData[i], i);
+                    _sprite.AddLayer((hologram, hologramSprite), targetAvatar.LayerData[i], i);
                 }
             }
 
             // Otherwise copy the target's current physical appearance
             else
             {
-                hologramSprite.CopyFrom(targetSprite);
+                _sprite.CopySprite((hologram, hologramSprite), (target.Value, targetSprite));
             }
         }
 
@@ -87,25 +87,27 @@ public sealed class HolopadSystem : SharedHolopadSystem
             if (string.IsNullOrEmpty(holopadhologram.RsiPath) || string.IsNullOrEmpty(holopadhologram.RsiState))
                 return;
 
-            var layer = new PrototypeLayerData();
-            layer.RsiPath = holopadhologram.RsiPath;
-            layer.State = holopadhologram.RsiState;
+            var layer = new PrototypeLayerData
+            {
+                RsiPath = holopadhologram.RsiPath,
+                State = holopadhologram.RsiState
+            };
 
-            hologramSprite.AddLayer(layer);
+            _sprite.AddLayer((hologram, hologramSprite), layer, null);
         }
 
         // Override specific values
-        hologramSprite.Color = Color.White;
-        hologramSprite.Offset = holopadhologram.Offset;
-        hologramSprite.DrawDepth = (int)DrawDepth.Mobs;
+        _sprite.SetColor((hologram, hologramSprite), Color.White);
+        _sprite.SetOffset((hologram, hologramSprite), holopadhologram.Offset);
+        _sprite.SetDrawDepth((hologram, hologramSprite), (int)DrawDepth.Mobs);
         hologramSprite.NoRotation = true;
         hologramSprite.DirectionOverride = Direction.South;
         hologramSprite.EnableDirectionOverride = true;
 
         // Remove shading from all layers (except displacement maps)
-        for (int i = 0; i < hologramSprite.AllLayers.Count(); i++)
+        for (var i = 0; i < hologramSprite.AllLayers.Count(); i++)
         {
-            if (hologramSprite.TryGetLayer(i, out var layer) && layer.ShaderPrototype != "DisplacedStencilDraw")
+            if (_sprite.TryGetLayer((hologram, hologramSprite), i, out var layer, false) && layer.ShaderPrototype != "DisplacedStencilDraw")
                 hologramSprite.LayerSetShader(i, "unshaded");
         }
 

--- a/Content.Client/Holopad/HolopadSystem.cs
+++ b/Content.Client/Holopad/HolopadSystem.cs
@@ -77,7 +77,7 @@ public sealed class HolopadSystem : SharedHolopadSystem
             // Otherwise copy the target's current physical appearance
             else
             {
-                _sprite.CopySprite((hologram, hologramSprite), (target.Value, targetSprite));
+                _sprite.CopySprite((target.Value, targetSprite), (hologram, hologramSprite));
             }
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 8 warnings in `HolopadSystem`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods with `SpriteSystem` methods.
Also changed some explicitly typed variables to `var`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Holopad still projecting the AI:
<img width="232" alt="Screenshot 2025-05-13 at 12 16 40 PM" src="https://github.com/user-attachments/assets/91ff61b2-5759-4c53-bfa6-d7e7d00d2cc1" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->