### PR TITLE
Added spray painters to Atmos lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -116,6 +116,7 @@
       - id: RCD
       - id: RCDAmmo
       - id: AirGrenade
+      - id: SprayPainter
 
 - type: entity
   id: LockerAtmosphericsFilled
@@ -133,6 +134,7 @@
       - id: RCD
       - id: RCDAmmo
       - id: AirGrenade
+      - id: SprayPainter
 
 - type: entity
   id: LockerEngineerFilledHardsuit


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added spray painters to Atmos lockers.

## Why / Balance
Because not every map has multiple painters mapped in Atmos (I am aware there is some in the youtool)

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
Toast_Enjoyer
:cl:
- add: Spray painters can now be found in Atmos lockers round start

