### PR TITLE
Cleanup more `SpriteComponent` warnings (part 2)

### DIFF
--- a/Content.Client/Buckle/BuckleSystem.cs
+++ b/Content.Client/Buckle/BuckleSystem.cs
@@ -13,6 +13,7 @@ internal sealed class BuckleSystem : SharedBuckleSystem
     [Dependency] private readonly RotationVisualizerSystem _rotationVisualizerSystem = default!;
     [Dependency] private readonly IEyeManager _eye = default!;
     [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -69,11 +70,11 @@ internal sealed class BuckleSystem : SharedBuckleSystem
             {
                 // This will only assign if empty, it won't get overwritten by new depth on multiple calls, which do happen easily
                 buckle.OriginalDrawDepth ??= buckledSprite.DrawDepth;
-                buckledSprite.DrawDepth = strapSprite.DrawDepth - 1;
+                _sprite.SetDrawDepth((buckledEntity, buckledSprite), strapSprite.DrawDepth - 1);
             }
             else if (buckle.OriginalDrawDepth.HasValue)
             {
-                buckledSprite.DrawDepth = buckle.OriginalDrawDepth.Value;
+                _sprite.SetDrawDepth((buckledEntity, buckledSprite), buckle.OriginalDrawDepth.Value);
                 buckle.OriginalDrawDepth = null;
             }
         }
@@ -97,7 +98,7 @@ internal sealed class BuckleSystem : SharedBuckleSystem
             return;
 
         ent.Comp.OriginalDrawDepth ??= buckledSprite.DrawDepth;
-        buckledSprite.DrawDepth = strapSprite.DrawDepth - 1;
+        _sprite.SetDrawDepth((ent.Owner, buckledSprite), strapSprite.DrawDepth - 1);
     }
 
     /// <summary>
@@ -111,7 +112,7 @@ internal sealed class BuckleSystem : SharedBuckleSystem
         if (!ent.Comp.OriginalDrawDepth.HasValue)
             return;
 
-        buckledSprite.DrawDepth = ent.Comp.OriginalDrawDepth.Value;
+        _sprite.SetDrawDepth((ent.Owner, buckledSprite), ent.Comp.OriginalDrawDepth.Value);
         ent.Comp.OriginalDrawDepth = null;
     }
 

--- a/Content.Client/Clock/ClockSystem.cs
+++ b/Content.Client/Clock/ClockSystem.cs
@@ -5,6 +5,8 @@ namespace Content.Client.Clock;
 
 public sealed class ClockSystem : SharedClockSystem
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -12,15 +14,15 @@ public sealed class ClockSystem : SharedClockSystem
         var query = EntityQueryEnumerator<ClockComponent, SpriteComponent>();
         while (query.MoveNext(out var uid, out var comp, out var sprite))
         {
-            if (!sprite.LayerMapTryGet(ClockVisualLayers.HourHand, out var hourLayer) ||
-                !sprite.LayerMapTryGet(ClockVisualLayers.MinuteHand, out var minuteLayer))
+            if (!_sprite.LayerMapTryGet((uid, sprite), ClockVisualLayers.HourHand, out var hourLayer, false) ||
+                !_sprite.LayerMapTryGet((uid, sprite), ClockVisualLayers.MinuteHand, out var minuteLayer, false))
                 continue;
 
             var time = GetClockTime((uid, comp));
             var hourState = $"{comp.HoursBase}{time.Hours % 12}";
             var minuteState = $"{comp.MinutesBase}{time.Minutes / 5}";
-            sprite.LayerSetState(hourLayer, hourState);
-            sprite.LayerSetState(minuteLayer, minuteState);
+            _sprite.LayerSetRsiState((uid, sprite), hourLayer, hourState);
+            _sprite.LayerSetRsiState((uid, sprite), minuteLayer, minuteState);
         }
     }
 }

--- a/Content.Client/Cuffs/CuffableSystem.cs
+++ b/Content.Client/Cuffs/CuffableSystem.cs
@@ -4,12 +4,14 @@ using Content.Shared.Cuffs.Components;
 using Content.Shared.Humanoid;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameStates;
