### PR TITLE
Wall inheritance cleanup

### DIFF
--- a/Content.Server/Construction/Commands/TileWallsCommand.cs
+++ b/Content.Server/Construction/Commands/TileWallsCommand.cs
@@ -25,6 +25,7 @@ public sealed class TileWallsCommand : IConsoleCommand
 
     [ValidatePrototypeId<TagPrototype>]
     public const string WallTag = "Wall";
+    public const string DiagonalTag = "Diagonal";
 
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
@@ -81,6 +82,11 @@ public sealed class TileWallsCommand : IConsoleCommand
             }
 
             if (!tagSystem.HasTag(child, WallTag))
+            {
+                continue;
+            }
+
+            if (tagSystem.HasTag(child, DiagonalTag))
             {
                 continue;
             }

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -21,7 +21,7 @@
   - type: Tag
     tags:
     - Wall
-  - type: IsRoof
+  - type: IsRoof #Good for diag?
   - type: Sprite
     drawdepth: Walls
   - type: Icon
@@ -44,521 +44,35 @@
         layer:
         - WallLayer
         density: 1000
-  - type: Occluder
   - type: Airtight
   - type: StaticPrice
     price: 75
-  - type: RadiationBlocker
+  - type: RadiationBlocker #Good for diag?
     resistance: 2
-  - type: BlockWeather
-  - type: SunShadowCast
+  - type: BlockWeather #Good for diag?
+  - type: SunShadowCast #Good for diag?
 
 - type: entity
+  abstract: true
   parent: BaseWall
-  id: WallBrick
-  name: brick wall
+  id: BaseFullWall
   components:
-  - type: Sprite
-    sprite: Structures/Walls/brick.rsi
-  - type: Icon
-    sprite: Structures/Walls/brick.rsi
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-
-  - type: IconSmooth
-    key: walls
-    base: brick
+  - type: Occluder # Breaks on diagonal walls
 
 - type: entity
+  abstract: true
   parent: BaseWall
-  id: WallClock
-  name: clock wall
+  id: WallDiagonalBase
+  suffix: Diagonal
   components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/clock.rsi
-  - type: Icon
-    sprite: Structures/Walls/clock.rsi
-  - type: Construction
-    graph: ClockworkGirder
-    node: clockworkWall
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          ClockworkGirder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: clock
-
-- type: entity
-  parent: BaseWall
-  id: WallClown
-  name: bananium wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/clown.rsi
-  - type: Icon
-    sprite: Structures/Walls/clown.rsi
-  - type: Construction
-    graph: Girder
-    node: bananiumWall
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: clown
-
-- type: entity
-  parent: BaseWall
-  id: WallMeat
-  name: meat wall
-  description: Sticky.
-  components:
-  - type: Tag
-    tags:
-      - Wall
-      - Structure
-  - type: Sprite
-    sprite: Structures/Walls/meat.rsi
-  - type: Icon
-    sprite: Structures/Walls/meat.rsi
-  - type: Construction
-    graph: Girder
-    node: meatWall
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 100 # weak
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: meat
-
-- type: entity
-  parent: BaseWall
-  id: WallCult
-  name: cult wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/cult.rsi
-  - type: Icon
-    sprite: Structures/Walls/cult.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: cult
-
-- type: entity
-  parent: BaseWall
-  id: WallDebug
-  name: debug wall
-  suffix: DEBUG
-  components:
-  - type: Tag
-    tags:
-      - Wall
-      - Debug
-  - type: Sprite
-    sprite: Structures/Walls/debug.rsi
-  - type: Icon
-    sprite: Structures/Walls/debug.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: debug
-
-- type: entity
-  parent: BaseWall
-  id: WallDiamond
-  name: diamond wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/diamond.rsi
-  - type: Icon
-    sprite: Structures/Walls/diamond.rsi
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: diamond
-
-- type: entity
-  parent: BaseWall
-  id: WallGold
-  name: gold wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/gold.rsi
-  - type: Icon
-    sprite: Structures/Walls/gold.rsi
-  - type: Construction
-    graph: Girder
-    node: goldWall
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    base: gold
-
-- type: entity
-  parent: BaseWall
-  id: WallIce
-  name: ice wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/ice.rsi
-  - type: Icon
-    sprite: Structures/Walls/ice.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: ice
-
-- type: entity
-  parent: BaseWall
-  id: WallPlasma
-  name: plasma wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/plasma.rsi
-  - type: Icon
-    sprite: Structures/Walls/plasma.rsi
-  - type: Construction
-    graph: Girder
-    node: plasmaWall
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    base: plasma
-  - type: RadiationBlocker
-    resistance: 5
-
-- type: entity
-  parent: BaseWall
-  id: WallPlastic
-  name: plastic wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/plastic.rsi
-  - type: Icon
-    sprite: Structures/Walls/plastic.rsi
-  - type: Construction
-    graph: Girder
-    node: plasticWall
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    base: plastic
-
-- type: entity
-  parent: BaseWall
-  id: WallPlastitaniumIndestructible
-  name: plastitanium wall
-  suffix: indestructible
-  components:
-    - type: Tag
-      tags:
-        - Wall
-    - type: Sprite
-      sprite: Structures/Walls/plastitanium.rsi
-    - type: Icon
-      sprite: Structures/Walls/plastitanium.rsi
-    - type: IconSmooth
-      key: walls
-      base: plastitanium
-
-- type: entity
-  parent: WallPlastitaniumIndestructible
-  id: WallPlastitanium
-  name: plastitanium wall
-  suffix: ""
-  components:
-    - type: Tag
-      tags:
-        - Wall
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 1000
-          behaviors:
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                Girder:
-                  min: 1
-                  max: 1
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-
-- type: entity
-  parent: WallShuttleDiagonal
-  id: WallPlastitaniumDiagonal
-  name: plastitanium wall
-  suffix: diagonal
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wall
-  components:
-  - type: Sprite
-    drawdepth: Walls
-    sprite: Structures/Walls/plastitanium_diagonal.rsi
-    state: state0
-  - type: IconSmooth
-    mode: Diagonal
-    key: walls
-    base: state
-  - type: Icon
-    sprite: Structures/Walls/plastitanium_diagonal.rsi
-    state: state0
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 2000
-      behaviors:
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
-        - !type:PlaySoundBehavior
-          sound:
-            collection: MetalSlam
-    - trigger:
-        !type:DamageTrigger
-        damage: 1000
-      behaviors:
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-
-- type: entity
-  id: WallPlastitaniumDiagonalIndestructible
-  name: plastitanium wall
-  suffix: diagonal, indestructible
-  description: Keeps the air in and the greytide out.
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wall
-  components:
-  - type: Transform
-    anchored: true
-  - type: Clickable
   - type: Tag
     tags:
     - Wall
     - Diagonal
