### PR TITLE
cleanup atmos air grenade code

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ReleaseGasOnTriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ReleaseGasOnTriggerSystem.cs
@@ -66,20 +66,7 @@ public sealed partial class ReleaseGasOnTriggerSystem : SharedReleaseGasOnTrigge
                 RemCompDeferred<ReleaseGasOnTriggerComponent>(uid);
                 continue;
             }
-
-            if (comp.ExponentialRise)
-                UpdateExponentialRise(comp, comp.RemoveFraction);
         }
-    }
-
-    /// <summary>
-    /// Updates the RemoveFraction for exponential rise.
-    /// </summary>
-    /// <remarks>See https://www.desmos.com/calculator/fx9gfrhoim</remarks>
-    private static void UpdateExponentialRise(ReleaseGasOnTriggerComponent comp, float baseFraction)
-    {
-        comp.TimesReleased++;
-        comp.RemoveFraction = 1f - MathF.Pow(1f - baseFraction, comp.TimesReleased);
     }
 
     private void UpdateAppearance(Entity<AppearanceComponent?> entity, bool state)
@@ -87,6 +74,6 @@ public sealed partial class ReleaseGasOnTriggerSystem : SharedReleaseGasOnTrigge
         if (!Resolve(entity, ref entity.Comp, false))
             return;
 
-        _appearance.SetData(entity, ReleaseGasOnTriggerComponent.ReleaseGasOnTriggerVisuals.Key, state);
+        _appearance.SetData(entity, ReleaseGasOnTriggerVisuals.Key, state);
     }
 }

--- a/Content.Shared/Explosion/Components/OnTrigger/ReleaseGasOnTriggerComponent.cs
+++ b/Content.Shared/Explosion/Components/OnTrigger/ReleaseGasOnTriggerComponent.cs
@@ -15,16 +15,6 @@ namespace Content.Shared.Explosion.Components.OnTrigger;
 public sealed partial class ReleaseGasOnTriggerComponent : Component
 {
     /// <summary>
-    /// Represents visual states for whatever visuals that need to be applied
-    /// on state changes.
-    /// </summary>
-    [Serializable] [NetSerializable]
-    public enum ReleaseGasOnTriggerVisuals : byte
-    {
-        Key,
-    }
-
-    /// <summary>
     /// Whether this grenade is active and releasing gas.
     /// Set to true when triggered, which starts gas release.
     /// </summary>
@@ -38,12 +28,6 @@ public sealed partial class ReleaseGasOnTriggerComponent : Component
     public GasMixture Air;
 
     /// <summary>
-    /// If true, the gas will be released in an exponential manner.
-    /// </summary>
-    [DataField]
-    public bool ExponentialRise;
-
-    /// <summary>
     /// Time at which the next release will occur.
     /// This is automatically set when the grenade activates.
     /// </summary>
@@ -53,7 +37,7 @@ public sealed partial class ReleaseGasOnTriggerComponent : Component
 
     /// <summary>
     /// The cap at which this grenade can fill the exposed atmosphere to.
-    /// The grenade automatically deletes itself when the pressure is reached.
+    /// This component automatically removes itself when the pressure limit is reached.
     /// </summary>
     /// <example>If set to 101.325, the grenade will only fill the exposed
     /// atmosphere up to 101.325 kPa.</example>
@@ -83,11 +67,14 @@ public sealed partial class ReleaseGasOnTriggerComponent : Component
     /// <remarks>Set when the grenade is activated.</remarks>
     [DataField(readOnly: true)]
     public float StartingTotalMoles;
+}
 
-    /// <summary>
-    /// Stores the number of times the grenade has been released,
-    /// for exponential rise calculations.
-    /// </summary>
-    [DataField]
-    public int TimesReleased;
+/// <summary>
+/// Represents visual states for whatever visuals that need to be applied
+/// on state changes.
+/// </summary>
+[Serializable, NetSerializable]
+public enum ReleaseGasOnTriggerVisuals : byte
+{
+    Key,
 }


### PR DESCRIPTION
## About the PR
Small follow up to https://github.com/space-wizards/space-station-14/pull/37531

## Why / Balance
code cleanup

## Technical details
Moves the enum out of the component.
Fixes a code comment that was out of date.
Removes the exponential rise code, simplifying the system. This was already discussed in discord, I should have made a change request in time.
This code was originally introduced because the total moles in the grenade were getting lower with each gas release and the exponential increase intended to compensate that. But since we are already storing and using the original amount, `Remove` will already release a constant amount of gas each tick as intended. See the screenshots below.

## Media
![1](https://github.com/user-attachments/assets/ad474964-196f-45b6-93ec-fa4955876c93)
![2](https://github.com/user-attachments/assets/39a4f3fc-ac9c-47af-aec0-ae2c9dfeb3eb)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Removed the `ExponentialRise` and `TimesReleased` from `ReleaseGasOnTriggerComponent`.
I doubt anyone has been using these since it just got merged.

**Changelog**
nope
