### PR TITLE
Removed recoil on hitscan laser weapons.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -14,6 +14,7 @@
     - suitStorage
   - type: AmmoCounter
   - type: Gun
+    cameraRecoilScalar: 0 #Notice: Lasers have 0 recoil, other energy projectile weapons like disabler and eshotgun vary.
     fireRate: 2
     selectedMode: SemiAuto
     availableModes:
@@ -37,6 +38,7 @@
   - type: AmmoCounter
   - type: Gun
     fireRate: 2
+    cameraRecoilScalar: 0 #Notice: Lasers have 0 recoil, other energy projectile weapons like disabler and eshotgun vary.
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -467,6 +469,7 @@
   - type: Gun
     fireRate: 2
     projectileSpeed: 35 # any higher and this causes issues in lag
+    cameraRecoilScalar: 1 #Placeholder - it fires a projectile, not a hitscan beam.
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: ProjectileBatteryAmmoProvider
@@ -527,6 +530,7 @@
   - type: Gun
     selectedMode: FullAuto
     fireRate: 4.5
+    cameraRecoilScalar: 1 #Placeholder - it fires a projectile, not a hitscan beam.
     availableModes:
       - SemiAuto
       - FullAuto
@@ -568,6 +572,7 @@
     slots:
     - Belt
   - type: Gun
+    cameraRecoilScalar: .25 #I watched a YouTube video of a taser test fire and it looked like it had a teeny tiny amount of recoil
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser.ogg
   - type: ProjectileBatteryAmmoProvider
@@ -683,6 +688,7 @@
   - type: Gun
     projectileSpeed: 10
     fireRate: 1.5
+    cameraRecoilScalar: 1 #Placeholder - it fires a projectile, not a hitscan beam.
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: ProjectileBatteryAmmoProvider
@@ -770,6 +776,7 @@
     sprite: Objects/Weapons/Guns/Battery/energy_shotgun.rsi
   - type: Gun
     fireRate: 2
+    cameraRecoilScalar: 1 #Placeholder - it fires a projectile, not a hitscan beam.
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: ProjectileBatteryAmmoProvider
@@ -831,6 +838,7 @@
     sprite: Objects/Weapons/Guns/Battery/temp_gun.rsi
   - type: Gun
     fireRate: 1
+    cameraRecoilScalar: 1 #Placeholder - it fires a projectile, not a hitscan beam.
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: ProjectileBatteryAmmoProvider


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Hitscan laser weapons have had their recoil reduced to zero.

## Why / Balance
According to all my google related research, and in keeping with popular sci-fi trends, lasers should not have appreciable recoil even when used as weapons. While the amount of recoil from any sort of focused-light beam is greater than zero, it is not strong enough to produce any sort of noticeable recoil (see flashlights).

Of course realism concerns are secondary to gameplay and ultimately that's the real focus of the PR. Laser weapons are a distinct class of weaponry when compared to kinetic firearms and they should both act and feel differently when compared against one another. Lasers act differently (hitscan beams that can pass through glass vs. kinetic projectiles that have travel time) but they feel similar to actually fire as a result of having identical recoil. This PR seeks to change that by removing recoil from hitscan lasers to make them feel more distinct and unique.

Projectile-based energy weapons (Disablers, the CHIMP, the Energy Shotgun, etc.) have kept their recoil at the default value of one. As they fire projectiles with travel time instead of hitscan lasers I feel that they are distinct from one another and did not attempt to tweak their recoil.

Tasers have a lowered recoil of 0.25 now however. Not that it matters much since they're not obtainable in regular gameplay but they shouldn't have the same kick as a ballistic weapon.

## Technical details
changes in battery_guns.yml to tweak laser recoil. The base versions of the different energy weapons have been given a recoil of zero and the projectile-based prototypes have been updated to keep their recoil the same. Notes also added for future reference.

## Media
Here's a test video I made when I was fiddling with laser recoil. Showcases recoilless lasers, the lower-recoil taser, and regular-recoil disablers.


https://github.com/user-attachments/assets/94b83df2-e387-43aa-9fe8-77034f10cc92


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Hitscan laser weapons no longer have recoil.