-  - type: Sprite
-    drawdepth: Walls
-    sprite: Structures/Walls/plastitanium_diagonal.rsi
-    state: state0
   - type: IconSmooth
     mode: Diagonal
     key: walls
     base: state
-  - type: Icon
-    sprite: Structures/Walls/plastitanium_diagonal.rsi
-    state: state0
-  - type: Physics
-    bodyType: Static
   - type: Airtight
     noAirWhenFullyAirBlocked: false
     airBlockedDirection:
@@ -578,8 +92,135 @@
         layer:
         - WallLayer
 
+
+# Standard Walls
+
 - type: entity
-  parent: BaseWall
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallSolid
+  name: solid wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/solid.rsi
+  - type: WallReplacementMarker
+  - type: Construction
+    graph: Girder
+    node: wall
+  - type: Icon
+    sprite: Structures/Walls/solid.rsi
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 400
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: IconSmooth
+    key: walls
+    base: solid
+
+- type: entity
+  parent: WallDiagonalBase
+  id: WallSolidDiagonal
+  name: solid wall
+  components:
+  - type: Sprite
+    drawdepth: Walls
+    sprite: Structures/Walls/solid_diagonal.rsi
+    state: state0
+  - type: Icon
+    sprite: Structures/Walls/solid_diagonal.rsi
+    state: state0
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 400
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+
+- type: entity
+  parent: WallSolid
+  id: WallSolidRust
+  suffix: rusted
+  components:
+  - type: Sprite
+    sprite: Structures/Walls/solid_rust.rsi
+  - type: Icon
+    sprite: Structures/Walls/solid_rust.rsi
+    state: full
+  - type: Construction
+    graph: Girder
+    node: wallrust
+  - type: IconSmooth
+    key: walls
+    base: solid
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
   id: WallReinforced
   name: reinforced wall
   components:
@@ -676,35 +317,136 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
 
-
 - type: entity
-  parent: WallShuttleDiagonal
+  parent: WallDiagonalBase
   id: WallReinforcedDiagonal
   name: reinforced wall
-  suffix: diagonal
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wall
   components:
-  - type: Tag
-    tags:
-    - Diagonal
   - type: Sprite
     drawdepth: Walls
     sprite: Structures/Walls/reinforced_diagonal.rsi
     state: state0
-  - type: IconSmooth
-    mode: Diagonal
-    key: walls
-    base: state
   - type: Icon
     sprite: Structures/Walls/reinforced_diagonal.rsi
     state: state0
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallicStrong
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallPlastitaniumIndestructible
+  name: plastitanium wall
+  suffix: indestructible
+  components:
+    - type: Sprite
+      sprite: Structures/Walls/plastitanium.rsi
+    - type: Icon
+      sprite: Structures/Walls/plastitanium.rsi
+    - type: IconSmooth
+      key: walls
+      base: plastitanium
+    - type: Damageable
+      damageContainer: StructuralInorganic
+      damageModifierSet: StructuralMetallicStrong
+
+- type: entity
+  parent: WallPlastitaniumIndestructible
+  id: WallPlastitanium
+  name: plastitanium wall
+  suffix: ""
+  components:
+    - type: Destructible
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 1000
+          behaviors:
+            - !type:SpawnEntitiesBehavior
+              spawn:
+                Girder:
+                  min: 1
+                  max: 1
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
+
+#Plastitanium
+- type: entity
+  parent: WallDiagonalBase
+  id: WallPlastitaniumDiagonalIndestructible
+  name: plastitanium wall
+  suffix: diagonal, indestructible
+  components:
+  - type: Sprite
+    drawdepth: Walls
+    sprite: Structures/Walls/plastitanium_diagonal.rsi
+    state: state0
+  - type: Icon
+    sprite: Structures/Walls/plastitanium_diagonal.rsi
+    state: state0
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallicStrong
+
+- type: entity
+  parent: WallPlastitaniumDiagonalIndestructible
+  id: WallPlastitaniumDiagonal
+  name: plastitanium wall
+  suffix: diagonal
+  components:
+  - type: Sprite
+    drawdepth: Walls
+    sprite: Structures/Walls/plastitanium_diagonal.rsi
+    state: state0
+  - type: Icon
+    sprite: Structures/Walls/plastitanium_diagonal.rsi
+    state: state0
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1000
+      behaviors:
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            Girder:
+              min: 1
+              max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalSlam
 
 # Riveting
 - type: entity
-  parent: BaseWall
+  parent:
+  - BaseWall
+  - BaseFullWall
   id: WallRiveted
   name: riveted wall
   components:
@@ -737,18 +479,57 @@
   - type: StaticPrice
     price: 150
 
+#Debug
 - type: entity
-  parent: BaseWall
-  id: WallSandstone
-  name: sandstone wall
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallDebug
+  name: debug wall
+  suffix: DEBUG
+  components:
+  - type: Tag
+    tags:
+      - Wall
+      - Debug
+  - type: Sprite
+    sprite: Structures/Walls/debug.rsi
+  - type: Icon
+    sprite: Structures/Walls/debug.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: debug
+
+
+# Material Walls
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallDiamond
+  name: diamond wall
   components:
   - type: Tag
     tags:
       - Wall
   - type: Sprite
-    sprite: Structures/Walls/sandstone.rsi
+    sprite: Structures/Walls/diamond.rsi
   - type: Icon
-    sprite: Structures/Walls/sandstone.rsi
+    sprite: Structures/Walls/diamond.rsi
   - type: RCDDeconstructable
     cost: 6
     delay: 8
@@ -768,10 +549,155 @@
         acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
-    base: sandstone
+    base: diamond
 
 - type: entity
-  parent: BaseWall
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallGold
+  name: gold wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/gold.rsi
+  - type: Icon
+    sprite: Structures/Walls/gold.rsi
+  - type: Construction
+    graph: Girder
+    node: goldWall
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: IconSmooth
+    key: walls
+    base: gold
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallPlasma
+  name: plasma wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/plasma.rsi
+  - type: Icon
+    sprite: Structures/Walls/plasma.rsi
+  - type: Construction
+    graph: Girder
+    node: plasmaWall
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: IconSmooth
+    key: walls
+    base: plasma
+  - type: RadiationBlocker
+    resistance: 5
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallPlastic
+  name: plastic wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/plastic.rsi
+  - type: Icon
+    sprite: Structures/Walls/plastic.rsi
+  - type: Construction
+    graph: Girder
+    node: plasticWall
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: IconSmooth
+    key: walls
+    base: plastic
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
   id: WallSilver
   name: silver wall
   components:
