### PR TITLE
reduced motion flash effect version 2

### DIFF
--- a/Content.Client/Flash/FlashOverlay.cs
+++ b/Content.Client/Flash/FlashOverlay.cs
@@ -1,8 +1,10 @@
+using Content.Shared.CCVar;
 using Content.Shared.Flash;
 using Content.Shared.Flash.Components;
 using Content.Shared.StatusEffect;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -15,21 +17,36 @@ namespace Content.Client.Flash
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
+        [Dependency] private readonly IConfigurationManager _configManager = default!;
 
         private readonly SharedFlashSystem _flash;
         private readonly StatusEffectsSystem _statusSys;
 
+        // time scale for the rotation speed of the shader, used for the reduced motion setting
+        // 1: normal effect
+        // 0: no movement
+        private float _timeScale;
+
         public override OverlaySpace Space => OverlaySpace.WorldSpace;
         private readonly ShaderInstance _shader;
         public float PercentComplete = 0.0f;
+        public float Phase = 0.0f;
         public Texture? ScreenshotTexture;
 
         public FlashOverlay()
         {
             IoCManager.InjectDependencies(this);
+
             _shader = _prototypeManager.Index<ShaderPrototype>("FlashedEffect").InstanceUnique();
             _flash = _entityManager.System<SharedFlashSystem>();
             _statusSys = _entityManager.System<StatusEffectsSystem>();
+
+            _configManager.OnValueChanged(CCVars.ReducedMotion, OnReducedMotionChanged, invokeImmediately: true);
+        }
+
+        private void OnReducedMotionChanged(bool reducedMotion)
+        {
+            _timeScale = reducedMotion ? 0.0f : 1.0f;
         }
 
         protected override void FrameUpdate(FrameEventArgs args)
@@ -47,8 +64,8 @@ namespace Content.Client.Flash
                 return;
 
             var curTime = _timing.CurTime;
-            var lastsFor = (float) (time.Value.Item2 - time.Value.Item1).TotalSeconds;
-            var timeDone = (float) (curTime - time.Value.Item1).TotalSeconds;
+            var lastsFor = (float)(time.Value.Item2 - time.Value.Item1).TotalSeconds;
+            var timeDone = (float)(curTime - time.Value.Item1).TotalSeconds;
 
             PercentComplete = timeDone / lastsFor;
         }
@@ -75,6 +92,8 @@ namespace Content.Client.Flash
 
             var worldHandle = args.WorldHandle;
             _shader.SetParameter("percentComplete", PercentComplete);
+            _shader.SetParameter("timeScale", _timeScale); // rotation speed
+            _shader.SetParameter("phase", Phase); // random starting phase
             worldHandle.UseShader(_shader);
             worldHandle.DrawTextureRectRegion(ScreenshotTexture, args.WorldBounds);
             worldHandle.UseShader(null);

--- a/Content.Client/Flash/FlashSystem.cs
+++ b/Content.Client/Flash/FlashSystem.cs
@@ -1,9 +1,9 @@
 using Content.Shared.Flash;
 using Content.Shared.Flash.Components;
-using Content.Shared.StatusEffect;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Player;
+using Robust.Shared.Random;
 
 namespace Content.Client.Flash;
 
@@ -11,6 +11,7 @@ public sealed class FlashSystem : SharedFlashSystem
 {
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     private FlashOverlay _overlay = default!;
 
@@ -43,6 +44,7 @@ public sealed class FlashSystem : SharedFlashSystem
         if (_player.LocalEntity == uid)
         {
             _overlay.RequestScreenTexture = true;
+            _overlay.Phase = _random.NextFloat(MathF.Tau); // random starting phase for movement effect
             _overlayMan.AddOverlay(_overlay);
         }
     }

--- a/Resources/Textures/Shaders/flashed_effect.swsl
+++ b/Resources/Textures/Shaders/flashed_effect.swsl
@@ -1,4 +1,13 @@
-﻿uniform highp float percentComplete;
+﻿// progress of the status effect
+// between 0 and 1
+uniform highp float percentComplete;
+// How fast to do the rotating motion.
+// 1 for normal effect.
+// 0 for the reduced motion setting.
+uniform highp float timeScale;
+// starting phase for the rotation effect
+// needed so it doesn't always look the same for 0 motion
+uniform highp float phase;
 const highp float fadeFalloffExp = 8.0;
 
 void fragment() {
@@ -6,8 +15,9 @@ void fragment() {
     highp float remaining = -pow(percentComplete, fadeFalloffExp) + 1.0;
 
     // Two ghost textures that spin around the character
-    highp vec4 tex1 = zTexture(vec2(UV.x + (0.02) * sin(TIME * 3.0), UV.y + (0.02) * cos(TIME * 3.0)));
-    highp vec4 tex2 = zTexture(vec2(UV.x + (0.01) * sin(TIME * 2.0), UV.y + (0.01) * cos(TIME * 2.0)));
+    highp float time = TIME * timeScale + phase;
+    highp vec4 tex1 = zTexture(vec2(UV.x + (0.02) * sin(time * 3.0), UV.y + (0.02) * cos(time * 3.0)));
+    highp vec4 tex2 = zTexture(vec2(UV.x + (0.01) * sin(time * 2.0), UV.y + (0.01) * cos(time * 2.0)));
 
     highp vec4 textureMix = mix(tex1, tex2, 0.5);
 


### PR DESCRIPTION
## About the PR
Based on the work of Quantum-cross in this PR https://github.com/space-wizards/space-station-14/pull/36288
In the internal maintainer discussion we don't want two completely different shaders for this for future maintainability and to make sure players can't get a combat advantage from the setting.

## Why / Balance
Accessibility feature

## Technical details
Instead of adding a completely new shader this PR just adds a timescale to the rotating motion in the shader.
To prevent it from looking the same each time we also add a random phase to the sin/cos functions.

## Media

https://github.com/user-attachments/assets/f129470c-f850-42be-86c2-26b54652e9a2



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Quantum-cross, slarticodefast
- add: Add reduced motion alternative to the flash effect
