### PR TITLE
Cleanup warnings in `AtmosPipeAppearanceSystem`

### DIFF
--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosPipeAppearanceSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosPipeAppearanceSystem.cs
@@ -11,6 +11,7 @@ namespace Content.Server.Atmos.Piping.EntitySystems;
 public sealed class AtmosPipeAppearanceSystem : EntitySystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!;
 
     public override void Initialize()
     {
@@ -55,10 +56,10 @@ public sealed class AtmosPipeAppearanceSystem : EntitySystem
 
         // find the cardinal directions of any connected entities
         var netConnectedDirections = PipeDirection.None;
-        var tile = grid.TileIndicesFor(xform.Coordinates);
+        var tile = _map.TileIndicesFor(xform.GridUid.Value, grid, xform.Coordinates);
         foreach (var neighbour in connected)
         {
-            var otherTile = grid.TileIndicesFor(Transform(neighbour).Coordinates);
+            var otherTile = _map.TileIndicesFor(xform.GridUid.Value, grid, Transform(neighbour).Coordinates);
 
             netConnectedDirections |= (otherTile - tile) switch
             {

--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosPipeAppearanceSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosPipeAppearanceSystem.cs
@@ -59,6 +59,7 @@ public sealed class AtmosPipeAppearanceSystem : EntitySystem
         var tile = _map.TileIndicesFor((xform.GridUid.Value, grid), xform.Coordinates);
         foreach (var neighbour in connected)
         {
+            // TODO z-levels, pipes across grids - we shouldn't assume that the neighboring tile's transform is on the same grid
             var otherTile = _map.TileIndicesFor((xform.GridUid.Value, grid), Transform(neighbour).Coordinates);
 
             netConnectedDirections |= (otherTile - tile) switch

--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosPipeAppearanceSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosPipeAppearanceSystem.cs
@@ -56,10 +56,10 @@ public sealed class AtmosPipeAppearanceSystem : EntitySystem
 
         // find the cardinal directions of any connected entities
         var netConnectedDirections = PipeDirection.None;
-        var tile = _map.TileIndicesFor(xform.GridUid.Value, grid, xform.Coordinates);
+        var tile = _map.TileIndicesFor((xform.GridUid.Value, grid), xform.Coordinates);
         foreach (var neighbour in connected)
         {
-            var otherTile = _map.TileIndicesFor(xform.GridUid.Value, grid, Transform(neighbour).Coordinates);
+            var otherTile = _map.TileIndicesFor((xform.GridUid.Value, grid), Transform(neighbour).Coordinates);
 
             netConnectedDirections |= (otherTile - tile) switch
             {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 2 warnings in `AtmosPipeAppearanceSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced obsolete `MapGridComponent` methods (`TileIndicesFor`) with `SharedMapSystem` methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Atmos pipes:
<img width="374" alt="Screenshot 2025-05-21 at 7 59 42 PM" src="https://github.com/user-attachments/assets/f99a41b8-d983-40d5-ac1b-650cd4eb352c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->