### PR TITLE
Fix some paradox clone traits

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -17,11 +17,13 @@
   # traits
   # - LegsParalyzed (you get healed)
   - LightweightDrunk
+  - Muted
   - Narcolepsy
   - Pacified
   - PainNumbness
   - Paracusia
   - PermanentBlindness
+  - Snoring
   - Unrevivable
   # job specific
   - BibleUser
@@ -37,6 +39,7 @@
   - BleatingAccent
   - DamagedSiliconAccent
   - FrenchAccent
+  - FrontalLisp
   - GermanAccent
   - LizardAccent
   - MobsterAccent


### PR DESCRIPTION
## About the PR
Muted, Snoring and Frontal Lisp are traits, but the components weren't whitelisted to be copied to clones.

## Why / Balance
bugfix

## Technical details
Just add them to the yaml whitelist.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed paradox clones not copying the mute, snoring and frontal lisp traits.
