### PR TITLE
Give kammerer tighter spread so it's not a complete downgrade to the enforcer

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
@@ -1,0 +1,22 @@
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
+
+namespace Content.Server.Weapons.Ranged.Systems;
+
+/// <summary>
+/// Ensures that GunSpreadModifierComponent works by listening to the GunGetAmmoSpreadEvent.
+/// Also adds an examine message.
+/// </summary>
+public sealed class GunSpreadModifierSystem: EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<GunSpreadModifierComponent, GunGetAmmoSpreadEvent>(OnGunGetAmmoSpread);
+    }
+
+    private void OnGunGetAmmoSpread(EntityUid uid, GunSpreadModifierComponent comp, GunGetAmmoSpreadEvent args)
+    {
+        args.Spread *= comp.Spread;
+    }
+}

--- a/Content.Shared/Weapons/Ranged/Components/GunSpreadModifierComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunSpreadModifierComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Weapons.Ranged.Components;
+
+/// <summary>
+/// This component modifies the spread of the gun it is attached to.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed class GunSpreadModifierComponent: Component
+{
+    /// <summary>
+    /// A scalar value multiplied by the spread built into the ammo itself.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Spread;
+}

--- a/Content.Shared/Weapons/Ranged/Components/GunSpreadModifierComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunSpreadModifierComponent.cs
@@ -6,11 +6,11 @@ namespace Content.Shared.Weapons.Ranged.Components;
 /// This component modifies the spread of the gun it is attached to.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed class GunSpreadModifierComponent: Component
+public sealed partial class GunSpreadModifierComponent: Component
 {
     /// <summary>
     /// A scalar value multiplied by the spread built into the ammo itself.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float Spread;
+    public float Spread = 1;
 }

--- a/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
@@ -21,7 +21,7 @@ public sealed class GunSpreadModifierSystem: EntitySystem
 
     private void OnExamine(EntityUid uid, GunSpreadModifierComponent comp, ExaminedEvent args)
     {
-        var percentage = comp.Spread * 100;
+        var percentage = Math.Round(comp.Spread * 100);
         var msg = Loc.GetString("examine-gun-spread-modifier", ("percentage", percentage));
         args.PushMarkup(msg);
     }

--- a/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
@@ -21,7 +21,7 @@ public sealed class GunSpreadModifierSystem: EntitySystem
 
     private void OnExamine(EntityUid uid, GunSpreadModifierComponent comp, ExaminedEvent args)
     {
-        var percentage = (1 / comp.Spread) * 100;
+        var percentage = comp.Spread * 100;
         var msg = Loc.GetString("examine-gun-spread-modifier", ("percentage", percentage));
         args.PushMarkup(msg);
     }

--- a/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
@@ -11,9 +11,10 @@ public sealed class GunSpreadModifierSystem: EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<GunSpreadModifierComponent, GunGetAmmoSpreadEvent>(OnGunGetAmmoSpread);
+        SubscribeLocalEvent<GunSpreadModifierComponent, ExaminedEvent>(OnExamine);
     }
 
-    private void OnGunGetAmmoSpread(EntityUid uid, GunSpreadModifierComponent comp, GunGetAmmoSpreadEvent args)
+    private void OnGunGetAmmoSpread(EntityUid uid, GunSpreadModifierComponent comp, ref GunGetAmmoSpreadEvent args)
     {
         args.Spread *= comp.Spread;
     }

--- a/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
@@ -20,7 +20,7 @@ public sealed class GunSpreadModifierSystem: EntitySystem
 
     private void OnExamine(EntityUid uid, GunSpreadModifierComponent comp, ExaminedEvent args)
     {
-        var percentage = comp.Spread * 100;
+        var percentage = (1 / comp.Spread) * 100;
         var msg = Loc.GetString("examine-gun-spread-modifier", ("percentage", percentage));
         args.PushMarkup(msg);
     }

--- a/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
@@ -1,12 +1,10 @@
+using Content.Shared.Examine;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 
-namespace Content.Server.Weapons.Ranged.Systems;
+namespace Content.Shared.Weapons.Ranged.Systems;
 
