### PR TITLE
Slime storage QoL

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -15,7 +15,6 @@
   # they like eat it idk lol
   - type: Storage
     clickInsert: false
-    openOnActivate: false
     grid:
     - 0,0,1,2
     maxItemSize: Large


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I let slimepeople open *their own* storage by interacting with themselves (LMB), others still have to open it the regular way, to avoid any issues.
Simply left clicking yourself with a free hand will open the storage now.

## Why / Balance
This was changed to allow slimepeople themselves easier access to their own storage, for their own QoL, and shouldn't affect balance in any real way.

## Technical details
Removed the line "openOnActivate: false" in 'slime.yml'

## Media
Before left-clicking myself.
![slimepersonpreLMB](https://github.com/user-attachments/assets/f540ec7b-aff3-496c-a7a7-02330576e5e5)

After left-clicking myself.
![slimepersonpostLMB](https://github.com/user-attachments/assets/88857c2e-c815-44ed-abc6-84ef6e6080d8)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None found.

**Changelog**
:cl:
- add: Added a new, faster way for slimepeople to access their own special inventory, with LMB.
