### PR TITLE
Missing contraband tags on explosives

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/payload.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/payload.yml
@@ -21,7 +21,7 @@
 
 - type: entity
   name: explosive payload
-  parent: BasePayload
+  parent: [ BasePayload, BaseSecurityContraband ]
   id: ExplosivePayload
   components:
   - type: Sprite
@@ -51,7 +51,7 @@
 
 - type: entity
   name: chemical payload
-  parent: BasePayload
+  parent: [ BasePayload, BaseMedicalScienceContraband ]
   id: ChemicalPayload
   description: A chemical payload. Has space to store two beakers. In combination with a trigger and a case, this can be used to initiate chemical reactions.
   components:
@@ -87,7 +87,7 @@
 
 - type: entity
   name: flash payload
-  parent: BasePayload
+  parent: [ BasePayload, BaseSecurityScienceCommandContraband ]
   id: FlashPayload
   description: A single-use flash payload.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/firebomb.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/firebomb.yml
@@ -2,7 +2,7 @@
 # ideally it would be dynamic and work by actually sparking the solution but that doesnt exist yet :(
 # with that you could make napalm ied instead of welding fuel with no additional complexity
 - type: entity
-  parent: BaseItem
+  parent: [ BaseItem, BaseMinorContraband ]
   id: FireBomb
   name: fire bomb
   description: A weak, improvised incendiary device.
@@ -55,7 +55,7 @@
 
 # has igniter but no fuel or wires
 - type: entity
-  parent: DrinkColaCanEmpty
+  parent: [ DrinkColaCanEmpty, BaseMinorContraband ]
   id: FireBombEmpty
   name: fire bomb
   suffix: empty

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pipebomb.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pipebomb.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: GrenadeBase
+  parent: [ GrenadeBase, BaseMinorContraband ]
   id: PipeBomb
   name: pipe bomb
   description: An improvised explosive made from pipes and wire.
@@ -32,7 +32,7 @@
     node: pipebomb
 
 - type: entity
-  parent: BaseItem
+  parent: [ BaseItem, BaseMinorContraband ]
   id: PipeBombGunpowder
   name: pipe bomb
   description: An improvised explosive made from a pipe. This one has no gunpowder.
@@ -47,7 +47,7 @@
     defaultTarget: pipebomb
 
 - type: entity
-  parent: BaseItem
+  parent: [ BaseItem, BaseMinorContraband ]
   id: PipeBombCable
   name: pipe bomb
   description: An improvised explosive made from a pipe. This one has no cable.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -83,7 +83,7 @@
 - type: entity
   name: seismic charge
   description: Concussion based explosive designed to destroy large amounts of rock.
-  parent: BasePlasticExplosive
+  parent: [ BasePlasticExplosive, BaseSecurityCargoContraband ]
   id: SeismicCharge
   components:
   - type: Sprite


### PR DESCRIPTION
## About the PR
Adds contraband tags onto some improvised and printed explosives that lacked them.

**New contraband tags are as follows:**
- Seismic Charge - Sec/Cargo
- Explosive Payload - Sec
- Flash Payload - SecSciCommand
- Chemical Payload - MedSci
- Pipebombs - Minor
- Firebombs - Minor

## Why / Balance
They are dangerous items and should be valid things to seize from the wrong hands.

## Technical details
Adds parents to the prototypes, all yaml.

## Media
![image](https://github.com/user-attachments/assets/2ab96565-2a12-4b13-bf76-750c252f595c)
![image](https://github.com/user-attachments/assets/81b5a023-ce64-40dd-afbe-e5dfa5f18cc6)
![image](https://github.com/user-attachments/assets/32d29e40-2490-4dad-891e-d879325cc42f)
![image](https://github.com/user-attachments/assets/be8883d5-e09a-46aa-baac-8ca89933b1aa)
![image](https://github.com/user-attachments/assets/c7425d88-8bb0-466a-890f-40e686484e76)
![image](https://github.com/user-attachments/assets/9789f225-e8c7-428f-8f4b-709c22d27676)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Seismic Charges are now marked as cargo/sec contraband
- tweak: Modular grenade payloads such as explosive or flash payloads, are now properly marked as their relative department's contraband.
- tweak: Improvised explosives are now considered minor contraband.