@@ -815,61 +741,395 @@
     key: walls
     base: silver
 
-#shuttle walls
 - type: entity
-  id: WallShuttleDiagonal
-  name: shuttle wall
-  suffix: Diagonal
-  description: Keeps the air in and the greytide out.
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wall
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallUranium
+  name: uranium wall
   components:
-  - type: Transform
-    anchored: true
+  - type: Sprite
+    sprite: Structures/Walls/uranium.rsi
+  - type: Icon
+    sprite: Structures/Walls/uranium.rsi
+  - type: Construction
+    graph: Girder
+    node: uraniumWall
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: IconSmooth
+    key: walls
+    base: uranium
+  - type: RadiationBlocker
+    resistance: 6
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallWood
+  name: wood wall
+  description: The traditional greytide defense.
+  components:
+  - type: Sprite
+    sprite: Structures/Walls/wood.rsi
+  - type: Icon
+    sprite: Structures/Walls/wood.rsi
+  - type: Construction
+    graph: Barricade
+    node: woodWall
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WoodDestroyHeavy
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WoodDestroyHeavy
+      - !type:ChangeConstructionNodeBehavior
+        node: Barricade
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: IconSmooth
+    key: woods
+    base: wood
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallWeb
+  name: web wall
+  description: Keeps the spiders in and the greytide out.
+  components:
   - type: Clickable
+  - type: MeleeSound
+    soundGroups:
+      Brute:
+        path:
+          "/Audio/Weapons/slash.ogg"
+  - type: Damageable
+    damageModifierSet: Web
   - type: Tag
     tags:
-    - Wall
-    - Diagonal
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/web.rsi
+  - type: Icon
+    sprite: Structures/Walls/web.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 30
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialWebSilk:
+            min: 1
+            max: 1
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WoodDestroy
+  - type: IconSmooth
+    key: webs
+    base: wall
+  - type: Construction
+    graph: WebStructures
+    node: wall
+
+
+# Misc Walls
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallBrick
+  name: brick wall
+  components:
+  - type: Sprite
+    sprite: Structures/Walls/brick.rsi
+  - type: Icon
+    sprite: Structures/Walls/brick.rsi
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: brick
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallClock
+  name: clock wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/clock.rsi
+  - type: Icon
+    sprite: Structures/Walls/clock.rsi
+  - type: Construction
+    graph: ClockworkGirder
+    node: clockworkWall
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          ClockworkGirder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: clock
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallClown
+  name: bananium wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/clown.rsi
+  - type: Icon
+    sprite: Structures/Walls/clown.rsi
+  - type: Construction
+    graph: Girder
+    node: bananiumWall
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: clown
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallCult
+  name: cult wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/cult.rsi
+  - type: Icon
+    sprite: Structures/Walls/cult.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: cult
+
+# Organic Walls
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallSandstone
+  name: sandstone wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/sandstone.rsi
+  - type: Icon
+    sprite: Structures/Walls/sandstone.rsi
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: sandstone
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallIce
+  name: ice wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/ice.rsi
+  - type: Icon
+    sprite: Structures/Walls/ice.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: ice
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallMeat
+  name: meat wall
+  description: Sticky.
+  components:
+  - type: Tag
+    tags:
+      - Wall
+      - Structure
+  - type: Sprite
+    sprite: Structures/Walls/meat.rsi
+  - type: Icon
+    sprite: Structures/Walls/meat.rsi
+  - type: Construction
+    graph: Girder
+    node: meatWall
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100 # weak
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: meat
+
+#shuttle walls
+- type: entity
+  parent: WallDiagonalBase
+  id: WallShuttleDiagonal
+  name: shuttle wall
+  components:
   - type: Sprite
     drawdepth: Walls
     sprite: Structures/Walls/shuttle_diagonal.rsi
     state: state0
-  - type: IconSmooth
-    mode: Diagonal
-    key: walls
-    base: state
   - type: Icon
     sprite: Structures/Walls/shuttle_diagonal.rsi
     state: state0
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallic
-  - type: Physics
-    bodyType: Static
   - type: Reflect
     reflectProb: 1
-  - type: Pullable
-  - type: Airtight
-    noAirWhenFullyAirBlocked: false
-    airBlockedDirection:
-    - South
-    - East
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PolygonShape
-            vertices:
-            - "-0.5,-0.5"
-            - "0.5,0.5"
-            - "0.5,-0.5"
-        mask:
-        - FullTileMask
-        layer:
-        - WallLayer
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallicStrong
   - type: Destructible
     thresholds:
     - trigger:
@@ -897,7 +1157,9 @@
     node: diagonalshuttleWall
 
 - type: entity
-  parent: BaseWall
+  parent:
+  - BaseWall
+  - BaseFullWall
   id: WallShuttle
   name: shuttle wall
   components:
@@ -956,241 +1218,13 @@
   - type: Reflect
     reflectProb: 1
 
