### PR TITLE
De-loot salvage, add reward crates

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
@@ -27,3 +27,13 @@
   cost: 750
   category: cargoproduct-category-name-cargo
   group: market
+
+- type: cargoProduct
+  id: CargoCrusherDagger
+  icon:
+    sprite: Objects/Weapons/Melee/crusher_dagger.rsi
+    state: icon
+  product: CrateCrusherDagger
+  cost: 2500
+  category: cargoproduct-category-name-cargo
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/salvage_rewards.yml
+++ b/Resources/Prototypes/Catalog/Cargo/salvage_rewards.yml
@@ -1,0 +1,83 @@
+# Rank 2
+- type: cargoProduct
+  id: CargoDoubleEmergencyTank
+  icon:
+    sprite: Objects/Tanks/emergency_double.rsi
+    state: icon
+  product: CrateDoubleEmergencyTank
+  cost: 2400
+  category: cargoproduct-category-name-cargo
+  group: SalvageJobReward2
+
+- type: cargoProduct
+  id: CargoSeismicCharge
+  icon:
+    sprite: Objects/Weapons/Bombs/seismic.rsi
+    state: icon
+  product: CrateSeismicCharge
+  cost: 1800
+  category: cargoproduct-category-name-cargo
+  group: SalvageJobReward2
+
+- type: cargoProduct
+  id: CargoCrusher
+  icon:
+    sprite: Objects/Weapons/Melee/crusher.rsi
+    state: icon
+  product: CrateCrusher
+  cost: 5000
+  category: cargoproduct-category-name-cargo
+  group: SalvageJobReward2
+
+- type: cargoProduct
+  id: CargoSalvageHardsuit
+  icon:
+    sprite: Clothing/OuterClothing/Hardsuits/salvage.rsi
+    state: icon
+  product: CrateSalvageHardsuit
+  cost: 7500
+  category: cargoproduct-category-name-cargo
+  group: SalvageJobReward2
+
+# Rank 3
+- type: cargoProduct
+  id: CargoFulton
+  icon:
+    sprite: /Textures/Objects/Tools/fulton.rsi
+    state: extraction_pack
+  product: CrateFulton
+  cost: 3000
+  category: cargoproduct-category-name-cargo
+  group: SalvageJobReward3
+
+- type: cargoProduct
+  id: CargoVoidJetpack
+  icon:
+    sprite: Objects/Tanks/Jetpacks/void.rsi
+    state: icon
+  product: CrateVoidJetpack
+  cost: 4000
+  category: cargoproduct-category-name-cargo
+  group: SalvageJobReward3
+
+- type: cargoProduct
+  id: CargoCrusherGlaive
+  icon:
+    sprite: Objects/Weapons/Melee/crusher_glaive.rsi
+    state: icon
+  product: CrateCrusherGlaive
+  cost: 8000
+  category: cargoproduct-category-name-cargo
+  group: SalvageJobReward3
+
+# Max Rank
+
+- type: cargoProduct
+  id: CargoSupremeSalvagerCloak
+  icon:
+    sprite: Clothing/Neck/Cloaks/miner.rsi
+    state: icon
+  product: CrateSupremeSalvagerCloak
+  cost: 25000
+  category: cargoproduct-category-name-cargo
+  group: SalvageJobRewardMAX

--- a/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
@@ -92,6 +92,119 @@
 
 - type: entity
   parent: CrateGenericSteel
+  id: CrateCrusherDagger
+  name: crusher dagger crate
+  description: Contains 4 crusher daggers for use by salvage.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage:
+        id: WeaponCrusherDagger
+        amount: 4
+
+# Salvage rewards
+- type: entity
+  parent: CrateGenericSteel
+  id: CrateSeismicCharge
+  name: seismic charge crate
+  description: Contains 6 seismic charges for use by salvage.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage:
+        id: SeismicCharge
+        amount: 6
+
+- type: entity
+  parent: CrateGenericSteel
+  id: CrateDoubleEmergencyTank
+  name: double emergency tank crate
+  description: Contains 2 double emergency oxygen tanks and 2 double emergency nitrogen tanks
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: DoubleEmergencyOxygenTankFilled
+          amount: 2
+        - id: DoubleEmergencyNitrogenTankFilled
+          amount: 2
+
+- type: entity
+  parent: CrateGenericSteel
+  id: CrateCrusher
+  name: crusher crate
+  description: Contains 2 crushers for use by salvage.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage:
+        id: WeaponCrusher
+        amount: 2
+
+- type: entity
+  parent: CrateGenericSteel
+  id: CrateFulton
+  name: fulton crate
+  description: Contains a fulton beacon and 8 fultons.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: FultonBeacon
+        - id: Fulton
+          amount: 8
+
+- type: entity
+  parent: CrateGenericSteel
+  id: CrateVoidJetpack
+  name: void jetpack crate
+  description: Contains a single void jetpack.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage:
+        id: JetpackVoidFilled
+
+- type: entity
+  parent: CrateGenericSteel
+  id: CrateSalvageHardsuit
+  name: salvage hardsuit crate
+  description: Contains a salvage hardsuit, breath mask, and oxygen tank.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: ClothingOuterHardsuitSalvage
+        - id: ClothingMaskBreath
+        - id: OxygenTankFilled
+
+- type: entity
+  parent: CrateGenericSteel
+  id: CrateCrusherGlaive
+  name: crusher glaive crate
+  description: Contains a crusher glaive for use by salvage.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage:
+        id: WeaponCrusherGlaive
+
+- type: entity
+  parent: CrateGenericSteel
+  id: CrateSupremeSalvagerCloak
+  name: supreme salvager cloak crate
+  description: Contains a cloak only to be worn by supreme salvagers. Wearing it undeservedly will result in your doom.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage:
+        id: ClothingNeckCloakSalvagerSupreme
+
+- type: entity
+  parent: CrateGenericSteel
   id: CratePartsT3
   name: tier 3 parts crate
   description: Contains 5 random tier 3 parts for upgrading machines.

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -128,9 +128,9 @@
 
 - type: entity
   parent: ClothingNeckBase
