### PR TITLE
Cleanup more `SpriteComponent` warnings (part 2)

### DIFF
--- a/Content.Client/Atmos/Visualizers/PortableScrubberVisualsSystem.cs
+++ b/Content.Client/Atmos/Visualizers/PortableScrubberVisualsSystem.cs
@@ -9,6 +9,8 @@ namespace Content.Client.Atmos.Visualizers
     /// </summary>
     public sealed class PortableScrubberSystem : VisualizerSystem<PortableScrubberVisualsComponent>
     {
+        [Dependency] private readonly SpriteSystem _sprite = default!;
+
         protected override void OnAppearanceChange(EntityUid uid, PortableScrubberVisualsComponent component, ref AppearanceChangeEvent args)
         {
             if (args.Sprite == null)
@@ -18,15 +20,15 @@ namespace Content.Client.Atmos.Visualizers
                 && AppearanceSystem.TryGetData<bool>(uid, PortableScrubberVisuals.IsRunning, out var isRunning, args.Component))
             {
                 var runningState = isRunning ? component.RunningState : component.IdleState;
-                args.Sprite.LayerSetState(PortableScrubberVisualLayers.IsRunning, runningState);
+                _sprite.LayerSetRsiState((uid, args.Sprite), PortableScrubberVisualLayers.IsRunning, runningState);
 
                 var fullState = isFull ? component.FullState : component.ReadyState;
-                args.Sprite.LayerSetState(PowerDeviceVisualLayers.Powered, fullState);
+                _sprite.LayerSetRsiState((uid, args.Sprite), PowerDeviceVisualLayers.Powered, fullState);
             }
 
             if (AppearanceSystem.TryGetData<bool>(uid, PortableScrubberVisuals.IsDraining, out var isDraining, args.Component))
             {
-                args.Sprite.LayerSetVisible(PortableScrubberVisualLayers.IsDraining, isDraining);
+                _sprite.LayerSetVisible((uid, args.Sprite), PortableScrubberVisualLayers.IsDraining, isDraining);
             }
         }
     }

--- a/Content.Client/Atmos/Visualizers/PortableScrubberVisualsSystem.cs
+++ b/Content.Client/Atmos/Visualizers/PortableScrubberVisualsSystem.cs
@@ -2,37 +2,37 @@ using Robust.Client.GameObjects;
 using Content.Shared.Atmos.Visuals;
 using Content.Client.Power;
 
-namespace Content.Client.Atmos.Visualizers
+namespace Content.Client.Atmos.Visualizers;
+
+/// <summary>
+/// Controls client-side visuals for portable scrubbers.
+/// </summary>
+public sealed class PortableScrubberSystem : VisualizerSystem<PortableScrubberVisualsComponent>
 {
-    /// <summary>
-    /// Controls client-side visuals for portable scrubbers.
-    /// </summary>
-    public sealed class PortableScrubberSystem : VisualizerSystem<PortableScrubberVisualsComponent>
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
+    protected override void OnAppearanceChange(EntityUid uid, PortableScrubberVisualsComponent component, ref AppearanceChangeEvent args)
     {
-        [Dependency] private readonly SpriteSystem _sprite = default!;
+        if (args.Sprite == null)
+            return;
 
-        protected override void OnAppearanceChange(EntityUid uid, PortableScrubberVisualsComponent component, ref AppearanceChangeEvent args)
+        if (AppearanceSystem.TryGetData<bool>(uid, PortableScrubberVisuals.IsFull, out var isFull, args.Component)
+            && AppearanceSystem.TryGetData<bool>(uid, PortableScrubberVisuals.IsRunning, out var isRunning, args.Component))
         {
-            if (args.Sprite == null)
-                return;
+            var runningState = isRunning ? component.RunningState : component.IdleState;
+            _sprite.LayerSetRsiState((uid, args.Sprite), PortableScrubberVisualLayers.IsRunning, runningState);
 
-            if (AppearanceSystem.TryGetData<bool>(uid, PortableScrubberVisuals.IsFull, out var isFull, args.Component)
-                && AppearanceSystem.TryGetData<bool>(uid, PortableScrubberVisuals.IsRunning, out var isRunning, args.Component))
-            {
-                var runningState = isRunning ? component.RunningState : component.IdleState;
-                _sprite.LayerSetRsiState((uid, args.Sprite), PortableScrubberVisualLayers.IsRunning, runningState);
+            var fullState = isFull ? component.FullState : component.ReadyState;
+            _sprite.LayerSetRsiState((uid, args.Sprite), PowerDeviceVisualLayers.Powered, fullState);
+        }
 
-                var fullState = isFull ? component.FullState : component.ReadyState;
-                _sprite.LayerSetRsiState((uid, args.Sprite), PowerDeviceVisualLayers.Powered, fullState);
-            }
-
-            if (AppearanceSystem.TryGetData<bool>(uid, PortableScrubberVisuals.IsDraining, out var isDraining, args.Component))
-            {
-                _sprite.LayerSetVisible((uid, args.Sprite), PortableScrubberVisualLayers.IsDraining, isDraining);
-            }
+        if (AppearanceSystem.TryGetData<bool>(uid, PortableScrubberVisuals.IsDraining, out var isDraining, args.Component))
+        {
+            _sprite.LayerSetVisible((uid, args.Sprite), PortableScrubberVisualLayers.IsDraining, isDraining);
         }
     }
 }
