### PR TITLE
Cleanup more `SpriteComponent` warnings (part 5)

### DIFF
--- a/Content.Client/Beam/BeamSystem.cs
+++ b/Content.Client/Beam/BeamSystem.cs
@@ -7,6 +7,8 @@ namespace Content.Client.Beam;
 
 public sealed class BeamSystem : SharedBeamSystem
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -21,11 +23,11 @@ public sealed class BeamSystem : SharedBeamSystem
 
         if (TryComp<SpriteComponent>(beam, out var sprites))
         {
-            sprites.Rotation = args.UserAngle;
+            _sprite.SetRotation((beam, sprites), args.UserAngle);
 
             if (args.BodyState != null)
             {
-                sprites.LayerSetState(0, args.BodyState);
+                _sprite.LayerSetRsiState((beam, sprites), 0, args.BodyState);
                 sprites.LayerSetShader(0, args.Shader);
             }
         }

--- a/Content.Client/Bed/StasisBedSystem.cs
+++ b/Content.Client/Bed/StasisBedSystem.cs
@@ -10,7 +10,7 @@ public sealed class StasisBedSystem : VisualizerSystem<StasisBedVisualsComponent
         if (args.Sprite != null
             && AppearanceSystem.TryGetData<bool>(uid, StasisBedVisuals.IsOn, out var isOn, args.Component))
         {
-            args.Sprite.LayerSetVisible(StasisBedVisualLayers.IsOn, isOn);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), StasisBedVisualLayers.IsOn, isOn);
         }
     }
 }

--- a/Content.Client/Botany/PotencyVisualsSystem.cs
+++ b/Content.Client/Botany/PotencyVisualsSystem.cs
@@ -15,7 +15,7 @@ public sealed class PotencyVisualsSystem : VisualizerSystem<PotencyVisualsCompon
         if (AppearanceSystem.TryGetData<float>(uid, ProduceVisuals.Potency, out var potency, args.Component))
         {
             var scale = MathHelper.Lerp(component.MinimumScale, component.MaximumScale, potency / 100);
-            args.Sprite.Scale = new Vector2(scale, scale);
+            SpriteSystem.SetScale((uid, args.Sprite), new Vector2(scale, scale));
         }
     }
 }

--- a/Content.Client/CardboardBox/CardboardBoxSystem.cs
+++ b/Content.Client/CardboardBox/CardboardBoxSystem.cs
@@ -13,6 +13,7 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private EntityQuery<BodyComponent> _bodyQuery;
 
@@ -74,7 +75,7 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
             if (!xformQuery.TryGetComponent(ent, out var entTransform) || !TryComp<SpriteComponent>(ent, out var sprite))
                 continue;
 
-            sprite.Offset = new Vector2(0, 1);
+            _sprite.SetOffset((ent, sprite), new Vector2(0, 1));
             _transform.SetParent(ent, entTransform, mob);
         }
 