-- type: entity
-  parent: BaseWall
-  id: WallSolid
-  name: solid wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/solid.rsi
-  - type: WallReplacementMarker
-  - type: Construction
-    graph: Girder
-    node: wall
-  - type: Icon
-    sprite: Structures/Walls/solid.rsi
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 400
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-    - trigger:
-        !type:DamageTrigger
-        damage: 200
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    base: solid
-
-- type: entity
-  parent: WallShuttleDiagonal
-  id: WallSolidDiagonal
-  name: solid wall
-  suffix: diagonal
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wall
-  components:
-  - type: Sprite
-    drawdepth: Walls
-    sprite: Structures/Walls/solid_diagonal.rsi
-    state: state0
-  - type: IconSmooth
-    mode: Diagonal
-    key: walls
-    base: state
-  - type: Icon
-    sprite: Structures/Walls/solid_diagonal.rsi
-    state: state0
-
-- type: entity
-  parent: WallSolid
-  id: WallSolidRust
-  suffix: rusted
-  components:
-  - type: Sprite
-    sprite: Structures/Walls/solid_rust.rsi
-  - type: Icon
-    sprite: Structures/Walls/solid_rust.rsi
-    state: full
-  - type: Construction
-    graph: Girder
-    node: wallrust
-  - type: IconSmooth
-    key: walls
-    base: solid
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-
-- type: entity
-  parent: BaseWall
-  id: WallUranium
-  name: uranium wall
-  components:
-  - type: Sprite
-    sprite: Structures/Walls/uranium.rsi
-  - type: Icon
-    sprite: Structures/Walls/uranium.rsi
-  - type: Construction
-    graph: Girder
-    node: uraniumWall
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    base: uranium
-  - type: RadiationBlocker
-    resistance: 6
-
-- type: entity
-  parent: BaseWall
-  id: WallWood
-  name: wood wall
-  description: The traditional greytide defense.
-  components:
-  - type: Sprite
-    sprite: Structures/Walls/wood.rsi
-  - type: Icon
-    sprite: Structures/Walls/wood.rsi
-  - type: Construction
-    graph: Barricade
-    node: woodWall
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: WoodDestroyHeavy
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: WoodDestroyHeavy
-      - !type:ChangeConstructionNodeBehavior
-        node: Barricade
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: IconSmooth
-    key: woods
-    base: wood
-
-- type: entity
-  parent: BaseWall
-  id: WallWeb
-  name: web wall
-  description: Keeps the spiders in and the greytide out.
-  components:
-  - type: Clickable
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        path:
-          "/Audio/Weapons/slash.ogg"
-  - type: Damageable
-    damageModifierSet: Web
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/web.rsi
-  - type: Icon
-    sprite: Structures/Walls/web.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 30
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          MaterialWebSilk:
-            min: 1
-            max: 1
-      - !type:PlaySoundBehavior
-        sound:
-          collection: WoodDestroy
-  - type: IconSmooth
-    key: webs
-    base: wall
-  - type: Construction
-    graph: WebStructures
-    node: wall
-
 
 # Lavalend Walls
 
 - type: entity
-  parent: BaseWall
+  parent:
+  - BaseWall
+  - BaseFullWall
   id: WallNecropolis
   name: stone wall
   components:
@@ -1214,7 +1248,9 @@
     base: necropolis
 
 - type: entity
-  parent: BaseWall
+  parent:
+  - BaseWall
+  - BaseFullWall
   id: WallMining
   name: mining wall
   components:
@@ -1243,7 +1279,7 @@
   - type: Appearance
 
 - type: entity
-  parent: WallShuttleDiagonal
+  parent: WallDiagonalBase
   id: WallMiningDiagonal
   name: mining wall
   suffix: diagonal
@@ -1263,12 +1299,42 @@
   - type: Icon
     sprite: Structures/Walls/mining_diagonal.rsi
     state: state0
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallicStrong
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
 
 
 # Vault Walls
 
 - type: entity
-  parent: BaseWall
+  parent:
+  - BaseWall
+  - BaseFullWall
   id: WallVaultAlien
   name: alien vault wall
   description: A mysterious ornate looking wall. There may be ancient dangers inside.
@@ -1311,6 +1377,7 @@
   - type: Icon
     sprite: Structures/Walls/vault.rsi
     state: sandstonevault
+
 
 # Mime
 
@@ -1367,7 +1434,9 @@
       state: forcewall
 
 - type: entity
-  parent: BaseWall
+  parent:
+  - BaseWall
+  - BaseFullWall
   id: WallCobblebrick
   name: cobblestone brick wall
   description: Stone by stone, perfectly fitted together to form a wall.

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -867,6 +867,8 @@
     node: diagonalshuttleWall
   - type: RadiationBlocker
     resistance: 5
+  - type: StaticPrice
+    price: 200
 
 - type: entity
   parent:

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -21,7 +21,7 @@
   - type: Tag
     tags:
     - Wall
-  - type: IsRoof #Good for diag?
+  - type: IsRoof
   - type: Sprite
     drawdepth: Walls
   - type: Icon
@@ -47,15 +47,15 @@
   - type: Airtight
   - type: StaticPrice
     price: 75
-  - type: RadiationBlocker #Good for diag?
+  - type: RadiationBlocker
     resistance: 2
-  - type: BlockWeather #Good for diag?
-  - type: SunShadowCast #Good for diag?
+  - type: BlockWeather
+  - type: SunShadowCast
 
 - type: entity
   abstract: true
   parent: BaseWall
-  id: BaseFullWall #don't forget to change down the line
+  id: BaseFullWall
   components:
   - type: Occluder # Breaks on diagonal walls
 
@@ -120,7 +120,6 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-
   - type: IconSmooth
     key: walls
     base: brick
@@ -132,9 +131,6 @@
   id: WallClock
   name: clock wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/clock.rsi
   - type: Icon
@@ -166,9 +162,6 @@
   id: WallClown
   name: bananium wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/clown.rsi
   - type: Icon
@@ -240,9 +233,6 @@
   id: WallCult
   name: cult wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/cult.rsi
   - type: Icon
@@ -304,9 +294,6 @@
   id: WallDiamond
   name: diamond wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/diamond.rsi
   - type: Icon
@@ -339,9 +326,6 @@
   id: WallGold
   name: gold wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/gold.rsi
   - type: Icon
@@ -386,9 +370,6 @@
   id: WallIce
   name: ice wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/ice.rsi
   - type: Icon
@@ -417,9 +398,6 @@
   id: WallPlasma
   name: plasma wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/plasma.rsi
   - type: Icon
@@ -466,9 +444,6 @@
   id: WallPlastic
   name: plastic wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/plastic.rsi
   - type: Icon
@@ -524,6 +499,8 @@
     - type: Damageable
       damageContainer: StructuralInorganic
       damageModifierSet: StructuralMetallicStrong
+    - type: RadiationBlocker
+      resistance: 5
 
 - type: entity
   parent: WallPlastitaniumIndestructible
@@ -561,6 +538,8 @@
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: StructuralMetallicStrong
+  - type: RadiationBlocker
+    resistance: 5
 
 - type: entity
   parent: WallPlastitaniumDiagonalIndestructible
@@ -730,6 +709,8 @@
           collection: MetalSlam
       - !type:DoActsBehavior
         acts: ["Destruction"]
+  - type: RadiationBlocker
+    resistance: 5
 
 # Riveting
 - type: entity
@@ -739,9 +720,6 @@
   id: WallRiveted
   name: riveted wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/riveted.rsi
   - type: Icon
@@ -775,9 +753,6 @@
   id: WallSandstone
   name: sandstone wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/sandstone.rsi
   - type: Icon
@@ -810,9 +785,6 @@
   id: WallSilver
   name: silver wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/silver.rsi
   - type: Icon
