### PR TITLE
Remove dependency of DoorComponent from PryingSystem, add PryableComponent

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -255,18 +255,6 @@ public sealed partial class DoorComponent : Component
     }
     #endregion
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool CanPry = true;
-
-    [DataField]
-    public ProtoId<ToolQualityPrototype> PryingQuality = "Prying";
-
-    /// <summary>
-    /// Default time that the door should take to pry open.
-    /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float PryTime = 1.5f;
-
     [DataField]
     public bool ChangeAirtight = true;
 

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -132,7 +132,7 @@ public abstract class SharedAirlockSystem : EntitySystem
         if (!component.Powered || args.PryPowered)
             return;
 
-        args.Message = "airlock-component-cannot-pry-is-powered-message";
+        args.Message = Loc.GetString("airlock-component-cannot-pry-is-powered-message");
 
         args.Cancelled = true;
     }

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.Bolts.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.Bolts.cs
@@ -24,7 +24,7 @@ public abstract partial class SharedDoorSystem
         if (!component.BoltsDown || args.Force)
             return;
 
-        args.Message = "airlock-component-cannot-pry-is-bolted-message";
+        args.Message = Loc.GetString("airlock-component-cannot-pry-is-bolted-message");
 
         args.Cancelled = true;
     }

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -76,7 +76,6 @@ public abstract partial class SharedDoorSystem : EntitySystem
         SubscribeLocalEvent<DoorComponent, PriedEvent>(OnAfterPry);
         SubscribeLocalEvent<DoorComponent, WeldableAttemptEvent>(OnWeldAttempt);
         SubscribeLocalEvent<DoorComponent, WeldableChangedEvent>(OnWeldChanged);
-        SubscribeLocalEvent<DoorComponent, GetPryTimeModifierEvent>(OnPryTimeModifier);
         SubscribeLocalEvent<DoorComponent, GotEmaggedEvent>(OnEmagged);
     }
 
@@ -213,14 +212,9 @@ public abstract partial class SharedDoorSystem : EntitySystem
         args.Handled = true;
     }
 
-    private void OnPryTimeModifier(EntityUid uid, DoorComponent door, ref GetPryTimeModifierEvent args)
-    {
-        args.BaseTime = door.PryTime;
-    }
-
     private void OnBeforePry(EntityUid uid, DoorComponent door, ref BeforePryEvent args)
     {
-        if (door.State == DoorState.Welded || !door.CanPry)
+        if (door.State == DoorState.Welded)
             args.Cancelled = true;
     }
 

--- a/Content.Shared/Prying/Components/PryableComponent.cs
+++ b/Content.Shared/Prying/Components/PryableComponent.cs
@@ -1,0 +1,21 @@
+﻿using Content.Shared.Tools;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Prying.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PryableComponent : Component
+{
+    [DataField]
+    public ProtoId<ToolQualityPrototype> PryingQuality = "Prying";
+
+    /// <summary>
+    /// Default time that the door should take to pry open.
+    /// </summary>
+    [DataField]
+    public float PryTime = 1.5f;
+
+    [DataField]
+    public string VerbLocStr = "door-pry";
+}

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -86,11 +86,12 @@ public record struct GetPryTimeModifierEvent
 {
     public readonly EntityUid User;
     public float PryTimeModifier = 1.0f;
-    public float BaseTime = 5.0f;
+    public readonly float BaseTime;
 
-    public GetPryTimeModifierEvent(EntityUid user)
+    public GetPryTimeModifierEvent(EntityUid user, float baseTime)
     {
         User = user;
+        BaseTime = baseTime;
     }
 }
 

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
-using Content.Shared.Doors.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Prying.Components;
@@ -29,7 +28,7 @@ public sealed class PryingSystem : EntitySystem
 
         // Mob prying doors
         SubscribeLocalEvent<PryableComponent, GetVerbsEvent<AlternativeVerb>>(OnDoorAltVerb);
-        SubscribeLocalEvent<PryableComponent, DoorPryDoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<PryableComponent, PryDoAfterEvent>(OnDoAfter);
         SubscribeLocalEvent<PryableComponent, InteractUsingEvent>(TryPryDoor);
         SubscribeLocalEvent<PryableComponent, GetPryTimeModifierEvent>(OnGetPryTimeModifier);
     }