+using Robust.Shared.Utility;
 
 namespace Content.Client.Cuffs;
 
 public sealed class CuffableSystem : SharedCuffableSystem
 {
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -22,7 +24,7 @@ public sealed class CuffableSystem : SharedCuffableSystem
     private void OnCuffableShutdown(EntityUid uid, CuffableComponent component, ComponentShutdown args)
     {
         if (TryComp<SpriteComponent>(uid, out var sprite))
-            sprite.LayerSetVisible(HumanoidVisualLayers.Handcuffs, false);
+            _sprite.LayerSetVisible((uid, sprite), HumanoidVisualLayers.Handcuffs, false);
     }
 
     private void OnCuffableHandleState(EntityUid uid, CuffableComponent component, ref ComponentHandleState args)
@@ -39,22 +41,22 @@ public sealed class CuffableSystem : SharedCuffableSystem
         if (!TryComp<SpriteComponent>(uid, out var sprite))
             return;
         var cuffed = cuffState.NumHandsCuffed > 0;
-        sprite.LayerSetVisible(HumanoidVisualLayers.Handcuffs, cuffed);
+        _sprite.LayerSetVisible((uid, sprite), HumanoidVisualLayers.Handcuffs, cuffed);
 
         // if they are not cuffed, that means that we didn't get a valid color,
         // iconstate, or RSI. that also means we don't need to update the sprites.
         if (!cuffed)
             return;
-        sprite.LayerSetColor(HumanoidVisualLayers.Handcuffs, cuffState.Color!.Value);
+        _sprite.LayerSetColor((uid, sprite), HumanoidVisualLayers.Handcuffs, cuffState.Color!.Value);
 
         if (!Equals(component.CurrentRSI, cuffState.RSI) && cuffState.RSI != null) // we don't want to keep loading the same RSI
         {
             component.CurrentRSI = cuffState.RSI;
-            sprite.LayerSetState(HumanoidVisualLayers.Handcuffs, cuffState.IconState, component.CurrentRSI);
+            _sprite.LayerSetRsi((uid, sprite), _sprite.LayerMapGet((uid, sprite), HumanoidVisualLayers.Handcuffs), new ResPath(component.CurrentRSI), cuffState.IconState);
         }
         else
         {
-            sprite.LayerSetState(HumanoidVisualLayers.Handcuffs, cuffState.IconState);
+            _sprite.LayerSetRsiState((uid, sprite), HumanoidVisualLayers.Handcuffs, cuffState.IconState);
         }
     }
 }

--- a/Content.Client/Light/EntitySystems/EmergencyLightSystem.cs
+++ b/Content.Client/Light/EntitySystems/EmergencyLightSystem.cs
@@ -6,6 +6,8 @@ namespace Content.Client.Light.EntitySystems;
 
 public sealed class EmergencyLightSystem : VisualizerSystem<EmergencyLightComponent>
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     protected override void OnAppearanceChange(EntityUid uid, EmergencyLightComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
@@ -14,13 +16,13 @@ public sealed class EmergencyLightSystem : VisualizerSystem<EmergencyLightCompon
         if (!AppearanceSystem.TryGetData<bool>(uid, EmergencyLightVisuals.On, out var on, args.Component))
             on = false;
 
-        args.Sprite.LayerSetVisible(EmergencyLightVisualLayers.LightOff, !on);
-        args.Sprite.LayerSetVisible(EmergencyLightVisualLayers.LightOn, on);
+        _sprite.LayerSetVisible((uid, args.Sprite), EmergencyLightVisualLayers.LightOff, !on);
+        _sprite.LayerSetVisible((uid, args.Sprite), EmergencyLightVisualLayers.LightOn, on);
 
         if (AppearanceSystem.TryGetData<Color>(uid, EmergencyLightVisuals.Color, out var color, args.Component))
         {
-            args.Sprite.LayerSetColor(EmergencyLightVisualLayers.LightOn, color);
-            args.Sprite.LayerSetColor(EmergencyLightVisualLayers.LightOff, color);
+            _sprite.LayerSetColor((uid, args.Sprite), EmergencyLightVisualLayers.LightOn, color);
+            _sprite.LayerSetColor((uid, args.Sprite), EmergencyLightVisualLayers.LightOff, color);
         }
     }
 }

