### PR TITLE
Adding EvenHealthChange to More Reagents

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -937,13 +937,12 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.05
-      - !type:HealthChange
+      - !type:EvenHealthChange
         damage:
-          groups:
-            Burn: -1
-            Brute: -1
-            Airloss: -1
-            Toxin: -1
+          Burn: -1
+          Toxin: -1
+          Airloss: -1
+          Brute: -1
 
 - type: reagent
   id: DriestMartini

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -164,16 +164,15 @@
       - !type:SatiateThirst
         factor: 1.5
     # Dragon doesn't require airloss healing, so omnizine is still best for humans.
+    # Want to use the EvenHealthChange property which requires the use of airloss.
       - !type:ModifyBloodLevel
         amount: 3
-      - !type:HealthChange
+      - !type:EvenHealthChange
         damage:
-          groups:
-            Burn: -5
-            Brute: -5
-            Toxin: -2
-          types:
-            Bloodloss: -5
+          Burn: -5
+          Toxin: -2
+          Airloss: -5
+          Brute: -5
       - !type:ModifyBleedAmount
         amount: -1.5
   # Just in case you REALLY want to water your plants

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -177,10 +177,9 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:HealthChange
+      - !type:EvenHealthChange
         damage:
-          groups:
-            Brute: -4
+          Brute: -4
       - !type:GenericStatusEffect
         key: Adrenaline
         component: IgnoreSlowOnDamage

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -143,10 +143,9 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:HealthChange
+      - !type:EvenHealthChange
         damage:
-          groups:
-            Brute: -2
+          Brute: -2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the new component EvenHealthChange to 4 reagents Bic, Doctor's Delight, Ichor, and Rororium.
Changes Ichor to include Airloss as a category so it would work with EvenHealthChange.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With the new component brought by #37129 it makes sense to add it to more reagents to make them stronger. This is also for the same reasons as EmoGarbage listed in his PR.

This also buffs dragons and hivelords healing effect.
## Technical details
<!-- Summary of code changes for easier review. -->
Changes HealthChange to EvenHealthChange on all listed reagents.

Changes Ichor to heal 5 Airloss instead of 5 Bloodloss.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Bicaridine, Doctor's Delight, Ichor, and Rororium all no longer "wastes" healing when administered to patients without even amounts of all damage types.