### PR TITLE
Cleanup warnings in `AirlockSystem`

### DIFF
--- a/Content.Client/Doors/AirlockSystem.cs
+++ b/Content.Client/Doors/AirlockSystem.cs
@@ -10,6 +10,7 @@ namespace Content.Client.Doors;
 public sealed class AirlockSystem : SharedAirlockSystem
 {
     [Dependency] private readonly AppearanceSystem _appearanceSystem = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -21,7 +22,7 @@ public sealed class AirlockSystem : SharedAirlockSystem
     private void OnComponentStartup(EntityUid uid, AirlockComponent comp, ComponentStartup args)
     {
         // Has to be on component startup because we don't know what order components initialize in and running this before DoorComponent inits _will_ crash.
-        if(!TryComp<DoorComponent>(uid, out var door))
+        if (!TryComp<DoorComponent>(uid, out var door))
             return;
 
         if (comp.OpenUnlitVisible) // Otherwise there are flashes of the fallback sprite between clicking on the door and the door closing animation starting.
@@ -31,17 +32,17 @@ public sealed class AirlockSystem : SharedAirlockSystem
         }
 
         ((Animation)door.OpeningAnimation).AnimationTracks.Add(new AnimationTrackSpriteFlick()
-            {
-                LayerKey = DoorVisualLayers.BaseUnlit,
-                KeyFrames = { new AnimationTrackSpriteFlick.KeyFrame(comp.OpeningSpriteState, 0f) },
-            }
+        {
+            LayerKey = DoorVisualLayers.BaseUnlit,
+            KeyFrames = { new AnimationTrackSpriteFlick.KeyFrame(comp.OpeningSpriteState, 0f) },
+        }
         );
 
         ((Animation)door.ClosingAnimation).AnimationTracks.Add(new AnimationTrackSpriteFlick()
-            {
-                LayerKey = DoorVisualLayers.BaseUnlit,
-                KeyFrames = { new AnimationTrackSpriteFlick.KeyFrame(comp.ClosingSpriteState, 0f) },
-            }
+        {
+            LayerKey = DoorVisualLayers.BaseUnlit,
+            KeyFrames = { new AnimationTrackSpriteFlick.KeyFrame(comp.ClosingSpriteState, 0f) },
+        }
         );
 
         door.DenyingAnimation = new Animation()
@@ -57,19 +58,19 @@ public sealed class AirlockSystem : SharedAirlockSystem
             }
         };
 
-        if(!comp.AnimatePanel)
+        if (!comp.AnimatePanel)
             return;
 
         ((Animation)door.OpeningAnimation).AnimationTracks.Add(new AnimationTrackSpriteFlick()
         {
             LayerKey = WiresVisualLayers.MaintenancePanel,
-            KeyFrames = {new AnimationTrackSpriteFlick.KeyFrame(comp.OpeningPanelSpriteState, 0f)},
+            KeyFrames = { new AnimationTrackSpriteFlick.KeyFrame(comp.OpeningPanelSpriteState, 0f) },
         });
 
         ((Animation)door.ClosingAnimation).AnimationTracks.Add(new AnimationTrackSpriteFlick
         {
             LayerKey = WiresVisualLayers.MaintenancePanel,
-            KeyFrames = {new AnimationTrackSpriteFlick.KeyFrame(comp.ClosingPanelSpriteState, 0f)},
+            KeyFrames = { new AnimationTrackSpriteFlick.KeyFrame(comp.ClosingPanelSpriteState, 0f) },
         });
     }
 
@@ -101,11 +102,12 @@ public sealed class AirlockSystem : SharedAirlockSystem
                     && !boltedVisible && !emergencyLightsVisible;
         }
 
-        args.Sprite.LayerSetVisible(DoorVisualLayers.BaseUnlit, unlitVisible);
-        args.Sprite.LayerSetVisible(DoorVisualLayers.BaseBolted, boltedVisible);
+        _sprite.LayerSetVisible((uid, args.Sprite), DoorVisualLayers.BaseUnlit, unlitVisible);
+        _sprite.LayerSetVisible((uid, args.Sprite), DoorVisualLayers.BaseBolted, boltedVisible);
         if (comp.EmergencyAccessLayer)
         {
-            args.Sprite.LayerSetVisible(
+            _sprite.LayerSetVisible(
+                (uid, args.Sprite),
                 DoorVisualLayers.BaseEmergencyAccess,
                     emergencyLightsVisible
                 &&  state != DoorState.Open
@@ -118,12 +120,12 @@ public sealed class AirlockSystem : SharedAirlockSystem
         switch (state)
         {
             case DoorState.Open:
-                args.Sprite.LayerSetState(DoorVisualLayers.BaseUnlit, comp.ClosingSpriteState);
-                args.Sprite.LayerSetAnimationTime(DoorVisualLayers.BaseUnlit, 0);
+                _sprite.LayerSetRsiState((uid, args.Sprite), DoorVisualLayers.BaseUnlit, comp.ClosingSpriteState);
+                _sprite.LayerSetAnimationTime((uid, args.Sprite), DoorVisualLayers.BaseUnlit, 0);
                 break;
             case DoorState.Closed:
-                args.Sprite.LayerSetState(DoorVisualLayers.BaseUnlit, comp.OpeningSpriteState);
-                args.Sprite.LayerSetAnimationTime(DoorVisualLayers.BaseUnlit, 0);
+                _sprite.LayerSetRsiState((uid, args.Sprite), DoorVisualLayers.BaseUnlit, comp.OpeningSpriteState);
+                _sprite.LayerSetAnimationTime((uid, args.Sprite), DoorVisualLayers.BaseUnlit, 0);
                 break;
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 7 warnings in `AirlockSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods with `SpriteSystem` methods.
Plus a few formatting fixes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Airlock animating with indicator lights:
<img width="169" alt="Screenshot 2025-05-13 at 7 52 30 PM" src="https://github.com/user-attachments/assets/1160489b-1815-4a23-8456-adcf7bb5828a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->