@@ -893,6 +865,8 @@
   - type: Construction
     graph: Girder
     node: diagonalshuttleWall
+  - type: RadiationBlocker
+    resistance: 5
 
 - type: entity
   parent:
@@ -963,9 +937,6 @@
   id: WallSolid
   name: solid wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/solid.rsi
   - type: WallReplacementMarker
@@ -1169,7 +1140,6 @@
   name: web wall
   description: Keeps the spiders in and the greytide out.
   components:
-  - type: Clickable
   - type: MeleeSound
     soundGroups:
       Brute:
@@ -1177,9 +1147,6 @@
           "/Audio/Weapons/slash.ogg"
   - type: Damageable
     damageModifierSet: Web
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/web.rsi
   - type: Icon
@@ -1217,9 +1184,6 @@
   id: WallNecropolis
   name: stone wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/necropolis.rsi
   - type: Icon
@@ -1243,9 +1207,6 @@
   id: WallMining
   name: mining wall
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/mining.rsi
   - type: Icon
@@ -1271,20 +1232,11 @@
   parent: WallDiagonalBase
   id: WallMiningDiagonal
   name: mining wall
-  suffix: diagonal
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wall
   components:
   - type: Sprite
     drawdepth: Walls
     sprite: Structures/Walls/mining_diagonal.rsi
     state: state0
-  - type: IconSmooth
-    mode: Diagonal
-    key: walls
-    base: state
   - type: Icon
     sprite: Structures/Walls/mining_diagonal.rsi
     state: state0
@@ -1429,9 +1381,6 @@
   name: cobblestone brick wall
   description: Stone by stone, perfectly fitted together to form a wall.
   components:
-  - type: Tag
-    tags:
-      - Wall
   - type: Sprite
     sprite: Structures/Walls/cobblebrick.rsi
   - type: Icon

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -1,7 +1,7 @@
 - type: entity
   abstract: true
   parent: BaseStructure
-  id: BaseWall
+  id: BaseStructureWall
   name: basewall
   description: Keeps the air in and the greytide out.
   placement:
@@ -54,14 +54,14 @@
 
 - type: entity
   abstract: true
-  parent: BaseWall
-  id: BaseFullWall
+  parent: BaseStructureWall
+  id: BaseWall
   components:
   - type: Occluder # Breaks on diagonal walls
 
 - type: entity
   abstract: true
-  parent: BaseWall
+  parent: BaseStructureWall
   id: WallDiagonalBase
   suffix: Diagonal
   components:
@@ -93,9 +93,7 @@
         - WallLayer
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallBrick
   name: brick wall
   components:
@@ -125,9 +123,7 @@
     base: brick
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallClock
   name: clock wall
   components:
@@ -156,9 +152,7 @@
     base: clock
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallClown
   name: bananium wall
   components:
@@ -191,9 +185,7 @@
     base: clown
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallMeat
   name: meat wall
   description: Sticky.
@@ -227,9 +219,7 @@
     base: meat
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallCult
   name: cult wall
   components:
@@ -255,9 +245,7 @@
     base: cult
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallDebug
   name: debug wall
   suffix: DEBUG
@@ -288,9 +276,7 @@
     base: debug
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallDiamond
   name: diamond wall
   components:
@@ -320,9 +306,7 @@
     base: diamond
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallGold
   name: gold wall
   components:
@@ -364,9 +348,7 @@
     base: gold
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallIce
   name: ice wall
   components:
@@ -392,9 +374,7 @@
     base: ice
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallPlasma
   name: plasma wall
   components:
@@ -438,9 +418,7 @@
     resistance: 5
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallPlastic
   name: plastic wall
   components:
@@ -482,9 +460,7 @@
     base: plastic
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallPlastitaniumIndestructible
   name: plastitanium wall
   suffix: indestructible
@@ -572,9 +548,7 @@
             collection: MetalSlam
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallReinforced
   name: reinforced wall
   components:
@@ -671,7 +645,6 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
 
-
 - type: entity
   parent: WallDiagonalBase
   id: WallReinforcedDiagonal
@@ -714,9 +687,7 @@
 
 # Riveting
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallRiveted
   name: riveted wall
   components:
@@ -747,9 +718,7 @@
     price: 150
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallSandstone
   name: sandstone wall
   components:
@@ -779,9 +748,7 @@
     base: sandstone
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallSilver
   name: silver wall
   components:
@@ -871,9 +838,7 @@
     price: 200
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallShuttle
   name: shuttle wall
   components:
@@ -933,9 +898,7 @@
     reflectProb: 1
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallSolid
   name: solid wall
   components:
@@ -1052,9 +1015,7 @@
         acts: ["Destruction"]
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallUranium
   name: uranium wall
   components:
@@ -1094,9 +1055,7 @@
     resistance: 6
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallWood
   name: wood wall
   description: The traditional greytide defense.
@@ -1135,9 +1094,7 @@
     base: wood
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallWeb
   name: web wall
   description: Keeps the spiders in and the greytide out.
@@ -1180,9 +1137,7 @@
 # Lavalend Walls
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallNecropolis
   name: stone wall
   components:
@@ -1203,9 +1158,7 @@
     base: necropolis
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallMining
   name: mining wall
   components:
@@ -1275,9 +1228,7 @@
 # Vault Walls
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallVaultAlien
   name: alien vault wall
   description: A mysterious ornate looking wall. There may be ancient dangers inside.
@@ -1376,9 +1327,7 @@
       state: forcewall
 
 - type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
+  parent: BaseWall
   id: WallCobblebrick
   name: cobblestone brick wall
   description: Stone by stone, perfectly fitted together to form a wall.

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -55,7 +55,7 @@
 - type: entity
   abstract: true
   parent: BaseWall
-  id: BaseFullWall
+  id: BaseFullWall #don't forget to change down the line
   components:
   - type: Occluder # Breaks on diagonal walls
 
