### PR TITLE
Devices with access restrictions list those restrictions in their examination description

### DIFF
--- a/Content.Shared/Access/Components/AccessReaderComponent.cs
+++ b/Content.Shared/Access/Components/AccessReaderComponent.cs
@@ -77,6 +77,16 @@ public sealed partial class AccessReaderComponent : Component
     /// </summary>
     [DataField]
     public bool BreakOnAccessBreaker = true;
+
+    /// <summary>
+    /// The examination text associated with this component.
+    /// </summary>
+    /// <remarks>
+    /// The text can be supplied with the 'access' variable to populate it
+    /// with a comma separated list of the access levels contained in <see cref="AccessLists"/>
+    /// </remarks>
+    [DataField]
+    public LocId ExaminationText = "access-reader-examination";
 }
 
 [DataDefinition, Serializable, NetSerializable]

--- a/Resources/Locale/en-US/access/systems/access-reader-system.ftl
+++ b/Resources/Locale/en-US/access/systems/access-reader-system.ftl
@@ -1,1 +1,5 @@
 access-reader-unknown-id = Unknown
+access-reader-access-label = [color=yellow]{$access}[/color]
+access-reader-examination = Access is restricted to those with {$access} access.
+access-reader-examination-functionality-restricted = {$access} access is required to use certain functions.
+access-reader-list-conjunction = or

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -128,6 +128,7 @@
       price: 150
     - type: AccessReader
       access: [ [ "Engineering" ] ]
+      examinationText: access-reader-examination-functionality-restricted
     - type: PryUnpowered
       pryModifier: 0.5
     - type: PointLight

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -74,6 +74,7 @@
     speakerVolume: Speak
   - type: AccessReader
     access: [[ "Command" ]]
+    examinationText: access-reader-examination-functionality-restricted
   - type: ActivatableUI
     key: enum.HolopadUiKey.InteractionWindow
   - type: ActivatableUIRequiresPower

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -400,6 +400,7 @@
         type: GenpopLockerBoundUserInterface
   - type: AccessReader # note! this access is for the UI, not the door. door access is handled on GenpopLocker
     access: [["Security"]]
+    examinationText: access-reader-examination-functionality-restricted
   - type: Lock
     locked: false
     useAccess: false

--- a/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
+++ b/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
@@ -19,6 +19,7 @@
   - type: AccessReader
     breakOnAccessBreaker: false
     access: [["Cryogenics"]]
+    examinationText: access-reader-examination-functionality-restricted
   - type: InteractionOutline
   - type: Cryostorage
   - type: Physics


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Entities with the AccessReaderComponent now list those restrictions in their examination description. The examination message can be customized on a per-entity basis

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's not immediately apparent to players what access privileges are required to interact with certain objects, particularly if an access configurator has been used to customize their access settings. This change informs players as to who can use the object

## Technical details
<!-- Summary of code changes for easier review. -->
The AccessReaderSystem now listens for ExaminedEvent and populates the examination UI with the appropriate details

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

An example where the description of the cryogenic sleep unit now specifies that Cryogenics access is required to access certain functions
![cryo_example](https://github.com/user-attachments/assets/dcc9dd49-c102-43eb-add6-e8cdc70b2697)

An example where an airlock has had its access settings altered - players can now readily see who can open it
![airlock-example](https://github.com/user-attachments/assets/0dc3fd48-ca1e-49b1-b9e9-2a7eef2c3052)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- add: Devices with access restrictions now list those restrictions in their examination description