@@ -135,7 +134,7 @@ public sealed class PryingSystem : EntitySystem
         var modEv = new GetPryTimeModifierEvent(user);
 
         RaiseLocalEvent(target, ref modEv);
-        var doAfterArgs = new DoAfterArgs(EntityManager, user, TimeSpan.FromSeconds(modEv.BaseTime * modEv.PryTimeModifier / toolModifier), new DoorPryDoAfterEvent(), target, target, tool)
+        var doAfterArgs = new DoAfterArgs(EntityManager, user, TimeSpan.FromSeconds(modEv.BaseTime * modEv.PryTimeModifier / toolModifier), new PryDoAfterEvent(), target, target, tool)
         {
             BreakOnDamage = true,
             BreakOnMove = true,
@@ -153,7 +152,7 @@ public sealed class PryingSystem : EntitySystem
         return _doAfterSystem.TryStartDoAfter(doAfterArgs, out id);
     }
 
-    private void OnDoAfter(EntityUid uid, PryableComponent door, DoorPryDoAfterEvent args)
+    private void OnDoAfter(EntityUid uid, PryableComponent door, PryDoAfterEvent args)
     {
         if (args.Cancelled)
             return;
@@ -185,4 +184,4 @@ public sealed class PryingSystem : EntitySystem
 }
 
 [Serializable, NetSerializable]
-public sealed partial class DoorPryDoAfterEvent : SimpleDoAfterEvent;
+public sealed partial class PryDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -27,12 +27,12 @@ public sealed class PryingSystem : EntitySystem
         base.Initialize();
 
         // Mob prying doors
-        SubscribeLocalEvent<PryableComponent, GetVerbsEvent<AlternativeVerb>>(OnDoorAltVerb);
+        SubscribeLocalEvent<PryableComponent, GetVerbsEvent<AlternativeVerb>>(OnPryableAltVerb);
         SubscribeLocalEvent<PryableComponent, PryDoAfterEvent>(OnDoAfter);
-        SubscribeLocalEvent<PryableComponent, InteractUsingEvent>(TryPryDoor);
+        SubscribeLocalEvent<PryableComponent, InteractUsingEvent>(OnInteractUsing);
     }
 
-    private void TryPryDoor(EntityUid uid, PryableComponent comp, InteractUsingEvent args)
+    private void OnInteractUsing(EntityUid uid, PryableComponent comp, InteractUsingEvent args)
     {
         if (args.Handled)
             return;
@@ -40,7 +40,7 @@ public sealed class PryingSystem : EntitySystem
         args.Handled = TryPry(uid, args.User, out _, args.Used);
     }
 
