### PR TITLE
Buff metal foam grenades

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -145,6 +145,7 @@
       - id: ClothingShoesBootsMag
       - id: RCD
       - id: RCDAmmo
+      - id: MetalFoamGrenade
 
 - type: entity
   id: LockerEngineerFilled
@@ -158,6 +159,7 @@
       - id: trayScanner
       - id: RCD
       - id: RCDAmmo
+      - id: MetalFoamGrenade
 
 - type: entity
   id: ClosetRadiationSuitFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -170,6 +170,7 @@
     - id: RCD
     - id: RCDAmmo
     - id: RubberStampCE
+    - id: MetalFoamGrenade
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -231,6 +231,9 @@
       state: metal_foam-north
     - map: [ "enum.EdgeLayer.West" ]
       state: metal_foam-west
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: FlimsyMetallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -213,7 +213,7 @@
 - type: entity
   id: FoamedAluminiumMetal
   name: foamed aluminium metal
-  description: "For sealing hull breaches."
+  description: "Leftover sparse foam from an aluminum foam grenade. Easily destroyed."
   parent: BaseFoamedMetal
   components:
   - type: Sprite
@@ -231,6 +231,14 @@
       state: metal_foam-north
     - map: [ "enum.EdgeLayer.West" ]
       state: metal_foam-west
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1 # Intentionally very weak to encourage speedy repair, think of it as thin webbing
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   id: ReactionFlash

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -448,15 +448,15 @@
   parent: [ BaseEngineeringContraband, SmokeGrenade ]
   id: MetalFoamGrenade
   name: metal foam grenade
-  description: An emergency tool used for patching breaches with special quick-set metal foam. Almost as good as real walls.
+  description: An emergency tool used for patching hull breaches with special quick-set metal foam. Almost as good as real floors!
   components:
   - type: Sprite
     sprite: Objects/Weapons/Grenades/metalfoam.rsi
   - type: OnUseTimerTrigger
-    delay: 1.5
+    delay: 5
   - type: SmokeOnTrigger
-    duration: 2
-    spreadAmount: 5
+    duration: 10
+    spreadAmount: 20
     smokePrototype: AluminiumMetalFoam
   - type: StaticPrice
     price: 350


### PR DESCRIPTION
## About the PR
Buffs metal foam grenades. They now spread to 20 tiles.

Nerfs metal foam walls. They now only have one health (one crowbar hit, or any other minor disruption).

Metal foam grenades can now be found in general station engineer's lockers.

## Why / Balance
Engineering is in quite a poor repair dynamic right now: repair is seen as extremely boring and a groan, which is not something we want to happen! Repair should be fun and exciting, especially if that's one of the only things engineering has got going for it right now.

This is largely due to a couple reasons:
- Repairwork currently heavily interacts with the construction system, which is slow and takes a while to master
- Damage to complex areas often require a whole team effort, and usually the area is never the same ever again
- All antagonists can currently damage the station faster than engineering can usually repair them, *always*. It's good to have engineering be in over their head *at the peak of the chaos*, or at the tail end of the round, but engineering shouldn't have more than what they can eat on their plate in the beginning of the round.
- Because of the extreme length of time engineering can take to repair things, whenever major damage is done (med bombed!!!) the decision to go home is usually very quickly made, and engineering seldom gets the chance to show off they can get things done quick. Most people presume that "it's all over". 

This PR reintroduces metal foam grenades as a viable option. They previously weren't seen as an option because:
- Metal foam walls had an absurd amount of health, which led to repairwork being "here, help me break down these walls for the next few minutes" which completely invalidated their intent (to be a speedy hull repair process).
- Because of the ability to completely screw over an entire hallway instantly they were commonly used only by antagonists.
- You could only get them through cargo, and nobody ever ordered them.

Now that they've been buffed and added to lockers, they can hopefully see some more use and give engineering more power in fixing massive hullbreaches.

In the future, engineering will see more power and emphasis on on-site material recycling using the RCD. However this is good change in the interim.

### Okay but what about the ~self~ antag chemist? He deserves to troll people!
The chemist can still make iron foam walls, which have the trollium health.

## Technical details
YAML

## Media
In the media, note that one grenade doesn't fix everything. Multiple grenades are required to patch the entire thing. This is a good cost-benefit balance in my opinion, as multiple engineers will have to team up and use their grenades if they want to patch holes the fast way.

Also note that... there's still repairwork to be done after you patch the floor! Pipes and tile still need to go down!

Damage was one (1) standard syndicate bomb bombing med.

![Content Client_W3aHRKmCiF](https://github.com/user-attachments/assets/9b72fce7-e958-4c10-bee6-a103e2e1ea45)
![Content Client_o3vRXHggKd](https://github.com/user-attachments/assets/e31e6fd2-3802-40ea-82c7-b1fd89f54c51)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
yuijsiujsdfluijsef

**Changelog**
:cl:
- add: Metal foam grenades have been added to station engineer lockers.
- tweak: Metal foam grenades have been tweaked to cover more area over a longer period of time.
- tweak: Metal foam grenades now have a 5 second timer.
- tweak: Aluminum foam walls now take one hit to destroy.
