### PR TITLE
Fix prototypes and datadefs so they pass analyzer checks (again)

### DIFF
--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -444,7 +444,7 @@ public abstract class SharedAnomalySystem : EntitySystem
 }
 
 [DataRecord]
-public record struct AnomalySpawnSettings()
+public partial record struct AnomalySpawnSettings()
 {
     /// <summary>
     /// should entities block spawning?

--- a/Content.Shared/Cargo/Prototypes/CargoAccountPrototype.cs
+++ b/Content.Shared/Cargo/Prototypes/CargoAccountPrototype.cs
@@ -11,7 +11,7 @@ public sealed partial class CargoAccountPrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]
-    public string ID { get; } = default!;
+    public string ID { get; private set; } = default!;
 
     /// <summary>
     /// Full IC name of the account.

--- a/Content.Shared/CartridgeLoader/Cartridges/NanoTaskUiMessageEvent.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/NanoTaskUiMessageEvent.cs
@@ -13,7 +13,7 @@ public interface INanoTaskUiMessagePayload
 ///     Dispatched when a new task is created
 /// </summary>
 [Serializable, NetSerializable, DataRecord]
-public sealed class NanoTaskAddTask : INanoTaskUiMessagePayload
+public sealed partial class NanoTaskAddTask : INanoTaskUiMessagePayload
 {
     /// <summary>
     ///     The newly created task
@@ -30,7 +30,7 @@ public sealed class NanoTaskAddTask : INanoTaskUiMessagePayload
 ///     Dispatched when an existing task is modified
 /// </summary>
 [Serializable, NetSerializable, DataRecord]
-public sealed class NanoTaskUpdateTask : INanoTaskUiMessagePayload
+public sealed partial class NanoTaskUpdateTask : INanoTaskUiMessagePayload
 {
     /// <summary>
     ///     The task that was updated and its ID
@@ -47,7 +47,7 @@ public sealed class NanoTaskUpdateTask : INanoTaskUiMessagePayload
 ///     Dispatched when an existing task is deleted
 /// </summary>
 [Serializable, NetSerializable, DataRecord]
-public sealed class NanoTaskDeleteTask : INanoTaskUiMessagePayload
+public sealed partial class NanoTaskDeleteTask : INanoTaskUiMessagePayload
 {
     /// <summary>
     ///     The ID of the task to delete
@@ -64,7 +64,7 @@ public sealed class NanoTaskDeleteTask : INanoTaskUiMessagePayload
 ///     Dispatched when a task is requested to be printed
 /// </summary>
 [Serializable, NetSerializable, DataRecord]
-public sealed class NanoTaskPrintTask : INanoTaskUiMessagePayload
+public sealed partial class NanoTaskPrintTask : INanoTaskUiMessagePayload
 {
     /// <summary>
     ///     The NanoTask to print

--- a/Content.Shared/CartridgeLoader/Cartridges/NanoTaskUiState.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/NanoTaskUiState.cs
@@ -17,7 +17,7 @@ public enum NanoTaskPriority : byte
 ///     The data relating to a single NanoTask item, but not its identifier
 /// </summary>
 [Serializable, NetSerializable, DataRecord]
-public sealed class NanoTaskItem
+public sealed partial class NanoTaskItem
 {
     /// <summary>
     ///     The maximum length of the Description and TaskIsFor fields
@@ -61,7 +61,7 @@ public sealed class NanoTaskItem
 ///     Pairs a NanoTask item and its identifier
 /// </summary>
 [Serializable, NetSerializable, DataRecord]
-public sealed class NanoTaskItemAndId
+public sealed partial class NanoTaskItemAndId
 {
     public readonly int Id;
     public readonly NanoTaskItem Data;

--- a/Content.Shared/Cloning/CloningSettingsPrototype.cs
+++ b/Content.Shared/Cloning/CloningSettingsPrototype.cs
@@ -19,11 +19,11 @@ public sealed partial class CloningSettingsPrototype : IPrototype, IInheritingPr
     public string ID { get; private set; } = default!;
 
     [ParentDataField(typeof(PrototypeIdArraySerializer<CloningSettingsPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     [AbstractDataField]
     [NeverPushInheritance]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 
     /// <summary>
     ///     Determines if cloning can be prevented by traits etc.

--- a/Content.Shared/RCD/RCDPrototype.cs
+++ b/Content.Shared/RCD/RCDPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.RCD;
 /// Contains the parameters for an RCD construction / operation
 /// </summary>
 [Prototype("rcd")]
-public sealed class RCDPrototype : IPrototype
+public sealed partial class RCDPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Silicons/StationAi/StationAiCustomizationGroupPrototype.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiCustomizationGroupPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Silicons.StationAi;
 public sealed partial class StationAiCustomizationGroupPrototype : IPrototype
 {
     [IdDataField]
-    public string ID { get; } = string.Empty;
+    public string ID { get; private set; } = string.Empty;
 
     /// <summary>
     /// The localized name of the customization.

--- a/Content.Shared/Silicons/StationAi/StationAiCustomizationPrototype.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiCustomizationPrototype.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Silicons.StationAi;
 public sealed partial class StationAiCustomizationPrototype : IPrototype, IInheritingPrototype
 {
     [IdDataField]
-    public string ID { get; } = string.Empty;
+    public string ID { get; private set; } = string.Empty;
 
     /// <summary>
     /// The (unlocalized) name of the customization.
@@ -42,7 +42,7 @@ public sealed partial class StationAiCustomizationPrototype : IPrototype, IInher
     /// </summary>
     [ViewVariables]
     [ParentDataFieldAttribute(typeof(AbstractPrototypeIdArraySerializer<StationAiCustomizationPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     /// <summary>
     /// Specifies whether the prototype is abstract.
@@ -50,5 +50,5 @@ public sealed partial class StationAiCustomizationPrototype : IPrototype, IInher
     [ViewVariables]
     [NeverPushInheritance]
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 }

--- a/Content.Shared/Xenoarchaeology/Artifact/Prototypes/XenoArchTriggerPrototype.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Prototypes/XenoArchTriggerPrototype.cs
@@ -11,7 +11,7 @@ public sealed partial class XenoArchTriggerPrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]
-    public string ID { get; } = default!;
+    public string ID { get; private set; } = default!;
 
     /// <summary>
     /// Tip for user on how to activate this trigger.


### PR DESCRIPTION
https://github.com/space-wizards/space-station-14/pull/35435 again to clean up new violations that have snuck in since then.

Previous description:
>Content changes to fix errors detected by https://github.com/space-wizards/RobustToolbox/pull/5699.

>This consists of a whole lot of little changes all over the place. Mostly making classes partial and giving ID fields private setters. Any DataFields without a setter (other than ID, Parents, or Abstract) had the setter removed and are now just plain fields.