### PR TITLE
Fixed Missing or Misconfigured Locale Keys

### DIFF
--- a/Content.Client/UserInterface/Systems/EscapeMenu/OptionsUIController.cs
+++ b/Content.Client/UserInterface/Systems/EscapeMenu/OptionsUIController.cs
@@ -26,7 +26,7 @@ public sealed class OptionsUIController : UIController
 
         if (!int.TryParse(args[0], out var tab))
         {
-            shell.WriteError(Loc.GetString("cmd-parse-failure-int", ("arg", args[0])));
+            shell.WriteError(Loc.GetString("cmd-parse-failure-integer", ("arg", args[0])));
             return;
         }
 

--- a/Content.Server/Administration/Commands/PanicBunkerCommand.cs
+++ b/Content.Server/Administration/Commands/PanicBunkerCommand.cs
@@ -187,6 +187,6 @@ public sealed class PanicBunkerMinOverallMinutesCommand : LocalizedCommands
         }
 
         _cfg.SetCVar(CCVars.PanicBunkerMinOverallMinutes, minutes);
-        shell.WriteLine(Loc.GetString("panicbunker-command-overall-minutes-age-set", ("minutes", minutes)));
+        shell.WriteLine(Loc.GetString("panicbunker-command-min-overall-minutes-set", ("minutes", minutes)));
     }
 }

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -233,7 +233,7 @@ namespace Content.Server.RoundEnd
             }
 
             _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("round-end-system-shuttle-recalled-announcement"),
-                Loc.GetString("Station"), false, colorOverride: Color.Gold);
+                Loc.GetString("round-end-system-shuttle-sender-announcement"), false, colorOverride: Color.Gold);
 
             _audio.PlayGlobal("/Audio/Announcements/shuttlerecalled.ogg", Filter.Broadcast(), true);
 