+
 public enum PortableScrubberVisualLayers : byte
 {
     IsRunning,

--- a/Content.Client/Dragon/DragonSystem.cs
+++ b/Content.Client/Dragon/DragonSystem.cs
@@ -7,6 +7,7 @@ namespace Content.Client.Dragon;
 public sealed class DragonSystem : EntitySystem
 {
     [Dependency] private readonly SharedPointLightSystem _lights = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -31,7 +32,7 @@ public sealed class DragonSystem : EntitySystem
         switch (state.State)
         {
             case DragonRiftState.Charging:
-                sprite?.LayerSetColor(0, Color.FromHex("#569fff"));
+                _sprite.LayerSetColor((uid, sprite), 0, Color.FromHex("#569fff"));
 
                 if (light != null)
                 {
@@ -39,7 +40,7 @@ public sealed class DragonSystem : EntitySystem
                 }
                 break;
             case DragonRiftState.AlmostFinished:
-                sprite?.LayerSetColor(0, Color.FromHex("#cf4cff"));
+                _sprite.LayerSetColor((uid, sprite), 0, Color.FromHex("#cf4cff"));
 
                 if (light != null)
                 {
@@ -47,7 +48,7 @@ public sealed class DragonSystem : EntitySystem
                 }
                 break;
             case DragonRiftState.Finished:
-                sprite?.LayerSetColor(0, Color.FromHex("#edbc36"));
+                _sprite.LayerSetColor((uid, sprite), 0, Color.FromHex("#edbc36"));
 
                 if (light != null)
                 {

--- a/Content.Client/Explosion/TriggerSystem.Proximity.cs
+++ b/Content.Client/Explosion/TriggerSystem.Proximity.cs
@@ -9,6 +9,7 @@ public sealed partial class TriggerSystem
 {
     [Dependency] private readonly AnimationPlayerSystem _player = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     /*
      * Currently all of the appearance stuff is hardcoded for portable flashers
@@ -79,7 +80,7 @@ public sealed partial class TriggerSystem
         if (!_appearance.TryGetData<ProximityTriggerVisuals>(uid, ProximityTriggerVisualState.State, out var state, appearance))
             return;
 
-        if (!spriteComponent.LayerMapTryGet(ProximityTriggerVisualLayers.Base, out var layer))
+        if (!_sprite.LayerMapTryGet((uid, spriteComponent), ProximityTriggerVisualLayers.Base, out var layer, false))
             // Don't do anything if the sprite doesn't have the layer.
             return;
 
@@ -89,7 +90,7 @@ public sealed partial class TriggerSystem
                 // Don't interrupt the flash animation
                 if (_player.HasRunningAnimation(uid, player, AnimKey)) return;
                 _player.Stop(uid, player, AnimKey);
-                spriteComponent.LayerSetState(layer, "on");
+                _sprite.LayerSetRsiState((uid, spriteComponent), layer, "on");
                 break;
             case ProximityTriggerVisuals.Active:
                 if (_player.HasRunningAnimation(uid, player, AnimKey)) return;
@@ -98,7 +99,7 @@ public sealed partial class TriggerSystem
             case ProximityTriggerVisuals.Off:
             default:
                 _player.Stop(uid, player, AnimKey);
-                spriteComponent.LayerSetState(layer, "off");
+                _sprite.LayerSetRsiState((uid, spriteComponent), layer, "off");
                 break;
         }
     }

--- a/Content.Client/Ghost/GhostSystem.cs
+++ b/Content.Client/Ghost/GhostSystem.cs
@@ -15,6 +15,7 @@ namespace Content.Client.Ghost
         [Dependency] private readonly SharedActionsSystem _actions = default!;
         [Dependency] private readonly PointLightSystem _pointLightSystem = default!;
         [Dependency] private readonly ContentEyeSystem _contentEye = default!;
+        [Dependency] private readonly SpriteSystem _sprite = default!;
 
         public int AvailableGhostRoleCount { get; private set; }
 
@@ -35,7 +36,7 @@ namespace Content.Client.Ghost
                 var query = AllEntityQuery<GhostComponent, SpriteComponent>();
                 while (query.MoveNext(out var uid, out _, out var sprite))
                 {
-                    sprite.Visible = value || uid == _playerManager.LocalEntity;
+                    _sprite.SetVisible((uid, sprite), value || uid == _playerManager.LocalEntity);
                 }
             }
         }
@@ -72,7 +73,7 @@ namespace Content.Client.Ghost
         private void OnStartup(EntityUid uid, GhostComponent component, ComponentStartup args)
         {
             if (TryComp(uid, out SpriteComponent? sprite))
-                sprite.Visible = GhostVisibility || uid == _playerManager.LocalEntity;
+                _sprite.SetVisible((uid, sprite), GhostVisibility || uid == _playerManager.LocalEntity);
         }
 
         private void OnToggleLighting(EntityUid uid, EyeComponent component, ToggleLightingActionEvent args)
@@ -150,7 +151,7 @@ namespace Content.Client.Ghost
         private void OnGhostState(EntityUid uid, GhostComponent component, ref AfterAutoHandleStateEvent args)
         {
             if (TryComp<SpriteComponent>(uid, out var sprite))
-                sprite.LayerSetColor(0, component.Color);
+                _sprite.LayerSetColor((uid, sprite), 0, component.Color);
 
             if (uid != _playerManager.LocalEntity)
                 return;

--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -43,6 +43,7 @@ public sealed class DragDropSystem : SharedDragDropSystem
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     // how often to recheck possible targets (prevents calling expensive
     // check logic each update)
@@ -178,7 +179,7 @@ public sealed class DragDropSystem : SharedDragDropSystem
 
     private bool OnUseMouseDown(in PointerInputCmdHandler.PointerInputCmdArgs args)
     {
-        if (args.Session?.AttachedEntity is not {Valid: true} dragger ||
+        if (args.Session?.AttachedEntity is not { Valid: true } dragger ||
             _combatMode.IsInCombatMode())
         {
             return false;
@@ -249,11 +250,11 @@ public sealed class DragDropSystem : SharedDragDropSystem
             var mousePos = _eyeManager.PixelToMap(screenPos);
             _dragShadow = EntityManager.SpawnEntity("dragshadow", mousePos);
             var dragSprite = Comp<SpriteComponent>(_dragShadow.Value);
-            dragSprite.CopyFrom(draggedSprite);
+            _sprite.CopySprite((_draggedEntity.Value, draggedSprite), (_dragShadow.Value, dragSprite));
             dragSprite.RenderOrder = EntityManager.CurrentTick.Value;
-            dragSprite.Color = dragSprite.Color.WithAlpha(0.7f);
+            _sprite.SetColor((_dragShadow.Value, dragSprite), dragSprite.Color.WithAlpha(0.7f));
             // keep it on top of everything
-            dragSprite.DrawDepth = (int) DrawDepth.Overlays;
+            _sprite.SetDrawDepth((_dragShadow.Value, dragSprite), (int)DrawDepth.Overlays);
             if (!dragSprite.NoRotation)
             {
                 _transformSystem.SetWorldRotationNoLerp(_dragShadow.Value, _transformSystem.GetWorldRotation(_draggedEntity.Value));

--- a/Content.Client/Lock/Visualizers/LockVisualizerSystem.cs
+++ b/Content.Client/Lock/Visualizers/LockVisualizerSystem.cs
@@ -6,6 +6,8 @@ namespace Content.Client.Lock.Visualizers;
 
 public sealed class LockVisualizerSystem : VisualizerSystem<LockVisualsComponent>
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     protected override void OnAppearanceChange(EntityUid uid, LockVisualsComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null
@@ -20,14 +22,14 @@ public sealed class LockVisualizerSystem : VisualizerSystem<LockVisualsComponent
 
         if (AppearanceSystem.TryGetData<bool>(uid, StorageVisuals.Open, out var open, args.Component))
         {
-            args.Sprite.LayerSetVisible(LockVisualLayers.Lock, !open);
+            _sprite.LayerSetVisible((uid, args.Sprite), LockVisualLayers.Lock, !open);
         }
-        else if (!(bool) unlockedStateExist!)
-            args.Sprite.LayerSetVisible(LockVisualLayers.Lock, locked);
+        else if (!(bool)unlockedStateExist!)
+            _sprite.LayerSetVisible((uid, args.Sprite), LockVisualLayers.Lock, locked);
 
-        if (!open && (bool) unlockedStateExist!)
+        if (!open && (bool)unlockedStateExist!)
         {
-            args.Sprite.LayerSetState(LockVisualLayers.Lock, locked ? comp.StateLocked : comp.StateUnlocked);
+            _sprite.LayerSetRsiState((uid, args.Sprite), LockVisualLayers.Lock, locked ? comp.StateLocked : comp.StateUnlocked);
         }
     }
 }

--- a/Content.Client/Mapping/MappingOverlay.cs
+++ b/Content.Client/Mapping/MappingOverlay.cs
@@ -15,6 +15,8 @@ public sealed class MappingOverlay : Overlay
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
 
+    private readonly SpriteSystem _sprite;
+
     // 1 off in case something else uses these colors since we use them to compare
     private static readonly Color PickColor = new(1, 255, 0);
     private static readonly Color DeleteColor = new(255, 1, 0);
@@ -30,6 +32,8 @@ public sealed class MappingOverlay : Overlay
     {
         IoCManager.InjectDependencies(this);
 
+        _sprite = _entities.System<SpriteSystem>();
+
         _state = state;
         _shader = _prototypes.Index<ShaderPrototype>("unshaded").Instance();
     }
@@ -42,7 +46,7 @@ public sealed class MappingOverlay : Overlay
                 continue;
 
             if (sprite.Color == DeleteColor || sprite.Color == PickColor)
-                sprite.Color = color;
+                _sprite.SetColor((id, sprite), color);
         }
 
         _oldColors.Clear();
@@ -61,7 +65,7 @@ public sealed class MappingOverlay : Overlay
                     _entities.TryGetComponent(entity, out SpriteComponent? sprite))
                 {
                     _oldColors[entity] = sprite.Color;
-                    sprite.Color = PickColor;
+                    _sprite.SetColor((entity, sprite), PickColor);
                 }
 
                 break;
@@ -72,7 +76,7 @@ public sealed class MappingOverlay : Overlay
                     _entities.TryGetComponent(entity, out SpriteComponent? sprite))
                 {
                     _oldColors[entity] = sprite.Color;
-                    sprite.Color = DeleteColor;
+                    _sprite.SetColor((entity, sprite), DeleteColor);
                 }
 
                 break;

--- a/Content.Client/Mech/MechSystem.cs
+++ b/Content.Client/Mech/MechSystem.cs
@@ -10,6 +10,7 @@ namespace Content.Client.Mech;
 public sealed class MechSystem : SharedMechSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -24,7 +25,7 @@ public sealed class MechSystem : SharedMechSystem
         if (args.Sprite == null)
             return;
 
-        if (!args.Sprite.TryGetLayer((int) MechVisualLayers.Base, out var layer))
+        if (!_sprite.LayerExists((uid, args.Sprite), MechVisualLayers.Base))
             return;
 
         var state = component.BaseState;
@@ -40,7 +41,7 @@ public sealed class MechSystem : SharedMechSystem
             drawDepth = DrawDepth.SmallMobs;
         }
 
-        layer.SetState(state);
-        args.Sprite.DrawDepth = (int) drawDepth;
+        _sprite.LayerSetRsiState((uid, args.Sprite), MechVisualLayers.Base, state);
+        _sprite.SetDrawDepth((uid, args.Sprite), (int)drawDepth);
     }
 }

--- a/Content.Client/PDA/PdaVisualizerSystem.cs
+++ b/Content.Client/PDA/PdaVisualizerSystem.cs
@@ -6,19 +6,20 @@ namespace Content.Client.PDA;
 
 public sealed class PdaVisualizerSystem : VisualizerSystem<PdaVisualsComponent>
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
     protected override void OnAppearanceChange(EntityUid uid, PdaVisualsComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
             return;
 
         if (AppearanceSystem.TryGetData<string>(uid, PdaVisuals.PdaType, out var pdaType, args.Component))
-            args.Sprite.LayerSetState(PdaVisualLayers.Base, pdaType);
+            _sprite.LayerSetRsiState((uid, args.Sprite), PdaVisualLayers.Base, pdaType);
 
         if (AppearanceSystem.TryGetData<bool>(uid, UnpoweredFlashlightVisuals.LightOn, out var isFlashlightOn, args.Component))
-            args.Sprite.LayerSetVisible(PdaVisualLayers.Flashlight, isFlashlightOn);
+            _sprite.LayerSetVisible((uid, args.Sprite), PdaVisualLayers.Flashlight, isFlashlightOn);
 
         if (AppearanceSystem.TryGetData<bool>(uid, PdaVisuals.IdCardInserted, out var isCardInserted, args.Component))
-            args.Sprite.LayerSetVisible(PdaVisualLayers.IdLight, isCardInserted);
+            _sprite.LayerSetVisible((uid, args.Sprite), PdaVisualLayers.IdLight, isCardInserted);
     }
 
     public enum PdaVisualLayers : byte

--- a/Content.Client/Paper/EnvelopeSystem.cs
+++ b/Content.Client/Paper/EnvelopeSystem.cs
@@ -5,6 +5,8 @@ namespace Content.Client.Paper;
 
 public sealed class EnvelopeSystem : VisualizerSystem<EnvelopeComponent>
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -21,9 +23,9 @@ public sealed class EnvelopeSystem : VisualizerSystem<EnvelopeComponent>
         if (!Resolve(ent.Owner, ref sprite))
             return;
 
-        sprite.LayerSetVisible(EnvelopeVisualLayers.Open, ent.Comp.State == EnvelopeComponent.EnvelopeState.Open);
-        sprite.LayerSetVisible(EnvelopeVisualLayers.Sealed, ent.Comp.State == EnvelopeComponent.EnvelopeState.Sealed);
-        sprite.LayerSetVisible(EnvelopeVisualLayers.Torn, ent.Comp.State == EnvelopeComponent.EnvelopeState.Torn);
+        _sprite.LayerSetVisible((ent.Owner, sprite), EnvelopeVisualLayers.Open, ent.Comp.State == EnvelopeComponent.EnvelopeState.Open);
+        _sprite.LayerSetVisible((ent.Owner, sprite), EnvelopeVisualLayers.Sealed, ent.Comp.State == EnvelopeComponent.EnvelopeState.Sealed);
+        _sprite.LayerSetVisible((ent.Owner, sprite), EnvelopeVisualLayers.Torn, ent.Comp.State == EnvelopeComponent.EnvelopeState.Torn);
     }
 
     public enum EnvelopeVisualLayers : byte

--- a/Content.Client/Sprite/SpriteFadeSystem.cs
+++ b/Content.Client/Sprite/SpriteFadeSystem.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using Content.Client.Gameplay;
 using Content.Shared.Sprite;
 using Robust.Client.GameObjects;
@@ -10,7 +9,6 @@ using Robust.Client.UserInterface;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Physics;
-using Robust.Shared.Physics.Components;
 
 namespace Content.Client.Sprite;
 
@@ -28,6 +26,7 @@ public sealed class SpriteFadeSystem : EntitySystem
     [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
     [Dependency] private readonly IInputManager _inputManager = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private List<(MapCoordinates Point, bool ExcludeBoundingBox)> _points = new();
 
@@ -58,7 +57,7 @@ public sealed class SpriteFadeSystem : EntitySystem
         if (MetaData(uid).EntityLifeStage >= EntityLifeStage.Terminating || !TryComp<SpriteComponent>(uid, out var sprite))
             return;
 
-        sprite.Color = sprite.Color.WithAlpha(component.OriginalAlpha);
+        _sprite.SetColor((uid, sprite), sprite.Color.WithAlpha(component.OriginalAlpha));
     }
 
     /// <summary>
@@ -132,7 +131,7 @@ public sealed class SpriteFadeSystem : EntitySystem
 
                     if (!sprite.Color.A.Equals(newColor))
                     {
-                        sprite.Color = sprite.Color.WithAlpha(newColor);
+                        _sprite.SetColor((ent, sprite), sprite.Color.WithAlpha(newColor));
                     }
                 }
             }
@@ -157,7 +156,7 @@ public sealed class SpriteFadeSystem : EntitySystem
 
             if (!newColor.Equals(sprite.Color.A))
             {
-                sprite.Color = sprite.Color.WithAlpha(newColor);
+                _sprite.SetColor((uid, sprite), sprite.Color.WithAlpha(newColor));
             }
             else
             {

--- a/Content.Client/StatusIcon/StatusIconOverlay.cs
+++ b/Content.Client/StatusIcon/StatusIconOverlay.cs
@@ -48,7 +48,7 @@ public sealed class StatusIconOverlay : Overlay
             if (xform.MapID != args.MapId || !sprite.Visible)
                 continue;
 
-            var bounds = comp.Bounds ?? sprite.Bounds;
+            var bounds = comp.Bounds ?? _sprite.GetLocalBounds((uid, sprite));
 
             var worldPos = _transform.GetWorldPosition(xform, xformQuery);
 
@@ -86,28 +86,28 @@ public sealed class StatusIconOverlay : Overlay
                 if (proto.LocationPreference == StatusIconLocationPreference.Left ||
                     proto.LocationPreference == StatusIconLocationPreference.None && countL <= countR)
                 {
-                    if (accOffsetL + texture.Height > sprite.Bounds.Height * EyeManager.PixelsPerMeter)
+                    if (accOffsetL + texture.Height > _sprite.GetLocalBounds((uid, sprite)).Height * EyeManager.PixelsPerMeter)
                         break;
                     if (proto.Layer == StatusIconLayer.Base)
                     {
                         accOffsetL += texture.Height;
                         countL++;
                     }
-                    yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float) (accOffsetL - proto.Offset) / EyeManager.PixelsPerMeter;
+                    yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float)(accOffsetL - proto.Offset) / EyeManager.PixelsPerMeter;
                     xOffset = -(bounds.Width + sprite.Offset.X) / 2f;
 
                 }
                 else
                 {
-                    if (accOffsetR + texture.Height > sprite.Bounds.Height * EyeManager.PixelsPerMeter)
+                    if (accOffsetR + texture.Height > _sprite.GetLocalBounds((uid, sprite)).Height * EyeManager.PixelsPerMeter)
                         break;
                     if (proto.Layer == StatusIconLayer.Base)
                     {
                         accOffsetR += texture.Height;
                         countR++;
                     }
-                    yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float) (accOffsetR - proto.Offset) / EyeManager.PixelsPerMeter;
-                    xOffset = (bounds.Width + sprite.Offset.X) / 2f - (float) texture.Width / EyeManager.PixelsPerMeter;
+                    yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float)(accOffsetR - proto.Offset) / EyeManager.PixelsPerMeter;
+                    xOffset = (bounds.Width + sprite.Offset.X) / 2f - (float)texture.Width / EyeManager.PixelsPerMeter;
 
                 }
 

--- a/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
+++ b/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
@@ -15,6 +15,7 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
 {
     [Dependency] private readonly SharedItemSystem _itemSys = default!;
     [Dependency] private readonly SharedPointLightSystem _lights = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -31,11 +32,11 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
         var modulate = AppearanceSystem.TryGetData<Color>(uid, ToggleableLightVisuals.Color, out var color, args.Component);
 
         // Update the item's sprite
-        if (args.Sprite != null && component.SpriteLayer != null && args.Sprite.LayerMapTryGet(component.SpriteLayer, out var layer))
+        if (args.Sprite != null && component.SpriteLayer != null && _sprite.LayerMapTryGet((uid, args.Sprite), component.SpriteLayer, out var layer, false))
         {
-            args.Sprite.LayerSetVisible(layer, enabled);
+            _sprite.LayerSetVisible((uid, args.Sprite), layer, enabled);
             if (modulate)
-                args.Sprite.LayerSetColor(layer, color);
+                _sprite.LayerSetColor((uid, args.Sprite), layer, color);
         }
 
         // Update any point-lights

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
@@ -49,14 +49,14 @@ public sealed partial class MeleeWeaponSystem
         {
             if (user != weapon
                 && TryComp(weapon, out SpriteComponent? weaponSpriteComponent))
-                sprite.CopyFrom(weaponSpriteComponent);
+                _sprite.CopySprite((weapon, weaponSpriteComponent), (animationUid, sprite));
 
             spriteRotation = meleeWeaponComponent.WideAnimationRotation;
 
             if (meleeWeaponComponent.SwingLeft)
                 angle *= -1;
         }
-        sprite.Rotation = localPos.ToWorldAngle();
+        _sprite.SetRotation((animationUid, sprite), localPos.ToWorldAngle());
         var distance = Math.Clamp(localPos.Length() / 2f, 0.2f, 1f);
 
         var xform = _xformQuery.GetComponent(animationUid);
@@ -74,7 +74,7 @@ public sealed partial class MeleeWeaponSystem
             case WeaponArcAnimation.Thrust:
                 track = EnsureComp<TrackUserComponent>(animationUid);
                 track.User = user;
-                _animation.Play(animationUid, GetThrustAnimation(sprite, distance, spriteRotation), ThrustAnimationKey);
+                _animation.Play(animationUid, GetThrustAnimation((animationUid, sprite), distance, spriteRotation), ThrustAnimationKey);
                 if (arcComponent.Fadeout)
                     _animation.Play(animationUid, GetFadeAnimation(sprite, 0.05f, 0.15f), FadeAnimationKey);
                 break;
@@ -132,13 +132,13 @@ public sealed partial class MeleeWeaponSystem
         };
     }
 
-    private Animation GetThrustAnimation(SpriteComponent sprite, float distance, Angle spriteRotation)
+    private Animation GetThrustAnimation(Entity<SpriteComponent> sprite, float distance, Angle spriteRotation)
     {
         const float thrustEnd = 0.05f;
         const float length = 0.15f;
-        var startOffset = sprite.Rotation.RotateVec(new Vector2(0f, -distance / 5f));
-        var endOffset = sprite.Rotation.RotateVec(new Vector2(0f, -distance));
-        sprite.Rotation += spriteRotation;
+        var startOffset = sprite.Comp.Rotation.RotateVec(new Vector2(0f, -distance / 5f));
+        var endOffset = sprite.Comp.Rotation.RotateVec(new Vector2(0f, -distance));
+        _sprite.SetRotation(sprite.AsNullable(), sprite.Comp.Rotation + spriteRotation);
 
         return new Animation()
         {

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -30,6 +30,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private readonly InputSystem _inputSystem = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
     [Dependency] private readonly MapSystem _map = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private EntityQuery<TransformComponent> _xformQuery;
 

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.ChamberMagazine.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.ChamberMagazine.cs
@@ -21,7 +21,7 @@ public sealed partial class GunSystem
     private void OnChamberMagazineAppearance(EntityUid uid, ChamberMagazineAmmoProviderComponent component, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null ||
-            !args.Sprite.LayerMapTryGet(GunVisualLayers.Base, out var boltLayer) ||
+            !_sprite.LayerMapTryGet((uid, args.Sprite), GunVisualLayers.Base, out var boltLayer, false) ||
             !Appearance.TryGetData(uid, AmmoVisuals.BoltClosed, out bool boltClosed))
         {
             return;
@@ -30,11 +30,11 @@ public sealed partial class GunSystem
         // Maybe re-using base layer for this will bite me someday but screw you future sloth.
         if (boltClosed)
         {
-            args.Sprite.LayerSetState(boltLayer, "base");
+            _sprite.LayerSetRsiState((uid, args.Sprite), boltLayer, "base");
         }
         else
         {
-            args.Sprite.LayerSetState(boltLayer, "bolt-open");
+            _sprite.LayerSetRsiState((uid, args.Sprite), boltLayer, "bolt-open");
         }
     }
 

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.SpentAmmo.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.SpentAmmo.cs
@@ -29,9 +29,7 @@ public sealed partial class GunSystem
         else
             state = component.State;
 
-        sprite.LayerSetState(AmmoVisualLayers.Base, state);
-        if (sprite.LayerExists(AmmoVisualLayers.Tip)){
-            sprite.RemoveLayer(AmmoVisualLayers.Tip);
-        }
+        _sprite.LayerSetRsiState((uid, sprite), AmmoVisualLayers.Base, state);
+        _sprite.RemoveLayer((uid, sprite), AmmoVisualLayers.Tip, false);
     }
 }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -130,9 +130,9 @@ public sealed partial class GunSystem : SharedGunSystem
             _xform.SetLocalRotationNoLerp(ent, xform.LocalRotation + delta, xform);
 
             sprite[EffectLayers.Unshaded].AutoAnimated = false;
-            sprite.LayerSetSprite(EffectLayers.Unshaded, rsi);
-            sprite.LayerSetState(EffectLayers.Unshaded, rsi.RsiState);
-            sprite.Scale = new Vector2(a.Distance, 1f);
+            _sprite.LayerSetSprite((ent, sprite), EffectLayers.Unshaded, rsi);
+            _sprite.LayerSetRsiState((ent, sprite), EffectLayers.Unshaded, rsi.RsiState);
+            _sprite.SetScale((ent, sprite), new Vector2(a.Distance, 1f));
             sprite[EffectLayers.Unshaded].Visible = true;
 
             var anim = new Animation()

--- a/Content.Client/Wires/Visualizers/WiresVisualizerSystem.cs
+++ b/Content.Client/Wires/Visualizers/WiresVisualizerSystem.cs
@@ -5,22 +5,24 @@ namespace Content.Client.Wires.Visualizers
 {
     public sealed class WiresVisualizerSystem : VisualizerSystem<WiresVisualsComponent>
     {
+        [Dependency] private readonly SpriteSystem _sprite = default!;
+
         protected override void OnAppearanceChange(EntityUid uid, WiresVisualsComponent component, ref AppearanceChangeEvent args)
         {
             if (args.Sprite == null)
                 return;
 
-            var layer = args.Sprite.LayerMapReserveBlank(WiresVisualLayers.MaintenancePanel);
+            var layer = _sprite.LayerMapReserve((uid, args.Sprite), WiresVisualLayers.MaintenancePanel);
 
-            if(args.AppearanceData.TryGetValue(WiresVisuals.MaintenancePanelState, out var panelStateObject) &&
+            if (args.AppearanceData.TryGetValue(WiresVisuals.MaintenancePanelState, out var panelStateObject) &&
                 panelStateObject is bool panelState)
             {
-                args.Sprite.LayerSetVisible(layer, panelState);
+                _sprite.LayerSetVisible((uid, args.Sprite), layer, panelState);
             }
             else
             {
                 //Mainly for spawn window
-                args.Sprite.LayerSetVisible(layer, false);
+                _sprite.LayerSetVisible((uid, args.Sprite), layer, false);
             }
         }
     }

--- a/Content.IntegrationTests/Tests/MagazineVisualsSpriteTest.cs
+++ b/Content.IntegrationTests/Tests/MagazineVisualsSpriteTest.cs
@@ -1,9 +1,7 @@
 using System.Collections.Generic;
 using Content.Client.Weapons.Ranged.Components;
-using Content.Shared.Prototypes;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests;
 
@@ -16,10 +14,11 @@ public sealed class MagazineVisualsSpriteTest
     [Test]
     public async Task MagazineVisualsSpritesExist()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
         var client = pair.Client;
         var toTest = new List<(int, string)>();
         var protos = pair.GetPrototypesWithComponent<MagazineVisualsComponent>();
+        var spriteSys = client.System<SpriteSystem>();
 
         await client.WaitAssertion(() =>
         {
@@ -36,9 +35,9 @@ public sealed class MagazineVisualsSpriteTest
                         @$"{proto.ID} has MagazineVisualsComponent but no AppearanceComponent.");
 
                     toTest.Clear();
-                    if (sprite.LayerMapTryGet(GunVisualLayers.Mag, out var magLayerId))
+                    if (spriteSys.LayerMapTryGet((uid, sprite), GunVisualLayers.Mag, out var magLayerId, false))
                         toTest.Add((magLayerId, ""));
-                    if (sprite.LayerMapTryGet(GunVisualLayers.MagUnshaded, out var magUnshadedLayerId))
+                    if (spriteSys.LayerMapTryGet((uid, sprite), GunVisualLayers.MagUnshaded, out var magUnshadedLayerId, false))
                         toTest.Add((magUnshadedLayerId, "-unshaded"));
 
                     Assert.That(
@@ -49,7 +48,7 @@ public sealed class MagazineVisualsSpriteTest
                     var start = visuals.ZeroVisible ? 0 : 1;
                     foreach (var (id, midfix) in toTest)
                     {
-                        Assert.That(sprite.TryGetLayer(id, out var layer));
+                        Assert.That(spriteSys.TryGetLayer((uid, sprite), id, out var layer, false));
                         var rsi = layer.ActualRsi;
                         for (var i = start; i < visuals.MagSteps; i++)
                         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 57 `SpriteComponent` obsoleted warnings across multiple files.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods and properties with `SpriteSystem` methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Not screenshotting everything here, but I tested stuff out for a bit.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->