### PR TITLE
Cleanup warnings in `AtmosPipeAppearanceSystem`

### DIFF
--- a/Content.Client/Atmos/EntitySystems/AtmosPipeAppearanceSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/AtmosPipeAppearanceSystem.cs
@@ -11,6 +11,7 @@ namespace Content.Client.Atmos.EntitySystems;
 public sealed class AtmosPipeAppearanceSystem : EntitySystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -27,19 +28,20 @@ public sealed class AtmosPipeAppearanceSystem : EntitySystem
 
         foreach (PipeConnectionLayer layerKey in Enum.GetValues(typeof(PipeConnectionLayer)))
         {
-            sprite.LayerMapReserveBlank(layerKey);
-            var layer = sprite.LayerMapGet(layerKey);
-            sprite.LayerSetRSI(layer, component.Sprite.RsiPath);
-            sprite.LayerSetState(layer, component.Sprite.RsiState);
-            sprite.LayerSetDirOffset(layer, ToOffset(layerKey));
+            var layer = _sprite.LayerMapReserve((uid, sprite), layerKey);
+            _sprite.LayerSetRsi((uid, sprite), layer, component.Sprite.RsiPath);
+            _sprite.LayerSetRsiState((uid, sprite), layer, component.Sprite.RsiState);
+            _sprite.LayerSetDirOffset((uid, sprite), layer, ToOffset(layerKey));
         }
     }
 
-    private void HideAllPipeConnection(SpriteComponent sprite)
+    private void HideAllPipeConnection(Entity<SpriteComponent> entity)
     {
-        foreach (PipeConnectionLayer layerKey in Enum.GetValues(typeof(PipeConnectionLayer)))
+        var sprite = entity.Comp;
+
+        foreach (var layerKey in Enum.GetValues<PipeConnectionLayer>())
         {
-            if (!sprite.LayerMapTryGet(layerKey, out var key))
+            if (!_sprite.LayerMapTryGet(entity.AsNullable(), layerKey, out var key, false))
                 continue;
 
             var layer = sprite[key];
@@ -61,7 +63,7 @@ public sealed class AtmosPipeAppearanceSystem : EntitySystem
 
         if (!_appearance.TryGetData<PipeDirection>(uid, PipeVisuals.VisualState, out var worldConnectedDirections, args.Component))
         {
-            HideAllPipeConnection(args.Sprite);
+            HideAllPipeConnection((uid, args.Sprite));
             return;
         }
 
@@ -71,13 +73,13 @@ public sealed class AtmosPipeAppearanceSystem : EntitySystem
         // transform connected directions to local-coordinates
         var connectedDirections = worldConnectedDirections.RotatePipeDirection(-Transform(uid).LocalRotation);
 
-        foreach (PipeConnectionLayer layerKey in Enum.GetValues(typeof(PipeConnectionLayer)))
+        foreach (var layerKey in Enum.GetValues<PipeConnectionLayer>())
         {
-            if (!args.Sprite.LayerMapTryGet(layerKey, out var key))
+            if (!_sprite.LayerMapTryGet((uid, args.Sprite), layerKey, out var key, false))
                 continue;
 
             var layer = args.Sprite[key];
-            var dir = (PipeDirection) layerKey;
+            var dir = (PipeDirection)layerKey;
             var visible = connectedDirections.HasDirection(dir);
 
             layer.Visible &= visible;

--- a/Content.Client/Atmos/EntitySystems/AtmosPipeAppearanceSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/AtmosPipeAppearanceSystem.cs
@@ -26,7 +26,7 @@ public sealed class AtmosPipeAppearanceSystem : EntitySystem
         if (!TryComp(uid, out SpriteComponent? sprite))
             return;
 
-        foreach (PipeConnectionLayer layerKey in Enum.GetValues(typeof(PipeConnectionLayer)))
+        foreach (var layerKey in Enum.GetValues<PipeConnectionLayer>())
         {
             var layer = _sprite.LayerMapReserve((uid, sprite), layerKey);
             _sprite.LayerSetRsi((uid, sprite), layer, component.Sprite.RsiPath);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 7 warnings in `AtmosPipeAppearanceSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods with `SpriteSystem` methods.

Also replaced some `Enum.GetValues(Type)` calls with `Enum<T>.GetValues()` and changed some explicitly typed variables to `var`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/space-wizards/space-station-14/issues/37448 prevents me from taking a screenshot of this.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->