### PR TITLE
Cleanup warning in `GridInRange`

### DIFF
--- a/Content.Shared/Random/Rules/GridInRange.cs
+++ b/Content.Shared/Random/Rules/GridInRange.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 
 namespace Content.Shared.Random.Rules;
 
@@ -10,6 +11,8 @@ public sealed partial class GridInRangeRule : RulesRule
 {
     [DataField]
     public float Range = 10f;
+
+    private List<Entity<MapGridComponent>> _grids = [];
 
     public override bool Check(EntityManager entManager, EntityUid uid)
     {
@@ -29,10 +32,10 @@ public sealed partial class GridInRangeRule : RulesRule
         var worldPos = transform.GetWorldPosition(xform);
         var gridRange = new Vector2(Range, Range);
 
-        foreach (var _ in mapManager.FindGridsIntersecting(xform.MapID, new Box2(worldPos - gridRange, worldPos + gridRange)))
-        {
+        _grids.Clear();
+        mapManager.FindGridsIntersecting(xform.MapID, new Box2(worldPos - gridRange, worldPos + gridRange), ref _grids);
+        if (_grids.Count > 0)
             return !Inverted;
-        }
 
         return Inverted;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a warning in `GridInRange.cs`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
`FindGridsIntersecting` was changed a while back to reuse an existing list of results instead of allocating and returning a new one. So we allocate one in the `GridInRangeRule` constructor, then just clear and pass it in when we need it. Simple enough.

Also changed the kinda-funky `foreach` loop with a discard. Now it just checks if the grids list isn't empty instead.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
My screen recording setup doesn't record audio, but I can confirm that ambient music still plays while in space and fades out when close to grids. This appears to be the only use of `GridInRangeRule`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->