### PR TITLE
Tweak "Escape" objective to allow yellowtexting

### DIFF
--- a/Content.Server/Objectives/Systems/EscapeShuttleConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/EscapeShuttleConditionSystem.cs
@@ -30,8 +30,9 @@ public sealed class EscapeShuttleConditionSystem : EntitySystem
             return 0f;
 
         // You're not escaping if you're restrained!
+        // Granting 50% as to allow for partial completion of the objective.
         if (TryComp<CuffableComponent>(mind.OwnedEntity, out var cuffed) && cuffed.CuffedHandCount > 0)
-            return 0f;
+            return _emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value) ? 0.5f : 0f;
 
         // Any emergency shuttle counts for this objective, but not pods.
         return _emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value) ? 1f : 0f;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Tweaked the "Escape alive and unrestrained" objective to allow yellowtexting.
Showing up handcuffed now counts as 50% completion, but showing up dead is still 0%

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Yellowtexting is cool. Lore-wise you get debriefed upon arrival, but who's to say it cannot happen after you leave jail?
It makes it way less punishing to get caught last second, as long as you actually catch the evac shuttle.
While someone might argue that being "dead" is still partially completing the objective, nobody will care if youre handcuffed when dead, which would just lead to free 50% completion, for that reason being dead still counts as 0%.

## Technical details
<!-- Summary of code changes for easier review. -->
EscapeShuttleCondition returns 50% progress if youre on the shuttle while cuffed.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/3c8450fd-db66-418a-968d-6638e00c7b4e)
![image](https://github.com/user-attachments/assets/754a3699-3b55-4d7d-98a2-c279a9021152)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The "Escape alive and unrestrained" objective now counts as partially complete if you show up handcuffed. Being dead still has it count as a total fail!
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