--- a/Content.Client/Cargo/Systems/CargoSystem.Telepad.cs
+++ b/Content.Client/Cargo/Systems/CargoSystem.Telepad.cs
@@ -10,6 +10,7 @@ namespace Content.Client.Cargo.Systems;
 public sealed partial class CargoSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private static readonly Animation CargoTelepadBeamAnimation = new()
     {
@@ -80,12 +81,12 @@ public sealed partial class CargoSystem
                     _player.Play((uid, player), CargoTelepadBeamAnimation, TelepadBeamKey);
                 break;
             case CargoTelepadState.Unpowered:
-                sprite.LayerSetVisible(CargoTelepadLayers.Beam, false);
+                _sprite.LayerSetVisible((uid, sprite), CargoTelepadLayers.Beam, false);
                 _player.Stop(uid, player, TelepadBeamKey);
                 _player.Stop(uid, player, TelepadIdleKey);
                 break;
             default:
-                sprite.LayerSetVisible(CargoTelepadLayers.Beam, true);
+                _sprite.LayerSetVisible((uid, sprite), CargoTelepadLayers.Beam, true);
 
                 if (_player.HasRunningAnimation(uid, player, TelepadIdleKey) ||
                     _player.HasRunningAnimation(uid, player, TelepadBeamKey))

--- a/Content.Client/Chasm/ChasmFallingVisualsSystem.cs
+++ b/Content.Client/Chasm/ChasmFallingVisualsSystem.cs
@@ -11,6 +11,7 @@ namespace Content.Client.Chasm;
 public sealed class ChasmFallingVisualsSystem : EntitySystem
 {
     [Dependency] private readonly AnimationPlayerSystem _anim = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private readonly string _chasmFallAnimationKey = "chasm_fall";
 
@@ -46,7 +47,7 @@ public sealed class ChasmFallingVisualsSystem : EntitySystem
         if (!TryComp<SpriteComponent>(uid, out var sprite))
             return;
 
-        sprite.Scale = component.OriginalScale;
+        _sprite.SetScale((uid, sprite), component.OriginalScale);
 
         if (!TryComp<AnimationPlayerComponent>(uid, out var player))
             return;

--- a/Content.Client/Chemistry/Visualizers/FoamVisualizerSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/FoamVisualizerSystem.cs
@@ -11,6 +11,7 @@ namespace Content.Client.Chemistry.Visualizers;
 public sealed class FoamVisualizerSystem : VisualizerSystem<FoamVisualsComponent>
 {
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -71,7 +72,7 @@ public sealed class FoamVisualizerSystem : VisualizerSystem<FoamVisualsComponent
             return;
 
         if (TryComp<SpriteComponent>(uid, out var sprite))
-            sprite.Visible = false;
+            _sprite.SetVisible((uid, sprite), false);
     }
 }
 

--- a/Content.Client/Delivery/DeliveryVisualizerSystem.cs
+++ b/Content.Client/Delivery/DeliveryVisualizerSystem.cs
@@ -9,7 +9,6 @@ public sealed class DeliveryVisualizerSystem : VisualizerSystem<DeliveryComponen
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
-    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private static readonly ProtoId<JobIconPrototype> UnknownIcon = "JobIconUnknown";
 
@@ -25,11 +24,11 @@ public sealed class DeliveryVisualizerSystem : VisualizerSystem<DeliveryComponen
 
         if (!_prototype.TryIndex<JobIconPrototype>(job, out var icon))
         {
-            args.Sprite.LayerSetTexture(DeliveryVisualLayers.JobStamp, _sprite.Frame0(_prototype.Index("JobIconUnknown")));
+            SpriteSystem.LayerSetTexture((uid, args.Sprite), DeliveryVisualLayers.JobStamp, SpriteSystem.Frame0(_prototype.Index("JobIconUnknown")));
             return;
         }
 
-        args.Sprite.LayerSetTexture(DeliveryVisualLayers.JobStamp, _sprite.Frame0(icon.Icon));
+        SpriteSystem.LayerSetTexture((uid, args.Sprite), DeliveryVisualLayers.JobStamp, SpriteSystem.Frame0(icon.Icon));
     }
 }
 

--- a/Content.Client/Doors/FirelockSystem.cs
+++ b/Content.Client/Doors/FirelockSystem.cs
@@ -8,6 +8,7 @@ namespace Content.Client.Doors;
 public sealed class FirelockSystem : SharedFirelockSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -18,7 +19,7 @@ public sealed class FirelockSystem : SharedFirelockSystem
     protected override void OnComponentStartup(Entity<FirelockComponent> ent, ref ComponentStartup args)
     {
         base.OnComponentStartup(ent, ref args);
-        if(!TryComp<DoorComponent>(ent.Owner, out var door))
+        if (!TryComp<DoorComponent>(ent.Owner, out var door))
             return;
 
         door.ClosedSpriteStates.Add((DoorVisualLayers.BaseUnlit, ent.Comp.WarningLightSpriteState));
@@ -57,7 +58,7 @@ public sealed class FirelockSystem : SharedFirelockSystem
             ||  state == DoorState.Denying
             || (_appearanceSystem.TryGetData<bool>(uid, DoorVisuals.ClosedLights, out var closedLights, args.Component) && closedLights);
 
-        args.Sprite.LayerSetVisible(DoorVisualLayers.BaseUnlit, unlitVisible && !boltedVisible);
-        args.Sprite.LayerSetVisible(DoorVisualLayers.BaseBolted, boltedVisible);
+        _sprite.LayerSetVisible((uid, args.Sprite), DoorVisualLayers.BaseUnlit, unlitVisible && !boltedVisible);
+        _sprite.LayerSetVisible((uid, args.Sprite), DoorVisualLayers.BaseBolted, boltedVisible);
     }
 }

