### PR TITLE
Fix Misplaced Mapping CL Entries

### DIFF
--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -3870,43 +3870,6 @@
   id: 8538
   time: '2025-05-20T16:55:21.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37592
-- author: spanky-spanky
-  changes:
-  - message: On Fland, the salvage job board has been added.
-    type: Add
-  id: 8539
-  time: '2025-05-20T23:27:31.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37653
-- author: spanky-spanky
-  changes:
-  - message: On Bagel, the salvage job board has been added.
-    type: Add
-  id: 8540
-  time: '2025-05-20T23:27:57.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37652
-- author: spanky-spanky
-  changes:
-  - message: On Marathon, the salvage job board has been added.
-    type: Add
-  - message: On Marathon, the default TEG has been improved.
-    type: Tweak
-  id: 8541
-  time: '2025-05-20T23:29:45.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37654
-- author: spanky-spanky
-  changes:
-  - message: On Omega, the salvage job board has been added.
-    type: Add
-  id: 8542
-  time: '2025-05-20T23:35:59.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37655
-- author: spanky-spanky
-  changes:
-  - message: On Packed, the salvage job board has been added.
-    type: Add
-  id: 8543
-  time: '2025-05-21T00:12:15.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37656
 - author: FrostWinters
   changes:
   - message: Histamines no longer cause radiation.

--- a/Resources/Changelog/Maps.yml
+++ b/Resources/Changelog/Maps.yml
@@ -195,4 +195,41 @@
   id: 22
   time: '2025-05-19T18:55:41.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37600
+- author: spanky-spanky
+  changes:
+  - message: On Fland, the salvage job board has been added.
+    type: Add
+  id: 8539
+  time: '2025-05-20T23:27:31.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/37653
+- author: spanky-spanky
+  changes:
+  - message: On Bagel, the salvage job board has been added.
+    type: Add
+  id: 8540
+  time: '2025-05-20T23:27:57.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/37652
+- author: spanky-spanky
+  changes:
+  - message: On Marathon, the salvage job board has been added.
+    type: Add
+  - message: On Marathon, the default TEG has been improved.
+    type: Tweak
+  id: 8541
+  time: '2025-05-20T23:29:45.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/37654
+- author: spanky-spanky
+  changes:
+  - message: On Omega, the salvage job board has been added.
+    type: Add
+  id: 8542
+  time: '2025-05-20T23:35:59.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/37655
+- author: spanky-spanky
+  changes:
+  - message: On Packed, the salvage job board has been added.
+    type: Add
+  id: 8543
+  time: '2025-05-21T00:12:15.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/37656
 Order: 1

--- a/Resources/Changelog/Maps.yml
+++ b/Resources/Changelog/Maps.yml
@@ -199,14 +199,14 @@
   changes:
   - message: On Fland, the salvage job board has been added.
     type: Add
-  id: 8539
+  id: 23
   time: '2025-05-20T23:27:31.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37653
 - author: spanky-spanky
   changes:
   - message: On Bagel, the salvage job board has been added.
     type: Add
-  id: 8540
+  id: 24
   time: '2025-05-20T23:27:57.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37652
 - author: spanky-spanky
@@ -215,21 +215,21 @@
     type: Add
   - message: On Marathon, the default TEG has been improved.
     type: Tweak
-  id: 8541
+  id: 25
   time: '2025-05-20T23:29:45.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37654
 - author: spanky-spanky
   changes:
   - message: On Omega, the salvage job board has been added.
     type: Add
-  id: 8542
+  id: 26
   time: '2025-05-20T23:35:59.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37655
 - author: spanky-spanky
   changes:
   - message: On Packed, the salvage job board has been added.
     type: Add
-  id: 8543
+  id: 27
   time: '2025-05-21T00:12:15.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37656
 Order: 1


### PR DESCRIPTION
## About the PR
Moves mapping changes by `spanky-spanky` to the mapping section because he messed up.

## Why / Balance
I accidentally put the CL emoji after MAPS: so it got put in the main changelog; this is me fixing it.

## Technical details
Moves lines from `Resources/Changelog/Changelog.yml` to `Resources/Changelog/Maps.yml`

## Media
**Before:**
![image](https://github.com/user-attachments/assets/de52f022-af74-46a1-bc42-b68395602569)

**After:**
![image](https://github.com/user-attachments/assets/e7776eb8-423a-4425-99b5-a11767cbe5ce)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
lol