--- a/Content.Client/Light/EntitySystems/LightBulbSystem.cs
+++ b/Content.Client/Light/EntitySystems/LightBulbSystem.cs
@@ -5,6 +5,8 @@ namespace Content.Client.Light.Visualizers;
 
 public sealed class LightBulbSystem : VisualizerSystem<LightBulbComponent>
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     protected override void OnAppearanceChange(EntityUid uid, LightBulbComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
@@ -16,13 +18,13 @@ public sealed class LightBulbSystem : VisualizerSystem<LightBulbComponent>
             switch (state)
             {
                 case LightBulbState.Normal:
-                    args.Sprite.LayerSetState(LightBulbVisualLayers.Base, comp.NormalSpriteState);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), LightBulbVisualLayers.Base, comp.NormalSpriteState);
                     break;
                 case LightBulbState.Broken:
-                    args.Sprite.LayerSetState(LightBulbVisualLayers.Base, comp.BrokenSpriteState);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), LightBulbVisualLayers.Base, comp.BrokenSpriteState);
                     break;
                 case LightBulbState.Burned:
-                    args.Sprite.LayerSetState(LightBulbVisualLayers.Base, comp.BurnedSpriteState);
+                    _sprite.LayerSetRsiState((uid, args.Sprite), LightBulbVisualLayers.Base, comp.BurnedSpriteState);
                     break;
             }
         }
@@ -30,7 +32,7 @@ public sealed class LightBulbSystem : VisualizerSystem<LightBulbComponent>
         // also update sprites color
         if (AppearanceSystem.TryGetData<Color>(uid, LightBulbVisuals.Color, out var color, args.Component))
         {
-            args.Sprite.Color = color;
+            _sprite.SetColor((uid, args.Sprite), color);
         }
     }
 }

