### PR TITLE
Ensure large entities don't get stuck on conveyor belt corners

### DIFF
--- a/Content.Shared/Physics/Controllers/SharedConveyorController.cs
+++ b/Content.Shared/Physics/Controllers/SharedConveyorController.cs
@@ -96,6 +96,11 @@ public abstract class SharedConveyorController : VirtualController
         {
             var other = contact.OtherEnt(conveyorUid);
 
+            if (contact.OtherFixture(conveyorUid).Item2.Hard && contact.OtherBody(conveyorUid).BodyType != BodyType.Static)
+            {
+                EnsureComp<ConveyedComponent>(other);
+            }
+
             if (_conveyedQuery.HasComp(other))
             {
                 PhysicsSystem.WakeBody(other);

--- a/Content.Shared/Physics/Controllers/SharedConveyorController.cs
+++ b/Content.Shared/Physics/Controllers/SharedConveyorController.cs
@@ -159,7 +159,9 @@ public abstract class SharedConveyorController : VirtualController
                 // We also don't want this to apply to mobs as they apply their own friction and otherwise
                 // they'll go too slow.
                 if (!_mover.UsedMobMovement.TryGetValue(ent.Entity.Owner, out var usedMob) || !usedMob)
+                {
                     _mover.Friction(0.2f, frameTime: frameTime, friction: 5f, ref velocity);
+                }
 
                 SharedMoverController.Accelerate(ref velocity, targetDir, 20f, frameTime);
             }

--- a/Content.Shared/Physics/Controllers/SharedConveyorController.cs
+++ b/Content.Shared/Physics/Controllers/SharedConveyorController.cs
@@ -395,7 +395,7 @@ public abstract class SharedConveyorController : VirtualController
 
             var other = contact.OtherEnt(ent.Owner);
 
-            if (_conveyorQuery.HasComp(other))
+            if (_conveyorQuery.TryComp(other, out var comp) && CanRun(comp))
                 return true;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR fixes a bug where large entities, such as crates or lockers, get stuck on corners when the inside of the corner has a hard physics object such as a wall or railing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Needed for Xeno station! Also, it's a bug!

It keeps the functionality of the belts the same, save for the fact items are now going to always trend to the center of the conveyor belt, where previously they could end up being offset by a few pixels. 

## Technical details
<!-- Summary of code changes for easier review. -->

The movement vector when going on a belt while being off-center has been changed to make it move more sideways (via a 0.2 multiplier to the conveyor direction).

This may not always be enough to prevent snagging on corners still, so to ensure the conveyed entity keeps moving the friction has a minimum speed. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Crates on conveyor belts can now go around tight corners again!
