### PR TITLE
Significantly improve Tesla generator power stability

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -56,11 +56,11 @@
     sprite: Structures/Power/Generation/Tesla/coil.rsi
     state: coil
   - type: Battery
-    maxCharge: 2000000
+    maxCharge: 5000000
     startingCharge: 0
   - type: BatteryDischarger
   - type: TeslaCoil
-    chargeFromLightning: 2000000
+    chargeFromLightning: 5000000
   - type: LightningTarget
     priority: 4
     hitProbability: 0.5

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -56,7 +56,7 @@
     sprite: Structures/Power/Generation/Tesla/coil.rsi
     state: coil
   - type: Battery
-    maxCharge: 1000000
+    maxCharge: 2000000
     startingCharge: 0
   - type: BatteryDischarger
   - type: TeslaCoil
@@ -67,8 +67,8 @@
     lightningResistance: 10
     lightningExplode: false
   - type: PowerNetworkBattery
-    maxSupply: 1000000
-    supplyRampTolerance: 1000000
+    maxSupply: 350000
+    supplyRampTolerance: 350000
   - type: Anchorable
   - type: Rotatable
   - type: Pullable


### PR DESCRIPTION
## About the PR
Modifies Tesla coils to make their power generation output over a longer period of time, in order to keep them constantly outputting while in a coil array in an active Tesla setup.

## Why / Balance
Following #37624 I went ahead and dove into it and found out that the Tesla coil power problem had gotten worse and now was supreme ass. No idea why nobody was complaining about this before.

Basically, tesla coils, whenever they are struck, instantly get 2 MJ dumped into their battery bank. This then gets dumped to the grid at a limit of 1 MW. Even in a 4 or 6-coil setup, this rapid release of power causes breakages in the supply of power, as all of the power is already dumped to the grid and wasted (SMESes can't charge that fast) before the next lightning strike from the Tesla comes in.

This is bad, as SMESes do *not* provide power to compensate for deficits instantaneously, intentionally.

This PR smoothes out and eliminates the gaps in power, which means that the station is always powered and thus no flickering is caused.

This also works towards the goal of making engines more attractive.

## Technical details
YAML changes.

## Media
I did a lot of testing, but here's proof.
![Content Client_mDr3i3UF3h](https://github.com/user-attachments/assets/3f5b98e5-1a8f-4e98-8b5e-0223bc49a9d8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Tesla coils can now hold a max capacity of 5 MJ, and receive 5 MJ of energy when struck by lightning.
- tweak: Tesla coils can now only output a maximum of 350 kW to the grid. This was done to make power flow smoother (it was triggering epilepsy in extreme circumstances).