### PR TITLE
specify indent_size for `meta.json` files in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -357,3 +357,6 @@ indent_size = 2
 
 [{*.yaml,*.yml}]
 ij_yaml_indent_sequence_value = false
+
+[meta.json]
+indent_size = 2


### PR DESCRIPTION
## About the PR

just change .editorconfig

## Why / Balance

`meta.json` files in RSIs are all over the place in terms of indentation. And by all over the place I mean it's either 2 or 4, we should pick one.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->