--- a/Content.Client/Doors/TurnstileSystem.cs
+++ b/Content.Client/Doors/TurnstileSystem.cs
@@ -13,8 +13,9 @@ namespace Content.Client.Doors;
 public sealed class TurnstileSystem : SharedTurnstileSystem
 {
     [Dependency] private readonly AnimationPlayerSystem _animationPlayer = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
-    private static EntProtoId _examineArrow = "TurnstileArrow";
+    private static readonly EntProtoId ExamineArrow = "TurnstileArrow";
 
     private const string AnimationKey = "Turnstile";
 
@@ -33,12 +34,12 @@ public sealed class TurnstileSystem : SharedTurnstileSystem
 
         if (!TryComp<SpriteComponent>(ent, out var sprite))
             return;
-        sprite.LayerSetState(TurnstileVisualLayers.Base, new RSI.StateId(ent.Comp.DefaultState));
+        _sprite.LayerSetRsiState((ent.Owner, sprite), TurnstileVisualLayers.Base, new RSI.StateId(ent.Comp.DefaultState));
     }
 
     private void OnExamined(Entity<TurnstileComponent> ent, ref ExaminedEvent args)
     {
-        Spawn(_examineArrow, new EntityCoordinates(ent, 0, 0));
+        Spawn(ExamineArrow, new EntityCoordinates(ent, 0, 0));
     }
 
     protected override void PlayAnimation(EntityUid uid, string stateId)

--- a/Content.Client/Ghost/GhostToggleSelfVisibility.cs
+++ b/Content.Client/Ghost/GhostToggleSelfVisibility.cs
@@ -25,6 +25,7 @@ public sealed class GhostToggleSelfVisibility : IConsoleCommand
         if (!entityManager.TryGetComponent(attachedEntity, out SpriteComponent? spriteComponent))
             return;
 
-        spriteComponent.Visible = !spriteComponent.Visible;
+        var spriteSys = entityManager.System<SpriteSystem>();
+        spriteSys.SetVisible((attachedEntity.Value, spriteComponent), !spriteComponent.Visible);
     }
 }

--- a/Content.Client/Items/Systems/ItemSystem.cs
+++ b/Content.Client/Items/Systems/ItemSystem.cs
@@ -13,6 +13,7 @@ namespace Content.Client.Items.Systems;
 public sealed class ItemSystem : SharedItemSystem
 {
     [Dependency] private readonly IResourceCache _resCache = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -27,12 +28,12 @@ public sealed class ItemSystem : SharedItemSystem
 
     private void OnUnequipped(EntityUid uid, SpriteComponent component, GotUnequippedEvent args)
     {
-        component.Visible = true;
+        _sprite.SetVisible((uid, component), true);
     }
 
     private void OnEquipped(EntityUid uid, SpriteComponent component, GotEquippedEvent args)
     {
-        component.Visible = false;
+        _sprite.SetVisible((uid, component), false);
     }
 
     #region InhandVisuals
@@ -58,7 +59,7 @@ public sealed class ItemSystem : SharedItemSystem
         if (!item.InhandVisuals.TryGetValue(args.Location, out var layers))
         {
             // get defaults
-            if (!TryGetDefaultVisuals(uid, item, defaultKey,  out layers))
+            if (!TryGetDefaultVisuals(uid, item, defaultKey, out layers))
                 return;
         }
 

--- a/Content.Client/Jittering/JitteringSystem.cs
+++ b/Content.Client/Jittering/JitteringSystem.cs
@@ -10,6 +10,7 @@ namespace Content.Client.Jittering
     {
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly AnimationPlayerSystem _animationPlayer = default!;
+        [Dependency] private readonly SpriteSystem _sprite = default!;
 
         private readonly float[] _sign = { -1, 1 };
         private readonly string _jitterAnimationKey = "jittering";
@@ -40,12 +41,12 @@ namespace Content.Client.Jittering
                 _animationPlayer.Stop(uid, animationPlayer, _jitterAnimationKey);
 
             if (TryComp(uid, out SpriteComponent? sprite))
-                sprite.Offset = jittering.StartOffset;
+                _sprite.SetOffset((uid, sprite), jittering.StartOffset);
         }
 
         private void OnAnimationCompleted(EntityUid uid, JitteringComponent jittering, AnimationCompletedEvent args)
         {
-            if(args.Key != _jitterAnimationKey)
+            if (args.Key != _jitterAnimationKey)
                 return;
 
             if (!args.Finished)
@@ -59,7 +60,7 @@ namespace Content.Client.Jittering
         private Animation GetAnimation(JitteringComponent jittering, SpriteComponent sprite)
         {
             var amplitude = MathF.Min(4f, jittering.Amplitude / 100f + 1f) / 10f;
-            var offset = new Vector2(_random.NextFloat(amplitude/4f, amplitude),
+            var offset = new Vector2(_random.NextFloat(amplitude / 4f, amplitude),
                 _random.NextFloat(amplitude / 4f, amplitude / 3f));
 
             offset.X *= _random.Pick(_sign);

--- a/Content.Client/Kudzu/KudzuVisualizerSystem.cs
+++ b/Content.Client/Kudzu/KudzuVisualizerSystem.cs
@@ -13,8 +13,8 @@ public sealed class KudzuVisualsSystem : VisualizerSystem<KudzuVisualsComponent>
         if (AppearanceSystem.TryGetData<int>(uid, KudzuVisuals.Variant, out var var, args.Component)
             && AppearanceSystem.TryGetData<int>(uid, KudzuVisuals.GrowthLevel, out var level, args.Component))
         {
-            var index = args.Sprite.LayerMapReserveBlank(component.Layer);
-            args.Sprite.LayerSetState(index, $"kudzu_{level}{var}");
+            var index = SpriteSystem.LayerMapReserve((uid, args.Sprite), $"{component.Layer}");
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), index, $"kudzu_{level}{var}");
         }
     }
 }

