### PR TITLE
Makes cargo sale computer properly indestructible

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -6,7 +6,6 @@
     - id: BoxFolderQmClipboard
     - id: CargoBountyComputerCircuitboard
     - id: CargoRequestComputerCircuitboard
-    - id: CargoSaleComputerCircuitboard
     - id: CargoShuttleConsoleCircuitboard
     - id: SalvageMagnetMachineCircuitboard
     - id: SalvageJobBoardComputerCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
@@ -1,20 +1,13 @@
 - type: entity
-  parent: BaseStructureComputer
-  id: BaseComputer
+  id: BaseComputerInteractable
+  abstract: true
   name: computer
-  placement:
-    mode: SnapgridCenter
   components:
   - type: Animateable
   - type: MeleeSound
     soundGroups:
       Brute:
         collection: GlassSmash
-  - type: Construction
-    graph: Computer
-    node: computer
-    containers:
-      - board
   - type: Computer
   - type: ApcPowerReceiver
     powerLoad: 200
@@ -76,17 +69,30 @@
   - type: Electrified
     enabled: false
     usesApcPower: true
+
+- type: entity
+  parent: [ BaseComputerInteractable, BaseStructureComputer ]
+  id: BaseComputer
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: Construction
+    graph: Computer
+    node: computer
+    containers:
+    - board
   - type: WiresPanel
   - type: WiresVisuals
   - type: Wires
     boardName: wires-board-name-computer
     layoutId: Computer
-#
-#     This is overwritten by children, so needs to be defined there
-#  - type: UserInterface
-#    interfaces:
-#      enum.WiresUiKey.Key:
-#        type: WiresBoundUserInterface
+
+- type: entity
+  parent: [ BaseComputerInteractable, BaseStructureComputerIndestructible ]
+  id: BaseComputerIndestructible
+  abstract: true
+  placement:
+    mode: SnapgridCenter
 
 - type: entity
   parent: BaseComputer

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1375,7 +1375,7 @@
 
 - type: entity
   id: ComputerPalletConsole
-  parent: BaseComputerAiAccess
+  parent: BaseComputerIndestructible
   name: cargo sale computer
   description: Used to sell goods loaded onto cargo pallets.
   components:
@@ -1412,6 +1412,7 @@
   - type: GuideHelp
     guides:
     - Cargo
+  - type: StationAiWhitelist
 
 - type: entity
   parent: BaseComputerAiAccess

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
@@ -1,6 +1,6 @@
 - type: entity
-  id: BaseStructureComputer
   parent: BaseStructure
+  id: BaseStructureComputerIndestructible
   abstract: true
   components:
   - type: Physics
@@ -19,14 +19,20 @@
   - type: InteractionOutline
   - type: Rotatable
   - type: Anchorable
-  - type: Construction
-    graph: Computer
-    node: frameUnsecured
   - type: Sprite
     drawdepth: Objects
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Electronic
+
+- type: entity
+  parent: BaseStructureComputerIndestructible
+  id: BaseStructureComputer
+  abstract: true
+  components:
+  - type: Construction
+    graph: Computer
+    node: frameUnsecured
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Part of the larger push to make the ATS more resistant to sabotage.

Now instead of simply being unanchorable, the sale consoles are completely indestructible and unable to be deconstructed.

Additionally removes the board from QM's locker due to not being necessary

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
ATS sabotage is something we want to move away from as it overly damages cargo's gameplay in a negative way. The computers are already unanchorable to prevent the most trivial sabotage, this is just going a step further.

Requiring QM to repair the computers if one is broken is better than nothing, but it still is a finite (QM only gets one board) and it enables goofy things like building a sale computer on-station (which is nonfunctional and shouldn't be a thing).

Making it properly indestructible makes it in-line with things like the pallets and the new spine on the ATS.

## Technical details
<!-- Summary of code changes for easier review. -->
prototype rearranging.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: The cargo sale computer is now unable to be destroyed or deconstructed.