@@ -92,8 +92,869 @@
         layer:
         - WallLayer
 
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallBrick
+  name: brick wall
+  components:
+  - type: Sprite
+    sprite: Structures/Walls/brick.rsi
+  - type: Icon
+    sprite: Structures/Walls/brick.rsi
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
-# Standard Walls
+  - type: IconSmooth
+    key: walls
+    base: brick
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallClock
+  name: clock wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/clock.rsi
+  - type: Icon
+    sprite: Structures/Walls/clock.rsi
+  - type: Construction
+    graph: ClockworkGirder
+    node: clockworkWall
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          ClockworkGirder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: clock
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallClown
+  name: bananium wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/clown.rsi
+  - type: Icon
+    sprite: Structures/Walls/clown.rsi
+  - type: Construction
+    graph: Girder
+    node: bananiumWall
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: clown
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallMeat
+  name: meat wall
+  description: Sticky.
+  components:
+  - type: Tag
+    tags:
+      - Wall
+      - Structure
+  - type: Sprite
+    sprite: Structures/Walls/meat.rsi
+  - type: Icon
+    sprite: Structures/Walls/meat.rsi
+  - type: Construction
+    graph: Girder
+    node: meatWall
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100 # weak
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: meat
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallCult
+  name: cult wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/cult.rsi
+  - type: Icon
+    sprite: Structures/Walls/cult.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: cult
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallDebug
+  name: debug wall
+  suffix: DEBUG
+  components:
+  - type: Tag
+    tags:
+      - Wall
+      - Debug
+  - type: Sprite
+    sprite: Structures/Walls/debug.rsi
+  - type: Icon
+    sprite: Structures/Walls/debug.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: debug
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallDiamond
+  name: diamond wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/diamond.rsi
+  - type: Icon
+    sprite: Structures/Walls/diamond.rsi
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: diamond
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallGold
+  name: gold wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/gold.rsi
+  - type: Icon
+    sprite: Structures/Walls/gold.rsi
+  - type: Construction
+    graph: Girder
+    node: goldWall
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: IconSmooth
+    key: walls
+    base: gold
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallIce
+  name: ice wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/ice.rsi
+  - type: Icon
+    sprite: Structures/Walls/ice.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: ice
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallPlasma
+  name: plasma wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/plasma.rsi
+  - type: Icon
+    sprite: Structures/Walls/plasma.rsi
+  - type: Construction
+    graph: Girder
+    node: plasmaWall
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: IconSmooth
+    key: walls
+    base: plasma
+  - type: RadiationBlocker
+    resistance: 5
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallPlastic
+  name: plastic wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/plastic.rsi
+  - type: Icon
+    sprite: Structures/Walls/plastic.rsi
+  - type: Construction
+    graph: Girder
+    node: plasticWall
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: IconSmooth
+    key: walls
+    base: plastic
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallPlastitaniumIndestructible
+  name: plastitanium wall
+  suffix: indestructible
+  components:
+    - type: Sprite
+      sprite: Structures/Walls/plastitanium.rsi
+    - type: Icon
+      sprite: Structures/Walls/plastitanium.rsi
+    - type: IconSmooth
+      key: walls
+      base: plastitanium
+    - type: Damageable
+      damageContainer: StructuralInorganic
+      damageModifierSet: StructuralMetallicStrong
+
+- type: entity
+  parent: WallPlastitaniumIndestructible
+  id: WallPlastitanium
+  name: plastitanium wall
+  suffix: ""
+  components:
+    - type: Destructible
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 1000
+          behaviors:
+            - !type:SpawnEntitiesBehavior
+              spawn:
+                Girder:
+                  min: 1
+                  max: 1
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
+
+- type: entity
+  parent: WallDiagonalBase
+  id: WallPlastitaniumDiagonalIndestructible
+  name: plastitanium wall
+  suffix: diagonal, indestructible
+  components:
+  - type: Sprite
+    drawdepth: Walls
+    sprite: Structures/Walls/plastitanium_diagonal.rsi
+    state: state0
+  - type: Icon
+    sprite: Structures/Walls/plastitanium_diagonal.rsi
+    state: state0
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallicStrong
+
+- type: entity
+  parent: WallPlastitaniumDiagonalIndestructible
+  id: WallPlastitaniumDiagonal
+  name: plastitanium wall
+  suffix: diagonal
+  components:
+  - type: Sprite
+    drawdepth: Walls
+    sprite: Structures/Walls/plastitanium_diagonal.rsi
+    state: state0
+  - type: Icon
+    sprite: Structures/Walls/plastitanium_diagonal.rsi
+    state: state0
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1000
+      behaviors:
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            Girder:
+              min: 1
+              max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalSlam
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallReinforced
+  name: reinforced wall
+  components:
+  - type: Sprite
+    sprite: Structures/Walls/solid.rsi
+  - type: Icon
+    sprite: Structures/Walls/solid.rsi
+    state: rgeneric
+  - type: Construction
+    graph: Girder
+    node: reinforcedWall
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallicStrong
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 400
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: IconSmooth
+    key: walls
+    base: reinf_over
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.ReinforcedWallVisuals.DeconstructionStage:
+        ReinforcedWallVisualLayers.Deconstruction:
+          -1: { visible: false }
+          0: { state: reinf_construct-0, visible: true}
+          1: { state: reinf_construct-1, visible: true}
+          2: { state: reinf_construct-2, visible: true}
+          3: { state: reinf_construct-3, visible: true}
+          4: { state: reinf_construct-4, visible: true}
+          5: { state: reinf_construct-5, visible: true}
+  - type: ReinforcedWallReplacementMarker
+  - type: StaticPrice
+    price: 250
+  - type: RadiationBlocker
+    resistance: 5
+
+- type: entity
+  parent: WallReinforced
+  id: WallReinforcedRust
+  suffix: rusted
+  components:
+  - type: Sprite
+    sprite: Structures/Walls/solid_rust.rsi
+  - type: Icon
+    sprite: Structures/Walls/solid_rust.rsi
+    state: rgeneric
+  - type: Construction
+    graph: Girder
+    node: reinforcedWallRust
+  - type: IconSmooth
+    key: walls
+    base: reinf_over
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 500
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 350
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+
+
+- type: entity
+  parent: WallDiagonalBase
+  id: WallReinforcedDiagonal
+  name: reinforced wall
+  components:
+  - type: Sprite
+    drawdepth: Walls
+    sprite: Structures/Walls/reinforced_diagonal.rsi
+    state: state0
+  - type: Icon
+    sprite: Structures/Walls/reinforced_diagonal.rsi
+    state: state0
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallicStrong
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+
+# Riveting
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallRiveted
+  name: riveted wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/riveted.rsi
+  - type: Icon
+    sprite: Structures/Walls/riveted.rsi
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallicStrong
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1000
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: riveted
+  - type: StaticPrice
+    price: 150
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallSandstone
+  name: sandstone wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/sandstone.rsi
+  - type: Icon
+    sprite: Structures/Walls/sandstone.rsi
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Girder:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: IconSmooth
+    key: walls
+    base: sandstone
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallSilver
+  name: silver wall
+  components:
+  - type: Tag
+    tags:
+      - Wall
+  - type: Sprite
+    sprite: Structures/Walls/silver.rsi
+  - type: Icon
+    sprite: Structures/Walls/silver.rsi
+  - type: Construction
+    graph: Girder
+    node: silverWall
+  - type: RCDDeconstructable
+    cost: 6
+    delay: 8
+    fx: EffectRCDDeconstruct8
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: IconSmooth
+    key: walls
+    base: silver
+
+#shuttle walls
+- type: entity
+  parent: WallDiagonalBase
+  id: WallShuttleDiagonal
+  name: shuttle wall
+  components:
+  - type: Sprite
+    drawdepth: Walls
+    sprite: Structures/Walls/shuttle_diagonal.rsi
+    state: state0
+  - type: Icon
+    sprite: Structures/Walls/shuttle_diagonal.rsi
+    state: state0
+  - type: Reflect
+    reflectProb: 1
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallicStrong
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: Construction
+    graph: Girder
+    node: diagonalshuttleWall
+
+- type: entity
+  parent:
+  - BaseWall
+  - BaseFullWall
+  id: WallShuttle
+  name: shuttle wall
+  components:
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallicStrong
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 400
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: StaticPrice
+    price: 250
+  - type: RadiationBlocker
+    resistance: 5
+  - type: Sprite
+    sprite: Structures/Walls/shuttle.rsi
+  - type: Icon
+    sprite: Structures/Walls/shuttle.rsi
+    state: full
+  - type: Construction
+    graph: Girder
+    node: shuttleWall
+  - type: IconSmooth
+    key: walls
+    base: state
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.ShuttleWallVisuals.DeconstructionStage:
+        ShuttleWallVisualLayers.Deconstruction:
+          -1: { visible: false }
+          0: { state: shuttle_construct-0, visible: true}
+          1: { state: shuttle_construct-1, visible: true}
+          2: { state: shuttle_construct-2, visible: true}
+          3: { state: shuttle_construct-3, visible: true}
+          4: { state: shuttle_construct-4, visible: true}
+          5: { state: shuttle_construct-5, visible: true}
+  - type: Reflect
+    reflectProb: 1
 
 - type: entity
   parent:
@@ -216,530 +1077,6 @@
         node: girder
       - !type:DoActsBehavior
         acts: ["Destruction"]
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallReinforced
-  name: reinforced wall
-  components:
-  - type: Sprite
-    sprite: Structures/Walls/solid.rsi
-  - type: Icon
-    sprite: Structures/Walls/solid.rsi
-    state: rgeneric
-  - type: Construction
-    graph: Girder
-    node: reinforcedWall
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallicStrong
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 600
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-    - trigger:
-        !type:DamageTrigger
-        damage: 400
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    base: reinf_over
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ReinforcedWallVisuals.DeconstructionStage:
-        ReinforcedWallVisualLayers.Deconstruction:
-          -1: { visible: false }
-          0: { state: reinf_construct-0, visible: true}
-          1: { state: reinf_construct-1, visible: true}
-          2: { state: reinf_construct-2, visible: true}
-          3: { state: reinf_construct-3, visible: true}
-          4: { state: reinf_construct-4, visible: true}
-          5: { state: reinf_construct-5, visible: true}
-  - type: ReinforcedWallReplacementMarker
-  - type: StaticPrice
-    price: 250
-  - type: RadiationBlocker
-    resistance: 5
-
-- type: entity
-  parent: WallReinforced
-  id: WallReinforcedRust
-  suffix: rusted
-  components:
-  - type: Sprite
-    sprite: Structures/Walls/solid_rust.rsi
-  - type: Icon
-    sprite: Structures/Walls/solid_rust.rsi
-    state: rgeneric
-  - type: Construction
-    graph: Girder
-    node: reinforcedWallRust
-  - type: IconSmooth
-    key: walls
-    base: reinf_over
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 500
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-    - trigger:
-        !type:DamageTrigger
-        damage: 350
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-
-- type: entity
-  parent: WallDiagonalBase
-  id: WallReinforcedDiagonal
-  name: reinforced wall
-  components:
-  - type: Sprite
-    drawdepth: Walls
-    sprite: Structures/Walls/reinforced_diagonal.rsi
-    state: state0
-  - type: Icon
-    sprite: Structures/Walls/reinforced_diagonal.rsi
-    state: state0
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallicStrong
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 600
-      behaviors:
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
-        - !type:PlaySoundBehavior
-          sound:
-            collection: MetalSlam
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallPlastitaniumIndestructible
-  name: plastitanium wall
-  suffix: indestructible
-  components:
-    - type: Sprite
-      sprite: Structures/Walls/plastitanium.rsi
-    - type: Icon
-      sprite: Structures/Walls/plastitanium.rsi
-    - type: IconSmooth
-      key: walls
-      base: plastitanium
-    - type: Damageable
-      damageContainer: StructuralInorganic
-      damageModifierSet: StructuralMetallicStrong
-
-- type: entity
-  parent: WallPlastitaniumIndestructible
-  id: WallPlastitanium
-  name: plastitanium wall
-  suffix: ""
-  components:
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 1000
-          behaviors:
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                Girder:
-                  min: 1
-                  max: 1
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-
-#Plastitanium
-- type: entity
-  parent: WallDiagonalBase
-  id: WallPlastitaniumDiagonalIndestructible
-  name: plastitanium wall
-  suffix: diagonal, indestructible
-  components:
-  - type: Sprite
-    drawdepth: Walls
-    sprite: Structures/Walls/plastitanium_diagonal.rsi
-    state: state0
-  - type: Icon
-    sprite: Structures/Walls/plastitanium_diagonal.rsi
-    state: state0
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallicStrong
-
-- type: entity
-  parent: WallPlastitaniumDiagonalIndestructible
-  id: WallPlastitaniumDiagonal
-  name: plastitanium wall
-  suffix: diagonal
-  components:
-  - type: Sprite
-    drawdepth: Walls
-    sprite: Structures/Walls/plastitanium_diagonal.rsi
-    state: state0
-  - type: Icon
-    sprite: Structures/Walls/plastitanium_diagonal.rsi
-    state: state0
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 1000
-      behaviors:
-        - !type:SpawnEntitiesBehavior
-          spawn:
-            Girder:
-              min: 1
-              max: 1
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
-        - !type:PlaySoundBehavior
-          sound:
-            collection: MetalSlam
-
-# Riveting
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallRiveted
-  name: riveted wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/riveted.rsi
-  - type: Icon
-    sprite: Structures/Walls/riveted.rsi
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallicStrong
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 1000
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: riveted
-  - type: StaticPrice
-    price: 150
-
-#Debug
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallDebug
-  name: debug wall
-  suffix: DEBUG
-  components:
-  - type: Tag
-    tags:
-      - Wall
-      - Debug
-  - type: Sprite
-    sprite: Structures/Walls/debug.rsi
-  - type: Icon
-    sprite: Structures/Walls/debug.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: debug
-
-
-# Material Walls
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallDiamond
-  name: diamond wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/diamond.rsi
-  - type: Icon
-    sprite: Structures/Walls/diamond.rsi
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: diamond
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallGold
-  name: gold wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/gold.rsi
-  - type: Icon
-    sprite: Structures/Walls/gold.rsi
-  - type: Construction
-    graph: Girder
-    node: goldWall
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    base: gold
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallPlasma
-  name: plasma wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/plasma.rsi
-  - type: Icon
-    sprite: Structures/Walls/plasma.rsi
-  - type: Construction
-    graph: Girder
-    node: plasmaWall
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    base: plasma
-  - type: RadiationBlocker
-    resistance: 5
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallPlastic
-  name: plastic wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/plastic.rsi
-  - type: Icon
-    sprite: Structures/Walls/plastic.rsi
-  - type: Construction
-    graph: Girder
-    node: plasticWall
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    base: plastic
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallSilver
-  name: silver wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/silver.rsi
-  - type: Icon
-    sprite: Structures/Walls/silver.rsi
-  - type: Construction
-    graph: Girder
-    node: silverWall
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    base: silver
 
 - type: entity
   parent:
