### PR TITLE
Red Candle state fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/candles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/candles.yml
@@ -75,7 +75,6 @@
       left:
       - state: inhand-left
         color: "#a12349"
-      - state: inhand-left-flame
       right:
       - state: inhand-right
         color: "#a12349"


### PR DESCRIPTION
## About the PR
fixes unlit red candles in your left hand using the lit sprite instead of the default sprite

## Why / Balance
candle

## Media
![image](https://github.com/user-attachments/assets/0f9bd1fd-4a31-4238-b26c-fdb72dc1b692)
note; before candle displays as lit despite being unlit

## Technical details
there was an extra state being set erroneously

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

