### PR TITLE
Kill the TEG meta with really big hammers

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
@@ -62,7 +62,7 @@
     # It fires processing on behalf of its connected circulators.
     - type: AtmosDevice
     - type: TegGenerator
-      thermalEfficiency: 0.2
+      thermalEfficiency: 0.1
 
     - type: DeviceNetwork
       deviceNetId: AtmosDevices

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
@@ -62,6 +62,7 @@
     # It fires processing on behalf of its connected circulators.
     - type: AtmosDevice
     - type: TegGenerator
+      thermalEfficiency: 0.2
 
     - type: DeviceNetwork
       deviceNetId: AtmosDevices


### PR DESCRIPTION
## Preamble
The TEG, as many of you know, has gotten to the point where it is now the superior long-term engine everyone sets up, ignoring other alternative engines like the Singularity and Tesla engine when available. This PR rebalances the TEG to move away from that meta, focusing on a specific style that promotes creativity and player interaction, rather than the exact opposite.

In this, I'll generally explain:
- How the TEG works as a baseline
- Why the TEG has taken over as the meta pick compared to other engines
- How this impacts the game/project in the long term
- What this PR's changes accomplish in terms of fixing the problem

### How the TEG works
In summary, the TEG works by exchanging the heat energy of gasses between the two sides (circulators) of the TEG. This is then converted to make electricity. Not all energy is transferred from one side to the other, instead it is done as a percentage of the gas' heat energy. In current master, 65% of the heat is taken from the gas and converted to electricity.

A really dumbed down example, if the TEG is currently restricted to being 50% efficient, than 50% of the gas energy will be taken from the hot side to do "work" and generate electricity. The other 50% is simply left behind to the waste gas on the hotside. This gas is still available to be reheated and more work can be done with it.

