### PR TITLE
Amber Station - Added Sec Beacons

### DIFF
--- a/Resources/Maps/amber.yml
+++ b/Resources/Maps/amber.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 260.0.0
+  engineVersion: 260.2.0
   forkId: ""
   forkVersion: ""
-  time: 05/18/2025 07:10:28
-  entityCount: 24795
+  time: 05/21/2025 22:05:57
+  entityCount: 24827
 maps:
 - 1
 grids:
@@ -128,7 +128,7 @@ entities:
           version: 7
         -2,-1:
           ind: -2,-1
-          tiles: DgAAAAAAAA4AAAAAAAAJAAAAAAEACQAAAAADAAkAAAAAAgAJAAAAAAAACQAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAkAAAAAAwAJAAAAAAMACQAAAAABAAgAAAAAAAAJAAAAAAEACQAAAAABAA4AAAAAAAAOAAAAAAAACQAAAAADAAkAAAAAAAAIAAAAAAAACAAAAAAAAAkAAAAAAQAIAAAAAAAACAAAAAAAAAgAAAAAAAAJAAAAAAMACQAAAAADAAkAAAAAAQAOAAAAAAAACQAAAAACAAkAAAAAAwAeAAAAAAAADgAAAAAAAAkAAAAAAAAJAAAAAAAACAAAAAAAAAgAAAAAAAAJAAAAAAIACQAAAAADAAkAAAAAAAAJAAAAAAAACQAAAAADAAkAAAAAAwAJAAAAAAMADgAAAAAAAAkAAAAAAAAJAAAAAAIAHgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAIAAAAAAAACQAAAAADAAkAAAAAAAAJAAAAAAAACQAAAAACAAgAAAAAAAAIAAAAAAAACAAAAAAAAA4AAAAAAAAJAAAAAAEACQAAAAADAA4AAAAAAAAOAAAAAAAALgAAAAAAACwAAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAACQAAAAACAAkAAAAAAgAOAAAAAAAALAAAAAAAAC4AAAAAAAAuAAAAAAAALgAAAAAAAC4AAAAAAAAsAAAAAAAALgAAAAAAAC4AAAAAAAAuAAAAAAAALgAAAAAAAC4AAAAAAAAuAAAAAAAADgAAAAAAAAkAAAAAAQAJAAAAAAEADgAAAAAAAA4AAAAAAAAsAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAALAAAAAAAAA4AAAAAAAAJAAAAAAIACQAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAcAAAAAAIAHAAAAAAAABwAAAAAAQAcAAAAAAEAIwAAAAACACMAAAAAAQAjAAAAAAEADgAAAAAAAA4AAAAAAAAOAAAAAAAACQAAAAADAAkAAAAAAgAOAAAAAAAADgAAAAAAABwAAAAAAgAcAAAAAAIAHAAAAAADABwAAAAAAwAcAAAAAAIAHAAAAAABAA4AAAAAAAAjAAAAAAEAIwAAAAACAA4AAAAAAAAOAAAAAAAACQAAAAAAAAkAAAAAAwAJAAAAAAAACQAAAAACAAkAAAAAAgAcAAAAAAAAHAAAAAACABwAAAAAAwAcAAAAAAIAHAAAAAAAABwAAAAAAwAOAAAAAAAAIwAAAAAAACMAAAAAAAAOAAAAAAAADgAAAAAAAAkAAAAAAAAJAAAAAAIACQAAAAABAAkAAAAAAQAOAAAAAAAAHAAAAAACABwAAAAAAwAcAAAAAAEAHAAAAAADABwAAAAAAwAcAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAACQAAAAAAAAkAAAAAAgAJAAAAAAMADgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAJAAAAAAEACQAAAAACAAkAAAAAAgAJAAAAAAEACQAAAAAAAAkAAAAAAgAJAAAAAAEACQAAAAACABwAAAAAAgAcAAAAAAEAHAAAAAAAABwAAAAAAQAcAAAAAAIAHAAAAAADABwAAAAAAgAcAAAAAAAACQAAAAABAAkAAAAAAQAPAAAAAAMADwAAAAAAAA8AAAAAAAAPAAAAAAIACQAAAAAAAAkAAAAAAgAcAAAAAAEAHAAAAAACABwAAAAAAQAcAAAAAAAAHAAAAAADABwAAAAAAAAcAAAAAAMAHAAAAAAAAAkAAAAAAAAJAAAAAAMADwAAAAACAA8AAAAAAAAPAAAAAAMADwAAAAADAAkAAAAAAwAJAAAAAAIAHAAAAAAAABwAAAAAAgAcAAAAAAEAHAAAAAAAABwAAAAAAAAcAAAAAAMAHAAAAAABABwAAAAAAQAJAAAAAAIACQAAAAABAA8AAAAAAQAPAAAAAAIADwAAAAACAA8AAAAAAgAJAAAAAAIADgAAAAAAAA4AAAAAAAAOAAAAAAAAHAAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAACQAAAAADAAkAAAAAAwAJAAAAAAMACQAAAAACAAkAAAAAAQAJAAAAAAAACQAAAAAAAA==
+          tiles: DgAAAAAAAA4AAAAAAAAJAAAAAAEACQAAAAADAAkAAAAAAgAJAAAAAAAACQAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAkAAAAAAwAJAAAAAAMACQAAAAABAAgAAAAAAAAJAAAAAAEACQAAAAABAA4AAAAAAAAOAAAAAAAACQAAAAADAAkAAAAAAAAIAAAAAAAACAAAAAAAAAkAAAAAAQAIAAAAAAAACAAAAAAAAAgAAAAAAAAJAAAAAAMACQAAAAADAAkAAAAAAQAOAAAAAAAACQAAAAACAAkAAAAAAwAeAAAAAAAADgAAAAAAAAkAAAAAAAAJAAAAAAAACAAAAAAAAAgAAAAAAAAJAAAAAAIACQAAAAADAAkAAAAAAAAJAAAAAAAACQAAAAADAAkAAAAAAwAJAAAAAAMADgAAAAAAAAkAAAAAAAAJAAAAAAIAHgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAIAAAAAAAACQAAAAADAAkAAAAAAAAJAAAAAAAACQAAAAACAAgAAAAAAAAIAAAAAAAACAAAAAAAAA4AAAAAAAAJAAAAAAEACQAAAAADAA4AAAAAAAAOAAAAAAAALgAAAAAAACwAAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAACQAAAAACAAkAAAAAAgAOAAAAAAAALAAAAAAAAC4AAAAAAAAuAAAAAAAALgAAAAAAAC4AAAAAAAAsAAAAAAAALgAAAAAAAC4AAAAAAAAuAAAAAAAALgAAAAAAAC4AAAAAAAAuAAAAAAAADgAAAAAAAAkAAAAAAQAJAAAAAAEADgAAAAAAAA4AAAAAAAAsAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAALAAAAAAAAA4AAAAAAAAJAAAAAAIACQAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAcAAAAAAIAHAAAAAAAABwAAAAAAQAcAAAAAAEAIwAAAAACACMAAAAAAQAjAAAAAAEADgAAAAAAAA4AAAAAAAAOAAAAAAAACQAAAAADAAkAAAAAAgAOAAAAAAAADgAAAAAAABwAAAAAAgAcAAAAAAIAHAAAAAADABwAAAAAAwAcAAAAAAIAHAAAAAABAA4AAAAAAAAjAAAAAAEAIwAAAAACAA4AAAAAAAAOAAAAAAAACQAAAAAAAAkAAAAAAwAJAAAAAAAACQAAAAACAAkAAAAAAgAcAAAAAAAAHAAAAAACABwAAAAAAwAcAAAAAAIAHAAAAAAAABwAAAAAAwAOAAAAAAAAIwAAAAAAACMAAAAAAAAOAAAAAAAADgAAAAAAAAkAAAAAAAAJAAAAAAIACQAAAAABAAkAAAAAAQAOAAAAAAAAHAAAAAACABwAAAAAAwAcAAAAAAEAHAAAAAADABwAAAAAAwAcAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAACQAAAAAAAAkAAAAAAgAJAAAAAAMADgAAAAAAABwAAAAAAAAcAAAAAAAADgAAAAAAAA4AAAAAAAAcAAAAAAAAHAAAAAAAAA4AAAAAAAAJAAAAAAEACQAAAAACAAkAAAAAAgAJAAAAAAEACQAAAAAAAAkAAAAAAgAJAAAAAAEACQAAAAACABwAAAAAAgAcAAAAAAEAHAAAAAAAABwAAAAAAQAcAAAAAAIAHAAAAAADABwAAAAAAgAcAAAAAAAACQAAAAABAAkAAAAAAQAPAAAAAAMADwAAAAAAAA8AAAAAAAAPAAAAAAIACQAAAAAAAAkAAAAAAgAcAAAAAAEAHAAAAAACABwAAAAAAQAcAAAAAAAAHAAAAAADABwAAAAAAAAcAAAAAAMAHAAAAAAAAAkAAAAAAAAJAAAAAAMADwAAAAACAA8AAAAAAAAPAAAAAAMADwAAAAADAAkAAAAAAwAJAAAAAAIAHAAAAAAAABwAAAAAAgAcAAAAAAEAHAAAAAAAABwAAAAAAAAcAAAAAAMAHAAAAAABABwAAAAAAQAJAAAAAAIACQAAAAABAA8AAAAAAQAPAAAAAAIADwAAAAACAA8AAAAAAgAJAAAAAAIADgAAAAAAAA4AAAAAAAAOAAAAAAAAHAAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAACQAAAAADAAkAAAAAAwAJAAAAAAMACQAAAAACAAkAAAAAAQAJAAAAAAAACQAAAAAAAA==
           version: 7
         -2,-2:
           ind: -2,-2
@@ -14534,7 +14534,8 @@ entities:
           -12,4:
             0: 15234
           -11,1:
-            0: 12492
+            0: 12364
+            7: 128
           -11,2:
             0: 53691
           -11,3:
@@ -14544,7 +14545,9 @@ entities:
           -10,0:
             0: 65520
           -10,1:
-            0: 255
+            0: 175
+            7: 16
+            8: 64
           -10,2:
             0: 60091
           -10,3:
@@ -16384,10 +16387,41 @@ entities:
           - 0
           - 0
           - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.6852
+          - 81.57766
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: NavMap
+    - type: ImplicitRoof
 - proto: AcousticGuitarInstrument
   entities:
   - uid: 10313
@@ -16435,15 +16469,6 @@ entities:
       container: 20698
 - proto: ActionToggleInternals
   entities:
-  - uid: 20606
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 20601
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 20601
   - uid: 20609
     mapInit: true
     paused: true
@@ -16455,15 +16480,6 @@ entities:
       container: 20607
 - proto: ActionToggleJetpack
   entities:
-  - uid: 20605
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 20601
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 20601
   - uid: 20608
     mapInit: true
     paused: true
@@ -16671,6 +16687,8 @@ entities:
       - 810
       - 2208
       - 23806
+      - 24826
+      - 24827
   - uid: 2237
     components:
     - type: Transform
@@ -17992,6 +18010,8 @@ entities:
       - 19008
       - 19006
       - 959
+      - 24826
+      - 24827
   - uid: 24059
     components:
     - type: MetaData
@@ -18611,13 +18631,6 @@ entities:
     - type: Transform
       pos: 34.5,2.5
       parent: 2
-- proto: AirlockEngineering
-  entities:
-  - uid: 15863
-    components:
-    - type: Transform
-      pos: -47.5,15.5
-      parent: 2
 - proto: AirlockEngineeringGlassLocked
   entities:
   - uid: 1267
@@ -18758,6 +18771,11 @@ entities:
     components:
     - type: Transform
       pos: -6.5,-20.5
+      parent: 2
+  - uid: 12490
+    components:
+    - type: Transform
+      pos: -47.5,15.5
       parent: 2
   - uid: 12754
     components:
@@ -19783,6 +19801,24 @@ entities:
     - type: Transform
       pos: 49.5,-57.5
       parent: 2
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,-5.5
+      parent: 2
+  - uid: 92
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -17.5,-5.5
+      parent: 2
+  - uid: 93
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -16.5,-5.5
+      parent: 2
   - uid: 110
     components:
     - type: Transform
@@ -20232,21 +20268,6 @@ entities:
     components:
     - type: Transform
       pos: -17.5,0.5
-      parent: 2
-  - uid: 23857
-    components:
-    - type: Transform
-      pos: -15.5,-5.5
-      parent: 2
-  - uid: 23858
-    components:
-    - type: Transform
-      pos: -16.5,-5.5
-      parent: 2
-  - uid: 23859
-    components:
-    - type: Transform
-      pos: -17.5,-5.5
       parent: 2
   - uid: 24468
     components:
@@ -31098,6 +31119,13 @@ entities:
     - type: Transform
       pos: -23.409725,21.646582
       parent: 2
+- proto: BoxMagazinePistol
+  entities:
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -26.85373,-6.388644
+      parent: 2
 - proto: BoxMouthSwab
   entities:
   - uid: 3435
@@ -31115,7 +31143,7 @@ entities:
   - uid: 12213
     components:
     - type: Transform
-      pos: -29.472397,0.68765736
+      pos: -29.344463,1.3928251
       parent: 2
   - uid: 24202
     components:
@@ -46629,6 +46657,11 @@ entities:
     - type: Transform
       pos: -26.5,20.5
       parent: 2
+  - uid: 1210
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 2
   - uid: 1230
     components:
     - type: Transform
@@ -46833,6 +46866,11 @@ entities:
     components:
     - type: Transform
       pos: 7.5,-23.5
+      parent: 2
+  - uid: 2179
+    components:
+    - type: Transform
+      pos: -4.5,-10.5
       parent: 2
   - uid: 2184
     components:
@@ -68433,6 +68471,11 @@ entities:
       parent: 2
 - proto: ClothingHeadHelmetRiot
   entities:
+  - uid: 12569
+    components:
+    - type: Transform
+      pos: -40.314,1.5935211
+      parent: 2
   - uid: 20682
     components:
     - type: Transform
@@ -68589,8 +68632,47 @@ entities:
     - type: Transform
       pos: 15.512381,-52.444633
       parent: 2
+- proto: ClothingOuterArmorBulletproof
+  entities:
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -38.693848,1.6182833
+      parent: 2
+  - uid: 12491
+    components:
+    - type: Transform
+      pos: -38.381348,1.5870333
+      parent: 2
+  - uid: 12514
+    components:
+    - type: Transform
+      pos: -38.693848,1.6182833
+      parent: 2
+  - uid: 12549
+    components:
+    - type: Transform
+      pos: -38.381348,1.5870333
+      parent: 2
+- proto: ClothingOuterArmorReflective
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -38.678223,1.5245333
+      parent: 2
+  - uid: 12567
+    components:
+    - type: Transform
+      pos: -38.396973,1.4307833
+      parent: 2
 - proto: ClothingOuterArmorRiot
   entities:
+  - uid: 12568
+    components:
+    - type: Transform
+      pos: -40.704624,1.5778961
+      parent: 2
   - uid: 20680
     components:
     - type: Transform
@@ -69563,6 +69645,12 @@ entities:
       parent: 2
 - proto: ComputerCriminalRecords
   entities:
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -29.5,0.5
+      parent: 2
   - uid: 7278
     components:
     - type: Transform
@@ -69759,7 +69847,7 @@ entities:
       parent: 2
 - proto: ComputerSalvageJobBoard
   entities:
-  - uid: 22474
+  - uid: 17659
     components:
     - type: Transform
       pos: 15.5,25.5
@@ -70687,6 +70775,13 @@ entities:
     - type: Transform
       pos: -16.5,-50.5
       parent: 2
+- proto: CrateSecurityTrackingMindshieldImplants
+  entities:
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -29.5,-7.5
+      parent: 2
 - proto: CrateServiceBoozeDispenser
   entities:
   - uid: 2764
@@ -71280,6 +71375,13 @@ entities:
     - type: Transform
       pos: -17.5,-54.5
       parent: 2
+- proto: DefaultStationBeaconBrigMed
+  entities:
+  - uid: 24809
+    components:
+    - type: Transform
+      pos: -44.5,-7.5
+      parent: 2
 - proto: DefaultStationBeaconCaptainsQuarters
   entities:
   - uid: 15722
@@ -71411,6 +71513,13 @@ entities:
     - type: Transform
       pos: -14.5,-47.5
       parent: 2
+- proto: DefaultStationBeaconHOSRoom
+  entities:
+  - uid: 24810
+    components:
+    - type: Transform
+      pos: -44.5,2.5
+      parent: 2
 - proto: DefaultStationBeaconJanitorsCloset
   entities:
   - uid: 21809
@@ -71459,6 +71568,13 @@ entities:
     components:
     - type: Transform
       pos: -47.5,-44.5
+      parent: 2
+- proto: DefaultStationBeaconPermaBrig
+  entities:
+  - uid: 24811
+    components:
+    - type: Transform
+      pos: -31.5,13.5
       parent: 2
 - proto: DefaultStationBeaconPowerBank
   entities:
@@ -71515,6 +71631,13 @@ entities:
     components:
     - type: Transform
       pos: 32.5,-30.5
+      parent: 2
+- proto: DefaultStationBeaconSecurity
+  entities:
+  - uid: 24813
+    components:
+    - type: Transform
+      pos: -34.5,-2.5
       parent: 2
 - proto: DefaultStationBeaconServerRoom
   entities:
@@ -71582,6 +71705,13 @@ entities:
     - type: Transform
       pos: -29.5,-61.5
       parent: 2
+- proto: DefaultStationBeaconWardensOffice
+  entities:
+  - uid: 24812
+    components:
+    - type: Transform
+      pos: -26.5,-6.5
+      parent: 2
 - proto: DefibrillatorCabinetFilled
   entities:
   - uid: 5482
@@ -71634,6 +71764,18 @@ entities:
     - type: Transform
       pos: 3.5,-46.5
       parent: 2
+- proto: DeployableBarrier
+  entities:
+  - uid: 24815
+    components:
+    - type: Transform
+      pos: -31.5,-5.5
+      parent: 2
+  - uid: 24816
+    components:
+    - type: Transform
+      pos: -31.5,-4.5
+      parent: 2
 - proto: DeskBell
   entities:
   - uid: 1746
@@ -71670,6 +71812,11 @@ entities:
     components:
     - type: Transform
       pos: -14.384096,-14.383596
+      parent: 2
+  - uid: 24825
+    components:
+    - type: Transform
+      pos: -14.417165,-2.3140416
       parent: 2
 - proto: DiceBag
   entities:
@@ -79355,6 +79502,12 @@ entities:
     - type: Transform
       pos: -25.5,-0.5
       parent: 2
+  - uid: 24824
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-0.5
+      parent: 2
 - proto: FaxMachineBase
   entities:
   - uid: 36
@@ -82111,6 +82264,26 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 24601
+  - uid: 24826
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 24035
+      - 2196
+  - uid: 24827
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-2.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 24035
+      - 2196
 - proto: Fireplace
   entities:
   - uid: 6141
@@ -115014,41 +115187,102 @@ entities:
   entities:
   - uid: 20618
     components:
+    - type: MetaData
+      name: disabler safe (5)
     - type: Transform
       pos: -41.5,3.5
       parent: 2
+    - type: Label
+      currentLabel: 5
+    - type: NameModifier
+      baseName: disabler safe
 - proto: GunSafeLaserCarbine
   entities:
   - uid: 20614
     components:
+    - type: MetaData
+      name: laser safe (3)
     - type: Transform
       pos: -37.5,5.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 114
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+    - type: Label
+      currentLabel: 3
+    - type: NameModifier
+      baseName: laser safe
 - proto: GunSafePistolMk58
   entities:
   - uid: 20656
     components:
+    - type: MetaData
+      name: mk58 safe (4)
     - type: Transform
       pos: -41.5,4.5
       parent: 2
+    - type: Label
+      currentLabel: 4
+    - type: NameModifier
+      baseName: mk58 safe
 - proto: GunSafeRifleLecter
   entities:
   - uid: 20676
     components:
+    - type: MetaData
+      name: lecter safe (2)
     - type: Transform
       pos: -35.5,5.5
       parent: 2
+    - type: Label
+      currentLabel: 2
+    - type: NameModifier
+      baseName: lecter safe
 - proto: GunSafeShotgunKammerer
   entities:
   - uid: 20615
     components:
+    - type: MetaData
+      name: kammerer safe (2)
     - type: Transform
       pos: -38.5,5.5
       parent: 2
+    - type: Label
+      currentLabel: 2
+    - type: NameModifier
+      baseName: kammerer safe
 - proto: GunSafeSubMachineGunDrozd
   entities:
   - uid: 20611
     components:
+    - type: MetaData
+      name: drozd safe (2)
     - type: Transform
       pos: -36.5,5.5
       parent: 2
@@ -115070,6 +115304,10 @@ entities:
         - 0
         - 0
         - 0
+    - type: Label
+      currentLabel: 2
+    - type: NameModifier
+      baseName: drozd safe
 - proto: GyroscopeUnanchored
   entities:
   - uid: 21926
@@ -115109,6 +115347,11 @@ entities:
     components:
     - type: Transform
       pos: 18.62692,3.6997924
+      parent: 2
+  - uid: 12573
+    components:
+    - type: Transform
+      pos: -45.356728,-5.5768757
       parent: 2
   - uid: 13069
     components:
@@ -115596,10 +115839,10 @@ entities:
       parent: 2
 - proto: HolopadSecurityFront
   entities:
-  - uid: 23336
+  - uid: 12603
     components:
     - type: Transform
-      pos: -28.5,-2.5
+      pos: -32.5,-2.5
       parent: 2
 - proto: HolopadSecurityInterrogation
   entities:
@@ -116108,6 +116351,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: -11.5,1.5
       parent: 2
+  - uid: 24823
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-4.5
+      parent: 2
 - proto: IntercomMedical
   entities:
   - uid: 21749
@@ -116122,6 +116371,20 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,-23.5
+      parent: 2
+- proto: IntercomSecurity
+  entities:
+  - uid: 12582
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-5.5
+      parent: 2
+  - uid: 12601
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -40.5,-4.5
       parent: 2
 - proto: IntercomSupply
   entities:
@@ -116190,27 +116453,19 @@ entities:
       parent: 2
 - proto: JetpackSecurityFilled
   entities:
-  - uid: 20601
+  - uid: 106
     components:
     - type: Transform
-      pos: -38.67241,1.7818651
-      parent: 2
-    - type: GasTank
-      toggleActionEntity: 20606
-    - type: Jetpack
-      toggleActionEntity: 20605
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 20605
-          - 20606
+      parent: 20664
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
   - uid: 20607
     components:
     - type: Transform
-      pos: -38.43271,1.6984739
-      parent: 2
+      parent: 20657
+    - type: Physics
+      canCollide: False
     - type: GasTank
       toggleActionEntity: 20609
     - type: Jetpack
@@ -116222,6 +116477,7 @@ entities:
           ents:
           - 20608
           - 20609
+    - type: InsideEntityStorage
 - proto: Jug
   entities:
   - uid: 12111
@@ -116658,6 +116914,24 @@ entities:
         - - Pressed
           - Toggle
         2243:
+        - - Pressed
+          - Toggle
+        24817:
+        - - Pressed
+          - Toggle
+        24818:
+        - - Pressed
+          - Toggle
+        24821:
+        - - Pressed
+          - Toggle
+        24819:
+        - - Pressed
+          - Toggle
+        24820:
+        - - Pressed
+          - Toggle
+        24822:
         - - Pressed
           - Toggle
   - uid: 12054
@@ -119743,6 +120017,11 @@ entities:
       parent: 2
 - proto: MedkitOxygenFilled
   entities:
+  - uid: 12337
+    components:
+    - type: Transform
+      pos: -45.381424,-6.4595532
+      parent: 2
   - uid: 14893
     components:
     - type: Transform
@@ -120709,7 +120988,7 @@ entities:
   - uid: 19939
     components:
     - type: Transform
-      pos: 14.507148,25.511553
+      pos: 14.4848795,25.54261
       parent: 2
   - uid: 20133
     components:
@@ -121627,11 +121906,6 @@ entities:
     components:
     - type: Transform
       pos: -22.5,-4.5
-      parent: 2
-  - uid: 23324
-    components:
-    - type: Transform
-      pos: -29.5,-7.5
       parent: 2
   - uid: 23328
     components:
@@ -125482,11 +125756,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -28.5,-38.5
       parent: 2
-  - uid: 12154
-    components:
-    - type: Transform
-      pos: -29.5,0.5
-      parent: 2
   - uid: 12178
     components:
     - type: Transform
@@ -127206,16 +127475,6 @@ entities:
     components:
     - type: Transform
       pos: -76.5,-54.5
-      parent: 2
-  - uid: 20565
-    components:
-    - type: Transform
-      pos: -4.5,-9.5
-      parent: 2
-  - uid: 20568
-    components:
-    - type: Transform
-      pos: -4.5,-10.5
       parent: 2
   - uid: 20749
     components:
@@ -133048,6 +133307,18 @@ entities:
         actions: !type:Container
           ents:
           - 20690
+- proto: RiotLaserShield
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -38.694805,1.4338875
+      parent: 2
+  - uid: 12495
+    components:
+    - type: Transform
+      pos: -38.413555,1.3557625
+      parent: 2
 - proto: RiotShield
   entities:
   - uid: 20691
@@ -133677,11 +133948,6 @@ entities:
     - type: Transform
       pos: -57.49946,-58.450542
       parent: 2
-  - uid: 20709
-    components:
-    - type: Transform
-      pos: -35.52191,1.520772
-      parent: 2
 - proto: SheetGlass10
   entities:
   - uid: 12500
@@ -133763,11 +134029,6 @@ entities:
     components:
     - type: Transform
       pos: -37.47171,-24.411203
-      parent: 2
-  - uid: 20722
-    components:
-    - type: Transform
-      pos: -35.480225,1.5416203
       parent: 2
 - proto: SheetPlastic10
   entities:
@@ -134460,6 +134721,42 @@ entities:
     components:
     - type: Transform
       pos: -25.5,8.5
+      parent: 2
+  - uid: 24817
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,-4.5
+      parent: 2
+  - uid: 24818
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -25.5,-4.5
+      parent: 2
+  - uid: 24819
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -28.5,-4.5
+      parent: 2
+  - uid: 24820
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -29.5,-4.5
+      parent: 2
+  - uid: 24821
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -27.5,-4.5
+      parent: 2
+  - uid: 24822
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -30.5,-5.5
       parent: 2
 - proto: ShuttersWindowOpen
   entities:
@@ -139008,6 +139305,8 @@ entities:
   entities:
   - uid: 20657
     components:
+    - type: MetaData
+      name: suit storage unit (3)
     - type: Transform
       pos: -39.5,5.5
       parent: 2
@@ -139017,8 +139316,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
+        - 1.8856695
+        - 7.0937095
         - 0
         - 0
         - 0
@@ -139037,8 +139336,15 @@ entities:
           ents:
           - 20660
           - 20662
+          - 20607
+    - type: Label
+      currentLabel: 3
+    - type: NameModifier
+      baseName: suit storage unit
   - uid: 20664
     components:
+    - type: MetaData
+      name: suit storage unit (3)
     - type: Transform
       pos: -40.5,5.5
       parent: 2
@@ -139048,8 +139354,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
+        - 1.8856695
+        - 7.0937095
         - 0
         - 0
         - 0
@@ -139066,8 +139372,13 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 20666
+          - 106
           - 20667
+          - 20666
+    - type: Label
+      currentLabel: 3
+    - type: NameModifier
+      baseName: suit storage unit
 - proto: SuitStorageWarden
   entities:
   - uid: 11895
@@ -139911,6 +140222,9 @@ entities:
       pos: -38.5,14.5
       parent: 2
     - type: SurveillanceCamera
+      setupAvailableNetworks:
+      - SurveillanceCameraSecurity
+      nameSet: True
       id: Genpop - Dorms
   - uid: 24599
     components:
@@ -139927,6 +140241,9 @@ entities:
       pos: -25.5,9.5
       parent: 2
     - type: SurveillanceCamera
+      setupAvailableNetworks:
+      - SurveillanceCameraSecurity
+      nameSet: True
       id: Genpop - Visitation
 - proto: SurveillanceCameraService
   entities:
@@ -142871,6 +143188,11 @@ entities:
     - type: Transform
       pos: 93.54507,-19.615318
       parent: 2
+  - uid: 24814
+    components:
+    - type: Transform
+      pos: -35.453438,1.7514868
+      parent: 2
 - proto: Tourniquet
   entities:
   - uid: 11574
@@ -143000,7 +143322,7 @@ entities:
   - uid: 23311
     components:
     - type: Transform
-      pos: -26.47277,-6.2551026
+      pos: -26.369354,-6.341769
       parent: 2
 - proto: ToyFigurineWizardFake
   entities:
@@ -143861,6 +144183,11 @@ entities:
       parent: 2
 - proto: VendingMachineTankDispenserEVA
   entities:
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 14.5,22.5
+      parent: 2
   - uid: 2055
     components:
     - type: Transform
@@ -143875,11 +144202,6 @@ entities:
     components:
     - type: Transform
       pos: -41.5,5.5
-      parent: 2
-  - uid: 21410
-    components:
-    - type: Transform
-      pos: 14.5,22.5
       parent: 2
 - proto: VendingMachineTheater
   entities:
@@ -143947,11 +144269,6 @@ entities:
       parent: 2
 - proto: WallReinforced
   entities:
-  - uid: 3
-    components:
-    - type: Transform
-      pos: -47.5,0.5
-      parent: 2
   - uid: 12
     components:
     - type: Transform
@@ -143967,20 +144284,10 @@ entities:
     - type: Transform
       pos: -38.5,7.5
       parent: 2
-  - uid: 20
-    components:
-    - type: Transform
-      pos: -14.5,24.5
-      parent: 2
   - uid: 32
     components:
     - type: Transform
       pos: -25.5,-11.5
-      parent: 2
-  - uid: 38
-    components:
-    - type: Transform
-      pos: -35.5,7.5
       parent: 2
   - uid: 60
     components:
@@ -143992,31 +144299,6 @@ entities:
     - type: Transform
       pos: -24.5,4.5
       parent: 2
-  - uid: 85
-    components:
-    - type: Transform
-      pos: -26.5,4.5
-      parent: 2
-  - uid: 92
-    components:
-    - type: Transform
-      pos: -21.5,9.5
-      parent: 2
-  - uid: 93
-    components:
-    - type: Transform
-      pos: -11.5,26.5
-      parent: 2
-  - uid: 106
-    components:
-    - type: Transform
-      pos: -12.5,24.5
-      parent: 2
-  - uid: 114
-    components:
-    - type: Transform
-      pos: -20.5,9.5
-      parent: 2
   - uid: 125
     components:
     - type: Transform
@@ -144025,7 +144307,7 @@ entities:
   - uid: 126
     components:
     - type: Transform
-      pos: 0.5,15.5
+      pos: 48.5,1.5
       parent: 2
   - uid: 138
     components:
@@ -144042,16 +144324,6 @@ entities:
     - type: Transform
       pos: 1.5,13.5
       parent: 2
-  - uid: 148
-    components:
-    - type: Transform
-      pos: -24.5,-9.5
-      parent: 2
-  - uid: 150
-    components:
-    - type: Transform
-      pos: -46.5,0.5
-      parent: 2
   - uid: 153
     components:
     - type: Transform
@@ -144061,11 +144333,6 @@ entities:
     components:
     - type: Transform
       pos: 47.5,-63.5
-      parent: 2
-  - uid: 156
-    components:
-    - type: Transform
-      pos: 9.5,15.5
       parent: 2
   - uid: 161
     components:
@@ -144087,16 +144354,6 @@ entities:
     - type: Transform
       pos: -39.5,7.5
       parent: 2
-  - uid: 179
-    components:
-    - type: Transform
-      pos: -47.5,-5.5
-      parent: 2
-  - uid: 185
-    components:
-    - type: Transform
-      pos: -30.5,-78.5
-      parent: 2
   - uid: 192
     components:
     - type: Transform
@@ -144116,16 +144373,6 @@ entities:
     components:
     - type: Transform
       pos: -20.5,11.5
-      parent: 2
-  - uid: 203
-    components:
-    - type: Transform
-      pos: -19.5,-5.5
-      parent: 2
-  - uid: 205
-    components:
-    - type: Transform
-      pos: -31.5,-10.5
       parent: 2
   - uid: 207
     components:
@@ -144207,11 +144454,6 @@ entities:
     - type: Transform
       pos: -22.5,17.5
       parent: 2
-  - uid: 272
-    components:
-    - type: Transform
-      pos: -43.5,28.5
-      parent: 2
   - uid: 275
     components:
     - type: Transform
@@ -144226,11 +144468,6 @@ entities:
     components:
     - type: Transform
       pos: -40.5,-4.5
-      parent: 2
-  - uid: 291
-    components:
-    - type: Transform
-      pos: -36.5,-11.5
       parent: 2
   - uid: 295
     components:
@@ -144247,11 +144484,6 @@ entities:
     - type: Transform
       pos: -4.5,-87.5
       parent: 2
-  - uid: 317
-    components:
-    - type: Transform
-      pos: -27.5,-9.5
-      parent: 2
   - uid: 330
     components:
     - type: Transform
@@ -144267,20 +144499,10 @@ entities:
     - type: Transform
       pos: -31.5,-11.5
       parent: 2
-  - uid: 333
-    components:
-    - type: Transform
-      pos: -33.5,-11.5
-      parent: 2
   - uid: 337
     components:
     - type: Transform
       pos: -38.5,-4.5
-      parent: 2
-  - uid: 338
-    components:
-    - type: Transform
-      pos: 13.5,-3.5
       parent: 2
   - uid: 345
     components:
@@ -144291,11 +144513,6 @@ entities:
     components:
     - type: Transform
       pos: -20.5,-9.5
-      parent: 2
-  - uid: 354
-    components:
-    - type: Transform
-      pos: -21.5,0.5
       parent: 2
   - uid: 360
     components:
@@ -144342,45 +144559,15 @@ entities:
     - type: Transform
       pos: -38.5,-11.5
       parent: 2
-  - uid: 389
-    components:
-    - type: Transform
-      pos: -33.5,6.5
-      parent: 2
   - uid: 391
     components:
     - type: Transform
       pos: -37.5,-11.5
       parent: 2
-  - uid: 392
-    components:
-    - type: Transform
-      pos: 50.5,-14.5
-      parent: 2
-  - uid: 395
-    components:
-    - type: Transform
-      pos: -35.5,-0.5
-      parent: 2
   - uid: 396
     components:
     - type: Transform
       pos: -43.5,6.5
-      parent: 2
-  - uid: 397
-    components:
-    - type: Transform
-      pos: -30.5,1.5
-      parent: 2
-  - uid: 398
-    components:
-    - type: Transform
-      pos: -26.5,-9.5
-      parent: 2
-  - uid: 401
-    components:
-    - type: Transform
-      pos: -27.5,-11.5
       parent: 2
   - uid: 406
     components:
@@ -144392,35 +144579,15 @@ entities:
     - type: Transform
       pos: -19.5,2.5
       parent: 2
-  - uid: 417
-    components:
-    - type: Transform
-      pos: -19.5,12.5
-      parent: 2
   - uid: 418
     components:
     - type: Transform
       pos: 48.5,-63.5
       parent: 2
-  - uid: 420
-    components:
-    - type: Transform
-      pos: -38.5,-5.5
-      parent: 2
-  - uid: 426
-    components:
-    - type: Transform
-      pos: -42.5,6.5
-      parent: 2
   - uid: 428
     components:
     - type: Transform
       pos: -37.5,-5.5
-      parent: 2
-  - uid: 429
-    components:
-    - type: Transform
-      pos: -42.5,4.5
       parent: 2
   - uid: 434
     components:
@@ -144431,11 +144598,6 @@ entities:
     components:
     - type: Transform
       pos: -34.5,-7.5
-      parent: 2
-  - uid: 440
-    components:
-    - type: Transform
-      pos: -35.5,-5.5
       parent: 2
   - uid: 441
     components:
@@ -144452,20 +144614,10 @@ entities:
     - type: Transform
       pos: -21.5,7.5
       parent: 2
-  - uid: 444
-    components:
-    - type: Transform
-      pos: -26.5,-0.5
-      parent: 2
   - uid: 447
     components:
     - type: Transform
       pos: -29.5,16.5
-      parent: 2
-  - uid: 448
-    components:
-    - type: Transform
-      pos: -41.5,-9.5
       parent: 2
   - uid: 453
     components:
@@ -144502,11 +144654,6 @@ entities:
     - type: Transform
       pos: 56.5,-47.5
       parent: 2
-  - uid: 483
-    components:
-    - type: Transform
-      pos: -35.5,0.5
-      parent: 2
   - uid: 489
     components:
     - type: Transform
@@ -144516,11 +144663,6 @@ entities:
     components:
     - type: Transform
       pos: -19.5,10.5
-      parent: 2
-  - uid: 491
-    components:
-    - type: Transform
-      pos: -26.5,-11.5
       parent: 2
   - uid: 492
     components:
@@ -144547,11 +144689,6 @@ entities:
     - type: Transform
       pos: -26.5,18.5
       parent: 2
-  - uid: 503
-    components:
-    - type: Transform
-      pos: -20.5,8.5
-      parent: 2
   - uid: 510
     components:
     - type: Transform
@@ -144562,16 +144699,6 @@ entities:
     - type: Transform
       pos: -46.5,-5.5
       parent: 2
-  - uid: 512
-    components:
-    - type: Transform
-      pos: -23.5,0.5
-      parent: 2
-  - uid: 520
-    components:
-    - type: Transform
-      pos: -14.5,0.5
-      parent: 2
   - uid: 527
     components:
     - type: Transform
@@ -144581,11 +144708,6 @@ entities:
     components:
     - type: Transform
       pos: 60.5,-46.5
-      parent: 2
-  - uid: 534
-    components:
-    - type: Transform
-      pos: 25.5,-38.5
       parent: 2
   - uid: 545
     components:
@@ -144622,11 +144744,6 @@ entities:
     - type: Transform
       pos: -23.5,-5.5
       parent: 2
-  - uid: 577
-    components:
-    - type: Transform
-      pos: -41.5,0.5
-      parent: 2
   - uid: 581
     components:
     - type: Transform
@@ -144662,11 +144779,6 @@ entities:
     - type: Transform
       pos: -30.5,-11.5
       parent: 2
-  - uid: 632
-    components:
-    - type: Transform
-      pos: -24.5,18.5
-      parent: 2
   - uid: 645
     components:
     - type: Transform
@@ -144681,16 +144793,6 @@ entities:
     components:
     - type: Transform
       pos: 47.5,-49.5
-      parent: 2
-  - uid: 661
-    components:
-    - type: Transform
-      pos: -33.5,4.5
-      parent: 2
-  - uid: 663
-    components:
-    - type: Transform
-      pos: -31.5,5.5
       parent: 2
   - uid: 668
     components:
@@ -144747,21 +144849,6 @@ entities:
     - type: Transform
       pos: -28.5,4.5
       parent: 2
-  - uid: 713
-    components:
-    - type: Transform
-      pos: -37.5,7.5
-      parent: 2
-  - uid: 714
-    components:
-    - type: Transform
-      pos: -19.5,11.5
-      parent: 2
-  - uid: 716
-    components:
-    - type: Transform
-      pos: -19.5,9.5
-      parent: 2
   - uid: 739
     components:
     - type: Transform
@@ -144771,11 +144858,6 @@ entities:
     components:
     - type: Transform
       pos: -38.5,18.5
-      parent: 2
-  - uid: 754
-    components:
-    - type: Transform
-      pos: -31.5,18.5
       parent: 2
   - uid: 785
     components:
@@ -144787,20 +144869,10 @@ entities:
     - type: Transform
       pos: 87.5,-34.5
       parent: 2
-  - uid: 796
-    components:
-    - type: Transform
-      pos: -26.5,17.5
-      parent: 2
   - uid: 800
     components:
     - type: Transform
       pos: -22.5,9.5
-      parent: 2
-  - uid: 802
-    components:
-    - type: Transform
-      pos: -30.5,0.5
       parent: 2
   - uid: 803
     components:
@@ -144827,25 +144899,10 @@ entities:
     - type: Transform
       pos: -43.5,4.5
       parent: 2
-  - uid: 832
-    components:
-    - type: Transform
-      pos: -20.5,2.5
-      parent: 2
   - uid: 833
     components:
     - type: Transform
       pos: -42.5,2.5
-      parent: 2
-  - uid: 837
-    components:
-    - type: Transform
-      pos: -46.5,-7.5
-      parent: 2
-  - uid: 838
-    components:
-    - type: Transform
-      pos: -33.5,7.5
       parent: 2
   - uid: 839
     components:
@@ -144862,45 +144919,15 @@ entities:
     - type: Transform
       pos: -30.5,-0.5
       parent: 2
-  - uid: 845
-    components:
-    - type: Transform
-      pos: -3.5,26.5
-      parent: 2
-  - uid: 847
-    components:
-    - type: Transform
-      pos: -26.5,8.5
-      parent: 2
-  - uid: 869
-    components:
-    - type: Transform
-      pos: 9.5,14.5
-      parent: 2
-  - uid: 879
-    components:
-    - type: Transform
-      pos: -0.5,15.5
-      parent: 2
   - uid: 892
     components:
     - type: Transform
       pos: 7.5,29.5
       parent: 2
-  - uid: 894
-    components:
-    - type: Transform
-      pos: -20.5,0.5
-      parent: 2
   - uid: 895
     components:
     - type: Transform
       pos: 1.5,29.5
-      parent: 2
-  - uid: 910
-    components:
-    - type: Transform
-      pos: -32.5,2.5
       parent: 2
   - uid: 918
     components:
@@ -144942,21 +144969,6 @@ entities:
     - type: Transform
       pos: 9.5,29.5
       parent: 2
-  - uid: 993
-    components:
-    - type: Transform
-      pos: -1.5,13.5
-      parent: 2
-  - uid: 998
-    components:
-    - type: Transform
-      pos: -42.5,3.5
-      parent: 2
-  - uid: 1007
-    components:
-    - type: Transform
-      pos: 0.5,13.5
-      parent: 2
   - uid: 1010
     components:
     - type: Transform
@@ -144972,25 +144984,10 @@ entities:
     - type: Transform
       pos: -34.5,-5.5
       parent: 2
-  - uid: 1044
-    components:
-    - type: Transform
-      pos: -1.5,27.5
-      parent: 2
-  - uid: 1050
-    components:
-    - type: Transform
-      pos: -26.5,3.5
-      parent: 2
   - uid: 1070
     components:
     - type: Transform
       pos: 86.5,-38.5
-      parent: 2
-  - uid: 1071
-    components:
-    - type: Transform
-      pos: -46.5,2.5
       parent: 2
   - uid: 1075
     components:
@@ -145002,30 +144999,15 @@ entities:
     - type: Transform
       pos: -21.5,4.5
       parent: 2
-  - uid: 1082
-    components:
-    - type: Transform
-      pos: -28.5,-57.5
-      parent: 2
   - uid: 1083
     components:
     - type: Transform
       pos: 56.5,-46.5
       parent: 2
-  - uid: 1086
-    components:
-    - type: Transform
-      pos: -20.5,-5.5
-      parent: 2
   - uid: 1102
     components:
     - type: Transform
       pos: -19.5,-6.5
-      parent: 2
-  - uid: 1107
-    components:
-    - type: Transform
-      pos: -20.5,1.5
       parent: 2
   - uid: 1109
     components:
@@ -145037,16 +145019,6 @@ entities:
     - type: Transform
       pos: -24.5,-11.5
       parent: 2
-  - uid: 1115
-    components:
-    - type: Transform
-      pos: 7.5,1.5
-      parent: 2
-  - uid: 1121
-    components:
-    - type: Transform
-      pos: -41.5,-8.5
-      parent: 2
   - uid: 1122
     components:
     - type: Transform
@@ -145056,16 +145028,6 @@ entities:
     components:
     - type: Transform
       pos: -20.5,17.5
-      parent: 2
-  - uid: 1132
-    components:
-    - type: Transform
-      pos: 25.5,-5.5
-      parent: 2
-  - uid: 1137
-    components:
-    - type: Transform
-      pos: -13.5,3.5
       parent: 2
   - uid: 1146
     components:
@@ -145137,11 +145099,6 @@ entities:
     - type: Transform
       pos: -33.5,-7.5
       parent: 2
-  - uid: 1182
-    components:
-    - type: Transform
-      pos: -20.5,3.5
-      parent: 2
   - uid: 1186
     components:
     - type: Transform
@@ -145152,20 +145109,10 @@ entities:
     - type: Transform
       pos: -20.5,-7.5
       parent: 2
-  - uid: 1191
-    components:
-    - type: Transform
-      pos: -31.5,-7.5
-      parent: 2
   - uid: 1193
     components:
     - type: Transform
       pos: 80.5,-45.5
-      parent: 2
-  - uid: 1194
-    components:
-    - type: Transform
-      pos: -23.5,-0.5
       parent: 2
   - uid: 1195
     components:
@@ -145197,20 +145144,10 @@ entities:
     - type: Transform
       pos: 57.5,-35.5
       parent: 2
-  - uid: 1241
-    components:
-    - type: Transform
-      pos: 4.5,-5.5
-      parent: 2
   - uid: 1252
     components:
     - type: Transform
       pos: -5.5,20.5
-      parent: 2
-  - uid: 1255
-    components:
-    - type: Transform
-      pos: -3.5,21.5
       parent: 2
   - uid: 1294
     components:
@@ -145272,11 +145209,6 @@ entities:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
-  - uid: 1424
-    components:
-    - type: Transform
-      pos: -4.5,6.5
-      parent: 2
   - uid: 1425
     components:
     - type: Transform
@@ -145286,21 +145218,6 @@ entities:
     components:
     - type: Transform
       pos: -2.5,7.5
-      parent: 2
-  - uid: 1427
-    components:
-    - type: Transform
-      pos: -2.5,6.5
-      parent: 2
-  - uid: 1430
-    components:
-    - type: Transform
-      pos: -0.5,6.5
-      parent: 2
-  - uid: 1431
-    components:
-    - type: Transform
-      pos: -0.5,5.5
       parent: 2
   - uid: 1433
     components:
@@ -145317,21 +145234,6 @@ entities:
     - type: Transform
       pos: 1.5,3.5
       parent: 2
-  - uid: 1438
-    components:
-    - type: Transform
-      pos: -0.5,3.5
-      parent: 2
-  - uid: 1443
-    components:
-    - type: Transform
-      pos: -6.5,3.5
-      parent: 2
-  - uid: 1446
-    components:
-    - type: Transform
-      pos: -8.5,3.5
-      parent: 2
   - uid: 1448
     components:
     - type: Transform
@@ -145341,16 +145243,6 @@ entities:
     components:
     - type: Transform
       pos: 27.5,17.5
-      parent: 2
-  - uid: 1483
-    components:
-    - type: Transform
-      pos: -28.5,-49.5
-      parent: 2
-  - uid: 1488
-    components:
-    - type: Transform
-      pos: -11.5,8.5
       parent: 2
   - uid: 1491
     components:
@@ -145372,20 +145264,10 @@ entities:
     - type: Transform
       pos: -4.5,13.5
       parent: 2
-  - uid: 1560
-    components:
-    - type: Transform
-      pos: -11.5,1.5
-      parent: 2
   - uid: 1564
     components:
     - type: Transform
       pos: -10.5,1.5
-      parent: 2
-  - uid: 1589
-    components:
-    - type: Transform
-      pos: -4.5,5.5
       parent: 2
   - uid: 1614
     components:
@@ -145402,11 +145284,6 @@ entities:
     - type: Transform
       pos: -0.5,4.5
       parent: 2
-  - uid: 1668
-    components:
-    - type: Transform
-      pos: 5.5,6.5
-      parent: 2
   - uid: 1680
     components:
     - type: Transform
@@ -145416,16 +145293,6 @@ entities:
     components:
     - type: Transform
       pos: 5.5,3.5
-      parent: 2
-  - uid: 1691
-    components:
-    - type: Transform
-      pos: -11.5,9.5
-      parent: 2
-  - uid: 1725
-    components:
-    - type: Transform
-      pos: 14.5,29.5
       parent: 2
   - uid: 1735
     components:
@@ -145462,11 +145329,6 @@ entities:
     - type: Transform
       pos: 91.5,-36.5
       parent: 2
-  - uid: 1843
-    components:
-    - type: Transform
-      pos: -29.5,-65.5
-      parent: 2
   - uid: 1844
     components:
     - type: Transform
@@ -145491,11 +145353,6 @@ entities:
     components:
     - type: Transform
       pos: 26.5,-47.5
-      parent: 2
-  - uid: 1874
-    components:
-    - type: Transform
-      pos: -27.5,-61.5
       parent: 2
   - uid: 1876
     components:
@@ -145527,35 +145384,10 @@ entities:
     - type: Transform
       pos: 53.5,-27.5
       parent: 2
-  - uid: 1923
-    components:
-    - type: Transform
-      pos: 15.5,-16.5
-      parent: 2
-  - uid: 1926
-    components:
-    - type: Transform
-      pos: -27.5,-62.5
-      parent: 2
   - uid: 1950
     components:
     - type: Transform
       pos: -28.5,-64.5
-      parent: 2
-  - uid: 1959
-    components:
-    - type: Transform
-      pos: -14.5,-4.5
-      parent: 2
-  - uid: 2029
-    components:
-    - type: Transform
-      pos: -27.5,-58.5
-      parent: 2
-  - uid: 2030
-    components:
-    - type: Transform
-      pos: 49.5,18.5
       parent: 2
   - uid: 2069
     components:
@@ -145697,11 +145529,6 @@ entities:
     - type: Transform
       pos: 54.5,-50.5
       parent: 2
-  - uid: 2317
-    components:
-    - type: Transform
-      pos: 9.5,-5.5
-      parent: 2
   - uid: 2335
     components:
     - type: Transform
@@ -145711,11 +145538,6 @@ entities:
     components:
     - type: Transform
       pos: 84.5,-40.5
-      parent: 2
-  - uid: 2351
-    components:
-    - type: Transform
-      pos: 33.5,27.5
       parent: 2
   - uid: 2355
     components:
@@ -145737,11 +145559,6 @@ entities:
     - type: Transform
       pos: -14.5,-0.5
       parent: 2
-  - uid: 2450
-    components:
-    - type: Transform
-      pos: -22.5,-57.5
-      parent: 2
   - uid: 2452
     components:
     - type: Transform
@@ -145752,11 +145569,6 @@ entities:
     - type: Transform
       pos: -25.5,-21.5
       parent: 2
-  - uid: 2488
-    components:
-    - type: Transform
-      pos: -25.5,-24.5
-      parent: 2
   - uid: 2490
     components:
     - type: Transform
@@ -145766,11 +145578,6 @@ entities:
     components:
     - type: Transform
       pos: -25.5,-23.5
-      parent: 2
-  - uid: 2507
-    components:
-    - type: Transform
-      pos: -32.5,18.5
       parent: 2
   - uid: 2515
     components:
@@ -145797,11 +145604,6 @@ entities:
     - type: Transform
       pos: -35.5,-83.5
       parent: 2
-  - uid: 2566
-    components:
-    - type: Transform
-      pos: -39.5,32.5
-      parent: 2
   - uid: 2572
     components:
     - type: Transform
@@ -145821,11 +145623,6 @@ entities:
     components:
     - type: Transform
       pos: -40.5,28.5
-      parent: 2
-  - uid: 2604
-    components:
-    - type: Transform
-      pos: -37.5,32.5
       parent: 2
   - uid: 2609
     components:
@@ -145967,11 +145764,6 @@ entities:
     - type: Transform
       pos: 37.5,-47.5
       parent: 2
-  - uid: 2936
-    components:
-    - type: Transform
-      pos: -5.5,-29.5
-      parent: 2
   - uid: 3017
     components:
     - type: Transform
@@ -146006,11 +145798,6 @@ entities:
     components:
     - type: Transform
       pos: -10.5,-46.5
-      parent: 2
-  - uid: 3100
-    components:
-    - type: Transform
-      pos: 4.5,-20.5
       parent: 2
   - uid: 3124
     components:
@@ -146067,11 +145854,6 @@ entities:
     - type: Transform
       pos: -5.5,-33.5
       parent: 2
-  - uid: 3228
-    components:
-    - type: Transform
-      pos: -2.5,-33.5
-      parent: 2
   - uid: 3229
     components:
     - type: Transform
@@ -146102,30 +145884,10 @@ entities:
     - type: Transform
       pos: 92.5,-36.5
       parent: 2
-  - uid: 3294
-    components:
-    - type: Transform
-      pos: -9.5,-51.5
-      parent: 2
-  - uid: 3300
-    components:
-    - type: Transform
-      pos: 31.5,-47.5
-      parent: 2
   - uid: 3303
     components:
     - type: Transform
       pos: 97.5,-41.5
-      parent: 2
-  - uid: 3304
-    components:
-    - type: Transform
-      pos: 41.5,-16.5
-      parent: 2
-  - uid: 3314
-    components:
-    - type: Transform
-      pos: -31.5,-63.5
       parent: 2
   - uid: 3323
     components:
@@ -146141,11 +145903,6 @@ entities:
     components:
     - type: Transform
       pos: -13.5,-57.5
-      parent: 2
-  - uid: 3389
-    components:
-    - type: Transform
-      pos: -9.5,13.5
       parent: 2
   - uid: 3409
     components:
@@ -146182,11 +145939,6 @@ entities:
     - type: Transform
       pos: 48.5,22.5
       parent: 2
-  - uid: 3535
-    components:
-    - type: Transform
-      pos: -0.5,-38.5
-      parent: 2
   - uid: 3536
     components:
     - type: Transform
@@ -146197,11 +145949,6 @@ entities:
     - type: Transform
       pos: 40.5,-63.5
       parent: 2
-  - uid: 3568
-    components:
-    - type: Transform
-      pos: 25.5,-37.5
-      parent: 2
   - uid: 3582
     components:
     - type: Transform
@@ -146211,11 +145958,6 @@ entities:
     components:
     - type: Transform
       pos: -13.5,-22.5
-      parent: 2
-  - uid: 3663
-    components:
-    - type: Transform
-      pos: 40.5,-18.5
       parent: 2
   - uid: 3666
     components:
@@ -146237,20 +145979,10 @@ entities:
     - type: Transform
       pos: 50.5,-47.5
       parent: 2
-  - uid: 3760
-    components:
-    - type: Transform
-      pos: 44.5,7.5
-      parent: 2
   - uid: 3782
     components:
     - type: Transform
       pos: 51.5,9.5
-      parent: 2
-  - uid: 3792
-    components:
-    - type: Transform
-      pos: 16.5,-61.5
       parent: 2
   - uid: 3797
     components:
@@ -146281,11 +146013,6 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-58.5
-      parent: 2
-  - uid: 3862
-    components:
-    - type: Transform
-      pos: -13.5,-71.5
       parent: 2
   - uid: 3863
     components:
@@ -146332,40 +146059,15 @@ entities:
     - type: Transform
       pos: 0.5,-35.5
       parent: 2
-  - uid: 4017
-    components:
-    - type: Transform
-      pos: 2.5,-38.5
-      parent: 2
   - uid: 4018
     components:
     - type: Transform
       pos: 2.5,-37.5
       parent: 2
-  - uid: 4046
-    components:
-    - type: Transform
-      pos: -54.5,-61.5
-      parent: 2
-  - uid: 4051
-    components:
-    - type: Transform
-      pos: -38.5,-31.5
-      parent: 2
-  - uid: 4061
-    components:
-    - type: Transform
-      pos: -60.5,-35.5
-      parent: 2
   - uid: 4112
     components:
     - type: Transform
       pos: 8.5,-59.5
-      parent: 2
-  - uid: 4164
-    components:
-    - type: Transform
-      pos: -30.5,-16.5
       parent: 2
   - uid: 4178
     components:
@@ -146387,20 +146089,10 @@ entities:
     - type: Transform
       pos: 43.5,-73.5
       parent: 2
-  - uid: 4212
-    components:
-    - type: Transform
-      pos: 18.5,-18.5
-      parent: 2
   - uid: 4223
     components:
     - type: Transform
       pos: -5.5,-59.5
-      parent: 2
-  - uid: 4256
-    components:
-    - type: Transform
-      pos: -25.5,-39.5
       parent: 2
   - uid: 4267
     components:
@@ -146446,11 +146138,6 @@ entities:
     components:
     - type: Transform
       pos: 42.5,-33.5
-      parent: 2
-  - uid: 4442
-    components:
-    - type: Transform
-      pos: -31.5,-49.5
       parent: 2
   - uid: 4447
     components:
@@ -146531,11 +146218,6 @@ entities:
     components:
     - type: Transform
       pos: 30.5,-47.5
-      parent: 2
-  - uid: 4594
-    components:
-    - type: Transform
-      pos: -32.5,-26.5
       parent: 2
   - uid: 4599
     components:
@@ -146622,20 +146304,10 @@ entities:
     - type: Transform
       pos: 51.5,18.5
       parent: 2
-  - uid: 4737
-    components:
-    - type: Transform
-      pos: 31.5,-32.5
-      parent: 2
   - uid: 4788
     components:
     - type: Transform
       pos: 31.5,-36.5
-      parent: 2
-  - uid: 4795
-    components:
-    - type: Transform
-      pos: 22.5,-7.5
       parent: 2
   - uid: 4846
     components:
@@ -146676,11 +146348,6 @@ entities:
     components:
     - type: Transform
       pos: -37.5,-66.5
-      parent: 2
-  - uid: 4884
-    components:
-    - type: Transform
-      pos: -28.5,35.5
       parent: 2
   - uid: 4888
     components:
@@ -146732,20 +146399,10 @@ entities:
     - type: Transform
       pos: -5.5,26.5
       parent: 2
-  - uid: 4945
-    components:
-    - type: Transform
-      pos: -27.5,-63.5
-      parent: 2
   - uid: 4960
     components:
     - type: Transform
       pos: -30.5,-43.5
-      parent: 2
-  - uid: 4966
-    components:
-    - type: Transform
-      pos: -35.5,-66.5
       parent: 2
   - uid: 4984
     components:
@@ -146767,20 +146424,10 @@ entities:
     - type: Transform
       pos: 18.5,29.5
       parent: 2
-  - uid: 5009
-    components:
-    - type: Transform
-      pos: -37.5,-74.5
-      parent: 2
   - uid: 5021
     components:
     - type: Transform
       pos: -8.5,26.5
-      parent: 2
-  - uid: 5029
-    components:
-    - type: Transform
-      pos: -53.5,-38.5
       parent: 2
   - uid: 5032
     components:
@@ -146821,11 +146468,6 @@ entities:
     components:
     - type: Transform
       pos: -9.5,18.5
-      parent: 2
-  - uid: 5102
-    components:
-    - type: Transform
-      pos: -9.5,16.5
       parent: 2
   - uid: 5108
     components:
@@ -146877,11 +146519,6 @@ entities:
     - type: Transform
       pos: 13.5,-0.5
       parent: 2
-  - uid: 5247
-    components:
-    - type: Transform
-      pos: -10.5,-22.5
-      parent: 2
   - uid: 5274
     components:
     - type: Transform
@@ -146907,31 +146544,6 @@ entities:
     - type: Transform
       pos: 43.5,-77.5
       parent: 2
-  - uid: 5317
-    components:
-    - type: Transform
-      pos: -16.5,24.5
-      parent: 2
-  - uid: 5324
-    components:
-    - type: Transform
-      pos: 4.5,29.5
-      parent: 2
-  - uid: 5327
-    components:
-    - type: Transform
-      pos: 4.5,28.5
-      parent: 2
-  - uid: 5334
-    components:
-    - type: Transform
-      pos: -18.5,27.5
-      parent: 2
-  - uid: 5342
-    components:
-    - type: Transform
-      pos: -3.5,16.5
-      parent: 2
   - uid: 5343
     components:
     - type: Transform
@@ -146947,11 +146559,6 @@ entities:
     - type: Transform
       pos: 80.5,-24.5
       parent: 2
-  - uid: 5349
-    components:
-    - type: Transform
-      pos: -8.5,25.5
-      parent: 2
   - uid: 5357
     components:
     - type: Transform
@@ -146962,30 +146569,10 @@ entities:
     - type: Transform
       pos: 54.5,-35.5
       parent: 2
-  - uid: 5384
-    components:
-    - type: Transform
-      pos: -7.5,20.5
-      parent: 2
-  - uid: 5387
-    components:
-    - type: Transform
-      pos: -63.5,-39.5
-      parent: 2
-  - uid: 5411
-    components:
-    - type: Transform
-      pos: -24.5,23.5
-      parent: 2
   - uid: 5426
     components:
     - type: Transform
       pos: 50.5,22.5
-      parent: 2
-  - uid: 5460
-    components:
-    - type: Transform
-      pos: -10.5,31.5
       parent: 2
   - uid: 5490
     components:
@@ -147002,11 +146589,6 @@ entities:
     - type: Transform
       pos: 60.5,-49.5
       parent: 2
-  - uid: 5510
-    components:
-    - type: Transform
-      pos: 25.5,-41.5
-      parent: 2
   - uid: 5515
     components:
     - type: Transform
@@ -147017,11 +146599,6 @@ entities:
     - type: Transform
       pos: -29.5,-49.5
       parent: 2
-  - uid: 5529
-    components:
-    - type: Transform
-      pos: 25.5,-46.5
-      parent: 2
   - uid: 5532
     components:
     - type: Transform
@@ -147031,11 +146608,6 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-54.5
-      parent: 2
-  - uid: 5544
-    components:
-    - type: Transform
-      pos: 5.5,-20.5
       parent: 2
   - uid: 5545
     components:
@@ -147066,11 +146638,6 @@ entities:
     components:
     - type: Transform
       pos: -40.5,-58.5
-      parent: 2
-  - uid: 5579
-    components:
-    - type: Transform
-      pos: -31.5,-46.5
       parent: 2
   - uid: 5581
     components:
@@ -147147,11 +146714,6 @@ entities:
     - type: Transform
       pos: 63.5,-63.5
       parent: 2
-  - uid: 5732
-    components:
-    - type: Transform
-      pos: 43.5,-19.5
-      parent: 2
   - uid: 5741
     components:
     - type: Transform
@@ -147167,11 +146729,6 @@ entities:
     - type: Transform
       pos: 13.5,-63.5
       parent: 2
-  - uid: 5771
-    components:
-    - type: Transform
-      pos: 13.5,-61.5
-      parent: 2
   - uid: 5775
     components:
     - type: Transform
@@ -147181,11 +146738,6 @@ entities:
     components:
     - type: Transform
       pos: 12.5,-66.5
-      parent: 2
-  - uid: 5811
-    components:
-    - type: Transform
-      pos: 24.5,20.5
       parent: 2
   - uid: 5814
     components:
@@ -147222,11 +146774,6 @@ entities:
     - type: Transform
       pos: 42.5,17.5
       parent: 2
-  - uid: 5839
-    components:
-    - type: Transform
-      pos: 32.5,-47.5
-      parent: 2
   - uid: 5843
     components:
     - type: Transform
@@ -147241,16 +146788,6 @@ entities:
     components:
     - type: Transform
       pos: 53.5,-34.5
-      parent: 2
-  - uid: 5939
-    components:
-    - type: Transform
-      pos: 41.5,-13.5
-      parent: 2
-  - uid: 5942
-    components:
-    - type: Transform
-      pos: 52.5,-10.5
       parent: 2
   - uid: 6035
     components:
@@ -147272,30 +146809,15 @@ entities:
     - type: Transform
       pos: 46.5,13.5
       parent: 2
-  - uid: 6165
-    components:
-    - type: Transform
-      pos: -31.5,-67.5
-      parent: 2
   - uid: 6188
     components:
     - type: Transform
       pos: -31.5,-83.5
       parent: 2
-  - uid: 6190
-    components:
-    - type: Transform
-      pos: 29.5,-47.5
-      parent: 2
   - uid: 6217
     components:
     - type: Transform
       pos: 40.5,-16.5
-      parent: 2
-  - uid: 6224
-    components:
-    - type: Transform
-      pos: -31.5,-68.5
       parent: 2
   - uid: 6233
     components:
@@ -147322,20 +146844,10 @@ entities:
     - type: Transform
       pos: 15.5,-61.5
       parent: 2
-  - uid: 6380
-    components:
-    - type: Transform
-      pos: 43.5,0.5
-      parent: 2
   - uid: 6384
     components:
     - type: Transform
       pos: -1.5,-85.5
-      parent: 2
-  - uid: 6406
-    components:
-    - type: Transform
-      pos: -10.5,-65.5
       parent: 2
   - uid: 6418
     components:
@@ -147352,25 +146864,10 @@ entities:
     - type: Transform
       pos: -10.5,-87.5
       parent: 2
-  - uid: 6482
-    components:
-    - type: Transform
-      pos: -25.5,-43.5
-      parent: 2
-  - uid: 6488
-    components:
-    - type: Transform
-      pos: -14.5,-57.5
-      parent: 2
   - uid: 6544
     components:
     - type: Transform
       pos: 15.5,-64.5
-      parent: 2
-  - uid: 6588
-    components:
-    - type: Transform
-      pos: -57.5,-39.5
       parent: 2
   - uid: 6617
     components:
@@ -147402,11 +146899,6 @@ entities:
     - type: Transform
       pos: 40.5,-17.5
       parent: 2
-  - uid: 6712
-    components:
-    - type: Transform
-      pos: -38.5,-28.5
-      parent: 2
   - uid: 6732
     components:
     - type: Transform
@@ -147431,11 +146923,6 @@ entities:
     components:
     - type: Transform
       pos: 60.5,-48.5
-      parent: 2
-  - uid: 6803
-    components:
-    - type: Transform
-      pos: 39.5,-32.5
       parent: 2
   - uid: 6823
     components:
@@ -147532,11 +147019,6 @@ entities:
     - type: Transform
       pos: 8.5,-5.5
       parent: 2
-  - uid: 7165
-    components:
-    - type: Transform
-      pos: -27.5,-55.5
-      parent: 2
   - uid: 7169
     components:
     - type: Transform
@@ -147562,11 +147044,6 @@ entities:
     - type: Transform
       pos: -10.5,26.5
       parent: 2
-  - uid: 7240
-    components:
-    - type: Transform
-      pos: -25.5,-33.5
-      parent: 2
   - uid: 7300
     components:
     - type: Transform
@@ -147576,11 +147053,6 @@ entities:
     components:
     - type: Transform
       pos: 40.5,-65.5
-      parent: 2
-  - uid: 7314
-    components:
-    - type: Transform
-      pos: 42.5,5.5
       parent: 2
   - uid: 7337
     components:
@@ -147602,30 +147074,15 @@ entities:
     - type: Transform
       pos: 28.5,-49.5
       parent: 2
-  - uid: 7419
-    components:
-    - type: Transform
-      pos: 26.5,-50.5
-      parent: 2
   - uid: 7422
     components:
     - type: Transform
       pos: 27.5,-52.5
       parent: 2
-  - uid: 7423
-    components:
-    - type: Transform
-      pos: 28.5,-52.5
-      parent: 2
   - uid: 7450
     components:
     - type: Transform
       pos: 50.5,-62.5
-      parent: 2
-  - uid: 7516
-    components:
-    - type: Transform
-      pos: -9.5,-56.5
       parent: 2
   - uid: 7520
     components:
@@ -147636,11 +147093,6 @@ entities:
     components:
     - type: Transform
       pos: 50.5,-39.5
-      parent: 2
-  - uid: 7671
-    components:
-    - type: Transform
-      pos: 18.5,-16.5
       parent: 2
   - uid: 7710
     components:
@@ -147757,11 +147209,6 @@ entities:
     - type: Transform
       pos: -0.5,14.5
       parent: 2
-  - uid: 8571
-    components:
-    - type: Transform
-      pos: 44.5,26.5
-      parent: 2
   - uid: 8594
     components:
     - type: Transform
@@ -147796,21 +147243,6 @@ entities:
     components:
     - type: Transform
       pos: 53.5,-15.5
-      parent: 2
-  - uid: 8768
-    components:
-    - type: Transform
-      pos: 47.5,0.5
-      parent: 2
-  - uid: 8771
-    components:
-    - type: Transform
-      pos: 47.5,1.5
-      parent: 2
-  - uid: 8774
-    components:
-    - type: Transform
-      pos: 47.5,4.5
       parent: 2
   - uid: 8779
     components:
@@ -147872,16 +147304,6 @@ entities:
     - type: Transform
       pos: 6.5,-72.5
       parent: 2
-  - uid: 9276
-    components:
-    - type: Transform
-      pos: 2.5,-20.5
-      parent: 2
-  - uid: 9283
-    components:
-    - type: Transform
-      pos: -30.5,-4.5
-      parent: 2
   - uid: 9298
     components:
     - type: Transform
@@ -147897,20 +147319,10 @@ entities:
     - type: Transform
       pos: -45.5,-58.5
       parent: 2
-  - uid: 9389
-    components:
-    - type: Transform
-      pos: 16.5,-16.5
-      parent: 2
   - uid: 9423
     components:
     - type: Transform
       pos: 11.5,3.5
-      parent: 2
-  - uid: 9495
-    components:
-    - type: Transform
-      pos: 15.5,4.5
       parent: 2
   - uid: 9566
     components:
@@ -147962,11 +147374,6 @@ entities:
     - type: Transform
       pos: 89.5,-53.5
       parent: 2
-  - uid: 9839
-    components:
-    - type: Transform
-      pos: -12.5,23.5
-      parent: 2
   - uid: 9862
     components:
     - type: Transform
@@ -148012,11 +147419,6 @@ entities:
     - type: Transform
       pos: 92.5,-43.5
       parent: 2
-  - uid: 10051
-    components:
-    - type: Transform
-      pos: -34.5,18.5
-      parent: 2
   - uid: 10065
     components:
     - type: Transform
@@ -148057,16 +147459,6 @@ entities:
     - type: Transform
       pos: -39.5,18.5
       parent: 2
-  - uid: 10148
-    components:
-    - type: Transform
-      pos: -32.5,-33.5
-      parent: 2
-  - uid: 10174
-    components:
-    - type: Transform
-      pos: -40.5,18.5
-      parent: 2
   - uid: 10195
     components:
     - type: Transform
@@ -148087,16 +147479,6 @@ entities:
     - type: Transform
       pos: 3.5,-5.5
       parent: 2
-  - uid: 10213
-    components:
-    - type: Transform
-      pos: -42.5,14.5
-      parent: 2
-  - uid: 10216
-    components:
-    - type: Transform
-      pos: -42.5,12.5
-      parent: 2
   - uid: 10219
     components:
     - type: Transform
@@ -148116,16 +147498,6 @@ entities:
     components:
     - type: Transform
       pos: -28.5,17.5
-      parent: 2
-  - uid: 10273
-    components:
-    - type: Transform
-      pos: -28.5,16.5
-      parent: 2
-  - uid: 10384
-    components:
-    - type: Transform
-      pos: -58.5,-61.5
       parent: 2
   - uid: 10423
     components:
@@ -148187,16 +147559,6 @@ entities:
     - type: Transform
       pos: -37.5,6.5
       parent: 2
-  - uid: 10609
-    components:
-    - type: Transform
-      pos: -38.5,6.5
-      parent: 2
-  - uid: 10615
-    components:
-    - type: Transform
-      pos: -39.5,6.5
-      parent: 2
   - uid: 10626
     components:
     - type: Transform
@@ -148206,11 +147568,6 @@ entities:
     components:
     - type: Transform
       pos: -41.5,6.5
-      parent: 2
-  - uid: 10635
-    components:
-    - type: Transform
-      pos: -33.5,-21.5
       parent: 2
   - uid: 10676
     components:
@@ -148241,11 +147598,6 @@ entities:
     components:
     - type: Transform
       pos: -28.5,26.5
-      parent: 2
-  - uid: 10794
-    components:
-    - type: Transform
-      pos: -43.5,-9.5
       parent: 2
   - uid: 10795
     components:
@@ -148282,11 +147634,6 @@ entities:
     - type: Transform
       pos: -41.5,2.5
       parent: 2
-  - uid: 11035
-    components:
-    - type: Transform
-      pos: -31.5,-39.5
-      parent: 2
   - uid: 11043
     components:
     - type: Transform
@@ -148311,16 +147658,6 @@ entities:
     components:
     - type: Transform
       pos: -41.5,-11.5
-      parent: 2
-  - uid: 11216
-    components:
-    - type: Transform
-      pos: 26.5,30.5
-      parent: 2
-  - uid: 11224
-    components:
-    - type: Transform
-      pos: -41.5,-10.5
       parent: 2
   - uid: 11241
     components:
@@ -148352,11 +147689,6 @@ entities:
     - type: Transform
       pos: -25.5,-38.5
       parent: 2
-  - uid: 11323
-    components:
-    - type: Transform
-      pos: -18.5,26.5
-      parent: 2
   - uid: 11324
     components:
     - type: Transform
@@ -148376,11 +147708,6 @@ entities:
     components:
     - type: Transform
       pos: 63.5,-67.5
-      parent: 2
-  - uid: 11578
-    components:
-    - type: Transform
-      pos: 12.5,-20.5
       parent: 2
   - uid: 11579
     components:
@@ -148412,16 +147739,6 @@ entities:
     - type: Transform
       pos: 45.5,14.5
       parent: 2
-  - uid: 12133
-    components:
-    - type: Transform
-      pos: -39.5,-39.5
-      parent: 2
-  - uid: 12217
-    components:
-    - type: Transform
-      pos: -36.5,-31.5
-      parent: 2
   - uid: 12226
     components:
     - type: Transform
@@ -148442,11 +147759,6 @@ entities:
     - type: Transform
       pos: -14.5,-22.5
       parent: 2
-  - uid: 12337
-    components:
-    - type: Transform
-      pos: -8.5,20.5
-      parent: 2
   - uid: 12359
     components:
     - type: Transform
@@ -148461,21 +147773,6 @@ entities:
     components:
     - type: Transform
       pos: -54.5,-20.5
-      parent: 2
-  - uid: 12490
-    components:
-    - type: Transform
-      pos: 12.5,9.5
-      parent: 2
-  - uid: 12491
-    components:
-    - type: Transform
-      pos: 11.5,9.5
-      parent: 2
-  - uid: 12495
-    components:
-    - type: Transform
-      pos: 13.5,5.5
       parent: 2
   - uid: 12501
     components:
@@ -148507,11 +147804,6 @@ entities:
     - type: Transform
       pos: -53.5,-35.5
       parent: 2
-  - uid: 12549
-    components:
-    - type: Transform
-      pos: -52.5,-35.5
-      parent: 2
   - uid: 12559
     components:
     - type: Transform
@@ -148522,11 +147814,6 @@ entities:
     - type: Transform
       pos: 96.5,-37.5
       parent: 2
-  - uid: 12567
-    components:
-    - type: Transform
-      pos: -47.5,-20.5
-      parent: 2
   - uid: 12572
     components:
     - type: Transform
@@ -148535,27 +147822,42 @@ entities:
   - uid: 12611
     components:
     - type: Transform
-      pos: -54.5,-24.5
+      pos: 49.5,-3.5
       parent: 2
   - uid: 12615
     components:
     - type: Transform
       pos: -44.5,11.5
       parent: 2
+  - uid: 12617
+    components:
+    - type: Transform
+      pos: 51.5,8.5
+      parent: 2
   - uid: 12620
     components:
     - type: Transform
       pos: -51.5,-24.5
       parent: 2
-  - uid: 12626
+  - uid: 12621
     components:
     - type: Transform
-      pos: -50.5,-32.5
+      pos: 45.5,18.5
+      parent: 2
+  - uid: 12622
+    components:
+    - type: Transform
+      pos: 47.5,18.5
+      parent: 2
+  - uid: 12628
+    components:
+    - type: Transform
+      pos: 41.5,22.5
       parent: 2
   - uid: 12629
     components:
     - type: Transform
-      pos: -44.5,10.5
+      pos: 43.5,22.5
       parent: 2
   - uid: 12630
     components:
@@ -148565,7 +147867,17 @@ entities:
   - uid: 12633
     components:
     - type: Transform
-      pos: -50.5,-25.5
+      pos: 44.5,24.5
+      parent: 2
+  - uid: 12637
+    components:
+    - type: Transform
+      pos: 44.5,25.5
+      parent: 2
+  - uid: 12648
+    components:
+    - type: Transform
+      pos: 39.5,23.5
       parent: 2
   - uid: 12649
     components:
@@ -148577,10 +147889,60 @@ entities:
     - type: Transform
       pos: -41.5,8.5
       parent: 2
+  - uid: 12653
+    components:
+    - type: Transform
+      pos: 44.5,13.5
+      parent: 2
+  - uid: 12655
+    components:
+    - type: Transform
+      pos: 45.5,15.5
+      parent: 2
+  - uid: 12656
+    components:
+    - type: Transform
+      pos: 42.5,7.5
+      parent: 2
+  - uid: 12690
+    components:
+    - type: Transform
+      pos: 44.5,4.5
+      parent: 2
+  - uid: 12691
+    components:
+    - type: Transform
+      pos: 43.5,4.5
+      parent: 2
+  - uid: 12693
+    components:
+    - type: Transform
+      pos: 49.5,22.5
+      parent: 2
   - uid: 12696
     components:
     - type: Transform
       pos: -53.5,-32.5
+      parent: 2
+  - uid: 12700
+    components:
+    - type: Transform
+      pos: 48.5,6.5
+      parent: 2
+  - uid: 12722
+    components:
+    - type: Transform
+      pos: 48.5,7.5
+      parent: 2
+  - uid: 12724
+    components:
+    - type: Transform
+      pos: 44.5,0.5
+      parent: 2
+  - uid: 12726
+    components:
+    - type: Transform
+      pos: 33.5,23.5
       parent: 2
   - uid: 12730
     components:
@@ -148592,10 +147954,40 @@ entities:
     - type: Transform
       pos: 8.5,-86.5
       parent: 2
+  - uid: 12734
+    components:
+    - type: Transform
+      pos: 30.5,26.5
+      parent: 2
+  - uid: 12735
+    components:
+    - type: Transform
+      pos: 26.5,26.5
+      parent: 2
   - uid: 12736
     components:
     - type: Transform
       pos: 7.5,-97.5
+      parent: 2
+  - uid: 12751
+    components:
+    - type: Transform
+      pos: 26.5,25.5
+      parent: 2
+  - uid: 12771
+    components:
+    - type: Transform
+      pos: 25.5,20.5
+      parent: 2
+  - uid: 12772
+    components:
+    - type: Transform
+      pos: 25.5,17.5
+      parent: 2
+  - uid: 12773
+    components:
+    - type: Transform
+      pos: 43.5,-17.5
       parent: 2
   - uid: 12774
     components:
@@ -148607,10 +147999,25 @@ entities:
     - type: Transform
       pos: -5.5,-64.5
       parent: 2
+  - uid: 12780
+    components:
+    - type: Transform
+      pos: 53.5,-14.5
+      parent: 2
+  - uid: 12784
+    components:
+    - type: Transform
+      pos: 42.5,-26.5
+      parent: 2
   - uid: 12787
     components:
     - type: Transform
       pos: 8.5,-64.5
+      parent: 2
+  - uid: 12790
+    components:
+    - type: Transform
+      pos: 37.5,-23.5
       parent: 2
   - uid: 12791
     components:
@@ -148622,6 +148029,41 @@ entities:
     - type: Transform
       pos: 6.5,-68.5
       parent: 2
+  - uid: 12799
+    components:
+    - type: Transform
+      pos: 40.5,-19.5
+      parent: 2
+  - uid: 12807
+    components:
+    - type: Transform
+      pos: 40.5,-27.5
+      parent: 2
+  - uid: 12809
+    components:
+    - type: Transform
+      pos: 40.5,-28.5
+      parent: 2
+  - uid: 12810
+    components:
+    - type: Transform
+      pos: 49.5,-7.5
+      parent: 2
+  - uid: 12811
+    components:
+    - type: Transform
+      pos: 42.5,-1.5
+      parent: 2
+  - uid: 12812
+    components:
+    - type: Transform
+      pos: 48.5,-3.5
+      parent: 2
+  - uid: 12825
+    components:
+    - type: Transform
+      pos: 25.5,-40.5
+      parent: 2
   - uid: 12826
     components:
     - type: Transform
@@ -148632,10 +148074,30 @@ entities:
     - type: Transform
       pos: 14.5,-90.5
       parent: 2
+  - uid: 12846
+    components:
+    - type: Transform
+      pos: 32.5,-32.5
+      parent: 2
+  - uid: 12848
+    components:
+    - type: Transform
+      pos: 29.5,-51.5
+      parent: 2
   - uid: 12852
     components:
     - type: Transform
       pos: -5.5,-54.5
+      parent: 2
+  - uid: 12853
+    components:
+    - type: Transform
+      pos: 29.5,-50.5
+      parent: 2
+  - uid: 12859
+    components:
+    - type: Transform
+      pos: 25.5,-43.5
       parent: 2
   - uid: 12873
     components:
@@ -148651,6 +148113,16 @@ entities:
     components:
     - type: Transform
       pos: -30.5,28.5
+      parent: 2
+  - uid: 12902
+    components:
+    - type: Transform
+      pos: 25.5,-42.5
+      parent: 2
+  - uid: 12921
+    components:
+    - type: Transform
+      pos: 25.5,-44.5
       parent: 2
   - uid: 12936
     components:
@@ -148677,6 +148149,11 @@ entities:
     - type: Transform
       pos: -37.5,28.5
       parent: 2
+  - uid: 12982
+    components:
+    - type: Transform
+      pos: 33.5,-47.5
+      parent: 2
   - uid: 12990
     components:
     - type: Transform
@@ -148697,11 +148174,6 @@ entities:
     - type: Transform
       pos: -36.5,29.5
       parent: 2
-  - uid: 13014
-    components:
-    - type: Transform
-      pos: -41.5,26.5
-      parent: 2
   - uid: 13019
     components:
     - type: Transform
@@ -148712,10 +148184,20 @@ entities:
     - type: Transform
       pos: -46.5,-23.5
       parent: 2
+  - uid: 13027
+    components:
+    - type: Transform
+      pos: 25.5,-32.5
+      parent: 2
+  - uid: 13057
+    components:
+    - type: Transform
+      pos: 42.5,-32.5
+      parent: 2
   - uid: 13090
     components:
     - type: Transform
-      pos: -48.5,2.5
+      pos: 41.5,-33.5
       parent: 2
   - uid: 13091
     components:
@@ -148725,12 +148207,22 @@ entities:
   - uid: 13120
     components:
     - type: Transform
-      pos: -48.5,6.5
+      pos: 40.5,-30.5
+      parent: 2
+  - uid: 13124
+    components:
+    - type: Transform
+      pos: 39.5,-30.5
       parent: 2
   - uid: 13137
     components:
     - type: Transform
       pos: -57.5,-10.5
+      parent: 2
+  - uid: 13141
+    components:
+    - type: Transform
+      pos: 31.5,-23.5
       parent: 2
   - uid: 13143
     components:
@@ -148742,6 +148234,16 @@ entities:
     - type: Transform
       pos: -55.5,3.5
       parent: 2
+  - uid: 13153
+    components:
+    - type: Transform
+      pos: 26.5,-5.5
+      parent: 2
+  - uid: 13167
+    components:
+    - type: Transform
+      pos: 25.5,-11.5
+      parent: 2
   - uid: 13194
     components:
     - type: Transform
@@ -148750,17 +148252,72 @@ entities:
   - uid: 13204
     components:
     - type: Transform
-      pos: 17.5,-16.5
+      pos: -40.5,-18.5
       parent: 2
   - uid: 13206
     components:
     - type: Transform
-      pos: -49.5,0.5
+      pos: -40.5,-19.5
+      parent: 2
+  - uid: 13209
+    components:
+    - type: Transform
+      pos: -39.5,-21.5
+      parent: 2
+  - uid: 13211
+    components:
+    - type: Transform
+      pos: -46.5,-19.5
+      parent: 2
+  - uid: 13219
+    components:
+    - type: Transform
+      pos: -29.5,-20.5
+      parent: 2
+  - uid: 13221
+    components:
+    - type: Transform
+      pos: -31.5,-16.5
+      parent: 2
+  - uid: 13223
+    components:
+    - type: Transform
+      pos: -31.5,-17.5
+      parent: 2
+  - uid: 13224
+    components:
+    - type: Transform
+      pos: -28.5,-16.5
+      parent: 2
+  - uid: 13225
+    components:
+    - type: Transform
+      pos: -28.5,-17.5
+      parent: 2
+  - uid: 13229
+    components:
+    - type: Transform
+      pos: -25.5,-17.5
       parent: 2
   - uid: 13234
     components:
     - type: Transform
       pos: -48.5,-11.5
+      parent: 2
+  - uid: 13250
+    components:
+    - type: Transform
+      pos: -21.5,32.5
+      parent: 2
+  - uid: 13257
+    components:
+    - type: Transform
+      pos: -21.5,28.5
+      parent: 2
+  - uid: 13281
+    components:
+    - type: Transform
+      pos: -28.5,25.5
       parent: 2
   - uid: 13283
     components:
@@ -148772,35 +148329,135 @@ entities:
     - type: Transform
       pos: -5.5,-66.5
       parent: 2
+  - uid: 13287
+    components:
+    - type: Transform
+      pos: -28.5,28.5
+      parent: 2
+  - uid: 13289
+    components:
+    - type: Transform
+      pos: -28.5,27.5
+      parent: 2
   - uid: 13339
     components:
     - type: Transform
-      pos: -58.5,-10.5
+      pos: -11.5,36.5
       parent: 2
   - uid: 13343
     components:
     - type: Transform
       pos: -48.5,3.5
       parent: 2
+  - uid: 13360
+    components:
+    - type: Transform
+      pos: -19.5,40.5
+      parent: 2
+  - uid: 13364
+    components:
+    - type: Transform
+      pos: -20.5,40.5
+      parent: 2
+  - uid: 13373
+    components:
+    - type: Transform
+      pos: -16.5,40.5
+      parent: 2
   - uid: 13386
     components:
     - type: Transform
       pos: -6.5,-80.5
       parent: 2
+  - uid: 13392
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 2
+  - uid: 13395
+    components:
+    - type: Transform
+      pos: -5.5,16.5
+      parent: 2
+  - uid: 13397
+    components:
+    - type: Transform
+      pos: -5.5,17.5
+      parent: 2
+  - uid: 13404
+    components:
+    - type: Transform
+      pos: -13.5,1.5
+      parent: 2
+  - uid: 13407
+    components:
+    - type: Transform
+      pos: -13.5,0.5
+      parent: 2
+  - uid: 13408
+    components:
+    - type: Transform
+      pos: -13.5,2.5
+      parent: 2
+  - uid: 13469
+    components:
+    - type: Transform
+      pos: -8.5,4.5
+      parent: 2
+  - uid: 13540
+    components:
+    - type: Transform
+      pos: -8.5,5.5
+      parent: 2
   - uid: 13616
     components:
     - type: Transform
-      pos: -49.5,-10.5
+      pos: -6.5,9.5
       parent: 2
   - uid: 13660
     components:
     - type: Transform
       pos: -47.5,7.5
       parent: 2
+  - uid: 13663
+    components:
+    - type: Transform
+      pos: -10.5,35.5
+      parent: 2
+  - uid: 13667
+    components:
+    - type: Transform
+      pos: -8.5,23.5
+      parent: 2
+  - uid: 13668
+    components:
+    - type: Transform
+      pos: -6.5,20.5
+      parent: 2
+  - uid: 13669
+    components:
+    - type: Transform
+      pos: -12.5,25.5
+      parent: 2
   - uid: 13670
     components:
     - type: Transform
       pos: 26.5,-60.5
+      parent: 2
+  - uid: 13671
+    components:
+    - type: Transform
+      pos: -15.5,24.5
+      parent: 2
+  - uid: 13674
+    components:
+    - type: Transform
+      pos: -13.5,24.5
+      parent: 2
+  - uid: 13693
+    components:
+    - type: Transform
+      pos: -2.5,27.5
       parent: 2
   - uid: 13700
     components:
@@ -148817,10 +148474,45 @@ entities:
     - type: Transform
       pos: -53.5,2.5
       parent: 2
+  - uid: 13704
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 2
+  - uid: 13712
+    components:
+    - type: Transform
+      pos: -3.5,17.5
+      parent: 2
   - uid: 13722
     components:
     - type: Transform
-      pos: -54.5,2.5
+      pos: -0.5,27.5
+      parent: 2
+  - uid: 13724
+    components:
+    - type: Transform
+      pos: 0.5,27.5
+      parent: 2
+  - uid: 13725
+    components:
+    - type: Transform
+      pos: 1.5,27.5
+      parent: 2
+  - uid: 13735
+    components:
+    - type: Transform
+      pos: 7.5,27.5
+      parent: 2
+  - uid: 13736
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 2
+  - uid: 13738
+    components:
+    - type: Transform
+      pos: -2.5,3.5
       parent: 2
   - uid: 13740
     components:
@@ -148847,15 +148539,55 @@ entities:
     - type: Transform
       pos: -45.5,-12.5
       parent: 2
+  - uid: 13757
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 2
+  - uid: 13758
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 2
+  - uid: 13762
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 2
   - uid: 13764
     components:
     - type: Transform
       pos: -44.5,-12.5
       parent: 2
+  - uid: 13765
+    components:
+    - type: Transform
+      pos: -1.5,15.5
+      parent: 2
+  - uid: 13773
+    components:
+    - type: Transform
+      pos: 19.5,16.5
+      parent: 2
+  - uid: 13779
+    components:
+    - type: Transform
+      pos: 20.5,16.5
+      parent: 2
+  - uid: 13783
+    components:
+    - type: Transform
+      pos: 20.5,11.5
+      parent: 2
   - uid: 13785
     components:
     - type: Transform
       pos: -43.5,-12.5
+      parent: 2
+  - uid: 13787
+    components:
+    - type: Transform
+      pos: 21.5,13.5
       parent: 2
   - uid: 13795
     components:
@@ -148867,15 +148599,50 @@ entities:
     - type: Transform
       pos: -43.5,-10.5
       parent: 2
+  - uid: 13813
+    components:
+    - type: Transform
+      pos: 18.5,11.5
+      parent: 2
   - uid: 13859
     components:
     - type: Transform
       pos: 18.5,-17.5
       parent: 2
+  - uid: 13866
+    components:
+    - type: Transform
+      pos: 14.5,14.5
+      parent: 2
+  - uid: 13867
+    components:
+    - type: Transform
+      pos: 7.5,13.5
+      parent: 2
+  - uid: 13880
+    components:
+    - type: Transform
+      pos: 13.5,9.5
+      parent: 2
+  - uid: 13882
+    components:
+    - type: Transform
+      pos: 13.5,0.5
+      parent: 2
+  - uid: 13883
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 2
   - uid: 13886
     components:
     - type: Transform
-      pos: -50.5,-42.5
+      pos: 24.5,24.5
+      parent: 2
+  - uid: 13887
+    components:
+    - type: Transform
+      pos: 28.5,30.5
       parent: 2
   - uid: 13888
     components:
@@ -148892,20 +148659,75 @@ entities:
     - type: Transform
       pos: -47.5,17.5
       parent: 2
+  - uid: 13892
+    components:
+    - type: Transform
+      pos: 19.5,23.5
+      parent: 2
+  - uid: 13897
+    components:
+    - type: Transform
+      pos: 18.5,20.5
+      parent: 2
+  - uid: 13900
+    components:
+    - type: Transform
+      pos: 18.5,26.5
+      parent: 2
+  - uid: 13901
+    components:
+    - type: Transform
+      pos: 18.5,18.5
+      parent: 2
+  - uid: 13903
+    components:
+    - type: Transform
+      pos: 15.5,30.5
+      parent: 2
+  - uid: 13904
+    components:
+    - type: Transform
+      pos: 13.5,29.5
+      parent: 2
+  - uid: 13906
+    components:
+    - type: Transform
+      pos: 9.5,27.5
+      parent: 2
   - uid: 13907
     components:
     - type: Transform
       pos: -46.5,17.5
       parent: 2
+  - uid: 13908
+    components:
+    - type: Transform
+      pos: 10.5,29.5
+      parent: 2
   - uid: 13911
     components:
     - type: Transform
-      pos: -46.5,-47.5
+      pos: 9.5,-13.5
+      parent: 2
+  - uid: 13912
+    components:
+    - type: Transform
+      pos: 11.5,-13.5
       parent: 2
   - uid: 13913
     components:
     - type: Transform
-      pos: -44.5,-47.5
+      pos: 12.5,-15.5
+      parent: 2
+  - uid: 13914
+    components:
+    - type: Transform
+      pos: 11.5,-15.5
+      parent: 2
+  - uid: 13917
+    components:
+    - type: Transform
+      pos: 13.5,-20.5
       parent: 2
   - uid: 13920
     components:
@@ -148917,6 +148739,16 @@ entities:
     - type: Transform
       pos: -43.5,-46.5
       parent: 2
+  - uid: 13975
+    components:
+    - type: Transform
+      pos: 17.5,-19.5
+      parent: 2
+  - uid: 14018
+    components:
+    - type: Transform
+      pos: 16.5,-20.5
+      parent: 2
   - uid: 14057
     components:
     - type: Transform
@@ -148927,45 +148759,100 @@ entities:
     - type: Transform
       pos: -44.5,7.5
       parent: 2
-  - uid: 14105
+  - uid: 14094
     components:
     - type: Transform
-      pos: -44.5,8.5
+      pos: 14.5,-16.5
+      parent: 2
+  - uid: 14098
+    components:
+    - type: Transform
+      pos: 14.5,-15.5
+      parent: 2
+  - uid: 14100
+    components:
+    - type: Transform
+      pos: 18.5,-23.5
+      parent: 2
+  - uid: 14101
+    components:
+    - type: Transform
+      pos: 24.5,-23.5
+      parent: 2
+  - uid: 14102
+    components:
+    - type: Transform
+      pos: 18.5,-19.5
+      parent: 2
+  - uid: 14131
+    components:
+    - type: Transform
+      pos: 6.5,-21.5
+      parent: 2
+  - uid: 14132
+    components:
+    - type: Transform
+      pos: 9.5,-11.5
+      parent: 2
+  - uid: 14133
+    components:
+    - type: Transform
+      pos: 11.5,-9.5
+      parent: 2
+  - uid: 14151
+    components:
+    - type: Transform
+      pos: 13.5,-6.5
       parent: 2
   - uid: 14164
     components:
     - type: Transform
       pos: -44.5,19.5
       parent: 2
+  - uid: 14176
+    components:
+    - type: Transform
+      pos: 10.5,-5.5
+      parent: 2
+  - uid: 14179
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 2
+  - uid: 14181
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
   - uid: 14211
     components:
     - type: Transform
       pos: -22.5,23.5
       parent: 2
-  - uid: 14235
+  - uid: 14247
     components:
     - type: Transform
-      pos: -44.5,16.5
+      pos: 14.5,-2.5
       parent: 2
   - uid: 14260
     components:
     - type: Transform
       pos: -44.5,13.5
       parent: 2
-  - uid: 14265
+  - uid: 14263
     components:
     - type: Transform
-      pos: -44.5,12.5
+      pos: 22.5,-8.5
       parent: 2
   - uid: 14302
     components:
     - type: Transform
-      pos: -28.5,-52.5
+      pos: -14.5,-10.5
       parent: 2
   - uid: 14309
     components:
     - type: Transform
-      pos: -44.5,14.5
+      pos: -14.5,-17.5
       parent: 2
   - uid: 14335
     components:
@@ -148975,12 +148862,17 @@ entities:
   - uid: 14363
     components:
     - type: Transform
-      pos: -39.5,-12.5
+      pos: -10.5,-47.5
       parent: 2
   - uid: 14364
     components:
     - type: Transform
-      pos: -39.5,-13.5
+      pos: -13.5,-53.5
+      parent: 2
+  - uid: 14365
+    components:
+    - type: Transform
+      pos: -9.5,-49.5
       parent: 2
   - uid: 14367
     components:
@@ -148997,6 +148889,11 @@ entities:
     - type: Transform
       pos: -35.5,-13.5
       parent: 2
+  - uid: 14379
+    components:
+    - type: Transform
+      pos: -9.5,-53.5
+      parent: 2
   - uid: 14380
     components:
     - type: Transform
@@ -149011,6 +148908,16 @@ entities:
     components:
     - type: Transform
       pos: -37.5,-14.5
+      parent: 2
+  - uid: 14399
+    components:
+    - type: Transform
+      pos: -3.5,-26.5
+      parent: 2
+  - uid: 14413
+    components:
+    - type: Transform
+      pos: 22.5,-32.5
       parent: 2
   - uid: 14430
     components:
@@ -149030,32 +148937,57 @@ entities:
   - uid: 14444
     components:
     - type: Transform
-      pos: -55.5,7.5
+      pos: 23.5,-32.5
       parent: 2
   - uid: 14447
     components:
     - type: Transform
       pos: -56.5,7.5
       parent: 2
+  - uid: 14448
+    components:
+    - type: Transform
+      pos: 21.5,-32.5
+      parent: 2
+  - uid: 14449
+    components:
+    - type: Transform
+      pos: 18.5,-31.5
+      parent: 2
   - uid: 14452
     components:
     - type: Transform
-      pos: -56.5,16.5
+      pos: 1.5,-38.5
       parent: 2
   - uid: 14455
     components:
     - type: Transform
-      pos: -55.5,16.5
+      pos: -0.5,-37.5
+      parent: 2
+  - uid: 14456
+    components:
+    - type: Transform
+      pos: 2.5,-35.5
+      parent: 2
+  - uid: 14477
+    components:
+    - type: Transform
+      pos: -1.5,-30.5
+      parent: 2
+  - uid: 14479
+    components:
+    - type: Transform
+      pos: -1.5,-29.5
       parent: 2
   - uid: 14485
     components:
     - type: Transform
-      pos: -45.5,17.5
+      pos: 17.5,-25.5
       parent: 2
   - uid: 14486
     components:
     - type: Transform
-      pos: -47.5,16.5
+      pos: 23.5,-27.5
       parent: 2
   - uid: 14492
     components:
@@ -149067,6 +148999,11 @@ entities:
     - type: Transform
       pos: 6.5,-69.5
       parent: 2
+  - uid: 14496
+    components:
+    - type: Transform
+      pos: 22.5,-29.5
+      parent: 2
   - uid: 14499
     components:
     - type: Transform
@@ -149075,12 +149012,32 @@ entities:
   - uid: 14500
     components:
     - type: Transform
-      pos: -42.5,13.5
+      pos: 18.5,-27.5
+      parent: 2
+  - uid: 14509
+    components:
+    - type: Transform
+      pos: -4.5,-69.5
+      parent: 2
+  - uid: 14510
+    components:
+    - type: Transform
+      pos: -13.5,-75.5
       parent: 2
   - uid: 14515
     components:
     - type: Transform
       pos: 46.5,-42.5
+      parent: 2
+  - uid: 14517
+    components:
+    - type: Transform
+      pos: -13.5,-73.5
+      parent: 2
+  - uid: 14543
+    components:
+    - type: Transform
+      pos: -3.5,-66.5
       parent: 2
   - uid: 14546
     components:
@@ -149092,15 +149049,10 @@ entities:
     - type: Transform
       pos: -37.5,24.5
       parent: 2
-  - uid: 14550
-    components:
-    - type: Transform
-      pos: -38.5,24.5
-      parent: 2
   - uid: 14553
     components:
     - type: Transform
-      pos: -37.5,25.5
+      pos: -5.5,-60.5
       parent: 2
   - uid: 14554
     components:
@@ -149142,6 +149094,31 @@ entities:
     - type: Transform
       pos: -30.5,29.5
       parent: 2
+  - uid: 14715
+    components:
+    - type: Transform
+      pos: -5.5,-61.5
+      parent: 2
+  - uid: 14744
+    components:
+    - type: Transform
+      pos: -9.5,-66.5
+      parent: 2
+  - uid: 14792
+    components:
+    - type: Transform
+      pos: -9.5,-57.5
+      parent: 2
+  - uid: 14816
+    components:
+    - type: Transform
+      pos: -13.5,-55.5
+      parent: 2
+  - uid: 14825
+    components:
+    - type: Transform
+      pos: -13.5,-69.5
+      parent: 2
   - uid: 14837
     components:
     - type: Transform
@@ -149150,7 +149127,7 @@ entities:
   - uid: 14852
     components:
     - type: Transform
-      pos: -0.5,-24.5
+      pos: -10.5,-66.5
       parent: 2
   - uid: 14877
     components:
@@ -149161,6 +149138,16 @@ entities:
     components:
     - type: Transform
       pos: -47.5,13.5
+      parent: 2
+  - uid: 14906
+    components:
+    - type: Transform
+      pos: 3.5,-54.5
+      parent: 2
+  - uid: 14908
+    components:
+    - type: Transform
+      pos: 17.5,-60.5
       parent: 2
   - uid: 14909
     components:
@@ -149187,25 +149174,20 @@ entities:
     - type: Transform
       pos: 7.5,-61.5
       parent: 2
-  - uid: 15008
-    components:
-    - type: Transform
-      pos: -59.5,-54.5
-      parent: 2
   - uid: 15015
     components:
     - type: Transform
-      pos: 13.5,8.5
+      pos: 8.5,-61.5
       parent: 2
   - uid: 15023
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 2
-  - uid: 15025
+  - uid: 15024
     components:
     - type: Transform
-      pos: -47.5,23.5
+      pos: -9.5,-27.5
       parent: 2
   - uid: 15026
     components:
@@ -149230,7 +149212,7 @@ entities:
   - uid: 15032
     components:
     - type: Transform
-      pos: -49.5,-2.5
+      pos: -10.5,-25.5
       parent: 2
   - uid: 15033
     components:
@@ -149285,7 +149267,7 @@ entities:
   - uid: 15142
     components:
     - type: Transform
-      pos: -11.5,6.5
+      pos: -30.5,-33.5
       parent: 2
   - uid: 15144
     components:
@@ -149296,11 +149278,6 @@ entities:
     components:
     - type: Transform
       pos: 1.5,15.5
-      parent: 2
-  - uid: 15168
-    components:
-    - type: Transform
-      pos: -56.5,21.5
       parent: 2
   - uid: 15175
     components:
@@ -149322,6 +149299,11 @@ entities:
     - type: Transform
       pos: -0.5,-85.5
       parent: 2
+  - uid: 15253
+    components:
+    - type: Transform
+      pos: -31.5,-62.5
+      parent: 2
   - uid: 15265
     components:
     - type: Transform
@@ -149330,7 +149312,7 @@ entities:
   - uid: 15283
     components:
     - type: Transform
-      pos: -29.5,-68.5
+      pos: -31.5,-70.5
       parent: 2
   - uid: 15286
     components:
@@ -149340,12 +149322,12 @@ entities:
   - uid: 15289
     components:
     - type: Transform
-      pos: -31.5,-66.5
+      pos: -31.5,-65.5
       parent: 2
   - uid: 15307
     components:
     - type: Transform
-      pos: 4.5,-59.5
+      pos: -36.5,-74.5
       parent: 2
   - uid: 15309
     components:
@@ -149375,7 +149357,7 @@ entities:
   - uid: 15336
     components:
     - type: Transform
-      pos: -47.5,-14.5
+      pos: -26.5,-43.5
       parent: 2
   - uid: 15342
     components:
@@ -149396,11 +149378,6 @@ entities:
     components:
     - type: Transform
       pos: -57.5,21.5
-      parent: 2
-  - uid: 15375
-    components:
-    - type: Transform
-      pos: -17.5,-68.5
       parent: 2
   - uid: 15389
     components:
@@ -149430,7 +149407,7 @@ entities:
   - uid: 15448
     components:
     - type: Transform
-      pos: -9.5,-71.5
+      pos: -26.5,-39.5
       parent: 2
   - uid: 15449
     components:
@@ -149450,7 +149427,7 @@ entities:
   - uid: 15456
     components:
     - type: Transform
-      pos: 36.5,23.5
+      pos: -27.5,-52.5
       parent: 2
   - uid: 15460
     components:
@@ -149462,6 +149439,11 @@ entities:
     - type: Transform
       pos: -10.5,-58.5
       parent: 2
+  - uid: 15466
+    components:
+    - type: Transform
+      pos: -28.5,-51.5
+      parent: 2
   - uid: 15467
     components:
     - type: Transform
@@ -149470,7 +149452,7 @@ entities:
   - uid: 15470
     components:
     - type: Transform
-      pos: -43.5,-14.5
+      pos: -27.5,-51.5
       parent: 2
   - uid: 15471
     components:
@@ -149482,15 +149464,15 @@ entities:
     - type: Transform
       pos: -58.5,-16.5
       parent: 2
-  - uid: 15475
-    components:
-    - type: Transform
-      pos: -53.5,-2.5
-      parent: 2
   - uid: 15476
     components:
     - type: Transform
-      pos: -57.5,-16.5
+      pos: -27.5,-54.5
+      parent: 2
+  - uid: 15478
+    components:
+    - type: Transform
+      pos: -27.5,-56.5
       parent: 2
   - uid: 15479
     components:
@@ -149515,7 +149497,7 @@ entities:
   - uid: 15568
     components:
     - type: Transform
-      pos: -59.5,-16.5
+      pos: -27.5,-57.5
       parent: 2
   - uid: 15572
     components:
@@ -149560,7 +149542,7 @@ entities:
   - uid: 15675
     components:
     - type: Transform
-      pos: -41.5,-17.5
+      pos: -27.5,-59.5
       parent: 2
   - uid: 15679
     components:
@@ -149575,7 +149557,7 @@ entities:
   - uid: 15708
     components:
     - type: Transform
-      pos: -10.5,27.5
+      pos: -32.5,-38.5
       parent: 2
   - uid: 15721
     components:
@@ -149587,16 +149569,6 @@ entities:
     - type: Transform
       pos: -21.5,23.5
       parent: 2
-  - uid: 15730
-    components:
-    - type: Transform
-      pos: -1.5,-33.5
-      parent: 2
-  - uid: 15732
-    components:
-    - type: Transform
-      pos: -45.5,16.5
-      parent: 2
   - uid: 15743
     components:
     - type: Transform
@@ -149605,7 +149577,7 @@ entities:
   - uid: 15786
     components:
     - type: Transform
-      pos: -54.5,-55.5
+      pos: -37.5,-58.5
       parent: 2
   - uid: 15788
     components:
@@ -149616,6 +149588,11 @@ entities:
     components:
     - type: Transform
       pos: -45.5,18.5
+      parent: 2
+  - uid: 15815
+    components:
+    - type: Transform
+      pos: -37.5,-59.5
       parent: 2
   - uid: 15838
     components:
@@ -149632,6 +149609,11 @@ entities:
     - type: Transform
       pos: -47.5,14.5
       parent: 2
+  - uid: 15863
+    components:
+    - type: Transform
+      pos: -31.5,-57.5
+      parent: 2
   - uid: 15865
     components:
     - type: Transform
@@ -149642,16 +149624,6 @@ entities:
     - type: Transform
       pos: 59.5,-70.5
       parent: 2
-  - uid: 15882
-    components:
-    - type: Transform
-      pos: -52.5,-39.5
-      parent: 2
-  - uid: 15883
-    components:
-    - type: Transform
-      pos: -45.5,23.5
-      parent: 2
   - uid: 15884
     components:
     - type: Transform
@@ -149660,7 +149632,7 @@ entities:
   - uid: 15893
     components:
     - type: Transform
-      pos: -43.5,24.5
+      pos: -21.5,-68.5
       parent: 2
   - uid: 15901
     components:
@@ -149675,22 +149647,22 @@ entities:
   - uid: 15904
     components:
     - type: Transform
-      pos: -3.5,-29.5
+      pos: -20.5,-45.5
       parent: 2
   - uid: 15905
     components:
     - type: Transform
-      pos: -51.5,-10.5
+      pos: -18.5,-45.5
       parent: 2
   - uid: 15906
     components:
     - type: Transform
-      pos: -49.5,-16.5
+      pos: -23.5,-57.5
       parent: 2
   - uid: 15909
     components:
     - type: Transform
-      pos: -50.5,-16.5
+      pos: -20.5,-57.5
       parent: 2
   - uid: 15913
     components:
@@ -149730,7 +149702,7 @@ entities:
   - uid: 15932
     components:
     - type: Transform
-      pos: -59.5,-10.5
+      pos: -22.5,-44.5
       parent: 2
   - uid: 15949
     components:
@@ -149746,11 +149718,6 @@ entities:
     components:
     - type: Transform
       pos: 8.5,-65.5
-      parent: 2
-  - uid: 15952
-    components:
-    - type: Transform
-      pos: 17.5,-23.5
       parent: 2
   - uid: 15953
     components:
@@ -149770,7 +149737,7 @@ entities:
   - uid: 15956
     components:
     - type: Transform
-      pos: -8.5,6.5
+      pos: -54.5,-56.5
       parent: 2
   - uid: 15957
     components:
@@ -149782,10 +149749,15 @@ entities:
     - type: Transform
       pos: -2.5,5.5
       parent: 2
+  - uid: 15959
+    components:
+    - type: Transform
+      pos: -54.5,-60.5
+      parent: 2
   - uid: 15960
     components:
     - type: Transform
-      pos: 19.5,-32.5
+      pos: -62.5,-58.5
       parent: 2
   - uid: 15961
     components:
@@ -149810,12 +149782,17 @@ entities:
   - uid: 15966
     components:
     - type: Transform
-      pos: 41.5,-30.5
+      pos: -64.5,-60.5
       parent: 2
   - uid: 15967
     components:
     - type: Transform
       pos: -6.5,4.5
+      parent: 2
+  - uid: 15971
+    components:
+    - type: Transform
+      pos: -64.5,-59.5
       parent: 2
   - uid: 15972
     components:
@@ -149855,7 +149832,7 @@ entities:
   - uid: 15979
     components:
     - type: Transform
-      pos: -9.5,1.5
+      pos: -47.5,-58.5
       parent: 2
   - uid: 15980
     components:
@@ -149900,12 +149877,12 @@ entities:
   - uid: 15991
     components:
     - type: Transform
-      pos: -3.5,-24.5
+      pos: -47.5,-47.5
       parent: 2
   - uid: 15993
     components:
     - type: Transform
-      pos: -10.5,-23.5
+      pos: -43.5,-45.5
       parent: 2
   - uid: 15994
     components:
@@ -149915,12 +149892,17 @@ entities:
   - uid: 15995
     components:
     - type: Transform
-      pos: 25.5,-45.5
+      pos: -43.5,-44.5
       parent: 2
   - uid: 15997
     components:
     - type: Transform
       pos: -5.5,-27.5
+      parent: 2
+  - uid: 15998
+    components:
+    - type: Transform
+      pos: -36.5,-39.5
       parent: 2
   - uid: 15999
     components:
@@ -149930,7 +149912,7 @@ entities:
   - uid: 16002
     components:
     - type: Transform
-      pos: -10.5,-27.5
+      pos: -36.5,-38.5
       parent: 2
   - uid: 16003
     components:
@@ -149945,7 +149927,12 @@ entities:
   - uid: 16017
     components:
     - type: Transform
-      pos: -28.5,32.5
+      pos: -46.5,-41.5
+      parent: 2
+  - uid: 16040
+    components:
+    - type: Transform
+      pos: -46.5,-40.5
       parent: 2
   - uid: 16055
     components:
@@ -149955,7 +149942,7 @@ entities:
   - uid: 16072
     components:
     - type: Transform
-      pos: 22.5,-27.5
+      pos: -32.5,-30.5
       parent: 2
   - uid: 16073
     components:
@@ -149980,7 +149967,7 @@ entities:
   - uid: 16083
     components:
     - type: Transform
-      pos: -13.5,-52.5
+      pos: -37.5,-31.5
       parent: 2
   - uid: 16088
     components:
@@ -150026,11 +150013,6 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-61.5
-      parent: 2
-  - uid: 16170
-    components:
-    - type: Transform
-      pos: -3.5,-72.5
       parent: 2
   - uid: 16187
     components:
@@ -150100,7 +150082,7 @@ entities:
   - uid: 16238
     components:
     - type: Transform
-      pos: -56.5,0.5
+      pos: -53.5,-36.5
       parent: 2
   - uid: 16245
     components:
@@ -150147,6 +150129,16 @@ entities:
     - type: Transform
       pos: -51.5,-19.5
       parent: 2
+  - uid: 16287
+    components:
+    - type: Transform
+      pos: -51.5,-39.5
+      parent: 2
+  - uid: 16294
+    components:
+    - type: Transform
+      pos: -49.5,-39.5
+      parent: 2
   - uid: 16297
     components:
     - type: Transform
@@ -150160,12 +150152,17 @@ entities:
   - uid: 16308
     components:
     - type: Transform
-      pos: -57.5,-19.5
+      pos: -52.5,-46.5
       parent: 2
   - uid: 16313
     components:
     - type: Transform
-      pos: -9.5,23.5
+      pos: -50.5,-46.5
+      parent: 2
+  - uid: 16323
+    components:
+    - type: Transform
+      pos: -62.5,-39.5
       parent: 2
   - uid: 16355
     components:
@@ -150190,7 +150187,7 @@ entities:
   - uid: 16369
     components:
     - type: Transform
-      pos: -54.5,-10.5
+      pos: -63.5,-35.5
       parent: 2
   - uid: 16399
     components:
@@ -150200,12 +150197,17 @@ entities:
   - uid: 16452
     components:
     - type: Transform
-      pos: 12.5,29.5
+      pos: -50.5,-35.5
       parent: 2
   - uid: 16453
     components:
     - type: Transform
-      pos: -10.5,28.5
+      pos: -49.5,-35.5
+      parent: 2
+  - uid: 16479
+    components:
+    - type: Transform
+      pos: -57.5,-32.5
       parent: 2
   - uid: 16497
     components:
@@ -150452,6 +150454,11 @@ entities:
     - type: Transform
       pos: 85.5,-44.5
       parent: 2
+  - uid: 16655
+    components:
+    - type: Transform
+      pos: -49.5,-25.5
+      parent: 2
   - uid: 16673
     components:
     - type: Transform
@@ -150470,7 +150477,7 @@ entities:
   - uid: 16724
     components:
     - type: Transform
-      pos: 49.5,-6.5
+      pos: -50.5,-24.5
       parent: 2
   - uid: 16731
     components:
@@ -150512,6 +150519,11 @@ entities:
     - type: Transform
       pos: 57.5,-66.5
       parent: 2
+  - uid: 16827
+    components:
+    - type: Transform
+      pos: -51.5,-28.5
+      parent: 2
   - uid: 16835
     components:
     - type: Transform
@@ -150552,15 +150564,15 @@ entities:
     - type: Transform
       pos: 89.5,-47.5
       parent: 2
-  - uid: 16894
-    components:
-    - type: Transform
-      pos: 48.5,-2.5
-      parent: 2
   - uid: 16895
     components:
     - type: Transform
       pos: 49.5,-9.5
+      parent: 2
+  - uid: 16899
+    components:
+    - type: Transform
+      pos: -58.5,-24.5
       parent: 2
   - uid: 16900
     components:
@@ -150582,15 +150594,20 @@ entities:
     - type: Transform
       pos: 14.5,-89.5
       parent: 2
+  - uid: 16947
+    components:
+    - type: Transform
+      pos: -57.5,-20.5
+      parent: 2
   - uid: 16948
     components:
     - type: Transform
       pos: 43.5,7.5
       parent: 2
-  - uid: 16964
+  - uid: 16949
     components:
     - type: Transform
-      pos: 42.5,6.5
+      pos: -56.5,-20.5
       parent: 2
   - uid: 16965
     components:
@@ -150617,11 +150634,6 @@ entities:
     - type: Transform
       pos: 60.5,-55.5
       parent: 2
-  - uid: 16999
-    components:
-    - type: Transform
-      pos: 51.5,13.5
-      parent: 2
   - uid: 17000
     components:
     - type: Transform
@@ -150646,11 +150658,6 @@ entities:
     components:
     - type: Transform
       pos: 91.5,-41.5
-      parent: 2
-  - uid: 17062
-    components:
-    - type: Transform
-      pos: 44.5,6.5
       parent: 2
   - uid: 17073
     components:
@@ -150677,11 +150684,6 @@ entities:
     - type: Transform
       pos: 89.5,-54.5
       parent: 2
-  - uid: 17120
-    components:
-    - type: Transform
-      pos: 26.5,-52.5
-      parent: 2
   - uid: 17124
     components:
     - type: Transform
@@ -150696,11 +150698,6 @@ entities:
     components:
     - type: Transform
       pos: 5.5,-24.5
-      parent: 2
-  - uid: 17144
-    components:
-    - type: Transform
-      pos: 4.5,-24.5
       parent: 2
   - uid: 17149
     components:
@@ -150752,11 +150749,6 @@ entities:
     - type: Transform
       pos: 98.5,-39.5
       parent: 2
-  - uid: 17527
-    components:
-    - type: Transform
-      pos: 48.5,3.5
-      parent: 2
   - uid: 17528
     components:
     - type: Transform
@@ -150791,11 +150783,6 @@ entities:
     components:
     - type: Transform
       pos: 43.5,-18.5
-      parent: 2
-  - uid: 17728
-    components:
-    - type: Transform
-      pos: 17.5,-29.5
       parent: 2
   - uid: 17730
     components:
@@ -150902,11 +150889,6 @@ entities:
     - type: Transform
       pos: -28.5,31.5
       parent: 2
-  - uid: 17848
-    components:
-    - type: Transform
-      pos: -14.5,-5.5
-      parent: 2
   - uid: 17849
     components:
     - type: Transform
@@ -150946,11 +150928,6 @@ entities:
     components:
     - type: Transform
       pos: -31.5,-64.5
-      parent: 2
-  - uid: 18179
-    components:
-    - type: Transform
-      pos: 40.5,-23.5
       parent: 2
   - uid: 18184
     components:
@@ -151027,45 +151004,20 @@ entities:
     - type: Transform
       pos: -24.5,39.5
       parent: 2
-  - uid: 18234
-    components:
-    - type: Transform
-      pos: -23.5,40.5
-      parent: 2
   - uid: 18243
     components:
     - type: Transform
       pos: -22.5,40.5
-      parent: 2
-  - uid: 18258
-    components:
-    - type: Transform
-      pos: -12.5,37.5
-      parent: 2
-  - uid: 18262
-    components:
-    - type: Transform
-      pos: -18.5,40.5
       parent: 2
   - uid: 18267
     components:
     - type: Transform
       pos: -27.5,36.5
       parent: 2
-  - uid: 18270
-    components:
-    - type: Transform
-      pos: -58.5,-39.5
-      parent: 2
   - uid: 18351
     components:
     - type: Transform
       pos: -10.5,-45.5
-      parent: 2
-  - uid: 18399
-    components:
-    - type: Transform
-      pos: -36.5,-70.5
       parent: 2
   - uid: 18400
     components:
@@ -151082,11 +151034,6 @@ entities:
     - type: Transform
       pos: -36.5,-66.5
       parent: 2
-  - uid: 18426
-    components:
-    - type: Transform
-      pos: -46.5,-24.5
-      parent: 2
   - uid: 18427
     components:
     - type: Transform
@@ -151101,11 +151048,6 @@ entities:
     components:
     - type: Transform
       pos: 54.5,-56.5
-      parent: 2
-  - uid: 18439
-    components:
-    - type: Transform
-      pos: 52.5,-14.5
       parent: 2
   - uid: 18442
     components:
@@ -151157,25 +151099,10 @@ entities:
     - type: Transform
       pos: -28.5,-65.5
       parent: 2
-  - uid: 18605
-    components:
-    - type: Transform
-      pos: -28.5,34.5
-      parent: 2
   - uid: 18725
     components:
     - type: Transform
       pos: -35.5,-81.5
-      parent: 2
-  - uid: 18847
-    components:
-    - type: Transform
-      pos: 42.5,-34.5
-      parent: 2
-  - uid: 18848
-    components:
-    - type: Transform
-      pos: -31.5,-59.5
       parent: 2
   - uid: 18877
     components:
@@ -151186,11 +151113,6 @@ entities:
     components:
     - type: Transform
       pos: 80.5,-38.5
-      parent: 2
-  - uid: 18967
-    components:
-    - type: Transform
-      pos: -25.5,-20.5
       parent: 2
   - uid: 18970
     components:
@@ -151222,20 +151144,10 @@ entities:
     - type: Transform
       pos: -28.5,-50.5
       parent: 2
-  - uid: 19156
-    components:
-    - type: Transform
-      pos: -52.5,-20.5
-      parent: 2
   - uid: 19157
     components:
     - type: Transform
       pos: 43.5,-76.5
-      parent: 2
-  - uid: 19222
-    components:
-    - type: Transform
-      pos: -36.5,-60.5
       parent: 2
   - uid: 19226
     components:
@@ -151246,11 +151158,6 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-15.5
-      parent: 2
-  - uid: 19229
-    components:
-    - type: Transform
-      pos: 4.5,-55.5
       parent: 2
   - uid: 19231
     components:
@@ -151272,11 +151179,6 @@ entities:
     - type: Transform
       pos: 17.5,13.5
       parent: 2
-  - uid: 19254
-    components:
-    - type: Transform
-      pos: -55.5,-61.5
-      parent: 2
   - uid: 19262
     components:
     - type: Transform
@@ -151286,11 +151188,6 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-57.5
-      parent: 2
-  - uid: 19265
-    components:
-    - type: Transform
-      pos: 44.5,15.5
       parent: 2
   - uid: 19266
     components:
@@ -151316,11 +151213,6 @@ entities:
     components:
     - type: Transform
       pos: 27.5,-69.5
-      parent: 2
-  - uid: 19559
-    components:
-    - type: Transform
-      pos: -51.5,-61.5
       parent: 2
   - uid: 19584
     components:
@@ -151352,11 +151244,6 @@ entities:
     - type: Transform
       pos: 13.5,2.5
       parent: 2
-  - uid: 19844
-    components:
-    - type: Transform
-      pos: 20.5,23.5
-      parent: 2
   - uid: 19892
     components:
     - type: Transform
@@ -151366,11 +151253,6 @@ entities:
     components:
     - type: Transform
       pos: 53.5,-33.5
-      parent: 2
-  - uid: 19894
-    components:
-    - type: Transform
-      pos: -43.5,-58.5
       parent: 2
   - uid: 19905
     components:
@@ -151397,11 +151279,6 @@ entities:
     - type: Transform
       pos: 37.5,-76.5
       parent: 2
-  - uid: 19916
-    components:
-    - type: Transform
-      pos: -55.5,-57.5
-      parent: 2
   - uid: 19919
     components:
     - type: Transform
@@ -151417,20 +151294,10 @@ entities:
     - type: Transform
       pos: -56.5,-21.5
       parent: 2
-  - uid: 20006
-    components:
-    - type: Transform
-      pos: -56.5,-22.5
-      parent: 2
   - uid: 20142
     components:
     - type: Transform
       pos: 36.5,-50.5
-      parent: 2
-  - uid: 20153
-    components:
-    - type: Transform
-      pos: -50.5,-60.5
       parent: 2
   - uid: 20160
     components:
@@ -151457,35 +151324,10 @@ entities:
     - type: Transform
       pos: -62.5,-60.5
       parent: 2
-  - uid: 20175
-    components:
-    - type: Transform
-      pos: -25.5,-34.5
-      parent: 2
-  - uid: 20178
-    components:
-    - type: Transform
-      pos: -40.5,-39.5
-      parent: 2
   - uid: 20181
     components:
     - type: Transform
       pos: 7.5,-72.5
-      parent: 2
-  - uid: 20193
-    components:
-    - type: Transform
-      pos: -35.5,-21.5
-      parent: 2
-  - uid: 20195
-    components:
-    - type: Transform
-      pos: -59.5,-60.5
-      parent: 2
-  - uid: 20221
-    components:
-    - type: Transform
-      pos: -31.5,-21.5
       parent: 2
   - uid: 20279
     components:
@@ -151497,50 +151339,25 @@ entities:
     - type: Transform
       pos: -36.5,-59.5
       parent: 2
-  - uid: 20320
-    components:
-    - type: Transform
-      pos: -50.5,-39.5
-      parent: 2
   - uid: 20541
     components:
     - type: Transform
       pos: -46.5,-20.5
-      parent: 2
-  - uid: 20634
-    components:
-    - type: Transform
-      pos: -53.5,-37.5
       parent: 2
   - uid: 20663
     components:
     - type: Transform
       pos: -52.5,-27.5
       parent: 2
-  - uid: 20670
-    components:
-    - type: Transform
-      pos: -52.5,-32.5
-      parent: 2
   - uid: 20767
     components:
     - type: Transform
       pos: -52.5,-26.5
       parent: 2
-  - uid: 21223
-    components:
-    - type: Transform
-      pos: -56.5,-32.5
-      parent: 2
   - uid: 21297
     components:
     - type: Transform
       pos: -56.5,-27.5
-      parent: 2
-  - uid: 21312
-    components:
-    - type: Transform
-      pos: -51.5,-42.5
       parent: 2
   - uid: 21314
     components:
@@ -151552,30 +151369,10 @@ entities:
     - type: Transform
       pos: -43.5,-43.5
       parent: 2
-  - uid: 21395
-    components:
-    - type: Transform
-      pos: -43.5,-47.5
-      parent: 2
-  - uid: 21426
-    components:
-    - type: Transform
-      pos: -48.5,-47.5
-      parent: 2
-  - uid: 21458
-    components:
-    - type: Transform
-      pos: 13.5,-7.5
-      parent: 2
   - uid: 21738
     components:
     - type: Transform
       pos: 4.5,-54.5
-      parent: 2
-  - uid: 21760
-    components:
-    - type: Transform
-      pos: 17.5,17.5
       parent: 2
   - uid: 21784
     components:
@@ -151587,30 +151384,15 @@ entities:
     - type: Transform
       pos: 48.5,25.5
       parent: 2
-  - uid: 21807
-    components:
-    - type: Transform
-      pos: -40.5,-42.5
-      parent: 2
   - uid: 21852
     components:
     - type: Transform
       pos: -31.5,-26.5
       parent: 2
-  - uid: 21860
-    components:
-    - type: Transform
-      pos: 48.5,18.5
-      parent: 2
   - uid: 21868
     components:
     - type: Transform
       pos: 11.5,-11.5
-      parent: 2
-  - uid: 21870
-    components:
-    - type: Transform
-      pos: 15.5,26.5
       parent: 2
   - uid: 21877
     components:
@@ -151622,25 +151404,10 @@ entities:
     - type: Transform
       pos: -62.5,-38.5
       parent: 2
-  - uid: 21879
-    components:
-    - type: Transform
-      pos: -62.5,-35.5
-      parent: 2
   - uid: 21881
     components:
     - type: Transform
       pos: -11.5,-52.5
-      parent: 2
-  - uid: 21886
-    components:
-    - type: Transform
-      pos: -62.5,-57.5
-      parent: 2
-  - uid: 21891
-    components:
-    - type: Transform
-      pos: -54.5,-57.5
       parent: 2
   - uid: 21897
     components:
@@ -151672,20 +151439,10 @@ entities:
     - type: Transform
       pos: 18.5,-32.5
       parent: 2
-  - uid: 22017
-    components:
-    - type: Transform
-      pos: 24.5,-32.5
-      parent: 2
   - uid: 22021
     components:
     - type: Transform
       pos: 27.5,-23.5
-      parent: 2
-  - uid: 22027
-    components:
-    - type: Transform
-      pos: 14.5,13.5
       parent: 2
   - uid: 22031
     components:
@@ -151902,11 +151659,6 @@ entities:
     - type: Transform
       pos: 39.5,-78.5
       parent: 2
-  - uid: 23619
-    components:
-    - type: Transform
-      pos: 22.5,16.5
-      parent: 2
   - uid: 23620
     components:
     - type: Transform
@@ -151932,11 +151684,6 @@ entities:
     - type: Transform
       pos: 36.5,26.5
       parent: 2
-  - uid: 23626
-    components:
-    - type: Transform
-      pos: 36.5,20.5
-      parent: 2
   - uid: 23627
     components:
     - type: Transform
@@ -151952,11 +151699,6 @@ entities:
     - type: Transform
       pos: 23.5,20.5
       parent: 2
-  - uid: 23630
-    components:
-    - type: Transform
-      pos: 48.5,23.5
-      parent: 2
   - uid: 23631
     components:
     - type: Transform
@@ -151966,11 +151708,6 @@ entities:
     components:
     - type: Transform
       pos: 28.5,26.5
-      parent: 2
-  - uid: 23633
-    components:
-    - type: Transform
-      pos: 18.5,16.5
       parent: 2
   - uid: 23634
     components:
@@ -152002,40 +151739,15 @@ entities:
     - type: Transform
       pos: 43.5,13.5
       parent: 2
-  - uid: 23640
-    components:
-    - type: Transform
-      pos: 22.5,15.5
-      parent: 2
-  - uid: 23641
-    components:
-    - type: Transform
-      pos: -4.5,-33.5
-      parent: 2
-  - uid: 23642
-    components:
-    - type: Transform
-      pos: 9.5,7.5
-      parent: 2
   - uid: 23643
     components:
     - type: Transform
       pos: 10.5,7.5
       parent: 2
-  - uid: 23644
-    components:
-    - type: Transform
-      pos: -5.5,-32.5
-      parent: 2
   - uid: 23645
     components:
     - type: Transform
       pos: 11.5,-7.5
-      parent: 2
-  - uid: 24232
-    components:
-    - type: Transform
-      pos: -30.5,16.5
       parent: 2
   - uid: 24752
     components:
@@ -152059,20 +151771,115 @@ entities:
       parent: 2
 - proto: WallReinforcedRust
   entities:
-  - uid: 5864
+  - uid: 4945
     components:
     - type: Transform
-      pos: -27.5,-68.5
+      pos: -47.5,-20.5
       parent: 2
-  - uid: 5886
+  - uid: 4966
     components:
     - type: Transform
-      pos: 44.5,25.5
+      pos: -50.5,-42.5
       parent: 2
-  - uid: 5888
+  - uid: 4974
     components:
     - type: Transform
-      pos: 30.5,26.5
+      pos: -25.5,-24.5
+      parent: 2
+  - uid: 5009
+    components:
+    - type: Transform
+      pos: -49.5,-2.5
+      parent: 2
+  - uid: 5247
+    components:
+    - type: Transform
+      pos: 48.5,23.5
+      parent: 2
+  - uid: 5317
+    components:
+    - type: Transform
+      pos: -31.5,-66.5
+      parent: 2
+  - uid: 5327
+    components:
+    - type: Transform
+      pos: 28.5,-6.5
+      parent: 2
+  - uid: 5331
+    components:
+    - type: Transform
+      pos: -31.5,-38.5
+      parent: 2
+  - uid: 5334
+    components:
+    - type: Transform
+      pos: -51.5,-61.5
+      parent: 2
+  - uid: 5387
+    components:
+    - type: Transform
+      pos: 41.5,-13.5
+      parent: 2
+  - uid: 5411
+    components:
+    - type: Transform
+      pos: -40.5,-42.5
+      parent: 2
+  - uid: 5425
+    components:
+    - type: Transform
+      pos: -43.5,24.5
+      parent: 2
+  - uid: 5488
+    components:
+    - type: Transform
+      pos: 13.5,-61.5
+      parent: 2
+  - uid: 5493
+    components:
+    - type: Transform
+      pos: -50.5,-25.5
+      parent: 2
+  - uid: 5512
+    components:
+    - type: Transform
+      pos: 42.5,22.5
+      parent: 2
+  - uid: 5529
+    components:
+    - type: Transform
+      pos: 18.5,-29.5
+      parent: 2
+  - uid: 5539
+    components:
+    - type: Transform
+      pos: 4.5,27.5
+      parent: 2
+  - uid: 5548
+    components:
+    - type: Transform
+      pos: -26.5,-26.5
+      parent: 2
+  - uid: 5579
+    components:
+    - type: Transform
+      pos: -18.5,40.5
+      parent: 2
+  - uid: 5723
+    components:
+    - type: Transform
+      pos: -36.5,-31.5
+      parent: 2
+  - uid: 5811
+    components:
+    - type: Transform
+      pos: 12.5,-3.5
+      parent: 2
+  - uid: 5830
+    components:
+    - type: Transform
+      pos: -46.5,2.5
       parent: 2
   - uid: 5901
     components:
@@ -152082,12 +151889,12 @@ entities:
   - uid: 5907
     components:
     - type: Transform
-      pos: 29.5,-50.5
+      pos: 4.5,-59.5
       parent: 2
-  - uid: 5909
+  - uid: 5915
     components:
     - type: Transform
-      pos: 25.5,20.5
+      pos: -35.5,0.5
       parent: 2
   - uid: 5947
     components:
@@ -152099,25 +151906,15 @@ entities:
     - type: Transform
       pos: 54.5,-23.5
       parent: 2
-  - uid: 5957
+  - uid: 5975
     components:
     - type: Transform
-      pos: -43.5,-44.5
-      parent: 2
-  - uid: 5970
-    components:
-    - type: Transform
-      pos: -59.5,-35.5
+      pos: -47.5,-14.5
       parent: 2
   - uid: 6028
     components:
     - type: Transform
       pos: 60.5,-78.5
-      parent: 2
-  - uid: 6053
-    components:
-    - type: Transform
-      pos: -21.5,-68.5
       parent: 2
   - uid: 6060
     components:
@@ -152127,57 +151924,57 @@ entities:
   - uid: 6085
     components:
     - type: Transform
-      pos: 21.5,-32.5
-      parent: 2
-  - uid: 6108
-    components:
-    - type: Transform
-      pos: -13.5,-53.5
+      pos: 16.5,-16.5
       parent: 2
   - uid: 6109
     components:
     - type: Transform
       pos: 47.5,-42.5
       parent: 2
+  - uid: 6112
+    components:
+    - type: Transform
+      pos: -25.5,-37.5
+      parent: 2
   - uid: 6122
     components:
     - type: Transform
-      pos: -5.5,-60.5
+      pos: -40.5,-39.5
       parent: 2
   - uid: 6145
     components:
     - type: Transform
-      pos: -29.5,-20.5
+      pos: -1.5,27.5
       parent: 2
-  - uid: 6149
+  - uid: 6160
     components:
     - type: Transform
-      pos: -53.5,-36.5
-      parent: 2
-  - uid: 6159
-    components:
-    - type: Transform
-      pos: -9.5,-72.5
+      pos: 4.5,29.5
       parent: 2
   - uid: 6161
     components:
     - type: Transform
       pos: 54.5,-57.5
       parent: 2
+  - uid: 6165
+    components:
+    - type: Transform
+      pos: -19.5,11.5
+      parent: 2
   - uid: 6186
     components:
     - type: Transform
-      pos: -20.5,40.5
+      pos: -28.5,16.5
+      parent: 2
+  - uid: 6190
+    components:
+    - type: Transform
+      pos: -53.5,-38.5
       parent: 2
   - uid: 6193
     components:
     - type: Transform
-      pos: 2.5,-35.5
-      parent: 2
-  - uid: 6207
-    components:
-    - type: Transform
-      pos: 25.5,-44.5
+      pos: -29.5,-68.5
       parent: 2
   - uid: 6225
     components:
@@ -152189,55 +151986,30 @@ entities:
     - type: Transform
       pos: -30.5,-81.5
       parent: 2
-  - uid: 6238
-    components:
-    - type: Transform
-      pos: 27.5,-32.5
-      parent: 2
   - uid: 6240
     components:
     - type: Transform
-      pos: 26.5,25.5
+      pos: 7.5,-64.5
       parent: 2
   - uid: 6254
     components:
     - type: Transform
-      pos: -27.5,-57.5
-      parent: 2
-  - uid: 6257
-    components:
-    - type: Transform
-      pos: 22.5,-8.5
+      pos: -63.5,-39.5
       parent: 2
   - uid: 6261
     components:
     - type: Transform
-      pos: -31.5,-38.5
+      pos: -39.5,32.5
       parent: 2
-  - uid: 6288
+  - uid: 6295
     components:
     - type: Transform
-      pos: -10.5,30.5
-      parent: 2
-  - uid: 6292
-    components:
-    - type: Transform
-      pos: -8.5,4.5
+      pos: -33.5,6.5
       parent: 2
   - uid: 6297
     components:
     - type: Transform
       pos: 44.5,-79.5
-      parent: 2
-  - uid: 6306
-    components:
-    - type: Transform
-      pos: -16.5,40.5
-      parent: 2
-  - uid: 6307
-    components:
-    - type: Transform
-      pos: 45.5,18.5
       parent: 2
   - uid: 6321
     components:
@@ -152249,11 +152021,6 @@ entities:
     - type: Transform
       pos: 9.5,-76.5
       parent: 2
-  - uid: 6352
-    components:
-    - type: Transform
-      pos: -52.5,-28.5
-      parent: 2
   - uid: 6353
     components:
     - type: Transform
@@ -152264,70 +152031,55 @@ entities:
     - type: Transform
       pos: 9.5,-80.5
       parent: 2
-  - uid: 6360
-    components:
-    - type: Transform
-      pos: 25.5,-42.5
-      parent: 2
   - uid: 6369
     components:
     - type: Transform
-      pos: -19.5,-45.5
+      pos: -26.5,37.5
       parent: 2
   - uid: 6374
     components:
     - type: Transform
-      pos: 48.5,7.5
+      pos: -25.5,-43.5
       parent: 2
   - uid: 6376
     components:
     - type: Transform
       pos: 13.5,-89.5
       parent: 2
-  - uid: 6379
-    components:
-    - type: Transform
-      pos: -5.5,17.5
-      parent: 2
-  - uid: 6389
-    components:
-    - type: Transform
-      pos: -54.5,-39.5
-      parent: 2
   - uid: 6397
     components:
     - type: Transform
-      pos: -26.5,-26.5
+      pos: -37.5,7.5
       parent: 2
   - uid: 6400
     components:
     - type: Transform
       pos: 67.5,-66.5
       parent: 2
-  - uid: 6407
+  - uid: 6406
     components:
     - type: Transform
-      pos: -13.5,-56.5
+      pos: -37.5,-74.5
       parent: 2
   - uid: 6427
     components:
     - type: Transform
-      pos: 42.5,7.5
+      pos: -8.5,6.5
       parent: 2
   - uid: 6428
     components:
     - type: Transform
-      pos: 12.5,-3.5
+      pos: 27.5,-32.5
       parent: 2
   - uid: 6430
     components:
     - type: Transform
-      pos: -9.5,-66.5
+      pos: -36.5,-60.5
       parent: 2
   - uid: 6433
     components:
     - type: Transform
-      pos: 26.5,26.5
+      pos: -28.5,-57.5
       parent: 2
   - uid: 6437
     components:
@@ -152339,11 +152091,6 @@ entities:
     - type: Transform
       pos: 85.5,-24.5
       parent: 2
-  - uid: 6446
-    components:
-    - type: Transform
-      pos: 37.5,-23.5
-      parent: 2
   - uid: 6464
     components:
     - type: Transform
@@ -152352,32 +152099,22 @@ entities:
   - uid: 6476
     components:
     - type: Transform
-      pos: -9.5,-54.5
+      pos: -54.5,-39.5
       parent: 2
-  - uid: 6493
+  - uid: 6482
     components:
     - type: Transform
-      pos: 25.5,17.5
+      pos: -8.5,25.5
       parent: 2
-  - uid: 6556
+  - uid: 6507
     components:
     - type: Transform
-      pos: -18.5,-45.5
+      pos: -53.5,-37.5
       parent: 2
-  - uid: 6604
+  - uid: 6572
     components:
     - type: Transform
-      pos: 40.5,-19.5
-      parent: 2
-  - uid: 6618
-    components:
-    - type: Transform
-      pos: 19.5,16.5
-      parent: 2
-  - uid: 6620
-    components:
-    - type: Transform
-      pos: 1.5,27.5
+      pos: -31.5,-68.5
       parent: 2
   - uid: 6623
     components:
@@ -152389,55 +152126,35 @@ entities:
     - type: Transform
       pos: 56.5,-45.5
       parent: 2
-  - uid: 6628
-    components:
-    - type: Transform
-      pos: -8.5,-27.5
-      parent: 2
-  - uid: 6629
-    components:
-    - type: Transform
-      pos: -11.5,36.5
-      parent: 2
-  - uid: 6632
-    components:
-    - type: Transform
-      pos: 11.5,-15.5
-      parent: 2
-  - uid: 6640
-    components:
-    - type: Transform
-      pos: 18.5,-29.5
-      parent: 2
   - uid: 6670
     components:
     - type: Transform
-      pos: 17.5,-19.5
+      pos: 14.5,29.5
       parent: 2
-  - uid: 6680
+  - uid: 6684
+    components:
+    - type: Transform
+      pos: 29.5,-47.5
+      parent: 2
+  - uid: 6685
     components:
     - type: Transform
       pos: 6.5,-23.5
       parent: 2
-  - uid: 6713
+  - uid: 6712
     components:
     - type: Transform
-      pos: -9.5,-53.5
+      pos: -41.5,-17.5
       parent: 2
   - uid: 6716
     components:
     - type: Transform
-      pos: -2.5,3.5
+      pos: -19.5,-68.5
       parent: 2
   - uid: 6739
     components:
     - type: Transform
-      pos: -50.5,-46.5
-      parent: 2
-  - uid: 6741
-    components:
-    - type: Transform
-      pos: -31.5,-33.5
+      pos: 9.5,15.5
       parent: 2
   - uid: 6781
     components:
@@ -152449,15 +152166,10 @@ entities:
     - type: Transform
       pos: 30.5,-66.5
       parent: 2
-  - uid: 6850
-    components:
-    - type: Transform
-      pos: -56.5,-26.5
-      parent: 2
   - uid: 6882
     components:
     - type: Transform
-      pos: -31.5,-17.5
+      pos: -57.5,-19.5
       parent: 2
   - uid: 6899
     components:
@@ -152472,62 +152184,27 @@ entities:
   - uid: 6905
     components:
     - type: Transform
-      pos: -10.5,-64.5
-      parent: 2
-  - uid: 6908
-    components:
-    - type: Transform
-      pos: 25.5,-43.5
+      pos: -44.5,8.5
       parent: 2
   - uid: 6923
     components:
     - type: Transform
-      pos: -62.5,-58.5
+      pos: -10.5,-27.5
       parent: 2
   - uid: 6925
     components:
     - type: Transform
-      pos: 5.5,-7.5
-      parent: 2
-  - uid: 6927
-    components:
-    - type: Transform
-      pos: -57.5,-32.5
+      pos: -19.5,9.5
       parent: 2
   - uid: 6933
     components:
     - type: Transform
-      pos: -19.5,-68.5
-      parent: 2
-  - uid: 6934
-    components:
-    - type: Transform
-      pos: -46.5,-42.5
-      parent: 2
-  - uid: 6968
-    components:
-    - type: Transform
-      pos: 9.5,-11.5
-      parent: 2
-  - uid: 6970
-    components:
-    - type: Transform
-      pos: 11.5,-8.5
+      pos: -10.5,-64.5
       parent: 2
   - uid: 6974
     components:
     - type: Transform
       pos: 91.5,-12.5
-      parent: 2
-  - uid: 6982
-    components:
-    - type: Transform
-      pos: 17.5,-60.5
-      parent: 2
-  - uid: 6988
-    components:
-    - type: Transform
-      pos: -21.5,32.5
       parent: 2
   - uid: 6993
     components:
@@ -152549,35 +152226,20 @@ entities:
     - type: Transform
       pos: 48.5,-62.5
       parent: 2
-  - uid: 7021
-    components:
-    - type: Transform
-      pos: -32.5,-30.5
-      parent: 2
   - uid: 7026
     components:
     - type: Transform
       pos: 63.5,-55.5
       parent: 2
-  - uid: 7060
+  - uid: 7077
     components:
     - type: Transform
-      pos: 39.5,-30.5
+      pos: 44.5,7.5
       parent: 2
-  - uid: 7092
+  - uid: 7098
     components:
     - type: Transform
-      pos: 22.5,-9.5
-      parent: 2
-  - uid: 7106
-    components:
-    - type: Transform
-      pos: -2.5,16.5
-      parent: 2
-  - uid: 7107
-    components:
-    - type: Transform
-      pos: -50.5,-24.5
+      pos: -38.5,24.5
       parent: 2
   - uid: 7118
     components:
@@ -152592,102 +152254,77 @@ entities:
   - uid: 7164
     components:
     - type: Transform
-      pos: -3.5,-66.5
+      pos: -9.5,-54.5
+      parent: 2
+  - uid: 7165
+    components:
+    - type: Transform
+      pos: 49.5,-6.5
       parent: 2
   - uid: 7167
     components:
     - type: Transform
-      pos: -57.5,-20.5
+      pos: -53.5,-47.5
       parent: 2
-  - uid: 7168
+  - uid: 7174
     components:
     - type: Transform
-      pos: 7.5,27.5
-      parent: 2
-  - uid: 7175
-    components:
-    - type: Transform
-      pos: -51.5,-35.5
-      parent: 2
-  - uid: 7210
-    components:
-    - type: Transform
-      pos: 13.5,29.5
+      pos: -10.5,-59.5
       parent: 2
   - uid: 7216
     components:
     - type: Transform
-      pos: 18.5,20.5
+      pos: 47.5,1.5
+      parent: 2
+  - uid: 7217
+    components:
+    - type: Transform
+      pos: -42.5,14.5
       parent: 2
   - uid: 7218
     components:
     - type: Transform
       pos: 44.5,-47.5
       parent: 2
-  - uid: 7222
-    components:
-    - type: Transform
-      pos: -27.5,-54.5
-      parent: 2
   - uid: 7228
     components:
     - type: Transform
-      pos: -9.5,17.5
+      pos: -58.5,-39.5
       parent: 2
   - uid: 7230
     components:
     - type: Transform
-      pos: 10.5,-5.5
+      pos: -35.5,-0.5
       parent: 2
   - uid: 7233
     components:
     - type: Transform
-      pos: 5.5,-11.5
+      pos: -52.5,-39.5
       parent: 2
-  - uid: 7286
+  - uid: 7241
     components:
     - type: Transform
-      pos: 42.5,-32.5
+      pos: -50.5,-32.5
+      parent: 2
+  - uid: 7283
+    components:
+    - type: Transform
+      pos: -9.5,23.5
       parent: 2
   - uid: 7293
     components:
     - type: Transform
       pos: 58.5,-67.5
       parent: 2
-  - uid: 7298
-    components:
-    - type: Transform
-      pos: 12.5,-15.5
-      parent: 2
   - uid: 7308
     components:
     - type: Transform
       pos: 42.5,-62.5
       parent: 2
-  - uid: 7315
-    components:
-    - type: Transform
-      pos: -31.5,-20.5
-      parent: 2
   - uid: 7318
     components:
     - type: Transform
       pos: 11.5,-76.5
-      parent: 2
-  - uid: 7320
-    components:
-    - type: Transform
-      pos: -30.5,-20.5
-      parent: 2
-  - uid: 7330
-    components:
-    - type: Transform
-      pos: -6.5,13.5
-      parent: 2
-  - uid: 7352
-    components:
-    - type: Transform
-      pos: -3.5,17.5
       parent: 2
   - uid: 7359
     components:
@@ -152707,102 +152344,52 @@ entities:
   - uid: 7430
     components:
     - type: Transform
-      pos: 5.5,-13.5
-      parent: 2
-  - uid: 7456
-    components:
-    - type: Transform
-      pos: -14.5,-17.5
+      pos: -10.5,-23.5
       parent: 2
   - uid: 7507
     components:
     - type: Transform
-      pos: 13.5,-20.5
+      pos: -14.5,-21.5
+      parent: 2
+  - uid: 7516
+    components:
+    - type: Transform
+      pos: -13.5,-71.5
       parent: 2
   - uid: 7518
     components:
     - type: Transform
-      pos: -0.5,27.5
-      parent: 2
-  - uid: 7529
-    components:
-    - type: Transform
-      pos: 26.5,-5.5
+      pos: -0.5,6.5
       parent: 2
   - uid: 7531
     components:
     - type: Transform
       pos: 43.5,-42.5
       parent: 2
-  - uid: 7546
-    components:
-    - type: Transform
-      pos: -35.5,-70.5
-      parent: 2
-  - uid: 7572
-    components:
-    - type: Transform
-      pos: -27.5,-51.5
-      parent: 2
-  - uid: 7588
-    components:
-    - type: Transform
-      pos: -10.5,-59.5
-      parent: 2
   - uid: 7605
     components:
     - type: Transform
       pos: 12.5,-68.5
       parent: 2
-  - uid: 7612
+  - uid: 7611
     components:
     - type: Transform
-      pos: -40.5,-19.5
+      pos: 5.5,-20.5
       parent: 2
   - uid: 7618
     components:
     - type: Transform
-      pos: -5.5,13.5
-      parent: 2
-  - uid: 7631
-    components:
-    - type: Transform
-      pos: -39.5,-21.5
+      pos: -46.5,-24.5
       parent: 2
   - uid: 7639
     components:
     - type: Transform
       pos: 86.5,-24.5
       parent: 2
-  - uid: 7641
-    components:
-    - type: Transform
-      pos: 42.5,-26.5
-      parent: 2
-  - uid: 7642
-    components:
-    - type: Transform
-      pos: -31.5,-62.5
-      parent: 2
-  - uid: 7643
-    components:
-    - type: Transform
-      pos: 11.5,-9.5
-      parent: 2
   - uid: 7659
     components:
     - type: Transform
-      pos: -13.5,0.5
-      parent: 2
-  - uid: 7661
-    components:
-    - type: Transform
-      pos: 25.5,-11.5
-      parent: 2
-  - uid: 7667
-    components:
-    - type: Transform
-      pos: 18.5,-31.5
+      pos: 5.5,6.5
       parent: 2
   - uid: 7673
     components:
@@ -152812,32 +152399,27 @@ entities:
   - uid: 7700
     components:
     - type: Transform
-      pos: 29.5,-51.5
-      parent: 2
-  - uid: 7701
-    components:
-    - type: Transform
-      pos: 23.5,-27.5
+      pos: 36.5,23.5
       parent: 2
   - uid: 7707
     components:
     - type: Transform
-      pos: 47.5,18.5
+      pos: -20.5,2.5
       parent: 2
   - uid: 7717
     components:
     - type: Transform
-      pos: 23.5,-5.5
+      pos: 15.5,4.5
       parent: 2
   - uid: 7723
     components:
     - type: Transform
-      pos: 14.5,-2.5
+      pos: -9.5,-72.5
       parent: 2
   - uid: 7724
     components:
     - type: Transform
-      pos: 10.5,29.5
+      pos: -43.5,-14.5
       parent: 2
   - uid: 7744
     components:
@@ -152847,12 +152429,7 @@ entities:
   - uid: 7758
     components:
     - type: Transform
-      pos: 40.5,-28.5
-      parent: 2
-  - uid: 7759
-    components:
-    - type: Transform
-      pos: -9.5,-27.5
+      pos: -1.5,-24.5
       parent: 2
   - uid: 7788
     components:
@@ -152862,97 +152439,37 @@ entities:
   - uid: 7796
     components:
     - type: Transform
-      pos: -37.5,-28.5
+      pos: -56.5,16.5
       parent: 2
   - uid: 7799
     components:
     - type: Transform
-      pos: -31.5,-70.5
-      parent: 2
-  - uid: 7820
-    components:
-    - type: Transform
-      pos: -47.5,-47.5
-      parent: 2
-  - uid: 7823
-    components:
-    - type: Transform
-      pos: 25.5,-40.5
-      parent: 2
-  - uid: 7831
-    components:
-    - type: Transform
-      pos: 41.5,-33.5
+      pos: -10.5,-65.5
       parent: 2
   - uid: 7943
     components:
     - type: Transform
       pos: 51.5,-32.5
       parent: 2
-  - uid: 8022
-    components:
-    - type: Transform
-      pos: -2.5,4.5
-      parent: 2
-  - uid: 8028
-    components:
-    - type: Transform
-      pos: -63.5,-35.5
-      parent: 2
   - uid: 8039
     components:
     - type: Transform
       pos: 56.5,-58.5
       parent: 2
-  - uid: 8047
-    components:
-    - type: Transform
-      pos: -49.5,-25.5
-      parent: 2
-  - uid: 8049
-    components:
-    - type: Transform
-      pos: 49.5,22.5
-      parent: 2
   - uid: 8051
     components:
     - type: Transform
-      pos: 29.5,-48.5
-      parent: 2
-  - uid: 8054
-    components:
-    - type: Transform
-      pos: -6.5,20.5
-      parent: 2
-  - uid: 8089
-    components:
-    - type: Transform
-      pos: -51.5,-32.5
-      parent: 2
-  - uid: 8105
-    components:
-    - type: Transform
-      pos: 45.5,13.5
+      pos: -59.5,-10.5
       parent: 2
   - uid: 8111
     components:
     - type: Transform
-      pos: 44.5,-14.5
+      pos: 31.5,-47.5
       parent: 2
   - uid: 8144
     components:
     - type: Transform
-      pos: -0.5,-54.5
-      parent: 2
-  - uid: 8175
-    components:
-    - type: Transform
-      pos: -53.5,-47.5
-      parent: 2
-  - uid: 8196
-    components:
-    - type: Transform
-      pos: 42.5,22.5
+      pos: -14.5,-4.5
       parent: 2
   - uid: 8204
     components:
@@ -152962,17 +152479,12 @@ entities:
   - uid: 8209
     components:
     - type: Transform
-      pos: 39.5,23.5
+      pos: 0.5,15.5
       parent: 2
   - uid: 8211
     components:
     - type: Transform
-      pos: 16.5,-20.5
-      parent: 2
-  - uid: 8235
-    components:
-    - type: Transform
-      pos: 18.5,26.5
+      pos: -22.5,-57.5
       parent: 2
   - uid: 8237
     components:
@@ -152984,85 +152496,40 @@ entities:
     - type: Transform
       pos: 8.5,-96.5
       parent: 2
-  - uid: 8271
+  - uid: 8278
     components:
     - type: Transform
-      pos: 32.5,-32.5
+      pos: -35.5,-66.5
       parent: 2
-  - uid: 8273
+  - uid: 8319
     components:
     - type: Transform
-      pos: -28.5,25.5
-      parent: 2
-  - uid: 8276
-    components:
-    - type: Transform
-      pos: -10.5,35.5
-      parent: 2
-  - uid: 8290
-    components:
-    - type: Transform
-      pos: -35.5,-59.5
-      parent: 2
-  - uid: 8318
-    components:
-    - type: Transform
-      pos: -22.5,-44.5
+      pos: -8.5,3.5
       parent: 2
   - uid: 8342
     components:
     - type: Transform
       pos: 8.5,-75.5
       parent: 2
-  - uid: 8376
+  - uid: 8364
     components:
     - type: Transform
-      pos: -1.5,15.5
+      pos: -5.5,-29.5
       parent: 2
-  - uid: 8386
+  - uid: 8393
     components:
     - type: Transform
-      pos: -8.5,23.5
-      parent: 2
-  - uid: 8388
-    components:
-    - type: Transform
-      pos: -19.5,40.5
-      parent: 2
-  - uid: 8392
-    components:
-    - type: Transform
-      pos: 3.5,-7.5
+      pos: -10.5,-22.5
       parent: 2
   - uid: 8399
     components:
     - type: Transform
-      pos: -43.5,-45.5
-      parent: 2
-  - uid: 8400
-    components:
-    - type: Transform
-      pos: 22.5,-6.5
+      pos: -9.5,17.5
       parent: 2
   - uid: 8404
     components:
     - type: Transform
       pos: 43.5,-41.5
-      parent: 2
-  - uid: 8412
-    components:
-    - type: Transform
-      pos: -2.5,27.5
-      parent: 2
-  - uid: 8463
-    components:
-    - type: Transform
-      pos: -21.5,28.5
-      parent: 2
-  - uid: 8492
-    components:
-    - type: Transform
-      pos: -13.5,24.5
       parent: 2
   - uid: 8526
     components:
@@ -153087,37 +152554,47 @@ entities:
   - uid: 8555
     components:
     - type: Transform
-      pos: -31.5,-65.5
+      pos: -41.5,0.5
       parent: 2
   - uid: 8559
     components:
     - type: Transform
-      pos: 14.5,-0.5
+      pos: -35.5,-78.5
+      parent: 2
+  - uid: 8571
+    components:
+    - type: Transform
+      pos: -31.5,-21.5
       parent: 2
   - uid: 8577
     components:
     - type: Transform
-      pos: -9.5,-49.5
+      pos: -44.5,10.5
       parent: 2
   - uid: 8623
     components:
     - type: Transform
-      pos: -26.5,-39.5
+      pos: 15.5,26.5
       parent: 2
   - uid: 8624
     components:
     - type: Transform
-      pos: -5.5,-69.5
+      pos: -28.5,35.5
+      parent: 2
+  - uid: 8645
+    components:
+    - type: Transform
+      pos: -45.5,16.5
       parent: 2
   - uid: 8703
     components:
     - type: Transform
-      pos: 13.5,0.5
+      pos: -46.5,-47.5
       parent: 2
   - uid: 8725
     components:
     - type: Transform
-      pos: -52.5,-46.5
+      pos: -12.5,37.5
       parent: 2
   - uid: 8737
     components:
@@ -153127,7 +152604,7 @@ entities:
   - uid: 8748
     components:
     - type: Transform
-      pos: -27.5,-52.5
+      pos: -6.5,3.5
       parent: 2
   - uid: 8750
     components:
@@ -153139,35 +152616,55 @@ entities:
     - type: Transform
       pos: 50.5,-74.5
       parent: 2
+  - uid: 8767
+    components:
+    - type: Transform
+      pos: -3.5,26.5
+      parent: 2
+  - uid: 8768
+    components:
+    - type: Transform
+      pos: -0.5,15.5
+      parent: 2
   - uid: 8770
     components:
     - type: Transform
       pos: 32.5,-68.5
+      parent: 2
+  - uid: 8771
+    components:
+    - type: Transform
+      pos: 14.5,-0.5
       parent: 2
   - uid: 8772
     components:
     - type: Transform
       pos: -8.5,-80.5
       parent: 2
+  - uid: 8774
+    components:
+    - type: Transform
+      pos: 22.5,16.5
+      parent: 2
   - uid: 8787
     components:
     - type: Transform
-      pos: -4.5,4.5
+      pos: -54.5,-57.5
       parent: 2
   - uid: 8853
     components:
     - type: Transform
-      pos: 14.5,-15.5
+      pos: -25.5,-20.5
       parent: 2
   - uid: 8861
     components:
     - type: Transform
-      pos: -24.5,24.5
+      pos: -54.5,-49.5
       parent: 2
   - uid: 8873
     components:
     - type: Transform
-      pos: -51.5,-28.5
+      pos: -40.5,18.5
       parent: 2
   - uid: 8878
     components:
@@ -153182,22 +152679,27 @@ entities:
   - uid: 8880
     components:
     - type: Transform
-      pos: 23.5,-32.5
+      pos: 36.5,-28.5
       parent: 2
   - uid: 8882
     components:
     - type: Transform
-      pos: 24.5,24.5
+      pos: 48.5,18.5
+      parent: 2
+  - uid: 8886
+    components:
+    - type: Transform
+      pos: -49.5,0.5
       parent: 2
   - uid: 8887
     components:
     - type: Transform
-      pos: -5.5,16.5
+      pos: -26.5,3.5
       parent: 2
   - uid: 8894
     components:
     - type: Transform
-      pos: 44.5,24.5
+      pos: -26.5,4.5
       parent: 2
   - uid: 8896
     components:
@@ -153207,17 +152709,27 @@ entities:
   - uid: 8904
     components:
     - type: Transform
-      pos: 25.5,-32.5
+      pos: -21.5,0.5
+      parent: 2
+  - uid: 8909
+    components:
+    - type: Transform
+      pos: -21.5,9.5
       parent: 2
   - uid: 8913
     components:
     - type: Transform
-      pos: -26.5,-43.5
+      pos: -60.5,-35.5
+      parent: 2
+  - uid: 9045
+    components:
+    - type: Transform
+      pos: 24.5,18.5
       parent: 2
   - uid: 9148
     components:
     - type: Transform
-      pos: 22.5,-32.5
+      pos: -3.5,-29.5
       parent: 2
   - uid: 9215
     components:
@@ -153232,12 +152744,17 @@ entities:
   - uid: 9262
     components:
     - type: Transform
-      pos: -51.5,-39.5
+      pos: 18.5,-16.5
       parent: 2
   - uid: 9271
     components:
     - type: Transform
-      pos: 40.5,-27.5
+      pos: -26.5,17.5
+      parent: 2
+  - uid: 9276
+    components:
+    - type: Transform
+      pos: 45.5,13.5
       parent: 2
   - uid: 9279
     components:
@@ -153252,37 +152769,67 @@ entities:
   - uid: 9281
     components:
     - type: Transform
-      pos: 33.5,23.5
+      pos: 4.5,28.5
+      parent: 2
+  - uid: 9283
+    components:
+    - type: Transform
+      pos: -59.5,-54.5
+      parent: 2
+  - uid: 9287
+    components:
+    - type: Transform
+      pos: -20.5,9.5
       parent: 2
   - uid: 9313
     components:
     - type: Transform
       pos: 42.5,-40.5
       parent: 2
+  - uid: 9323
+    components:
+    - type: Transform
+      pos: -47.5,0.5
+      parent: 2
   - uid: 9333
     components:
     - type: Transform
-      pos: -36.5,-38.5
+      pos: -62.5,-35.5
+      parent: 2
+  - uid: 9389
+    components:
+    - type: Transform
+      pos: -14.5,-5.5
       parent: 2
   - uid: 9399
     components:
     - type: Transform
-      pos: -13.5,-55.5
+      pos: 29.5,26.5
+      parent: 2
+  - uid: 9407
+    components:
+    - type: Transform
+      pos: -27.5,-9.5
       parent: 2
   - uid: 9420
     components:
     - type: Transform
-      pos: 7.5,-64.5
+      pos: 7.5,1.5
       parent: 2
   - uid: 9430
     components:
     - type: Transform
       pos: 6.5,-73.5
       parent: 2
+  - uid: 9495
+    components:
+    - type: Transform
+      pos: -36.5,-11.5
+      parent: 2
   - uid: 9507
     components:
     - type: Transform
-      pos: -15.5,24.5
+      pos: 12.5,9.5
       parent: 2
   - uid: 9542
     components:
@@ -153292,77 +152839,97 @@ entities:
   - uid: 9549
     components:
     - type: Transform
-      pos: 19.5,11.5
+      pos: -30.5,1.5
       parent: 2
   - uid: 9555
     components:
     - type: Transform
-      pos: 49.5,-3.5
+      pos: -11.5,8.5
       parent: 2
   - uid: 9556
     components:
     - type: Transform
-      pos: 48.5,6.5
+      pos: -11.5,-45.5
       parent: 2
   - uid: 9562
     components:
     - type: Transform
-      pos: -13.5,1.5
+      pos: -54.5,-61.5
       parent: 2
   - uid: 9571
     components:
     - type: Transform
-      pos: 40.5,-25.5
+      pos: -51.5,-32.5
       parent: 2
   - uid: 9600
     components:
     - type: Transform
-      pos: -36.5,-39.5
+      pos: -49.5,-10.5
       parent: 2
   - uid: 9613
     components:
     - type: Transform
-      pos: 44.5,13.5
+      pos: 39.5,-16.5
       parent: 2
   - uid: 9617
     components:
     - type: Transform
-      pos: -54.5,-49.5
+      pos: 17.5,-16.5
       parent: 2
   - uid: 9656
     components:
     - type: Transform
-      pos: -13.5,-73.5
+      pos: 33.5,27.5
+      parent: 2
+  - uid: 9668
+    components:
+    - type: Transform
+      pos: 20.5,23.5
       parent: 2
   - uid: 9678
     components:
     - type: Transform
-      pos: 18.5,18.5
+      pos: -54.5,-55.5
+      parent: 2
+  - uid: 9687
+    components:
+    - type: Transform
+      pos: 4.5,-55.5
       parent: 2
   - uid: 9701
     components:
     - type: Transform
-      pos: -28.5,27.5
+      pos: -33.5,-21.5
       parent: 2
   - uid: 9708
     components:
     - type: Transform
-      pos: -56.5,-20.5
+      pos: -58.5,-50.5
+      parent: 2
+  - uid: 9719
+    components:
+    - type: Transform
+      pos: -27.5,-55.5
       parent: 2
   - uid: 9799
     components:
     - type: Transform
-      pos: 14.5,14.5
+      pos: -31.5,-20.5
+      parent: 2
+  - uid: 9839
+    components:
+    - type: Transform
+      pos: 14.5,4.5
       parent: 2
   - uid: 9852
     components:
     - type: Transform
-      pos: -14.5,-21.5
+      pos: -2.5,6.5
       parent: 2
   - uid: 9858
     components:
     - type: Transform
-      pos: 1.5,-38.5
+      pos: 41.5,-30.5
       parent: 2
   - uid: 9894
     components:
@@ -153372,17 +152939,17 @@ entities:
   - uid: 9897
     components:
     - type: Transform
-      pos: 9.5,27.5
+      pos: -31.5,-49.5
       parent: 2
   - uid: 9898
     components:
     - type: Transform
-      pos: -64.5,-60.5
+      pos: -19.5,12.5
       parent: 2
   - uid: 9899
     components:
     - type: Transform
-      pos: -20.5,-45.5
+      pos: -18.5,28.5
       parent: 2
   - uid: 9922
     components:
@@ -153392,17 +152959,17 @@ entities:
   - uid: 9933
     components:
     - type: Transform
-      pos: -51.5,-45.5
+      pos: 29.5,-48.5
       parent: 2
   - uid: 9944
     components:
     - type: Transform
-      pos: 24.5,-23.5
+      pos: -27.5,-63.5
       parent: 2
   - uid: 9971
     components:
     - type: Transform
-      pos: -4.5,-69.5
+      pos: -36.5,-70.5
       parent: 2
   - uid: 9996
     components:
@@ -153419,70 +152986,115 @@ entities:
     - type: Transform
       pos: 14.5,-65.5
       parent: 2
+  - uid: 10009
+    components:
+    - type: Transform
+      pos: -42.5,13.5
+      parent: 2
   - uid: 10023
     components:
     - type: Transform
-      pos: -31.5,-57.5
+      pos: -58.5,-10.5
+      parent: 2
+  - uid: 10051
+    components:
+    - type: Transform
+      pos: 50.5,-14.5
       parent: 2
   - uid: 10055
     components:
     - type: Transform
-      pos: 6.5,-21.5
+      pos: -31.5,-33.5
+      parent: 2
+  - uid: 10059
+    components:
+    - type: Transform
+      pos: 52.5,-10.5
       parent: 2
   - uid: 10061
     components:
     - type: Transform
-      pos: -28.5,-17.5
+      pos: -30.5,-65.5
       parent: 2
   - uid: 10096
     components:
     - type: Transform
-      pos: 14.5,-16.5
+      pos: 12.5,29.5
       parent: 2
   - uid: 10121
     components:
     - type: Transform
-      pos: 0.5,27.5
+      pos: -42.5,4.5
+      parent: 2
+  - uid: 10148
+    components:
+    - type: Transform
+      pos: -9.5,-56.5
       parent: 2
   - uid: 10173
     components:
     - type: Transform
       pos: 53.5,-32.5
       parent: 2
+  - uid: 10174
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 2
   - uid: 10175
     components:
     - type: Transform
       pos: 51.5,-72.5
       parent: 2
+  - uid: 10182
+    components:
+    - type: Transform
+      pos: 4.5,-20.5
+      parent: 2
+  - uid: 10187
+    components:
+    - type: Transform
+      pos: -56.5,0.5
+      parent: 2
   - uid: 10188
     components:
     - type: Transform
-      pos: -13.5,-75.5
+      pos: -3.5,21.5
       parent: 2
   - uid: 10193
     components:
     - type: Transform
       pos: 36.5,-51.5
       parent: 2
+  - uid: 10213
+    components:
+    - type: Transform
+      pos: -39.5,6.5
+      parent: 2
+  - uid: 10216
+    components:
+    - type: Transform
+      pos: -51.5,-35.5
+      parent: 2
   - uid: 10218
     components:
     - type: Transform
-      pos: 29.5,26.5
+      pos: 44.5,15.5
       parent: 2
   - uid: 10228
     components:
     - type: Transform
-      pos: -58.5,-50.5
+      pos: -37.5,25.5
       parent: 2
   - uid: 10230
     components:
     - type: Transform
-      pos: 23.5,-29.5
+      pos: 27.5,19.5
       parent: 2
   - uid: 10241
     components:
     - type: Transform
-      pos: -40.5,-18.5
+      pos: -52.5,-61.5
       parent: 2
   - uid: 10252
     components:
@@ -153494,30 +153106,45 @@ entities:
     - type: Transform
       pos: 90.5,-12.5
       parent: 2
+  - uid: 10273
+    components:
+    - type: Transform
+      pos: -59.5,-35.5
+      parent: 2
+  - uid: 10384
+    components:
+    - type: Transform
+      pos: 44.5,22.5
+      parent: 2
   - uid: 10389
     components:
     - type: Transform
-      pos: -35.5,-78.5
+      pos: -23.5,40.5
       parent: 2
   - uid: 10410
     components:
     - type: Transform
-      pos: -31.5,-16.5
+      pos: -41.5,-9.5
       parent: 2
   - uid: 10412
     components:
     - type: Transform
-      pos: 28.5,-6.5
+      pos: -3.5,-72.5
       parent: 2
   - uid: 10417
     components:
     - type: Transform
-      pos: -1.5,-29.5
+      pos: -30.5,-78.5
+      parent: 2
+  - uid: 10419
+    components:
+    - type: Transform
+      pos: -27.5,-68.5
       parent: 2
   - uid: 10422
     components:
     - type: Transform
-      pos: 18.5,-23.5
+      pos: 47.5,4.5
       parent: 2
   - uid: 10425
     components:
@@ -153529,35 +153156,40 @@ entities:
     - type: Transform
       pos: 13.5,-65.5
       parent: 2
+  - uid: 10467
+    components:
+    - type: Transform
+      pos: -14.5,0.5
+      parent: 2
   - uid: 10483
     components:
     - type: Transform
-      pos: 49.5,-7.5
+      pos: 32.5,-47.5
       parent: 2
   - uid: 10494
     components:
     - type: Transform
-      pos: -27.5,-59.5
+      pos: 24.5,20.5
       parent: 2
   - uid: 10498
     components:
     - type: Transform
-      pos: 17.5,-25.5
+      pos: -48.5,2.5
       parent: 2
   - uid: 10531
     components:
     - type: Transform
-      pos: 22.5,-29.5
+      pos: -25.5,-39.5
       parent: 2
   - uid: 10536
     components:
     - type: Transform
-      pos: -26.5,37.5
+      pos: -50.5,-39.5
       parent: 2
   - uid: 10541
     components:
     - type: Transform
-      pos: 25.5,-34.5
+      pos: -52.5,-32.5
       parent: 2
   - uid: 10550
     components:
@@ -153567,22 +153199,47 @@ entities:
   - uid: 10557
     components:
     - type: Transform
-      pos: -32.5,-38.5
+      pos: 36.5,20.5
       parent: 2
   - uid: 10571
     components:
     - type: Transform
       pos: 38.5,-67.5
       parent: 2
+  - uid: 10609
+    components:
+    - type: Transform
+      pos: -41.5,-10.5
+      parent: 2
   - uid: 10610
     components:
     - type: Transform
-      pos: -25.5,-17.5
+      pos: 26.5,-50.5
+      parent: 2
+  - uid: 10611
+    components:
+    - type: Transform
+      pos: 12.5,-20.5
+      parent: 2
+  - uid: 10612
+    components:
+    - type: Transform
+      pos: -10.5,28.5
+      parent: 2
+  - uid: 10615
+    components:
+    - type: Transform
+      pos: -51.5,-10.5
+      parent: 2
+  - uid: 10618
+    components:
+    - type: Transform
+      pos: -5.5,13.5
       parent: 2
   - uid: 10627
     components:
     - type: Transform
-      pos: 42.5,18.5
+      pos: -13.5,-56.5
       parent: 2
   - uid: 10629
     components:
@@ -153592,27 +153249,37 @@ entities:
   - uid: 10630
     components:
     - type: Transform
-      pos: 28.5,-9.5
+      pos: -39.5,-12.5
+      parent: 2
+  - uid: 10635
+    components:
+    - type: Transform
+      pos: -20.5,25.5
+      parent: 2
+  - uid: 10668
+    components:
+    - type: Transform
+      pos: -49.5,-16.5
       parent: 2
   - uid: 10679
     components:
     - type: Transform
-      pos: -37.5,-58.5
+      pos: 52.5,-14.5
       parent: 2
   - uid: 10691
     components:
     - type: Transform
-      pos: 39.5,-16.5
+      pos: -35.5,-70.5
       parent: 2
   - uid: 10693
     components:
     - type: Transform
-      pos: 42.5,-1.5
+      pos: 42.5,6.5
       parent: 2
   - uid: 10694
     components:
     - type: Transform
-      pos: -31.5,-58.5
+      pos: 25.5,-37.5
       parent: 2
   - uid: 10695
     components:
@@ -153627,17 +153294,17 @@ entities:
   - uid: 10704
     components:
     - type: Transform
-      pos: -5.5,-61.5
+      pos: 12.5,-7.5
       parent: 2
   - uid: 10705
     components:
     - type: Transform
-      pos: -52.5,-61.5
+      pos: -33.5,4.5
       parent: 2
   - uid: 10706
     components:
     - type: Transform
-      pos: -30.5,-65.5
+      pos: -41.5,-8.5
       parent: 2
   - uid: 10708
     components:
@@ -153652,7 +153319,7 @@ entities:
   - uid: 10711
     components:
     - type: Transform
-      pos: -27.5,-49.5
+      pos: 13.5,-7.5
       parent: 2
   - uid: 10715
     components:
@@ -153662,7 +153329,7 @@ entities:
   - uid: 10748
     components:
     - type: Transform
-      pos: -1.5,-30.5
+      pos: -27.5,-58.5
       parent: 2
   - uid: 10767
     components:
@@ -153672,47 +153339,52 @@ entities:
   - uid: 10777
     components:
     - type: Transform
-      pos: -0.5,-37.5
+      pos: -9.5,-51.5
       parent: 2
   - uid: 10780
     components:
     - type: Transform
-      pos: -0.5,9.5
+      pos: 26.5,-52.5
       parent: 2
   - uid: 10788
     components:
     - type: Transform
-      pos: 20.5,11.5
+      pos: 26.5,30.5
       parent: 2
   - uid: 10789
     components:
     - type: Transform
-      pos: 19.5,23.5
+      pos: -31.5,-46.5
+      parent: 2
+  - uid: 10794
+    components:
+    - type: Transform
+      pos: 40.5,-23.5
       parent: 2
   - uid: 10820
     components:
     - type: Transform
-      pos: -43.5,-42.5
+      pos: -0.5,5.5
       parent: 2
   - uid: 10822
     components:
     - type: Transform
-      pos: -49.5,-35.5
+      pos: -9.5,1.5
       parent: 2
   - uid: 10826
     components:
     - type: Transform
-      pos: 33.5,-47.5
+      pos: -45.5,23.5
       parent: 2
   - uid: 10830
     components:
     - type: Transform
-      pos: -3.5,-26.5
+      pos: -4.5,6.5
       parent: 2
   - uid: 10843
     components:
     - type: Transform
-      pos: -12.5,25.5
+      pos: 11.5,9.5
       parent: 2
   - uid: 10850
     components:
@@ -153722,7 +153394,7 @@ entities:
   - uid: 10858
     components:
     - type: Transform
-      pos: 43.5,4.5
+      pos: -55.5,-61.5
       parent: 2
   - uid: 10879
     components:
@@ -153732,7 +153404,7 @@ entities:
   - uid: 10880
     components:
     - type: Transform
-      pos: 36.5,-28.5
+      pos: -20.5,0.5
       parent: 2
   - uid: 10885
     components:
@@ -153747,57 +153419,67 @@ entities:
   - uid: 10914
     components:
     - type: Transform
-      pos: 45.5,15.5
+      pos: 22.5,-27.5
       parent: 2
   - uid: 10925
     components:
     - type: Transform
-      pos: 21.5,13.5
+      pos: -44.5,12.5
       parent: 2
   - uid: 10968
     components:
     - type: Transform
       pos: 4.5,-86.5
       parent: 2
+  - uid: 10970
+    components:
+    - type: Transform
+      pos: 28.5,-52.5
+      parent: 2
   - uid: 10971
     components:
     - type: Transform
-      pos: -8.5,5.5
+      pos: -14.5,-57.5
       parent: 2
   - uid: 10978
     components:
     - type: Transform
-      pos: -27.5,-56.5
+      pos: -1.5,-33.5
       parent: 2
   - uid: 11017
     components:
     - type: Transform
-      pos: 15.5,30.5
+      pos: 13.5,8.5
       parent: 2
   - uid: 11021
     components:
     - type: Transform
-      pos: 51.5,8.5
+      pos: -29.5,-65.5
       parent: 2
   - uid: 11022
     components:
     - type: Transform
-      pos: -62.5,-39.5
+      pos: -30.5,-4.5
       parent: 2
   - uid: 11023
     components:
     - type: Transform
-      pos: 43.5,22.5
+      pos: 43.5,-19.5
       parent: 2
   - uid: 11033
     components:
     - type: Transform
-      pos: 18.5,25.5
+      pos: -31.5,-39.5
+      parent: 2
+  - uid: 11035
+    components:
+    - type: Transform
+      pos: 17.5,17.5
       parent: 2
   - uid: 11038
     components:
     - type: Transform
-      pos: -13.5,-69.5
+      pos: -39.5,-39.5
       parent: 2
   - uid: 11039
     components:
@@ -153807,42 +153489,42 @@ entities:
   - uid: 11040
     components:
     - type: Transform
-      pos: 22.5,-5.5
+      pos: -17.5,-68.5
       parent: 2
   - uid: 11042
     components:
     - type: Transform
-      pos: 7.5,-20.5
+      pos: -0.5,-24.5
       parent: 2
   - uid: 11047
     components:
     - type: Transform
-      pos: -20.5,25.5
+      pos: -56.5,21.5
       parent: 2
   - uid: 11059
     components:
     - type: Transform
-      pos: -37.5,-59.5
+      pos: -47.5,23.5
       parent: 2
   - uid: 11074
     components:
     - type: Transform
-      pos: -61.5,-35.5
+      pos: -51.5,-45.5
       parent: 2
   - uid: 11076
     components:
     - type: Transform
-      pos: -10.5,-66.5
+      pos: -43.5,-42.5
       parent: 2
   - uid: 11082
     components:
     - type: Transform
-      pos: -28.5,-16.5
+      pos: -10.5,31.5
       parent: 2
   - uid: 11106
     components:
     - type: Transform
-      pos: -1.5,-24.5
+      pos: -11.5,6.5
       parent: 2
   - uid: 11109
     components:
@@ -153852,12 +153534,17 @@ entities:
   - uid: 11122
     components:
     - type: Transform
-      pos: -28.5,28.5
+      pos: 23.5,-29.5
+      parent: 2
+  - uid: 11161
+    components:
+    - type: Transform
+      pos: 25.5,-38.5
       parent: 2
   - uid: 11165
     components:
     - type: Transform
-      pos: 31.5,-23.5
+      pos: -8.5,20.5
       parent: 2
   - uid: 11187
     components:
@@ -153867,7 +153554,7 @@ entities:
   - uid: 11198
     components:
     - type: Transform
-      pos: 43.5,-17.5
+      pos: -20.5,3.5
       parent: 2
   - uid: 11199
     components:
@@ -153877,37 +153564,57 @@ entities:
   - uid: 11202
     components:
     - type: Transform
-      pos: 53.5,-14.5
+      pos: 22.5,-28.5
+      parent: 2
+  - uid: 11205
+    components:
+    - type: Transform
+      pos: 25.5,-34.5
       parent: 2
   - uid: 11209
     components:
     - type: Transform
       pos: 61.5,-70.5
       parent: 2
+  - uid: 11212
+    components:
+    - type: Transform
+      pos: -19.5,-45.5
+      parent: 2
+  - uid: 11216
+    components:
+    - type: Transform
+      pos: 18.5,25.5
+      parent: 2
+  - uid: 11224
+    components:
+    - type: Transform
+      pos: -48.5,-47.5
+      parent: 2
   - uid: 11239
     components:
     - type: Transform
-      pos: 44.5,0.5
+      pos: -55.5,-57.5
       parent: 2
   - uid: 11252
     components:
     - type: Transform
-      pos: -23.5,-57.5
+      pos: -3.5,16.5
       parent: 2
   - uid: 11253
     components:
     - type: Transform
-      pos: 40.5,-26.5
+      pos: -42.5,6.5
       parent: 2
   - uid: 11261
     components:
     - type: Transform
-      pos: -18.5,28.5
+      pos: -9.5,-71.5
       parent: 2
   - uid: 11266
     components:
     - type: Transform
-      pos: 20.5,16.5
+      pos: -9.5,13.5
       parent: 2
   - uid: 11286
     components:
@@ -153917,17 +153624,22 @@ entities:
   - uid: 11287
     components:
     - type: Transform
-      pos: 13.5,9.5
+      pos: -31.5,5.5
       parent: 2
   - uid: 11292
     components:
     - type: Transform
-      pos: -25.5,-37.5
+      pos: -28.5,-49.5
       parent: 2
   - uid: 11297
     components:
     - type: Transform
-      pos: -36.5,-74.5
+      pos: 51.5,13.5
+      parent: 2
+  - uid: 11323
+    components:
+    - type: Transform
+      pos: -46.5,-42.5
       parent: 2
   - uid: 11332
     components:
@@ -153937,42 +153649,47 @@ entities:
   - uid: 11347
     components:
     - type: Transform
-      pos: 18.5,11.5
+      pos: -31.5,18.5
       parent: 2
   - uid: 11389
     components:
     - type: Transform
-      pos: 16.5,-60.5
+      pos: 23.5,-5.5
       parent: 2
   - uid: 11396
     components:
     - type: Transform
-      pos: -46.5,-40.5
+      pos: -44.5,-47.5
       parent: 2
   - uid: 11399
     components:
     - type: Transform
-      pos: 4.5,27.5
+      pos: -41.5,26.5
       parent: 2
   - uid: 11402
     components:
     - type: Transform
-      pos: -20.5,-57.5
+      pos: -25.5,-34.5
+      parent: 2
+  - uid: 11435
+    components:
+    - type: Transform
+      pos: 13.5,4.5
       parent: 2
   - uid: 11439
     components:
     - type: Transform
-      pos: 48.5,1.5
+      pos: -30.5,-16.5
       parent: 2
   - uid: 11455
     components:
     - type: Transform
-      pos: -28.5,-51.5
+      pos: -34.5,18.5
       parent: 2
   - uid: 11498
     components:
     - type: Transform
-      pos: -10.5,-25.5
+      pos: 22.5,-6.5
       parent: 2
   - uid: 11503
     components:
@@ -153982,22 +153699,27 @@ entities:
   - uid: 11523
     components:
     - type: Transform
-      pos: 8.5,-61.5
+      pos: -47.5,-5.5
       parent: 2
   - uid: 11554
     components:
     - type: Transform
-      pos: 13.5,-6.5
+      pos: -7.5,20.5
       parent: 2
   - uid: 11572
     components:
     - type: Transform
-      pos: -46.5,-19.5
+      pos: -56.5,-32.5
       parent: 2
   - uid: 11575
     components:
     - type: Transform
-      pos: 48.5,-3.5
+      pos: -45.5,17.5
+      parent: 2
+  - uid: 11578
+    components:
+    - type: Transform
+      pos: -42.5,3.5
       parent: 2
   - uid: 11594
     components:
@@ -154007,7 +153729,7 @@ entities:
   - uid: 11595
     components:
     - type: Transform
-      pos: -47.5,-58.5
+      pos: -46.5,0.5
       parent: 2
   - uid: 11609
     components:
@@ -154022,7 +153744,7 @@ entities:
   - uid: 11636
     components:
     - type: Transform
-      pos: -14.5,-10.5
+      pos: 42.5,5.5
       parent: 2
   - uid: 11637
     components:
@@ -154032,22 +153754,27 @@ entities:
   - uid: 11655
     components:
     - type: Transform
-      pos: 40.5,-30.5
+      pos: -52.5,-35.5
       parent: 2
   - uid: 11656
     components:
     - type: Transform
-      pos: 11.5,-13.5
+      pos: -2.5,-33.5
+      parent: 2
+  - uid: 11722
+    components:
+    - type: Transform
+      pos: 19.5,-32.5
       parent: 2
   - uid: 11766
     components:
     - type: Transform
-      pos: 18.5,-27.5
+      pos: -44.5,16.5
       parent: 2
   - uid: 11787
     components:
     - type: Transform
-      pos: 44.5,4.5
+      pos: 7.5,-20.5
       parent: 2
   - uid: 11795
     components:
@@ -154057,17 +153784,17 @@ entities:
   - uid: 11803
     components:
     - type: Transform
-      pos: -46.5,-41.5
+      pos: -28.5,32.5
       parent: 2
   - uid: 11824
     components:
     - type: Transform
-      pos: 5.5,7.5
+      pos: 14.5,13.5
       parent: 2
   - uid: 11825
     components:
     - type: Transform
-      pos: -49.5,-39.5
+      pos: 42.5,-34.5
       parent: 2
   - uid: 11841
     components:
@@ -154077,12 +153804,12 @@ entities:
   - uid: 11844
     components:
     - type: Transform
-      pos: 13.5,4.5
+      pos: -31.5,-59.5
       parent: 2
   - uid: 11859
     components:
     - type: Transform
-      pos: 18.5,-19.5
+      pos: 40.5,-18.5
       parent: 2
   - uid: 11875
     components:
@@ -154092,27 +153819,27 @@ entities:
   - uid: 11881
     components:
     - type: Transform
-      pos: 5.5,5.5
+      pos: 44.5,-14.5
       parent: 2
   - uid: 11882
     components:
     - type: Transform
-      pos: -6.5,9.5
+      pos: -18.5,27.5
       parent: 2
   - uid: 11883
     components:
     - type: Transform
-      pos: 22.5,-28.5
+      pos: -43.5,-58.5
       parent: 2
   - uid: 11886
     components:
     - type: Transform
-      pos: -10.5,-47.5
+      pos: 5.5,-13.5
       parent: 2
   - uid: 11892
     components:
     - type: Transform
-      pos: 44.5,22.5
+      pos: -20.5,8.5
       parent: 2
   - uid: 11894
     components:
@@ -154122,32 +153849,32 @@ entities:
   - uid: 11903
     components:
     - type: Transform
-      pos: -30.5,-33.5
+      pos: -30.5,16.5
       parent: 2
   - uid: 11905
     components:
     - type: Transform
-      pos: -54.5,-60.5
+      pos: -26.5,-0.5
       parent: 2
   - uid: 11927
     components:
     - type: Transform
-      pos: 4.5,-13.5
+      pos: -13.5,3.5
       parent: 2
   - uid: 11931
     components:
     - type: Transform
-      pos: 3.5,-54.5
+      pos: 18.5,-18.5
       parent: 2
   - uid: 11936
     components:
     - type: Transform
-      pos: -64.5,-59.5
+      pos: -12.5,23.5
       parent: 2
   - uid: 11938
     components:
     - type: Transform
-      pos: -13.5,2.5
+      pos: 47.5,0.5
       parent: 2
   - uid: 11939
     components:
@@ -154157,32 +153884,42 @@ entities:
   - uid: 11966
     components:
     - type: Transform
-      pos: 26.5,20.5
+      pos: 39.5,-32.5
+      parent: 2
+  - uid: 11974
+    components:
+    - type: Transform
+      pos: -50.5,-16.5
+      parent: 2
+  - uid: 11976
+    components:
+    - type: Transform
+      pos: -10.5,30.5
       parent: 2
   - uid: 11985
     components:
     - type: Transform
-      pos: 41.5,22.5
+      pos: -57.5,-39.5
       parent: 2
   - uid: 11987
     components:
     - type: Transform
-      pos: -54.5,-56.5
+      pos: 40.5,-25.5
       parent: 2
   - uid: 11991
     components:
     - type: Transform
-      pos: 14.5,4.5
+      pos: -57.5,-16.5
       parent: 2
   - uid: 11997
     components:
     - type: Transform
-      pos: 12.5,-7.5
+      pos: 19.5,11.5
       parent: 2
   - uid: 12005
     components:
     - type: Transform
-      pos: 28.5,30.5
+      pos: 28.5,-9.5
       parent: 2
   - uid: 12026
     components:
@@ -154192,7 +153929,7 @@ entities:
   - uid: 12029
     components:
     - type: Transform
-      pos: -37.5,-31.5
+      pos: 48.5,3.5
       parent: 2
   - uid: 12032
     components:
@@ -154207,7 +153944,7 @@ entities:
   - uid: 12049
     components:
     - type: Transform
-      pos: -26.5,24.5
+      pos: -24.5,-9.5
       parent: 2
   - uid: 12063
     components:
@@ -154217,12 +153954,12 @@ entities:
   - uid: 12074
     components:
     - type: Transform
-      pos: 27.5,19.5
+      pos: 2.5,-20.5
       parent: 2
   - uid: 12075
     components:
     - type: Transform
-      pos: 24.5,18.5
+      pos: 24.5,-32.5
       parent: 2
   - uid: 12116
     components:
@@ -154232,22 +153969,522 @@ entities:
   - uid: 12118
     components:
     - type: Transform
-      pos: -14.5,-9.5
+      pos: -28.5,34.5
       parent: 2
   - uid: 12127
     components:
     - type: Transform
       pos: 32.5,-67.5
       parent: 2
-  - uid: 16040
+  - uid: 12133
     components:
     - type: Transform
-      pos: -58.5,-24.5
+      pos: -33.5,-11.5
+      parent: 2
+  - uid: 16964
+    components:
+    - type: Transform
+      pos: -62.5,-57.5
+      parent: 2
+  - uid: 16995
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 2
+  - uid: 16999
+    components:
+    - type: Transform
+      pos: -43.5,-47.5
+      parent: 2
+  - uid: 17011
+    components:
+    - type: Transform
+      pos: 11.5,-8.5
+      parent: 2
+  - uid: 17062
+    components:
+    - type: Transform
+      pos: -39.5,-13.5
+      parent: 2
+  - uid: 17120
+    components:
+    - type: Transform
+      pos: -3.5,-24.5
+      parent: 2
+  - uid: 17144
+    components:
+    - type: Transform
+      pos: -59.5,-16.5
+      parent: 2
+  - uid: 17188
+    components:
+    - type: Transform
+      pos: 26.5,20.5
+      parent: 2
+  - uid: 17527
+    components:
+    - type: Transform
+      pos: 49.5,18.5
+      parent: 2
+  - uid: 17728
+    components:
+    - type: Transform
+      pos: -0.5,-38.5
+      parent: 2
+  - uid: 17752
+    components:
+    - type: Transform
+      pos: -54.5,-24.5
+      parent: 2
+  - uid: 17848
+    components:
+    - type: Transform
+      pos: 43.5,0.5
+      parent: 2
+  - uid: 18179
+    components:
+    - type: Transform
+      pos: -26.5,24.5
+      parent: 2
+  - uid: 18211
+    components:
+    - type: Transform
+      pos: 16.5,-60.5
+      parent: 2
+  - uid: 18234
+    components:
+    - type: Transform
+      pos: 13.5,5.5
+      parent: 2
+  - uid: 18258
+    components:
+    - type: Transform
+      pos: -37.5,32.5
+      parent: 2
+  - uid: 18262
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 2
+  - uid: 18270
+    components:
+    - type: Transform
+      pos: -37.5,-28.5
+      parent: 2
+  - uid: 18382
+    components:
+    - type: Transform
+      pos: -43.5,28.5
+      parent: 2
+  - uid: 18388
+    components:
+    - type: Transform
+      pos: -13.5,-52.5
+      parent: 2
+  - uid: 18399
+    components:
+    - type: Transform
+      pos: 4.5,-24.5
+      parent: 2
+  - uid: 18426
+    components:
+    - type: Transform
+      pos: -4.5,-33.5
+      parent: 2
+  - uid: 18439
+    components:
+    - type: Transform
+      pos: 41.5,-16.5
+      parent: 2
+  - uid: 18516
+    components:
+    - type: Transform
+      pos: -10.5,27.5
+      parent: 2
+  - uid: 18605
+    components:
+    - type: Transform
+      pos: -48.5,6.5
+      parent: 2
+  - uid: 18724
+    components:
+    - type: Transform
+      pos: -42.5,12.5
+      parent: 2
+  - uid: 18847
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 2
+  - uid: 18848
+    components:
+    - type: Transform
+      pos: -23.5,-0.5
+      parent: 2
+  - uid: 18863
+    components:
+    - type: Transform
+      pos: -32.5,18.5
+      parent: 2
+  - uid: 18967
+    components:
+    - type: Transform
+      pos: -55.5,16.5
+      parent: 2
+  - uid: 19156
+    components:
+    - type: Transform
+      pos: -11.5,9.5
+      parent: 2
+  - uid: 19222
+    components:
+    - type: Transform
+      pos: -52.5,-20.5
+      parent: 2
+  - uid: 19229
+    components:
+    - type: Transform
+      pos: 13.5,-3.5
+      parent: 2
+  - uid: 19240
+    components:
+    - type: Transform
+      pos: -38.5,-31.5
+      parent: 2
+  - uid: 19245
+    components:
+    - type: Transform
+      pos: -12.5,24.5
+      parent: 2
+  - uid: 19254
+    components:
+    - type: Transform
+      pos: -20.5,1.5
+      parent: 2
+  - uid: 19261
+    components:
+    - type: Transform
+      pos: -55.5,7.5
+      parent: 2
+  - uid: 19265
+    components:
+    - type: Transform
+      pos: -54.5,2.5
+      parent: 2
+  - uid: 19348
+    components:
+    - type: Transform
+      pos: -16.5,24.5
+      parent: 2
+  - uid: 19559
+    components:
+    - type: Transform
+      pos: 31.5,-32.5
+      parent: 2
+  - uid: 19626
+    components:
+    - type: Transform
+      pos: 18.5,16.5
+      parent: 2
+  - uid: 19844
+    components:
+    - type: Transform
+      pos: -31.5,-7.5
+      parent: 2
+  - uid: 19894
+    components:
+    - type: Transform
+      pos: -32.5,-33.5
+      parent: 2
+  - uid: 19895
+    components:
+    - type: Transform
+      pos: -61.5,-35.5
+      parent: 2
+  - uid: 19916
+    components:
+    - type: Transform
+      pos: -32.5,2.5
+      parent: 2
+  - uid: 20006
+    components:
+    - type: Transform
+      pos: -50.5,-60.5
+      parent: 2
+  - uid: 20122
+    components:
+    - type: Transform
+      pos: -27.5,-49.5
+      parent: 2
+  - uid: 20153
+    components:
+    - type: Transform
+      pos: -8.5,-27.5
+      parent: 2
+  - uid: 20166
+    components:
+    - type: Transform
+      pos: -38.5,-5.5
+      parent: 2
+  - uid: 20172
+    components:
+    - type: Transform
+      pos: -46.5,-7.5
+      parent: 2
+  - uid: 20175
+    components:
+    - type: Transform
+      pos: -5.5,-32.5
+      parent: 2
+  - uid: 20178
+    components:
+    - type: Transform
+      pos: -52.5,-28.5
+      parent: 2
+  - uid: 20193
+    components:
+    - type: Transform
+      pos: -19.5,-5.5
+      parent: 2
+  - uid: 20195
+    components:
+    - type: Transform
+      pos: -0.5,-54.5
+      parent: 2
+  - uid: 20221
+    components:
+    - type: Transform
+      pos: 2.5,-38.5
+      parent: 2
+  - uid: 20255
+    components:
+    - type: Transform
+      pos: -33.5,7.5
+      parent: 2
+  - uid: 20320
+    components:
+    - type: Transform
+      pos: -35.5,-21.5
       parent: 2
   - uid: 20321
     components:
     - type: Transform
       pos: 56.5,-50.5
+      parent: 2
+  - uid: 20392
+    components:
+    - type: Transform
+      pos: -27.5,-62.5
+      parent: 2
+  - uid: 20601
+    components:
+    - type: Transform
+      pos: -5.5,-69.5
+      parent: 2
+  - uid: 20605
+    components:
+    - type: Transform
+      pos: 44.5,26.5
+      parent: 2
+  - uid: 20606
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 2
+  - uid: 20634
+    components:
+    - type: Transform
+      pos: 25.5,-45.5
+      parent: 2
+  - uid: 20670
+    components:
+    - type: Transform
+      pos: -54.5,-10.5
+      parent: 2
+  - uid: 20706
+    components:
+    - type: Transform
+      pos: -31.5,-58.5
+      parent: 2
+  - uid: 20709
+    components:
+    - type: Transform
+      pos: -27.5,-61.5
+      parent: 2
+  - uid: 20722
+    components:
+    - type: Transform
+      pos: -35.5,-5.5
+      parent: 2
+  - uid: 21223
+    components:
+    - type: Transform
+      pos: -30.5,0.5
+      parent: 2
+  - uid: 21312
+    components:
+    - type: Transform
+      pos: 48.5,-2.5
+      parent: 2
+  - uid: 21363
+    components:
+    - type: Transform
+      pos: 22.5,15.5
+      parent: 2
+  - uid: 21395
+    components:
+    - type: Transform
+      pos: -24.5,23.5
+      parent: 2
+  - uid: 21426
+    components:
+    - type: Transform
+      pos: -20.5,-5.5
+      parent: 2
+  - uid: 21438
+    components:
+    - type: Transform
+      pos: -53.5,-2.5
+      parent: 2
+  - uid: 21458
+    components:
+    - type: Transform
+      pos: 42.5,18.5
+      parent: 2
+  - uid: 21760
+    components:
+    - type: Transform
+      pos: -14.5,24.5
+      parent: 2
+  - uid: 21803
+    components:
+    - type: Transform
+      pos: -44.5,14.5
+      parent: 2
+  - uid: 21807
+    components:
+    - type: Transform
+      pos: 44.5,6.5
+      parent: 2
+  - uid: 21860
+    components:
+    - type: Transform
+      pos: 22.5,-9.5
+      parent: 2
+  - uid: 21870
+    components:
+    - type: Transform
+      pos: -26.5,8.5
+      parent: 2
+  - uid: 21879
+    components:
+    - type: Transform
+      pos: -11.5,26.5
+      parent: 2
+  - uid: 21886
+    components:
+    - type: Transform
+      pos: -51.5,-42.5
+      parent: 2
+  - uid: 21891
+    components:
+    - type: Transform
+      pos: -24.5,24.5
+      parent: 2
+  - uid: 22005
+    components:
+    - type: Transform
+      pos: -26.5,-9.5
+      parent: 2
+  - uid: 22010
+    components:
+    - type: Transform
+      pos: -9.5,16.5
+      parent: 2
+  - uid: 22016
+    components:
+    - type: Transform
+      pos: -56.5,-26.5
+      parent: 2
+  - uid: 22017
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 2
+  - uid: 22027
+    components:
+    - type: Transform
+      pos: -14.5,-9.5
+      parent: 2
+  - uid: 22101
+    components:
+    - type: Transform
+      pos: 25.5,-5.5
+      parent: 2
+  - uid: 22102
+    components:
+    - type: Transform
+      pos: 17.5,-29.5
+      parent: 2
+  - uid: 22108
+    components:
+    - type: Transform
+      pos: -58.5,-61.5
+      parent: 2
+  - uid: 23324
+    components:
+    - type: Transform
+      pos: 15.5,-16.5
+      parent: 2
+  - uid: 23336
+    components:
+    - type: Transform
+      pos: 9.5,-5.5
+      parent: 2
+  - uid: 23340
+    components:
+    - type: Transform
+      pos: -31.5,-67.5
+      parent: 2
+  - uid: 23619
+    components:
+    - type: Transform
+      pos: -59.5,-60.5
+      parent: 2
+  - uid: 23626
+    components:
+    - type: Transform
+      pos: 25.5,-41.5
+      parent: 2
+  - uid: 23630
+    components:
+    - type: Transform
+      pos: -31.5,-10.5
+      parent: 2
+  - uid: 23633
+    components:
+    - type: Transform
+      pos: -31.5,-63.5
+      parent: 2
+  - uid: 23640
+    components:
+    - type: Transform
+      pos: -23.5,0.5
+      parent: 2
+  - uid: 23641
+    components:
+    - type: Transform
+      pos: 17.5,-23.5
+      parent: 2
+  - uid: 23642
+    components:
+    - type: Transform
+      pos: -32.5,-26.5
+      parent: 2
+  - uid: 23644
+    components:
+    - type: Transform
+      pos: 22.5,-5.5
       parent: 2
   - uid: 23647
     components:
@@ -154272,12 +154509,12 @@ entities:
   - uid: 23652
     components:
     - type: Transform
-      pos: -11.5,-45.5
+      pos: -24.5,18.5
       parent: 2
   - uid: 23654
     components:
     - type: Transform
-      pos: 7.5,13.5
+      pos: -25.5,-33.5
       parent: 2
   - uid: 23655
     components:
@@ -154287,7 +154524,7 @@ entities:
   - uid: 23658
     components:
     - type: Transform
-      pos: -9.5,-57.5
+      pos: 25.5,-46.5
       parent: 2
   - uid: 23660
     components:
@@ -154297,7 +154534,7 @@ entities:
   - uid: 23662
     components:
     - type: Transform
-      pos: 9.5,-13.5
+      pos: -47.5,16.5
       parent: 2
   - uid: 23663
     components:
@@ -154307,7 +154544,92 @@ entities:
   - uid: 23664
     components:
     - type: Transform
-      pos: -50.5,-35.5
+      pos: -11.5,1.5
+      parent: 2
+  - uid: 23857
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 2
+  - uid: 23858
+    components:
+    - type: Transform
+      pos: -56.5,-22.5
+      parent: 2
+  - uid: 23859
+    components:
+    - type: Transform
+      pos: -35.5,7.5
+      parent: 2
+  - uid: 24232
+    components:
+    - type: Transform
+      pos: -18.5,26.5
+      parent: 2
+  - uid: 24796
+    components:
+    - type: Transform
+      pos: -38.5,6.5
+      parent: 2
+  - uid: 24797
+    components:
+    - type: Transform
+      pos: -26.5,-11.5
+      parent: 2
+  - uid: 24798
+    components:
+    - type: Transform
+      pos: -38.5,-28.5
+      parent: 2
+  - uid: 24799
+    components:
+    - type: Transform
+      pos: 9.5,14.5
+      parent: 2
+  - uid: 24800
+    components:
+    - type: Transform
+      pos: -30.5,-20.5
+      parent: 2
+  - uid: 24801
+    components:
+    - type: Transform
+      pos: -28.5,-52.5
+      parent: 2
+  - uid: 24802
+    components:
+    - type: Transform
+      pos: 16.5,-61.5
+      parent: 2
+  - uid: 24803
+    components:
+    - type: Transform
+      pos: 22.5,-7.5
+      parent: 2
+  - uid: 24804
+    components:
+    - type: Transform
+      pos: -43.5,-9.5
+      parent: 2
+  - uid: 24805
+    components:
+    - type: Transform
+      pos: 40.5,-26.5
+      parent: 2
+  - uid: 24806
+    components:
+    - type: Transform
+      pos: -35.5,-59.5
+      parent: 2
+  - uid: 24807
+    components:
+    - type: Transform
+      pos: -27.5,-11.5
+      parent: 2
+  - uid: 24808
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
       parent: 2
 - proto: WallSolid
   entities:
@@ -154315,16 +154637,6 @@ entities:
     components:
     - type: Transform
       pos: -15.5,21.5
-      parent: 2
-  - uid: 152
-    components:
-    - type: Transform
-      pos: 15.5,-50.5
-      parent: 2
-  - uid: 177
-    components:
-    - type: Transform
-      pos: 0.5,-16.5
       parent: 2
   - uid: 208
     components:
@@ -154335,11 +154647,6 @@ entities:
     components:
     - type: Transform
       pos: -37.5,-34.5
-      parent: 2
-  - uid: 305
-    components:
-    - type: Transform
-      pos: -9.5,-16.5
       parent: 2
   - uid: 319
     components:
@@ -154371,40 +154678,10 @@ entities:
     - type: Transform
       pos: -27.5,23.5
       parent: 2
-  - uid: 416
-    components:
-    - type: Transform
-      pos: -27.5,22.5
-      parent: 2
-  - uid: 422
-    components:
-    - type: Transform
-      pos: -27.5,21.5
-      parent: 2
-  - uid: 433
-    components:
-    - type: Transform
-      pos: -10.5,-4.5
-      parent: 2
   - uid: 542
     components:
     - type: Transform
       pos: 67.5,-58.5
-      parent: 2
-  - uid: 548
-    components:
-    - type: Transform
-      pos: 23.5,-1.5
-      parent: 2
-  - uid: 590
-    components:
-    - type: Transform
-      pos: 8.5,-37.5
-      parent: 2
-  - uid: 611
-    components:
-    - type: Transform
-      pos: -21.5,21.5
       parent: 2
   - uid: 620
     components:
@@ -154436,30 +154713,15 @@ entities:
     - type: Transform
       pos: -30.5,-14.5
       parent: 2
-  - uid: 697
-    components:
-    - type: Transform
-      pos: -30.5,-13.5
-      parent: 2
   - uid: 766
     components:
     - type: Transform
       pos: -32.5,-34.5
       parent: 2
-  - uid: 834
-    components:
-    - type: Transform
-      pos: -39.5,16.5
-      parent: 2
   - uid: 835
     components:
     - type: Transform
       pos: -41.5,-56.5
-      parent: 2
-  - uid: 870
-    components:
-    - type: Transform
-      pos: -13.5,-25.5
       parent: 2
   - uid: 919
     components:
@@ -154501,11 +154763,6 @@ entities:
     - type: Transform
       pos: 71.5,-59.5
       parent: 2
-  - uid: 1110
-    components:
-    - type: Transform
-      pos: -39.5,-25.5
-      parent: 2
   - uid: 1112
     components:
     - type: Transform
@@ -154526,11 +154783,6 @@ entities:
     - type: Transform
       pos: 33.5,-17.5
       parent: 2
-  - uid: 1150
-    components:
-    - type: Transform
-      pos: 17.5,4.5
-      parent: 2
   - uid: 1155
     components:
     - type: Transform
@@ -154541,11 +154793,6 @@ entities:
     - type: Transform
       pos: -10.5,-16.5
       parent: 2
-  - uid: 1159
-    components:
-    - type: Transform
-      pos: -17.5,17.5
-      parent: 2
   - uid: 1165
     components:
     - type: Transform
@@ -154555,11 +154802,6 @@ entities:
     components:
     - type: Transform
       pos: 85.5,-20.5
-      parent: 2
-  - uid: 1302
-    components:
-    - type: Transform
-      pos: 30.5,19.5
       parent: 2
   - uid: 1376
     components:
@@ -154576,11 +154818,6 @@ entities:
     - type: Transform
       pos: -12.5,18.5
       parent: 2
-  - uid: 1412
-    components:
-    - type: Transform
-      pos: -6.5,-12.5
-      parent: 2
   - uid: 1439
     components:
     - type: Transform
@@ -154590,11 +154827,6 @@ entities:
     components:
     - type: Transform
       pos: 21.5,-45.5
-      parent: 2
-  - uid: 1481
-    components:
-    - type: Transform
-      pos: -6.5,-45.5
       parent: 2
   - uid: 1489
     components:
@@ -154610,11 +154842,6 @@ entities:
     components:
     - type: Transform
       pos: -15.5,-26.5
-      parent: 2
-  - uid: 1517
-    components:
-    - type: Transform
-      pos: -34.5,-16.5
       parent: 2
   - uid: 1574
     components:
@@ -154656,11 +154883,6 @@ entities:
     - type: Transform
       pos: -12.5,-5.5
       parent: 2
-  - uid: 1711
-    components:
-    - type: Transform
-      pos: 34.5,-6.5
-      parent: 2
   - uid: 1714
     components:
     - type: Transform
@@ -154686,20 +154908,10 @@ entities:
     - type: Transform
       pos: 27.5,-40.5
       parent: 2
-  - uid: 1893
-    components:
-    - type: Transform
-      pos: 3.5,-15.5
-      parent: 2
   - uid: 2063
     components:
     - type: Transform
       pos: 15.5,-4.5
-      parent: 2
-  - uid: 2068
-    components:
-    - type: Transform
-      pos: -41.5,-25.5
       parent: 2
   - uid: 2072
     components:
@@ -154710,16 +154922,6 @@ entities:
     components:
     - type: Transform
       pos: 45.5,-31.5
-      parent: 2
-  - uid: 2075
-    components:
-    - type: Transform
-      pos: 46.5,-31.5
-      parent: 2
-  - uid: 2094
-    components:
-    - type: Transform
-      pos: 36.5,-33.5
       parent: 2
   - uid: 2143
     components:
@@ -154740,11 +154942,6 @@ entities:
     components:
     - type: Transform
       pos: 38.5,4.5
-      parent: 2
-  - uid: 2277
-    components:
-    - type: Transform
-      pos: -36.5,-34.5
       parent: 2
   - uid: 2284
     components:
@@ -154801,20 +154998,10 @@ entities:
     - type: Transform
       pos: -18.5,0.5
       parent: 2
-  - uid: 2364
-    components:
-    - type: Transform
-      pos: -33.5,21.5
-      parent: 2
   - uid: 2366
     components:
     - type: Transform
       pos: -28.5,18.5
-      parent: 2
-  - uid: 2368
-    components:
-    - type: Transform
-      pos: -17.5,12.5
       parent: 2
   - uid: 2369
     components:
@@ -154831,11 +155018,6 @@ entities:
     - type: Transform
       pos: -37.5,-16.5
       parent: 2
-  - uid: 2378
-    components:
-    - type: Transform
-      pos: -39.5,-17.5
-      parent: 2
   - uid: 2379
     components:
     - type: Transform
@@ -154845,11 +155027,6 @@ entities:
     components:
     - type: Transform
       pos: -18.5,-12.5
-      parent: 2
-  - uid: 2394
-    components:
-    - type: Transform
-      pos: -34.5,21.5
       parent: 2
   - uid: 2413
     components:
@@ -154861,35 +155038,15 @@ entities:
     - type: Transform
       pos: -20.5,21.5
       parent: 2
-  - uid: 2438
-    components:
-    - type: Transform
-      pos: 40.5,-5.5
-      parent: 2
-  - uid: 2448
-    components:
-    - type: Transform
-      pos: -34.5,20.5
-      parent: 2
   - uid: 2449
     components:
     - type: Transform
       pos: -30.5,21.5
       parent: 2
-  - uid: 2454
-    components:
-    - type: Transform
-      pos: 46.5,-26.5
-      parent: 2
   - uid: 2467
     components:
     - type: Transform
       pos: -28.5,19.5
-      parent: 2
-  - uid: 2521
-    components:
-    - type: Transform
-      pos: -30.5,19.5
       parent: 2
   - uid: 2551
     components:
@@ -154901,11 +155058,6 @@ entities:
     - type: Transform
       pos: -7.5,-29.5
       parent: 2
-  - uid: 2607
-    components:
-    - type: Transform
-      pos: -6.5,-29.5
-      parent: 2
   - uid: 2624
     components:
     - type: Transform
@@ -154915,16 +155067,6 @@ entities:
     components:
     - type: Transform
       pos: -18.5,-13.5
-      parent: 2
-  - uid: 2634
-    components:
-    - type: Transform
-      pos: -31.5,21.5
-      parent: 2
-  - uid: 2682
-    components:
-    - type: Transform
-      pos: 23.5,-45.5
       parent: 2
   - uid: 2687
     components:
@@ -154976,25 +155118,10 @@ entities:
     - type: Transform
       pos: -12.5,-16.5
       parent: 2
-  - uid: 2943
-    components:
-    - type: Transform
-      pos: 13.5,-46.5
-      parent: 2
   - uid: 2983
     components:
     - type: Transform
       pos: -17.5,-49.5
-      parent: 2
-  - uid: 3030
-    components:
-    - type: Transform
-      pos: 1.5,-16.5
-      parent: 2
-  - uid: 3067
-    components:
-    - type: Transform
-      pos: 30.5,-46.5
       parent: 2
   - uid: 3072
     components:
@@ -155011,11 +155138,6 @@ entities:
     - type: Transform
       pos: 23.5,-43.5
       parent: 2
-  - uid: 3081
-    components:
-    - type: Transform
-      pos: -21.5,-21.5
-      parent: 2
   - uid: 3087
     components:
     - type: Transform
@@ -155030,11 +155152,6 @@ entities:
     components:
     - type: Transform
       pos: -16.5,-29.5
-      parent: 2
-  - uid: 3127
-    components:
-    - type: Transform
-      pos: 33.5,-18.5
       parent: 2
   - uid: 3137
     components:
@@ -155070,11 +155187,6 @@ entities:
     components:
     - type: Transform
       pos: -13.5,-28.5
-      parent: 2
-  - uid: 3220
-    components:
-    - type: Transform
-      pos: 2.5,-28.5
       parent: 2
   - uid: 3231
     components:
@@ -155121,11 +155233,6 @@ entities:
     - type: Transform
       pos: 49.5,-27.5
       parent: 2
-  - uid: 3305
-    components:
-    - type: Transform
-      pos: -13.5,-36.5
-      parent: 2
   - uid: 3308
     components:
     - type: Transform
@@ -155166,11 +155273,6 @@ entities:
     - type: Transform
       pos: -15.5,-21.5
       parent: 2
-  - uid: 3355
-    components:
-    - type: Transform
-      pos: 22.5,-17.5
-      parent: 2
   - uid: 3379
     components:
     - type: Transform
@@ -155186,11 +155288,6 @@ entities:
     - type: Transform
       pos: 14.5,-7.5
       parent: 2
-  - uid: 3410
-    components:
-    - type: Transform
-      pos: -21.5,-29.5
-      parent: 2
   - uid: 3411
     components:
     - type: Transform
@@ -155200,21 +155297,6 @@ entities:
     components:
     - type: Transform
       pos: 14.5,-9.5
-      parent: 2
-  - uid: 3429
-    components:
-    - type: Transform
-      pos: -17.5,-26.5
-      parent: 2
-  - uid: 3442
-    components:
-    - type: Transform
-      pos: -13.5,-39.5
-      parent: 2
-  - uid: 3448
-    components:
-    - type: Transform
-      pos: -0.5,-42.5
       parent: 2
   - uid: 3453
     components:
@@ -155241,11 +155323,6 @@ entities:
     - type: Transform
       pos: -3.5,-36.5
       parent: 2
-  - uid: 3480
-    components:
-    - type: Transform
-      pos: -1.5,-36.5
-      parent: 2
   - uid: 3481
     components:
     - type: Transform
@@ -155260,11 +155337,6 @@ entities:
     components:
     - type: Transform
       pos: 6.5,-26.5
-      parent: 2
-  - uid: 3509
-    components:
-    - type: Transform
-      pos: 13.5,-37.5
       parent: 2
   - uid: 3518
     components:
@@ -155301,16 +155373,6 @@ entities:
     - type: Transform
       pos: 20.5,-34.5
       parent: 2
-  - uid: 3773
-    components:
-    - type: Transform
-      pos: 13.5,-34.5
-      parent: 2
-  - uid: 3812
-    components:
-    - type: Transform
-      pos: 0.5,-45.5
-      parent: 2
   - uid: 3813
     components:
     - type: Transform
@@ -155325,16 +155387,6 @@ entities:
     components:
     - type: Transform
       pos: -9.5,-29.5
-      parent: 2
-  - uid: 3834
-    components:
-    - type: Transform
-      pos: 12.5,-45.5
-      parent: 2
-  - uid: 3840
-    components:
-    - type: Transform
-      pos: 12.5,-46.5
       parent: 2
   - uid: 3841
     components:
@@ -155351,11 +155403,6 @@ entities:
     - type: Transform
       pos: 23.5,-35.5
       parent: 2
-  - uid: 3853
-    components:
-    - type: Transform
-      pos: 23.5,-34.5
-      parent: 2
   - uid: 3854
     components:
     - type: Transform
@@ -155371,11 +155418,6 @@ entities:
     - type: Transform
       pos: -53.5,-56.5
       parent: 2
-  - uid: 3983
-    components:
-    - type: Transform
-      pos: -50.5,-53.5
-      parent: 2
   - uid: 4004
     components:
     - type: Transform
@@ -155390,11 +155432,6 @@ entities:
     components:
     - type: Transform
       pos: -0.5,-30.5
-      parent: 2
-  - uid: 4044
-    components:
-    - type: Transform
-      pos: 25.5,-1.5
       parent: 2
   - uid: 4055
     components:
@@ -155415,11 +155452,6 @@ entities:
     components:
     - type: Transform
       pos: 46.5,-59.5
-      parent: 2
-  - uid: 4173
-    components:
-    - type: Transform
-      pos: 35.5,-39.5
       parent: 2
   - uid: 4179
     components:
@@ -155456,11 +155488,6 @@ entities:
     - type: Transform
       pos: 28.5,-40.5
       parent: 2
-  - uid: 4340
-    components:
-    - type: Transform
-      pos: 30.5,-40.5
-      parent: 2
   - uid: 4441
     components:
     - type: Transform
@@ -155480,21 +155507,6 @@ entities:
     components:
     - type: Transform
       pos: 28.5,9.5
-      parent: 2
-  - uid: 4481
-    components:
-    - type: Transform
-      pos: 30.5,-44.5
-      parent: 2
-  - uid: 4520
-    components:
-    - type: Transform
-      pos: 0.5,-42.5
-      parent: 2
-  - uid: 4524
-    components:
-    - type: Transform
-      pos: 33.5,-14.5
       parent: 2
   - uid: 4558
     components:
@@ -155516,30 +155528,15 @@ entities:
     - type: Transform
       pos: 68.5,-66.5
       parent: 2
-  - uid: 4789
-    components:
-    - type: Transform
-      pos: 18.5,-0.5
-      parent: 2
-  - uid: 4828
-    components:
-    - type: Transform
-      pos: -36.5,-25.5
-      parent: 2
   - uid: 4862
     components:
     - type: Transform
       pos: 71.5,-68.5
       parent: 2
-  - uid: 4871
+  - uid: 4884
     components:
     - type: Transform
-      pos: 8.5,-32.5
-      parent: 2
-  - uid: 4883
-    components:
-    - type: Transform
-      pos: 18.5,-5.5
+      pos: 37.5,-39.5
       parent: 2
   - uid: 4885
     components:
@@ -155566,10 +155563,20 @@ entities:
     - type: Transform
       pos: -35.5,-55.5
       parent: 2
+  - uid: 5029
+    components:
+    - type: Transform
+      pos: 30.5,-39.5
+      parent: 2
   - uid: 5101
     components:
     - type: Transform
       pos: 35.5,10.5
+      parent: 2
+  - uid: 5102
+    components:
+    - type: Transform
+      pos: 18.5,-51.5
       parent: 2
   - uid: 5155
     components:
@@ -155584,12 +155591,17 @@ entities:
   - uid: 5165
     components:
     - type: Transform
-      pos: 23.5,-44.5
+      pos: 22.5,-48.5
       parent: 2
   - uid: 5175
     components:
     - type: Transform
       pos: 42.5,-6.5
+      parent: 2
+  - uid: 5176
+    components:
+    - type: Transform
+      pos: 20.5,-12.5
       parent: 2
   - uid: 5181
     components:
@@ -155631,45 +155643,70 @@ entities:
     - type: Transform
       pos: -10.5,-15.5
       parent: 2
+  - uid: 5290
+    components:
+    - type: Transform
+      pos: 44.5,-27.5
+      parent: 2
   - uid: 5304
     components:
     - type: Transform
-      pos: 7.5,-37.5
+      pos: -13.5,-9.5
       parent: 2
   - uid: 5319
     components:
     - type: Transform
       pos: 35.5,5.5
       parent: 2
+  - uid: 5324
+    components:
+    - type: Transform
+      pos: 16.5,-48.5
+      parent: 2
+  - uid: 5342
+    components:
+    - type: Transform
+      pos: -5.5,-35.5
+      parent: 2
+  - uid: 5349
+    components:
+    - type: Transform
+      pos: 29.5,-19.5
+      parent: 2
+  - uid: 5384
+    components:
+    - type: Transform
+      pos: -52.5,-31.5
+      parent: 2
   - uid: 5413
     components:
     - type: Transform
-      pos: 22.5,4.5
+      pos: 34.5,5.5
       parent: 2
   - uid: 5422
     components:
     - type: Transform
       pos: 11.5,21.5
       parent: 2
-  - uid: 5425
+  - uid: 5460
     components:
     - type: Transform
-      pos: 40.5,16.5
+      pos: 39.5,-2.5
       parent: 2
   - uid: 5479
     components:
     - type: Transform
       pos: -41.5,-34.5
       parent: 2
-  - uid: 5488
+  - uid: 5510
     components:
     - type: Transform
-      pos: 0.5,-46.5
+      pos: 47.5,-23.5
       parent: 2
   - uid: 5513
     components:
     - type: Transform
-      pos: 10.5,26.5
+      pos: 12.5,-34.5
       parent: 2
   - uid: 5522
     components:
@@ -155686,10 +155723,20 @@ entities:
     - type: Transform
       pos: 44.5,-7.5
       parent: 2
+  - uid: 5544
+    components:
+    - type: Transform
+      pos: 14.5,-8.5
+      parent: 2
   - uid: 5547
     components:
     - type: Transform
       pos: 36.5,16.5
+      parent: 2
+  - uid: 5569
+    components:
+    - type: Transform
+      pos: 35.5,-0.5
       parent: 2
   - uid: 5572
     components:
@@ -155699,12 +155746,12 @@ entities:
   - uid: 5580
     components:
     - type: Transform
-      pos: 29.5,20.5
+      pos: -17.5,-44.5
       parent: 2
   - uid: 5585
     components:
     - type: Transform
-      pos: -11.5,-49.5
+      pos: -51.5,-49.5
       parent: 2
   - uid: 5601
     components:
@@ -155725,6 +155772,11 @@ entities:
     components:
     - type: Transform
       pos: 63.5,-79.5
+      parent: 2
+  - uid: 5636
+    components:
+    - type: Transform
+      pos: 13.5,18.5
       parent: 2
   - uid: 5653
     components:
@@ -155756,10 +155808,10 @@ entities:
     - type: Transform
       pos: -20.5,-39.5
       parent: 2
-  - uid: 5723
+  - uid: 5732
     components:
     - type: Transform
-      pos: 39.5,9.5
+      pos: 14.5,-54.5
       parent: 2
   - uid: 5733
     components:
@@ -155776,6 +155828,11 @@ entities:
     - type: Transform
       pos: -14.5,-25.5
       parent: 2
+  - uid: 5754
+    components:
+    - type: Transform
+      pos: -5.5,-16.5
+      parent: 2
   - uid: 5766
     components:
     - type: Transform
@@ -155791,6 +155848,11 @@ entities:
     - type: Transform
       pos: 33.5,-12.5
       parent: 2
+  - uid: 5771
+    components:
+    - type: Transform
+      pos: 12.5,-58.5
+      parent: 2
   - uid: 5773
     components:
     - type: Transform
@@ -155804,7 +155866,7 @@ entities:
   - uid: 5777
     components:
     - type: Transform
-      pos: 33.5,-11.5
+      pos: 13.5,-50.5
       parent: 2
   - uid: 5778
     components:
@@ -155819,7 +155881,7 @@ entities:
   - uid: 5784
     components:
     - type: Transform
-      pos: 34.5,-4.5
+      pos: 24.5,4.5
       parent: 2
   - uid: 5795
     components:
@@ -155851,6 +155913,11 @@ entities:
     - type: Transform
       pos: -20.5,-31.5
       parent: 2
+  - uid: 5806
+    components:
+    - type: Transform
+      pos: 38.5,13.5
+      parent: 2
   - uid: 5812
     components:
     - type: Transform
@@ -155866,11 +155933,6 @@ entities:
     - type: Transform
       pos: 35.5,11.5
       parent: 2
-  - uid: 5830
-    components:
-    - type: Transform
-      pos: 8.5,-26.5
-      parent: 2
   - uid: 5835
     components:
     - type: Transform
@@ -155881,10 +155943,20 @@ entities:
     - type: Transform
       pos: 86.5,-17.5
       parent: 2
+  - uid: 5839
+    components:
+    - type: Transform
+      pos: 34.5,-7.5
+      parent: 2
   - uid: 5859
     components:
     - type: Transform
       pos: 5.5,-40.5
+      parent: 2
+  - uid: 5864
+    components:
+    - type: Transform
+      pos: 39.5,7.5
       parent: 2
   - uid: 5875
     components:
@@ -155896,6 +155968,16 @@ entities:
     - type: Transform
       pos: 39.5,1.5
       parent: 2
+  - uid: 5886
+    components:
+    - type: Transform
+      pos: 26.5,-40.5
+      parent: 2
+  - uid: 5888
+    components:
+    - type: Transform
+      pos: 33.5,-16.5
+      parent: 2
   - uid: 5895
     components:
     - type: Transform
@@ -155904,17 +155986,17 @@ entities:
   - uid: 5906
     components:
     - type: Transform
-      pos: 4.5,-35.5
+      pos: 8.5,-35.5
+      parent: 2
+  - uid: 5909
+    components:
+    - type: Transform
+      pos: 39.5,-12.5
       parent: 2
   - uid: 5912
     components:
     - type: Transform
       pos: 6.5,-29.5
-      parent: 2
-  - uid: 5915
-    components:
-    - type: Transform
-      pos: 4.5,-27.5
       parent: 2
   - uid: 5916
     components:
@@ -155924,17 +156006,32 @@ entities:
   - uid: 5928
     components:
     - type: Transform
-      pos: 4.5,-29.5
+      pos: 19.5,-34.5
+      parent: 2
+  - uid: 5939
+    components:
+    - type: Transform
+      pos: -44.5,-52.5
       parent: 2
   - uid: 5940
     components:
     - type: Transform
       pos: 4.5,-33.5
       parent: 2
+  - uid: 5942
+    components:
+    - type: Transform
+      pos: 29.5,24.5
+      parent: 2
   - uid: 5955
     components:
     - type: Transform
-      pos: 22.5,-46.5
+      pos: 40.5,0.5
+      parent: 2
+  - uid: 5957
+    components:
+    - type: Transform
+      pos: 35.5,12.5
       parent: 2
   - uid: 5958
     components:
@@ -155956,15 +156053,15 @@ entities:
     - type: Transform
       pos: 21.5,-51.5
       parent: 2
-  - uid: 5975
+  - uid: 5970
     components:
     - type: Transform
-      pos: 22.5,-47.5
+      pos: -12.5,-29.5
       parent: 2
   - uid: 6023
     components:
     - type: Transform
-      pos: 6.5,-32.5
+      pos: 12.5,-35.5
       parent: 2
   - uid: 6024
     components:
@@ -155986,70 +156083,160 @@ entities:
     - type: Transform
       pos: 39.5,-9.5
       parent: 2
+  - uid: 6053
+    components:
+    - type: Transform
+      pos: 4.5,-32.5
+      parent: 2
   - uid: 6069
     components:
     - type: Transform
       pos: 39.5,-5.5
       parent: 2
-  - uid: 6112
+  - uid: 6108
     components:
     - type: Transform
-      pos: 33.5,-13.5
+      pos: 8.5,-58.5
+      parent: 2
+  - uid: 6149
+    components:
+    - type: Transform
+      pos: -47.5,-55.5
       parent: 2
   - uid: 6152
     components:
     - type: Transform
-      pos: 17.5,8.5
+      pos: 12.5,-54.5
       parent: 2
   - uid: 6158
     components:
     - type: Transform
       pos: 34.5,-0.5
       parent: 2
-  - uid: 6160
+  - uid: 6159
     components:
     - type: Transform
-      pos: 36.5,-0.5
+      pos: -50.5,-56.5
+      parent: 2
+  - uid: 6207
+    components:
+    - type: Transform
+      pos: 24.5,9.5
+      parent: 2
+  - uid: 6224
+    components:
+    - type: Transform
+      pos: 6.5,-35.5
+      parent: 2
+  - uid: 6238
+    components:
+    - type: Transform
+      pos: -41.5,-24.5
       parent: 2
   - uid: 6241
     components:
     - type: Transform
-      pos: 34.5,-3.5
+      pos: 20.5,-51.5
       parent: 2
-  - uid: 6295
+  - uid: 6257
     components:
     - type: Transform
-      pos: 6.5,-43.5
+      pos: -12.5,-49.5
+      parent: 2
+  - uid: 6288
+    components:
+    - type: Transform
+      pos: 2.5,-34.5
+      parent: 2
+  - uid: 6292
+    components:
+    - type: Transform
+      pos: -11.5,-25.5
       parent: 2
   - uid: 6300
     components:
     - type: Transform
       pos: 20.5,-42.5
       parent: 2
+  - uid: 6306
+    components:
+    - type: Transform
+      pos: 10.5,22.5
+      parent: 2
+  - uid: 6307
+    components:
+    - type: Transform
+      pos: 17.5,1.5
+      parent: 2
   - uid: 6346
     components:
     - type: Transform
       pos: 8.5,-46.5
+      parent: 2
+  - uid: 6352
+    components:
+    - type: Transform
+      pos: 1.5,21.5
       parent: 2
   - uid: 6356
     components:
     - type: Transform
       pos: -15.5,-49.5
       parent: 2
+  - uid: 6360
+    components:
+    - type: Transform
+      pos: 46.5,-4.5
+      parent: 2
   - uid: 6365
     components:
     - type: Transform
       pos: 20.5,-44.5
       parent: 2
+  - uid: 6379
+    components:
+    - type: Transform
+      pos: -18.5,-49.5
+      parent: 2
+  - uid: 6380
+    components:
+    - type: Transform
+      pos: 35.5,16.5
+      parent: 2
+  - uid: 6389
+    components:
+    - type: Transform
+      pos: 39.5,10.5
+      parent: 2
+  - uid: 6407
+    components:
+    - type: Transform
+      pos: 37.5,7.5
+      parent: 2
   - uid: 6429
     components:
     - type: Transform
-      pos: 12.5,-55.5
+      pos: 39.5,-1.5
+      parent: 2
+  - uid: 6446
+    components:
+    - type: Transform
+      pos: 20.5,-58.5
+      parent: 2
+  - uid: 6488
+    components:
+    - type: Transform
+      pos: -39.5,-43.5
+      parent: 2
+  - uid: 6493
+    components:
+    - type: Transform
+      pos: 39.5,-0.5
       parent: 2
   - uid: 6494
     components:
     - type: Transform
-      pos: 25.5,-2.5
+      pos: -21.5,-39.5
       parent: 2
   - uid: 6495
     components:
@@ -156061,15 +156248,10 @@ entities:
     - type: Transform
       pos: 39.5,8.5
       parent: 2
-  - uid: 6507
-    components:
-    - type: Transform
-      pos: -16.5,-49.5
-      parent: 2
   - uid: 6517
     components:
     - type: Transform
-      pos: 3.5,-42.5
+      pos: 2.5,-30.5
       parent: 2
   - uid: 6518
     components:
@@ -156086,6 +156268,11 @@ entities:
     - type: Transform
       pos: 8.5,-43.5
       parent: 2
+  - uid: 6556
+    components:
+    - type: Transform
+      pos: -5.5,-46.5
+      parent: 2
   - uid: 6561
     components:
     - type: Transform
@@ -156094,12 +156281,52 @@ entities:
   - uid: 6566
     components:
     - type: Transform
-      pos: 17.5,-14.5
+      pos: -44.5,-54.5
       parent: 2
-  - uid: 6572
+  - uid: 6588
     components:
     - type: Transform
-      pos: 17.5,-15.5
+      pos: -47.5,-49.5
+      parent: 2
+  - uid: 6604
+    components:
+    - type: Transform
+      pos: 5.5,-35.5
+      parent: 2
+  - uid: 6618
+    components:
+    - type: Transform
+      pos: 22.5,-45.5
+      parent: 2
+  - uid: 6620
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 2
+  - uid: 6628
+    components:
+    - type: Transform
+      pos: 48.5,-14.5
+      parent: 2
+  - uid: 6629
+    components:
+    - type: Transform
+      pos: -16.5,18.5
+      parent: 2
+  - uid: 6632
+    components:
+    - type: Transform
+      pos: -21.5,-51.5
+      parent: 2
+  - uid: 6640
+    components:
+    - type: Transform
+      pos: 17.5,-57.5
+      parent: 2
+  - uid: 6680
+    components:
+    - type: Transform
+      pos: 30.5,23.5
       parent: 2
   - uid: 6681
     components:
@@ -156109,37 +156336,87 @@ entities:
   - uid: 6682
     components:
     - type: Transform
-      pos: 21.5,-55.5
+      pos: 18.5,-53.5
       parent: 2
-  - uid: 6684
+  - uid: 6713
     components:
     - type: Transform
-      pos: 19.5,-55.5
+      pos: 47.5,-10.5
       parent: 2
-  - uid: 6685
+  - uid: 6741
     components:
     - type: Transform
-      pos: 18.5,-55.5
+      pos: 22.5,-18.5
+      parent: 2
+  - uid: 6803
+    components:
+    - type: Transform
+      pos: -45.5,-49.5
       parent: 2
   - uid: 6840
     components:
     - type: Transform
       pos: 22.5,-42.5
       parent: 2
+  - uid: 6850
+    components:
+    - type: Transform
+      pos: -35.5,-56.5
+      parent: 2
   - uid: 6863
     components:
     - type: Transform
       pos: 21.5,-42.5
+      parent: 2
+  - uid: 6908
+    components:
+    - type: Transform
+      pos: -41.5,-22.5
+      parent: 2
+  - uid: 6927
+    components:
+    - type: Transform
+      pos: -15.5,-28.5
       parent: 2
   - uid: 6929
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 2
+  - uid: 6934
+    components:
+    - type: Transform
+      pos: -39.5,-46.5
+      parent: 2
+  - uid: 6968
+    components:
+    - type: Transform
+      pos: 22.5,-52.5
+      parent: 2
+  - uid: 6970
+    components:
+    - type: Transform
+      pos: 16.5,-45.5
+      parent: 2
+  - uid: 6982
+    components:
+    - type: Transform
+      pos: 29.5,-1.5
+      parent: 2
+  - uid: 6988
+    components:
+    - type: Transform
+      pos: 34.5,-1.5
+      parent: 2
   - uid: 6992
     components:
     - type: Transform
-      pos: -39.5,-51.5
+      pos: 30.5,16.5
+      parent: 2
+  - uid: 7021
+    components:
+    - type: Transform
+      pos: 7.5,-26.5
       parent: 2
   - uid: 7022
     components:
@@ -156151,35 +156428,55 @@ entities:
     - type: Transform
       pos: -37.5,-56.5
       parent: 2
+  - uid: 7060
+    components:
+    - type: Transform
+      pos: 2.5,-46.5
+      parent: 2
   - uid: 7069
     components:
     - type: Transform
       pos: 15.5,-54.5
       parent: 2
-  - uid: 7077
-    components:
-    - type: Transform
-      pos: 48.5,-6.5
-      parent: 2
   - uid: 7080
     components:
     - type: Transform
-      pos: -42.5,-52.5
+      pos: 20.5,-57.5
       parent: 2
-  - uid: 7098
+  - uid: 7092
     components:
     - type: Transform
-      pos: 42.5,-8.5
+      pos: -52.5,-56.5
       parent: 2
-  - uid: 7174
+  - uid: 7106
     components:
     - type: Transform
-      pos: 3.5,-45.5
+      pos: 35.5,-5.5
       parent: 2
-  - uid: 7217
+  - uid: 7107
     components:
     - type: Transform
-      pos: 24.5,-18.5
+      pos: -6.5,-9.5
+      parent: 2
+  - uid: 7168
+    components:
+    - type: Transform
+      pos: 22.5,-54.5
+      parent: 2
+  - uid: 7175
+    components:
+    - type: Transform
+      pos: 27.5,-15.5
+      parent: 2
+  - uid: 7210
+    components:
+    - type: Transform
+      pos: -10.5,-33.5
+      parent: 2
+  - uid: 7222
+    components:
+    - type: Transform
+      pos: 25.5,-15.5
       parent: 2
   - uid: 7224
     components:
@@ -156191,25 +156488,30 @@ entities:
     - type: Transform
       pos: 29.5,-17.5
       parent: 2
-  - uid: 7241
+  - uid: 7240
     components:
     - type: Transform
-      pos: 44.5,-26.5
+      pos: 44.5,-31.5
       parent: 2
   - uid: 7277
     components:
     - type: Transform
       pos: 38.5,1.5
       parent: 2
-  - uid: 7283
-    components:
-    - type: Transform
-      pos: 34.5,4.5
-      parent: 2
   - uid: 7285
     components:
     - type: Transform
       pos: 40.5,1.5
+      parent: 2
+  - uid: 7286
+    components:
+    - type: Transform
+      pos: 39.5,-39.5
+      parent: 2
+  - uid: 7298
+    components:
+    - type: Transform
+      pos: 19.5,-12.5
       parent: 2
   - uid: 7299
     components:
@@ -156221,10 +156523,55 @@ entities:
     - type: Transform
       pos: 40.5,4.5
       parent: 2
+  - uid: 7314
+    components:
+    - type: Transform
+      pos: 17.5,9.5
+      parent: 2
+  - uid: 7315
+    components:
+    - type: Transform
+      pos: 29.5,-11.5
+      parent: 2
+  - uid: 7320
+    components:
+    - type: Transform
+      pos: -13.5,-37.5
+      parent: 2
+  - uid: 7330
+    components:
+    - type: Transform
+      pos: 16.5,-46.5
+      parent: 2
+  - uid: 7352
+    components:
+    - type: Transform
+      pos: -39.5,-56.5
+      parent: 2
   - uid: 7403
     components:
     - type: Transform
       pos: 37.5,5.5
+      parent: 2
+  - uid: 7419
+    components:
+    - type: Transform
+      pos: -18.5,-31.5
+      parent: 2
+  - uid: 7423
+    components:
+    - type: Transform
+      pos: 29.5,3.5
+      parent: 2
+  - uid: 7456
+    components:
+    - type: Transform
+      pos: -47.5,-50.5
+      parent: 2
+  - uid: 7529
+    components:
+    - type: Transform
+      pos: -38.5,-56.5
       parent: 2
   - uid: 7534
     components:
@@ -156236,30 +156583,90 @@ entities:
     - type: Transform
       pos: -11.5,-44.5
       parent: 2
+  - uid: 7546
+    components:
+    - type: Transform
+      pos: -46.5,-34.5
+      parent: 2
+  - uid: 7572
+    components:
+    - type: Transform
+      pos: 31.5,-26.5
+      parent: 2
+  - uid: 7588
+    components:
+    - type: Transform
+      pos: -13.5,-29.5
+      parent: 2
   - uid: 7596
     components:
     - type: Transform
       pos: 1.5,-46.5
       parent: 2
-  - uid: 7611
+  - uid: 7612
     components:
     - type: Transform
-      pos: 12.5,-50.5
+      pos: 27.5,14.5
+      parent: 2
+  - uid: 7631
+    components:
+    - type: Transform
+      pos: -21.5,-35.5
       parent: 2
   - uid: 7635
     components:
     - type: Transform
       pos: -39.5,-52.5
       parent: 2
+  - uid: 7641
+    components:
+    - type: Transform
+      pos: 23.5,-2.5
+      parent: 2
+  - uid: 7642
+    components:
+    - type: Transform
+      pos: 2.5,-31.5
+      parent: 2
+  - uid: 7643
+    components:
+    - type: Transform
+      pos: 5.5,-46.5
+      parent: 2
   - uid: 7657
     components:
     - type: Transform
       pos: -8.5,-89.5
       parent: 2
+  - uid: 7661
+    components:
+    - type: Transform
+      pos: 31.5,-28.5
+      parent: 2
   - uid: 7666
     components:
     - type: Transform
       pos: 34.5,7.5
+      parent: 2
+  - uid: 7667
+    components:
+    - type: Transform
+      pos: 26.5,9.5
+      parent: 2
+  - uid: 7671
+    components:
+    - type: Transform
+      pos: 22.5,-1.5
+      parent: 2
+  - uid: 7701
+    components:
+    - type: Transform
+      pos: -10.5,-35.5
+      parent: 2
+  - uid: 7759
+    components:
+    - type: Transform
+      pos: 40.5,-4.5
       parent: 2
   - uid: 7760
     components:
@@ -156271,35 +156678,135 @@ entities:
     - type: Transform
       pos: 10.5,27.5
       parent: 2
+  - uid: 7820
+    components:
+    - type: Transform
+      pos: -35.5,-49.5
+      parent: 2
+  - uid: 7823
+    components:
+    - type: Transform
+      pos: -24.5,-54.5
+      parent: 2
+  - uid: 7831
+    components:
+    - type: Transform
+      pos: -14.5,19.5
+      parent: 2
   - uid: 7933
     components:
     - type: Transform
-      pos: 22.5,-15.5
+      pos: -12.5,19.5
       parent: 2
-  - uid: 8278
+  - uid: 8022
     components:
     - type: Transform
-      pos: 46.5,-8.5
+      pos: -39.5,-53.5
+      parent: 2
+  - uid: 8028
+    components:
+    - type: Transform
+      pos: 22.5,-14.5
+      parent: 2
+  - uid: 8047
+    components:
+    - type: Transform
+      pos: 39.5,-14.5
+      parent: 2
+  - uid: 8049
+    components:
+    - type: Transform
+      pos: -50.5,-50.5
+      parent: 2
+  - uid: 8054
+    components:
+    - type: Transform
+      pos: -18.5,21.5
+      parent: 2
+  - uid: 8089
+    components:
+    - type: Transform
+      pos: 9.5,21.5
+      parent: 2
+  - uid: 8105
+    components:
+    - type: Transform
+      pos: 12.5,-37.5
+      parent: 2
+  - uid: 8175
+    components:
+    - type: Transform
+      pos: 29.5,0.5
+      parent: 2
+  - uid: 8196
+    components:
+    - type: Transform
+      pos: 19.5,-37.5
+      parent: 2
+  - uid: 8235
+    components:
+    - type: Transform
+      pos: 46.5,-10.5
+      parent: 2
+  - uid: 8271
+    components:
+    - type: Transform
+      pos: -46.5,-33.5
+      parent: 2
+  - uid: 8273
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 2
+  - uid: 8276
+    components:
+    - type: Transform
+      pos: 22.5,-50.5
+      parent: 2
+  - uid: 8290
+    components:
+    - type: Transform
+      pos: 23.5,3.5
       parent: 2
   - uid: 8305
     components:
     - type: Transform
-      pos: 46.5,-14.5
+      pos: 13.5,-12.5
       parent: 2
-  - uid: 8319
+  - uid: 8318
     components:
     - type: Transform
-      pos: 46.5,-11.5
+      pos: -45.5,-33.5
       parent: 2
-  - uid: 8364
+  - uid: 8376
     components:
     - type: Transform
-      pos: 20.5,-38.5
+      pos: 33.5,-10.5
       parent: 2
-  - uid: 8393
+  - uid: 8386
     components:
     - type: Transform
-      pos: 47.5,-6.5
+      pos: -21.5,-25.5
+      parent: 2
+  - uid: 8388
+    components:
+    - type: Transform
+      pos: 6.5,-37.5
+      parent: 2
+  - uid: 8392
+    components:
+    - type: Transform
+      pos: 40.5,-12.5
+      parent: 2
+  - uid: 8400
+    components:
+    - type: Transform
+      pos: -20.5,-28.5
+      parent: 2
+  - uid: 8412
+    components:
+    - type: Transform
+      pos: 23.5,-39.5
       parent: 2
   - uid: 8421
     components:
@@ -156311,10 +156818,20 @@ entities:
     - type: Transform
       pos: -44.5,-56.5
       parent: 2
+  - uid: 8463
+    components:
+    - type: Transform
+      pos: 22.5,-51.5
+      parent: 2
   - uid: 8466
     components:
     - type: Transform
-      pos: -3.5,-16.5
+      pos: 19.5,-1.5
+      parent: 2
+  - uid: 8492
+    components:
+    - type: Transform
+      pos: -20.5,-35.5
       parent: 2
   - uid: 8503
     components:
@@ -156324,47 +156841,22 @@ entities:
   - uid: 8542
     components:
     - type: Transform
-      pos: 17.5,-12.5
-      parent: 2
-  - uid: 8645
-    components:
-    - type: Transform
-      pos: 40.5,7.5
+      pos: 35.5,15.5
       parent: 2
   - uid: 8654
     components:
     - type: Transform
       pos: 34.5,9.5
       parent: 2
-  - uid: 8767
-    components:
-    - type: Transform
-      pos: -2.5,-16.5
-      parent: 2
   - uid: 8829
     components:
     - type: Transform
       pos: -11.5,18.5
       parent: 2
-  - uid: 8886
-    components:
-    - type: Transform
-      pos: 46.5,-15.5
-      parent: 2
-  - uid: 8909
-    components:
-    - type: Transform
-      pos: 45.5,-26.5
-      parent: 2
   - uid: 8984
     components:
     - type: Transform
       pos: 44.5,-28.5
-      parent: 2
-  - uid: 9045
-    components:
-    - type: Transform
-      pos: 44.5,-29.5
       parent: 2
   - uid: 9047
     components:
@@ -156391,11 +156883,6 @@ entities:
     - type: Transform
       pos: 51.5,-23.5
       parent: 2
-  - uid: 9287
-    components:
-    - type: Transform
-      pos: -41.5,-26.5
-      parent: 2
   - uid: 9306
     components:
     - type: Transform
@@ -156411,11 +156898,6 @@ entities:
     - type: Transform
       pos: 12.5,-60.5
       parent: 2
-  - uid: 9323
-    components:
-    - type: Transform
-      pos: 51.5,-19.5
-      parent: 2
   - uid: 9367
     components:
     - type: Transform
@@ -156430,11 +156912,6 @@ entities:
     components:
     - type: Transform
       pos: 23.5,-59.5
-      parent: 2
-  - uid: 9407
-    components:
-    - type: Transform
-      pos: 22.5,-12.5
       parent: 2
   - uid: 9429
     components:
@@ -156486,11 +156963,6 @@ entities:
     - type: Transform
       pos: 29.5,-2.5
       parent: 2
-  - uid: 9668
-    components:
-    - type: Transform
-      pos: -37.5,9.5
-      parent: 2
   - uid: 9675
     components:
     - type: Transform
@@ -156511,11 +156983,6 @@ entities:
     - type: Transform
       pos: 17.5,0.5
       parent: 2
-  - uid: 9687
-    components:
-    - type: Transform
-      pos: -35.5,-46.5
-      parent: 2
   - uid: 9714
     components:
     - type: Transform
@@ -156525,11 +156992,6 @@ entities:
     components:
     - type: Transform
       pos: -41.5,10.5
-      parent: 2
-  - uid: 9719
-    components:
-    - type: Transform
-      pos: -40.5,14.5
       parent: 2
   - uid: 9725
     components:
@@ -156556,11 +157018,6 @@ entities:
     - type: Transform
       pos: 65.5,-74.5
       parent: 2
-  - uid: 10009
-    components:
-    - type: Transform
-      pos: -40.5,10.5
-      parent: 2
   - uid: 10011
     components:
     - type: Transform
@@ -156570,11 +157027,6 @@ entities:
     components:
     - type: Transform
       pos: 18.5,9.5
-      parent: 2
-  - uid: 10059
-    components:
-    - type: Transform
-      pos: 19.5,9.5
       parent: 2
   - uid: 10109
     components:
@@ -156616,16 +157068,6 @@ entities:
     - type: Transform
       pos: -39.5,14.5
       parent: 2
-  - uid: 10182
-    components:
-    - type: Transform
-      pos: -41.5,14.5
-      parent: 2
-  - uid: 10187
-    components:
-    - type: Transform
-      pos: 2.5,-15.5
-      parent: 2
   - uid: 10196
     components:
     - type: Transform
@@ -156635,11 +157077,6 @@ entities:
     components:
     - type: Transform
       pos: 29.5,-4.5
-      parent: 2
-  - uid: 10419
-    components:
-    - type: Transform
-      pos: -32.5,17.5
       parent: 2
   - uid: 10420
     components:
@@ -156661,11 +157098,6 @@ entities:
     - type: Transform
       pos: -6.5,12.5
       parent: 2
-  - uid: 10467
-    components:
-    - type: Transform
-      pos: -50.5,-55.5
-      parent: 2
   - uid: 10472
     components:
     - type: Transform
@@ -156685,21 +157117,6 @@ entities:
     components:
     - type: Transform
       pos: 23.5,0.5
-      parent: 2
-  - uid: 10611
-    components:
-    - type: Transform
-      pos: -6.5,-8.5
-      parent: 2
-  - uid: 10612
-    components:
-    - type: Transform
-      pos: 15.5,-0.5
-      parent: 2
-  - uid: 10618
-    components:
-    - type: Transform
-      pos: 19.5,-5.5
       parent: 2
   - uid: 10622
     components:
@@ -156735,11 +157152,6 @@ entities:
     components:
     - type: Transform
       pos: -38.5,-50.5
-      parent: 2
-  - uid: 10668
-    components:
-    - type: Transform
-      pos: -34.5,-0.5
       parent: 2
   - uid: 10671
     components:
@@ -156796,11 +157208,6 @@ entities:
     - type: Transform
       pos: 73.5,-74.5
       parent: 2
-  - uid: 10970
-    components:
-    - type: Transform
-      pos: 12.5,-56.5
-      parent: 2
   - uid: 11104
     components:
     - type: Transform
@@ -156815,21 +157222,6 @@ entities:
     components:
     - type: Transform
       pos: -6.5,-11.5
-      parent: 2
-  - uid: 11161
-    components:
-    - type: Transform
-      pos: 17.5,-8.5
-      parent: 2
-  - uid: 11205
-    components:
-    - type: Transform
-      pos: 12.5,-23.5
-      parent: 2
-  - uid: 11212
-    components:
-    - type: Transform
-      pos: 15.5,-5.5
       parent: 2
   - uid: 11228
     components:
@@ -156856,11 +157248,6 @@ entities:
     - type: Transform
       pos: -26.5,-37.5
       parent: 2
-  - uid: 11435
-    components:
-    - type: Transform
-      pos: 23.5,9.5
-      parent: 2
   - uid: 11518
     components:
     - type: Transform
@@ -156870,11 +157257,6 @@ entities:
     components:
     - type: Transform
       pos: 63.5,-80.5
-      parent: 2
-  - uid: 11722
-    components:
-    - type: Transform
-      pos: -45.5,-26.5
       parent: 2
   - uid: 11848
     components:
@@ -156951,11 +157333,6 @@ entities:
     - type: Transform
       pos: 13.5,21.5
       parent: 2
-  - uid: 12514
-    components:
-    - type: Transform
-      pos: -46.5,-35.5
-      parent: 2
   - uid: 12564
     components:
     - type: Transform
@@ -156991,11 +157368,6 @@ entities:
     - type: Transform
       pos: -41.5,20.5
       parent: 2
-  - uid: 12700
-    components:
-    - type: Transform
-      pos: -24.5,19.5
-      parent: 2
   - uid: 12720
     components:
     - type: Transform
@@ -157005,16 +157377,6 @@ entities:
     components:
     - type: Transform
       pos: 8.5,-57.5
-      parent: 2
-  - uid: 12770
-    components:
-    - type: Transform
-      pos: -30.5,22.5
-      parent: 2
-  - uid: 12773
-    components:
-    - type: Transform
-      pos: -56.5,-31.5
       parent: 2
   - uid: 12797
     components:
@@ -157061,11 +157423,6 @@ entities:
     - type: Transform
       pos: -30.5,26.5
       parent: 2
-  - uid: 12942
-    components:
-    - type: Transform
-      pos: 22.5,-16.5
-      parent: 2
   - uid: 13072
     components:
     - type: Transform
@@ -157085,11 +157442,6 @@ entities:
     components:
     - type: Transform
       pos: 50.5,-49.5
-      parent: 2
-  - uid: 13153
-    components:
-    - type: Transform
-      pos: 26.5,12.5
       parent: 2
   - uid: 13177
     components:
@@ -157120,11 +157472,6 @@ entities:
     components:
     - type: Transform
       pos: -45.5,-55.5
-      parent: 2
-  - uid: 13215
-    components:
-    - type: Transform
-      pos: 14.5,-12.5
       parent: 2
   - uid: 13222
     components:
@@ -157176,20 +157523,10 @@ entities:
     - type: Transform
       pos: -46.5,9.5
       parent: 2
-  - uid: 13360
-    components:
-    - type: Transform
-      pos: 28.5,-13.5
-      parent: 2
   - uid: 13366
     components:
     - type: Transform
       pos: -49.5,9.5
-      parent: 2
-  - uid: 13373
-    components:
-    - type: Transform
-      pos: -50.5,9.5
       parent: 2
   - uid: 13672
     components:
@@ -157201,40 +157538,20 @@ entities:
     - type: Transform
       pos: 30.5,17.5
       parent: 2
-  - uid: 13712
-    components:
-    - type: Transform
-      pos: -44.5,-57.5
-      parent: 2
   - uid: 13720
     components:
     - type: Transform
       pos: 21.5,-5.5
-      parent: 2
-  - uid: 13727
-    components:
-    - type: Transform
-      pos: 1.5,-42.5
       parent: 2
   - uid: 13756
     components:
     - type: Transform
       pos: 26.5,-19.5
       parent: 2
-  - uid: 13757
-    components:
-    - type: Transform
-      pos: 27.5,-19.5
-      parent: 2
   - uid: 13759
     components:
     - type: Transform
       pos: 22.5,-19.5
-      parent: 2
-  - uid: 13787
-    components:
-    - type: Transform
-      pos: -29.5,-23.5
       parent: 2
   - uid: 13801
     components:
@@ -157255,11 +157572,6 @@ entities:
     components:
     - type: Transform
       pos: 22.5,-57.5
-      parent: 2
-  - uid: 14018
-    components:
-    - type: Transform
-      pos: -49.5,20.5
       parent: 2
   - uid: 14126
     components:
@@ -157291,16 +157603,6 @@ entities:
     - type: Transform
       pos: -36.5,-40.5
       parent: 2
-  - uid: 14175
-    components:
-    - type: Transform
-      pos: -42.5,-47.5
-      parent: 2
-  - uid: 14176
-    components:
-    - type: Transform
-      pos: -41.5,-47.5
-      parent: 2
   - uid: 14177
     components:
     - type: Transform
@@ -157315,16 +157617,6 @@ entities:
     components:
     - type: Transform
       pos: -39.5,-47.5
-      parent: 2
-  - uid: 14448
-    components:
-    - type: Transform
-      pos: -51.5,16.5
-      parent: 2
-  - uid: 14449
-    components:
-    - type: Transform
-      pos: -50.5,16.5
       parent: 2
   - uid: 14451
     components:
@@ -157391,40 +157683,15 @@ entities:
     - type: Transform
       pos: -50.5,21.5
       parent: 2
-  - uid: 15013
-    components:
-    - type: Transform
-      pos: -51.5,21.5
-      parent: 2
-  - uid: 15024
-    components:
-    - type: Transform
-      pos: -48.5,20.5
-      parent: 2
   - uid: 15041
     components:
     - type: Transform
       pos: 2.5,-42.5
       parent: 2
-  - uid: 15045
-    components:
-    - type: Transform
-      pos: 12.5,-59.5
-      parent: 2
-  - uid: 15251
-    components:
-    - type: Transform
-      pos: -36.5,-47.5
-      parent: 2
   - uid: 15252
     components:
     - type: Transform
       pos: -37.5,-47.5
-      parent: 2
-  - uid: 15253
-    components:
-    - type: Transform
-      pos: -42.5,-51.5
       parent: 2
   - uid: 15345
     components:
@@ -157440,16 +157707,6 @@ entities:
     components:
     - type: Transform
       pos: -24.5,21.5
-      parent: 2
-  - uid: 15466
-    components:
-    - type: Transform
-      pos: 17.5,-59.5
-      parent: 2
-  - uid: 15478
-    components:
-    - type: Transform
-      pos: 43.5,-8.5
       parent: 2
   - uid: 15606
     components:
@@ -157476,20 +157733,10 @@ entities:
     - type: Transform
       pos: 38.5,12.5
       parent: 2
-  - uid: 15815
-    components:
-    - type: Transform
-      pos: 8.5,21.5
-      parent: 2
   - uid: 15877
     components:
     - type: Transform
       pos: -48.5,17.5
-      parent: 2
-  - uid: 15896
-    components:
-    - type: Transform
-      pos: 17.5,-0.5
       parent: 2
   - uid: 15903
     components:
@@ -157561,45 +157808,20 @@ entities:
     - type: Transform
       pos: -54.5,14.5
       parent: 2
-  - uid: 16287
-    components:
-    - type: Transform
-      pos: -54.5,12.5
-      parent: 2
-  - uid: 16294
-    components:
-    - type: Transform
-      pos: -55.5,14.5
-      parent: 2
   - uid: 16298
     components:
     - type: Transform
       pos: -55.5,9.5
-      parent: 2
-  - uid: 16323
-    components:
-    - type: Transform
-      pos: 15.5,-12.5
       parent: 2
   - uid: 16359
     components:
     - type: Transform
       pos: -47.5,9.5
       parent: 2
-  - uid: 16360
-    components:
-    - type: Transform
-      pos: -47.5,10.5
-      parent: 2
   - uid: 16478
     components:
     - type: Transform
       pos: -49.5,14.5
-      parent: 2
-  - uid: 16479
-    components:
-    - type: Transform
-      pos: -52.5,14.5
       parent: 2
   - uid: 16480
     components:
@@ -157611,25 +157833,10 @@ entities:
     - type: Transform
       pos: -50.5,14.5
       parent: 2
-  - uid: 16530
-    components:
-    - type: Transform
-      pos: 6.5,21.5
-      parent: 2
-  - uid: 16655
-    components:
-    - type: Transform
-      pos: 34.5,10.5
-      parent: 2
   - uid: 16758
     components:
     - type: Transform
       pos: 49.5,-40.5
-      parent: 2
-  - uid: 16899
-    components:
-    - type: Transform
-      pos: -44.5,-53.5
       parent: 2
   - uid: 16911
     components:
@@ -157666,35 +157873,15 @@ entities:
     - type: Transform
       pos: -48.5,-52.5
       parent: 2
-  - uid: 16947
-    components:
-    - type: Transform
-      pos: -21.5,-17.5
-      parent: 2
-  - uid: 16949
-    components:
-    - type: Transform
-      pos: 47.5,-26.5
-      parent: 2
   - uid: 17001
     components:
     - type: Transform
       pos: 18.5,-52.5
       parent: 2
-  - uid: 17011
-    components:
-    - type: Transform
-      pos: 10.5,21.5
-      parent: 2
   - uid: 17153
     components:
     - type: Transform
       pos: -42.5,-56.5
-      parent: 2
-  - uid: 17188
-    components:
-    - type: Transform
-      pos: -40.5,-56.5
       parent: 2
   - uid: 17296
     components:
@@ -157726,11 +157913,6 @@ entities:
     - type: Transform
       pos: 86.5,-22.5
       parent: 2
-  - uid: 17752
-    components:
-    - type: Transform
-      pos: -46.5,-49.5
-      parent: 2
   - uid: 17837
     components:
     - type: Transform
@@ -157746,20 +157928,10 @@ entities:
     - type: Transform
       pos: 30.5,20.5
       parent: 2
-  - uid: 18211
-    components:
-    - type: Transform
-      pos: -25.5,-48.5
-      parent: 2
   - uid: 18341
     components:
     - type: Transform
       pos: 93.5,-20.5
-      parent: 2
-  - uid: 18382
-    components:
-    - type: Transform
-      pos: 20.5,-55.5
       parent: 2
   - uid: 18424
     components:
@@ -157821,11 +157993,6 @@ entities:
     - type: Transform
       pos: 30.5,9.5
       parent: 2
-  - uid: 18863
-    components:
-    - type: Transform
-      pos: 46.5,-13.5
-      parent: 2
   - uid: 19187
     components:
     - type: Transform
@@ -157846,20 +158013,10 @@ entities:
     - type: Transform
       pos: -8.5,-90.5
       parent: 2
-  - uid: 19895
-    components:
-    - type: Transform
-      pos: 30.5,15.5
-      parent: 2
   - uid: 19918
     components:
     - type: Transform
       pos: -11.5,21.5
-      parent: 2
-  - uid: 20172
-    components:
-    - type: Transform
-      pos: 20.5,9.5
       parent: 2
   - uid: 20176
     components:
@@ -157881,30 +158038,15 @@ entities:
     - type: Transform
       pos: -21.5,-55.5
       parent: 2
-  - uid: 20255
-    components:
-    - type: Transform
-      pos: 30.5,12.5
-      parent: 2
   - uid: 20319
     components:
     - type: Transform
       pos: 23.5,-38.5
       parent: 2
-  - uid: 20392
-    components:
-    - type: Transform
-      pos: -6.5,-46.5
-      parent: 2
   - uid: 20510
     components:
     - type: Transform
       pos: -31.5,19.5
-      parent: 2
-  - uid: 20706
-    components:
-    - type: Transform
-      pos: 2.5,-39.5
       parent: 2
   - uid: 20715
     components:
@@ -157936,11 +158078,6 @@ entities:
     - type: Transform
       pos: 14.5,-50.5
       parent: 2
-  - uid: 21803
-    components:
-    - type: Transform
-      pos: 4.5,-31.5
-      parent: 2
   - uid: 21900
     components:
     - type: Transform
@@ -157955,16 +158092,6 @@ entities:
     components:
     - type: Transform
       pos: -54.5,-52.5
-      parent: 2
-  - uid: 22005
-    components:
-    - type: Transform
-      pos: 17.5,20.5
-      parent: 2
-  - uid: 22010
-    components:
-    - type: Transform
-      pos: 22.5,9.5
       parent: 2
   - uid: 22015
     components:
@@ -158016,11 +158143,6 @@ entities:
     - type: Transform
       pos: -23.5,-55.5
       parent: 2
-  - uid: 23340
-    components:
-    - type: Transform
-      pos: -23.5,-56.5
-      parent: 2
   - uid: 23435
     components:
     - type: Transform
@@ -158033,300 +158155,1115 @@ entities:
       parent: 2
 - proto: WallSolidRust
   entities:
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -51.5,16.5
+      parent: 2
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 40.5,10.5
+      parent: 2
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 6.5,21.5
+      parent: 2
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 23.5,-34.5
+      parent: 2
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 16.5,-50.5
+      parent: 2
+  - uid: 272
+    components:
+    - type: Transform
+      pos: 6.5,-32.5
+      parent: 2
+  - uid: 291
+    components:
+    - type: Transform
+      pos: 22.5,-47.5
+      parent: 2
+  - uid: 305
+    components:
+    - type: Transform
+      pos: 48.5,-6.5
+      parent: 2
   - uid: 311
     components:
     - type: Transform
-      pos: -15.5,-28.5
+      pos: -6.5,-16.5
       parent: 2
-  - uid: 1027
+  - uid: 317
+    components:
+    - type: Transform
+      pos: 22.5,-17.5
+      parent: 2
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 46.5,-14.5
+      parent: 2
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 4.5,-35.5
+      parent: 2
+  - uid: 354
+    components:
+    - type: Transform
+      pos: 43.5,-8.5
+      parent: 2
+  - uid: 389
+    components:
+    - type: Transform
+      pos: 12.5,-45.5
+      parent: 2
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -6.5,-46.5
+      parent: 2
+  - uid: 395
+    components:
+    - type: Transform
+      pos: -46.5,-49.5
+      parent: 2
+  - uid: 397
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 2
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -17.5,12.5
+      parent: 2
+  - uid: 401
+    components:
+    - type: Transform
+      pos: 23.5,-44.5
+      parent: 2
+  - uid: 416
+    components:
+    - type: Transform
+      pos: 15.5,-12.5
+      parent: 2
+  - uid: 417
     components:
     - type: Transform
       pos: 7.5,-40.5
       parent: 2
-  - uid: 1045
+  - uid: 420
     components:
     - type: Transform
-      pos: 17.5,3.5
+      pos: -35.5,-46.5
       parent: 2
-  - uid: 1053
+  - uid: 422
     components:
     - type: Transform
-      pos: -50.5,-50.5
+      pos: 22.5,4.5
       parent: 2
-  - uid: 1104
+  - uid: 426
     components:
     - type: Transform
-      pos: -13.5,-29.5
+      pos: 17.5,8.5
       parent: 2
-  - uid: 1245
+  - uid: 429
     components:
     - type: Transform
-      pos: 17.5,9.5
+      pos: -41.5,-25.5
       parent: 2
-  - uid: 1432
+  - uid: 433
+    components:
+    - type: Transform
+      pos: 29.5,-15.5
+      parent: 2
+  - uid: 440
+    components:
+    - type: Transform
+      pos: -50.5,16.5
+      parent: 2
+  - uid: 444
+    components:
+    - type: Transform
+      pos: -21.5,-26.5
+      parent: 2
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 33.5,-13.5
+      parent: 2
+  - uid: 483
+    components:
+    - type: Transform
+      pos: -21.5,-30.5
+      parent: 2
+  - uid: 491
+    components:
+    - type: Transform
+      pos: 23.5,9.5
+      parent: 2
+  - uid: 503
+    components:
+    - type: Transform
+      pos: 47.5,-26.5
+      parent: 2
+  - uid: 512
+    components:
+    - type: Transform
+      pos: 27.5,-19.5
+      parent: 2
+  - uid: 520
+    components:
+    - type: Transform
+      pos: -34.5,-0.5
+      parent: 2
+  - uid: 534
+    components:
+    - type: Transform
+      pos: -38.5,-34.5
+      parent: 2
+  - uid: 548
+    components:
+    - type: Transform
+      pos: -51.5,21.5
+      parent: 2
+  - uid: 577
+    components:
+    - type: Transform
+      pos: -47.5,10.5
+      parent: 2
+  - uid: 590
+    components:
+    - type: Transform
+      pos: 25.5,-19.5
+      parent: 2
+  - uid: 611
+    components:
+    - type: Transform
+      pos: 12.5,-23.5
+      parent: 2
+  - uid: 632
+    components:
+    - type: Transform
+      pos: 12.5,-50.5
+      parent: 2
+  - uid: 661
+    components:
+    - type: Transform
+      pos: 19.5,-5.5
+      parent: 2
+  - uid: 663
+    components:
+    - type: Transform
+      pos: 29.5,20.5
+      parent: 2
+  - uid: 697
+    components:
+    - type: Transform
+      pos: 40.5,3.5
+      parent: 2
+  - uid: 713
+    components:
+    - type: Transform
+      pos: 3.5,-45.5
+      parent: 2
+  - uid: 714
+    components:
+    - type: Transform
+      pos: -6.5,-12.5
+      parent: 2
+  - uid: 716
+    components:
+    - type: Transform
+      pos: 34.5,-6.5
+      parent: 2
+  - uid: 754
+    components:
+    - type: Transform
+      pos: 21.5,-55.5
+      parent: 2
+  - uid: 796
+    components:
+    - type: Transform
+      pos: -2.5,-16.5
+      parent: 2
+  - uid: 802
+    components:
+    - type: Transform
+      pos: 17.5,20.5
+      parent: 2
+  - uid: 832
+    components:
+    - type: Transform
+      pos: -44.5,-53.5
+      parent: 2
+  - uid: 834
+    components:
+    - type: Transform
+      pos: -37.5,9.5
+      parent: 2
+  - uid: 837
+    components:
+    - type: Transform
+      pos: 30.5,-40.5
+      parent: 2
+  - uid: 838
+    components:
+    - type: Transform
+      pos: 3.5,-42.5
+      parent: 2
+  - uid: 845
+    components:
+    - type: Transform
+      pos: 30.5,15.5
+      parent: 2
+  - uid: 847
     components:
     - type: Transform
       pos: 8.5,-54.5
       parent: 2
+  - uid: 869
+    components:
+    - type: Transform
+      pos: -41.5,-47.5
+      parent: 2
+  - uid: 870
+    components:
+    - type: Transform
+      pos: 40.5,-3.5
+      parent: 2
+  - uid: 879
+    components:
+    - type: Transform
+      pos: -24.5,19.5
+      parent: 2
+  - uid: 894
+    components:
+    - type: Transform
+      pos: -56.5,-31.5
+      parent: 2
+  - uid: 910
+    components:
+    - type: Transform
+      pos: 8.5,-26.5
+      parent: 2
+  - uid: 993
+    components:
+    - type: Transform
+      pos: 25.5,-2.5
+      parent: 2
+  - uid: 998
+    components:
+    - type: Transform
+      pos: -26.5,-49.5
+      parent: 2
+  - uid: 1007
+    components:
+    - type: Transform
+      pos: -42.5,-52.5
+      parent: 2
+  - uid: 1027
+    components:
+    - type: Transform
+      pos: 15.5,-50.5
+      parent: 2
+  - uid: 1044
+    components:
+    - type: Transform
+      pos: -12.5,-30.5
+      parent: 2
+  - uid: 1045
+    components:
+    - type: Transform
+      pos: -30.5,-13.5
+      parent: 2
+  - uid: 1050
+    components:
+    - type: Transform
+      pos: 25.5,-1.5
+      parent: 2
+  - uid: 1053
+    components:
+    - type: Transform
+      pos: 5.5,-26.5
+      parent: 2
+  - uid: 1071
+    components:
+    - type: Transform
+      pos: 17.5,-15.5
+      parent: 2
+  - uid: 1082
+    components:
+    - type: Transform
+      pos: 17.5,-11.5
+      parent: 2
+  - uid: 1086
+    components:
+    - type: Transform
+      pos: 39.5,9.5
+      parent: 2
+  - uid: 1104
+    components:
+    - type: Transform
+      pos: 13.5,17.5
+      parent: 2
+  - uid: 1107
+    components:
+    - type: Transform
+      pos: 12.5,-55.5
+      parent: 2
+  - uid: 1110
+    components:
+    - type: Transform
+      pos: 12.5,-59.5
+      parent: 2
+  - uid: 1115
+    components:
+    - type: Transform
+      pos: 17.5,-14.5
+      parent: 2
+  - uid: 1121
+    components:
+    - type: Transform
+      pos: 44.5,-29.5
+      parent: 2
+  - uid: 1132
+    components:
+    - type: Transform
+      pos: 51.5,-19.5
+      parent: 2
+  - uid: 1137
+    components:
+    - type: Transform
+      pos: -11.5,-49.5
+      parent: 2
+  - uid: 1150
+    components:
+    - type: Transform
+      pos: 36.5,-33.5
+      parent: 2
+  - uid: 1159
+    components:
+    - type: Transform
+      pos: 20.5,9.5
+      parent: 2
+  - uid: 1182
+    components:
+    - type: Transform
+      pos: -25.5,-48.5
+      parent: 2
+  - uid: 1191
+    components:
+    - type: Transform
+      pos: 45.5,-26.5
+      parent: 2
+  - uid: 1194
+    components:
+    - type: Transform
+      pos: 46.5,-7.5
+      parent: 2
+  - uid: 1241
+    components:
+    - type: Transform
+      pos: 46.5,-26.5
+      parent: 2
+  - uid: 1245
+    components:
+    - type: Transform
+      pos: 0.5,-45.5
+      parent: 2
+  - uid: 1255
+    components:
+    - type: Transform
+      pos: 4.5,-27.5
+      parent: 2
+  - uid: 1302
+    components:
+    - type: Transform
+      pos: 8.5,-37.5
+      parent: 2
+  - uid: 1412
+    components:
+    - type: Transform
+      pos: 17.5,-8.5
+      parent: 2
+  - uid: 1424
+    components:
+    - type: Transform
+      pos: -34.5,20.5
+      parent: 2
+  - uid: 1427
+    components:
+    - type: Transform
+      pos: 22.5,-46.5
+      parent: 2
+  - uid: 1430
+    components:
+    - type: Transform
+      pos: -13.5,-25.5
+      parent: 2
+  - uid: 1431
+    components:
+    - type: Transform
+      pos: 6.5,-43.5
+      parent: 2
+  - uid: 1432
+    components:
+    - type: Transform
+      pos: 17.5,4.5
+      parent: 2
+  - uid: 1438
+    components:
+    - type: Transform
+      pos: -21.5,-21.5
+      parent: 2
   - uid: 1440
     components:
     - type: Transform
-      pos: -5.5,-35.5
+      pos: -50.5,-51.5
+      parent: 2
+  - uid: 1443
+    components:
+    - type: Transform
+      pos: 4.5,-31.5
+      parent: 2
+  - uid: 1446
+    components:
+    - type: Transform
+      pos: 46.5,-11.5
+      parent: 2
+  - uid: 1481
+    components:
+    - type: Transform
+      pos: -48.5,20.5
+      parent: 2
+  - uid: 1483
+    components:
+    - type: Transform
+      pos: 18.5,-5.5
       parent: 2
   - uid: 1484
     components:
     - type: Transform
-      pos: 26.5,14.5
+      pos: -6.5,-45.5
+      parent: 2
+  - uid: 1488
+    components:
+    - type: Transform
+      pos: -54.5,12.5
+      parent: 2
+  - uid: 1517
+    components:
+    - type: Transform
+      pos: -21.5,21.5
       parent: 2
   - uid: 1530
     components:
     - type: Transform
-      pos: 29.5,-19.5
+      pos: 42.5,-5.5
+      parent: 2
+  - uid: 1560
+    components:
+    - type: Transform
+      pos: 30.5,-45.5
+      parent: 2
+  - uid: 1589
+    components:
+    - type: Transform
+      pos: 24.5,-16.5
       parent: 2
   - uid: 1663
     components:
     - type: Transform
-      pos: 39.5,10.5
+      pos: 46.5,-13.5
+      parent: 2
+  - uid: 1668
+    components:
+    - type: Transform
+      pos: -40.5,10.5
+      parent: 2
+  - uid: 1691
+    components:
+    - type: Transform
+      pos: 8.5,-32.5
+      parent: 2
+  - uid: 1711
+    components:
+    - type: Transform
+      pos: 17.5,3.5
+      parent: 2
+  - uid: 1725
+    components:
+    - type: Transform
+      pos: -6.5,-29.5
       parent: 2
   - uid: 1783
     components:
     - type: Transform
-      pos: -51.5,-49.5
+      pos: 33.5,-14.5
+      parent: 2
+  - uid: 1843
+    components:
+    - type: Transform
+      pos: 22.5,-15.5
+      parent: 2
+  - uid: 1874
+    components:
+    - type: Transform
+      pos: 17.5,-59.5
+      parent: 2
+  - uid: 1893
+    components:
+    - type: Transform
+      pos: 34.5,-2.5
+      parent: 2
+  - uid: 1923
+    components:
+    - type: Transform
+      pos: -40.5,-38.5
+      parent: 2
+  - uid: 1926
+    components:
+    - type: Transform
+      pos: 19.5,-2.5
+      parent: 2
+  - uid: 1959
+    components:
+    - type: Transform
+      pos: 46.5,-8.5
+      parent: 2
+  - uid: 2029
+    components:
+    - type: Transform
+      pos: -1.5,-36.5
+      parent: 2
+  - uid: 2030
+    components:
+    - type: Transform
+      pos: -39.5,-17.5
+      parent: 2
+  - uid: 2068
+    components:
+    - type: Transform
+      pos: -46.5,-35.5
+      parent: 2
+  - uid: 2075
+    components:
+    - type: Transform
+      pos: 40.5,16.5
+      parent: 2
+  - uid: 2094
+    components:
+    - type: Transform
+      pos: 40.5,7.5
       parent: 2
   - uid: 2139
     components:
     - type: Transform
-      pos: -16.5,-31.5
+      pos: -40.5,-56.5
+      parent: 2
+  - uid: 2277
+    components:
+    - type: Transform
+      pos: 2.5,-39.5
+      parent: 2
+  - uid: 2317
+    components:
+    - type: Transform
+      pos: -42.5,-51.5
+      parent: 2
+  - uid: 2351
+    components:
+    - type: Transform
+      pos: -3.5,-16.5
       parent: 2
   - uid: 2353
     components:
     - type: Transform
-      pos: 30.5,23.5
+      pos: 33.5,-5.5
+      parent: 2
+  - uid: 2364
+    components:
+    - type: Transform
+      pos: 23.5,-45.5
+      parent: 2
+  - uid: 2368
+    components:
+    - type: Transform
+      pos: 46.5,-15.5
+      parent: 2
+  - uid: 2378
+    components:
+    - type: Transform
+      pos: 22.5,9.5
+      parent: 2
+  - uid: 2394
+    components:
+    - type: Transform
+      pos: 0.5,-46.5
+      parent: 2
+  - uid: 2438
+    components:
+    - type: Transform
+      pos: -23.5,-54.5
+      parent: 2
+  - uid: 2448
+    components:
+    - type: Transform
+      pos: 18.5,-0.5
+      parent: 2
+  - uid: 2450
+    components:
+    - type: Transform
+      pos: 12.5,-52.5
+      parent: 2
+  - uid: 2454
+    components:
+    - type: Transform
+      pos: 29.5,-5.5
+      parent: 2
+  - uid: 2488
+    components:
+    - type: Transform
+      pos: -31.5,21.5
+      parent: 2
+  - uid: 2507
+    components:
+    - type: Transform
+      pos: 18.5,-55.5
+      parent: 2
+  - uid: 2521
+    components:
+    - type: Transform
+      pos: -12.5,20.5
+      parent: 2
+  - uid: 2566
+    components:
+    - type: Transform
+      pos: -14.5,21.5
+      parent: 2
+  - uid: 2604
+    components:
+    - type: Transform
+      pos: -49.5,20.5
+      parent: 2
+  - uid: 2607
+    components:
+    - type: Transform
+      pos: -52.5,14.5
       parent: 2
   - uid: 2610
     components:
     - type: Transform
-      pos: -5.5,-16.5
+      pos: 26.5,12.5
+      parent: 2
+  - uid: 2634
+    components:
+    - type: Transform
+      pos: -41.5,-26.5
+      parent: 2
+  - uid: 2682
+    components:
+    - type: Transform
+      pos: 2.5,-33.5
       parent: 2
   - uid: 2756
     components:
     - type: Transform
-      pos: -18.5,-31.5
+      pos: -36.5,-34.5
       parent: 2
   - uid: 2805
     components:
     - type: Transform
       pos: -2.5,-88.5
       parent: 2
+  - uid: 2936
+    components:
+    - type: Transform
+      pos: -44.5,-57.5
+      parent: 2
+  - uid: 2943
+    components:
+    - type: Transform
+      pos: 2.5,21.5
+      parent: 2
   - uid: 3016
     components:
     - type: Transform
-      pos: -39.5,-53.5
+      pos: -32.5,17.5
+      parent: 2
+  - uid: 3030
+    components:
+    - type: Transform
+      pos: -21.5,-29.5
+      parent: 2
+  - uid: 3067
+    components:
+    - type: Transform
+      pos: 24.5,-18.5
+      parent: 2
+  - uid: 3081
+    components:
+    - type: Transform
+      pos: -10.5,18.5
+      parent: 2
+  - uid: 3100
+    components:
+    - type: Transform
+      pos: 34.5,4.5
+      parent: 2
+  - uid: 3127
+    components:
+    - type: Transform
+      pos: 11.5,-2.5
+      parent: 2
+  - uid: 3220
+    components:
+    - type: Transform
+      pos: 46.5,-31.5
+      parent: 2
+  - uid: 3228
+    components:
+    - type: Transform
+      pos: -13.5,-39.5
       parent: 2
   - uid: 3251
     components:
     - type: Transform
-      pos: -38.5,-34.5
+      pos: 8.5,21.5
       parent: 2
   - uid: 3282
     components:
     - type: Transform
       pos: 47.5,-39.5
       parent: 2
+  - uid: 3294
+    components:
+    - type: Transform
+      pos: -34.5,21.5
+      parent: 2
   - uid: 3298
     components:
     - type: Transform
-      pos: 34.5,-2.5
+      pos: -18.5,-28.5
+      parent: 2
+  - uid: 3300
+    components:
+    - type: Transform
+      pos: -20.5,-21.5
+      parent: 2
+  - uid: 3304
+    components:
+    - type: Transform
+      pos: -11.5,-16.5
+      parent: 2
+  - uid: 3305
+    components:
+    - type: Transform
+      pos: 20.5,-55.5
       parent: 2
   - uid: 3306
     components:
     - type: Transform
       pos: 6.5,-91.5
       parent: 2
+  - uid: 3314
+    components:
+    - type: Transform
+      pos: 36.5,-0.5
+      parent: 2
   - uid: 3341
     components:
     - type: Transform
-      pos: -11.5,-25.5
+      pos: -50.5,-53.5
+      parent: 2
+  - uid: 3355
+    components:
+    - type: Transform
+      pos: -39.5,16.5
+      parent: 2
+  - uid: 3389
+    components:
+    - type: Transform
+      pos: -36.5,-25.5
+      parent: 2
+  - uid: 3410
+    components:
+    - type: Transform
+      pos: 44.5,-26.5
+      parent: 2
+  - uid: 3429
+    components:
+    - type: Transform
+      pos: -13.5,-36.5
+      parent: 2
+  - uid: 3442
+    components:
+    - type: Transform
+      pos: 3.5,-15.5
       parent: 2
   - uid: 3447
     components:
     - type: Transform
       pos: 43.5,-55.5
       parent: 2
+  - uid: 3448
+    components:
+    - type: Transform
+      pos: 12.5,-56.5
+      parent: 2
+  - uid: 3480
+    components:
+    - type: Transform
+      pos: -41.5,14.5
+      parent: 2
   - uid: 3504
     components:
     - type: Transform
-      pos: 46.5,-7.5
+      pos: -21.5,-17.5
+      parent: 2
+  - uid: 3509
+    components:
+    - type: Transform
+      pos: -55.5,14.5
+      parent: 2
+  - uid: 3535
+    components:
+    - type: Transform
+      pos: 10.5,21.5
+      parent: 2
+  - uid: 3568
+    components:
+    - type: Transform
+      pos: 30.5,12.5
+      parent: 2
+  - uid: 3663
+    components:
+    - type: Transform
+      pos: 13.5,-34.5
+      parent: 2
+  - uid: 3760
+    components:
+    - type: Transform
+      pos: -33.5,21.5
+      parent: 2
+  - uid: 3773
+    components:
+    - type: Transform
+      pos: 4.5,-29.5
+      parent: 2
+  - uid: 3792
+    components:
+    - type: Transform
+      pos: -10.5,-14.5
+      parent: 2
+  - uid: 3812
+    components:
+    - type: Transform
+      pos: -14.5,-39.5
+      parent: 2
+  - uid: 3834
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+  - uid: 3840
+    components:
+    - type: Transform
+      pos: 20.5,-38.5
+      parent: 2
+  - uid: 3853
+    components:
+    - type: Transform
+      pos: 10.5,26.5
+      parent: 2
+  - uid: 3862
+    components:
+    - type: Transform
+      pos: 0.5,-42.5
       parent: 2
   - uid: 3965
     components:
     - type: Transform
-      pos: 4.5,-32.5
+      pos: -16.5,-31.5
+      parent: 2
+  - uid: 3983
+    components:
+    - type: Transform
+      pos: 34.5,-3.5
+      parent: 2
+  - uid: 4017
+    components:
+    - type: Transform
+      pos: 2.5,-29.5
+      parent: 2
+  - uid: 4044
+    components:
+    - type: Transform
+      pos: 39.5,-10.5
+      parent: 2
+  - uid: 4046
+    components:
+    - type: Transform
+      pos: -0.5,-42.5
+      parent: 2
+  - uid: 4051
+    components:
+    - type: Transform
+      pos: -40.5,-25.5
+      parent: 2
+  - uid: 4061
+    components:
+    - type: Transform
+      pos: 26.5,14.5
+      parent: 2
+  - uid: 4164
+    components:
+    - type: Transform
+      pos: 38.5,-0.5
+      parent: 2
+  - uid: 4173
+    components:
+    - type: Transform
+      pos: 19.5,9.5
       parent: 2
   - uid: 4182
     components:
     - type: Transform
-      pos: -41.5,-22.5
+      pos: 14.5,-12.5
+      parent: 2
+  - uid: 4212
+    components:
+    - type: Transform
+      pos: 13.5,-46.5
+      parent: 2
+  - uid: 4256
+    components:
+    - type: Transform
+      pos: 1.5,-30.5
       parent: 2
   - uid: 4269
     components:
     - type: Transform
-      pos: -38.5,-56.5
+      pos: 13.5,-37.5
+      parent: 2
+  - uid: 4340
+    components:
+    - type: Transform
+      pos: 1.5,-42.5
       parent: 2
   - uid: 4346
     components:
     - type: Transform
-      pos: -24.5,-54.5
+      pos: -39.5,-51.5
+      parent: 2
+  - uid: 4442
+    components:
+    - type: Transform
+      pos: -40.5,-22.5
+      parent: 2
+  - uid: 4481
+    components:
+    - type: Transform
+      pos: 46.5,-6.5
+      parent: 2
+  - uid: 4520
+    components:
+    - type: Transform
+      pos: 0.5,-16.5
+      parent: 2
+  - uid: 4524
+    components:
+    - type: Transform
+      pos: 17.5,-0.5
       parent: 2
   - uid: 4544
     components:
     - type: Transform
-      pos: 19.5,-1.5
+      pos: -9.5,-16.5
+      parent: 2
+  - uid: 4594
+    components:
+    - type: Transform
+      pos: 34.5,10.5
       parent: 2
   - uid: 4719
     components:
     - type: Transform
       pos: 9.5,-91.5
       parent: 2
+  - uid: 4737
+    components:
+    - type: Transform
+      pos: 33.5,-11.5
+      parent: 2
+  - uid: 4789
+    components:
+    - type: Transform
+      pos: 30.5,19.5
+      parent: 2
+  - uid: 4795
+    components:
+    - type: Transform
+      pos: 7.5,-37.5
+      parent: 2
   - uid: 4811
     components:
     - type: Transform
-      pos: -39.5,-43.5
+      pos: -45.5,-26.5
       parent: 2
-  - uid: 4974
+  - uid: 4828
     components:
     - type: Transform
-      pos: -52.5,-56.5
+      pos: 33.5,-18.5
+      parent: 2
+  - uid: 4871
+    components:
+    - type: Transform
+      pos: 34.5,8.5
+      parent: 2
+  - uid: 4883
+    components:
+    - type: Transform
+      pos: -51.5,-47.5
       parent: 2
   - uid: 5114
     components:
     - type: Transform
       pos: 25.5,-57.5
       parent: 2
-  - uid: 5176
-    components:
-    - type: Transform
-      pos: 8.5,-58.5
-      parent: 2
-  - uid: 5290
-    components:
-    - type: Transform
-      pos: 11.5,-2.5
-      parent: 2
-  - uid: 5331
-    components:
-    - type: Transform
-      pos: -6.5,-6.5
-      parent: 2
   - uid: 5378
     components:
     - type: Transform
       pos: 66.5,-79.5
-      parent: 2
-  - uid: 5493
-    components:
-    - type: Transform
-      pos: 40.5,0.5
-      parent: 2
-  - uid: 5512
-    components:
-    - type: Transform
-      pos: 38.5,13.5
-      parent: 2
-  - uid: 5539
-    components:
-    - type: Transform
-      pos: 46.5,-6.5
-      parent: 2
-  - uid: 5548
-    components:
-    - type: Transform
-      pos: 20.5,-51.5
-      parent: 2
-  - uid: 5569
-    components:
-    - type: Transform
-      pos: 34.5,5.5
-      parent: 2
-  - uid: 5636
-    components:
-    - type: Transform
-      pos: -18.5,-49.5
       parent: 2
   - uid: 5736
     components:
     - type: Transform
       pos: -6.5,-91.5
       parent: 2
-  - uid: 5754
-    components:
-    - type: Transform
-      pos: 39.5,-39.5
-      parent: 2
-  - uid: 5806
-    components:
-    - type: Transform
-      pos: 13.5,17.5
-      parent: 2
-  - uid: 12568
-    components:
-    - type: Transform
-      pos: -5.5,-46.5
-      parent: 2
-  - uid: 12569
-    components:
-    - type: Transform
-      pos: 17.5,-11.5
-      parent: 2
   - uid: 12570
     components:
     - type: Transform
       pos: 61.5,-76.5
-      parent: 2
-  - uid: 12573
-    components:
-    - type: Transform
-      pos: -40.5,-22.5
-      parent: 2
-  - uid: 12582
-    components:
-    - type: Transform
-      pos: 40.5,3.5
-      parent: 2
-  - uid: 12601
-    components:
-    - type: Transform
-      pos: 20.5,-58.5
-      parent: 2
-  - uid: 12603
-    components:
-    - type: Transform
-      pos: -39.5,-56.5
       parent: 2
   - uid: 12616
     components:
     - type: Transform
       pos: 42.5,-38.5
       parent: 2
-  - uid: 12617
-    components:
-    - type: Transform
-      pos: 34.5,8.5
-      parent: 2
   - uid: 12618
     components:
     - type: Transform
-      pos: -47.5,-49.5
-      parent: 2
-  - uid: 12621
-    components:
-    - type: Transform
-      pos: -12.5,-30.5
-      parent: 2
-  - uid: 12622
-    components:
-    - type: Transform
-      pos: 2.5,-34.5
+      pos: 34.5,-4.5
       parent: 2
   - uid: 12624
     components:
@@ -158338,55 +159275,15 @@ entities:
     - type: Transform
       pos: 49.5,-58.5
       parent: 2
-  - uid: 12628
+  - uid: 12626
     components:
     - type: Transform
-      pos: -0.5,-5.5
-      parent: 2
-  - uid: 12637
-    components:
-    - type: Transform
-      pos: 18.5,-51.5
-      parent: 2
-  - uid: 12648
-    components:
-    - type: Transform
-      pos: 40.5,-4.5
-      parent: 2
-  - uid: 12653
-    components:
-    - type: Transform
-      pos: -50.5,-56.5
-      parent: 2
-  - uid: 12655
-    components:
-    - type: Transform
-      pos: 29.5,-1.5
-      parent: 2
-  - uid: 12656
-    components:
-    - type: Transform
-      pos: -12.5,21.5
-      parent: 2
-  - uid: 12690
-    components:
-    - type: Transform
-      pos: 33.5,-5.5
-      parent: 2
-  - uid: 12691
-    components:
-    - type: Transform
-      pos: 29.5,24.5
+      pos: -10.5,-5.5
       parent: 2
   - uid: 12692
     components:
     - type: Transform
       pos: 63.5,-76.5
-      parent: 2
-  - uid: 12693
-    components:
-    - type: Transform
-      pos: 25.5,-19.5
       parent: 2
   - uid: 12705
     components:
@@ -158398,70 +159295,15 @@ entities:
     - type: Transform
       pos: 92.5,-30.5
       parent: 2
-  - uid: 12722
+  - uid: 12770
     components:
     - type: Transform
-      pos: -26.5,-49.5
-      parent: 2
-  - uid: 12724
-    components:
-    - type: Transform
-      pos: 48.5,-14.5
-      parent: 2
-  - uid: 12726
-    components:
-    - type: Transform
-      pos: 31.5,-28.5
-      parent: 2
-  - uid: 12734
-    components:
-    - type: Transform
-      pos: 22.5,-52.5
-      parent: 2
-  - uid: 12735
-    components:
-    - type: Transform
-      pos: 24.5,-16.5
-      parent: 2
-  - uid: 12751
-    components:
-    - type: Transform
-      pos: -10.5,-14.5
-      parent: 2
-  - uid: 12771
-    components:
-    - type: Transform
-      pos: 33.5,-16.5
-      parent: 2
-  - uid: 12772
-    components:
-    - type: Transform
-      pos: 22.5,-51.5
+      pos: -21.5,-52.5
       parent: 2
   - uid: 12775
     components:
     - type: Transform
       pos: 11.5,-90.5
-      parent: 2
-  - uid: 12780
-    components:
-    - type: Transform
-      pos: 23.5,-2.5
-      parent: 2
-  - uid: 12784
-    components:
-    - type: Transform
-      pos: -20.5,-28.5
-      parent: 2
-  - uid: 12790
-    components:
-    - type: Transform
-      pos: 47.5,-10.5
-      parent: 2
-  - uid: 12799
-    components:
-    - type: Transform
-      pos: -40.5,-25.5
       parent: 2
   - uid: 12800
     components:
@@ -158471,127 +159313,47 @@ entities:
   - uid: 12801
     components:
     - type: Transform
-      pos: -21.5,-30.5
+      pos: 40.5,-5.5
       parent: 2
   - uid: 12806
     components:
     - type: Transform
       pos: 66.5,-73.5
       parent: 2
-  - uid: 12807
-    components:
-    - type: Transform
-      pos: 44.5,-31.5
-      parent: 2
-  - uid: 12809
-    components:
-    - type: Transform
-      pos: 37.5,7.5
-      parent: 2
-  - uid: 12810
-    components:
-    - type: Transform
-      pos: -23.5,-54.5
-      parent: 2
-  - uid: 12811
-    components:
-    - type: Transform
-      pos: 2.5,-33.5
-      parent: 2
-  - uid: 12812
-    components:
-    - type: Transform
-      pos: 13.5,-12.5
-      parent: 2
   - uid: 12813
     components:
     - type: Transform
       pos: 94.5,-20.5
-      parent: 2
-  - uid: 12825
-    components:
-    - type: Transform
-      pos: 37.5,-39.5
-      parent: 2
-  - uid: 12846
-    components:
-    - type: Transform
-      pos: -51.5,-47.5
-      parent: 2
-  - uid: 12848
-    components:
-    - type: Transform
-      pos: 31.5,-26.5
-      parent: 2
-  - uid: 12853
-    components:
-    - type: Transform
-      pos: -46.5,-34.5
       parent: 2
   - uid: 12858
     components:
     - type: Transform
       pos: 85.5,-17.5
       parent: 2
-  - uid: 12859
+  - uid: 12942
     components:
     - type: Transform
-      pos: 40.5,-3.5
+      pos: 42.5,-8.5
       parent: 2
-  - uid: 12902
+  - uid: 13014
     components:
     - type: Transform
-      pos: -6.5,-16.5
-      parent: 2
-  - uid: 12921
-    components:
-    - type: Transform
-      pos: 47.5,-23.5
-      parent: 2
-  - uid: 12982
-    components:
-    - type: Transform
-      pos: 2.5,-29.5
-      parent: 2
-  - uid: 13027
-    components:
-    - type: Transform
-      pos: 19.5,-34.5
-      parent: 2
-  - uid: 13057
-    components:
-    - type: Transform
-      pos: -44.5,-52.5
+      pos: 33.5,-15.5
       parent: 2
   - uid: 13123
     components:
     - type: Transform
       pos: 69.5,-67.5
       parent: 2
-  - uid: 13124
-    components:
-    - type: Transform
-      pos: 2.5,-30.5
-      parent: 2
   - uid: 13132
     components:
     - type: Transform
       pos: 26.5,-57.5
       parent: 2
-  - uid: 13141
-    components:
-    - type: Transform
-      pos: 24.5,4.5
-      parent: 2
   - uid: 13157
     components:
     - type: Transform
-      pos: -18.5,-28.5
-      parent: 2
-  - uid: 13167
-    components:
-    - type: Transform
-      pos: 19.5,-2.5
+      pos: 2.5,-15.5
       parent: 2
   - uid: 13191
     components:
@@ -158608,65 +159370,20 @@ entities:
     - type: Transform
       pos: 43.5,-38.5
       parent: 2
-  - uid: 13209
+  - uid: 13215
     components:
     - type: Transform
-      pos: -40.5,-38.5
-      parent: 2
-  - uid: 13211
-    components:
-    - type: Transform
-      pos: 25.5,-15.5
-      parent: 2
-  - uid: 13219
-    components:
-    - type: Transform
-      pos: 19.5,-37.5
-      parent: 2
-  - uid: 13221
-    components:
-    - type: Transform
-      pos: -12.5,20.5
-      parent: 2
-  - uid: 13223
-    components:
-    - type: Transform
-      pos: 30.5,-45.5
-      parent: 2
-  - uid: 13224
-    components:
-    - type: Transform
-      pos: -21.5,-26.5
-      parent: 2
-  - uid: 13225
-    components:
-    - type: Transform
-      pos: 14.5,-54.5
+      pos: -23.5,-56.5
       parent: 2
   - uid: 13227
     components:
     - type: Transform
       pos: 72.5,-75.5
       parent: 2
-  - uid: 13229
-    components:
-    - type: Transform
-      pos: 22.5,-14.5
-      parent: 2
-  - uid: 13250
-    components:
-    - type: Transform
-      pos: 17.5,1.5
-      parent: 2
   - uid: 13252
     components:
     - type: Transform
-      pos: 2.5,-31.5
-      parent: 2
-  - uid: 13257
-    components:
-    - type: Transform
-      pos: 29.5,-15.5
+      pos: -42.5,-47.5
       parent: 2
   - uid: 13268
     components:
@@ -158676,37 +159393,22 @@ entities:
   - uid: 13269
     components:
     - type: Transform
-      pos: -39.5,-46.5
+      pos: 35.5,-39.5
       parent: 2
   - uid: 13273
     components:
     - type: Transform
-      pos: 8.5,-35.5
+      pos: 16.5,-52.5
       parent: 2
   - uid: 13274
     components:
     - type: Transform
       pos: -5.5,-92.5
       parent: 2
-  - uid: 13281
-    components:
-    - type: Transform
-      pos: 46.5,-4.5
-      parent: 2
-  - uid: 13287
-    components:
-    - type: Transform
-      pos: -20.5,-21.5
-      parent: 2
-  - uid: 13289
-    components:
-    - type: Transform
-      pos: 17.5,-57.5
-      parent: 2
   - uid: 13292
     components:
     - type: Transform
-      pos: 39.5,-10.5
+      pos: 28.5,-13.5
       parent: 2
   - uid: 13296
     components:
@@ -158718,385 +159420,110 @@ entities:
     - type: Transform
       pos: 67.5,-59.5
       parent: 2
-  - uid: 13364
-    components:
-    - type: Transform
-      pos: -16.5,18.5
-      parent: 2
   - uid: 13391
     components:
     - type: Transform
-      pos: -11.5,-16.5
-      parent: 2
-  - uid: 13392
-    components:
-    - type: Transform
-      pos: 5.5,-46.5
-      parent: 2
-  - uid: 13395
-    components:
-    - type: Transform
-      pos: 27.5,14.5
-      parent: 2
-  - uid: 13397
-    components:
-    - type: Transform
-      pos: 40.5,10.5
+      pos: -40.5,14.5
       parent: 2
   - uid: 13401
     components:
     - type: Transform
       pos: 41.5,-54.5
       parent: 2
-  - uid: 13404
-    components:
-    - type: Transform
-      pos: 33.5,-10.5
-      parent: 2
-  - uid: 13407
-    components:
-    - type: Transform
-      pos: -10.5,18.5
-      parent: 2
-  - uid: 13408
-    components:
-    - type: Transform
-      pos: -14.5,-39.5
-      parent: 2
   - uid: 13409
     components:
     - type: Transform
       pos: 5.5,-89.5
-      parent: 2
-  - uid: 13469
-    components:
-    - type: Transform
-      pos: -10.5,-33.5
       parent: 2
   - uid: 13531
     components:
     - type: Transform
       pos: 45.5,-40.5
       parent: 2
-  - uid: 13540
-    components:
-    - type: Transform
-      pos: 29.5,-11.5
-      parent: 2
-  - uid: 13663
-    components:
-    - type: Transform
-      pos: -12.5,19.5
-      parent: 2
-  - uid: 13667
-    components:
-    - type: Transform
-      pos: 16.5,-46.5
-      parent: 2
-  - uid: 13668
-    components:
-    - type: Transform
-      pos: 42.5,-5.5
-      parent: 2
-  - uid: 13669
-    components:
-    - type: Transform
-      pos: 30.5,16.5
-      parent: 2
-  - uid: 13671
-    components:
-    - type: Transform
-      pos: -47.5,-50.5
-      parent: 2
-  - uid: 13674
-    components:
-    - type: Transform
-      pos: 27.5,-15.5
-      parent: 2
   - uid: 13691
     components:
     - type: Transform
       pos: 44.5,-34.5
-      parent: 2
-  - uid: 13693
-    components:
-    - type: Transform
-      pos: -35.5,-56.5
-      parent: 2
-  - uid: 13704
-    components:
-    - type: Transform
-      pos: 20.5,-57.5
       parent: 2
   - uid: 13706
     components:
     - type: Transform
       pos: 71.5,-67.5
       parent: 2
-  - uid: 13724
+  - uid: 13727
     components:
     - type: Transform
-      pos: 12.5,-34.5
-      parent: 2
-  - uid: 13725
-    components:
-    - type: Transform
-      pos: 2.5,21.5
-      parent: 2
-  - uid: 13735
-    components:
-    - type: Transform
-      pos: -17.5,-44.5
-      parent: 2
-  - uid: 13736
-    components:
-    - type: Transform
-      pos: 25.5,9.5
-      parent: 2
-  - uid: 13738
-    components:
-    - type: Transform
-      pos: 29.5,-5.5
-      parent: 2
-  - uid: 13758
-    components:
-    - type: Transform
-      pos: 14.5,-8.5
-      parent: 2
-  - uid: 13762
-    components:
-    - type: Transform
-      pos: 39.5,-2.5
-      parent: 2
-  - uid: 13765
-    components:
-    - type: Transform
-      pos: 29.5,3.5
-      parent: 2
-  - uid: 13773
-    components:
-    - type: Transform
-      pos: -12.5,-49.5
-      parent: 2
-  - uid: 13779
-    components:
-    - type: Transform
-      pos: 1.5,-30.5
+      pos: -13.5,-35.5
       parent: 2
   - uid: 13782
     components:
     - type: Transform
       pos: 54.5,-52.5
       parent: 2
-  - uid: 13783
-    components:
-    - type: Transform
-      pos: 30.5,-39.5
-      parent: 2
   - uid: 13794
     components:
     - type: Transform
-      pos: -14.5,21.5
+      pos: 29.5,-0.5
       parent: 2
   - uid: 13812
     components:
     - type: Transform
       pos: 49.5,-26.5
       parent: 2
-  - uid: 13813
-    components:
-    - type: Transform
-      pos: 22.5,-45.5
-      parent: 2
-  - uid: 13866
-    components:
-    - type: Transform
-      pos: -12.5,-29.5
-      parent: 2
-  - uid: 13867
-    components:
-    - type: Transform
-      pos: 19.5,-38.5
-      parent: 2
-  - uid: 13880
-    components:
-    - type: Transform
-      pos: -21.5,-35.5
-      parent: 2
-  - uid: 13882
-    components:
-    - type: Transform
-      pos: 24.5,9.5
-      parent: 2
-  - uid: 13883
-    components:
-    - type: Transform
-      pos: 7.5,-46.5
-      parent: 2
-  - uid: 13887
-    components:
-    - type: Transform
-      pos: 12.5,-58.5
-      parent: 2
-  - uid: 13892
-    components:
-    - type: Transform
-      pos: -41.5,-24.5
-      parent: 2
-  - uid: 13897
-    components:
-    - type: Transform
-      pos: -35.5,-49.5
-      parent: 2
-  - uid: 13900
-    components:
-    - type: Transform
-      pos: 2.5,-46.5
-      parent: 2
-  - uid: 13901
-    components:
-    - type: Transform
-      pos: -45.5,-33.5
-      parent: 2
-  - uid: 13903
-    components:
-    - type: Transform
-      pos: 22.5,-54.5
-      parent: 2
-  - uid: 13904
-    components:
-    - type: Transform
-      pos: 12.5,-54.5
-      parent: 2
-  - uid: 13906
-    components:
-    - type: Transform
-      pos: 12.5,-35.5
-      parent: 2
-  - uid: 13908
-    components:
-    - type: Transform
-      pos: 7.5,-26.5
-      parent: 2
-  - uid: 13912
-    components:
-    - type: Transform
-      pos: -18.5,21.5
-      parent: 2
-  - uid: 13914
-    components:
-    - type: Transform
-      pos: -25.5,-49.5
-      parent: 2
-  - uid: 13917
-    components:
-    - type: Transform
-      pos: 22.5,-18.5
-      parent: 2
   - uid: 13922
     components:
     - type: Transform
       pos: -2.5,-96.5
-      parent: 2
-  - uid: 13975
-    components:
-    - type: Transform
-      pos: 46.5,-10.5
-      parent: 2
-  - uid: 14094
-    components:
-    - type: Transform
-      pos: 40.5,-12.5
       parent: 2
   - uid: 14095
     components:
     - type: Transform
       pos: 10.5,-91.5
       parent: 2
-  - uid: 14098
-    components:
-    - type: Transform
-      pos: 26.5,-40.5
-      parent: 2
   - uid: 14099
     components:
     - type: Transform
       pos: 23.5,-58.5
       parent: 2
-  - uid: 14100
-    components:
-    - type: Transform
-      pos: -20.5,-35.5
-      parent: 2
-  - uid: 14101
-    components:
-    - type: Transform
-      pos: 20.5,-12.5
-      parent: 2
-  - uid: 14102
-    components:
-    - type: Transform
-      pos: 12.5,-37.5
-      parent: 2
   - uid: 14104
     components:
     - type: Transform
-      pos: -10.5,-0.5
+      pos: 2.5,-28.5
       parent: 2
-  - uid: 14131
+  - uid: 14105
     components:
     - type: Transform
-      pos: 44.5,-27.5
-      parent: 2
-  - uid: 14132
-    components:
-    - type: Transform
-      pos: 39.5,-0.5
-      parent: 2
-  - uid: 14133
-    components:
-    - type: Transform
-      pos: 16.5,-48.5
+      pos: 23.5,-1.5
       parent: 2
   - uid: 14137
     components:
     - type: Transform
-      pos: 34.5,-1.5
+      pos: -34.5,-16.5
       parent: 2
   - uid: 14150
     components:
     - type: Transform
       pos: -2.5,-97.5
       parent: 2
-  - uid: 14151
+  - uid: 14175
     components:
     - type: Transform
-      pos: -52.5,-31.5
-      parent: 2
-  - uid: 14179
-    components:
-    - type: Transform
-      pos: -47.5,-55.5
-      parent: 2
-  - uid: 14181
-    components:
-    - type: Transform
-      pos: 35.5,-5.5
+      pos: -36.5,-47.5
       parent: 2
   - uid: 14190
     components:
     - type: Transform
-      pos: 13.5,18.5
+      pos: 15.5,-5.5
       parent: 2
-  - uid: 14247
+  - uid: 14235
     components:
     - type: Transform
-      pos: -6.5,-9.5
+      pos: -27.5,22.5
       parent: 2
-  - uid: 14263
+  - uid: 14265
     components:
     - type: Transform
-      pos: 35.5,16.5
+      pos: -12.5,21.5
       parent: 2
   - uid: 14276
     components:
@@ -159106,12 +159533,12 @@ entities:
   - uid: 14279
     components:
     - type: Transform
-      pos: -21.5,-51.5
+      pos: 30.5,-46.5
       parent: 2
   - uid: 14280
     components:
     - type: Transform
-      pos: 18.5,-1.5
+      pos: 30.5,-44.5
       parent: 2
   - uid: 14314
     components:
@@ -159126,47 +159553,12 @@ entities:
   - uid: 14348
     components:
     - type: Transform
-      pos: -10.5,-5.5
-      parent: 2
-  - uid: 14365
-    components:
-    - type: Transform
-      pos: -13.5,-37.5
-      parent: 2
-  - uid: 14379
-    components:
-    - type: Transform
-      pos: -0.5,-16.5
+      pos: 19.5,-55.5
       parent: 2
   - uid: 14386
     components:
     - type: Transform
       pos: 86.5,-18.5
-      parent: 2
-  - uid: 14399
-    components:
-    - type: Transform
-      pos: 9.5,21.5
-      parent: 2
-  - uid: 14413
-    components:
-    - type: Transform
-      pos: 33.5,-15.5
-      parent: 2
-  - uid: 14456
-    components:
-    - type: Transform
-      pos: 29.5,-0.5
-      parent: 2
-  - uid: 14477
-    components:
-    - type: Transform
-      pos: 38.5,-0.5
-      parent: 2
-  - uid: 14479
-    components:
-    - type: Transform
-      pos: 39.5,-12.5
       parent: 2
   - uid: 14481
     components:
@@ -159176,12 +159568,7 @@ entities:
   - uid: 14484
     components:
     - type: Transform
-      pos: 23.5,-39.5
-      parent: 2
-  - uid: 14496
-    components:
-    - type: Transform
-      pos: 5.5,-35.5
+      pos: 15.5,-7.5
       parent: 2
   - uid: 14501
     components:
@@ -159191,72 +159578,32 @@ entities:
   - uid: 14503
     components:
     - type: Transform
-      pos: 23.5,3.5
-      parent: 2
-  - uid: 14509
-    components:
-    - type: Transform
-      pos: -14.5,19.5
-      parent: 2
-  - uid: 14510
-    components:
-    - type: Transform
-      pos: -21.5,-25.5
-      parent: 2
-  - uid: 14517
-    components:
-    - type: Transform
-      pos: 35.5,15.5
+      pos: 47.5,-6.5
       parent: 2
   - uid: 14525
     components:
     - type: Transform
-      pos: 16.5,-50.5
+      pos: 22.5,-12.5
       parent: 2
-  - uid: 14543
+  - uid: 14550
     components:
     - type: Transform
-      pos: 18.5,-53.5
-      parent: 2
-  - uid: 14715
-    components:
-    - type: Transform
-      pos: -46.5,-33.5
-      parent: 2
-  - uid: 14744
-    components:
-    - type: Transform
-      pos: 19.5,-12.5
+      pos: 12.5,-46.5
       parent: 2
   - uid: 14773
     components:
     - type: Transform
-      pos: 6.5,-35.5
+      pos: -17.5,-26.5
       parent: 2
   - uid: 14787
     components:
     - type: Transform
-      pos: 22.5,-50.5
-      parent: 2
-  - uid: 14792
-    components:
-    - type: Transform
-      pos: 10.5,22.5
+      pos: 25.5,9.5
       parent: 2
   - uid: 14811
     components:
     - type: Transform
       pos: 66.5,-74.5
-      parent: 2
-  - uid: 14816
-    components:
-    - type: Transform
-      pos: 16.5,-45.5
-      parent: 2
-  - uid: 14825
-    components:
-    - type: Transform
-      pos: -50.5,-51.5
       parent: 2
   - uid: 14833
     components:
@@ -159271,17 +159618,72 @@ entities:
   - uid: 14853
     components:
     - type: Transform
-      pos: 22.5,-1.5
+      pos: -50.5,-55.5
       parent: 2
-  - uid: 14906
+  - uid: 15008
     components:
     - type: Transform
-      pos: 39.5,-1.5
+      pos: 1.5,-16.5
       parent: 2
-  - uid: 14908
+  - uid: 15013
     components:
     - type: Transform
-      pos: 6.5,-37.5
+      pos: 22.5,-16.5
+      parent: 2
+  - uid: 15025
+    components:
+    - type: Transform
+      pos: 18.5,-1.5
+      parent: 2
+  - uid: 15045
+    components:
+    - type: Transform
+      pos: 19.5,-38.5
+      parent: 2
+  - uid: 15168
+    components:
+    - type: Transform
+      pos: 44.5,-9.5
+      parent: 2
+  - uid: 15251
+    components:
+    - type: Transform
+      pos: -25.5,-49.5
+      parent: 2
+  - uid: 15375
+    components:
+    - type: Transform
+      pos: 15.5,-0.5
+      parent: 2
+  - uid: 15475
+    components:
+    - type: Transform
+      pos: -30.5,22.5
+      parent: 2
+  - uid: 15730
+    components:
+    - type: Transform
+      pos: -50.5,9.5
+      parent: 2
+  - uid: 15732
+    components:
+    - type: Transform
+      pos: 17.5,-12.5
+      parent: 2
+  - uid: 15882
+    components:
+    - type: Transform
+      pos: -0.5,-16.5
+      parent: 2
+  - uid: 15883
+    components:
+    - type: Transform
+      pos: 7.5,-46.5
+      parent: 2
+  - uid: 15896
+    components:
+    - type: Transform
+      pos: -30.5,19.5
       parent: 2
   - uid: 15900
     components:
@@ -159291,112 +159693,32 @@ entities:
   - uid: 15944
     components:
     - type: Transform
-      pos: -44.5,-54.5
+      pos: -39.5,-25.5
       parent: 2
-  - uid: 15959
+  - uid: 15952
     components:
     - type: Transform
-      pos: 39.5,-14.5
+      pos: -10.5,-4.5
       parent: 2
-  - uid: 15971
+  - uid: 16170
     components:
     - type: Transform
-      pos: 15.5,-7.5
+      pos: -27.5,21.5
       parent: 2
-  - uid: 15998
+  - uid: 16360
     components:
     - type: Transform
-      pos: 12.5,-52.5
+      pos: -16.5,-49.5
       parent: 2
-  - uid: 16827
+  - uid: 16530
     components:
     - type: Transform
-      pos: 29.5,0.5
+      pos: -29.5,-23.5
       parent: 2
-  - uid: 16995
+  - uid: 16894
     components:
     - type: Transform
-      pos: -13.5,-9.5
-      parent: 2
-  - uid: 18388
-    components:
-    - type: Transform
-      pos: -13.5,-35.5
-      parent: 2
-  - uid: 18516
-    components:
-    - type: Transform
-      pos: 22.5,-48.5
-      parent: 2
-  - uid: 18724
-    components:
-    - type: Transform
-      pos: 1.5,21.5
-      parent: 2
-  - uid: 19240
-    components:
-    - type: Transform
-      pos: 26.5,9.5
-      parent: 2
-  - uid: 19245
-    components:
-    - type: Transform
-      pos: 35.5,-0.5
-      parent: 2
-  - uid: 19261
-    components:
-    - type: Transform
-      pos: 35.5,12.5
-      parent: 2
-  - uid: 19348
-    components:
-    - type: Transform
-      pos: -10.5,-35.5
-      parent: 2
-  - uid: 19626
-    components:
-    - type: Transform
-      pos: 39.5,7.5
-      parent: 2
-  - uid: 20122
-    components:
-    - type: Transform
-      pos: 44.5,-9.5
-      parent: 2
-  - uid: 20166
-    components:
-    - type: Transform
-      pos: 16.5,-52.5
-      parent: 2
-  - uid: 21363
-    components:
-    - type: Transform
-      pos: -45.5,-49.5
-      parent: 2
-  - uid: 21438
-    components:
-    - type: Transform
-      pos: 5.5,-26.5
-      parent: 2
-  - uid: 22016
-    components:
-    - type: Transform
-      pos: 34.5,-7.5
-      parent: 2
-  - uid: 22101
-    components:
-    - type: Transform
-      pos: -21.5,-52.5
-      parent: 2
-  - uid: 22102
-    components:
-    - type: Transform
-      pos: -21.5,-39.5
-      parent: 2
-  - uid: 22108
-    components:
-    - type: Transform
-      pos: 13.5,-50.5
+      pos: -17.5,17.5
       parent: 2
   - uid: 23607
     components:
@@ -159708,6 +160030,15 @@ entities:
     - type: Transform
       pos: -37.5,-6.5
       parent: 2
+- proto: WeaponLaserCarbine
+  entities:
+  - uid: 114
+    components:
+    - type: Transform
+      parent: 20614
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: WeaponShotgunEnforcer
   entities:
   - uid: 20591
@@ -159904,6 +160235,62 @@ entities:
     - type: Transform
       pos: -19.5,-43.5
       parent: 2
+  - uid: 12154
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -25.5,-4.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        11782:
+        - - DoorStatus
+          - Close
+        11789:
+        - - DoorStatus
+          - Close
+  - uid: 12217
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,-4.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        11789:
+        - - DoorStatus
+          - Close
+        11782:
+        - - DoorStatus
+          - Close
+  - uid: 20565
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-15.5
+      parent: 2
+  - uid: 20568
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-3.5
+      parent: 2
+  - uid: 21410
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-2.5
+      parent: 2
+  - uid: 22474
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-14.5
+      parent: 2
 - proto: WindoorChapelLocked
   entities:
   - uid: 5903
@@ -159942,24 +160329,6 @@ entities:
       parent: 2
 - proto: WindoorSecure
   entities:
-  - uid: 79
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-15.5
-      parent: 2
-  - uid: 1210
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-2.5
-      parent: 2
-  - uid: 2179
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-3.5
-      parent: 2
   - uid: 3235
     components:
     - type: Transform
@@ -160033,29 +160402,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -31.5,3.5
       parent: 2
-  - uid: 11974
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-4.5
-      parent: 2
-  - uid: 11976
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,-4.5
-      parent: 2
   - uid: 12433
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,17.5
-      parent: 2
-  - uid: 17659
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-14.5
       parent: 2
   - uid: 18592
     components:
@@ -160108,11 +160459,31 @@ entities:
     - type: Transform
       pos: -25.5,-4.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        12154:
+        - - DoorStatus
+          - Close
+        12217:
+        - - DoorStatus
+          - Close
   - uid: 11789
     components:
     - type: Transform
       pos: -24.5,-4.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        12217:
+        - - DoorStatus
+          - Close
+        12154:
+        - - DoorStatus
+          - Close
 - proto: WindoorSecureAtmosphericsLocked
   entities:
   - uid: 2181
@@ -160426,6 +160797,11 @@ entities:
       parent: 2
 - proto: WindoorSecureSecurityLocked
   entities:
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -39.5,-0.5
+      parent: 2
   - uid: 11625
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Turns out I forgot to give sec beacons and barriers

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Missing important things

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

### Render 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Southbridge
- fix: On Amber, gave security its missing beacon and barriers.

