### PR TITLE
Add Practice Magazines to the Secfab

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -22,6 +22,11 @@
   - MagazineBoxRiflePractice
   - WeaponDisablerPractice
   - WeaponLaserCarbinePractice
+  - MagazineLightRiflePractice
+  - MagazineRiflePractice
+  - MagazinePistolPractice
+  - SpeedLoaderMagnumPractice
+  - MagazinePistolSubMachineGunPractice
   - WeaponFlareGunSecurity
 
 # Shared between secfab and emagged autolathe

--- a/Resources/Prototypes/Recipes/Lathes/ammo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/ammo.yml
@@ -223,6 +223,13 @@
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
+  id: MagazinePistolSubMachineGunPractice
+  result: MagazinePistolSubMachineGunPractice
+  materials:
+    Steel: 150
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
   id: MagazinePistolSubMachineGunUranium
   result: MagazinePistolSubMachineGunUranium
   materials:


### PR DESCRIPTION

## About the PR
Added the practice variants of all the magazines the secfab can print to its roundstart recipes. 
## Why / Balance
You can already print empty magazines and practice bullets, so this is just a simple QoL pr.
## Media
Trust me I just forgot to take a picture

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: Seam_Less
- add: Added practice magazines to the Secfab as a roundstart recipe

