### PR TITLE
Metabolism metabolizes all reagents, limits poisons only

### DIFF
--- a/Content.Server/Body/Components/MetabolizerComponent.cs
+++ b/Content.Server/Body/Components/MetabolizerComponent.cs
@@ -55,12 +55,12 @@ namespace Content.Server.Body.Components
         public bool RemoveEmpty = false;
 
         /// <summary>
-        ///     How many reagents can this metabolizer process at once?
+        ///     How many poisons can this metabolizer process at once?
         ///     Used to nerf 'stacked poisons' where having 5+ different poisons in a syringe, even at low
         ///     quantity, would be muuuuch better than just one poison acting.
         /// </summary>
-        [DataField("maxReagents")]
-        public int MaxReagentsProcessable = 3;
+        [DataField]
+        public int MaxPoisons = 3;
 
         /// <summary>
         ///     A list of metabolism groups that this metabolizer will act on, in order of precedence.

--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -165,7 +165,7 @@ namespace Content.Server.Body.Systems
                 }
 
                 // Already processed all poisons, skip to the next reagent.
-                if (poisons >= ent.Comp1.MaxPoisons && proto.Metabolisms.ContainsKey(PoisonGroup))
+                if (poisons > ent.Comp1.MaxPoisons && proto.Metabolisms.ContainsKey(PoisonGroup))
                     continue;
 
 

--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -28,6 +28,7 @@ namespace Content.Server.Body.Systems
 
         private EntityQuery<OrganComponent> _organQuery;
         private EntityQuery<SolutionContainerManagerComponent> _solutionQuery;
+        private static readonly string PoisonGroup = "Poison";
 
         public override void Initialize()
         {
@@ -146,7 +147,7 @@ namespace Content.Server.Body.Systems
             var list = solution.Contents.ToArray();
             _random.Shuffle(list);
 
-            int reagents = 0;
+            int poisons = 0;
             foreach (var (reagent, quantity) in list)
             {
                 if (!_prototypeManager.TryIndex<ReagentPrototype>(reagent.Prototype, out var proto))
@@ -163,9 +164,9 @@ namespace Content.Server.Body.Systems
                     continue;
                 }
 
-                // we're done here entirely if this is true
-                if (reagents >= ent.Comp1.MaxReagentsProcessable)
-                    return;
+                // Already processed all poisons, skip to the next reagent.
+                if (poisons >= ent.Comp1.MaxPoisons && proto.Metabolisms.ContainsKey(PoisonGroup))
+                    continue;
 
 
                 // loop over all our groups and see which ones apply
@@ -223,8 +224,9 @@ namespace Content.Server.Body.Systems
                 {
                     solution.RemoveReagent(reagent, mostToRemove);
 
-                    // We have processed a reagant, so count it towards the cap
-                    reagents += 1;
+                    // We have processed a poison, so count it towards the cap
+                    if (proto.Metabolisms.ContainsKey(PoisonGroup))
+                        poisons++;
                 }
             }
 

--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -84,7 +84,7 @@
           Quantity: 5
   - type: Stomach
   - type: Metabolizer
-    maxReagents: 3
+    maxPoisons: 3
     metabolizerTypes: [ Animal ]
     groups:
     - id: Food
@@ -117,7 +117,7 @@
     state: liver
   - type: Organ
   - type: Metabolizer
-    maxReagents: 1
+    maxPoisons: 1
     metabolizerTypes: [ Animal ]
     groups:
     - id: Alcohol
@@ -136,7 +136,7 @@
     state: heart-on
   - type: Organ
   - type: Metabolizer
-    maxReagents: 2
+    maxPoisons: 2
     metabolizerTypes: [ Animal ]
     groups:
     - id: Medicine
@@ -158,7 +158,7 @@
     - state: kidney-r
   - type: Organ
   - type: Metabolizer
-    maxReagents: 5
+    maxPoisons: 5
     metabolizerTypes: [ Animal ]
     removeEmpty: true
   - type: Item

--- a/Resources/Prototypes/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/slimes.yml
@@ -9,7 +9,7 @@
       state: brain-slime
     - type: Stomach
     - type: Metabolizer
-      maxReagents: 3
+      maxPoisons: 3
       metabolizerTypes: [ Slime ]
       removeEmpty: true
       groups:

--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -99,7 +99,7 @@
     heldPrefix: heart
   - type: Metabolizer
     updateInterval: 1.5
-    maxReagents: 2
+    maxPoisons: 2
     metabolizerTypes: [Arachnid]
     groups:
     - id: Medicine
@@ -120,7 +120,7 @@
     state: liver
   - type: Metabolizer # The liver metabolizes certain chemicals only, like alcohol.
     updateInterval: 1.5
-    maxReagents: 1
+    maxPoisons: 1
     metabolizerTypes: [Animal]
     groups:
     - id: Alcohol
@@ -143,7 +143,7 @@
     heldPrefix: kidneys
   - type: Metabolizer
     updateInterval: 1.5
-    maxReagents: 5
+    maxPoisons: 5
     metabolizerTypes: [Animal]
     removeEmpty: true
 

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -82,7 +82,7 @@
           Quantity: 5
   - type: Stomach
   - type: Metabolizer
