### PR TITLE
Acquisition Slips fitting in folders and clipboards

### DIFF
--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -122,7 +122,7 @@ public sealed class PaperSystem : EntitySystem
                 if (entity.Comp.EditingDisabled)
                 {
                     var paperEditingDisabledMessage = Loc.GetString("paper-tamper-proof-modified-message");
-                    _popupSystem.PopupPredicted(paperEditingDisabledMessage, entity, args.User);
+                    _popupSystem.PopupEntity(paperEditingDisabledMessage, entity, args.User);
 
                     args.Handled = true;
                     return;

--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -122,7 +122,7 @@ public sealed class PaperSystem : EntitySystem
                 if (entity.Comp.EditingDisabled)
                 {
                     var paperEditingDisabledMessage = Loc.GetString("paper-tamper-proof-modified-message");
-                    _popupSystem.PopupEntity(paperEditingDisabledMessage, entity, args.User);
+                    _popupSystem.PopupPredicted(paperEditingDisabledMessage, entity, args.User);
 
                     args.Handled = true;
                     return;

--- a/Resources/Prototypes/Entities/Objects/Misc/acquisition_slips.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/acquisition_slips.yml
@@ -19,6 +19,7 @@
     tags:
     - Trash
     - Document
+    - Paper
   - type: Paper
     editingDisabled: true
   - type: PaperVisuals

--- a/Resources/Prototypes/Entities/Objects/Misc/acquisition_slips.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/acquisition_slips.yml
@@ -18,6 +18,7 @@
   - type: Tag
     tags:
     - Trash
+    - Document
   - type: Paper
     editingDisabled: true
   - type: PaperVisuals


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Cargo request acquisition slips could not fit into folders or clipboards previously. This PR changes that by allowing the slips to fit into folders and clipboards, like other papers.

## Why / Balance
Consistency. Paper forms should be able to fit into paper holders, i.e. clipboards and folders.

## Technical details
Addition of one tag to the acquisition slip prototype, "Document" and "Paper."

## Media
Not needed. Minor QoL/consistency change.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Cargo acquisition slips can now fit into folders, clipboards, and envelopes, like other papers can.