-    private void OnDoorAltVerb(Entity<PryableComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    private void OnPryableAltVerb(Entity<PryableComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
         if (!args.CanInteract || !args.CanAccess)
             return;

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -72,6 +72,7 @@
       path: /Audio/Machines/airlock_close.ogg
     denySound:
       path: /Audio/Machines/airlock_deny.ogg
+  - type: Pryable
   - type: ContainerContainer
     containers:
       board: !type:Container

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -66,6 +66,7 @@
       path: /Audio/Machines/airlock_close.ogg
     denySound:
       path: /Audio/Machines/airlock_deny.ogg
+  - type: Pryable
   - type: Weldable
     fuel: 10
     time: 10

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -102,6 +102,7 @@
         path: /Audio/Machines/airlock_deny.ogg
       openingAnimationTime: 0.6
       closingAnimationTime: 0.6
+    - type: Pryable
     - type: Weldable
       fuel: 5
       time: 3

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -18,7 +18,6 @@
     openTimeTwo: 0.4
     openingAnimationTime: 1.0
     closingAnimationTime: 1.0
-    canPry: false
     crushDamage:
       types:
         Blunt: 25 # yowch

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -55,7 +55,6 @@
       path: /Audio/Machines/shutter.ogg
     closeSound:
       path: /Audio/Machines/shutter.ogg
-  - type: Pryable
   - type: Weldable
     time: 3
   - type: Appearance
@@ -104,8 +103,15 @@
   - type: BlockWeather
 
 - type: entity
-  id: ShuttersNormal
+  id: BaseShutterPryable
   parent: BaseShutter
+  abstract: true
+  components:
+  - type: Pryable
+
+- type: entity
+  id: ShuttersNormal
+  parent: BaseShutterPryable
   components:
   - type: Occluder
   - type: Construction
@@ -132,7 +138,7 @@
 
 - type: entity
   id: ShuttersRadiation
-  parent: BaseShutter
+  parent: BaseShutterPryable
   name: radiation shutters
   description: Why did they make these shutters radioactive?
   components:
@@ -168,7 +174,7 @@
 
 - type: entity
   id: ShuttersWindow
-  parent: BaseShutter
+  parent: BaseShutterPryable
   name: window shutters
   description: The Best (TM) place to see your friends explode!
   components:

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -55,6 +55,7 @@
       path: /Audio/Machines/shutter.ogg
     closeSound:
       path: /Audio/Machines/shutter.ogg
+  - type: Pryable
   - type: Weldable
     time: 3
   - type: Appearance

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -123,6 +123,7 @@
       path: /Audio/Machines/windoor_open.ogg
     denySound:
       path: /Audio/Machines/airlock_deny.ogg
+  - type: Pryable
   - type: Airlock
     keepOpenIfClicked: true
     openPanelVisible: true

--- a/Resources/Prototypes/Entities/Structures/Walls/fence_metal.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/fence_metal.yml
@@ -311,7 +311,6 @@
   - type: Door
     openSpriteState: door_opened
     closedSpriteState: door_closed
-    canPry: false
     occludes: false
     changeAirtight: false
     bumpOpen: false

--- a/Resources/Prototypes/Entities/Structures/Walls/fence_wood.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/fence_wood.yml
@@ -237,7 +237,6 @@
   - type: Door
     openSpriteState: door_opened
     closedSpriteState: door_closed
-    canPry: false
     occludes: false
     changeAirtight: false
     bumpOpen: false
@@ -415,7 +414,6 @@
   - type: Door
     openSpriteState: door_opened_small
     closedSpriteState: door_closed_small
-    canPry: false
     occludes: false
     changeAirtight: false
     bumpOpen: false

--- a/SpaceStation14.sln.DotSettings
+++ b/SpaceStation14.sln.DotSettings
@@ -695,6 +695,7 @@ public sealed partial class $CLASS$ : Shared$CLASS$ {
     <s:Boolean x:Key="/Default/UserDictionary/Words/=preemptively/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=prefs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Protolathe/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=pryable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pullable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Redescribe/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reparenting/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
## About the PR

I want turnstiles to exhibit unique behavior on prying with a tool, and instead of bringing `TurnstileComponent` into `PryingSystem`, I saw the light yesterday and am doing the reverse.

I remove common prying datafields from `DoorComponent` and bring them into a new component `PryableComponent`. The `CanPry` datafield is removed and replaced by the existence of `PryableComponent` on an entity.


All of the `PryingSystem` events are largely unchanged:

> `PryingSystem` will continue to raise `BeforePryEvent` to query the entity if prying is allowed or not given the properties of the tool, the state of the user, and the state of the entity.
> 
> `PryingSystem` will continue to raise `GetPryTimeModifierEvent` to query the entity if the time it takes to pry will be modified due to the state of the user or the state of the entity.
> 
> `PryingSystem` will continue to raise `PriedEvent` to notify that a pry DoAfter has been completed from a given user.

## Why / Balance

Clean up, refactor, allow cleaner integration of planned features in #37350.

## Technical details

See `About` section, not much more complicated than that.

Basically just lets me slap `PryableComponent` on something like turnstiles and add in unique checks for if it can be pried and unique time modifiers without having to duplicate checks for `DoorComponent` with `TurnstileComponent`

## Media

none

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
The following properties have been remove from `DoorComponent`:
- CanPry
- PryingQuality
- PryTime

`PryableComponent` has been added with `PryingQuality` and `PryTime`.

`CanPry` has been "replaced" with the existence of `PryableComponent` on an entity.

Prototypes with `CanPry: False` has that datafield removed.

`PryableComponent` has been added to:
- Airlock
- BaseFirelock
- BaseShutter
- BaseWindoor
- HighSecDoor

Abstract prototype `BaseShutterPryable` is parented from `BaseShutter`, all shutters are parented to `BaseShutterPryable` except `BlastDoor` which shouldn't be pryable.

Handlers of `BeforePryEvent` should put a fully localized message in the `Message` field instead of just the `loc-string` as before.

`GetPryTimeModifierEvent` requires the base pry time as an argument. Normally this will be the `PryTime` field of the `PryableComponent`


