### PR TITLE
Allow scrap generators to be fultoned & Decrease Fulton delay

### DIFF
--- a/Content.Shared/Salvage/Fulton/FultonComponent.cs
+++ b/Content.Shared/Salvage/Fulton/FultonComponent.cs
@@ -32,7 +32,7 @@ public sealed partial class FultonComponent : Component
     /// How long the fulton will remain before teleporting to the beacon.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("duration")]
-    public TimeSpan FultonDuration = TimeSpan.FromSeconds(45);
+    public TimeSpan FultonDuration = TimeSpan.FromSeconds(30);
 
     [ViewVariables(VVAccess.ReadWrite), DataField("whitelist"), AutoNetworkedField]
     public EntityWhitelist? Whitelist = new()

--- a/Content.Shared/Salvage/Fulton/FultonedComponent.cs
+++ b/Content.Shared/Salvage/Fulton/FultonedComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class FultonedComponent : Component
     public EntityUid? Beacon;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("fultonDuration"), AutoNetworkedField]
-    public TimeSpan FultonDuration = TimeSpan.FromSeconds(45);
+    public TimeSpan FultonDuration = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// When the fulton is travelling to the beacon.

--- a/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
@@ -34,6 +34,7 @@
   description: Worthless junk. You could probably get some materials out of it though.
   suffix: Scrap
   components:
+  - type: Anchorable
   - type: InteractionOutline
   - type: Damageable
     damageContainer: Inorganic


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Let the scrap generators found in space be able to be whisked away.
Reduce the amount of time it takes for a Fultoned object to make its way to the beacon.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fultons are an excellent utility item primarily utilized by Salvagers. Many of the objects they will encounter are these scrap generators, which are a great source of material. However, they were unable to be fultoned, which I feel reduced the appeal of obtaining the fulton and beacon.
I personally found it unappealing to spend the time and hassle making carrying a single broken generator from a magnet'd Space Debris back to station. This change would make be an additional boost of enjoyment to finding the fulton and beacon. (or their blueprints)

I believe the Fulton delay should be reduced from 45 seconds to 30 seconds to account for the broadcast on Cargo radio that tells the listeners that the magnetized debris will disappear in 30 seconds.
In the event that a salvager collects their loot and utilizes a fulton within that previous 15 second window, the actively fultoned loot will be all lost to the depths of space.

This change will have a side effect of additionally "buffing" the Thief's kit which includes a fulton kit.

## Technical details
Adds the Anchorable component to BaseScrapLarge which currently only the scrap, broken down generators inherit from.
Changes the duration of both FultonComponent and FultonedComponent from 45 seconds to 30 seconds.
(From my testing, only changing the duration on FultonedComponent actually resulted in the correct change.)

## Media

https://github.com/user-attachments/assets/15ad057b-704a-4708-8f14-ca47cd26a6fe



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Scrap generators can now be fultoned
- tweak: Fulton delay reduced to 30 seconds from 45
