### PR TITLE
Cleanup warnings in `EmitterSystem`

### DIFF
--- a/Content.Client/Singularity/Systems/EmitterSystem.cs
+++ b/Content.Client/Singularity/Systems/EmitterSystem.cs
@@ -7,6 +7,7 @@ namespace Content.Client.Singularity.Systems;
 public sealed class EmitterSystem : SharedEmitterSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -22,7 +23,7 @@ public sealed class EmitterSystem : SharedEmitterSystem
         if (!_appearance.TryGetData<EmitterVisualState>(uid, EmitterVisuals.VisualState, out var state, args.Component))
             state = EmitterVisualState.Off;
 
-        if (!args.Sprite.LayerMapTryGet(EmitterVisualLayers.Lights, out var layer))
+        if (!_sprite.LayerMapTryGet((uid, args.Sprite), EmitterVisualLayers.Lights, out var layer, false))
             return;
 
         switch (state)
@@ -30,17 +31,17 @@ public sealed class EmitterSystem : SharedEmitterSystem
             case EmitterVisualState.On:
                 if (component.OnState == null)
                     break;
-                args.Sprite.LayerSetVisible(layer, true);
-                args.Sprite.LayerSetState(layer, component.OnState);
+                _sprite.LayerSetVisible((uid, args.Sprite), layer, true);
+                _sprite.LayerSetRsiState((uid, args.Sprite), layer, component.OnState);
                 break;
             case EmitterVisualState.Underpowered:
                 if (component.UnderpoweredState == null)
                     break;
-                args.Sprite.LayerSetVisible(layer, true);
-                args.Sprite.LayerSetState(layer, component.UnderpoweredState);
+                _sprite.LayerSetVisible((uid, args.Sprite), layer, true);
+                _sprite.LayerSetRsiState((uid, args.Sprite), layer, component.UnderpoweredState);
                 break;
             case EmitterVisualState.Off:
-                args.Sprite.LayerSetVisible(layer, false);
+                _sprite.LayerSetVisible((uid, args.Sprite), layer, false);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 6 warnings in `EmitterSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods with `SpriteSystem` methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Emitters in different power states:
<img width="241" alt="Screenshot 2025-05-14 at 3 53 58 PM" src="https://github.com/user-attachments/assets/7a26b628-edea-47ef-959e-ca594bd4be29" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->