### PR TITLE
Fix EOF newline check

### DIFF
--- a/.github/workflows/check-trailing-whitespace.yml
+++ b/.github/workflows/check-trailing-whitespace.yml
@@ -39,8 +39,13 @@ jobs:
 
           # Check for missing EOF newline
           if [ -f "$file" ] && [ -s "$file" ]; then
-            last_char=$(tail -c 1 "$file")
-            if [ "$last_char" != "" ] && [ "$last_char" != $'\n' ]; then
+            # I know it looks really dumb adding an x to the output here but it's required because
+            # command substitution will strip ALL trailing newlines, but we're exactly interested in trailing newlines!
+            # We can trick it by ensuring that the output of the command substitution does not end in a newline, thus
+            # preserving any newlines before the 'x'.
+            # See https://bash-hackers.gabe565.com/syntax/expansion/cmdsubst/
+            last_char=$(tail -c 1 "$file"; echo -n "x")
+            if [ "$last_char" != "x" ] && [ "$last_char" != $'\nx' ]; then
               echo "::error file=$file::Missing newline at end of file"
               has_missing_eof_newline=1
             fi


### PR DESCRIPTION
## About the PR

Command substitution strips newline characters, so it's not actually comparing the last character against `\n`

## Why / Balance

Fix

## Technical details

I know it looks really dumb adding an x to the output here but it's required because command substitution will strip ALL trailing newlines, but we're exactly interested in trailing newlines!
We can trick it by ensuring that the output of the command substitution does not end in a newline, thus preserving any newlines before the 'x'.
See https://bash-hackers.gabe565.com/syntax/expansion/cmdsubst/

## Why does command substitution strip newlines?

I have a calculator program, `calc`. 

if I type `calc "4+4"` I expect to get 8.

If I type that in a terminal I expect it to look like:

```
clownOS$ calc "4+4"
8
clownOS$ 
```

In order to make it look like that, the `calc` program actually outputs `8\n`, if it only outputs `8` it will look like:

```
clownOS$ calc "4+4"
8clownOS$ 
```

Now say I want to use the result in a command substitution.

If command substitution DIDN'T strip newlines, it would look like this:

```
clownOS$ echo "The answer is $(calc "4+4")!"
The answer is 8
!
clownOS$ 
```

when you would actually expect

```
clownOS$ echo "The answer is $(calc "4+4")!"
The answer is 8!
clownOS$ 
```

So command substitution strips the newline so that you don't need to tell the application what context its running in to decide whether to output a newline.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

none
