### PR TITLE
Cleanup more `SpriteComponent` warnings (part 6)

### DIFF
--- a/Content.Client/BarSign/BarSignSystem.cs
+++ b/Content.Client/BarSign/BarSignSystem.cs
@@ -41,12 +41,12 @@ public sealed class BarSignSystem : VisualizerSystem<BarSignComponent>
             && sign.Current != null
             && _prototypeManager.TryIndex(sign.Current, out var proto))
         {
-            sprite.LayerSetSprite(0, proto.Icon);
+            SpriteSystem.LayerSetSprite((id, sprite), 0, proto.Icon);
             sprite.LayerSetShader(0, "unshaded");
         }
         else
         {
-            sprite.LayerSetState(0, "empty");
+            SpriteSystem.LayerSetRsiState((id, sprite), 0, "empty");
             sprite.LayerSetShader(0, null, null);
         }
     }

--- a/Content.Client/Clothing/FlippableClothingVisualizerSystem.cs
+++ b/Content.Client/Clothing/FlippableClothingVisualizerSystem.cs
@@ -32,7 +32,7 @@ public sealed class FlippableClothingVisualizerSystem : VisualizerSystem<Flippab
 
         if (clothing.MappedLayer == null ||
             !AppearanceSystem.TryGetData<bool>(ent, FoldableSystem.FoldedVisuals.State, out var folding) ||
-            !sprite.LayerMapTryGet(folding ? ent.Comp.FoldingLayer : ent.Comp.UnfoldingLayer, out var idx))
+            !SpriteSystem.LayerMapTryGet((ent.Owner, sprite), folding ? ent.Comp.FoldingLayer : ent.Comp.UnfoldingLayer, out var idx, false))
             return;
 
         // add each layer to the visuals

--- a/Content.Client/Construction/FlatpackSystem.cs
+++ b/Content.Client/Construction/FlatpackSystem.cs
@@ -9,6 +9,7 @@ namespace Content.Client.Construction;
 public sealed class FlatpackSystem : SharedFlatpackSystem
 {
     [Dependency] private readonly AppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -43,6 +44,6 @@ public sealed class FlatpackSystem : SharedFlatpackSystem
         }
 
         if (color != null)
-            args.Sprite.LayerSetColor(FlatpackVisualLayers.Overlay, color.Value);
+            _sprite.LayerSetColor((ent.Owner, args.Sprite), FlatpackVisualLayers.Overlay, color.Value);
     }
 }

--- a/Content.Client/Explosion/ClusterGrenadeVisualizerSystem.cs
+++ b/Content.Client/Explosion/ClusterGrenadeVisualizerSystem.cs
@@ -12,6 +12,6 @@ public sealed class ClusterGrenadeVisualizerSystem : VisualizerSystem<ClusterGre
             return;
 
         if (AppearanceSystem.TryGetData<int>(uid, ClusterGrenadeVisuals.GrenadesCounter, out var grenadesCounter, args.Component))
-            args.Sprite.LayerSetState(0, $"{comp.State}-{grenadesCounter}");
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), 0, $"{comp.State}-{grenadesCounter}");
     }
 }

--- a/Content.Client/Materials/RecyclerVisualizerSystem.cs
+++ b/Content.Client/Materials/RecyclerVisualizerSystem.cs
@@ -8,7 +8,7 @@ public sealed class RecyclerVisualizerSystem : VisualizerSystem<RecyclerVisualsC
 {
     protected override void OnAppearanceChange(EntityUid uid, RecyclerVisualsComponent component, ref AppearanceChangeEvent args)
     {
-        if (args.Sprite == null || !args.Sprite.LayerMapTryGet(RecyclerVisualLayers.Main, out var layer))
+        if (args.Sprite == null || !SpriteSystem.LayerMapTryGet((uid, args.Sprite), RecyclerVisualLayers.Main, out var layer, false))
             return;
 
         AppearanceSystem.TryGetData<ConveyorState>(uid, ConveyorVisuals.State, out var running);
@@ -22,6 +22,6 @@ public sealed class RecyclerVisualizerSystem : VisualizerSystem<RecyclerVisualsC
         var bloodyKey = bloody ? component.BloodyKey : string.Empty;
 
         var state = $"{component.BaseKey}{activityState}{bloodyKey}";
-        args.Sprite.LayerSetState(layer, state);
+        SpriteSystem.LayerSetRsiState((uid, args.Sprite), layer, state);
     }
 }

