### PR TITLE
Cleanup more `SpriteComponent` warnings (part 1)

### DIFF
--- a/Content.Client/AlertLevel/AlertLevelDisplaySystem.cs
+++ b/Content.Client/AlertLevel/AlertLevelDisplaySystem.cs
@@ -8,6 +8,8 @@ namespace Content.Client.AlertLevel;
 
 public sealed class AlertLevelDisplaySystem : EntitySystem
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -21,26 +23,26 @@ public sealed class AlertLevelDisplaySystem : EntitySystem
         {
             return;
         }
-        var layer = args.Sprite.LayerMapReserveBlank(AlertLevelDisplay.Layer);
+        var layer = _sprite.LayerMapReserve((uid, args.Sprite), AlertLevelDisplay.Layer);
 
         if (args.AppearanceData.TryGetValue(AlertLevelDisplay.Powered, out var poweredObject))
         {
-            args.Sprite.LayerSetVisible(layer, poweredObject is true);
+            _sprite.LayerSetVisible((uid, args.Sprite), layer, poweredObject is true);
         }
 
         if (!args.AppearanceData.TryGetValue(AlertLevelDisplay.CurrentLevel, out var level))
         {
-            args.Sprite.LayerSetState(layer, alertLevelDisplay.AlertVisuals.Values.First());
+            _sprite.LayerSetRsiState((uid, args.Sprite), layer, alertLevelDisplay.AlertVisuals.Values.First());
             return;
         }
 
-        if (alertLevelDisplay.AlertVisuals.TryGetValue((string) level, out var visual))
+        if (alertLevelDisplay.AlertVisuals.TryGetValue((string)level, out var visual))
         {
-            args.Sprite.LayerSetState(layer, visual);
+            _sprite.LayerSetRsiState((uid, args.Sprite), layer, visual);
         }
         else
         {
-            args.Sprite.LayerSetState(layer, alertLevelDisplay.AlertVisuals.Values.First());
+            _sprite.LayerSetRsiState((uid, args.Sprite), layer, alertLevelDisplay.AlertVisuals.Values.First());
         }
     }
 }

--- a/Content.Client/Botany/PlantHolderVisualizerSystem.cs
+++ b/Content.Client/Botany/PlantHolderVisualizerSystem.cs
@@ -38,7 +38,7 @@ public sealed class PlantHolderVisualizerSystem : VisualizerSystem<PlantHolderVi
 
             if (valid)
             {
-                _sprite.LayerSetRsi((uid, args.Sprite), (int)PlantHolderLayers.Plant, new ResPath(rsi));
+                _sprite.LayerSetRsi((uid, args.Sprite), PlantHolderLayers.Plant, new ResPath(rsi));
                 _sprite.LayerSetRsiState((uid, args.Sprite), PlantHolderLayers.Plant, state);
             }
         }

--- a/Content.Client/Botany/PlantHolderVisualizerSystem.cs
+++ b/Content.Client/Botany/PlantHolderVisualizerSystem.cs
@@ -1,11 +1,14 @@
 using Content.Client.Botany.Components;
 using Content.Shared.Botany;
 using Robust.Client.GameObjects;
+using Robust.Shared.Utility;
 
 namespace Content.Client.Botany;
 
 public sealed class PlantHolderVisualizerSystem : VisualizerSystem<PlantHolderVisualsComponent>
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -17,8 +20,8 @@ public sealed class PlantHolderVisualizerSystem : VisualizerSystem<PlantHolderVi
         if (!TryComp<SpriteComponent>(uid, out var sprite))
             return;
 
-        sprite.LayerMapReserveBlank(PlantHolderLayers.Plant);
-        sprite.LayerSetVisible(PlantHolderLayers.Plant, false);
+        _sprite.LayerMapReserve((uid, sprite), PlantHolderLayers.Plant);
+        _sprite.LayerSetVisible((uid, sprite), PlantHolderLayers.Plant, false);
     }
 
     protected override void OnAppearanceChange(EntityUid uid, PlantHolderVisualsComponent component, ref AppearanceChangeEvent args)
