### PR TITLE
Researchable & Printable Hyper Capacity Cells

### DIFF
--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -18,7 +18,7 @@ research-technology-advanced-atmospherics = Advanced Atmospherics
 research-technology-advanced-tools = Advanced Tools
 research-technology-super-powercells = Super Powercells
 research-technology-bluespace-storage = Bluespace Storage
-research-technology-portable-fission = Portable Fission
+research-technology-maximised-powercells = Maximised Powercells
 research-technology-space-scanning = Space Scanning
 research-technology-excavation = Mass Excavation
 

--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -18,7 +18,7 @@ research-technology-advanced-atmospherics = Advanced Atmospherics
 research-technology-advanced-tools = Advanced Tools
 research-technology-super-powercells = Super Powercells
 research-technology-bluespace-storage = Bluespace Storage
-research-technology-maximized-powercells = Maximized Powercells
+research-technology-optimized-microgalvanism = Optimized Microgalvanism
 research-technology-space-scanning = Space Scanning
 research-technology-excavation = Mass Excavation
 

--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -18,7 +18,7 @@ research-technology-advanced-atmospherics = Advanced Atmospherics
 research-technology-advanced-tools = Advanced Tools
 research-technology-super-powercells = Super Powercells
 research-technology-bluespace-storage = Bluespace Storage
-research-technology-maximised-powercells = Maximised Powercells
+research-technology-maximized-powercells = Maximized Powercells
 research-technology-space-scanning = Space Scanning
 research-technology-excavation = Mass Excavation
 

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -175,7 +175,7 @@
 
 - type: entity
   name: hyper-capacity power cell
-  description: A rechargeable standardized power cell. This one looks like a rare and powerful prototype.
+  description: A rechargeable standardized power cell. This iteration pushes the upper limits of portable power storage, boasting 40% more capacity than its predecessor.
   id: PowerCellHyper
   suffix: Full
   parent: BasePowerCell

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -175,7 +175,7 @@
 
 - type: entity
   name: hyper-capacity power cell
-  description: A rechargeable standardized power cell. This iteration pushes the upper limits of portable power storage, boasting 40% more capacity than its predecessor.
+  description: A rechargeable standardized power cell. This iteration pushes the upper limits of portable power storage, boasting 66% more capacity than its predecessor.
   id: PowerCellHyper
   suffix: Full
   parent: BasePowerCell

--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -46,6 +46,7 @@
   recipes:
   - PowerCellMicroreactor
   - PowerCellHigh
+  - PowerCellHyper
 
 - type: latheRecipePack
   id: ScienceWeapons

--- a/Resources/Prototypes/Recipes/Lathes/powercells.yml
+++ b/Resources/Prototypes/Recipes/Lathes/powercells.yml
@@ -39,10 +39,11 @@
   - Parts
   completetime: 10
   materials:
-    Steel: 600
-    Glass: 600
+    Steel: 800
+    Glass: 700
     Plasma: 300
     Gold: 200
+    Silver: 300
 
 - type: latheRecipe
   id: PowerCellMicroreactor

--- a/Resources/Prototypes/Recipes/Lathes/powercells.yml
+++ b/Resources/Prototypes/Recipes/Lathes/powercells.yml
@@ -33,6 +33,19 @@
     Gold: 50
 
 - type: latheRecipe
+  id: PowerCellHyper
+  result: PowerCellHyperPrinted
+  categories:
+  - Parts
+  completetime: 10
+  materials:
+    Steel: 600
+    Glass: 600
+    Uranium: 100
+    Gold: 200
+    Silver: 100
+
+- type: latheRecipe
   id: PowerCellMicroreactor
   result: PowerCellMicroreactorPrinted
   categories:

--- a/Resources/Prototypes/Recipes/Lathes/powercells.yml
+++ b/Resources/Prototypes/Recipes/Lathes/powercells.yml
@@ -41,9 +41,8 @@
   materials:
     Steel: 600
     Glass: 600
-    Uranium: 100
+    Plasma: 300
     Gold: 200
-    Silver: 100
 
 - type: latheRecipe
   id: PowerCellMicroreactor

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -200,8 +200,8 @@
   - ClothingBackpackDuffelHolding
 
 - type: technology
-  id: MaximisedPowercells
-  name: research-technology-maximised-powercells
+  id: MaximizedPowercells
+  name: research-technology-maximized-powercells
   icon:
     sprite: Objects/Power/power_cells.rsi
     state: microreactor

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -200,14 +200,14 @@
   - ClothingBackpackDuffelHolding
 
 - type: technology
-  id: MaximizedPowercells
-  name: research-technology-maximized-powercells
+  id: OptimizedMicrogalvanism
+  name: research-technology-optimized-microgalvanism
   icon:
     sprite: Objects/Power/power_cells.rsi
     state: microreactor
   discipline: Industrial
   tier: 3
-  cost: 12500
+  cost: 10000
   recipeUnlocks:
   - PowerCellMicroreactor
   - PowerCellHyper

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -27,7 +27,7 @@
   recipeUnlocks:
   - RadarConsoleCircuitboard
   - HandHeldMassScanner
-  
+
 - type: technology
   id: AdvancedPowercells
   name: research-technology-advanced-powercells
@@ -200,15 +200,16 @@
   - ClothingBackpackDuffelHolding
 
 - type: technology
-  id: PortableFission
-  name: research-technology-portable-fission
+  id: MaximisedPowercells
+  name: research-technology-maximised-powercells
   icon:
     sprite: Objects/Power/power_cells.rsi
     state: microreactor
   discipline: Industrial
   tier: 3
-  cost: 10000
+  cost: 12500
   recipeUnlocks:
   - PowerCellMicroreactor
+  - PowerCellHyper
   technologyPrerequisites:
   - AdvancedPowercells


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Hyper Capacity cells are now tacked onto what was the Tier 3 Industrial technology 'Portable Fission'.
They can be printed at a Protolathe for 8 Steel, 7 Glass, 3 Plasma and 2 Gold, 3 Silver.
The Portable Fission technology has been renamed to Optimized Microgalvanism to better reflect that it now contains Hyper Capacity cells in addition to Microreactors.
The description of Hyper Capacity cells have been rewritten to better reflect that they can now be printed and are no longer obscenely rare commodities.

## Why / Balance
Maints have been planning to remove salvage expeditions from the game for a while, as it stands this is the only source of Hypercaps (aside from extracting them from Syndie Assaultborgs, but that's far from practical), this PR serves to prevent this item from being made unobtainable in the near(?) future and promote more players to acquire T3 Industrial.
Hypercaps are considerably more expensive than Highcaps, but unlike Microreactors do not require uranium in their recipe, which should hopefully allow them to exist as a viable sidegrade to them.

As an aside, if anyone viewing this PR has concepts for how to acquire the other expedition exclusive items (Antique Cell, Teslagun, Cloning) that may end up being made unavailable, please let me know as I intend to make followup PRs.

## Technical details
All yaml and ftl value changes.

## Media
![maximised3](https://github.com/user-attachments/assets/80167a14-c7c6-4df1-9700-41d521ff1731)
![hypercap3](https://github.com/user-attachments/assets/2d8c7f91-5e79-45e5-a9ef-4a95108fbf33)



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
research-technology-portable-fission and technology id PortableFission have been renamed to research-technology-optimized-microgalvanism and technology id OptimizedMicrogalvanism respectively.

**Changelog**
:cl:
- add: Hyper Capacity Powercells are now available as Tier 3 Industrial Research.
- tweak: The Tier 3 Industrial Research 'Portable Fission' has been renamed to Optimized Microgalvanism to better reflect this.