--- a/Content.Client/Light/Visualizers/PoweredLightVisualizerSystem.cs
+++ b/Content.Client/Light/Visualizers/PoweredLightVisualizerSystem.cs
@@ -11,6 +11,7 @@ public sealed class PoweredLightVisualizerSystem : VisualizerSystem<PoweredLight
 {
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -27,16 +28,16 @@ public sealed class PoweredLightVisualizerSystem : VisualizerSystem<PoweredLight
             return;
 
         if (comp.SpriteStateMap.TryGetValue(state, out var spriteState))
-            args.Sprite.LayerSetState(PoweredLightLayers.Base, spriteState);
+            _sprite.LayerSetRsiState((uid, args.Sprite), PoweredLightLayers.Base, spriteState);
 
-        if (args.Sprite.LayerExists(PoweredLightLayers.Glow))
+        if (_sprite.LayerExists((uid, args.Sprite), PoweredLightLayers.Glow))
         {
             if (TryComp<PointLightComponent>(uid, out var light))
             {
-                args.Sprite.LayerSetColor(PoweredLightLayers.Glow, light.Color);
+                _sprite.LayerSetColor((uid, args.Sprite), PoweredLightLayers.Glow, light.Color);
             }
 
-            args.Sprite.LayerSetVisible(PoweredLightLayers.Glow, state == PoweredLightState.On);
+            _sprite.LayerSetVisible((uid, args.Sprite), PoweredLightLayers.Glow, state == PoweredLightState.On);
         }
 
         SetBlinkingAnimation(
@@ -56,7 +57,7 @@ public sealed class PoweredLightVisualizerSystem : VisualizerSystem<PoweredLight
             return;
         if (args.Key != PoweredLightVisualsComponent.BlinkingAnimationKey)
             return;
-        if(!comp.IsBlinking)
+        if (!comp.IsBlinking)
             return;
 
         AnimationSystem.Play((uid, animationPlayer), BlinkingAnimation(comp), PoweredLightVisualsComponent.BlinkingAnimationKey);

--- a/Content.Client/Paper/UI/PaperVisualizerSystem.cs
+++ b/Content.Client/Paper/UI/PaperVisualizerSystem.cs
@@ -6,24 +6,26 @@ namespace Content.Client.Paper.UI;
 
 public sealed class PaperVisualizerSystem : VisualizerSystem<PaperVisualsComponent>
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     protected override void OnAppearanceChange(EntityUid uid, PaperVisualsComponent component, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
             return;
 
         if (AppearanceSystem.TryGetData<PaperStatus>(uid, PaperVisuals.Status, out var writingStatus, args.Component))
-            args.Sprite.LayerSetVisible(PaperVisualLayers.Writing, writingStatus == PaperStatus.Written);
+            _sprite.LayerSetVisible((uid, args.Sprite), PaperVisualLayers.Writing, writingStatus == PaperStatus.Written);
 
         if (AppearanceSystem.TryGetData<string>(uid, PaperVisuals.Stamp, out var stampState, args.Component))
         {
             if (stampState != string.Empty)
             {
-                args.Sprite.LayerSetState(PaperVisualLayers.Stamp, stampState);
-                args.Sprite.LayerSetVisible(PaperVisualLayers.Stamp, true);
+                _sprite.LayerSetRsiState((uid, args.Sprite), PaperVisualLayers.Stamp, stampState);
+                _sprite.LayerSetVisible((uid, args.Sprite), PaperVisualLayers.Stamp, true);
             }
             else
             {
-                args.Sprite.LayerSetVisible(PaperVisualLayers.Stamp, false);
+                _sprite.LayerSetVisible((uid, args.Sprite), PaperVisualLayers.Stamp, false);
             }
 
         }

--- a/Content.Client/ParticleAccelerator/ParticleAcceleratorPartVisualizerSystem.cs
+++ b/Content.Client/ParticleAccelerator/ParticleAcceleratorPartVisualizerSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Shared.Singularity.Components;
 using Robust.Client.GameObjects;
 
@@ -6,12 +5,14 @@ namespace Content.Client.ParticleAccelerator;
 
 public sealed class ParticleAcceleratorPartVisualizerSystem : VisualizerSystem<ParticleAcceleratorPartVisualsComponent>
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     protected override void OnAppearanceChange(EntityUid uid, ParticleAcceleratorPartVisualsComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
             return;
 
-        if (!args.Sprite.LayerMapTryGet(ParticleAcceleratorVisualLayers.Unlit, out var index))
+        if (!_sprite.LayerMapTryGet((uid, args.Sprite), ParticleAcceleratorVisualLayers.Unlit, out var index, false))
             return;
 
         if (!AppearanceSystem.TryGetData<ParticleAcceleratorVisualState>(uid, ParticleAcceleratorVisuals.VisualState, out var state, args.Component))
@@ -21,12 +22,12 @@ public sealed class ParticleAcceleratorPartVisualizerSystem : VisualizerSystem<P
 
         if (state != ParticleAcceleratorVisualState.Unpowered)
         {
-            args.Sprite.LayerSetVisible(index, true);
-            args.Sprite.LayerSetState(index, comp.StateBase + comp.StatesSuffixes[state]);
+            _sprite.LayerSetVisible((uid, args.Sprite), index, true);
+            _sprite.LayerSetRsiState((uid, args.Sprite), index, comp.StateBase + comp.StatesSuffixes[state]);
         }
         else
         {
-            args.Sprite.LayerSetVisible(index, false);
+            _sprite.LayerSetVisible((uid, args.Sprite), index, false);
         }
     }
 }

--- a/Content.Client/PowerCell/PowerCellSystem.cs
+++ b/Content.Client/PowerCell/PowerCellSystem.cs
@@ -9,6 +9,7 @@ namespace Content.Client.PowerCell;
 public sealed class PowerCellSystem : SharedPowerCellSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -44,19 +45,19 @@ public sealed class PowerCellSystem : SharedPowerCellSystem
         if (args.Sprite == null)
             return;
 
-        if (!args.Sprite.TryGetLayer((int) PowerCellVisualLayers.Unshaded, out var unshadedLayer))
+        if (!_sprite.LayerExists((uid, args.Sprite), PowerCellVisualLayers.Unshaded))
             return;
 
         if (_appearance.TryGetData<byte>(uid, PowerCellVisuals.ChargeLevel, out var level, args.Component))
         {
             if (level == 0)
             {
-                unshadedLayer.Visible = false;
+                _sprite.LayerSetVisible((uid, args.Sprite), PowerCellVisualLayers.Unshaded, false);
                 return;
             }
 
-            unshadedLayer.Visible = true;
-            args.Sprite.LayerSetState(PowerCellVisualLayers.Unshaded, $"o{level}");
+            _sprite.LayerSetVisible((uid, args.Sprite), PowerCellVisualLayers.Unshaded, false);
+            _sprite.LayerSetRsiState((uid, args.Sprite), PowerCellVisualLayers.Unshaded, $"o{level}");
         }
     }
 

--- a/Content.Client/Sprite/RandomSpriteSystem.cs
+++ b/Content.Client/Sprite/RandomSpriteSystem.cs
@@ -11,6 +11,7 @@ public sealed class RandomSpriteSystem : SharedRandomSpriteSystem
 {
     [Dependency] private readonly IReflectionManager _reflection = default!;
     [Dependency] private readonly ClientClothingSystem _clothing = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -63,10 +64,10 @@ public sealed class RandomSpriteSystem : SharedRandomSpriteSystem
             int index;
             if (_reflection.TryParseEnumReference(layer.Key, out var @enum))
             {
-                if (!sprite.LayerMapTryGet(@enum, out index, logError: true))
+                if (!_sprite.LayerMapTryGet((uid, sprite), @enum, out index, logMissing: true))
                     continue;
             }
-            else if (!sprite.LayerMapTryGet(layer.Key, out index))
+            else if (!_sprite.LayerMapTryGet((uid, sprite), layer.Key, out index, false))
             {
                 if (layer.Key is not { } strKey || !int.TryParse(strKey, out index))
                 {
@@ -74,8 +75,8 @@ public sealed class RandomSpriteSystem : SharedRandomSpriteSystem
                     continue;
                 }
             }
-            sprite.LayerSetState(index, layer.Value.State);
-            sprite.LayerSetColor(index, layer.Value.Color ?? Color.White);
+            _sprite.LayerSetRsiState((uid, sprite), index, layer.Value.State);
+            _sprite.LayerSetColor((uid, sprite), index, layer.Value.Color ?? Color.White);
         }
     }
 }

