### PR TITLE
Adds default "Toggle" to "Status" linking port

### DIFF
--- a/Resources/Prototypes/DeviceLinking/source_ports.yml
+++ b/Resources/Prototypes/DeviceLinking/source_ports.yml
@@ -20,6 +20,7 @@
   id: Status
   name: signal-port-name-status-transmitter
   description: signal-port-description-status-transmitter
+  defaultLinks: [ Toggle ]
 
 - type: sourcePort
   id: Left


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
- Allows for default linking of shutters/blast doors, lights, etc.
- We are standardizing cargo conveyors/doors to use switches downstream. This allows us to use the default link for QoL.

## Technical details
n/a

## Media
**Blast Door**
![image](https://github.com/user-attachments/assets/c78ae1a2-1621-498e-86b2-a020c4fa3269)
**Conveyor**
![image](https://github.com/user-attachments/assets/680c930b-c616-4312-9fab-9aebb75b3d20)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
🆑 Velcroboy
- tweak: Shutters, blast doors, and lights can now be linked using the "Link Defaults" button. 
