### PR TITLE
Fixed talking when sleeping while on crit

### DIFF
--- a/Content.Server/Damage/ForceSay/DamageForceSaySystem.cs
+++ b/Content.Server/Damage/ForceSay/DamageForceSaySystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Damage.Events;
 using Content.Shared.Damage.ForceSay;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Stunnable;
 using Robust.Shared.Player;
@@ -85,6 +86,9 @@ public sealed class DamageForceSaySystem : EntitySystem
     private void OnSleep(EntityUid uid, DamageForceSayComponent component, SleepStateChangedEvent args)
     {
         if (!args.FellAsleep)
+            return;
+
+        if (Comp<MobStateComponent>(uid).CurrentState != MobState.Alive)
             return;
 
         TryForceSay(uid, component);

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -140,7 +140,9 @@ public sealed partial class SleepingSystem : EntitySystem
 
     private void OnSpeakAttempt(Entity<SleepingComponent> ent, ref SpeakAttemptEvent args)
     {
-        // TODO reduce duplication of this behavior with MobStateSystem somehow
+        if (Comp<MobStateComponent>(ent).CurrentState != MobState.Alive)
+            args.Cancel();
+
         if (HasComp<AllowNextCritSpeechComponent>(ent))
         {
             RemCompDeferred<AllowNextCritSpeechComponent>(ent);

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -140,9 +140,6 @@ public sealed partial class SleepingSystem : EntitySystem
 
     private void OnSpeakAttempt(Entity<SleepingComponent> ent, ref SpeakAttemptEvent args)
     {
-        if (Comp<MobStateComponent>(ent).CurrentState != MobState.Alive)
-            args.Cancel();
-
         if (HasComp<AllowNextCritSpeechComponent>(ent))
         {
             RemCompDeferred<AllowNextCritSpeechComponent>(ent);


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Fixed bug where a crited player could talk if used the sleep action

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix

## Technical details
<!-- Summary of code changes for easier review. -->
I changed SleepingSystem, added two lines to check if the MobState is "Alive" on OnSpeakAttempt method

## Media
https://github.com/user-attachments/assets/f1d227ce-32fb-422a-86ad-535de3367ab3

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Falling asleep while crit will no longer cause you to say whatever is typed in your chatbox.