--- a/Content.Client/Storage/Systems/ItemCounterSystem.cs
+++ b/Content.Client/Storage/Systems/ItemCounterSystem.cs
@@ -10,6 +10,7 @@ namespace Content.Client.Storage.Systems;
 public sealed class ItemCounterSystem : SharedItemCounterSystem
 {
     [Dependency] private readonly AppearanceSystem _appearanceSystem = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -41,23 +42,23 @@ public sealed class ItemCounterSystem : SharedItemCounterSystem
     public void ProcessOpaqueSprite(EntityUid uid, string layer, int count, int maxCount, List<string> states, bool hide = false, SpriteComponent? sprite = null)
     {
         if (!Resolve(uid, ref sprite)
-        ||  !sprite.LayerMapTryGet(layer, out var layerKey, logError: true))
+        || !_sprite.LayerMapTryGet((uid, sprite), layer, out var layerKey, logMissing: true))
             return;
-        
+
         var activeState = ContentHelpers.RoundToEqualLevels(count, maxCount, states.Count);
-        sprite.LayerSetState(layerKey, states[activeState]);
-        sprite.LayerSetVisible(layerKey, !hide);
+        _sprite.LayerSetRsiState((uid, sprite), layerKey, states[activeState]);
+        _sprite.LayerSetVisible((uid, sprite), layerKey, !hide);
     }
 
     public void ProcessCompositeSprite(EntityUid uid, int count, int maxCount, List<string> layers, bool hide = false, SpriteComponent? sprite = null)
     {
-        if(!Resolve(uid, ref sprite))
+        if (!Resolve(uid, ref sprite))
             return;
-        
+
         var activeTill = ContentHelpers.RoundToNearestLevels(count, maxCount, layers.Count);
-        for(var i = 0; i < layers.Count; ++i)
+        for (var i = 0; i < layers.Count; ++i)
         {
-            sprite.LayerSetVisible(layers[i], !hide && i < activeTill);
+            _sprite.LayerSetVisible((uid, sprite), layers[i], !hide && i < activeTill);
         }
     }
 