-  id: ClothingNeckCloakMiner
-  name: miner's cloak
-  description: Worn by the most skilled miners, for one who has moved mountains and filled valleys.
+  id: ClothingNeckCloakSalvagerSupreme
+  name: supereme salvager's cloak
+  description: Worn by the most skilled salvagers, for one who has mastered space and made the mining asteroid his domain. They don't just hand these things out, y'know?
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/miner.rsi

--- a/Resources/Prototypes/Procedural/Magnet/space_debris_templates.yml
+++ b/Resources/Prototypes/Procedural/Magnet/space_debris_templates.yml
@@ -96,10 +96,7 @@
     entities:
     - SalvageSpawnerTreasure
     - SalvageSpawnerTreasure
-    - SalvageSpawnerEquipment
-    - SalvageSpawnerEquipment
     - SalvageSpawnerTreasureValuable
-    - SalvageSpawnerEquipmentValuable
   - !type:BiomeEntityLayer
     allowedTiles:
     - FloorSteel

--- a/Resources/Prototypes/Procedural/vgroid.yml
+++ b/Resources/Prototypes/Procedural/vgroid.yml
@@ -163,25 +163,15 @@
     table: !type:NestedSelector
       tableId: SalvageScrapSpawnerValuable
   - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 25
+    minCount: 30
+    maxCount: 45
     table: !type:NestedSelector
       tableId: SalvageTreasureSpawnerCommon
   - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 25
-    table: !type:NestedSelector
-      tableId: SalvageEquipmentSpawnerCommon
-  - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 20
+    minCount: 30
+    maxCount: 45
     table: !type:NestedSelector
       tableId: SalvageTreasureSpawnerValuable
-  - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 20
-    table: !type:NestedSelector
-      tableId: SalvageEquipmentSpawnerValuable
   - !type:MobsDunGen
     minCount: 8
     maxCount: 15

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -635,3 +635,6 @@ CigaretteBread: CigaretteBbqSauce
 ClothingOuterHardsuitBasic: ClothingOuterHardsuitEVA
 ClothingHeadHelmetHardsuitBasic: null
 SuitStorageBasic: SuitStorageEVA
+
+# 2025-05-18
+ClothingNeckCloakMiner: null


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds various crates to cargo for salvage gear and equipment. Hooks a bunch of them into the new job board system.

### Non-job board
- 4 crushers for 2500

### Rank 2 unlocks
- 6 seismic charges for 1800
- 4 double emergency tanks for 2400
- 2 crushers for 5000
- 1 salvage hardsuit for 7500

### Rank 3 unlocks
- 1 fulton beacon and 8 fultons for 3000
- 1 void jetpack for 4000
- 1 crusher glaive for 8000

### Max rank unlock
- 1 supreme salvager cloak for 25000

The miner cloak has been migrated out of maps and turned into the supreme salvager cloak. It's now exclusively available through this process.

Removed all equipment spawns from the vgroid and procgen magnets.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The acquisition of loot through exploration has pretty bad incentives on salvage. Primarily, it pushes them to explore more and more dangerous locations instead of doing something that is productive to the station. The job board is a move to integrate them more into the money-making side of cargo, so it makes sense to also have things for them to spend money on.

The crates are all basically just equipment from the table, split out into tiers by rough rarity. The remaining equipment not purchasable is researchable through science.

## Technical details
<!-- Summary of code changes for easier review. -->
n/a

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/3de58904-d9b0-4e89-9fed-cbe0f5c75792)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`ClothingNeckCloakMiner` has been changed to `ClothingNeckCloakSalvagerSupreme`. Note that it has been migrated to null as  to remove it from maps.

**Changelog**
:cl:
- add: Various salvage equipment can now be unlocked through the job board and purchased through cargo.
- tweak: Space debris and the mining asteroid no longer generate salvage equipment

