### PR TITLE
Cleanup warnings in `DamageStateVisualizerSystem`

### DIFF
--- a/Content.Client/DamageState/DamageStateVisualizerSystem.cs
+++ b/Content.Client/DamageState/DamageStateVisualizerSystem.cs
@@ -6,6 +6,8 @@ namespace Content.Client.DamageState;
 
 public sealed class DamageStateVisualizerSystem : VisualizerSystem<DamageStateVisualsComponent>
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     protected override void OnAppearanceChange(EntityUid uid, DamageStateVisualsComponent component, ref AppearanceChangeEvent args)
     {
         var sprite = args.Sprite;
@@ -21,34 +23,34 @@ public sealed class DamageStateVisualizerSystem : VisualizerSystem<DamageStateVi
         }
 
         // Brain no worky rn so this was just easier.
-        foreach (var key in new []{ DamageStateVisualLayers.Base, DamageStateVisualLayers.BaseUnshaded })
+        foreach (var key in new[] { DamageStateVisualLayers.Base, DamageStateVisualLayers.BaseUnshaded })
         {
-            if (!sprite.LayerMapTryGet(key, out _)) continue;
+            if (!_sprite.LayerMapTryGet((uid, sprite), key, out _, false)) continue;
 
-            sprite.LayerSetVisible(key, false);
+            _sprite.LayerSetVisible((uid, sprite), key, false);
         }
 
         foreach (var (key, state) in layers)
         {
             // Inheritance moment.
-            if (!sprite.LayerMapTryGet(key, out _)) continue;
+            if (!_sprite.LayerMapTryGet((uid, sprite), key, out _, false)) continue;
 
-            sprite.LayerSetVisible(key, true);
-            sprite.LayerSetState(key, state);
+            _sprite.LayerSetVisible((uid, sprite), key, true);
+            _sprite.LayerSetRsiState((uid, sprite), key, state);
         }
 
         // So they don't draw over mobs anymore
         if (data == MobState.Dead)
         {
-            if (sprite.DrawDepth > (int) DrawDepth.DeadMobs)
+            if (sprite.DrawDepth > (int)DrawDepth.DeadMobs)
             {
                 component.OriginalDrawDepth = sprite.DrawDepth;
-                sprite.DrawDepth = (int) DrawDepth.DeadMobs;
+                _sprite.SetDrawDepth((uid, sprite), (int)DrawDepth.DeadMobs);
             }
         }
         else if (component.OriginalDrawDepth != null)
         {
-            sprite.DrawDepth = component.OriginalDrawDepth.Value;
+            _sprite.SetDrawDepth((uid, sprite), component.OriginalDrawDepth.Value);
             component.OriginalDrawDepth = null;
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 7 warnings in `DamageStateVisualizerSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods and properties with `SpriteSystem` methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
A mouse showcasing different damage state visuals:
<img width="117" alt="Screenshot 2025-05-13 at 8 02 46 PM" src="https://github.com/user-attachments/assets/264356a7-4f9c-4ee9-a168-bdd1d6c5587e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->