### PR TITLE
fixing fire locks

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -22,6 +22,8 @@ using Robust.Server.GameObjects;
 using System.Linq;
 using Content.Shared.DeviceNetwork.Events;
 using Content.Shared.DeviceNetwork.Components;
+using Content.Server.Doors.Systems;
+using Content.Shared.Doors.Components;
 
 namespace Content.Server.Atmos.Monitor.Systems;
 
@@ -45,6 +47,8 @@ public sealed class AirAlarmSystem : EntitySystem
     [Dependency] private readonly DeviceListSystem _deviceList = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
+
+    [Dependency] private readonly FirelockSystem _firelock = default!;
 
     #region Device Network API
 
@@ -681,7 +685,7 @@ public sealed class AirAlarmSystem : EntitySystem
 
     private const float Delay = 8f;
     private float _timer;
-
+    #endregion
     public override void Update(float frameTime)
     {
         _timer += frameTime;
@@ -692,8 +696,22 @@ public sealed class AirAlarmSystem : EntitySystem
             {
                 SyncAllSensors(uid);
             }
+
+            var query = EntityQueryEnumerator<AtmosAlarmableComponent, DeviceListComponent>();
+            while (query.MoveNext(out var uid, out var atmosAlarmable, out var deviceList)) //closing undesirably open airlocks
+            {
+                if (atmosAlarmable.LastAlarmState == AtmosAlarmType.Danger && this.IsPowered(uid, EntityManager))
+                {
+                    var indoor = GetEntityQuery<DoorComponent>();
+                    var infirelock = GetEntityQuery<FirelockComponent>();
+                    foreach (EntityUid i in deviceList.Devices)
+                    {
+                        if (!indoor.TryGetComponent(i, out var nouse) && !infirelock.TryGetComponent(i, out var nouse2)) continue;
+                        var door = indoor.GetComponent(i); var firelock = infirelock.GetComponent(i);
+                        if (door.State == DoorState.Open && this.IsPowered(i, EntityManager)) _firelock.UrgentClosure(i, door, firelock);
+                    }
+                }
+            }
         }
     }
-
-    #endregion
 }

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Popups;
 using Content.Shared.Prying.Components;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
+using System.Linq;
 
 namespace Content.Shared.Doors.Systems;
 
@@ -31,6 +32,21 @@ public abstract class SharedFirelockSystem : EntitySystem
         SubscribeLocalEvent<FirelockComponent, ComponentStartup>(OnComponentStartup);
 
         SubscribeLocalEvent<FirelockComponent, ExaminedEvent>(OnExamined);
+    }
+
+    public void UrgentClosure(EntityUid uid, DoorComponent door, FirelockComponent firelock) //unsafe, better EmergencyPressureStop(I wanted it this way)
+    {
+        if (firelock.EmergencyCloseCooldown == null || _gameTiming.CurTime > firelock.EmergencyCloseCooldown)
+        {
+            firelock.EmergencyCloseCooldown = _gameTiming.CurTime + firelock.EmergencyCloseCooldownDuration;
+            var ev = new BeforeDoorClosedEvent(door.PerformCollisionCheck, false);
+            RaiseLocalEvent(uid, ev);
+            if (!ev.Cancelled && ev.PerformCollisionCheck && !_doorSystem.GetColliding(uid).Any())
+            {
+
+                _doorSystem.StartClosing(uid, door);
+            }
+        }
     }
 
     public bool EmergencyPressureStop(EntityUid uid, FirelockComponent? firelock = null, DoorComponent? door = null)


### PR DESCRIPTION
## About the PR
The alarm sources are now checking the fire locks for re-closure.

## Why / Balance
In the event of a botany fire or other disasters, the air alarms will correctly isolate the source of the problem, regardless of the smart guy with the tire iron, who URGENTLY needs to pass through a room at 1000 degrees. Previously, the airlocksremained open and everyone suffered. No, I'm not burned out.

## Technical details
It's nothing serious.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: fire locks have learned how to close again.