--- a/Content.Client/Markers/MarkerSystem.cs
+++ b/Content.Client/Markers/MarkerSystem.cs
@@ -5,6 +5,8 @@ namespace Content.Client.Markers;
 
 public sealed class MarkerSystem : EntitySystem
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     private bool _markersVisible;
 
     public bool MarkersVisible
@@ -33,7 +35,7 @@ public sealed class MarkerSystem : EntitySystem
     {
         if (EntityManager.TryGetComponent(uid, out SpriteComponent? sprite))
         {
-            sprite.Visible = MarkersVisible;
+            _sprite.SetVisible((uid, sprite), MarkersVisible);
         }
     }
 

--- a/Content.Client/Movement/Systems/JetpackSystem.cs
+++ b/Content.Client/Movement/Systems/JetpackSystem.cs
@@ -16,6 +16,7 @@ public sealed class JetpackSystem : SharedJetpackSystem
     [Dependency] private readonly ClothingSystem _clothing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -34,7 +35,8 @@ public sealed class JetpackSystem : SharedJetpackSystem
         Appearance.TryGetData<bool>(uid, JetpackVisuals.Enabled, out var enabled, args.Component);
 
         var state = "icon" + (enabled ? "-on" : "");
-        args.Sprite?.LayerSetState(0, state);
+        if (args.Sprite != null)
+            _sprite.LayerSetRsiState((uid, args.Sprite), 0, state);
 
         if (TryComp<ClothingComponent>(uid, out var clothing))
             _clothing.SetEquippedPrefix(uid, enabled ? "on" : null, clothing);

--- a/Content.Client/Nutrition/EntitySystems/InfantSystem.cs
+++ b/Content.Client/Nutrition/EntitySystems/InfantSystem.cs
@@ -8,6 +8,8 @@ namespace Content.Client.Nutrition.EntitySystems;
 /// </summary>
 public sealed class InfantSystem : EntitySystem
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     /// <inheritdoc/>
     public override void Initialize()
     {
@@ -21,7 +23,7 @@ public sealed class InfantSystem : EntitySystem
             return;
 
         component.DefaultScale = sprite.Scale;
-        sprite.Scale = component.VisualScale;
+        _sprite.SetScale((uid, sprite), component.VisualScale);
     }
 
     private void OnShutdown(EntityUid uid, InfantComponent component, ComponentShutdown args)
@@ -29,6 +31,6 @@ public sealed class InfantSystem : EntitySystem
         if (!TryComp<SpriteComponent>(uid, out var sprite))
             return;
 
