### PR TITLE
Update chemvend.yml Added more Welding fuel Jugs to the Syndicate ChemVend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -52,7 +52,7 @@
     JugSodium: 2
     JugSugar: 3
     JugSulfur: 1
-    JugWeldingFuel: 1
+    JugWeldingFuel: 3
     PlasmaChemistryVial: 1
   contrabandInventory:
     DrinkLithiumFlask: 1


### PR DESCRIPTION
Changed number of welding fuel jugs in the syndicate Chemvend to 3 since you can't drain welders into the Chem Master anymore.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the amount of welding fuel jugs in the syndicate Chem vend

## Why / Balance
Since you are unable to drain welding fuel from welders into the Chem Master, you can no longer make enough napalm for a flamethrower to be worth considering as a strategy. Since this change was made to stop infinite welding fuel from self-regenerating welders, this PR fixes an unintended nerf to the Nukies.

## Technical details
Changed a 1 to a 3.

## Media
N/A

## Requirements
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed number of welding fuel jugs in the Syndicate ChemVend from 1 to 3

