### PR TITLE
fix: digest reagents created from in-stomach reactions

### DIFF
--- a/Content.Server/Body/Systems/StomachSystem.cs
+++ b/Content.Server/Body/Systems/StomachSystem.cs
@@ -3,6 +3,8 @@ using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Body.Organ;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Chemistry.Reaction;
+using Content.Shared.Chemistry.Reagent;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -20,6 +22,8 @@ namespace Content.Server.Body.Systems
             SubscribeLocalEvent<StomachComponent, MapInitEvent>(OnMapInit);
             SubscribeLocalEvent<StomachComponent, EntityUnpausedEvent>(OnUnpaused);
             SubscribeLocalEvent<StomachComponent, ApplyMetabolicMultiplierEvent>(OnApplyMetabolicMultiplier);
+            SubscribeLocalEvent<StomachComponent, ReactionAttemptEvent>(OnReactionAttempt);
+            SubscribeLocalEvent<StomachComponent, SolutionRelayEvent<ReactionAttemptEvent>>(OnReactionAttempt);
         }
 
         private void OnMapInit(Entity<StomachComponent> ent, ref MapInitEvent args)
@@ -30,6 +34,27 @@ namespace Content.Server.Body.Systems
         private void OnUnpaused(Entity<StomachComponent> ent, ref EntityUnpausedEvent args)
         {
             ent.Comp.NextUpdate += args.PausedTime;
+        }
+
+        private void OnReactionAttempt(Entity<StomachComponent> ent, ref ReactionAttemptEvent args)
+        {
+            if (args.Cancelled)
+                return;
+
+            // If our stomach has a reaction (e.g., table salt + water) which
+            // produces reagents, make sure we add that to our reagent deltas.
+            foreach (var (product, amt) in args.Reaction.Products)
+            {
+                ent.Comp.ReagentDeltas.Add(new StomachComponent.ReagentDelta(new ReagentQuantity(product, amt)));
+            }
+        }
+
+        private void OnReactionAttempt(Entity<StomachComponent> ent, ref SolutionRelayEvent<ReactionAttemptEvent> args)
+        {
+            if (args.Name != DefaultSolutionName)
+                return;
+
+            OnReactionAttempt(ent, ref args.Event);
         }
 
         public override void Update(float frameTime)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
If a reaction occurs in a stomach we should make sure we add the produced reagents to our tracked reagent deltas to ensure they get processed after an appropriate delay.

This does not handle removal of tracking of the consumed reactants, as this is meant to be a stopgap solution until something like #35071 is merged, as this can be a fairly significant bug. (Eat some chips and water, end up with a stomach that is permanently full.) The behavior without the removal is... "fine". Not totally accurate, but this is a rare scenario anyway.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes #26386, fixes #25751.


## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<details>
<summary>Super exciting screenshots</summary>
<img width="785" alt="image" src="https://github.com/user-attachments/assets/cac86791-c955-4ba8-9f84-cd5e400d5167" />
<img width="816" alt="image" src="https://github.com/user-attachments/assets/2c1f3869-897f-4f42-a741-6f60ccd3ca95" />
</details>


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
