### PR TITLE
Cleanup warnings in `AnomalySystem`

### DIFF
--- a/Content.Client/Anomaly/AnomalySystem.cs
+++ b/Content.Client/Anomaly/AnomalySystem.cs
@@ -11,6 +11,7 @@ public sealed class AnomalySystem : SharedAnomalySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly FloatingVisualizerSystem _floating = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -49,12 +50,12 @@ public sealed class AnomalySystem : SharedAnomalySystem
         if (HasComp<AnomalySupercriticalComponent>(uid))
             pulsing = true;
 
-        if (!sprite.LayerMapTryGet(AnomalyVisualLayers.Base, out var layer) ||
-            !sprite.LayerMapTryGet(AnomalyVisualLayers.Animated, out var animatedLayer))
+        if (!_sprite.LayerMapTryGet((uid, sprite), AnomalyVisualLayers.Base, out var layer, false) ||
+            !_sprite.LayerMapTryGet((uid, sprite), AnomalyVisualLayers.Animated, out var animatedLayer, false))
             return;
 
-        sprite.LayerSetVisible(layer, !pulsing);
-        sprite.LayerSetVisible(animatedLayer, pulsing);
+        _sprite.LayerSetVisible((uid, sprite), layer, !pulsing);
+        _sprite.LayerSetVisible((uid, sprite), animatedLayer, pulsing);
     }
 
     public override void Update(float frameTime)
@@ -63,16 +64,16 @@ public sealed class AnomalySystem : SharedAnomalySystem
 
         var query = EntityQueryEnumerator<AnomalySupercriticalComponent, SpriteComponent>();
 
-        while (query.MoveNext(out var super, out var sprite))
+        while (query.MoveNext(out var uid, out var super, out var sprite))
         {
-            var completion = 1f - (float) ((super.EndTime - _timing.CurTime) / super.SupercriticalDuration);
+            var completion = 1f - (float)((super.EndTime - _timing.CurTime) / super.SupercriticalDuration);
             var scale = completion * (super.MaxScaleAmount - 1f) + 1f;
-            sprite.Scale = new Vector2(scale, scale);
+            _sprite.SetScale((uid, sprite), new Vector2(scale, scale));
 
-            var transparency = (byte) (65 * (1f - completion) + 190);
+            var transparency = (byte)(65 * (1f - completion) + 190);
             if (transparency < sprite.Color.AByte)
             {
-                sprite.Color = sprite.Color.WithAlpha(transparency);
+                _sprite.SetColor((uid, sprite), sprite.Color.WithAlpha(transparency));
             }
         }
     }
@@ -82,7 +83,7 @@ public sealed class AnomalySystem : SharedAnomalySystem
         if (!TryComp<SpriteComponent>(ent, out var sprite))
             return;
 
-        sprite.Scale = Vector2.One;
-        sprite.Color = sprite.Color.WithAlpha(1f);
+        _sprite.SetScale((ent.Owner, sprite), Vector2.One);
+        _sprite.SetColor((ent.Owner, sprite), sprite.Color.WithAlpha(1f));
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 8 warnings in `AnomalySystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods and properties with `SpriteSystem` methods.
Also altered the `EntityQueryEnumerator` in `Update` to include the uid.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
An anomaly still being anomalous:
<img width="232" alt="Screenshot 2025-05-13 at 5 24 48 PM" src="https://github.com/user-attachments/assets/078f1917-1650-4579-b455-db34938913bf" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->