--- a/Content.Client/Storage/Systems/ItemMapperSystem.cs
+++ b/Content.Client/Storage/Systems/ItemMapperSystem.cs
@@ -9,6 +9,7 @@ namespace Content.Client.Storage.Systems;
 public sealed class ItemMapperSystem : SharedItemMapperSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -48,9 +49,9 @@ public sealed class ItemMapperSystem : SharedItemMapperSystem
 
         foreach (var sprite in component.SpriteLayers)
         {
-            spriteComponent.LayerMapReserveBlank(sprite);
-            spriteComponent.LayerSetSprite(sprite, new SpriteSpecifier.Rsi(component.RSIPath!.Value, sprite));
-            spriteComponent.LayerSetVisible(sprite, false);
+            _sprite.LayerMapReserve((owner, spriteComponent), sprite);
+            _sprite.LayerSetSprite((owner, spriteComponent), sprite, new SpriteSpecifier.Rsi(component.RSIPath!.Value, sprite));
+            _sprite.LayerSetVisible((owner, spriteComponent), sprite, false);
         }
     }
 
@@ -63,7 +64,7 @@ public sealed class ItemMapperSystem : SharedItemMapperSystem
         foreach (var layerName in component.SpriteLayers)
         {
             var show = wrapper.QueuedEntities.Contains(layerName);
-            spriteComponent.LayerSetVisible(layerName, show);
+            _sprite.LayerSetVisible((owner, spriteComponent), layerName, show);
         }
     }
 }

--- a/Content.Client/Storage/Systems/StorageContainerVisualsSystem.cs
+++ b/Content.Client/Storage/Systems/StorageContainerVisualsSystem.cs
@@ -8,6 +8,8 @@ namespace Content.Client.Storage.Systems;
 /// <inheritdoc cref="StorageContainerVisualsComponent"/>
 public sealed class StorageContainerVisualsSystem : VisualizerSystem<StorageContainerVisualsComponent>
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     protected override void OnAppearanceChange(EntityUid uid, StorageContainerVisualsComponent component, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
@@ -19,9 +21,9 @@ public sealed class StorageContainerVisualsSystem : VisualizerSystem<StorageCont
         if (!AppearanceSystem.TryGetData<int>(uid, StorageVisuals.Capacity, out var capacity, args.Component))
             return;
 
-        var fraction = used / (float) capacity;
+        var fraction = used / (float)capacity;
 
-        if (!args.Sprite.LayerMapTryGet(component.FillLayer, out var fillLayer))
+        if (!_sprite.LayerMapTryGet((uid, args.Sprite), component.FillLayer, out var fillLayer, false))
             return;
 
         var closestFillSprite = Math.Min(ContentHelpers.RoundToNearestLevels(fraction, 1, component.MaxFillLevels + 1),
@@ -32,13 +34,13 @@ public sealed class StorageContainerVisualsSystem : VisualizerSystem<StorageCont
             if (component.FillBaseName == null)
                 return;
 
-            args.Sprite.LayerSetVisible(fillLayer, true);
+            _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, true);
             var stateName = component.FillBaseName + closestFillSprite;
-            args.Sprite.LayerSetState(fillLayer, stateName);
+            _sprite.LayerSetRsiState((uid, args.Sprite), fillLayer, stateName);
         }
         else
         {
-            args.Sprite.LayerSetVisible(fillLayer, false);
+            _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, false);
         }
     }
 }

