### PR TITLE
Added Purchasable Potted Plant Crate

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -347,3 +347,13 @@
   cost: 1500
   category: cargoproduct-category-name-fun
   group: market
+
+- type: cargoProduct
+  id: FunPlants
+  icon:
+    sprite: Structures/Furniture/potted_plants.rsi
+    state: plant-01
+  product: CratePlants
+  cost: 1000
+  category: cargoproduct-category-name-fun
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -43,6 +43,49 @@
     - id: PlushieArachind
     - id: PlushiePenguin
 
+- type: entityTable
+  id: AllPottedPlantsTable
+  table: !type:GroupSelector
+    children:
+    - id: PottedPlant0
+    - id: PottedPlant1
+    - id: PottedPlant2
+    - id: PottedPlant3
+    - id: PottedPlant4
+    - id: PottedPlant5
+    - id: PottedPlant6
+    - id: PottedPlant7
+    - id: PottedPlant8
+    - id: PottedPlant10
+    - id: PottedPlant11
+    - id: PottedPlant12
+    - id: PottedPlant13
+    - id: PottedPlant14
+    - id: PottedPlant15
+    - id: PottedPlant16
+    - id: PottedPlant17
+    - id: PottedPlant18
+    - id: PottedPlant19
+    - id: PottedPlant20
+    - id: PottedPlant21
+    - id: PottedPlant22
+    - id: PottedPlant23
+    - id: PottedPlant24
+    - id: PottedPlant26
+
+- type: entity
+  id: CratePlants
+  parent: CrateGenericSteel
+  name: plant crate
+  description: A variety pack of potted plants to spruce up your station!
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: AllPottedPlantsTable
+        rolls: !type:ConstantNumberSelector
+          value: 5
+
 - type: entity
   id: CrateFunPlushie
   parent: CrateGenericSteel


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a variety pack of potted plants for purchase in the "fun" section.

## Why / Balance
There is currently no way to get new potted plants. This provides a simple way to get more if wanted for decorations.

## Technical details
Added a new entity table with all the potted plants, and a crate that uses that table, similar to the plushies and other similar crates.
Added a new entry in the cargo_fun file for the new crate at 1000 spesos.

## Media
![image](https://github.com/user-attachments/assets/dc3c5233-29a4-423a-8e84-2932e8225937)
![image](https://github.com/user-attachments/assets/2c08c130-984f-4dd8-99a7-41410f6a825b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added purchasable potted plant crate!