-    maxReagents: 6
+    maxPoisons: 6
     metabolizerTypes: [ Plant ]
     removeEmpty: true
     groups:
@@ -108,7 +108,7 @@
   - type: Item
     size: Small
     heldPrefix: lungs
-  - type: Lung 
+  - type: Lung
   - type: Metabolizer
     removeEmpty: true
     solutionOnBody: false
@@ -137,7 +137,7 @@
   description: "The source of incredible, unending intelligence. Honk."
   components:
   - type: Brain
-  - type: Nymph # This will make the organs turn into a nymph when they're removed. 
+  - type: Nymph # This will make the organs turn into a nymph when they're removed.
     entityPrototype: OrganDionaNymphBrain
     transferMind: true
 
@@ -176,11 +176,11 @@
 
 - type: entity
   id: OrganDionaNymphStomach
-  parent: MobDionaNymphAccent 
+  parent: MobDionaNymphAccent
   categories: [ HideSpawnMenu ]
   name: diona nymph
   suffix: Stomach
-  description: Contains the stomach of a formerly fully-formed Diona. It doesn't taste any better for it. 
+  description: Contains the stomach of a formerly fully-formed Diona. It doesn't taste any better for it.
   components:
   - type: IsDeadIC
   - type: Body
@@ -192,7 +192,7 @@
   categories: [ HideSpawnMenu ]
   name: diona nymph
   suffix: Lungs
-  description: Contains the lungs of a formerly fully-formed Diona. Breathtaking. 
+  description: Contains the lungs of a formerly fully-formed Diona. Breathtaking.
   components:
   - type: IsDeadIC
   - type: Body

--- a/Resources/Prototypes/Body/Organs/dwarf.yml
+++ b/Resources/Prototypes/Body/Organs/dwarf.yml
@@ -34,5 +34,5 @@
   - type: Stomach
   - type: Metabolizer
     # mm very yummy
-    maxReagents: 5
+    maxPoisons: 5
     metabolizerTypes: [Dwarf]

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -74,7 +74,7 @@
   - type: Item
     size: Small
     heldPrefix: brain
-  
+
 - type: entity
   id: OrganHumanEyes
   parent: BaseHumanOrgan
@@ -167,7 +167,7 @@
   # This is done because these chemicals need to have some effect even if they aren't being filtered out of your body.
   # You're technically 'immune to poison' without a heart, but.. uhh, you'll have bigger problems on your hands.
   - type: Metabolizer
-    maxReagents: 2
+    maxPoisons: 2
     metabolizerTypes: [Human]
     groups:
     - id: Medicine
@@ -203,7 +203,7 @@
   # to intestines instead.
   - type: Metabolizer
     # mm yummy
-    maxReagents: 3
+    maxPoisons: 3
     metabolizerTypes: [Human]
     groups:
     - id: Food
@@ -221,7 +221,7 @@
     size: Small
     heldPrefix: liver
   - type: Metabolizer # The liver metabolizes certain chemicals only, like alcohol.
-    maxReagents: 1
+    maxPoisons: 1
     metabolizerTypes: [Human]
     groups:
     - id: Alcohol
@@ -242,6 +242,6 @@
     heldPrefix: kidneys
   # The kidneys just remove anything that doesn't currently have any metabolisms, as a stopgap.
   - type: Metabolizer
-    maxReagents: 5
+    maxPoisons: 5
     metabolizerTypes: [Human]
     removeEmpty: true

--- a/Resources/Prototypes/Body/Organs/moth.yml
+++ b/Resources/Prototypes/Body/Organs/moth.yml
@@ -19,7 +19,7 @@
         - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: Metabolizer
-    maxReagents: 3
+    maxPoisons: 3
     metabolizerTypes: [ Moth ]
     removeEmpty: true
     groups:

--- a/Resources/Prototypes/Body/Organs/slime.yml
+++ b/Resources/Prototypes/Body/Organs/slime.yml
@@ -9,7 +9,7 @@
       state: brain-slime
     - type: Stomach
     - type: Metabolizer
-      maxReagents: 6
+      maxPoisons: 6
       metabolizerTypes: [ Slime ]
       removeEmpty: true
       groups:
@@ -37,7 +37,7 @@
       size: Small
       heldPrefix: brain
 
-      
+
 - type: entity
   id: OrganSlimeLungs
   parent: BaseHumanOrgan


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Atomized out of #37580

Metabolizers now metabolize all reagents, instead limiting the amount of different poisons that can be metabolized at a time.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
`Used to nerf 'stacked poisons' where having 5+ different poisons in a syringe, even at low quantity, would be muuuuch better than just one poison acting.`
This was the original intention behind MaxReagents. So why limit the amount of reagents and not by poison?
This is a very minor change and probably wont even be noticable.

## Technical details
<!-- Summary of code changes for easier review. -->
Renamed MaxReagents to MaxPoisons. Only count reagents in MaxReagents if they are in the Poison group.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/405aa3c5-904a-4bfb-b05c-80b7c4adb1fd

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`MaxReagentsProcessable` field in MetabolizerComponent has been renamed to `MaxPoisons`.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: neuPanda
- tweak: Metabolism now metabolizes all reagents at once, only limiting the amount of poisons.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
