### PR TITLE
Limit shuttle collision damage

### DIFF
--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -258,7 +258,7 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> ImpactSlowdown =
-        CVarDef.Create("shuttle.impact.slowdown", 0.8f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.impact.slowdown", 10f, CVar.SERVERONLY);
 
     /// <summary>
     /// Minimum velocity change from impact for special throw effects (e.g. stuns, beakers breaking) to occur

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -258,7 +258,7 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> ImpactSlowdown =
-        CVarDef.Create("shuttle.impact.slowdown", 10f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.impact.slowdown", 8f, CVar.SERVERONLY);
 
     /// <summary>
     /// Minimum velocity change from impact for special throw effects (e.g. stuns, beakers breaking) to occur


### PR DESCRIPTION
## About the PR
The velocity of a shuttle now gets reduced much more quickly, when destroying tiles. This means that high-speed ramming will make significantly "shallower" areas of destruction, but low-speed impacts don't get much less dangerous for your own ship than before

## Why / Balance
With a maximum velocity of 60, heavier ships could potentially delete an entire department's worth of the station. While this is _really cool_, it is generally not good for roundflow.

## Technical details
cvar adjustment

## Media
edit: Actual value was reduced to 8 so damage is somewhat higher than shown on the middle image

![ramming](https://github.com/user-attachments/assets/e2aaa0fc-4de5-4e3f-a51c-e0bf69cfddb4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
shuttle.impact.slowdown was increased from it's debut value of 0.8 to 10, greatly decreasing the potential maximum damage of a high-speed high-mass impact.

**Changelog**
:cl: Errant
- tweak: High-energy shuttle impacts now deal much less damage.