--- a/Content.Server/Salvage/SalvageSystem.Expeditions.cs
+++ b/Content.Server/Salvage/SalvageSystem.Expeditions.cs
@@ -128,7 +128,7 @@ public sealed partial class SalvageSystem
     {
         var component = expedition.Comp;
         component.NextOffer = _timing.CurTime + TimeSpan.FromSeconds(_cooldown);
-        Announce(uid, Loc.GetString("salvage-expedition-mission-completed"));
+        Announce(uid, Loc.GetString("salvage-expedition-completed"));
         component.ActiveMission = 0;
         component.Cooldown = true;
         UpdateConsoles(expedition);

--- a/Resources/Locale/en-US/actions/actions/actions-commands.ftl
+++ b/Resources/Locale/en-US/actions/actions/actions-commands.ftl
@@ -1,7 +1,7 @@
 ﻿## Actions Commands loc
 
 ## Upgradeaction command loc
-upgradeaction-command-help = Usage: upgradeaction <entityUid> [level] # im assuming it's formatted like this
+upgradeaction-command-help = Usage: upgradeaction <entityUid> [level]
 upgradeaction-command-need-one-argument = upgradeaction needs at least one argument, the action entity uid. The second optional argument is a specified level.
 upgradeaction-command-max-two-arguments = upgradeaction has a maximum of two arguments, the action entity uid and the (optional) level to set.
 upgradeaction-command-second-argument-not-number = upgradeaction's second argument can only be a number.

--- a/Resources/Locale/en-US/actions/actions/actions-commands.ftl
+++ b/Resources/Locale/en-US/actions/actions/actions-commands.ftl
@@ -1,6 +1,7 @@
 ﻿## Actions Commands loc
 
 ## Upgradeaction command loc
+upgradeaction-command-help = Usage: upgradeaction <entityUid> [level] # im assuming it's formatted like this
 upgradeaction-command-need-one-argument = upgradeaction needs at least one argument, the action entity uid. The second optional argument is a specified level.
 upgradeaction-command-max-two-arguments = upgradeaction has a maximum of two arguments, the action entity uid and the (optional) level to set.
 upgradeaction-command-second-argument-not-number = upgradeaction's second argument can only be a number.

--- a/Resources/Locale/en-US/commands/colornetwork-command.ftl
+++ b/Resources/Locale/en-US/commands/colornetwork-command.ftl
@@ -1,3 +1,5 @@
 cmd-colornetwork-desc = Paints the atmos devices in the specified color
 cmd-colornetwork-help = colornetwork <uid> Pipe <HexColor>
 cmd-colornetwork-no-access = You are not currently able to use mapping commands.
+shell-entity-is-not-node-container = Target entity is not a node container.
+shell-node-group-is-invalid = Invalid node group specified. Valid groups: { $groups }.

--- a/Resources/Locale/en-US/components/screen-component.ftl
+++ b/Resources/Locale/en-US/components/screen-component.ftl
@@ -1,2 +1,2 @@
-screen-text = text
-screen-color = color
+screen-text = screenText
+screen-color = screenColor

--- a/Resources/Locale/en-US/components/screen-component.ftl
+++ b/Resources/Locale/en-US/components/screen-component.ftl
@@ -1,0 +1,2 @@
+screen-text = text
+screen-color = color

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -337,6 +337,7 @@ ui-options-net-pvs-leave-tooltip = This limits the rate at which the client will
 ## Toggle window console command
 cmd-options-desc = Opens options menu, optionally with a specific tab selected.
 cmd-options-help = Usage: options [tab]
+ cmd-parse-failure-int = Failed to parse '{ $arg }' as a valid tab ID.
 
 ## Accessibility menu
 

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -337,7 +337,6 @@ ui-options-net-pvs-leave-tooltip = This limits the rate at which the client will
 ## Toggle window console command
 cmd-options-desc = Opens options menu, optionally with a specific tab selected.
 cmd-options-help = Usage: options [tab]
- cmd-parse-failure-int = Failed to parse '{ $arg }' as a valid tab ID.
 
 ## Accessibility menu
 

--- a/Resources/Locale/en-US/info/ban.ftl
+++ b/Resources/Locale/en-US/info/ban.ftl
@@ -27,7 +27,7 @@ cmd-banpanel-player-err = The specified player could not be found
 cmd-banlist-desc = Lists a user's active bans.
 cmd-banlist-help = Usage: banlist <name or user ID>
 cmd-banlist-empty = No active bans found for {$user}
-cmd-banlistF-hint = <name/user ID>
+cmd-banlist-hint = <name/user ID>
 
 cmd-ban_exemption_update-desc = Set an exemption to a type of ban on a player.
 cmd-ban_exemption_update-help = Usage: ban_exemption_update <player> <flag> [<flag> [...]]

--- a/Resources/Locale/en-US/ninja/ninja-actions.ftl
+++ b/Resources/Locale/en-US/ninja/ninja-actions.ftl
@@ -4,6 +4,7 @@ ninja-suit-cooldown = The suit needs time to recuperate from the last attack.
 ninja-cell-downgrade = The suit will only accept a new power cell that is better than the current one!
 ninja-cell-too-large = This power source does not fit in the ninja suit!
 
+ninja-download-fail = Server has no research data...
 ninja-research-steal-fail = No new research nodes were stolen...
 ninja-research-steal-success = Stole {$count} new nodes from {THE($server)}.
 

--- a/Resources/Locale/en-US/ui/spray-painter-window.ftl
+++ b/Resources/Locale/en-US/ui/spray-painter-window.ftl
@@ -1,0 +1,1 @@
+pipe-painter-no-color-selected = (No color selected)


### PR DESCRIPTION
## About the PR  
first PR ever, bear with me if i did anything stupid ᓚᘏᗢ💧
Addresses localization issues found in #34343:  

- **cmd-banlist-hint**: Fixed what I believe was a typo in the FTL file (`cmd-banlistF-hint` → `cmd-banlist-hint`).
- **RoundEndSystem.cs**: Was using an incorrect key for "Station" corrected to the proper localization key (`Station` -> `round-end-system-shuttle-sender-announcement`).
- ~~**cmd-parse-failure-int**: Added to `options-menu.ftl` as:~~
  > ~~`"Failed to parse '{ $arg }' as a valid tab ID."`~~
   - This was actually an incorrectly named key in the .cs, corrected `cmd-parse-failure-int` -> `cmd-parse-failure-integer` to match project-wide naming convention.
- **ninja-download-fail**: Added to `ninja-actions.ftl` as:
  > `"Server has no research data..."`
- **panicbunker-command-min-overall-minutes-set**:  
  Previously used incorrect key `panicbunker-command-overall-minutes-age-set` updated to correct naming convention. :3
- **spray-painter-window.ftl**: Added under the `ui` locale directory (unsure if this is the correct location), adds key `pipe-painter-no-color-selected` as:
  > `"(No color selected)"`
- **SalvageSystem.Expeditions.cs**: Key updated to match `expeditions.ftl` (`salvage-expedition-mission-completed` -> `salvage-expedition-completed`).
- **screen-component.ftl**: Added (not certain this is the right place for screen-color and screen-text).
- **colornetwork-command.ftl**: Added:
  - `shell-entity-is-not-node-container` as `"Target entity is not a node container."`
  - `shell-node-group-is-invalid` as `"Invalid node group specified. Valid groups: { $groups }."`
- **upgradeaction-command-help**: Added this key based on best guess wasn't able to test it.

### Notes related to #34343::
- **dungen_pack_vis** and **whitelist-not-whitelisted**: These are mentioned in the issue #34343: that this PR addresses but I couldn't figure out how to trigger these keys to show up in-game to understand the context of how they're used so I did not do anything for these. 
- **planetcommand**, **shared strippable**, and **adminverbsystem**: These were either already fixed or the relevant keys no longer exist.

## Why / Balance  
- Ensures all game text can be properly localized.  
- Less raw string keys in-game, that's a good thing! ＼(ﾟｰﾟ＼)

## Technical details  
- Verified key names.
- Added missing keys.

## Media  
N/A (Text-only changes)  

## Requirements  
- [X] I have read and followed the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).  
- [X] No ingame showcase needed.  

## Breaking changes  
I hope not.  （；´д｀）ゞ

**Changelog**  