-        sprite.Scale = component.DefaultScale;
+        _sprite.SetScale((uid, sprite), component.DefaultScale);
     }
 }

--- a/Content.Client/Orbit/OrbitVisualsSystem.cs
+++ b/Content.Client/Orbit/OrbitVisualsSystem.cs
@@ -13,6 +13,7 @@ public sealed class OrbitVisualsSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly AnimationPlayerSystem _animations = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private readonly string _orbitStopKey = "orbiting_stop";
 
@@ -63,14 +64,15 @@ public sealed class OrbitVisualsSystem : EntitySystem
     {
         base.FrameUpdate(frameTime);
 
-        foreach (var (orbit, sprite) in EntityManager.EntityQuery<OrbitVisualsComponent, SpriteComponent>())
+        var query = EntityManager.EntityQueryEnumerator<OrbitVisualsComponent, SpriteComponent>();
+        while (query.MoveNext(out var uid, out var orbit, out var sprite))
         {
             var progress = (float)(_timing.CurTime.TotalSeconds / orbit.OrbitLength) % 1;
             var angle = new Angle(Math.PI * 2 * progress);
             var vec = angle.RotateVec(new Vector2(orbit.OrbitDistance, 0));
 
-            sprite.Rotation = angle;
-            sprite.Offset = vec;
+            _sprite.SetRotation((uid, sprite), angle);
+            _sprite.SetOffset((uid, sprite), vec);
         }
     }
 

--- a/Content.Client/Polymorph/Systems/ChameleonProjectorSystem.cs
+++ b/Content.Client/Polymorph/Systems/ChameleonProjectorSystem.cs
@@ -11,6 +11,7 @@ namespace Content.Client.Polymorph.Systems;
 public sealed class ChameleonProjectorSystem : SharedChameleonProjectorSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private EntityQuery<AppearanceComponent> _appearanceQuery;
     private EntityQuery<SpriteComponent> _spriteQuery;
@@ -47,13 +48,13 @@ public sealed class ChameleonProjectorSystem : SharedChameleonProjectorSystem
             return;
 
         ent.Comp.WasVisible = sprite.Visible;
-        sprite.Visible = false;
+        _sprite.SetVisible((ent.Owner, sprite), false);
     }
 
     private void OnShutdown(Entity<ChameleonDisguisedComponent> ent, ref ComponentShutdown args)
     {
         if (_spriteQuery.TryComp(ent, out var sprite))
-            sprite.Visible = ent.Comp.WasVisible;
+            _sprite.SetVisible((ent.Owner, sprite), ent.Comp.WasVisible);
     }
 
     private void OnGetFlashEffectTargetEvent(Entity<ChameleonDisguisedComponent> ent, ref GetFlashEffectTargetEvent args)

--- a/Content.Client/Power/Visualizers/CableVisualizerSystem.cs
+++ b/Content.Client/Power/Visualizers/CableVisualizerSystem.cs
@@ -7,6 +7,7 @@ namespace Content.Client.Power.Visualizers;
 public sealed class CableVisualizerSystem : EntitySystem
 {
     [Dependency] private readonly AppearanceSystem _appearanceSystem = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -30,8 +31,8 @@ public sealed class CableVisualizerSystem : EntitySystem
         if (!_appearanceSystem.TryGetData<WireVisDirFlags>(uid, WireVisVisuals.ConnectedMask, out var mask, args.Component))
             mask = WireVisDirFlags.None;
 
-        args.Sprite.LayerSetState(0, $"{component.StatePrefix}{(int) mask}");
+        _sprite.LayerSetRsiState((uid, args.Sprite), 0, $"{component.StatePrefix}{(int)mask}");
         if (component.ExtraLayerPrefix != null)
-            args.Sprite.LayerSetState(1, $"{component.ExtraLayerPrefix}{(int) mask}");
+            _sprite.LayerSetRsiState((uid, args.Sprite), 1, $"{component.ExtraLayerPrefix}{(int)mask}");
     }
 }

