### PR TITLE
Buff gas canister volumes moderately

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -4,7 +4,7 @@
     sprite: Structures/Storage/canister.rsi
     state: grey
   product: AirCanister
-  cost: 300
+  cost: 600
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: OxygenCanister
-  cost: 300
+  cost: 600
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: NitrogenCanister
-  cost: 300
+  cost: 500
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -54,7 +54,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
-  cost: 400 # even though it's poisonous, it comes locked and only damages you slowly even with high amounts (tested)
+  cost: 670 # even though it's poisonous, it comes locked and only damages you slowly even with high amounts (tested)
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -94,7 +94,7 @@
     sprite: Structures/Storage/canister.rsi
     state: orange
   product: PlasmaCanister
-  cost: 2500 # for reference, bagel's 3x1 roundstart plasma chamber contains ~16kmol for free, this is $2.5k for 1870mol, so $20k to nearly refill a 3x1 (some are 3x3) chamber
+  cost: 4200 # for reference, bagel's 3x1 roundstart plasma chamber contains ~16kmol for free, this is $4.2k for 2769 mol
   category: cargoproduct-category-name-atmospherics
   group: market
 

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -123,7 +123,7 @@
         - state: yellow
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 1500
         moles: # List of gasses for easy reference
           - 0 # oxygen
           - 0 # nitrogen
@@ -172,10 +172,10 @@
       - state: grey
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 1500
       moles:
-        - 393.0592071 # oxygen 21%
-        - 1478.6513029 # nitrogen 79%
+      - 581.56 # oxygen 21%
+      - 2187.79 # nitrogen 79%
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -212,9 +212,9 @@
       - state: blue
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 1500
       moles:
-        - 1871.71051 # oxygen
+      - 2769.36 # oxygen
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -248,7 +248,7 @@
   components:
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 1500
       moles:
         - 18710.71051 # oxygen
       temperature: 72
@@ -266,10 +266,10 @@
         - state: red
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 1500
         moles:
           - 0 # oxygen
-          - 1871.71051 # nitrogen
+          - 2769.36 # nitrogen
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -303,7 +303,7 @@
   components:
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 1500
       moles:
         - 0 # oxygen
         - 18710.71051 # nitrogen
@@ -322,11 +322,11 @@
         - state: black
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 1500
         moles:
           - 0 # oxygen
           - 0 # nitrogen
-          - 1871.71051 # CO2
+          - 2769.36 # CO2
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -362,7 +362,7 @@
   components:
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 1500
       moles:
         - 0 # oxygen
         - 0 # nitrogen
@@ -382,12 +382,12 @@
         - state: orange
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 1500
         moles:
           - 0 # oxygen
           - 0 # nitrogen
           - 0 # carbon dioxide
-          - 1871.71051 # plasma
+          - 2769.36 # plasma
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -426,13 +426,13 @@
         - state: green
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 1500
         moles:
           - 0 # oxygen
           - 0 # nitrogen
           - 0 # CO2
           - 0 # Plasma
-          - 1871.71051 # Tritium
+          - 2769.36 # Tritium
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -471,14 +471,14 @@
         - state: water_vapor
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 1500
         moles:
           - 0 # oxygen
           - 0 # nitrogen
           - 0 # CO2
           - 0 # Plasma
           - 0 # Tritium
-          - 1871.71051 # Water vapor
+          - 2769.36 # Water vapor
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -515,7 +515,7 @@
         - state: greenys
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 1500
         moles:
           - 0 # oxygen
           - 0 # nitrogen
@@ -523,7 +523,7 @@
           - 0 # Plasma
           - 0 # Tritium
           - 0 #  Water vapor
-          - 1871.71051 # Ammonia
+          - 2769.36 # Ammonia
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -562,7 +562,7 @@
         - state: redws
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 1500
         moles:
           - 0 # oxygen
           - 0 # nitrogen
@@ -571,7 +571,7 @@
           - 0 # Tritium
           - 0 #  Water vapor
           - 0 # Ammonia
-          - 1871.71051 # N2O
+          - 2769.36 # N2O
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -610,7 +610,7 @@
     - state: frezon
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 1500
       moles:
       - 0 # oxygen
       - 0 # nitrogen
@@ -620,7 +620,7 @@
       - 0 # Water vapor
       - 0 # Ammonia
       - 0 # N2O
-      - 1871.71051 # Frezon
+      - 2769.36 # Frezon
       temperature: 293.15
   - type: Destructible
     thresholds:


### PR DESCRIPTION
## About the PR
Gas canister volumes have been buffed to 1500 L. For reference, they used to have a volume of 1000 L. The volume of a standard tile is 2500 L.

The prices of these canisters have increased respectively, how they are still an attractive option.

## Why / Balance
Gas canisters are in a poor state when talking about player rewards. A player expects a gas tank to fill a very large air volume when dumped to the atmosphere! After all, they contain ~1871 mols of gas at 4500 kPa, 20C.

This is not the case. They currently only have enough volume to fill about 18 tiles. This is poor, as air grenades fill 30 tiles!

This PR buffs canisters so that regular air canisters at 4500 kPa can fill rooms (to 101.325 kPa) up to ~26 tiles. This makes these canisters an attractive option for refilling rooms quickly, as slogging that canister across the station, or buying them from Atmospherics, pays off. Also note that oftentimes the goal of hastily dumping a canister is to not fill the room up to a perfect, livable atmosphere, but to fill it to the point where people stop taking extreme barotrauma damage.

Do note that Atmospheric Technicians can fill these canisters up to 9000 kPa using a volumetric pump, enabling even higher molar amounts, leading to more tiles filled!

This PR is an alternative to another PR that extremely buffs canisters beyond the capacity of a standard tile and introduces mini canisters, which I think is unrealistic and too extreme of a buff, when Atmospherics can simply fill their cans to a higher pressure.

## Technical details
YAML

## Media
Not necessary, but I did testing

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: The volume of large gas canisters have been increased to 1500L to encourage their usage in resolving pressure problems in spaced rooms. The gas that starts inside of the tanks and the price of them has increased to compensate.