### PR TITLE
Shuttle speed bump

### DIFF
--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -17,10 +17,10 @@ namespace Content.Server.Shuttles.Components
         public const float BrakeCoefficient = 1.5f;
 
         /// <summary>
-        /// Maximum velocity assuming unupgraded, tier 1 thrusters
+        /// Maximum velocity.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float BaseMaxLinearVelocity = 20f;
+        public float BaseMaxLinearVelocity = 40f;
 
         public const float MaxAngularVelocity = 4f;
 

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -20,7 +20,7 @@ namespace Content.Server.Shuttles.Components
         /// Maximum velocity.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float BaseMaxLinearVelocity = 40f;
+        public float BaseMaxLinearVelocity = 60f;
 
         public const float MaxAngularVelocity = 4f;
 


### PR DESCRIPTION
Better to play with shuttle impacts with and 20 was just a stupid "game no handle" cap rather than gameplay consideration.

**Changelog**
:cl:
- tweak: Raise shuttle speed cap from 20 to 60m/s.