### PR TITLE
Cleanup warnings in `RevenantSystem`

### DIFF
--- a/Content.Client/Revenant/RevenantSystem.cs
+++ b/Content.Client/Revenant/RevenantSystem.cs
@@ -8,6 +8,7 @@ namespace Content.Client.Revenant;
 public sealed class RevenantSystem : EntitySystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -24,18 +25,18 @@ public sealed class RevenantSystem : EntitySystem
 
         if (_appearance.TryGetData<bool>(uid, RevenantVisuals.Harvesting, out var harvesting, args.Component) && harvesting)
         {
-            args.Sprite.LayerSetState(0, component.HarvestingState);
+            _sprite.LayerSetRsiState((uid, args.Sprite), 0, component.HarvestingState);
         }
         else if (_appearance.TryGetData<bool>(uid, RevenantVisuals.Stunned, out var stunned, args.Component) && stunned)
         {
-            args.Sprite.LayerSetState(0, component.StunnedState);
+            _sprite.LayerSetRsiState((uid, args.Sprite), 0, component.StunnedState);
         }
         else if (_appearance.TryGetData<bool>(uid, RevenantVisuals.Corporeal, out var corporeal, args.Component))
         {
             if (corporeal)
-                args.Sprite.LayerSetState(0, component.CorporealState);
+                _sprite.LayerSetRsiState((uid, args.Sprite), 0, component.CorporealState);
             else
-                args.Sprite.LayerSetState(0, component.State);
+                _sprite.LayerSetRsiState((uid, args.Sprite), 0, component.State);
         }
     }
 
@@ -44,10 +45,9 @@ public sealed class RevenantSystem : EntitySystem
         if (args.Alert.ID != ent.Comp.EssenceAlert)
             return;
 
-        var sprite = args.SpriteViewEnt.Comp;
         var essence = Math.Clamp(ent.Comp.Essence.Int(), 0, 999);
-        sprite.LayerSetState(RevenantVisualLayers.Digit1, $"{(essence / 100) % 10}");
-        sprite.LayerSetState(RevenantVisualLayers.Digit2, $"{(essence / 10) % 10}");
-        sprite.LayerSetState(RevenantVisualLayers.Digit3, $"{essence % 10}");
+        _sprite.LayerSetRsiState(args.SpriteViewEnt.AsNullable(), RevenantVisualLayers.Digit1, $"{(essence / 100) % 10}");
+        _sprite.LayerSetRsiState(args.SpriteViewEnt.AsNullable(), RevenantVisualLayers.Digit2, $"{(essence / 10) % 10}");
+        _sprite.LayerSetRsiState(args.SpriteViewEnt.AsNullable(), RevenantVisualLayers.Digit3, $"{essence % 10}");
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 7 warnings in `RevenantSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent.LayerSetState` with `SpriteSystem.LayerSetRsiState`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Revenant still visibly harvesting:
<img width="79" alt="Screenshot 2025-05-13 at 5 42 44 PM" src="https://github.com/user-attachments/assets/ba7a5ad9-70ac-42b0-917f-3deb093720dd" />
Essence counter still counting essence:
<img width="79" alt="Screenshot 2025-05-13 at 5 41 15 PM" src="https://github.com/user-attachments/assets/d67c1379-eb81-4f07-8a3f-f8cc59eceabc" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->