### PR TITLE
Cleanup warnings in `AtmosAlarmableVisualsSystem`

### DIFF
--- a/Content.Client/Atmos/Monitor/AtmosAlarmableVisualsSystem.cs
+++ b/Content.Client/Atmos/Monitor/AtmosAlarmableVisualsSystem.cs
@@ -7,9 +7,11 @@ namespace Content.Client.Atmos.Monitor;
 
 public sealed class AtmosAlarmableVisualsSystem : VisualizerSystem<AtmosAlarmableVisualsComponent>
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     protected override void OnAppearanceChange(EntityUid uid, AtmosAlarmableVisualsComponent component, ref AppearanceChangeEvent args)
     {
-        if (args.Sprite == null || !args.Sprite.LayerMapTryGet(component.LayerMap, out var layer))
+        if (args.Sprite == null || !_sprite.LayerMapTryGet((uid, args.Sprite), component.LayerMap, out var layer, false))
             return;
 
         if (!args.AppearanceData.TryGetValue(PowerDeviceVisuals.Powered, out var poweredObject) ||
@@ -22,8 +24,8 @@ public sealed class AtmosAlarmableVisualsSystem : VisualizerSystem<AtmosAlarmabl
         {
             foreach (var visLayer in component.HideOnDepowered)
             {
-                if (args.Sprite.LayerMapTryGet(visLayer, out var powerVisibilityLayer))
-                    args.Sprite.LayerSetVisible(powerVisibilityLayer, powered);
+                if (_sprite.LayerMapTryGet((uid, args.Sprite), visLayer, out var powerVisibilityLayer, false))
+                    _sprite.LayerSetVisible((uid, args.Sprite), powerVisibilityLayer, powered);
             }
         }
 
@@ -31,8 +33,8 @@ public sealed class AtmosAlarmableVisualsSystem : VisualizerSystem<AtmosAlarmabl
         {
             foreach (var (setLayer, powerState) in component.SetOnDepowered)
             {
-                if (args.Sprite.LayerMapTryGet(setLayer, out var setStateLayer))
-                    args.Sprite.LayerSetState(setStateLayer, new RSI.StateId(powerState));
+                if (_sprite.LayerMapTryGet((uid, args.Sprite), setLayer, out var setStateLayer, false))
+                    _sprite.LayerSetRsiState((uid, args.Sprite), setStateLayer, new RSI.StateId(powerState));
             }
         }
 
@@ -41,7 +43,7 @@ public sealed class AtmosAlarmableVisualsSystem : VisualizerSystem<AtmosAlarmabl
             && powered
             && component.AlarmStates.TryGetValue(alarmType, out var state))
         {
-            args.Sprite.LayerSetState(layer, new RSI.StateId(state));
+            _sprite.LayerSetRsiState((uid, args.Sprite), layer, new RSI.StateId(state));
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 6 warnings in `AtmosAlarmableVisualsSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods with `SpriteSystem` methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Air alarm being alarmed by the absence of air:
<img width="411" alt="Screenshot 2025-05-14 at 5 42 52 PM" src="https://github.com/user-attachments/assets/b1218e9e-53ba-4e7c-ab02-66a223ecc061" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->