### PR TITLE
Improve meat spike forensics & behavior

### DIFF
--- a/Content.Server/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicsSystem.cs
@@ -20,6 +20,8 @@ using Robust.Shared.Random;
 using Content.Shared.Verbs;
 using Robust.Shared.Utility;
 using Content.Shared.Hands.Components;
+using Content.Shared.Kitchen;
+using Content.Shared.Mobs;
 
 namespace Content.Server.Forensics
 {
@@ -41,6 +43,9 @@ namespace Content.Server.Forensics
             SubscribeLocalEvent<ForensicsComponent, BeingGibbedEvent>(OnBeingGibbed);
             SubscribeLocalEvent<ForensicsComponent, MeleeHitEvent>(OnMeleeHit);
             SubscribeLocalEvent<ForensicsComponent, GotRehydratedEvent>(OnRehydrated);
+            SubscribeLocalEvent<DnaComponent, KitchenSpikedEvent>(OnKitchenSpiked);
+            SubscribeLocalEvent<ForensicsComponent, KitchenSpikeGetPieceEvent>(OnKitchenSpikeGetPiece);
+
             SubscribeLocalEvent<CleansForensicsComponent, AfterInteractEvent>(OnAfterInteract, after: new[] { typeof(AbsorbentSystem) });
             SubscribeLocalEvent<ForensicsComponent, CleanForensicsDoAfterEvent>(OnCleanForensicsDoAfter);
             SubscribeLocalEvent<DnaComponent, TransferDnaEvent>(OnTransferDnaEvent);
@@ -116,6 +121,21 @@ namespace Content.Server.Forensics
         private void OnRehydrated(Entity<ForensicsComponent> ent, ref GotRehydratedEvent args)
         {
             CopyForensicsFrom(ent.Comp, args.Target);
+        }
+
+        private void OnKitchenSpiked(Entity<DnaComponent> ent, ref KitchenSpikedEvent args)
+        {
+            if (ent.Comp.DNA != null)
+            {
+                var forensicsComp = EnsureComp<ForensicsComponent>(args.SpikeUid);
+                forensicsComp.DNAs.Add(ent.Comp.DNA);
+            }
+            ApplyEvidence(args.SpikerUid, args.SpikeUid);
+        }
+
+        private void OnKitchenSpikeGetPiece(Entity<ForensicsComponent> ent, ref KitchenSpikeGetPieceEvent args)
+        {
+            ApplyEvidence(ent.Owner, args.PieceUid);
         }
 
         /// <summary>

--- a/Content.Shared/Kitchen/Components/KitchenSpikeComponent.cs
+++ b/Content.Shared/Kitchen/Components/KitchenSpikeComponent.cs
@@ -11,18 +11,27 @@ public sealed partial class KitchenSpikeComponent : Component
     [DataField("delay")]
     public float SpikeDelay = 7.0f;
 
-    [ViewVariables(VVAccess.ReadWrite)]
     [DataField("sound")]
     public SoundSpecifier SpikeSound = new SoundPathSpecifier("/Audio/Effects/Fluids/splat.ogg");
 
+    [DataField]
     public List<string>? PrototypesToSpawn;
 
     // TODO: Spiking alive mobs? (Replace with uid) (deal damage to their limbs on spiking, kill on first butcher attempt?)
+    [DataField]
     public string MeatSource1p = "?";
+
+    [DataField]
     public string MeatSource0 = "?";
-    public string Victim = "?";
+
+    [DataField]
+    public string? VictimName = null;
+
+    [DataField]
+    public string? VictimDna = null;
 
     // Prevents simultaneous spiking of two bodies (could be replaced with CancellationToken, but I don't see any situation where Cancel could be called)
+    [DataField]
     public bool InUse;
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
+++ b/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
@@ -36,3 +36,16 @@ public abstract class SharedKitchenSpikeSystem : EntitySystem
 public sealed partial class SpikeDoAfterEvent : SimpleDoAfterEvent
 {
 }
+
+/// <summary>
+/// Event raised on an entity when it gets spiked.
+/// </summary>
+[ByRefEvent]
+public record struct KitchenSpikedEvent(EntityUid VictimUid, EntityUid SpikeUid, EntityUid SpikerUid);
+
+/// <summary>
+/// Event raised on an entity carving a piece of meat.
+/// </summary>
+[ByRefEvent]
+public record struct KitchenSpikeGetPieceEvent(EntityUid PieceUid);
+

--- a/Resources/Locale/en-US/kitchen/components/kitchen-spike-component.ftl
+++ b/Resources/Locale/en-US/kitchen/components/kitchen-spike-component.ftl
@@ -15,4 +15,4 @@ comp-kitchen-spike-knife-needed = You need a knife to do this.
 comp-kitchen-spike-remove-meat = You remove some meat from { THE($victim) }.
 comp-kitchen-spike-remove-meat-last = You remove the last piece of meat from { THE($victim) }!
 
-comp-kitchen-spike-meat-name = { $name } ({ $victim })
+comp-kitchen-spike-meat-name = { $baseName } ({ $victim })


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR improves the meat spike's forensics, ensuring better naming, DNA and forensics evidence.

It also no makes meat spikes no longer delete worn items; they instead drop to the ground when someone is meatspiked.

- Meat spikes now include DNA forensics when a creature is spiked, and while spiked it displays the creature's name.
- Attaching someone to a meat spike or carving meat off a meat spike now includes hand forensics.
- Meat carved off a spike no longer has the person's name, but instead includes the DNA.
- Carving meat gives DNA forensics on the knife used.

This PR supercedes #26749. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Because meat spikes were using outdated code and just lacked general forensics evidence to it. 

## Technical details
<!-- Summary of code changes for easier review. -->

Raises some kitchen spike events when spiking and carving to apply forensics, and the naming of the kitchen spike is done with the proper Name Modifier system instead of hard-setting the entity name.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Meat carved from meat spikes no longer include the victim's name.
- fix: Meat spikes now include the victim's DNA and the spiker's hand forensics when spiking and carving.
- fix: Worn items no longer get deleted when meat spiked.
