### PR TITLE
Soaked Smokes Volume Revert

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -92,7 +92,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -107,7 +107,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -122,7 +122,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -137,7 +137,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -152,7 +152,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -167,7 +167,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -182,7 +182,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -197,7 +197,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -212,7 +212,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -227,7 +227,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -242,7 +242,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -257,7 +257,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -272,7 +272,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -287,7 +287,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -302,7 +302,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -317,7 +317,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -332,7 +332,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -347,7 +347,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -362,7 +362,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -377,7 +377,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -392,7 +392,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -407,7 +407,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
@@ -422,7 +422,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
         - ReagentId: Nicotine
           Quantity: 10
@@ -437,7 +437,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
         - ReagentId: Nicotine
           Quantity: 10
@@ -452,7 +452,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
         - ReagentId: Nicotine
           Quantity: 10


### PR DESCRIPTION
## About the PR
Reverted a small part of #36979 to return the volume of Dan's Soaked Smokes to their previous maximum of 40u. No other changes or reversions made to that PR other than this.

## Why / Balance
A unique element of Dan's Soaked Smokes was the ability to custom soak and smoke them due to their expanded empty capacity when compared to a regular cigarette. Removing this fun element of the smokes without having a suitable replacement for high volume custom cigarettes was not an ideal outcome of the otherwise useful PR #36979. This small reversion was created to add back the extra empty space for people to enjoy making their own soaked cigarettes again — as discussed with a Maintainer in that PR's comments.

## Technical details
All `SoakedCigarette` entities have their `maxVol` reverted to 40u.

## Media
![image](https://github.com/user-attachments/assets/49aa7ab0-2e03-4409-ba8d-4550c452687f)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Soaked Smokes retain their 40u max capacity.
