### PR TITLE
Cleanup warnings in `CryoPodSystem`

### DIFF
--- a/Content.Client/Medical/Cryogenics/CryoPodSystem.cs
+++ b/Content.Client/Medical/Cryogenics/CryoPodSystem.cs
@@ -9,6 +9,7 @@ namespace Content.Client.Medical.Cryogenics;
 public sealed class CryoPodSystem : SharedCryoPodSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -32,7 +33,7 @@ public sealed class CryoPodSystem : SharedCryoPodSystem
         }
 
         component.PreviousOffset = spriteComponent.Offset;
-        spriteComponent.Offset = new Vector2(0, 1);
+        _sprite.SetOffset((uid, spriteComponent), new Vector2(0, 1));
     }
 
     private void OnCryoPodRemoval(EntityUid uid, InsideCryoPodComponent component, ComponentRemove args)
@@ -42,7 +43,7 @@ public sealed class CryoPodSystem : SharedCryoPodSystem
             return;
         }
 
-        spriteComponent.Offset = component.PreviousOffset;
+        _sprite.SetOffset((uid, spriteComponent), component.PreviousOffset);
     }
 
     private void OnAppearanceChange(EntityUid uid, CryoPodComponent component, ref AppearanceChangeEvent args)
@@ -60,14 +61,14 @@ public sealed class CryoPodSystem : SharedCryoPodSystem
 
         if (isOpen)
         {
-            args.Sprite.LayerSetState(CryoPodVisualLayers.Base, "pod-open");
-            args.Sprite.LayerSetVisible(CryoPodVisualLayers.Cover, false);
+            _sprite.LayerSetRsiState((uid, args.Sprite), CryoPodVisualLayers.Base, "pod-open");
+            _sprite.LayerSetVisible((uid, args.Sprite), CryoPodVisualLayers.Cover, false);
         }
         else
         {
-            args.Sprite.LayerSetState(CryoPodVisualLayers.Base, isOn ? "pod-on" : "pod-off");
-            args.Sprite.LayerSetState(CryoPodVisualLayers.Cover, isOn ? "cover-on" : "cover-off");
-            args.Sprite.LayerSetVisible(CryoPodVisualLayers.Cover, true);
+            _sprite.LayerSetRsiState((uid, args.Sprite), CryoPodVisualLayers.Base, isOn ? "pod-on" : "pod-off");
+            _sprite.LayerSetRsiState((uid, args.Sprite), CryoPodVisualLayers.Cover, isOn ? "cover-on" : "cover-off");
+            _sprite.LayerSetVisible((uid, args.Sprite), CryoPodVisualLayers.Cover, true);
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 7 warnings in `CryoPodSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods and properties with `SpriteSystem` methods

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Cryopods still showing occupied state:
<img width="169" alt="Screenshot 2025-05-13 at 7 42 01 PM" src="https://github.com/user-attachments/assets/954222f2-9ed4-410f-a5c9-a5f9d1c3d858" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->