--- a/Content.Client/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Client/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -14,6 +14,7 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
 {
     [Dependency] private readonly BorgSystem _borgSystem = default!;
     [Dependency] private readonly AppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -39,8 +40,8 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
     {
         if (TryComp(entity, out SpriteComponent? sprite))
         {
-            sprite.LayerSetState(BorgVisualLayers.Body, prototype.SpriteBodyState);
-            sprite.LayerSetState(BorgVisualLayers.LightStatus, prototype.SpriteToggleLightState);
+            _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.Body, prototype.SpriteBodyState);
+            _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.LightStatus, prototype.SpriteToggleLightState);
         }
 
         if (TryComp(entity, out BorgChassisComponent? chassis))

--- a/Content.Client/Silicons/StationAi/StationAiSystem.cs
+++ b/Content.Client/Silicons/StationAi/StationAiSystem.cs
@@ -11,6 +11,7 @@ public sealed partial class StationAiSystem : SharedStationAiSystem
     [Dependency] private readonly IOverlayManager _overlayMgr = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private StationAiOverlay? _overlay;
 
@@ -81,9 +82,9 @@ public sealed partial class StationAiSystem : SharedStationAiSystem
             return;
 
         if (_appearance.TryGetData<PrototypeLayerData>(entity.Owner, StationAiVisualState.Key, out var layerData, args.Component))
-            args.Sprite.LayerSetData(StationAiVisualState.Key, layerData);
+            _sprite.LayerSetData((entity.Owner, args.Sprite), StationAiVisualState.Key, layerData);
 
-        args.Sprite.LayerSetVisible(StationAiVisualState.Key, layerData != null);
+        _sprite.LayerSetVisible((entity.Owner, args.Sprite), StationAiVisualState.Key, layerData != null);
     }
 
     public override void Shutdown()

--- a/Content.Client/Singularity/Visualizers/RadiationCollectorSystem.cs
+++ b/Content.Client/Singularity/Visualizers/RadiationCollectorSystem.cs
@@ -1,4 +1,3 @@
-using System;
 using Content.Shared.Singularity.Components;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
@@ -16,7 +15,8 @@ public sealed class RadiationCollectorSystem : VisualizerSystem<RadiationCollect
 
     private void OnComponentInit(EntityUid uid, RadiationCollectorComponent comp, ComponentInit args)
     {
-        comp.ActivateAnimation = new Animation {
+        comp.ActivateAnimation = new Animation
+        {
             Length = TimeSpan.FromSeconds(0.8f),
             AnimationTracks = {
                 new AnimationTrackSpriteFlick() {
@@ -26,7 +26,8 @@ public sealed class RadiationCollectorSystem : VisualizerSystem<RadiationCollect
             }
         };
 
-        comp.DeactiveAnimation = new Animation {
+        comp.DeactiveAnimation = new Animation
+        {
             Length = TimeSpan.FromSeconds(0.8f),
             AnimationTracks = {
                 new AnimationTrackSpriteFlick() {
@@ -46,10 +47,10 @@ public sealed class RadiationCollectorSystem : VisualizerSystem<RadiationCollect
         if (AnimationSystem.HasRunningAnimation(uid, animPlayer, RadiationCollectorComponent.AnimationKey))
             return;
 
-        var targetState = (RadiationCollectorVisualState) (state & RadiationCollectorVisualState.Active);
-        var destinationState = (RadiationCollectorVisualState) (comp.CurrentState & RadiationCollectorVisualState.Active);
+        var targetState = state & RadiationCollectorVisualState.Active;
+        var destinationState = comp.CurrentState & RadiationCollectorVisualState.Active;
         if (targetState != destinationState) // If where we're going is not where we want to be then we must go there next.
-            targetState = (RadiationCollectorVisualState) (targetState | RadiationCollectorVisualState.Deactivating); // Convert to transition state.
+            targetState |= RadiationCollectorVisualState.Deactivating; // Convert to transition state.
 
         comp.CurrentState = state;
 
@@ -63,10 +64,10 @@ public sealed class RadiationCollectorSystem : VisualizerSystem<RadiationCollect
                 break;
 
             case RadiationCollectorVisualState.Active:
-                sprite.LayerSetState(RadiationCollectorVisualLayers.Main, comp.ActiveState);
+                SpriteSystem.LayerSetRsiState((uid, sprite), RadiationCollectorVisualLayers.Main, comp.ActiveState);
                 break;
             case RadiationCollectorVisualState.Deactive:
-                sprite.LayerSetState(RadiationCollectorVisualLayers.Main, comp.InactiveState);
+                SpriteSystem.LayerSetRsiState((uid, sprite), RadiationCollectorVisualLayers.Main, comp.InactiveState);
                 break;
         }
     }
@@ -84,7 +85,7 @@ public sealed class RadiationCollectorSystem : VisualizerSystem<RadiationCollect
             state = comp.CurrentState;
 
         // Convert to terminal state.
-        var targetState = (RadiationCollectorVisualState) (state & RadiationCollectorVisualState.Active);
+        var targetState = state & RadiationCollectorVisualState.Active;
 
         UpdateVisuals(uid, targetState, comp, sprite, animPlayer);
     }

--- a/Content.Client/Smoking/BurnStateVisualizerSystem.cs
+++ b/Content.Client/Smoking/BurnStateVisualizerSystem.cs
@@ -19,7 +19,7 @@ public sealed class BurnStateVisualizerSystem : VisualizerSystem<BurnStateVisual
             _ => component.UnlitIcon
         };
 
-        args.Sprite.LayerSetState(0, state);
+        SpriteSystem.LayerSetRsiState((uid, args.Sprite), 0, state);
     }
 }
 

--- a/Content.Client/Storage/Visualizers/StorageFillVisualizerSystem.cs
+++ b/Content.Client/Storage/Visualizers/StorageFillVisualizerSystem.cs
@@ -15,6 +15,6 @@ public sealed class StorageFillVisualizerSystem : VisualizerSystem<StorageFillVi
             return;
 
         var state = $"{component.FillBaseName}-{level}";
-        args.Sprite.LayerSetState(StorageFillLayers.Fill, state);
+        SpriteSystem.LayerSetRsiState((uid, args.Sprite), StorageFillLayers.Fill, state);
     }
 }