--- a/Content.Client/Mech/MechAssemblyVisualizerSystem.cs
+++ b/Content.Client/Mech/MechAssemblyVisualizerSystem.cs
@@ -19,6 +19,7 @@ public sealed class MechAssemblyVisualizerSystem : VisualizerSystem<MechAssembly
 
         var state = component.StatePrefix + stage;
 
-        args.Sprite?.LayerSetState(0, state);
+        if (args.Sprite != null)
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), 0, state);
     }
 }

--- a/Content.Client/Mech/MechAssemblyVisualizerSystem.cs
+++ b/Content.Client/Mech/MechAssemblyVisualizerSystem.cs
@@ -12,14 +12,13 @@ public sealed class MechAssemblyVisualizerSystem : VisualizerSystem<MechAssembly
     protected override void OnAppearanceChange(EntityUid uid, MechAssemblyVisualsComponent component,
         ref AppearanceChangeEvent args)
     {
-        base.OnAppearanceChange(uid, component, ref args);
+        if (args.Sprite == null)
+            return;
 
         if (!AppearanceSystem.TryGetData<int>(uid, MechAssemblyVisuals.State, out var stage, args.Component))
             return;
 
         var state = component.StatePrefix + stage;
-
-        if (args.Sprite != null)
-            SpriteSystem.LayerSetRsiState((uid, args.Sprite), 0, state);
+        SpriteSystem.LayerSetRsiState((uid, args.Sprite), 0, state);
     }
 }

--- a/Content.Client/Mining/MiningOverlay.cs
+++ b/Content.Client/Mining/MiningOverlay.cs
@@ -62,7 +62,7 @@ public sealed class MiningOverlay : Overlay
             if (xform.MapID != args.MapId || !sprite.Visible)
                 continue;
 
-            if (!sprite.LayerMapTryGet(MiningScannerVisualLayers.Overlay, out var idx))
+            if (!_sprite.LayerMapTryGet((ore, sprite), MiningScannerVisualLayers.Overlay, out var idx, false))
                 continue;
             var layer = sprite[idx];
 
@@ -85,10 +85,10 @@ public sealed class MiningOverlay : Overlay
 
             var alpha = animTime < viewerComp.AnimationDuration
                 ? 0
-                : (float) Math.Clamp((animTime - viewerComp.AnimationDuration) / viewerComp.AnimationDuration, 0f, 1f);
+                : (float)Math.Clamp((animTime - viewerComp.AnimationDuration) / viewerComp.AnimationDuration, 0f, 1f);
             var color = Color.White.WithAlpha(alpha);
 
-            handle.DrawTexture(texture, -(Vector2) texture.Size / 2f / EyeManager.PixelsPerMeter, layer.Rotation, modulate: color);
+            handle.DrawTexture(texture, -(Vector2)texture.Size / 2f / EyeManager.PixelsPerMeter, layer.Rotation, modulate: color);
 
         }
         handle.SetTransform(Matrix3x2.Identity);

--- a/Content.Client/Movement/Systems/ClientSpriteMovementSystem.cs
+++ b/Content.Client/Movement/Systems/ClientSpriteMovementSystem.cs
@@ -9,6 +9,8 @@ namespace Content.Client.Movement.Systems;
 /// </summary>
 public sealed class ClientSpriteMovementSystem : SharedSpriteMovementSystem
 {
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
     private EntityQuery<SpriteComponent> _spriteQuery;
 
     public override void Initialize()
@@ -29,14 +31,14 @@ public sealed class ClientSpriteMovementSystem : SharedSpriteMovementSystem
         {
             foreach (var (layer, state) in ent.Comp.MovementLayers)
             {
-                sprite.LayerSetData(layer, state);
+                _sprite.LayerSetData((ent.Owner, sprite), layer, state);
             }
         }
         else
         {
             foreach (var (layer, state) in ent.Comp.NoMovementLayers)
             {
-                sprite.LayerSetData(layer, state);
+                _sprite.LayerSetData((ent.Owner, sprite), layer, state);
             }
         }
     }

