### PR TITLE
remove ignition functional from welder component

### DIFF
--- a/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
+++ b/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Atmos.EntitySystems;
 using Content.Shared.IgnitionSource;
 
 namespace Content.Server.IgnitionSource;
+
 public sealed partial class IgnitionSourceSystem : SharedIgnitionSourceSystem
 {
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;

--- a/Content.Server/Tools/ToolSystem.cs
+++ b/Content.Server/Tools/ToolSystem.cs
@@ -1,8 +1,6 @@
-using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.FixedPoint;
 using Content.Shared.Tools.Components;
-using Robust.Server.GameObjects;
 
 using SharedToolSystem = Content.Shared.Tools.Systems.SharedToolSystem;
 
@@ -10,20 +8,6 @@ namespace Content.Server.Tools;
 
 public sealed class ToolSystem : SharedToolSystem
 {
-    [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
-    [Dependency] private readonly TransformSystem _transformSystem = default!;
-
-    public override void TurnOn(Entity<WelderComponent> entity, EntityUid? user)
-    {
-        base.TurnOn(entity, user);
-        var xform = Transform(entity);
-        if (xform.GridUid is { } gridUid)
-        {
-            var position = _transformSystem.GetGridOrMapTilePosition(entity.Owner, xform);
-            _atmosphereSystem.HotspotExpose(gridUid, position, 700, 50, entity.Owner, true);
-        }
-    }
-
     public override void Update(float frameTime)
     {
         base.Update(frameTime);

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
@@ -29,7 +29,7 @@ public abstract partial class SharedToolSystem
         SubscribeLocalEvent<WelderComponent, ItemToggleActivateAttemptEvent>(OnActivateAttempt);
     }
 
-    public virtual void TurnOn(Entity<WelderComponent> entity, EntityUid? user)
+    public void TurnOn(Entity<WelderComponent> entity, EntityUid? user)
     {
         if (!SolutionContainerSystem.TryGetSolution(entity.Owner, entity.Comp.FuelSolutionName, out var solutionComp, out _))
             return;


### PR DESCRIPTION
## About the PR
Technical pr, removed one event.

## Why / Balance
this isn't void, isn't method, isn't event. This is trolling, literally ZERO reasons for welder component leave fixed amount of heat per tick when we have IgnitionSourceSystem and component togglers.

## Media

https://github.com/user-attachments/assets/30f02358-a880-4842-84e0-ae078ff412e3

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
WelderComponent no longer ignite gas. Use IgnitionSourceComponent instead of it.

**Changelog**
:cl: