### PR TITLE
AutomaticAtmosSystem uses MassDataChangedEvent, clarifies TileMassMultiplier

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AutomaticAtmosSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AutomaticAtmosSystem.cs
@@ -25,7 +25,7 @@ public sealed class AutomaticAtmosSystem : EntitySystem
             return;
 
         // We can't actually count how many tiles there are efficiently, so instead estimate with the mass.
-        if (ev.NewMass / ShuttleSystem.TileMassMultiplier >= 7.0f)
+        if (ev.NewMass / ShuttleSystem.TileDensityMultiplier >= 7.0f)
         {
             AddComp<GridAtmosphereComponent>(ent);
             Log.Info($"Giving grid {ent} GridAtmosphereComponent.");

--- a/Content.Server/Atmos/EntitySystems/AutomaticAtmosSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AutomaticAtmosSystem.cs
@@ -1,8 +1,7 @@
 using Content.Server.Atmos.Components;
 using Content.Server.Shuttles.Systems;
-using Content.Shared.Maps;
-using Robust.Shared.Map;
-using Robust.Shared.Physics.Components;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Physics.Events;
 
 namespace Content.Server.Atmos.EntitySystems;
 
@@ -12,46 +11,29 @@ namespace Content.Server.Atmos.EntitySystems;
 /// </summary>
 public sealed class AutomaticAtmosSystem : EntitySystem
 {
-    [Dependency] private readonly ITileDefinitionManager _tileDefinitionManager = default!;
     [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<TileChangedEvent>(OnTileChanged);
+        SubscribeLocalEvent<MapGridComponent, MassDataChangedEvent>(OnMassDataChanged);
     }
 
-    private void OnTileChanged(ref TileChangedEvent ev)
+    private void OnMassDataChanged(Entity<MapGridComponent> ent, ref MassDataChangedEvent ev)
     {
-        if (_atmosphereSystem.HasAtmosphere(ev.Entity) || !TryComp<PhysicsComponent>(ev.Entity, out var physics))
+        if (_atmosphereSystem.HasAtmosphere(ent))
             return;
 
-        foreach (var change in ev.Changes)
+        // We can't actually count how many tiles there are efficiently, so instead estimate with the mass.
+        if (ev.NewMass / ShuttleSystem.TileMassMultiplier >= 7.0f)
         {
-            // Only if a atmos-holding tile has been added or removed.
-            // Also, these calls are surprisingly slow.
-            // TODO: Make tiledefmanager cache the IsSpace property, and turn this lookup-through-two-interfaces into
-            // TODO: a simple array lookup, as tile IDs are likely contiguous, and there's at most 2^16 possibilities anyway.
-
-            var oldSpace = change.OldTile.IsSpace(_tileDefinitionManager);
-            var newSpace = change.NewTile.IsSpace(_tileDefinitionManager);
-
-            if (!(oldSpace && !newSpace ||
-                  !oldSpace && newSpace))
-            {
-                continue;
-            }
-
-            // We can't actually count how many tiles there are efficiently, so instead estimate with the mass.
-            if (physics.Mass / ShuttleSystem.TileMassMultiplier >= 7.0f)
-            {
-                AddComp<GridAtmosphereComponent>(ev.Entity);
-                Log.Info($"Giving grid {ev.Entity} GridAtmosphereComponent.");
-            }
-
-            // It's not super important to remove it should the grid become too small again.
-            // If explosions ever gain the ability to outright shatter grids, do rethink this.
-            return;
+            AddComp<GridAtmosphereComponent>(ent);
+            Log.Info($"Giving grid {ent} GridAtmosphereComponent.");
         }
+
+        // It's not super important to remove it should the grid become too small again.
+        // If explosions ever gain the ability to outright shatter grids, do rethink this.
+
+        return;
     }
 }

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -75,7 +75,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<TransformComponent> _xformQuery;
 
-    public const float TileMassMultiplier = 0.5f;
+    public const float TileDensityMultiplier = 0.5f;
 
     public override void Initialize()
     {
@@ -111,7 +111,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
     {
         foreach (var fixture in args.NewFixtures)
         {
-            _physics.SetDensity(uid, fixture.Key, fixture.Value, TileMassMultiplier, false, manager);
+            _physics.SetDensity(uid, fixture.Key, fixture.Value, TileDensityMultiplier, false, manager);
             _fixtures.SetRestitution(uid, fixture.Key, fixture.Value, 0.1f, false, manager);
         }
     }


### PR DESCRIPTION
## About the PR
#37506

Also renames `TileMassMultiplier` to `TileDensityMultiplier` for clarity.

## Why / Balance
No more tile checking. Was already estimating using mass anyways.

## Media
![dotnet_1beVseYefv](https://github.com/user-attachments/assets/2acf28a8-e587-4372-8ba5-c5d455242799)
![dotnet_XExZoYGRyf](https://github.com/user-attachments/assets/c2736b8d-0471-411a-a05b-0e5f52cb3768)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
`ShuttleSystem.TileMassMultiplier` was renamed to `ShuttleSystem.TileDensityMultiplier`.
