### PR TITLE
Fix weather audio persisting even when associated comp is deleted

### DIFF
--- a/Content.Client/Weather/WeatherSystem.cs
+++ b/Content.Client/Weather/WeatherSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Numerics;
 using Content.Shared.Light.Components;
 using Content.Shared.Weather;
@@ -24,6 +25,7 @@ public sealed class WeatherSystem : SharedWeatherSystem
     {
         base.Initialize();
         SubscribeLocalEvent<WeatherComponent, ComponentHandleState>(OnWeatherHandleState);
+        SubscribeLocalEvent<WeatherComponent, ComponentShutdown>(OnWeatherRemoved);
     }
 
     protected override void Run(EntityUid uid, WeatherData weather, WeatherPrototype weatherProto, float frameTime)
@@ -136,6 +138,7 @@ public sealed class WeatherSystem : SharedWeatherSystem
         return true;
     }
 
+    private void OnWeatherRemoved(EntityUid uid, WeatherComponent component, ref ComponentShutdown args) => component.Weather.ToList().ForEach(w => EndWeather(uid, component, w.Key));
     private void OnWeatherHandleState(EntityUid uid, WeatherComponent component, ref ComponentHandleState args)
     {
         if (args.Current is not WeatherComponentState state)

--- a/Content.Shared/Weather/SharedWeatherSystem.cs
+++ b/Content.Shared/Weather/SharedWeatherSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Shared.Light.Components;
 using Content.Shared.Light.EntitySystems;
 using Content.Shared.Maps;
@@ -27,6 +28,7 @@ public abstract class SharedWeatherSystem : EntitySystem
     {
         base.Initialize();
         _blockQuery = GetEntityQuery<BlockWeatherComponent>();
+
         SubscribeLocalEvent<WeatherComponent, EntityUnpausedEvent>(OnWeatherUnpaused);
     }
 
@@ -216,9 +218,9 @@ public abstract class SharedWeatherSystem : EntitySystem
         if (!component.Weather.TryGetValue(proto, out var data))
             return;
 
-        _audio.Stop(data.Stream);
-        data.Stream = null;
         component.Weather.Remove(proto);
+        _audio.SetState(data.Stream, Robust.Shared.Audio.Components.AudioState.Stopped, true); // _audio.Stop(); is cooked here and doesn't work
+        data.Stream = null;
         Dirty(uid, component);
     }
 


### PR DESCRIPTION
## About the PR
See title
fix also applies for weather audio persisting when leaving maps with weather that get deleted right after you leave (aka expeds)

## Why / Balance
bugfix
Fixes #35081

## Technical details
added OnWeatherRemoved on weathersystem: calls EndWeather when the comp is shutting down
and changed a call for SharedAudioSys from .Stop(EntUid stream) to .SetState(EntUid stream, AudioState.Stopped) [i had to do it]

## Media
n/a

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