@@ -31,12 +34,12 @@ public sealed class PlantHolderVisualizerSystem : VisualizerSystem<PlantHolderVi
         {
             var valid = !string.IsNullOrWhiteSpace(state);
 
-            args.Sprite.LayerSetVisible(PlantHolderLayers.Plant, valid);
+            _sprite.LayerSetVisible((uid, args.Sprite), PlantHolderLayers.Plant, valid);
 
             if (valid)
             {
-                args.Sprite.LayerSetRSI(PlantHolderLayers.Plant, rsi);
-                args.Sprite.LayerSetState(PlantHolderLayers.Plant, state);
+                _sprite.LayerSetRsi((uid, args.Sprite), (int)PlantHolderLayers.Plant, new ResPath(rsi));
+                _sprite.LayerSetRsiState((uid, args.Sprite), PlantHolderLayers.Plant, state);
             }
         }
     }

--- a/Content.Client/Electrocution/ElectrocutionHUDVisualizerSystem.cs
+++ b/Content.Client/Electrocution/ElectrocutionHUDVisualizerSystem.cs
@@ -54,7 +54,7 @@ public sealed class ElectrocutionHUDVisualizerSystem : VisualizerSystem<Electroc
     private void ShowHUD()
     {
         var electrifiedQuery = AllEntityQuery<ElectrocutionHUDVisualsComponent, AppearanceComponent, SpriteComponent>();
-        while (electrifiedQuery.MoveNext(out var uid, out var _, out var appearanceComp, out var spriteComp))
+        while (electrifiedQuery.MoveNext(out var uid, out _, out var appearanceComp, out var spriteComp))
         {
             if (!AppearanceSystem.TryGetData<bool>(uid, ElectrifiedVisuals.IsElectrified, out var electrified, appearanceComp))
                 continue;
@@ -68,7 +68,7 @@ public sealed class ElectrocutionHUDVisualizerSystem : VisualizerSystem<Electroc
     private void RemoveHUD()
     {
         var electrifiedQuery = AllEntityQuery<ElectrocutionHUDVisualsComponent, AppearanceComponent, SpriteComponent>();
-        while (electrifiedQuery.MoveNext(out var uid, out var _, out _, out var spriteComp))
+        while (electrifiedQuery.MoveNext(out var uid, out _, out _, out var spriteComp))
         {
             _sprite.LayerSetVisible((uid, spriteComp), ElectrifiedLayers.HUD, false);
         }

--- a/Content.Client/Electrocution/ElectrocutionHUDVisualizerSystem.cs
+++ b/Content.Client/Electrocution/ElectrocutionHUDVisualizerSystem.cs
@@ -11,6 +11,7 @@ namespace Content.Client.Electrocution;
 public sealed class ElectrocutionHUDVisualizerSystem : VisualizerSystem<ElectrocutionHUDVisualsComponent>
 {
     [Dependency] private readonly IPlayerManager _playerMan = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -58,10 +59,7 @@ public sealed class ElectrocutionHUDVisualizerSystem : VisualizerSystem<Electroc
             if (!AppearanceSystem.TryGetData<bool>(uid, ElectrifiedVisuals.IsElectrified, out var electrified, appearanceComp))
                 continue;
 
-            if (electrified)
-                spriteComp.LayerSetVisible(ElectrifiedLayers.HUD, true);
-            else
-                spriteComp.LayerSetVisible(ElectrifiedLayers.HUD, false);
+            _sprite.LayerSetVisible((uid, spriteComp), ElectrifiedLayers.HUD, electrified);
         }
     }
 
@@ -70,10 +68,9 @@ public sealed class ElectrocutionHUDVisualizerSystem : VisualizerSystem<Electroc
     private void RemoveHUD()
     {
         var electrifiedQuery = AllEntityQuery<ElectrocutionHUDVisualsComponent, AppearanceComponent, SpriteComponent>();
-        while (electrifiedQuery.MoveNext(out var uid, out var _, out var appearanceComp, out var spriteComp))
+        while (electrifiedQuery.MoveNext(out var uid, out var _, out _, out var spriteComp))
         {
-
-            spriteComp.LayerSetVisible(ElectrifiedLayers.HUD, false);
+            _sprite.LayerSetVisible((uid, spriteComp), ElectrifiedLayers.HUD, false);
         }
     }
 
@@ -87,9 +84,6 @@ public sealed class ElectrocutionHUDVisualizerSystem : VisualizerSystem<Electroc
             return;
 
         var player = _playerMan.LocalEntity;
-        if (electrified && HasComp<ShowElectrocutionHUDComponent>(player))
-            args.Sprite.LayerSetVisible(ElectrifiedLayers.HUD, true);
-        else
-            args.Sprite.LayerSetVisible(ElectrifiedLayers.HUD, false);
+        _sprite.LayerSetVisible((uid, args.Sprite), ElectrifiedLayers.HUD, electrified && HasComp<ShowElectrocutionHUDComponent>(player));
     }
 }

