### PR TITLE
Cleanup warnings in `DisplacementMapSystem`

### DIFF
--- a/Content.Client/DisplacementMap/DisplacementMapSystem.cs
+++ b/Content.Client/DisplacementMap/DisplacementMapSystem.cs
@@ -33,8 +33,7 @@ public sealed class DisplacementMapSystem : EntitySystem
         if (data.ShaderOverride != null)
             sprite.Comp.LayerSetShader(index, data.ShaderOverride);
 
-        if (_sprite.LayerMapTryGet(sprite.AsNullable(), displacementKey, out var oldIndex, false))
-            _sprite.RemoveLayer(sprite.AsNullable(), oldIndex);
+        _sprite.RemoveLayer(sprite.AsNullable(), displacementKey, false);
 
         //allows you not to write it every time in the YML
         foreach (var pair in data.SizeMaps)

--- a/Content.Client/DisplacementMap/DisplacementMapSystem.cs
+++ b/Content.Client/DisplacementMap/DisplacementMapSystem.cs
@@ -14,7 +14,7 @@ public sealed class DisplacementMapSystem : EntitySystem
     /// Attempting to apply a displacement map to a specific layer of SpriteComponent
     /// </summary>
     /// <param name="data">Information package for applying the displacement map</param>
-    /// <param name="sprite">SpriteComponent</param>
+    /// <param name="sprite">Entity with SpriteComponent</param>
     /// <param name="index">Index of the layer where the new map layer will be added</param>
     /// <param name="key">Unique layer key, which will determine which layer to apply displacement map to</param>
     /// <param name="displacementKey">The key of the new displacement map layer added by this function.</param>

--- a/Content.Client/DisplacementMap/DisplacementMapSystem.cs
+++ b/Content.Client/DisplacementMap/DisplacementMapSystem.cs
@@ -8,6 +8,7 @@ namespace Content.Client.DisplacementMap;
 public sealed class DisplacementMapSystem : EntitySystem
 {
     [Dependency] private readonly ISerializationManager _serialization = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     /// <summary>
     /// Attempting to apply a displacement map to a specific layer of SpriteComponent
@@ -19,7 +20,7 @@ public sealed class DisplacementMapSystem : EntitySystem
     /// <param name="displacementKey">The key of the new displacement map layer added by this function.</param>
     /// <returns></returns>
     public bool TryAddDisplacement(DisplacementData data,
-        SpriteComponent sprite,
+        Entity<SpriteComponent> sprite,
         int index,
         object key,
         out string displacementKey)
@@ -30,10 +31,10 @@ public sealed class DisplacementMapSystem : EntitySystem
             return false;
 
         if (data.ShaderOverride != null)
-            sprite.LayerSetShader(index, data.ShaderOverride);
+            sprite.Comp.LayerSetShader(index, data.ShaderOverride);
 
-        if (sprite.LayerMapTryGet(displacementKey, out var oldIndex))
-            sprite.RemoveLayer(oldIndex);
+        if (_sprite.LayerMapTryGet(sprite.AsNullable(), displacementKey, out var oldIndex, false))
+            _sprite.RemoveLayer(sprite.AsNullable(), oldIndex);
 
         //allows you not to write it every time in the YML
         foreach (var pair in data.SizeMaps)
@@ -55,7 +56,7 @@ public sealed class DisplacementMapSystem : EntitySystem
         // We choose a displacement map from the possible ones, matching the size with the original layer size.
         // If there is no such a map, we use a standard 32 by 32 one
         var displacementDataLayer = data.SizeMaps[EyeManager.PixelsPerMeter];
-        var actualRSI = sprite.LayerGetActualRSI(index);
+        var actualRSI = _sprite.LayerGetEffectiveRsi(sprite.AsNullable(), index);
         if (actualRSI is not null)
         {
             if (actualRSI.Size.X != actualRSI.Size.Y)
@@ -72,9 +73,20 @@ public sealed class DisplacementMapSystem : EntitySystem
         var displacementLayer = _serialization.CreateCopy(displacementDataLayer, notNullableOverride: true);
         displacementLayer.CopyToShaderParameters!.LayerKey = key.ToString() ?? "this is impossible";
 
-        sprite.AddLayer(displacementLayer, index);
-        sprite.LayerMapSet(displacementKey, index);
+        _sprite.AddLayer(sprite.AsNullable(), displacementLayer, index);
+        _sprite.LayerMapSet(sprite.AsNullable(), displacementKey, index);
 
         return true;
+    }
+
+    /// <inheritdoc cref="TryAddDisplacement"/>
+    [Obsolete("Use the Entity<SpriteComponent> overload")]
+    public bool TryAddDisplacement(DisplacementData data,
+        SpriteComponent sprite,
+        int index,
+        object key,
+        out string displacementKey)
+    {
+        return TryAddDisplacement(data, (sprite.Owner, sprite), index, key, out displacementKey);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 5 warnings in `DisplacementMapSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
- Adds an overload to `TryAddDisplacement` that takes an `Entity<SpriteComponent>` instead of a `SpriteComponent`. This overload uses `SpriteSystem` methods instead of `SpriteComponent`.
- Marks the old `SpriteComponent` version of `TryAddDisplacement` as obsolete. It now calls the new overload. This means there are some new warnings to clean up in a few places where the old version was used.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Vox displacing the captain's jumpsuit:
<img width="205" alt="Screenshot 2025-05-16 at 11 23 55 AM" src="https://github.com/user-attachments/assets/ac828218-98cd-408f-ace4-46e0ad52e6a1" /><img width="205" alt="Screenshot 2025-05-16 at 11 23 58 AM" src="https://github.com/user-attachments/assets/f8a90996-b900-4713-98c7-78fb4009110a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->