### PR TITLE
Cleanup 2 warnings in `ReagentDispenserSystem`

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -134,7 +134,7 @@ namespace Content.Server.Chemistry.EntitySystems
             // Ensure that the reagent is something this reagent dispenser can dispense.
             var storageLocation = message.StorageLocation;
             var storedContainer = storage.StoredItems.FirstOrDefault(kvp => kvp.Value == storageLocation).Key;
-            if (storedContainer == default)
+            if (storedContainer == EntityUid.Invalid)
                 return;
 
             var outputContainer = _itemSlotsSystem.GetItemOrNull(reagentDispenser, SharedReagentDispenser.OutputSlotName);
@@ -165,7 +165,7 @@ namespace Content.Server.Chemistry.EntitySystems
 
             var storageLocation = message.StorageLocation;
             var storedContainer = storage.StoredItems.FirstOrDefault(kvp => kvp.Value == storageLocation).Key;
-            if (storedContainer == default)
+            if (storedContainer == EntityUid.Invalid)
                 return;
 
             _handsSystem.TryPickupAnyHand(message.Actor, storedContainer);

--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -50,7 +50,7 @@ namespace Content.Server.Chemistry.EntitySystems
             SubscribeLocalEvent<ReagentDispenserComponent, ReagentDispenserEjectContainerMessage>(OnEjectReagentMessage);
             SubscribeLocalEvent<ReagentDispenserComponent, ReagentDispenserClearContainerSolutionMessage>(OnClearContainerSolutionMessage);
 
-            SubscribeLocalEvent<ReagentDispenserComponent, MapInitEvent>(OnMapInit, before: new []{typeof(ItemSlotsSystem)});
+            SubscribeLocalEvent<ReagentDispenserComponent, MapInitEvent>(OnMapInit, before: new[] { typeof(ItemSlotsSystem) });
         }
 
         private void SubscribeUpdateUiState<T>(Entity<ReagentDispenserComponent> ent, ref T ev)
@@ -134,7 +134,7 @@ namespace Content.Server.Chemistry.EntitySystems
             // Ensure that the reagent is something this reagent dispenser can dispense.
             var storageLocation = message.StorageLocation;
             var storedContainer = storage.StoredItems.FirstOrDefault(kvp => kvp.Value == storageLocation).Key;
-            if (storedContainer == null)
+            if (storedContainer == default)
                 return;
 
             var outputContainer = _itemSlotsSystem.GetItemOrNull(reagentDispenser, SharedReagentDispenser.OutputSlotName);
@@ -165,7 +165,7 @@ namespace Content.Server.Chemistry.EntitySystems
 
             var storageLocation = message.StorageLocation;
             var storedContainer = storage.StoredItems.FirstOrDefault(kvp => kvp.Value == storageLocation).Key;
-            if (storedContainer == null)
+            if (storedContainer == default)
                 return;
 
             _handsSystem.TryPickupAnyHand(message.Actor, storedContainer);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 2 warnings in `ReagentDispenserSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
```cs
if (storedContainer == null)
    return;
```
That doesn't do anything, because `storedContainer` can't be null.

Instead we compare it with `EntityUid.Invalid`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->