### PR TITLE
Make electrified security grill on MaxSecurity airlock uncuttable without insuls

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -1,17 +1,20 @@
 using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Construction.Components;
+using Content.Server.Electrocution;
 using Content.Server.Temperature.Components;
 using Content.Shared.Construction;
 using Content.Shared.Construction.Components;
 using Content.Shared.Construction.EntitySystems;
 using Content.Shared.Construction.Steps;
 using Content.Shared.DoAfter;
+using Content.Shared.Electrocution;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Prying.Systems;
 using Content.Shared.Radio.EntitySystems;
 using Content.Shared.Stacks;
+using Content.Shared.Stunnable;
 using Content.Shared.Temperature;
 using Content.Shared.Tools.Systems;
 using Robust.Shared.Containers;
@@ -360,6 +363,19 @@ namespace Content.Server.Construction
                         return _toolSystem.HasQuality(interactUsing.Used, toolInsertStep.Tool)
                             ? HandleResult.Validated
                             : HandleResult.False;
+                    }
+
+                    if (toolInsertStep.TryElectrocute && EntityManager.TryGetComponent<ElectrifiedComponent>(uid, out var electrified))
+                    {
+                        var currentValue = electrified.Enabled;
+                        electrified.Enabled = true;
+
+                        EntityManager.EntitySysManager.GetEntitySystem<ElectrocutionSystem>().TryDoElectrifiedAct(uid, user.Value, electrified: electrified);
+
+                        electrified.Enabled = currentValue;
+
+                        if(EntityManager.HasComponent<StunnedComponent>(user.Value))
+                            return HandleResult.False;
                     }
 
                     // If we're handling an event after its DoAfter finished...

--- a/Content.Shared/Construction/Steps/ToolConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/ToolConstructionGraphStep.cs
@@ -15,6 +15,8 @@ namespace Content.Shared.Construction.Steps
 
         [DataField("examine")] public string ExamineOverride { get; private set; } = string.Empty;
 
+        [DataField] public bool TryElectrocute { get; private set; }
+
         public override void DoExamine(ExaminedEvent examinedEvent)
         {
             if (!string.IsNullOrEmpty(ExamineOverride))

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
@@ -365,7 +365,6 @@
     edges:
     - to: highSecurity
       completed:
-      - !type:AttemptElectrocute
       - !type:GivePrototype
         prototype: PartRodMetal1
         amount: 2
@@ -373,6 +372,7 @@
       - !type:WirePanel {}
       steps:
       - tool: Cutting
+        tryElectrocute: true
         doAfter: 0.5
 
     - to: superMaxSecurityUnfinished


### PR DESCRIPTION
## About the PR

This brings the max security electrified grille on an airlock in line with every other power line and electrified grille in the game.

If you are not wearing sufficient insulation, you will not be able to cut the grille.

## Why / Balance

Seems weird that the feature of the highest security door is just a little zappy zap and a small inconvenience.

## Technical details

I was looking all over for where to put this in the construction system for a cancelable action and I ended up putting it in the unholy hell of whatever `HandleInteraction` is.

This is handled by a `DataField` `TryElectrocute` on `ToolConstructionGraphStep`.

There doesn't seem to be any other place that can easily "cancel" the construction action given a condition on the user of construction.

Literally the only place that tries to electrocute the user on a construction step is this airlock step so...

## Media

BEFORE:

https://github.com/user-attachments/assets/68dada04-870f-42b4-87cb-f736378fc9d9

AFTER:

https://github.com/user-attachments/assets/1ef3e146-7395-4af7-b57a-87e5326f51bd

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

none

**Changelog**
:cl:
- fix: You can no longer cut the electrified grille of max security doors without electrical insulation
