### PR TITLE
Remove `ParallaxVV` property from `ParallaxComponent`

### DIFF
--- a/Content.Shared/Parallax/ParallaxComponent.cs
+++ b/Content.Shared/Parallax/ParallaxComponent.cs
@@ -12,17 +12,4 @@ public sealed partial class ParallaxComponent : Component
     // I wish I could use a typeserializer here but parallax is extremely client-dependent.
     [DataField, AutoNetworkedField]
     public string Parallax = "Default";
-
-    [UsedImplicitly, ViewVariables(VVAccess.ReadWrite)]
-    // ReSharper disable once InconsistentNaming
-    public string ParallaxVV
-    {
-        get => Parallax;
-        set
-        {
-            if (value.Equals(Parallax)) return;
-            Parallax = value;
-            IoCManager.Resolve<IEntityManager>().Dirty(this);
-        }
-    }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Deleted the `ParallaxVV` property in `ParallaxComponent`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1 more warning for https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
All it does is set the `Parallax` field and call `Dirty`. Just editing the `Parallax` field directly does the same thing.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->