### PR TITLE
Use velocity along normal for shuttle impacts

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -107,6 +107,7 @@ public sealed partial class ShuttleSystem
         var ourXform = Transform(args.OurEntity);
         var otherXform = Transform(args.OtherEntity);
         var worldPoints = args.WorldPoints;
+        var worldNormal = args.WorldNormal;
 
         for (var i = 0; i < worldPoints.Length; i++)
         {
@@ -117,7 +118,12 @@ public sealed partial class ShuttleSystem
 
             var ourVelocity = _physics.GetLinearVelocity(args.OurEntity, ourPoint.Position, ourBody, ourXform);
             var otherVelocity = _physics.GetLinearVelocity(args.OtherEntity, otherPoint.Position, otherBody, otherXform);
-            var jungleDiff = (ourVelocity - otherVelocity).Length();
+            var topDiff = (ourVelocity - otherVelocity);
+            var jungleDiff = topDiff.Length();
+
+            // Get the velocity in relation to the contact normal
+            var dotProduct = MathF.Abs(Vector2.Dot(topDiff.Normalized(), worldNormal.Normalized()));
+            jungleDiff *= dotProduct;
 
             // this is cursed but makes it so that collisions of small grid with large grid count the inertia as being approximately the small grid's
             var effectiveInertiaMult = (ourBody.FixturesMass * otherBody.FixturesMass) / (ourBody.FixturesMass + otherBody.FixturesMass);

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -122,6 +122,8 @@ public sealed partial class ShuttleSystem
             var jungleDiff = topDiff.Length();
 
             // Get the velocity in relation to the contact normal
+            // If this still causes issues see https://box2d.org/posts/2020/06/ghost-collisions/
+            // This should only be a potential problem on chunk seams.
             var dotProduct = MathF.Abs(Vector2.Dot(topDiff.Normalized(), worldNormal.Normalized()));
             jungleDiff *= dotProduct;
 


### PR DESCRIPTION
Scrapes shouldn't have the same level of destruction as full-on ramming anymore. Also detecting scrapes should be a lot easier for future stuff.

Requires https://github.com/space-wizards/RobustToolbox/pull/5954

Note that this may not be perfect due to ghost collisions, see https://box2d.org/posts/2020/06/ghost-collisions/

**Changelog**
:cl:
- tweak: Shuttle impact force is now proportional to direction of impact.