--- a/Content.Client/SurveillanceCamera/SurveillanceCameraVisualsSystem.cs
+++ b/Content.Client/SurveillanceCamera/SurveillanceCameraVisualsSystem.cs
@@ -5,6 +5,8 @@ namespace Content.Client.SurveillanceCamera;
 
 public sealed class SurveillanceCameraVisualsSystem : EntitySystem
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -18,12 +20,12 @@ public sealed class SurveillanceCameraVisualsSystem : EntitySystem
         if (!args.AppearanceData.TryGetValue(SurveillanceCameraVisualsKey.Key, out var data)
             || data is not SurveillanceCameraVisuals key
             || args.Sprite == null
-            || !args.Sprite.LayerMapTryGet(SurveillanceCameraVisualsKey.Layer, out int layer)
+            || !_sprite.LayerMapTryGet((uid, args.Sprite), SurveillanceCameraVisualsKey.Layer, out var layer, false)
             || !component.CameraSprites.TryGetValue(key, out var state))
         {
             return;
         }
 
-        args.Sprite.LayerSetState(layer, state);
+        _sprite.LayerSetRsiState((uid, args.Sprite), layer, state);
     }
 }

--- a/Content.Client/Throwing/ThrownItemVisualizerSystem.cs
+++ b/Content.Client/Throwing/ThrownItemVisualizerSystem.cs
@@ -11,6 +11,7 @@ namespace Content.Client.Throwing;
 public sealed class ThrownItemVisualizerSystem : EntitySystem
 {
     [Dependency] private readonly AnimationPlayerSystem _anim = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private const string AnimationKey = "thrown-item";
 
@@ -46,7 +47,7 @@ public sealed class ThrownItemVisualizerSystem : EntitySystem
             return;
 
         if (TryComp<SpriteComponent>(uid, out var sprite) && component.OriginalScale != null)
-            sprite.Scale = component.OriginalScale.Value;
+            _sprite.SetScale((uid, sprite), component.OriginalScale.Value);
 
         _anim.Stop(uid, AnimationKey);
     }
@@ -60,7 +61,7 @@ public sealed class ThrownItemVisualizerSystem : EntitySystem
             return null;
 
         var scale = ent.Comp2.Scale;
-        var lenFloat = (float) length.TotalSeconds;
+        var lenFloat = (float)length.TotalSeconds;
 
         // TODO use like actual easings here
         return new Animation