--- a/Content.Client/Ensnaring/EnsnareableSystem.cs
+++ b/Content.Client/Ensnaring/EnsnareableSystem.cs
@@ -1,12 +1,14 @@
 using Content.Shared.Ensnaring;
 using Content.Shared.Ensnaring.Components;
 using Robust.Client.GameObjects;
+using Robust.Shared.Utility;
 
 namespace Content.Client.Ensnaring;
 
 public sealed class EnsnareableSystem : SharedEnsnareableSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -19,25 +21,25 @@ public sealed class EnsnareableSystem : SharedEnsnareableSystem
     {
         base.OnEnsnareInit(ent, ref args);
 
-        if(!TryComp<SpriteComponent>(ent.Owner, out var sprite))
+        if (!TryComp<SpriteComponent>(ent.Owner, out var sprite))
             return;
 
         // TODO remove this, this should just be in yaml.
-        sprite.LayerMapReserveBlank(EnsnaredVisualLayers.Ensnared);
+        _sprite.LayerMapReserve((ent.Owner, sprite), EnsnaredVisualLayers.Ensnared);
     }
 
     private void OnAppearanceChange(EntityUid uid, EnsnareableComponent component, ref AppearanceChangeEvent args)
     {
-        if (args.Sprite == null || !args.Sprite.LayerMapTryGet(EnsnaredVisualLayers.Ensnared, out var layer))
+        if (args.Sprite == null || !_sprite.LayerMapTryGet((uid, args.Sprite), EnsnaredVisualLayers.Ensnared, out var layer, false))
             return;
 
         if (_appearance.TryGetData<bool>(uid, EnsnareableVisuals.IsEnsnared, out var isEnsnared, args.Component))
         {
             if (component.Sprite != null)
             {
-                args.Sprite.LayerSetRSI(layer, component.Sprite);
-                args.Sprite.LayerSetState(layer, component.State);
-                args.Sprite.LayerSetVisible(layer, isEnsnared);
+                _sprite.LayerSetRsi((uid, args.Sprite), layer, new ResPath(component.Sprite));
+                _sprite.LayerSetRsiState((uid, args.Sprite), layer, component.State);
+                _sprite.LayerSetVisible((uid, args.Sprite), layer, isEnsnared);
             }
         }
     }

