### PR TITLE
Add "unsafe" contraband examine text

### DIFF
--- a/Content.Server/AlertLevel/AlertLevelDisplaySystem.cs
+++ b/Content.Server/AlertLevel/AlertLevelDisplaySystem.cs
@@ -31,7 +31,7 @@ public sealed class AlertLevelDisplaySystem : EntitySystem
         if (TryComp(uid, out AppearanceComponent? appearance))
         {
             var stationUid = _stationSystem.GetOwningStation(uid);
-            if (stationUid != null && TryComp(stationUid, out AlertLevelComponent? alert))
+            if (stationUid != null && TryComp(stationUid, out Shared.AlertLevel.AlertLevelComponent? alert))
             {
                 _appearance.SetData(uid, AlertLevelDisplay.CurrentLevel, alert.CurrentLevel, appearance);
             }

--- a/Content.Server/AlertLevel/AlertLevelSystem.cs
+++ b/Content.Server/AlertLevel/AlertLevelSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.Chat.Systems;
 using Content.Server.Station.Systems;
+using Content.Shared.AlertLevel;
 using Content.Shared.CCVar;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -28,7 +29,7 @@ public sealed class AlertLevelSystem : EntitySystem
 
     public override void Update(float time)
     {
-        var query = EntityQueryEnumerator<AlertLevelComponent>();
+        var query = EntityQueryEnumerator<Shared.AlertLevel.AlertLevelComponent>();
 
         while (query.MoveNext(out var station, out var alert))
         {
@@ -48,7 +49,7 @@ public sealed class AlertLevelSystem : EntitySystem
 
     private void OnStationInitialize(StationInitializedEvent args)
     {
-        if (!TryComp<AlertLevelComponent>(args.Station, out var alertLevelComponent))
+        if (!TryComp<Shared.AlertLevel.AlertLevelComponent>(args.Station, out var alertLevelComponent))
             return;
 
         if (!_prototypeManager.TryIndex(alertLevelComponent.AlertLevelPrototype, out AlertLevelPrototype? alerts))
@@ -76,7 +77,7 @@ public sealed class AlertLevelSystem : EntitySystem
             return;
         }
 
-        var query = EntityQueryEnumerator<AlertLevelComponent>();
+        var query = EntityQueryEnumerator<Shared.AlertLevel.AlertLevelComponent>();
         while (query.MoveNext(out var uid, out var comp))
         {
             comp.AlertLevels = alerts;
@@ -96,7 +97,7 @@ public sealed class AlertLevelSystem : EntitySystem
         RaiseLocalEvent(new AlertLevelPrototypeReloadedEvent());
     }
 
-    public string GetLevel(EntityUid station, AlertLevelComponent? alert = null)
+    public string GetLevel(EntityUid station, Shared.AlertLevel.AlertLevelComponent? alert = null)
     {
         if (!Resolve(station, ref alert))
         {
@@ -106,7 +107,7 @@ public sealed class AlertLevelSystem : EntitySystem
         return alert.CurrentLevel;
     }
 
-    public float GetAlertLevelDelay(EntityUid station, AlertLevelComponent? alert = null)
+    public float GetAlertLevelDelay(EntityUid station, Shared.AlertLevel.AlertLevelComponent? alert = null)
     {
         if (!Resolve(station, ref alert))
         {
@@ -121,7 +122,7 @@ public sealed class AlertLevelSystem : EntitySystem
     /// Returns an empty string if the station has no alert levels defined.
     /// </summary>
     /// <param name="station">The station entity.</param>
-    public string GetDefaultLevel(Entity<AlertLevelComponent?> station)
+    public string GetDefaultLevel(Entity<Shared.AlertLevel.AlertLevelComponent?> station)
     {
         if (!Resolve(station.Owner, ref station.Comp) || station.Comp.AlertLevels == null)
         {
@@ -140,7 +141,7 @@ public sealed class AlertLevelSystem : EntitySystem
     /// <param name="force">Force the alert change. This applies if the alert level is not selectable or not.</param>
     /// <param name="locked">Will it be possible to change level by crew.</param>
     public void SetLevel(EntityUid station, string level, bool playSound, bool announce, bool force = false,
-        bool locked = false, MetaDataComponent? dataComponent = null, AlertLevelComponent? component = null)
+        bool locked = false, MetaDataComponent? dataComponent = null, Shared.AlertLevel.AlertLevelComponent? component = null)
     {
         if (!Resolve(station, ref component, ref dataComponent)
             || component.AlertLevels == null

--- a/Content.Server/AlertLevel/Commands/SetAlertLevelCommand.cs
+++ b/Content.Server/AlertLevel/Commands/SetAlertLevelCommand.cs
@@ -81,7 +81,7 @@ namespace Content.Server.AlertLevel.Commands
         private string[] GetStationLevelNames(EntityUid station)
         {
             var entityManager = IoCManager.Resolve<IEntityManager>();
-            if (!entityManager.TryGetComponent<AlertLevelComponent>(station, out var alertLevelComp))
+            if (!entityManager.TryGetComponent<Shared.AlertLevel.AlertLevelComponent>(station, out var alertLevelComp))
                 return new string[]{};
 
             if (alertLevelComp.AlertLevels == null)

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -138,7 +138,7 @@ namespace Content.Server.Communications
 
             if (stationUid != null)
             {
-                if (TryComp(stationUid.Value, out AlertLevelComponent? alertComp) &&
+                if (TryComp(stationUid.Value, out Shared.AlertLevel.AlertLevelComponent? alertComp) &&
                     alertComp.AlertLevels != null)
                 {
                     if (alertComp.IsSelectable)

--- a/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
@@ -56,7 +56,7 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
                         Loc.GetString(component.BatteryStateText[component.State]))));
 
             // Show alert level on the light itself.
-            if (!TryComp<AlertLevelComponent>(_station.GetOwningStation(uid), out var alerts))
+            if (!TryComp<Shared.AlertLevel.AlertLevelComponent>(_station.GetOwningStation(uid), out var alerts))
                 return;
 
             if (alerts.AlertLevels == null)
@@ -94,7 +94,7 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
 
     private void OnAlertLevelChanged(AlertLevelChangedEvent ev)
     {
-        if (!TryComp<AlertLevelComponent>(ev.Station, out var alert))
+        if (!TryComp<Shared.AlertLevel.AlertLevelComponent>(ev.Station, out var alert))
             return;
 
         if (alert.AlertLevels == null || !alert.AlertLevels.Levels.TryGetValue(ev.AlertLevel, out var details))
@@ -173,7 +173,7 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
         if (!TryComp<ApcPowerReceiverComponent>(entity.Owner, out var receiver))
             return;
 
-        if (!TryComp<AlertLevelComponent>(_station.GetOwningStation(entity.Owner), out var alerts))
+        if (!TryComp<Shared.AlertLevel.AlertLevelComponent>(_station.GetOwningStation(entity.Owner), out var alerts))
             return;
 
         if (alerts.AlertLevels == null || !alerts.AlertLevels.Levels.TryGetValue(alerts.CurrentLevel, out var details))

--- a/Content.Server/PDA/PdaSystem.cs
+++ b/Content.Server/PDA/PdaSystem.cs
@@ -292,7 +292,7 @@ namespace Content.Server.PDA
         private void UpdateAlertLevel(EntityUid uid, PdaComponent pda)
         {
             var station = _station.GetOwningStation(uid);
-            if (!TryComp(station, out AlertLevelComponent? alertComp) ||
+            if (!TryComp(station, out Shared.AlertLevel.AlertLevelComponent? alertComp) ||
                 alertComp.AlertLevels == null)
                 return;
             pda.StationAlertLevel = alertComp.CurrentLevel;

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -11,6 +11,7 @@ using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
+using Content.Shared.AlertLevel;
 using Content.Shared.Database;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.GameTicking;
@@ -131,7 +132,7 @@ namespace Content.Server.RoundEnd
             if (requester != null)
             {
                 var stationUid = _stationSystem.GetOwningStation(requester.Value);
-                if (TryComp<AlertLevelComponent>(stationUid, out var alertLevel))
+                if (TryComp<Shared.AlertLevel.AlertLevelComponent>(stationUid, out var alertLevel))
                 {
                     duration = _protoManager
                         .Index<AlertLevelPrototype>(AlertLevelSystem.DefaultAlertLevelSet)

--- a/Content.Shared/AlertLevel/AlertLevelComponent.cs
+++ b/Content.Shared/AlertLevel/AlertLevelComponent.cs
@@ -1,12 +1,13 @@
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
-namespace Content.Server.AlertLevel;
+namespace Content.Shared.AlertLevel;
 
 /// <summary>
 /// Alert level component. This is the component given to a station to
 /// signify its alert level state.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(fieldDeltas: true)]
 public sealed partial class AlertLevelComponent : Component
 {
     /// <summary>
@@ -16,18 +17,22 @@ public sealed partial class AlertLevelComponent : Component
     public AlertLevelPrototype? AlertLevels;
 
     // Once stations are a prototype, this should be used.
-    [DataField("alertLevelPrototype", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<AlertLevelPrototype>))]
-    public string AlertLevelPrototype = default!;
+    [DataField]
+    [AutoNetworkedField]
+    public ProtoId<AlertLevelPrototype> AlertLevelPrototype;
 
     /// <summary>
     /// The current level on the station.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)] public string CurrentLevel = string.Empty;
+    [ViewVariables(VVAccess.ReadWrite)]
+    [AutoNetworkedField]
+    public string CurrentLevel = string.Empty;
 
     /// <summary>
-    /// Is current station level can be changed by crew.
+    /// If the current station level can be changed by crew.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)] public bool IsLevelLocked = false;
+    [ViewVariables(VVAccess.ReadWrite)]
+    public bool IsLevelLocked = false;
 
     [ViewVariables] public float CurrentDelay = 0;
     [ViewVariables] public bool ActiveDelay;

--- a/Content.Shared/AlertLevel/AlertLevelPrototype.cs
+++ b/Content.Shared/AlertLevel/AlertLevelPrototype.cs
@@ -1,7 +1,7 @@
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 
-namespace Content.Server.AlertLevel;
+namespace Content.Shared.AlertLevel;
 
 [Prototype("alertLevels")]
 public sealed partial class AlertLevelPrototype : IPrototype

--- a/Content.Shared/Contraband/ContrabandComponent.cs
+++ b/Content.Shared/Contraband/ContrabandComponent.cs
@@ -33,4 +33,13 @@ public sealed partial class ContrabandComponent : Component
     [DataField]
     [AutoNetworkedField]
     public HashSet<ProtoId<JobPrototype>> AllowedJobs = new();
+
+    /// <summary>
+    ///     Which alert levels are considered safe for this item?
+    ///     If not on a safe alert level, will show "unsafe" examine text.
+    ///     If this set is empty, all alert levels will be considered safe.
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public HashSet<string> AllowedAlertLevels = new();
 }

--- a/Content.Shared/Station/Components/StationTrackerComponent.cs
+++ b/Content.Shared/Station/Components/StationTrackerComponent.cs
@@ -15,4 +15,11 @@ public sealed partial class StationTrackerComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public EntityUid? Station;
+
+    /// <summary>
+    /// The station that this entity was last on, if any.
+    /// Null only if the entity has never been on a station.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? LastSeenStation;
 }

--- a/Content.Shared/Station/SharedStationSystem.cs
+++ b/Content.Shared/Station/SharedStationSystem.cs
@@ -94,6 +94,10 @@ public abstract partial class SharedStationSystem : EntitySystem
             return;
 
         ent.Comp.Station = station;
+
+        if (station.HasValue)
+            ent.Comp.LastSeenStation = station;
+
         Dirty(ent);
     }
 
@@ -107,5 +111,17 @@ public abstract partial class SharedStationSystem : EntitySystem
             return null;
 
         return ent.Comp.Station;
+    }
+
+    /// <summary>
+    /// Gets the station an entity was last on, if any.
+    /// </summary>
+    [PublicAPI]
+    public EntityUid? GetLastStation(Entity<StationTrackerComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp, logMissing: false))
+            return null;
+
+        return ent.Comp.LastSeenStation;
     }
 }

--- a/Resources/Locale/en-US/contraband/contraband-severity.ftl
+++ b/Resources/Locale/en-US/contraband/contraband-severity.ftl
@@ -8,6 +8,7 @@ contraband-examine-text-Magical = [color=#b337b3]This item is highly illegal Mag
 
 contraband-examine-text-avoid-carrying-around = [color=red][italic]You probably want to avoid visibly carrying this around without a good reason.[/italic][/color]
 contraband-examine-text-in-the-clear = [color=green][italic]You should be in the clear to visibly carry this around.[/italic][/color]
+contraband-examine-text-unsafe = [color=goldenrod][italic]It is probably unsafe to continue carrying this around.[/italic][/color]
 
 contraband-examinable-verb-text = Legality
 contraband-examinable-verb-message = Check legality of this item.

--- a/Resources/Locale/en-US/contraband/contraband-severity.ftl
+++ b/Resources/Locale/en-US/contraband/contraband-severity.ftl
@@ -8,7 +8,7 @@ contraband-examine-text-Magical = [color=#b337b3]This item is highly illegal Mag
 
 contraband-examine-text-avoid-carrying-around = [color=red][italic]You probably want to avoid visibly carrying this around without a good reason.[/italic][/color]
 contraband-examine-text-in-the-clear = [color=green][italic]You should be in the clear to visibly carry this around.[/italic][/color]
-contraband-examine-text-unsafe = [color=goldenrod][italic]It is probably unsafe to continue carrying this around.[/italic][/color]
+contraband-examine-text-unsafe = [color=goldenrod][italic]It is probably unsafe to continue carrying this around at the current alert level.[/italic][/color]
 
 contraband-examinable-verb-text = Legality
 contraband-examinable-verb-message = Check legality of this item.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
1. AlertLevelComponent and AlertLevelPrototype have been moved to Shared, to support the contraband change.
2. StationTrackerComponent now holds on to the last seen station.
3. Support has been added for "allowed alert levels" for contraband. If they are specified, the usual green "in the clear" text will be replaced with an "unsafe" text if not on the correct alert level.

## Why / Balance
The intended use is as thus (not done yet, but planned for the future):

The contents of the Armoury would be marked with a new contraband status, perhaps titled "Emergency Use Only". If not on Red, Delta, Gamma, or Epsilon alert, security personnel would be warned with the new examine text that they should not be using these guns.
It's only a warning and not red text as
a) Currently it is not an arrestable offence under space law.
b) There are numerous times when red alert SHOULD be called, but a comms console can't be accessed to change the alert level.

## Technical details
AlertLevelComponent and AlertLevelPrototype moved to shared, and references updated as required.

Contraband examine now does the following steps:
1. Does the user have the required access to hold the contraband? If no, return red text.
2. Are there any alert level values listed in the contraband? If no, return green text.
4. Add StationTrackerComponent to the user and check their last station.
5. Is the current alert level unsuitable for the contraband? If yes, return yellow text.
6. Return green text.

Slight issue: if the first time a person examines an alert-level-restricted item is not on a grid, the above steps will not return yellow text until the first time a player touches a grid.

## Media
Not in game, nothing to show

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
AlertLevelComponent + AlertLevelPrototype move.

**Changelog**
no cl cuz no player facing changes.
