### PR TITLE
Optimise storage a quadrillion times

### DIFF
--- a/Content.Client/Storage/Systems/StorageSystem.cs
+++ b/Content.Client/Storage/Systems/StorageSystem.cs
@@ -63,6 +63,8 @@ public sealed class StorageSystem : SharedStorageSystem
             component.SavedLocations[loc.Key] = new(loc.Value);
         }
 
+        UpdateOccupied((uid, component));
+
         var uiDirty = !component.StoredItems.SequenceEqual(_oldStoredItems);
 
         if (uiDirty && UI.TryGetOpenUi<StorageBoundUserInterface>(uid, StorageComponent.StorageUiKey.Key, out var storageBui))

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Examine;
 using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Storage;
 using JetBrains.Annotations;
+using Robust.Shared.Collections;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -206,15 +207,21 @@ public abstract class SharedItemSystem : EntitySystem
     public IReadOnlyList<Box2i> GetAdjustedItemShape(Entity<ItemComponent?> entity, Angle rotation, Vector2i position)
     {
         if (!Resolve(entity, ref entity.Comp))
-            return new Box2i[] { };
+            return [];
 
+        var adjustedShapes = new List<Box2i>();
+        GetAdjustedItemShape(adjustedShapes, entity, rotation, position);
+        return adjustedShapes;
+    }
+
+    public void GetAdjustedItemShape(List<Box2i> adjustedShapes, Entity<ItemComponent?> entity, Angle rotation, Vector2i position)
+    {
         var shapes = GetItemShape(entity);
         var boundingShape = shapes.GetBoundingBox();
         var boundingCenter = ((Box2) boundingShape).Center;
         var matty = Matrix3Helpers.CreateTransform(boundingCenter, rotation);
         var drift = boundingShape.BottomLeft - matty.TransformBox(boundingShape).BottomLeft;
 
-        var adjustedShapes = new List<Box2i>();
         foreach (var shape in shapes)
         {
             var transformed = matty.TransformBox(shape).Translated(drift);
@@ -223,8 +230,6 @@ public abstract class SharedItemSystem : EntitySystem
 
             adjustedShapes.Add(translated);
         }
-
-        return adjustedShapes;
     }
 
     /// <summary>

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1319,7 +1319,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
         if (storageEnt.Comp.StoredItems.TryGetValue(itemEnt.Owner, out var existing))
         {
-            GetOccupied(itemEnt, existing, _ignored);
+            AddOccupied(itemEnt, existing, _ignored);
         }
 
         // This uses a faster path than the typical codepaths
@@ -1567,7 +1567,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
         if (storageEnt.Comp.StoredItems.TryGetValue(itemEnt.Owner, out var existing))
         {
-            GetOccupied(itemEnt, existing, _ignored);
+            AddOccupied(itemEnt, existing, _ignored);
         }
 
         return ItemFitsInGridLocation(storageEnt.Comp.OccupiedGrid, itemShape, _ignored);
@@ -1624,15 +1624,15 @@ public abstract class SharedStorageSystem : EntitySystem
 
     private void AddOccupiedEntity(Entity<StorageComponent> storageEnt, Entity<ItemComponent?> itemEnt, ItemStorageLocation location)
     {
-        GetOccupied(itemEnt, location, storageEnt.Comp.OccupiedGrid);
+        AddOccupied(itemEnt, location, storageEnt.Comp.OccupiedGrid);
 
         Dirty(storageEnt);
     }
 
-    private void GetOccupied(Entity<ItemComponent?> itemEnt, ItemStorageLocation location, Dictionary<Vector2i, ulong> occupied)
+    private void AddOccupied(Entity<ItemComponent?> itemEnt, ItemStorageLocation location, Dictionary<Vector2i, ulong> occupied)
     {
         var adjustedShape = ItemSystem.GetAdjustedItemShape((itemEnt.Owner, itemEnt.Comp), location);
-        GetOccupied(adjustedShape, occupied);
+        AddOccupied(adjustedShape, occupied);
     }
 
     private void RemoveOccupied(IReadOnlyList<Box2i> adjustedShape, Dictionary<Vector2i, ulong> occupied)
@@ -1670,7 +1670,7 @@ public abstract class SharedStorageSystem : EntitySystem
         }
     }
 
