### PR TITLE
Adds Wizard's Den (Replaces Wizard Shuttle)

### DIFF
--- a/Resources/Maps/Nonstations/wizardsden.yml
+++ b/Resources/Maps/Nonstations/wizardsden.yml
@@ -1,0 +1,4464 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 260.2.0
+  forkId: ""
+  forkVersion: ""
+  time: 05/21/2025 22:03:24
+  entityCount: 684
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  3: Space
+  2: FloorBasalt
+  6: FloorDark
+  0: FloorDarkDiagonal
+  5: FloorDarkMono
+  4: FloorDarkPavementVertical
+  9: FloorShowroom
+  14: FloorTechMaint
+  13: FloorTechMaint2
+  12: FloorWhite
+  11: FloorWhiteMini
+  7: FloorWood
+  8: FloorWoodTile
+  10: Lattice
+  1: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Wizard's Den
+    - type: Transform
+      pos: -0.5138889,-0.4756779
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AAAAAAABAAAAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAwAAAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAEAAAAAAIABQAAAAACAAIAAAAAAAACAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABQAAAAACAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAYAAAAAAQAGAAAAAAMABgAAAAADAAYAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAHAAAAAAIABwAAAAACAAgAAAAAAQAGAAAAAAMABgAAAAACAAEAAAAAAAAJAAAAAAAAAQAAAAAAAAkAAAAAAAABAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABwAAAAADAAcAAAAAAQAIAAAAAAAACAAAAAACAAYAAAAAAQABAAAAAAAACQAAAAAAAAEAAAAAAAAJAAAAAAAAAQAAAAAAAAoAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAcAAAAAAwAHAAAAAAAACAAAAAAAAAgAAAAAAwAGAAAAAAAAAQAAAAAAAAsAAAAAAwALAAAAAAMACwAAAAABAAEAAAAAAAAKAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAHAAAAAAIABwAAAAACAAgAAAAAAwAIAAAAAAIABgAAAAADAAUAAAAAAgALAAAAAAMACwAAAAAAAAEAAAAAAAABAAAAAAAACgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABwAAAAADAAcAAAAAAgAIAAAAAAMACAAAAAABAAYAAAAAAgABAAAAAAAADAAAAAACAAwAAAAAAAABAAAAAAAACgAAAAAAAAoAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAcAAAAAAQAHAAAAAAIACAAAAAACAAgAAAAAAAAGAAAAAAIAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAoAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAHAAAAAAAABwAAAAABAAYAAAAAAwAGAAAAAAMABgAAAAAAAAEAAAAAAAAKAAAAAAAACgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABgAAAAAAAAYAAAAAAQAGAAAAAAEABgAAAAADAAEAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAYAAAAAAgAGAAAAAAIABgAAAAADAAEAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAAAAAAACAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAAAAAAAAQADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAAFAAAAAAMAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAGAAAAAAEABgAAAAADAAYAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAQAAAAAAAAcAAAAAAQAIAAAAAAEACAAAAAABAAEAAAAAAAAGAAAAAAMABgAAAAACAAgAAAAAAgAHAAAAAAMAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAEAAAAAAAAHAAAAAAIACAAAAAAAAAgAAAAAAQABAAAAAAAABgAAAAACAAgAAAAAAQAIAAAAAAIABwAAAAACAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAoAAAAAAAABAAAAAAAABwAAAAACAAcAAAAAAwAHAAAAAAMAAQAAAAAAAAYAAAAAAgAIAAAAAAEACAAAAAABAAcAAAAAAgADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAKAAAAAAAAAQAAAAAAAAEAAAAAAAAGAAAAAAIABgAAAAABAAUAAAAAAgAGAAAAAAAACAAAAAACAAgAAAAAAAAHAAAAAAEAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAACgAAAAAAAAoAAAAAAAABAAAAAAAABgAAAAAAAAYAAAAAAQABAAAAAAAABgAAAAACAAgAAAAAAgAIAAAAAAMABwAAAAABAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAKAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAYAAAAAAgAIAAAAAAAACAAAAAADAAcAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAKAAAAAAAACgAAAAAAAAEAAAAAAAAGAAAAAAIABgAAAAACAAYAAAAAAQAHAAAAAAMAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAYAAAAAAAAGAAAAAAIABgAAAAACAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAABgAAAAAAAAYAAAAAAwADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAA==
+          version: 7
+        -1,-1:
+          ind: -1,-1
+          tiles: AwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAANAAAAAAAAAQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAADQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAAOAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAAFAAAAAAEAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAAAAAAABAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: AgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAANAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAADQAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAADgAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAADQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAUAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAEAAAAAAEABQAAAAADAAIAAAAAAAACAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAADAAAAAAAAAQABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: ImplicitRoof
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            93: -2,-9
+            94: -2,-10
+            95: 2,-9
+            96: 2,-10
+            148: 0,13
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNe
+          decals:
+            10: 1,1
+            35: -2,2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNw
+          decals:
+            9: -1,1
+            36: 2,2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSe
+          decals:
+            11: 1,-1
+            37: -2,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSw
+          decals:
+            12: -1,-1
+            38: 2,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineE
+          decals:
+            15: 1,0
+            26: -2,1
+            27: -2,0
+            28: -2,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineN
+          decals:
+            16: 0,1
+            41: -3,2
+            42: 3,2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineS
+          decals:
+            13: 0,-1
+            39: -3,-2
+            40: 3,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineW
+          decals:
+            14: -1,0
+            31: 2,-1
+            32: 2,0
+            33: 2,1
+        - node:
+            color: '#52B4E996'
+            id: CheckerNWSE
+          decals:
+            107: 6,9
+            108: 7,9
+            109: 8,6
+            110: 8,5
+            111: 6,6
+            112: 6,5
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            161: 0,-7
+        - node:
+            color: '#8D03A5FF'
+            id: DiagonalCheckerAOverlay
+          decals:
+            0: -1,1
+            1: -1,0
+            2: -1,-1
+            3: 0,-1
+            4: 1,-1
+            5: 1,0
+            6: 0,0
+            7: 0,1
+            8: 1,1
+        - node:
+            color: '#8D03A566'
+            id: HalfTileOverlayGreyscale
+          decals:
+            147: 0,13
+        - node:
+            color: '#52B4E996'
+            id: MiniTileCheckerBOverlay
+          decals:
+            102: 6,7
+            103: 7,7
+            104: 8,7
+            105: 7,8
+            106: 6,8
+        - node:
+            color: '#8D03A566'
+            id: QuarterTileOverlayGreyscale
+          decals:
+            113: -4,5
+            114: -4,6
+            115: -4,7
+            116: -4,8
+            117: -4,9
+            118: -4,10
+            119: -4,11
+            139: -3,4
+            142: -2,13
+            143: -1,13
+            155: -3,11
+            156: -3,12
+            157: -2,12
+        - node:
+            color: '#8D03A566'
+            id: QuarterTileOverlayGreyscale180
+          decals:
+            135: -1,4
+            136: -2,4
+            137: -3,4
+            138: -4,5
+        - node:
+            color: '#8D03A566'
+            id: QuarterTileOverlayGreyscale270
+          decals:
+            131: 4,5
+            132: 3,4
+            133: 2,4
+            134: 1,4
+        - node:
+            color: '#8D03A566'
+            id: QuarterTileOverlayGreyscale90
+          decals:
+            122: 4,5
+            123: 4,6
+            124: 4,7
+            125: 4,8
+            126: 4,9
+            127: 4,10
+            128: 4,11
+            140: 3,4
+            145: 2,13
+            146: 1,13
+            158: 3,11
+            159: 3,12
+            160: 2,12
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Remains
+          decals:
+            17: 3,-5
+            18: -6,1
+        - node:
+            color: '#FFFFFFFF'
+            id: Rock03
+          decals:
+            20: 1.799864,-4.383193
+        - node:
+            color: '#FFFFFFFF'
+            id: Rock05
+          decals:
+            19: -3.3147194,-5.9780507
+        - node:
+            color: '#FFFFFFFF'
+            id: Rock06
+          decals:
+            22: 3.268614,-6.9995937
+            23: 5.231406,1.6660407
+        - node:
+            color: '#FFFFFFFF'
+            id: Rock07
+          decals:
+            21: -2.8668027,-4.2268343
+            24: -5.185261,-1.8468163
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerNE
+          decals:
+            89: 1,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerNW
+          decals:
+            88: -1,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallNE
+          decals:
+            100: -2,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallNW
+          decals:
+            101: 2,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallSE
+          decals:
+            84: -2,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallSW
+          decals:
+            85: 2,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            90: 1,-11
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineN
+          decals:
+            81: 0,-6
+            82: -1,-6
+            83: 1,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            92: -1,-11
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            87: 0,-10
+            97: 0,-4
+            98: -1,-4
+            99: 1,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNe
+          decals:
+            60: -3,5
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNw
+          decals:
+            59: 3,5
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            152: -2,11
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSw
+          decals:
+            151: 2,11
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerNe
+          decals:
+            61: -3,4
+            66: -4,5
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerNw
+          decals:
+            62: 3,4
+            67: 4,5
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerSe
+          decals:
+            68: -4,11
+            154: -2,12
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerSw
+          decals:
+            65: 4,11
+            153: 2,12
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            69: -4,10
+            70: -4,9
+            71: -4,8
+            72: -4,7
+            73: -4,6
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            43: -2,4
+            44: -1,4
+            45: 0,4
+            46: 1,4
+            47: 2,4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            51: -1,12
+            52: 0,12
+            53: 1,12
+            79: -7,8
+            80: -6,8
+            149: -3,11
+            150: 3,11
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineW
+          decals:
+            74: 4,6
+            75: 4,7
+            76: 4,8
+            77: 4,9
+            78: 4,10
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 4095
+          0,-1:
+            0: 65295
+          -1,0:
+            0: 3822
+          0,1:
+            0: 65535
+          -1,1:
+            0: 65534
+          0,2:
+            0: 65535
+          -1,2:
+            0: 65535
+          0,3:
+            0: 127
+          -1,3:
+            0: 206
+          1,1:
+            0: 54608
+          1,2:
+            0: 4573
+            1: 49152
+          1,0:
+            0: 1638
+          1,-1:
+            0: 26112
+          2,1:
+            0: 4368
+            1: 17408
+          2,0:
+            0: 32
+          2,2:
+            1: 612
+          -3,1:
+            1: 16384
+          -3,2:
+            1: 2244
+          -2,1:
+            0: 30576
+          -2,2:
+            0: 102
+            1: 24576
+          -2,0:
+            0: 3276
+          -2,-1:
+            0: 52225
+          -1,-1:
+            0: 60942
+          -2,-2:
+            0: 2176
+          -1,-3:
+            0: 56448
+          -1,-2:
+            0: 65337
+          -1,-4:
+            0: 1024
+          0,-3:
+            0: 30512
+          0,-2:
+            0: 65427
+          1,-2:
+            0: 272
+          1,-3:
+            0: 16384
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: IFF
+      color: '#BF40BFFF'
+- proto: AirCanister
+  entities:
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 1
+- proto: AirlockSyndicate
+  entities:
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,9.5
+      parent: 1
+- proto: BarberScissors
+  entities:
+  - uid: 649
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+- proto: BarSignTheAleNath
+  entities:
+  - uid: 654
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+- proto: Bed
+  entities:
+  - uid: 503
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+- proto: BedsheetWiz
+  entities:
+  - uid: 506
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,5.5
+      parent: 1
+- proto: BookNarsieLegend
+  entities:
+  - uid: 362
+    components:
+    - type: Transform
+      pos: -1.9141665,4.7120576
+      parent: 1
+- proto: BookRandomStory
+  entities:
+  - uid: 466
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+- proto: BooksBag
+  entities:
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+- proto: Bookshelf
+  entities:
+  - uid: 471
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 475
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+- proto: BookshelfFilled
+  entities:
+  - uid: 343
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 346
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 419
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 420
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 421
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 422
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 438
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 447
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 449
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 450
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 566
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 567
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 568
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 569
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 570
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 571
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 572
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 582
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 584
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 655
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 679
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 680
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 681
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 682
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 683
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 684
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 257
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 418
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 574
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 578
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 579
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 580
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 581
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 583
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-10.5
+      parent: 1
+- proto: CandleBlackInfinite
+  entities:
+  - uid: 352
+    components:
+    - type: Transform
+      pos: 0.34585947,8.704459
+      parent: 1
+- proto: CandleBlueSmallInfinite
+  entities:
+  - uid: 388
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.9964747,13.631708
+      parent: 1
+- proto: CandleGreenSmallInfinite
+  entities:
+  - uid: 351
+    components:
+    - type: Transform
+      pos: 0.5854428,8.558525
+      parent: 1
+- proto: CandleInfinite
+  entities:
+  - uid: 407
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+- proto: CandleRedSmallInfinite
+  entities:
+  - uid: 408
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.2612925,4.618674
+      parent: 1
+- proto: CarpetBlack
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+- proto: CarpetPurple
+  entities:
+  - uid: 342
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 514
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 515
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 516
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 517
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-8.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 467
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,12.5
+      parent: 1
+- proto: ChairWood
+  entities:
+  - uid: 468
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 512
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,6.5
+      parent: 1
+- proto: ClockworkShield
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -1.4069316,1.4175825
+      parent: 1
+- proto: ClothingBeltUtilityFilled
+  entities:
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+- proto: ClothingBeltWand
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 2.5877786,0.864011
+      parent: 1
+- proto: ClothingHandsGlovesCombat
+  entities:
+  - uid: 411
+    components:
+    - type: Transform
+      pos: -0.54519194,13.694252
+      parent: 1
+- proto: ClothingHeadHatWitch1
+  entities:
+  - uid: 508
+    components:
+    - type: Transform
+      parent: 507
+    - type: Physics
+      canCollide: False
+- proto: ClothingHeadHelmetWizardHelm
+  entities:
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+- proto: ClothingMaskGasChameleon
+  entities:
+  - uid: 404
+    components:
+    - type: Transform
+      pos: -0.8681086,13.66298
+      parent: 1
+- proto: ClothingShoesWizard
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 2.508839,1.4894459
+      parent: 1
+- proto: ClothingUniformJumpskirtColorBlack
+  entities:
+  - uid: 510
+    components:
+    - type: Transform
+      parent: 507
+    - type: Physics
+      canCollide: False
+- proto: ClothingUniformJumpsuitColorBlack
+  entities:
+  - uid: 509
+    components:
+    - type: Transform
+      parent: 507
+    - type: Physics
+      canCollide: False
+- proto: ComfyChair
+  entities:
+  - uid: 340
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+- proto: CrayonRainbow
+  entities:
+  - uid: 646
+    components:
+    - type: Transform
+      pos: 4.36567,6.0431795
+      parent: 1
+- proto: CrystalBlue
+  entities:
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+- proto: CrystalPink
+  entities:
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+- proto: CurtainsPurpleOpen
+  entities:
+  - uid: 513
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+- proto: DiceBag
+  entities:
+  - uid: 645
+    components:
+    - type: Transform
+      pos: 0.6416618,9.1801815
+      parent: 1
+- proto: DogBed
+  entities:
+  - uid: 501
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+- proto: Dresser
+  entities:
+  - uid: 507
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+    - type: Storage
+      storedItems:
+        508:
+          position: 0,0
+          _rotation: East
+        509:
+          position: 2,0
+          _rotation: South
+        510:
+          position: 4,0
+          _rotation: South
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 508
+          - 509
+          - 510
+- proto: DrinkAleBottleFull
+  entities:
+  - uid: 651
+    components:
+    - type: Transform
+      pos: -6.64086,5.9211173
+      parent: 1
+- proto: DrinkGlass
+  entities:
+  - uid: 652
+    components:
+    - type: Transform
+      pos: -6.4131513,5.5922756
+      parent: 1
+  - uid: 653
+    components:
+    - type: Transform
+      pos: -6.2777348,5.686091
+      parent: 1
+- proto: FaxMachineSyndie
+  entities:
+  - uid: 463
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+    - type: FaxMachine
+      name: Wizard's Den
+- proto: FigureSpawner
+  entities:
+  - uid: 470
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+- proto: Fireplace
+  entities:
+  - uid: 504
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+- proto: FloorDrain
+  entities:
+  - uid: 618
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: FloorLavaEntity
+  entities:
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+- proto: FloraStalagmite
+  entities:
+  - uid: 308
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-1.5
+      parent: 1
+- proto: FoodBurgerSpell
+  entities:
+  - uid: 647
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 644
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 544
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 549
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 550
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 641
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 279
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 291
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 292
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 293
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 294
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 295
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 296
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 297
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 298
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 299
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 300
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 301
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 523
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 524
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 525
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 526
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 529
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 531
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 532
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 533
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 534
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 535
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 536
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 537
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 538
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 539
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 540
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 541
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 551
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 552
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 553
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 554
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 556
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 557
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 626
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 627
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 628
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 629
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 630
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 632
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 635
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 636
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 637
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 638
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 639
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 640
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 642
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 643
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 281
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 288
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 519
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 520
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 527
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 528
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 530
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 555
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 631
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 282
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 289
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 522
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 543
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 548
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 634
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 290
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 521
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 542
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 547
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 633
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 262
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 390
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 391
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 395
+    components:
+    - type: Transform
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 396
+    components:
+    - type: Transform
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 397
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+- proto: HospitalCurtainsOpen
+  entities:
+  - uid: 619
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+- proto: LuxuryPen
+  entities:
+  - uid: 478
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -1.6541514,-0.17837936
+      parent: 1
+- proto: MedkitOxygenFilled
+  entities:
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -1.391187,-0.4181292
+      parent: 1
+- proto: Mirror
+  entities:
+  - uid: 625
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,10.5
+      parent: 1
+- proto: MirrorShield
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -1.7423494,1.6781805
+      parent: 1
+- proto: Paper
+  entities:
+  - uid: 479
+    components:
+    - type: Transform
+      pos: 4.548043,5.679018
+      parent: 1
+  - uid: 480
+    components:
+    - type: Transform
+      pos: 4.6209593,5.762409
+      parent: 1
+- proto: PaperBin5
+  entities:
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+- proto: PersonalAI
+  entities:
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -1.4747214,0.57214147
+      parent: 1
+- proto: PlasmaDoor
+  entities:
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+- proto: PlasmaWindow
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+- proto: PlushieLizard
+  entities:
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+- proto: PonderingOrbWizard
+  entities:
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 2.3481953,0.30111992
+      parent: 1
+- proto: PosterContrabandEnlistGorlex
+  entities:
+  - uid: 481
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 1
+- proto: PosterContrabandPower
+  entities:
+  - uid: 484
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 1
+- proto: PottedPlantRandom
+  entities:
+  - uid: 271
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 648
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+- proto: PowerCellRecharger
+  entities:
+  - uid: 403
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,13.5
+      parent: 1
+- proto: PoweredDimSmallLight
+  entities:
+  - uid: 118
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 272
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-10.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 485
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 486
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 565
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 620
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,5.5
+      parent: 1
+- proto: PoweredWarmSmallLight
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 505
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-7.5
+      parent: 1
+- proto: Railing
+  entities:
+  - uid: 249
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 1
+- proto: RailingCornerSmall
+  entities:
+  - uid: 251
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+- proto: RandomPosterAny
+  entities:
+  - uid: 409
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 483
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+- proto: RandomStalagmiteOrCrystal
+  entities:
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 6.5,-8.5
+      parent: 1
+  - uid: 604
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 611
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 612
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+- proto: RandomVendingDrinks
+  entities:
+  - uid: 359
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+- proto: RandomVendingSnacks
+  entities:
+  - uid: 454
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+- proto: ReinforcedPlasmaWindow
+  entities:
+  - uid: 364
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 371
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+- proto: SignElectricalMed
+  entities:
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 482
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 1
+- proto: SinkWide
+  entities:
+  - uid: 624
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+- proto: Skub
+  entities:
+  - uid: 623
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+- proto: SMESBasic
+  entities:
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 1
+- proto: SoapOmega
+  entities:
+  - uid: 622
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+- proto: SpawnMobLizard
+  entities:
+  - uid: 518
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+- proto: SpawnPointWizard
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: StealthBox
+  entities:
+  - uid: 621
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+    - type: Stealth
+      enabled: False
+    - type: EntityStorage
+      open: True
+- proto: SubstationBasic
+  entities:
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 1
+- proto: TableCarpet
+  entities:
+  - uid: 341
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+- proto: TableFancyOrange
+  entities:
+  - uid: 345
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+- proto: TableFancyPurple
+  entities:
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+- proto: TableFancyRed
+  entities:
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 398
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+- proto: TableStone
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+- proto: TableWood
+  entities:
+  - uid: 502
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 511
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+- proto: TargetStrange
+  entities:
+  - uid: 650
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+- proto: ToiletEmpty
+  entities:
+  - uid: 617
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,5.5
+      parent: 1
+- proto: ToyFigurineWizard
+  entities:
+  - uid: 477
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+- proto: VendingMachineGames
+  entities:
+  - uid: 462
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+- proto: VendingMachineMagivend
+  entities:
+  - uid: 453
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 273
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
+- proto: WallPlasma
+  entities:
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 339
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 377
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      pos: -4.5,12.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 383
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 384
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 406
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      pos: -8.5,8.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      pos: -8.5,7.5
+      parent: 1
+  - uid: 495
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 1
+  - uid: 496
+    components:
+    - type: Transform
+      pos: -8.5,5.5
+      parent: 1
+  - uid: 497
+    components:
+    - type: Transform
+      pos: -8.5,4.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 585
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 586
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 587
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 589
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 590
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 591
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 592
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 593
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 594
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 1
+  - uid: 595
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 597
+    components:
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 1
+  - uid: 601
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+- proto: WallPlastitanium
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 0.5,-11.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 3.5,-10.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 1
+- proto: WallRockBasalt
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 6.5,-6.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -0.5,-15.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 1.5,-15.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 1.5,-13.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 3.5,-12.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 5.5,-10.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 5.5,-9.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 5.5,-8.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 4.5,-8.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      pos: -9.5,4.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 1
+  - uid: 558
+    components:
+    - type: Transform
+      pos: -9.5,3.5
+      parent: 1
+  - uid: 559
+    components:
+    - type: Transform
+      pos: -9.5,1.5
+      parent: 1
+  - uid: 560
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 1
+  - uid: 561
+    components:
+    - type: Transform
+      pos: -9.5,2.5
+      parent: 1
+  - uid: 562
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 1
+  - uid: 563
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 1
+  - uid: 564
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 1
+  - uid: 596
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 1
+  - uid: 598
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 1
+  - uid: 599
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 600
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 602
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 603
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 606
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 1
+  - uid: 607
+    components:
+    - type: Transform
+      pos: 6.5,-9.5
+      parent: 1
+  - uid: 608
+    components:
+    - type: Transform
+      pos: 7.5,-9.5
+      parent: 1
+  - uid: 609
+    components:
+    - type: Transform
+      pos: 7.5,-8.5
+      parent: 1
+  - uid: 610
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 1
+  - uid: 613
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 614
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 615
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 616
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 656
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 1
+  - uid: 657
+    components:
+    - type: Transform
+      pos: 5.5,-13.5
+      parent: 1
+  - uid: 658
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 1
+  - uid: 659
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 1
+  - uid: 660
+    components:
+    - type: Transform
+      pos: 7.5,-10.5
+      parent: 1
+  - uid: 661
+    components:
+    - type: Transform
+      pos: 8.5,-8.5
+      parent: 1
+  - uid: 662
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 1
+  - uid: 663
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 1
+  - uid: 664
+    components:
+    - type: Transform
+      pos: -4.5,-12.5
+      parent: 1
+  - uid: 665
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 1
+  - uid: 666
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 1
+  - uid: 667
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 668
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 1
+  - uid: 669
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 1
+  - uid: 670
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 1
+  - uid: 671
+    components:
+    - type: Transform
+      pos: -7.5,-8.5
+      parent: 1
+  - uid: 672
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 1
+  - uid: 673
+    components:
+    - type: Transform
+      pos: 9.5,-5.5
+      parent: 1
+  - uid: 674
+    components:
+    - type: Transform
+      pos: 7.5,-11.5
+      parent: 1
+  - uid: 675
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 1
+  - uid: 676
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 1
+  - uid: 677
+    components:
+    - type: Transform
+      pos: 3.5,-14.5
+      parent: 1
+  - uid: 678
+    components:
+    - type: Transform
+      pos: 2.5,-15.5
+      parent: 1
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 402
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,13.5
+      parent: 1
+- proto: WindoorPlasma
+  entities:
+  - uid: 588
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 605
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,6.5
+      parent: 1
+- proto: WizardComputerComms
+  entities:
+  - uid: 365
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+- proto: WoodblockInstrument
+  entities:
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 2.5347729,-0.35558593
+      parent: 1
+...

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -271,7 +271,7 @@
     - WizardSurviveObjective
     - WizardDemonstrateObjective
   - type: LoadMapRule
-    gridPath: /Maps/Shuttles/wizard.yml
+    gridPath: /Maps/Nonstations/wizardsden.yml
   - type: RuleGrids
   - type: AntagSelection
   - type: AntagLoadProfileRule


### PR DESCRIPTION
## About the PR
Adds a new Nonstation grid,` wizardsden.yml`, designed for the wizard to spawn on. This has more or less the same equipment from the wizard shuttle but does not have navigation or FTL ability, thereby forcing the wizard to use the teleportation scroll.

## Why / Balance
Wizard no longer has a shuttle, but a den instead.
Works to fulfill https://github.com/space-wizards/space-station-14/issues/37643 and https://github.com/space-wizards/space-station-14/issues/37644

## Technical details
Adds new grid `Resources/Maps/Nonstations/wizardsden.yml`
Changes file path in `Resources/Prototypes/GameRules/roundstart.yml`

## Media
**Render:**
![image](https://github.com/user-attachments/assets/f098630e-cd22-4006-bc6d-05b4ca0baf27)
**In-Round:**
![image](https://github.com/user-attachments/assets/7cf6344c-8c01-44d7-815c-e97f5457f2dd)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: The wizard now spawns in a den instead of a shuttle.