### PR TITLE
Kill resolves in vote commands

### DIFF
--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -72,16 +72,12 @@ namespace Content.Server.Voting
         [Dependency] private readonly VoteWebhooks _voteWebhooks = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
 
-        private ISawmill _sawmill = default!;
-
         private const int MaxArgCount = 10;
 
         public override string Command => "customvote";
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            _sawmill = Logger.GetSawmill("vote");
-
             if (args.Length < 3 || args.Length > MaxArgCount)
             {
                 shell.WriteError(Loc.GetString("shell-need-between-arguments",("lower", 3), ("upper", 10)));

--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -8,10 +8,8 @@ using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
 using Content.Shared.Voting;
-using Robust.Server;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
-using Robust.Shared.Utility;
 
 namespace Content.Server.Voting
 {
@@ -154,6 +152,7 @@ namespace Content.Server.Voting
     public sealed class VoteCommand : LocalizedEntityCommands
     {
         [Dependency] private readonly IVoteManager _voteManager = default!;
+
         public override string Command => "vote";
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Converts all commands within votecommand.cs to localized entity commands and uses dependencies instead of resolves. Also performed some minor cleanup. Minor progress towards #13099 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->