### PR TITLE
Cogni on the nukie planet so people can disconnect without an admins help.

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -54,6 +54,7 @@
     JugSulfur: 1
     JugWeldingFuel: 1
     PlasmaChemistryVial: 1
+    ChemistryBottleCognizine: 1
   contrabandInventory:
     DrinkLithiumFlask: 1
     StrangePill: 3


### PR DESCRIPTION
About the PR
Added Cogni to the syndiejuice machine.

Why / Balance
Getting the chance to play a nuclear operative, commander or agent is an exceptionally rare event, but unfortunately things happen without warning, whether the emergency is social, medical or otherwise, there are times where you have to get up.
This can be rough because if no admin is on, you have effectively just lost a player, granted there are some adminless remedies, i.e buying a reinforcement, but that deeply digs into your valueable telecrystal.
By providing nukies cognie innately, they are able to full on prevent these rare, yet troubling circumstances entirely without the need of third part intervention, saving both the admins and the players stress.

Technical details
Added one line of code to vending_machines.yml.

Media
![image](https://github.com/user-attachments/assets/f8dce713-82c5-4fa5-8a79-54ccc97a8db7)


Requirements
[ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
[X ] I have added media to this PR or it does not require an ingame showcase.
Breaking changes
Changelog
Added cognizine to the syndiejuice so admin intervention is no longer required in the event of a nukie having an emergency and needing to leave.