### PR TITLE
Fix typingindicator doing a naughty

### DIFF
--- a/Content.Client/Chat/TypingIndicator/TypingIndicatorSystem.cs
+++ b/Content.Client/Chat/TypingIndicator/TypingIndicatorSystem.cs
@@ -63,6 +63,9 @@ public sealed class TypingIndicatorSystem : SharedTypingIndicatorSystem
     {
         base.Update(frameTime);
 
+        if (!_time.IsFirstTimePredicted)
+            return;
+
         // check if client didn't changed chat text box for a long time
         if (_isClientTyping)
         {


### PR DESCRIPTION
How this wasn't caught before but raisepredictiveevent should never get raised when re-running states.