### PR TITLE
Fix yaml linter and misc errors

### DIFF
--- a/Content.Client/Light/Components/LightBehaviourComponent.cs
+++ b/Content.Client/Light/Components/LightBehaviourComponent.cs
@@ -238,6 +238,9 @@ namespace Content.Client.Light.Components
 
         public override void OnInitialize()
         {
+            // This is very janky. This could easily result in no visible animation at all if the random values happen
+            // to all be close to each other.
+            // TODO ANIMATIONS
             _randomValue1 = (float)InterpolateLinear(StartValue, EndValue, (float)_random.NextDouble());
             _randomValue2 = (float)InterpolateLinear(StartValue, EndValue, (float)_random.NextDouble());
             _randomValue3 = (float)InterpolateLinear(StartValue, EndValue, (float)_random.NextDouble());

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -122,6 +122,8 @@ public abstract partial class SharedStationAiSystem : EntitySystem
                 Category = VerbCategory.Debug,
                 Act = () =>
                 {
+                    if (_net.IsClient)
+                        return;
                     var brain = SpawnInContainerOrDrop(DefaultAi, ent.Owner, StationAiCoreComponent.Container);
                     _mind.ControlMob(user, brain);
                 },

--- a/Resources/Prototypes/Catalog/Fills/Boxes/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/medical.yml
@@ -102,6 +102,7 @@
     layers:
       - state: box
       - state: bodybags
+  - type: Storage
     whitelist:
       tags:
         - BodyBag

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -116,6 +116,7 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Duffels/mime.rsi
+  - type: Storage
     storageOpenSound:
       collection: null
     storageInsertSound:

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -85,8 +85,8 @@
         id: blinking
         interpolate: Nearest
         maxDuration: 1.0
-        minValue: 0.1
-        maxValue: 2.0
+        startValue: 0.1
+        endValue: 2.0
         isLooped: true
   - type: PowerCellSlot
     cellSlotId: cell_slot
@@ -227,8 +227,8 @@
         id: blinking
         interpolate: Nearest
         maxDuration: 1.0
-        minValue: 0.1
-        maxValue: 2.0
+        startValue: 0.1
+        endValue: 2.0
         isLooped: true
   - type: Battery
     maxCharge: 600 #lights drain 3/s but recharge of 2 makes this 1/s. Therefore 600 is 10 minutes of light.

--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -37,8 +37,8 @@
         id: blinking
         interpolate: Nearest
         maxDuration: 1.0
-        minValue: 0.1
-        maxValue: 2.0
+        startValue: 0.1
+        endValue: 2.0
         isLooped: true
   - type: ToggleableLightVisuals
     spriteLayer: light

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -279,8 +279,8 @@
         id: blinking
         interpolate: Nearest
         maxDuration: 1.0
-        minValue: 0.1
-        maxValue: 2.0
+        startValue: 0.1
+        endValue: 2.0
         isLooped: true
   - type: Battery
     maxCharge: 600

--- a/Resources/Prototypes/Entities/Markers/pointing.yml
+++ b/Resources/Prototypes/Entities/Markers/pointing.yml
@@ -9,7 +9,7 @@
   - type: Sprite
     sprite: Interface/Misc/pointing.rsi
     state: pointing
-    drawDepth: Overlays
+    drawdepth: Overlays
     noRot: true
   - type: PointingArrow
     duration: 4

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -218,8 +218,8 @@
       id: blinking
       interpolate: Nearest
       maxDuration: 1.0
-      minValue: 0.1
-      maxValue: 2.0
+      startValue: 0.1
+      endValue: 2.0
       isLooped: true
   - type: ToggleableLightVisuals
   - type: PointLight

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -343,7 +343,6 @@
     solution: bloodstream
     transferAmount: 5
   - type: DamageStateVisuals
-    rotate: true
     states:
       Alive:
         Base: alive

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -77,7 +77,6 @@
       Dead: 0
     baseDecayRate: 0.1
   - type: DamageStateVisuals
-    rotate: true
     states:
       Alive:
         Base: regalrat

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -79,7 +79,6 @@
       groups:
         Brute: 6
   - type: DamageStateVisuals
-    rotate: true
     states:
       Alive:
         Base: running

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1643,9 +1643,9 @@
   components:
   - type: Sprite
     sprite: Structures/Power/Generation/Tesla/energy_miniball.rsi
-    shader: unshaded
     layers:
     - state: tesla_projectile
+      shader: unshaded
   - type: PointLight
     enabled: true
     radius: 5
@@ -1669,8 +1669,9 @@
   components:
   - type: Sprite
     sprite: Objects/Fun/toys.rsi
-    state: orb
-    shader: unshaded
+    layers:
+    - state: orb
+      shader: unshaded
   - type: PointLight
     radius: 2
     color: "#00CCFF"
@@ -1894,7 +1895,6 @@
   - type: Sprite
     sprite: Objects/Fun/whoopie.rsi
     state: icon
-    quickEquip: false
   - type: Tag
     tags:
       - Payload

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -21,8 +21,8 @@
         id: blinking
         interpolate: Nearest
         maxDuration: 1.0
-        minValue: 0.1
-        maxValue: 2.0
+        startValue: 0.1
+        endValue: 2.0
         isLooped: true
   - type: PowerCellSlot
     cellSlotId: cell_slot

--- a/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
@@ -73,7 +73,6 @@
   description: Get out there and slang some dogs.
   components:
     - type: Sprite
-      netSync: false
       noRot: true
       sprite: Objects/Specific/Kitchen/food_carts.rsi
       layers:
@@ -154,7 +153,6 @@
   description: It's the Ice Cream Man! It's the Ice Cream Man!
   components:
     - type: Sprite
-      netSync: false
       noRot: true
       sprite: Objects/Specific/Kitchen/food_carts.rsi
       layers:

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -24,8 +24,8 @@
         id: blinking
         interpolate: Nearest
         maxDuration: 1.0
-        minValue: 0.1
-        maxValue: 2.0
+        startValue: 0.1
+        endValue: 2.0
         isLooped: true
   - type: ToggleableLightVisuals
     spriteLayer: light

--- a/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
@@ -134,8 +134,8 @@
         - !type:PulseBehaviour
           interpolate: Cubic
           maxDuration: 10.0
-          minValue: 1.0
-          maxValue: 7.0
+          startValue: 1.0
+          endValue: 7.0
           isLooped: true
           property: Energy
           enabled: true
@@ -198,7 +198,7 @@
           interpolate: Nearest
           minDuration: 0.2
           maxDuration: 1.0
-          maxValue: 0.2
+          endValue: 0.2
           property: AnimatedEnable
           isLooped: true
           enabled: true
@@ -237,8 +237,8 @@
         - !type:FadeBehaviour
           interpolate: Cubic
           maxDuration: 5.0
-          minValue: 0.0
-          maxValue: 10.0
+          startValue: 0.0
+          endValue: 10.0
           isLooped: true
           property: Energy
           enabled: true
@@ -269,8 +269,8 @@
           interpolate: Cubic
           minDuration: 1.0
           maxDuration: 5.0
-          minValue: 2.0
-          maxValue: 10.0
+          startValue: 2.0
+          endValue: 10.0
           isLooped: true
           enabled: true
 
@@ -300,7 +300,7 @@
         - !type:RandomizeBehaviour
           interpolate: Nearest
           maxDuration: 0.5
-          minValue: 10.0
-          maxValue: 25.0
+          startValue: 10.0
+          endValue: 25.0
           isLooped: true
           enabled: true

--- a/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
@@ -21,8 +21,8 @@
           id: blinking
           interpolate: Nearest
           maxDuration: 1.0
-          minValue: 0.1
-          maxValue: 2.0
+          startValue: 0.1
+          endValue: 2.0
           isLooped: true
     - type: Sprite
       sprite: Objects/Tools/lantern.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
@@ -106,7 +106,7 @@
     proto: CartridgeCaselessRifle
     capacity: 10
   - type: Sprite
-    slayers:
+    layers:
     - state: red
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/clockwork.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/clockwork.yml
@@ -6,6 +6,7 @@
   components:
   - type: Sprite
     sprite: Structures/Doors/Windoors/clockwork_windoor.rsi
+  - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -77,10 +77,10 @@
       - GhostOnlyWarp
   - type: Sprite
     sprite: Structures/Power/Generation/Singularity/singularity_1.rsi
-    shader: unshaded
     layers:
     - map: [ "VisualLevel" ]
       state: singularity_1
+      shader: unshaded
   - type: GenericVisualizer
     visuals:
       enum.SingularityAppearanceKeys.Singularity:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
@@ -101,9 +101,9 @@
   - type: Sprite
     drawdepth: Effects
     sprite: Structures/Power/Generation/Tesla/energy_ball.rsi
-    shader: unshaded
     layers:
     - state: energy_ball
+      shader: unshaded
   - type: EmitSoundOnSpawn
     sound:
       path: /Audio/Effects/tesla_collapse.ogg
@@ -149,8 +149,8 @@
   - type: Sprite
     drawdepth: Effects
     sprite: Structures/Power/Generation/Tesla/energy_miniball.rsi
-    shader: unshaded
     layers:
     - state: tesla_projectile
+      shader: unshaded
   - type: Electrified
     requirePower: false

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -173,7 +173,6 @@
     sprite: Structures/Power/Cables/lv_cable.rsi
     state: lvcable_0
   - type: Icon
-    color: Green
     sprite: Structures/Power/Cables/lv_cable.rsi
     state: lvcable_4
   - type: NodeContainer

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -311,7 +311,7 @@
             max: 1
   - type: Appearance
   - type: EntityStorageVisuals
-    stateBase: base
+    # stateBase: base  // This field does not exist. this is probably a bug. TODO
     stateDoorOpen: base
     stateDoorClosed: door
   - type: LockVisuals

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/timer.yml
@@ -66,7 +66,7 @@
     color: FloralWhite
     textOffset: 0,6
     timerOffset: 0,6
-    textLength: 5
+    # textLength: 5 This field does not exist. Bug?
     rows: 1
   - type: Sprite
     drawdepth: WallMountedItems

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -1984,7 +1984,7 @@
     - map: [ "enum.EdgeLayer.West" ]
       state: rock_chromite_west
     - state: rock_coal
-    map: [ "enum.MiningScannerVisualLayers.Overlay" ]
+      map: [ "enum.MiningScannerVisualLayers.Overlay" ]
 
 - type: entity
   id: WallRockChromiteGold

--- a/Resources/Prototypes/Parallaxes/amber.yml
+++ b/Resources/Prototypes/Parallaxes/amber.yml
@@ -48,5 +48,5 @@
         !type:GeneratedParallaxTextureSource
         id: ""
         configPath: "/Prototypes/Parallaxes/parallax_config.toml"
-        slowness: 0.875
+      slowness: 0.875
   layersLQUseHQ: false

--- a/Resources/Prototypes/Parallaxes/aspid.yml
+++ b/Resources/Prototypes/Parallaxes/aspid.yml
@@ -36,5 +36,5 @@
         !type:GeneratedParallaxTextureSource
         id: ""
         configPath: "/Prototypes/Parallaxes/parallax_config.toml"
-        slowness: 0.875
+      slowness: 0.875
   layersLQUseHQ: false

--- a/Resources/Prototypes/Parallaxes/bagel.yml
+++ b/Resources/Prototypes/Parallaxes/bagel.yml
@@ -37,5 +37,5 @@
         !type:GeneratedParallaxTextureSource
         id: ""
         configPath: "/Prototypes/Parallaxes/parallax_config.toml"
-        slowness: 0.875
+      slowness: 0.875
   layersLQUseHQ: false

--- a/Resources/Prototypes/Parallaxes/core.yml
+++ b/Resources/Prototypes/Parallaxes/core.yml
@@ -37,5 +37,5 @@
         !type:GeneratedParallaxTextureSource
         id: ""
         configPath: "/Prototypes/Parallaxes/parallax_config.toml"
-        slowness: 0.875
+      slowness: 0.875
   layersLQUseHQ: false

--- a/Resources/Prototypes/Parallaxes/default.yml
+++ b/Resources/Prototypes/Parallaxes/default.yml
@@ -34,7 +34,7 @@
         !type:GeneratedParallaxTextureSource
         id: ""
         configPath: "/Prototypes/Parallaxes/parallax_config.toml"
-        slowness: 0.875
+      slowness: 0.875
   layersLQUseHQ: false
 
 # Because hyperspace and the menu need their own.
@@ -71,6 +71,6 @@
         !type:GeneratedParallaxTextureSource
         id: ""
         configPath: "/Prototypes/Parallaxes/parallax_config.toml"
-        slowness: 0.5
+      slowness: 0.5
   layersLQUseHQ: false
 

--- a/Resources/Prototypes/Parallaxes/kettle.yml
+++ b/Resources/Prototypes/Parallaxes/kettle.yml
@@ -36,5 +36,5 @@
         !type:GeneratedParallaxTextureSource
         id: ""
         configPath: "/Prototypes/Parallaxes/parallax_config.toml"
-        slowness: 0.875
+      slowness: 0.875
   layersLQUseHQ: false

--- a/Resources/Prototypes/Parallaxes/origin.yml
+++ b/Resources/Prototypes/Parallaxes/origin.yml
@@ -37,5 +37,5 @@
         !type:GeneratedParallaxTextureSource
         id: ""
         configPath: "/Prototypes/Parallaxes/parallax_config.toml"
-        slowness: 0.875
+      slowness: 0.875
   layersLQUseHQ: false

--- a/Resources/Prototypes/Parallaxes/plasma.yml
+++ b/Resources/Prototypes/Parallaxes/plasma.yml
@@ -49,5 +49,5 @@
         !type:GeneratedParallaxTextureSource
         id: ""
         configPath: "/Prototypes/Parallaxes/parallax_config.toml"
-        slowness: 0.875
+      slowness: 0.875
   layersLQUseHQ: false

--- a/Resources/Prototypes/Parallaxes/train.yml
+++ b/Resources/Prototypes/Parallaxes/train.yml
@@ -63,6 +63,6 @@
         !type:GeneratedParallaxTextureSource
         id: ""
         configPath: "/Prototypes/Parallaxes/parallax_config.toml"
-        slowness: 0.875
+      slowness: 0.875
       scrolling: "0, -0.475"
   layersLQUseHQ: false


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/5930

## About the PR
The yaml linter has not been reporting errors on client-exclusive components (e.g., sprites & light animations).
This PR fixes the linter and the various errors that it now actually reports.

## Why / Balance
For the most part, this just changes entities to how they were supposed behave/appear. But maybe the current visuals are preferred. E.g., the singularity is seemingly meant to be unshaded, but has been shaded for so long that maybe the light-influenced version is preferred? The difference is somewhat subtle, as the singularity acts as it's own light source.

## Media

Singularity before:
![Content Client_RvZLv8IndE](https://github.com/user-attachments/assets/049a2a9a-3cf2-4d6b-a914-824e8281091c)

Singularity After:
![Content Client_AaD10rAHRB](https://github.com/user-attachments/assets/b92c80f1-7c95-4b27-8867-6335b5b8f5b8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
This isn't really a breaking change, but should probably still be announced for forks.
- A bug in the yaml linter was causing it to not report errors on client-side components. If you update your fork, you may have to deal with various errors that were previously unreported.