@@ -869,354 +1206,6 @@
   - type: Construction
     graph: WebStructures
     node: wall
-
-
-# Misc Walls
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallBrick
-  name: brick wall
-  components:
-  - type: Sprite
-    sprite: Structures/Walls/brick.rsi
-  - type: Icon
-    sprite: Structures/Walls/brick.rsi
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: brick
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallClock
-  name: clock wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/clock.rsi
-  - type: Icon
-    sprite: Structures/Walls/clock.rsi
-  - type: Construction
-    graph: ClockworkGirder
-    node: clockworkWall
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          ClockworkGirder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: clock
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallClown
-  name: bananium wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/clown.rsi
-  - type: Icon
-    sprite: Structures/Walls/clown.rsi
-  - type: Construction
-    graph: Girder
-    node: bananiumWall
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: clown
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallCult
-  name: cult wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/cult.rsi
-  - type: Icon
-    sprite: Structures/Walls/cult.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: cult
-
-# Organic Walls
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallSandstone
-  name: sandstone wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/sandstone.rsi
-  - type: Icon
-    sprite: Structures/Walls/sandstone.rsi
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 8
-    fx: EffectRCDDeconstruct8
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: sandstone
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallIce
-  name: ice wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-  - type: Sprite
-    sprite: Structures/Walls/ice.rsi
-  - type: Icon
-    sprite: Structures/Walls/ice.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: ice
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallMeat
-  name: meat wall
-  description: Sticky.
-  components:
-  - type: Tag
-    tags:
-      - Wall
-      - Structure
-  - type: Sprite
-    sprite: Structures/Walls/meat.rsi
-  - type: Icon
-    sprite: Structures/Walls/meat.rsi
-  - type: Construction
-    graph: Girder
-    node: meatWall
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 100 # weak
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: meat
-
-#shuttle walls
-- type: entity
-  parent: WallDiagonalBase
-  id: WallShuttleDiagonal
-  name: shuttle wall
-  components:
-  - type: Sprite
-    drawdepth: Walls
-    sprite: Structures/Walls/shuttle_diagonal.rsi
-    state: state0
-  - type: Icon
-    sprite: Structures/Walls/shuttle_diagonal.rsi
-    state: state0
-  - type: Reflect
-    reflectProb: 1
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallicStrong
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 600
-      behaviors:
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
-        - !type:PlaySoundBehavior
-          sound:
-            collection: MetalSlam
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: Construction
-    graph: Girder
-    node: diagonalshuttleWall
-
-- type: entity
-  parent:
-  - BaseWall
-  - BaseFullWall
-  id: WallShuttle
-  name: shuttle wall
-  components:
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallicStrong
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 600
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-    - trigger:
-        !type:DamageTrigger
-        damage: 400
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-  - type: StaticPrice
-    price: 250
-  - type: RadiationBlocker
-    resistance: 5
-  - type: Sprite
-    sprite: Structures/Walls/shuttle.rsi
-  - type: Icon
-    sprite: Structures/Walls/shuttle.rsi
-    state: full
-  - type: Construction
-    graph: Girder
-    node: shuttleWall
-  - type: IconSmooth
-    key: walls
-    base: state
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ShuttleWallVisuals.DeconstructionStage:
-        ShuttleWallVisualLayers.Deconstruction:
-          -1: { visible: false }
-          0: { state: shuttle_construct-0, visible: true}
-          1: { state: shuttle_construct-1, visible: true}
-          2: { state: shuttle_construct-2, visible: true}
-          3: { state: shuttle_construct-3, visible: true}
-          4: { state: shuttle_construct-4, visible: true}
-          5: { state: shuttle_construct-5, visible: true}
-  - type: Reflect
-    reflectProb: 1
 
 
 # Lavalend Walls
@@ -1377,7 +1366,6 @@
   - type: Icon
     sprite: Structures/Walls/vault.rsi
     state: sandstonevault
-
 
 # Mime
 


### PR DESCRIPTION
## About the PR
Things here were getting pretty messy
- Fixes diagonal versions of walls inheriting rebound
- Fixes diagonal walls having more HP than their full wall variants
- Fixes tags being all over the place
- Fixes diagonal walls not inheriting features from full wall variants
- Fixes many walls having the wrong damage modifiers
- Fixes other random things walls were inheriting for no reason
- Fixes Radiation Blocker not being applied consistently
- Reduces lots of redundant copy/paste
- Fixes `tilewalls` cmd from changing tiles under diagnal walls

## Todo: 
- Should walls be inheriting the `Structure` tag from `BaseStructure`? only the meat wall previously was.
- I didn't touch RCDable walls but it seems inconsistent a bit. 


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
~~I made a second parent for walls so it wouldn't shock the system for downstreams.~~

## Media
n/a

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
~~Downstreams will want to add the new parent to their walls probably~~

**Changelog**
n/a