-/// <summary>
-/// Ensures that GunSpreadModifierComponent works by listening to the GunGetAmmoSpreadEvent.
-/// Also adds an examine message.
-/// </summary>
+
 public sealed class GunSpreadModifierSystem: EntitySystem
 {
     public override void Initialize()
@@ -18,5 +16,12 @@ public sealed class GunSpreadModifierSystem: EntitySystem
     private void OnGunGetAmmoSpread(EntityUid uid, GunSpreadModifierComponent comp, GunGetAmmoSpreadEvent args)
     {
         args.Spread *= comp.Spread;
+    }
+
+    private void OnExamine(EntityUid uid, GunSpreadModifierComponent comp, ExaminedEvent args)
+    {
+        var percentage = comp.Spread * 100;
+        var msg = Loc.GetString("examine-gun-spread-modifier", ("percentage", percentage));
+        args.PushMarkup(msg);
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
@@ -22,7 +22,9 @@ public sealed class GunSpreadModifierSystem: EntitySystem
     private void OnExamine(EntityUid uid, GunSpreadModifierComponent comp, ExaminedEvent args)
     {
         var percentage = Math.Round(comp.Spread * 100);
-        var msg = Loc.GetString("examine-gun-spread-modifier", ("percentage", percentage));
+        var loc = percentage < 100 ? "examine-gun-spread-modifier-reduction" : "examine-gun-spread-modifier-increase";
+        percentage = percentage < 100 ? 100 - percentage : percentage - 100;
+        var msg = Loc.GetString(loc, ("percentage", percentage));
         args.PushMarkup(msg);
     }
 }

--- a/Resources/Locale/en-US/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/gun.ftl
@@ -52,4 +52,5 @@ gun-revolver-spun = Spun
 gun-speedloader-empty = Speedloader empty
 
 # GunSpreadModifier
-examine-gun-spread-modifier = It has [color=yellow]{$percentage}%[/color] of the usual spread.
+examine-gun-spread-modifier-reduction = The spread has been reduced by [color=yellow]{$percentage}[/color].
+examine-gun-spread-modifier-increase = The spread has been increased by [color=yellow]{$percentage}[/color].

--- a/Resources/Locale/en-US/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/gun.ftl
@@ -52,5 +52,5 @@ gun-revolver-spun = Spun
 gun-speedloader-empty = Speedloader empty
 
 # GunSpreadModifier
-examine-gun-spread-modifier-reduction = The spread has been reduced by [color=yellow]{$percentage}[/color].
-examine-gun-spread-modifier-increase = The spread has been increased by [color=yellow]{$percentage}[/color].
+examine-gun-spread-modifier-reduction = The spread has been reduced by [color=yellow]{$percentage}%[/color].
+examine-gun-spread-modifier-increase = The spread has been increased by [color=yellow]{$percentage}%[/color].

--- a/Resources/Locale/en-US/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/gun.ftl
@@ -50,3 +50,6 @@ gun-revolver-insert = Inserted
 gun-revolver-spin = Spin revolver
 gun-revolver-spun = Spun
 gun-speedloader-empty = Speedloader empty
+
+# GunSpreadModifier
+examine-gun-spread-modifier = It has [color=yellow]{$percentage}%[/color] tighter spread than usual.

--- a/Resources/Locale/en-US/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/gun.ftl
@@ -52,4 +52,4 @@ gun-revolver-spun = Spun
 gun-speedloader-empty = Speedloader empty
 
 # GunSpreadModifier
-examine-gun-spread-modifier = It has [color=yellow]{$percentage}%[/color] tighter spread than usual.
+examine-gun-spread-modifier = It has [color=yellow]{$percentage}%[/color] of the usual spread.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -176,7 +176,7 @@
   - type: Gun
     fireRate: 1
   - type: GunSpreadModifier
-    spread: 0.5
+    spread: 0.6
   - type: Tag
     tags:
     - WeaponShotgunKammerer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -175,6 +175,8 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 1
+  - type: GunSpreadModifier
+    spread: 0.5
   - type: Tag
     tags:
     - WeaponShotgunKammerer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Kammerer has _60%_ as much spread as the enforcer (numbers subject to change).

## Why / Balance
As it currently stands, the kammerer is numerically equivalent or inferior than the enforcer in every way. This doesn't make sense as the kammerer is only found in the armoury while the enforcer is ordered from cargo. If anything, the kammerer should be stronger.
There is a comment in the kammerer prototype that says that it is meant to have tighter spread.
![image](https://github.com/user-attachments/assets/8e00aef0-d8ee-48d6-b88e-fe0de8cc2a32)

If this is too strong, I can very easily widen the spread a bit or limit the gun back to having an ammo capacity of 4. I can even make it fire fewer pellets.

## Technical details
<!-- Summary of code changes for easier review. -->
* Added a GunSpreadModifierComponent, modifies the spread of any gun it is attached to and also has an examine message
* Added GunSpreadModifierSystem, ensures the component works by subscribing to an event in the GunSystem

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Examining the kammerer:
![Screenshot from 2025-05-19 21-09-41](https://github.com/user-attachments/assets/81d2c1bf-fc73-400b-a174-87a5122c61b5)

Spread of the kammerer with this change:
![Screenshot from 2025-05-19 21-11-25](https://github.com/user-attachments/assets/6ef93efc-0dd9-4322-9392-11d67e25034d)

Spread of the enforcer (to compare against):
![Screenshot from 2025-05-19 21-11-05](https://github.com/user-attachments/assets/7db2deb3-2ae6-44cb-a102-857a8f8c6a8e)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Kammerer now has a tighter spread to compensate for its lower rate of fire.