--- a/Content.Client/Pinpointer/PinpointerSystem.cs
+++ b/Content.Client/Pinpointer/PinpointerSystem.cs
@@ -7,6 +7,7 @@ namespace Content.Client.Pinpointer;
 public sealed class PinpointerSystem : SharedPinpointerSystem
 {
     [Dependency] private readonly IEyeManager _eyeManager = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Update(float frameTime)
     {
@@ -18,7 +19,7 @@ public sealed class PinpointerSystem : SharedPinpointerSystem
         // because eye can change it rotation anytime
         // we need to update this arrow in a update loop
         var query = EntityQueryEnumerator<PinpointerComponent, SpriteComponent>();
-        while (query.MoveNext(out var _, out var pinpointer, out var sprite))
+        while (query.MoveNext(out var uid, out var pinpointer, out var sprite))
         {
             if (!pinpointer.HasTarget)
                 continue;
@@ -30,10 +31,10 @@ public sealed class PinpointerSystem : SharedPinpointerSystem
                 case Distance.Close:
                 case Distance.Medium:
                 case Distance.Far:
-                    sprite.LayerSetRotation(PinpointerLayers.Screen, angle);
+                    _sprite.LayerSetRotation((uid, sprite), PinpointerLayers.Screen, angle);
                     break;
                 default:
-                    sprite.LayerSetRotation(PinpointerLayers.Screen, Angle.Zero);
+                    _sprite.LayerSetRotation((uid, sprite), PinpointerLayers.Screen, Angle.Zero);
                     break;
             }
         }

--- a/Content.Client/Stack/StackSystem.cs
+++ b/Content.Client/Stack/StackSystem.cs
@@ -12,6 +12,7 @@ namespace Content.Client.Stack
     {
         [Dependency] private readonly AppearanceSystem _appearanceSystem = default!;
         [Dependency] private readonly ItemCounterSystem _counterSystem = default!;
+        [Dependency] private readonly SpriteSystem _sprite = default!;
 
         public override void Initialize()
         {
@@ -37,7 +38,7 @@ namespace Content.Client.Stack
 
                 for (var i = 0; i < sprite.AllLayers.Count(); i++)
                 {
-                    sprite.LayerSetColor(i, color);
+                    _sprite.LayerSetColor((uid, sprite), i, color);
                 }
             }
 
@@ -107,7 +108,7 @@ namespace Content.Client.Stack
         /// <param name="maxCount">The maximum possible number of items in the stack. Will be set to the number of selectable layers.</param>
         private static void ApplyThreshold(StackLayerThresholdComponent comp, ref int actual, ref int maxCount)
         {
-            // We must stop before we run out of thresholds or layers, whichever's smaller. 
+            // We must stop before we run out of thresholds or layers, whichever's smaller.
             maxCount = Math.Min(comp.Thresholds.Count + 1, maxCount);
             var newActual = 0;
             foreach (var threshold in comp.Thresholds)

--- a/Content.Client/Tools/ToolSystem.cs
+++ b/Content.Client/Tools/ToolSystem.cs
@@ -9,6 +9,8 @@ namespace Content.Client.Tools
 {
     public sealed class ToolSystem : SharedToolSystem
     {
+        [Dependency] private readonly SpriteSystem _sprite = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -36,7 +38,7 @@ namespace Content.Client.Tools
             {
                 var current = multiple.Entries[multiple.CurrentEntry];
                 if (current.Sprite != null)
-                    sprite.LayerSetSprite(0, current.Sprite);
+                    _sprite.LayerSetSprite((uid, sprite), 0, current.Sprite);
             }
         }
     }

--- a/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
@@ -74,7 +74,7 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
         {
             var msg = FormattedMessage.FromMarkupOrThrow(Loc.GetString(Alert.Name));
             var desc = FormattedMessage.FromMarkupOrThrow(Loc.GetString(Alert.Description));
-            return new ActionAlertTooltip(msg, desc) {Cooldown = Cooldown};
+            return new ActionAlertTooltip(msg, desc) { Cooldown = Cooldown };
         }
 
         /// <summary>
@@ -88,9 +88,10 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
 
             if (!_entityManager.TryGetComponent<SpriteComponent>(_spriteViewEntity, out var sprite))
                 return;
+            var spriteSys = _entityManager.System<SpriteSystem>();
             var icon = Alert.GetIcon(_severity);
-            if (sprite.LayerMapTryGet(AlertVisualLayers.Base, out var layer))
-                sprite.LayerSetSprite(layer, icon);
+            if (spriteSys.LayerMapTryGet((_spriteViewEntity, sprite), AlertVisualLayers.Base, out var layer, false))
+                spriteSys.LayerSetSprite((_spriteViewEntity, sprite), layer, icon);
         }
 
         protected override void FrameUpdate(FrameEventArgs args)
@@ -116,9 +117,10 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
             _spriteViewEntity = _entityManager.Spawn(Alert.AlertViewEntity);
             if (_entityManager.TryGetComponent<SpriteComponent>(_spriteViewEntity, out var sprite))
             {
+                var spriteSys = _entityManager.System<SpriteSystem>();
                 var icon = Alert.GetIcon(_severity);
-                if (sprite.LayerMapTryGet(AlertVisualLayers.Base, out var layer))
-                    sprite.LayerSetSprite(layer, icon);
+                if (spriteSys.LayerMapTryGet((_spriteViewEntity, sprite), AlertVisualLayers.Base, out var layer, false))
+                    spriteSys.LayerSetSprite((_spriteViewEntity, sprite), layer, icon);
             }
 
             _icon.SetEntity(_spriteViewEntity);

--- a/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
@@ -14,6 +14,8 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
     {
         [Dependency] private readonly IEntityManager _entityManager = default!;
 
+        private readonly SpriteSystem _sprite;
+
         public AlertPrototype Alert { get; }
 
         /// <summary>
@@ -52,6 +54,7 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
             MuteSounds = true;
 
             IoCManager.InjectDependencies(this);
+            _sprite = _entityManager.System<SpriteSystem>();
             TooltipSupplier = SupplyTooltip;
             Alert = alert;
             _severity = severity;
@@ -88,10 +91,9 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
 
             if (!_entityManager.TryGetComponent<SpriteComponent>(_spriteViewEntity, out var sprite))
                 return;
-            var spriteSys = _entityManager.System<SpriteSystem>();
             var icon = Alert.GetIcon(_severity);
-            if (spriteSys.LayerMapTryGet((_spriteViewEntity, sprite), AlertVisualLayers.Base, out var layer, false))
-                spriteSys.LayerSetSprite((_spriteViewEntity, sprite), layer, icon);
+            if (_sprite.LayerMapTryGet((_spriteViewEntity, sprite), AlertVisualLayers.Base, out var layer, false))
+                _sprite.LayerSetSprite((_spriteViewEntity, sprite), layer, icon);
         }
 
         protected override void FrameUpdate(FrameEventArgs args)
@@ -117,10 +119,9 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
             _spriteViewEntity = _entityManager.Spawn(Alert.AlertViewEntity);
             if (_entityManager.TryGetComponent<SpriteComponent>(_spriteViewEntity, out var sprite))
             {
-                var spriteSys = _entityManager.System<SpriteSystem>();
                 var icon = Alert.GetIcon(_severity);
-                if (spriteSys.LayerMapTryGet((_spriteViewEntity, sprite), AlertVisualLayers.Base, out var layer, false))
-                    spriteSys.LayerSetSprite((_spriteViewEntity, sprite), layer, icon);
+                if (_sprite.LayerMapTryGet((_spriteViewEntity, sprite), AlertVisualLayers.Base, out var layer, false))
+                    _sprite.LayerSetSprite((_spriteViewEntity, sprite), layer, icon);
             }
 
             _icon.SetEntity(_spriteViewEntity);

--- a/Content.Client/Zombies/ZombieSystem.cs
+++ b/Content.Client/Zombies/ZombieSystem.cs
@@ -12,6 +12,7 @@ namespace Content.Client.Zombies;
 public sealed class ZombieSystem : SharedZombieSystem
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -47,7 +48,7 @@ public sealed class ZombieSystem : SharedZombieSystem
 
         for (var i = 0; i < sprite.AllLayers.Count(); i++)
         {
-            sprite.LayerSetColor(i, component.SkinColor);
+            _sprite.LayerSetColor((uid, sprite), i, component.SkinColor);
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 22 `SpriteComponent` obsoleted warnings across 14 more files.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced SpriteComponent methods and properties with SpriteSystem methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="229" alt="Screenshot 2025-05-19 at 11 01 17 AM" src="https://github.com/user-attachments/assets/35db0eb4-3022-4feb-bc3a-939031fe9b35" />
<img width="262" alt="Screenshot 2025-05-19 at 11 04 40 AM" src="https://github.com/user-attachments/assets/a3079136-c829-445e-8f85-be7cc493fa70" />
<img width="262" alt="Screenshot 2025-05-19 at 11 05 16 AM" src="https://github.com/user-attachments/assets/7e2e625e-d21a-4db9-a50b-734ff83e5d89" />
<img width="262" alt="Screenshot 2025-05-19 at 11 07 53 AM" src="https://github.com/user-attachments/assets/598768b3-fe13-4fc6-9e91-e14142f5cf59" />
<img width="262" alt="Screenshot 2025-05-19 at 11 08 42 AM" src="https://github.com/user-attachments/assets/24798b51-f48a-486b-8a94-15ef48ccab7a" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->