The TEG also takes advantage of [Carnot efficiency](https://en.wikipedia.org/wiki/Carnot%27s_theorem_(thermodynamics)), which defines the maximum efficiency that a heat engine can operate at. In the case of the TEG, maximum efficiency is achieved by maximizing the difference in temperatures between the hot and cold sides.

### Why the TEG is now a meta pick
The TEG emerged as a meta pick after the popularization of single loop TEG designs (like the Gar-TEG) which were extremely easy to construct, teach, and use in-round forever. The Gar-TEG's purpose was meant to be an introductory tool in Grasshopper to get new players interested in the TEG and expose them to the atmospherics systems that were in the game.

These single loop designs commonly use a mini 2x1 burn chamber which dumps superheated gas directly into the hotside. The hotside waste is then ran through a single radiator. Due to radiator math, this would be instantly cooled to low enough temperatures suitable for the coldside. It doesn't matter that only 65% of the energy was used for conversion on the hotside, 65% of 15000K is still 9750K, an insane amount of heat which easily makes the TEG produce a lot of power.

These designs were easy to build, setup-and-forget solutions that lasted the entire round with absolutely zero intervention required from Atmospherics (unless your APC got trolled by a random event or otherwise). It directly goes against the Atmos Roadmap, which plans to move away from setup-and-forget solutions. These setups were so good, that it didn't really encourage new Atmospheric Technicians or Engineers to seek out more efficient or creative designs; why do more when the thing that takes 2 seconds to stamp down does everything you need?

The TEG, in comparison to engines like the Singularity or Tesla, have absolutely zero potential downsides to its operation. There are no emitters to look after, coils to repair, or radiation collectors to refill. You simply construct a 2x1 box, fill it with plasma, light it up, and pump it through the TEG with one radiator for the coldside gas.

This is largely due to the fact that Atmospherics is very lacking in content. There is no ΔP window shattering, tritium-radiation, or pipe bursting yet, as work on Atmospherics takes an extremely long time due to the complex nature of gasses and thermodynamics in real life, and it's hard to get right (as this serves as the foundation for more content). You can see this when I attempted to make the Pressure Relief Valve, and got trolled super hard when my derivation was incorrect. I was saved by someone who actually knows thermodynamics.

### How this impacts/impacted the game
I have noticed that over time players are terminally allergic to setting up engines. I've been terminally playing CE for a while, and the player base shifting from always running cool engines like the Singularity/Tesla to always running the TEG cannot be understated.

This has recently gotten to the point that some Atmospheric Technicians are establishing a superiority complex and directing engineers to not setup engines or killing them when the TEG is operational because "it's a dangerous engine and a hazard to the crew". Notably, one person told me that an Atmospheric Technician went as far to prosecute the Engineering subdepartment for terrorism (???) and hold a court case, as they attempted to set up a Tesla. This is obviously a hyperbole and stark example, but people who've been playing this game for a long time have noticed that players do not do engines anymore.

This is made even worse when a new engineer attempts to experiment with the TEG. Atmospheric Technicians tend to put down and shun engineers who attempt to experiment with the TEG, blocking some person out of interacting with the TEG and its surrounding systems. The Atmos tech then constructs whatever single-loop they already have half-stamped-down and then goes off to do nothing for the rest of the shift.

It's important to note that the TEG meta and the surrounding behavior after this fact happened in a period where power balance was extremely bad, to the point where a single-loop TEG almost seemed to be necessary for ensuring smooth power flow for the rest of the round. This accelerated the declaration of the TEG as a meta engine.

Generally, this is bad for the long term health of the project. If Atmos techs just shit on new engineers for even *bothering* to do half of their job, what the hell else am I supposed to do besides waiting around for some syndicate to blow up medical? Why bother setting up solars when the TEG can easily produce enough power for the station 3-4 times over? It's horrible compared to what we *should* be promoting and cultivating between Engineering and Atmospherics: collaboration.

### How the problem is fixed
So, we've already ran over how single loop designs work: they simply run hot gas through the TEG and the waste of that gas is directed through a radiator to make it cold, which then runs through the coldside. Because 65% of the heat energy was taken from the gas when running across the hotside, we don't have to worry about energy conservation since we can simply throttle the TEG to the power we want to output. This will easily last us the entire round.

To solve this, the TEG now only takes a fraction of the energy of the gas each run (10%). When someone attempts to run their very hot gas through a single loop, they cannot possibly extract enough energy from the gas in one go. Remember that the gas is mostly comprised of oxygen with a small fraction of this being CO2 or water vapor. Oxygen has a very low specific heat, so it doesn't have much """heat energy inside of it""" when running through the TEG, which contributes to a low power output. Additionally, because this gas is immediately cooled and reused in the coldside, you are basically wasting 90% of the heat you just spent creating using your plasma.

This leads to single loops not producing enough energy at all for the station. Attempts to push more gas through the TEG in hopes of increasing power will simply lead to wasted plasma.

This promotes dual-loop designs, which conserve the energy of gasses and reuse it. Dual loop designs run a pure, high-heat-capacity gas through a radiator inside a burn chamber, which heats up the gas for use in the TEG. While the TEG will only use 10% of the heat from this gas, because the gas has a high heat capacity, it will still extract a relatively large amount of energy from the gas and produce enough energy to power the station. The waste from this gas can be reheated in the burn chamber, which leads to energy being conserved.

This PR doesn't change efficiencies in terms of "great, now I'll need more plasma to burn in the TEG". It instead migrates over to designs that take advantage of recycling that unused energy. It effectively kills easy to make, no-maintenance single loop designs and promotes dual loop designs that require a little bit more interaction. And more importantly, it removes the TEG as this shining, easy to stamp down meta that screws over all other major engines.

### But what about (TEG only station)?
All TEG-only stations currently feature a robust dual-loop design which is easy to work and toy with.

### But what about (other engine that supposedly sucks)?
I've recently rebalanced engines to output much more stable power, and more power in general.

### But what about (time it takes to setup these engines vs. how much time we get before the station blacks out)?
I've recently rebalanced power across all stations to promote extended runtimes when the AME and solars is setup. I'm also thinking of buffing it more in the future to help engineering some more.

I'm also going to improve mapping standards soon. But that's a lot of work.

### I used (gas) in my dual loop TEG and it wasn't producing as much power!
Use a gas that has a reasonably high specific heat capacity, like CO2, water vapor, or plasma. Gasses like N2 or O2 have relatively low specific heat capacities and don't work as well.

I intentionally waited until after the stable cutoff to see how this would play out on Vulture.

## Media
nuh uh

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: The TEG's efficiency in extracting power from gasses has been tweaked to promote dual-loop designs that recycle the waste heat of gasses, and punish "meta" single loop designs.
