### PR TITLE
make some stuff require two hands

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
@@ -10,6 +10,10 @@
     - state: icon
   - type: Item
     size: Huge
+  - type: MultiHandedItem #huge device
+  - type: HeldSpeedModifier
+    walkModifier: 0.60
+    sprintModifier: 0.60
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
@@ -12,8 +12,8 @@
     size: Huge
   - type: MultiHandedItem #huge device
   - type: HeldSpeedModifier
-    walkModifier: 0.60
-    sprintModifier: 0.60
+    walkModifier: 0.75
+    sprintModifier: 0.75
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Objects/Power/powersink.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powersink.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: PowerSink
   parent: [BaseMachine, BaseSyndicateContraband]
   name: power sink
@@ -6,6 +6,10 @@
   components:
     - type: Item
       size: Huge
+    - type: MultiHandedItem
+    - type: HeldSpeedModifier #verrryy heavy
+      walkModifier: 0.45
+      sprintModifier: 0.45
     - type: NodeContainer
       examinable: true
       nodes:

--- a/Resources/Prototypes/Entities/Objects/Power/powersink.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powersink.yml
@@ -8,8 +8,8 @@
       size: Huge
     - type: MultiHandedItem
     - type: HeldSpeedModifier #verrryy heavy
-      walkModifier: 0.45
-      sprintModifier: 0.45
+      walkModifier: 0.60
+      sprintModifier: 0.60
     - type: NodeContainer
       examinable: true
       nodes:

--- a/Resources/Prototypes/Entities/Objects/Tools/thief.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/thief.yml
@@ -9,7 +9,6 @@
       range: 2 # Slightly larger than fulton beacon's random offset
     - type: Item
       size: Normal
-    - type: MultiHandedItem #looks pretty big
     - type: Physics
       bodyType: Dynamic
     - type: Fixtures

--- a/Resources/Prototypes/Entities/Objects/Tools/thief.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/thief.yml
@@ -9,6 +9,7 @@
       range: 2 # Slightly larger than fulton beacon's random offset
     - type: Item
       size: Normal
+    - type: MultiHandedItem #looks pretty big
     - type: Physics
       bodyType: Dynamic
     - type: Fixtures


### PR DESCRIPTION
## About the PR
made the singularity beacon and powersink require two free hands to hold and slow you down significantly when held

## Why / Balance
makes sense and required for https://github.com/space-wizards/space-station-14/pull/37682

## Technical details
yml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Singularity beacons and powersinks now require two free hands to hold.
