### PR TITLE
Buff singularity rad collectors

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
@@ -57,7 +57,7 @@
     sprite: Structures/Power/Generation/Singularity/collector.rsi
     state: static
   - type: RadiationCollector
-    chargeModifier: 7500
+    chargeModifier: 10000
     radiationReactiveGases:
       - reactantPrototype: Plasma
         powerGenerationEfficiency: 1

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
@@ -57,7 +57,7 @@
     sprite: Structures/Power/Generation/Singularity/collector.rsi
     state: static
   - type: RadiationCollector
-    chargeModifier: 10000
+    chargeModifier: 15000
     radiationReactiveGases:
       - reactantPrototype: Plasma
         powerGenerationEfficiency: 1


### PR DESCRIPTION
## About the PR
Buffs singularity collector power output.

## Why / Balance
Currently singularity collectors are way too slow at refilling a station's main batteries after a large discharge (which is expected after engineering's power setup phase is complete). This is especially prominent in radiation collectors which are mapped behind glass in a pressurized environment (as they receive a lower amount of radiation). This leads to a lot of problems (the station potentially draining its PA SMES is a big one, this is an issue I plan to fix later).

We want to move towards internal radiation collectors following discussion in maintainer meetings. It's just better for game design and makes more sense.

This is working towards a larger goal of:
- Making station engines more attractive to run and maintain
- Reducing common noobtraps in running engines
- Killing the prominent TEG meta
- Increasing the amount of time the station can run on batteries with zero intervention roundstart (missing engineering department or otherwise)

## Technical details
YAML

## Media
Hard to show, but my testing was extensive. Trust me bro.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
heheheh nuh uh

**Changelog**
:cl:
- tweak: Radiation collector power output has been buffed. Remember engineers, the third level on the PA is safe for long term use!