### PR TITLE
Don't group damage in the HealthChange.cs guidebook text

### DIFF
--- a/Content.Server/EntityEffects/Effects/HealthChange.cs
+++ b/Content.Server/EntityEffects/Effects/HealthChange.cs
@@ -64,48 +64,6 @@ namespace Content.Server.EntityEffects.Effects
 
             damageSpec = entSys.GetEntitySystem<DamageableSystem>().ApplyUniversalAllModifiers(damageSpec);
 
-            foreach (var group in prototype.EnumeratePrototypes<DamageGroupPrototype>())
-            {
-                if (!damageSpec.TryGetDamageInGroup(group, out var amount))
-                    continue;
-
-                var relevantTypes = damageSpec.DamageDict
-                    .Where(x => x.Value != FixedPoint2.Zero && group.DamageTypes.Contains(x.Key)).ToList();
-
-                if (relevantTypes.Count != group.DamageTypes.Count)
-                    continue;
-
-                var sum = FixedPoint2.Zero;
-                foreach (var type in group.DamageTypes)
-                {
-                    sum += damageSpec.DamageDict.GetValueOrDefault(type);
-                }
-
-                // if the total sum of all the types equal the damage amount,
-                // assume that they're evenly distributed.
-                if (sum != amount)
-                    continue;
-
-                var sign = FixedPoint2.Sign(amount);
-
-                if (sign < 0)
-                    heals = true;
-                if (sign > 0)
-                    deals = true;
-
-                damages.Add(
-                    Loc.GetString("health-change-display",
-                        ("kind", group.LocalizedName),
-                        ("amount", MathF.Abs(amount.Float())),
-                        ("deltasign", sign)
-                    ));
-
-                foreach (var type in group.DamageTypes)
-                {
-                    damageSpec.DamageDict.Remove(type);
-                }
-            }
-
             foreach (var (kind, amount) in damageSpec.DamageDict)
             {
                 var sign = FixedPoint2.Sign(amount);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes the chem guidebook text to not group damage in the normal `HealthChange` effect.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's more obvious now with the `EvenHealthChange` effect, but healing damage is not based around groups and treating it as such is super misleading.

If a player sees someone has 20 brute damage and administers 10u of bicaridine, the actual effectiveness can vary from 100% to 33%, due to how the split damage is distributed. As such, it makes more sense to be specific about how the damage is split so that players can better understand how the healing works.

## Technical details
<!-- Summary of code changes for easier review. -->
Just removes a bunch of complicated shitcode

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
old:
![image](https://github.com/user-attachments/assets/1149d38a-c3ba-40ce-bab1-54eddc5cdac6)

new:
![image](https://github.com/user-attachments/assets/a0dbc0ff-b862-495e-9926-e18b0b512d07)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: The guidebook is now more explicit about how damage/healing from chemicals is split.

