### PR TITLE
Fix stripping window for more than 2 hands

### DIFF
--- a/Content.Client/Strip/StrippingMenu.cs
+++ b/Content.Client/Strip/StrippingMenu.cs
@@ -8,7 +8,7 @@ namespace Content.Client.Strip
     public sealed class StrippingMenu : DefaultWindow
     {
         public LayoutContainer InventoryContainer = new();
-        public BoxContainer HandsContainer = new() { Orientation = LayoutOrientation.Horizontal };
+        public LayoutContainer HandsContainer = new();
         public BoxContainer SnareContainer = new();
         public bool Dirty = true;
 


### PR DESCRIPTION
## About the PR
The stripping window UI was previously completely messed up for anything with more than 2 hands.
Needed for 4 handed arachnids.

## Why / Balance
bugfix

## Technical details
Replaced the BoxContainer for the hands with a Layout container so they no longer move around when rescaling the window and have the same spacing as the rest of the inventory.
`InvalidateMeasure` is still broken for `Layoutcontainers` so I replaced the existing bandaid with a more elaborate one. We count the number or rows and columns and resize the window accordingly instead of giving it a constant value.

## Media
Before:
![1](https://github.com/user-attachments/assets/9993c7a3-9ecc-43a3-bd45-7acdb6bb3d5f)
![2](https://github.com/user-attachments/assets/28093bec-bbb3-4f9a-bfdf-517119d104f2)
After:
![3](https://github.com/user-attachments/assets/9fe02020-6cd9-4e66-8488-51ae217b5cdf)
![4](https://github.com/user-attachments/assets/2266e586-f1bf-4a9d-8be2-1377121ec9e8)
![5](https://github.com/user-attachments/assets/c6e8c76c-ec1d-4fa2-8759-235154c3abf5)
![6](https://github.com/user-attachments/assets/9a8b209a-ee15-403f-8f07-d900eefa6451)
(the borgi inventory is set up to have these locations, so not my fault it is so large, but the window shows all of them properly)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed the stripping UI layout when having more than 2 hands.