-    private void GetOccupied(IReadOnlyList<Box2i> adjustedShape, Dictionary<Vector2i, ulong> occupied)
+    private void AddOccupied(IReadOnlyList<Box2i> adjustedShape, Dictionary<Vector2i, ulong> occupied)
     {
         foreach (var box in adjustedShape)
         {

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -244,6 +244,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
     private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
     {
+        // TODO: This should update all entities in storage as well.
         if (args.ByType.ContainsKey(typeof(ItemSizePrototype))
             || (args.Removed?.ContainsKey(typeof(ItemSizePrototype)) ?? false))
         {
@@ -1376,6 +1377,8 @@ public abstract class SharedStorageSystem : EntitySystem
             if (!storageEnt.Comp.OccupiedGrid.TryGetValue(storageChunkOrigin, out var occupied))
                 continue;
 
+            // This has a lot of redundant tile checks but with the fast path it shouldn't matter for average ss14
+            // use cases.
             for (var y = bottom; y <= top; y++)
             {
                 for (var x = left; x <= right; x++)

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1359,6 +1359,7 @@ public abstract class SharedStorageSystem : EntitySystem
         {
             // Only need to check 2 angles for a rectangle.
             angles.Add(startAngle);
+            // Idk if there's a preferred facing but + or - 90 pick one.
             angles.Add(startAngle + Angle.FromDegrees(90));
         }
 
@@ -1370,7 +1371,10 @@ public abstract class SharedStorageSystem : EntitySystem
             var bottom = Math.Max(storageChunkOrigin.Y, storageBounding.Bottom);
             var top = Math.Min(storageChunkOrigin.Y + StorageComponent.ChunkSize - 1, storageBounding.Top);
             var right = Math.Min(storageChunkOrigin.X + StorageComponent.ChunkSize - 1, storageBounding.Right);
-            var occupied = storageEnt.Comp.OccupiedGrid.GetValueOrDefault(storageChunkOrigin);
+
+            // No data so assume empty.
+            if (!storageEnt.Comp.OccupiedGrid.TryGetValue(storageChunkOrigin, out var occupied))
+                continue;
 
             for (var y = bottom; y <= top; y++)
             {
@@ -1577,7 +1581,7 @@ public abstract class SharedStorageSystem : EntitySystem
         if (!Resolve(storageEnt, ref storageEnt.Comp))
             return false;
 
-        var chunkOrigin = SharedMapSystem.GetChunkIndices(location, StorageComponent.ChunkSize);
+        var chunkOrigin = SharedMapSystem.GetChunkIndices(location, StorageComponent.ChunkSize) * StorageComponent.ChunkSize;
 
         // No entry so assume it's occupied.
         if (!storageEnt.Comp.OccupiedGrid.TryGetValue(chunkOrigin, out var occupiedMask))
@@ -1613,7 +1617,7 @@ public abstract class SharedStorageSystem : EntitySystem
                 for (var y = box.Bottom; y <= box.Top; y++)
                 {
                     var index = new Vector2i(x, y);
-                    var chunkOrigin = SharedMapSystem.GetChunkIndices(index, StorageComponent.ChunkSize);
+                    var chunkOrigin = SharedMapSystem.GetChunkIndices(index, StorageComponent.ChunkSize) * StorageComponent.ChunkSize;
                     var chunkRelative = SharedMapSystem.GetChunkRelative(index, StorageComponent.ChunkSize);
 
                     // If we can't find the flag mark the entire thing as occupied
@@ -1697,7 +1701,7 @@ public abstract class SharedStorageSystem : EntitySystem
                 for (var y = box.Bottom; y <= box.Top; y++)
                 {
                     var index = new Vector2i(x, y);
-                    var chunkOrigin = SharedMapSystem.GetChunkIndices(index, StorageComponent.ChunkSize);
+                    var chunkOrigin = SharedMapSystem.GetChunkIndices(index, StorageComponent.ChunkSize) * StorageComponent.ChunkSize;
                     var chunkRelative = SharedMapSystem.GetChunkRelative(index, StorageComponent.ChunkSize);
                     var existing = storageEnt.Comp.OccupiedGrid.GetOrNew(chunkOrigin);
                     var flag = SharedMapSystem.ToBitmask(chunkRelative, StorageComponent.ChunkSize);

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1357,7 +1357,7 @@ public abstract class SharedStorageSystem : EntitySystem
         }
         else
         {
-            var shape = itemShape.First();
+            var shape = itemShape[0];
 
             // At least 1 check for a square.
             angles.Add(startAngle);

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1346,7 +1346,6 @@ public abstract class SharedStorageSystem : EntitySystem
         var chunkEnumerator = new ChunkIndicesEnumerator(storageBounding, StorageComponent.ChunkSize);
         var angles = new ValueList<Angle>();
 
-        // TODO: Could also have a variant that only checks 1 angle.
         if (!fastAngles)
         {
             angles.Clear();
@@ -1358,10 +1357,17 @@ public abstract class SharedStorageSystem : EntitySystem
         }
         else
         {
-            // Only need to check 2 angles for a rectangle.
+            var shape = itemShape.First();
+
+            // At least 1 check for a square.
             angles.Add(startAngle);
-            // Idk if there's a preferred facing but + or - 90 pick one.
-            angles.Add(startAngle + Angle.FromDegrees(90));
+
+            // If it's a rectangle make it 2.
+            if (shape.Width != shape.Height)
+            {
+                // Idk if there's a preferred facing but + or - 90 pick one.
+                angles.Add(startAngle + Angle.FromDegrees(90));
+            }
         }
 
         while (chunkEnumerator.MoveNext(out var storageChunk))

--- a/Content.Shared/Storage/StorageComponent.cs
+++ b/Content.Shared/Storage/StorageComponent.cs
@@ -19,6 +19,14 @@ namespace Content.Shared.Storage
     {
         public static string ContainerId = "storagebase";
 
+        public const byte ChunkSize = 8;
+
+        // No datafield because we can just derive it from stored items.
+        /// <summary>
+        /// Bitmask of occupied tiles
+        /// </summary>
+        public Dictionary<Vector2i, ulong> OccupiedGrid = new();
+
         [ViewVariables]
         public Container Container = default!;
 


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/37635

Draft so I can cleanup the API a bit and get some more savings but caching what tiles are occupied already gives us stupid savings.

CBF taking a video but framegraph
![image](https://github.com/user-attachments/assets/a9d64b2a-d93f-4677-8b7e-23e88c9f41bd)

This is as about as fast as I think I can get it short of having a linkedlist of free tiles or something but I don't think it's worth it. At the very least storage should never lag again (short of the clientside frameupdate callers may need to use the new codepaths).

:cl:
- fix: Picking up items with area pickups (e.g. trash bags) no longer lags the game.