### PR TITLE
Add validation test for `ExplosionPrototype`s

### DIFF
--- a/Content.IntegrationTests/Tests/Explosion/ExplosionPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Explosion/ExplosionPrototypeTest.cs
@@ -1,0 +1,28 @@
+using Content.Shared.Explosion;
+
+namespace Content.IntegrationTests.Tests.Explosion;
+
+public sealed class ExplosionPrototypeTest
+{
+    [Test]
+    public async Task ValidateExplosionPrototypes()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var protoMan = server.ProtoMan;
+
+        var protos = protoMan.EnumeratePrototypes<ExplosionPrototype>();
+
+        Assert.Multiple(() =>
+        {
+            foreach (var proto in protos)
+            {
+                Assert.That(proto._tileBreakChance, Is.Not.Empty, $"Empty tile break chance definitions for explosion prototype: {proto.ID}");
+                Assert.That(proto._tileBreakChance, Has.Length.EqualTo(proto._tileBreakIntensity.Length), $"Malformed tile break chance definitions for explosion prototype: {proto.ID}");
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Shared/Explosion/ExplosionPrototype.cs
+++ b/Content.Shared/Explosion/ExplosionPrototype.cs
@@ -115,19 +115,13 @@ public sealed partial class ExplosionPrototype : IPrototype
     /// </summary>
     public float TileBreakChance(float intensity)
     {
-        if (_tileBreakChance.Length == 0 || _tileBreakChance.Length != _tileBreakIntensity.Length)
-        {
-            Logger.Error($"Malformed tile break chance definitions for explosion prototype: {ID}");
-            return 0;
-        }
-
         if (intensity >= _tileBreakIntensity[^1] || _tileBreakIntensity.Length == 1)
             return _tileBreakChance[^1];
 
         if (intensity <= _tileBreakIntensity[0])
             return _tileBreakChance[0];
 
-        int i = Array.FindIndex(_tileBreakIntensity, k => k >= intensity);
+        var i = Array.FindIndex(_tileBreakIntensity, k => k >= intensity);
 
         var slope = (_tileBreakChance[i] - _tileBreakChance[i - 1]) / (_tileBreakIntensity[i] - _tileBreakIntensity[i - 1]);
         return _tileBreakChance[i - 1] + slope * (intensity - _tileBreakIntensity[i - 1]);

--- a/Content.Shared/Explosion/ExplosionPrototype.cs
+++ b/Content.Shared/Explosion/ExplosionPrototype.cs
@@ -36,14 +36,14 @@ public sealed partial class ExplosionPrototype : IPrototype
     ///     explosion intensity to a tile break chance via linear interpolation.
     /// </summary>
     [DataField("tileBreakChance")]
-    private float[] _tileBreakChance = { 0f, 1f };
+    public float[] _tileBreakChance = { 0f, 1f };
 
     /// <summary>
     ///     This set of points, together with <see cref="_tileBreakChance"/> define a function that maps the
     ///     explosion intensity to a tile break chance via linear interpolation.
     /// </summary>
     [DataField("tileBreakIntensity")]
-    private float[] _tileBreakIntensity = {0f, 15f };
+    public float[] _tileBreakIntensity = { 0f, 15f };
 
     /// <summary>
     ///     When a tile is broken by an explosion, the intensity is reduced by this amount and is used to try and


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds an integration test that checks that the `_tileBreakChance` and `_tileBreakIntensity` datafields in every `ExplosionPrototype` are valid (i.e. they have matching, non-zero lengths).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is actually part of [PZW](https://github.com/space-wizards/space-station-14/issues/33279) - there's an obsolete static logger call in `ExplosionPrototype` where this validation was performed at runtime. By moving this validation to a test, the runtime check is no longer needed and the warning can be removed.

## Technical details
<!-- Summary of code changes for easier review. -->
The test enumerates `ExplosionPrototypes` and asserts that the `_tileBreakChance` and `_tileBreakIntensity` datafields have matching, non-zero lengths.

Deleted the runtime check in `ExplosionPrototype.TileBreakChance`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->