### PR TITLE
Fix content for `PhysicsMapComponent` engine PR

### DIFF
--- a/Content.Shared/Friction/TileFrictionController.cs
+++ b/Content.Shared/Friction/TileFrictionController.cs
@@ -55,10 +55,8 @@ namespace Content.Shared.Friction
         {
             base.UpdateBeforeMapSolve(prediction, mapComponent, frameTime);
 
-            foreach (var body in mapComponent.AwakeBodies)
+            foreach (var (uid, body) in mapComponent.AwakeBodies)
             {
-                var uid = body.Owner;
-
                 // Only apply friction when it's not a mob (or the mob doesn't have control)
                 // We may want to instead only apply friction to dynamic entities and not mobs ever.
                 if (prediction && !body.Predict || _mover.UseMobMovement(uid))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Updates a little bit of code in `TileFrictionController` to support an [engine PR](https://github.com/space-wizards/RobustToolbox/pull/5948).
Requires https://github.com/space-wizards/RobustToolbox/pull/5948

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It also fixes 1 warning, so that's nice.
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
`PhysicsMapComponent.AwakeBodies` is now a `HashSet<Entity<PhysicsComponent>>` instead of a `HashSet<PhysicsComponent>`, so we need to split each entry into the uid and component to use it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->