### PR TITLE
Slightly re-nerf zombification speed

### DIFF
--- a/Content.Shared/Zombies/PendingZombieComponent.cs
+++ b/Content.Shared/Zombies/PendingZombieComponent.cs
@@ -17,7 +17,7 @@ public sealed partial class PendingZombieComponent : Component
     {
         DamageDict = new ()
         {
-            { "Poison", 0.4 },
+            { "Poison", 0.3 },
         }
     };
 
@@ -34,7 +34,7 @@ public sealed partial class PendingZombieComponent : Component
     /// The amount of time left before the infected begins to take damage.
     /// </summary>
     [DataField("gracePeriod"), ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan GracePeriod = TimeSpan.Zero;
+    public TimeSpan GracePeriod = TimeSpan.FromMinutes(2);
 
     /// <summary>
     /// The minimum amount of time initial infected have before they start taking infection damage.


### PR DESCRIPTION
#34472 fixed a bug with `PendingZombieComponent` having way too long a grace period, and also doubled the infection damage. This reduced the TTK from infection alone from ~19 minutes to ~2 minutes. This PR brings the TTK back up to ~5 minutes. 

## About the PR
- Changed the default grace period from Zero to 2 minutes.
- Reduced damage from poison down from 0.4 to 0.3. This will still kill voxes, but at a slower rate.

## Why / Balance
General player feedback I've been hearing is that it is too short, and also prevents most counterplay, considering there is practically no way to be cured if you're more than 90 seconds away from the nearest source of ambuzol. This PR will keep the infection deadly, but allow people to actually be saved by the cure.

## Technical details
Editing component fields

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: UpAndLeaves
- tweak: You now have three extra minutes to get to a cure before succumbing to Romerol and other zombie infections.