--- a/Content.Client/Fluids/PuddleSystem.cs
+++ b/Content.Client/Fluids/PuddleSystem.cs
@@ -10,6 +10,7 @@ namespace Content.Client.Fluids;
 public sealed class PuddleSystem : SharedPuddleSystem
 {
     [Dependency] private readonly IconSmoothSystem _smooth = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -27,7 +28,7 @@ public sealed class PuddleSystem : SharedPuddleSystem
 
         if (args.AppearanceData.TryGetValue(PuddleVisuals.CurrentVolume, out var volumeObj))
         {
-            volume = (float) volumeObj;
+            volume = (float)volumeObj;
         }
 
         // Update smoothing and sprite based on volume.
@@ -35,19 +36,19 @@ public sealed class PuddleSystem : SharedPuddleSystem
         {
             if (volume < LowThreshold)
             {
-                args.Sprite.LayerSetState(0, $"{smooth.StateBase}a");
+                _sprite.LayerSetRsiState((uid, args.Sprite), 0, $"{smooth.StateBase}a");
                 _smooth.SetEnabled(uid, false, smooth);
             }
             else if (volume < MediumThreshold)
             {
-                args.Sprite.LayerSetState(0, $"{smooth.StateBase}b");
+                _sprite.LayerSetRsiState((uid, args.Sprite), 0, $"{smooth.StateBase}b");
                 _smooth.SetEnabled(uid, false, smooth);
             }
             else
             {
                 if (!smooth.Enabled)
                 {
-                    args.Sprite.LayerSetState(0, $"{smooth.StateBase}0");
+                    _sprite.LayerSetRsiState((uid, args.Sprite), 0, $"{smooth.StateBase}0");
                     _smooth.SetEnabled(uid, true, smooth);
                     _smooth.DirtyNeighbours(uid);
                 }
@@ -58,12 +59,12 @@ public sealed class PuddleSystem : SharedPuddleSystem
 
         if (args.AppearanceData.TryGetValue(PuddleVisuals.SolutionColor, out var colorObj))
         {
-            var color = (Color) colorObj;
-            args.Sprite.Color = color * baseColor;
+            var color = (Color)colorObj;
+            _sprite.SetColor((uid, args.Sprite), color * baseColor);
         }
         else
         {
-            args.Sprite.Color *= baseColor;
+            _sprite.SetColor((uid, args.Sprite), args.Sprite.Color * baseColor);
         }
     }
 

--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -17,6 +17,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Client.Hands.Systems
 {
@@ -28,6 +29,7 @@ namespace Content.Client.Hands.Systems
 
         [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
         [Dependency] private readonly StrippableSystem _stripSys = default!;
+        [Dependency] private readonly SpriteSystem _sprite = default!;
         [Dependency] private readonly ExamineSystem _examine = default!;
         [Dependency] private readonly DisplacementMapSystem _displacement = default!;
 
@@ -297,7 +299,7 @@ namespace Content.Client.Hands.Systems
             {
                 foreach (var key in revealedLayers)
                 {
-                    sprite.RemoveLayer(key);
+                    _sprite.RemoveLayer((uid, sprite), key);
                 }
 
                 revealedLayers.Clear();
@@ -333,7 +335,7 @@ namespace Content.Client.Hands.Systems
                     continue;
                 }
 
-                var index = sprite.LayerMapReserveBlank(key);
+                var index = _sprite.LayerMapReserve((uid, sprite), key);
 
                 // In case no RSI is given, use the item's base RSI as a default. This cuts down on a lot of unnecessary yaml entries.
                 if (layerData.RsiPath == null
@@ -341,12 +343,12 @@ namespace Content.Client.Hands.Systems
                     && sprite[index].Rsi == null)
                 {
                     if (TryComp<ItemComponent>(held, out var itemComponent) && itemComponent.RsiPath != null)
-                        sprite.LayerSetRSI(index, itemComponent.RsiPath);
+                        _sprite.LayerSetRsi((uid, sprite), index, new ResPath(itemComponent.RsiPath));
                     else if (TryComp(held, out SpriteComponent? clothingSprite))
-                        sprite.LayerSetRSI(index, clothingSprite.BaseRSI);
+                        _sprite.LayerSetRsi((uid, sprite), index, clothingSprite.BaseRSI);
                 }
 
-                sprite.LayerSetData(index, layerData);
+                _sprite.LayerSetData((uid, sprite), index, layerData);
 
                 // Add displacement maps
                 var displacement = hand.Location switch

--- a/Content.Client/Weapons/Misc/TetherGunSystem.cs
+++ b/Content.Client/Weapons/Misc/TetherGunSystem.cs
@@ -17,6 +17,7 @@ public sealed class TetherGunSystem : SharedTetherGunSystem
     [Dependency] private readonly IOverlayManager _overlay = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly MapSystem _mapSystem = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -33,7 +34,7 @@ public sealed class TetherGunSystem : SharedTetherGunSystem
         if (!TryComp<SpriteComponent>(component.Tethered, out var sprite))
             return;
 
-        sprite.Color = component.LineColor;
+        _sprite.SetColor((component.Tethered.Value, sprite), component.LineColor);
     }
 
     public override void Shutdown()
@@ -58,7 +59,7 @@ public sealed class TetherGunSystem : SharedTetherGunSystem
         var player = _player.LocalEntity;
 
         if (player == null ||
-            !TryGetTetherGun(player.Value, out var gunUid, out var gun) ||
+            !TryGetTetherGun(player.Value, out _, out var gun) ||
             gun.TetherEntity == null)
         {
             return;
@@ -81,11 +82,11 @@ public sealed class TetherGunSystem : SharedTetherGunSystem
             coords = TransformSystem.ToCoordinates(_mapSystem.GetMap(mouseWorldPos.MapId), mouseWorldPos);
         }
 
-        const float BufferDistance = 0.1f;
+        const float bufferDistance = 0.1f;
 
         if (TryComp(gun.TetherEntity, out TransformComponent? tetherXform) &&
             tetherXform.Coordinates.TryDistance(EntityManager, TransformSystem, coords, out var distance) &&
-            distance < BufferDistance)
+            distance < bufferDistance)
         {
             return;
         }
@@ -105,11 +106,11 @@ public sealed class TetherGunSystem : SharedTetherGunSystem
 
         if (TryComp<ForceGunComponent>(component.Tetherer, out var force))
         {
-            sprite.Color = force.LineColor;
+            _sprite.SetColor((uid, sprite), force.LineColor);
         }
         else if (TryComp<TetherGunComponent>(component.Tetherer, out var tether))
         {
-            sprite.Color = tether.LineColor;
+            _sprite.SetColor((uid, sprite), tether.LineColor);
         }
     }
 
@@ -118,6 +119,6 @@ public sealed class TetherGunSystem : SharedTetherGunSystem
         if (!TryComp<SpriteComponent>(uid, out var sprite))
             return;
 
-        sprite.Color = Color.White;
+        _sprite.SetColor((uid, sprite), Color.White);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 34 `SpriteComponent` obsoleted warnings across multiple files.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

The number of warnings per file is getting smaller, so it's time to start combining these PRs.

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods and properties with `SpriteSystem` methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Puddles:
<img width="266" alt="Screenshot 2025-05-15 at 9 40 38 PM" src="https://github.com/user-attachments/assets/88cde267-f263-4317-b29c-b76550d200c2" />
Plant holders:
<img width="266" alt="Screenshot 2025-05-16 at 10 19 11 AM" src="https://github.com/user-attachments/assets/f81fa2cb-f92e-4848-bafd-3f01d79d69ea" />
In-hands:
<img width="266" alt="Screenshot 2025-05-16 at 10 20 10 AM" src="https://github.com/user-attachments/assets/2e4be23b-0f2e-4922-b12b-623b6e494566" />
Ensnaring:
<img width="254" alt="Screenshot 2025-05-16 at 10 26 50 AM" src="https://github.com/user-attachments/assets/eb958b09-c493-4646-8983-c6e5190febbb" />
Electrified door:
<img width="254" alt="Screenshot 2025-05-16 at 10 31 15 AM" src="https://github.com/user-attachments/assets/7d4867d0-a80d-4132-a258-1f83531bb32c" />
Tether gun object highlight:
<img width="205" alt="Screenshot 2025-05-16 at 10 35 07 AM" src="https://github.com/user-attachments/assets/1633ec98-c1ad-4219-9c23-1a12be4969be" />
[Tether gun beam visuals seem to be broken outside of this PR.](https://github.com/space-wizards/space-station-14/issues/37509)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->