--- a/Content.Client/Tools/Visualizers/WeldableVisualizerSystem.cs
+++ b/Content.Client/Tools/Visualizers/WeldableVisualizerSystem.cs
@@ -11,9 +11,9 @@ public sealed class WeldableVisualizerSystem : VisualizerSystem<WeldableComponen
             return;
 
         AppearanceSystem.TryGetData<bool>(uid, WeldableVisuals.IsWelded, out var isWelded, args.Component);
-        if (args.Sprite.LayerMapTryGet(WeldableLayers.BaseWelded, out var layer))
+        if (SpriteSystem.LayerMapTryGet((uid, args.Sprite), WeldableLayers.BaseWelded, out var layer, false))
         {
-            args.Sprite.LayerSetVisible(layer, isWelded);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), layer, isWelded);
         }
     }
 }

--- a/Content.Client/Trigger/TimerTriggerVisualizerSystem.cs
+++ b/Content.Client/Trigger/TimerTriggerVisualizerSystem.cs
@@ -19,7 +19,8 @@ public sealed class TimerTriggerVisualizerSystem : VisualizerSystem<TimerTrigger
 
     private void OnComponentInit(EntityUid uid, TimerTriggerVisualsComponent comp, ComponentInit args)
     {
-        comp.PrimingAnimation = new Animation {
+        comp.PrimingAnimation = new Animation
+        {
             Length = TimeSpan.MaxValue,
             AnimationTracks = {
                 new AnimationTrackSpriteFlick() {
@@ -32,7 +33,8 @@ public sealed class TimerTriggerVisualizerSystem : VisualizerSystem<TimerTrigger
         if (comp.PrimingSound != null)
         {
             comp.PrimingAnimation.AnimationTracks.Add(
-                new AnimationTrackPlaySound() {
+                new AnimationTrackPlaySound()
+                {
                     KeyFrames = { new AnimationTrackPlaySound.KeyFrame(_audioSystem.ResolveSound(comp.PrimingSound), 0) }
                 }
             );
@@ -42,7 +44,7 @@ public sealed class TimerTriggerVisualizerSystem : VisualizerSystem<TimerTrigger
     protected override void OnAppearanceChange(EntityUid uid, TimerTriggerVisualsComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null
-        ||  !TryComp<AnimationPlayerComponent>(uid, out var animPlayer))
+        || !TryComp<AnimationPlayerComponent>(uid, out var animPlayer))
             return;
 
         if (!AppearanceSystem.TryGetData<TriggerVisualState>(uid, TriggerVisuals.VisualState, out var state, args.Component))
@@ -55,7 +57,7 @@ public sealed class TimerTriggerVisualizerSystem : VisualizerSystem<TimerTrigger
                     AnimationSystem.Play((uid, animPlayer), comp.PrimingAnimation, TimerTriggerVisualsComponent.AnimationKey);
                 break;
             case TriggerVisualState.Unprimed:
-                args.Sprite.LayerSetState(TriggerVisualLayers.Base, comp.UnprimedSprite);
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), TriggerVisualLayers.Base, comp.UnprimedSprite);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/Content.IntegrationTests/Tests/ClickableTest.cs
+++ b/Content.IntegrationTests/Tests/ClickableTest.cs
@@ -53,6 +53,7 @@ namespace Content.IntegrationTests.Tests
             var eyeManager = client.ResolveDependency<IEyeManager>();
             var spriteQuery = clientEntManager.GetEntityQuery<SpriteComponent>();
             var eye = client.ResolveDependency<IEyeManager>().CurrentEye;
+            var spriteSys = clientEntManager.System<SpriteSystem>();
 
             var testMap = await pair.CreateTestMap();
 
@@ -73,7 +74,7 @@ namespace Content.IntegrationTests.Tests
             await client.WaitPost(() =>
             {
                 var sprite = spriteQuery.GetComponent(clientEnt);
-                sprite.Scale = new Vector2(scale, scale);
+                spriteSys.SetScale((clientEnt, sprite), new Vector2(scale, scale));
 
                 // these tests currently all assume player eye is 0
                 eyeManager.CurrentEye.Rotation = 0;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 43 `SpriteComponent` obsoleted warnings across 30 more files.

Are you sick of these PRs yet? I know I am. We're almost done though.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `SpriteComponent` methods and properties with `SpriteSystem` methods. A few other minor fixes too.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Not this time, but basic testing was done.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->