--- a/Content.Client/Turrets/DeployableTurretSystem.cs
+++ b/Content.Client/Turrets/DeployableTurretSystem.cs
@@ -9,6 +9,7 @@ public sealed partial class DeployableTurretSystem : SharedDeployableTurretSyste
 {
     [Dependency] private readonly AppearanceSystem _appearance = default!;
     [Dependency] private readonly AnimationPlayerSystem _animation = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -90,13 +91,13 @@ public sealed partial class DeployableTurretSystem : SharedDeployableTurretSyste
         var destinationState = ent.Comp.VisualState & DeployableTurretState.Deployed;
 
         if (targetState != destinationState)
-            targetState = targetState | DeployableTurretState.Retracting;
+            targetState |= DeployableTurretState.Retracting;
 
         ent.Comp.VisualState = state;
 
         // Toggle layer visibility
-        sprite.LayerSetVisible(DeployableTurretVisuals.Weapon, (targetState & DeployableTurretState.Deployed) > 0);
-        sprite.LayerSetVisible(PowerDeviceVisualLayers.Powered, HasAmmo(ent) && targetState == DeployableTurretState.Retracted);
+        _sprite.LayerSetVisible((ent.Owner, sprite), DeployableTurretVisuals.Weapon, (targetState & DeployableTurretState.Deployed) > 0);
+        _sprite.LayerSetVisible((ent.Owner, sprite), PowerDeviceVisualLayers.Powered, HasAmmo(ent) && targetState == DeployableTurretState.Retracted);
 
         // Change the visual state
         switch (targetState)
@@ -110,11 +111,11 @@ public sealed partial class DeployableTurretSystem : SharedDeployableTurretSyste
                 break;
 
             case DeployableTurretState.Deployed:
-                sprite.LayerSetState(DeployableTurretVisuals.Turret, ent.Comp.DeployedState);
+                _sprite.LayerSetRsiState((ent.Owner, sprite), DeployableTurretVisuals.Turret, ent.Comp.DeployedState);
                 break;
 
             case DeployableTurretState.Retracted:
-                sprite.LayerSetState(DeployableTurretVisuals.Turret, ent.Comp.RetractedState);
+                _sprite.LayerSetRsiState((ent.Owner, sprite), DeployableTurretVisuals.Turret, ent.Comp.RetractedState);
                 break;
         }
     }

--- a/Content.Client/Weapons/Marker/DamageMarkerSystem.cs
+++ b/Content.Client/Weapons/Marker/DamageMarkerSystem.cs
@@ -7,6 +7,7 @@ namespace Content.Client.Weapons.Marker;
 public sealed class DamageMarkerSystem : SharedDamageMarkerSystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -20,16 +21,16 @@ public sealed class DamageMarkerSystem : SharedDamageMarkerSystem
         if (!_timing.ApplyingState || component.Effect == null || !TryComp<SpriteComponent>(uid, out var sprite))
             return;
 
-        var layer = sprite.LayerMapReserveBlank(DamageMarkerKey.Key);
-        sprite.LayerSetState(layer, component.Effect.RsiState, component.Effect.RsiPath);
+        var layer = _sprite.LayerMapReserve((uid, sprite), DamageMarkerKey.Key);
+        _sprite.LayerSetRsi((uid, sprite), layer, component.Effect.RsiPath, component.Effect.RsiState);
     }
 
     private void OnMarkerShutdown(EntityUid uid, DamageMarkerComponent component, ComponentShutdown args)
     {
-        if (!_timing.ApplyingState || !TryComp<SpriteComponent>(uid, out var sprite) || !sprite.LayerMapTryGet(DamageMarkerKey.Key, out var weh))
+        if (!_timing.ApplyingState || !TryComp<SpriteComponent>(uid, out var sprite) || !_sprite.LayerMapTryGet((uid, sprite), DamageMarkerKey.Key, out var weh, false))
             return;
 
-        sprite.RemoveLayer(weh);
+        _sprite.RemoveLayer((uid, sprite), weh);
     }
 
     private enum DamageMarkerKey : byte


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 68 `SpriteComponent` obsoleted warnings across multiple files.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods and properties with `SpriteSystem` methods.
Some private method signatures were changed, and a few other minor issues were cleaned up.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Not screenshotting everything here, but I tested stuff out for a bit.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->