### PR TITLE
Update `NodeHelpers` and `Node.GetReachableNodes` to use `Entity<MapGridComponent>`

### DIFF
--- a/Content.Server/DeviceLinking/Systems/PowerSensorSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/PowerSensorSystem.cs
@@ -107,7 +107,7 @@ public sealed class PowerSensorSystem : EntitySystem
         if (!TryComp(xform.GridUid, out MapGridComponent? grid))
             return;
 
-        var cables = deviceNode.GetReachableNodes(xform, _nodeQuery, _xformQuery, grid, EntityManager);
+        var cables = deviceNode.GetReachableNodes(xform, _nodeQuery, _xformQuery, (xform.GridUid.Value, grid), EntityManager);
         foreach (var node in cables)
         {
             if (node.NodeGroup == null)

--- a/Content.Server/Electrocution/ElectrocutionNode.cs
+++ b/Content.Server/Electrocution/ElectrocutionNode.cs
@@ -17,7 +17,7 @@ namespace Content.Server.Electrocution
         public override IEnumerable<Node> GetReachableNodes(TransformComponent xform,
             EntityQuery<NodeContainerComponent> nodeQuery,
             EntityQuery<TransformComponent> xformQuery,
-            MapGridComponent? grid,
+            Entity<MapGridComponent>? grid,
             IEntityManager entMan)
         {
             if (CableEntity == null || NodeName == null)

--- a/Content.Server/NodeContainer/EntitySystems/NodeGroupSystem.cs
+++ b/Content.Server/NodeContainer/EntitySystems/NodeGroupSystem.cs
@@ -350,12 +350,13 @@ namespace Content.Server.NodeContainer.EntitySystems
         private IEnumerable<Node> GetCompatibleNodes(Node node, EntityQuery<TransformComponent> xformQuery, EntityQuery<NodeContainerComponent> nodeQuery)
         {
             var xform = xformQuery.GetComponent(node.Owner);
-            TryComp<MapGridComponent>(xform.GridUid, out var grid);
+            if (!TryComp<MapGridComponent>(xform.GridUid, out var grid))
+                yield break;
 
             if (!node.Connectable(EntityManager, xform))
                 yield break;
 
-            foreach (var reachable in node.GetReachableNodes(xform, nodeQuery, xformQuery, grid, EntityManager))
+            foreach (var reachable in node.GetReachableNodes(xform, nodeQuery, xformQuery, (xform.GridUid.Value, grid), EntityManager))
             {
                 DebugTools.Assert(reachable != node, "GetReachableNodes() should not include self.");
 

--- a/Content.Server/NodeContainer/Nodes/AdjacentNode.cs
+++ b/Content.Server/NodeContainer/Nodes/AdjacentNode.cs
@@ -1,5 +1,4 @@
 using Content.Shared.NodeContainer;
-using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 
 namespace Content.Server.NodeContainer.Nodes
@@ -13,15 +12,16 @@ namespace Content.Server.NodeContainer.Nodes
         public override IEnumerable<Node> GetReachableNodes(TransformComponent xform,
             EntityQuery<NodeContainerComponent> nodeQuery,
             EntityQuery<TransformComponent> xformQuery,
-            MapGridComponent? grid,
+            Entity<MapGridComponent>? grid,
             IEntityManager entMan)
         {
-            if (!xform.Anchored || grid == null)
+            if (!xform.Anchored || grid is not { } gridEnt)
                 yield break;
 
-            var gridIndex = grid.TileIndicesFor(xform.Coordinates);
+            var mapSystem = entMan.System<SharedMapSystem>();
+            var gridIndex = mapSystem.TileIndicesFor(gridEnt, xform.Coordinates);
 
-            foreach (var (_, node) in NodeHelpers.GetCardinalNeighborNodes(nodeQuery, grid, gridIndex))
+            foreach (var (_, node) in NodeHelpers.GetCardinalNeighborNodes(nodeQuery, gridEnt, gridIndex, mapSystem))
             {
                 if (node != this)
                     yield return node;

--- a/Content.Server/NodeContainer/Nodes/NodeHelpers.cs
+++ b/Content.Server/NodeContainer/Nodes/NodeHelpers.cs
@@ -10,9 +10,10 @@ namespace Content.Server.NodeContainer.Nodes
     /// </summary>
     public static class NodeHelpers
     {
-        public static IEnumerable<Node> GetNodesInTile(EntityQuery<NodeContainerComponent> nodeQuery, MapGridComponent grid, Vector2i coords)
+        public static IEnumerable<Node> GetNodesInTile(EntityQuery<NodeContainerComponent> nodeQuery, Entity<MapGridComponent> grid, Vector2i coords, IEntityManager entMan)
         {
-            foreach (var entityUid in grid.GetAnchoredEntities(coords))
+            var mapSys = entMan.System<SharedMapSystem>();
+            foreach (var entityUid in mapSys.GetAnchoredEntities(grid, coords))
             {
                 if (!nodeQuery.TryGetComponent(entityUid, out var container))
                     continue;
@@ -24,13 +25,20 @@ namespace Content.Server.NodeContainer.Nodes
             }
         }
 
+        [Obsolete("Use the overload that takes Entity<MapGridComponent> and IEntityManager")]
+        public static IEnumerable<Node> GetNodesInTile(EntityQuery<NodeContainerComponent> nodeQuery, MapGridComponent grid, Vector2i coords)
+        {
+            return GetNodesInTile(nodeQuery, (grid.Owner, grid), coords, IoCManager.Resolve<IEntityManager>());
+        }
+
         public static IEnumerable<(Direction dir, Node node)> GetCardinalNeighborNodes(
             EntityQuery<NodeContainerComponent> nodeQuery,
-            MapGridComponent grid,
+            Entity<MapGridComponent> grid,
             Vector2i coords,
+            IEntityManager entMan,
             bool includeSameTile = true)
         {
-            foreach (var (dir, entityUid) in GetCardinalNeighborCells(grid, coords, includeSameTile))
+            foreach (var (dir, entityUid) in GetCardinalNeighborCells(grid, coords, entMan, includeSameTile))
             {
                 if (!nodeQuery.TryGetComponent(entityUid, out var container))
                     continue;
@@ -42,29 +50,51 @@ namespace Content.Server.NodeContainer.Nodes
             }
         }
 
+        [Obsolete("Use the overload that takes Entity<MapGridComponent> and IEntityManager")]
+        public static IEnumerable<(Direction dir, Node node)> GetCardinalNeighborNodes(
+            EntityQuery<NodeContainerComponent> nodeQuery,
+            MapGridComponent grid,
+            Vector2i coords,
+            bool includeSameTile = true)
+        {
+            return GetCardinalNeighborNodes(nodeQuery, (grid.Owner, grid), coords, IoCManager.Resolve<IEntityManager>(), includeSameTile);
+        }
+
+        [SuppressMessage("ReSharper", "EnforceForeachStatementBraces")]
+        public static IEnumerable<(Direction dir, EntityUid entity)> GetCardinalNeighborCells(
+            Entity<MapGridComponent> grid,
+            Vector2i coords,
+            IEntityManager entMan,
+            bool includeSameTile = true)
+        {
+            var mapSys = entMan.System<SharedMapSystem>();
+            if (includeSameTile)
+            {
+                foreach (var uid in mapSys.GetAnchoredEntities(grid, coords))
+                    yield return (Direction.Invalid, uid);
+            }
+
+            foreach (var uid in mapSys.GetAnchoredEntities(grid, coords + (0, 1)))
+                yield return (Direction.North, uid);
+
+            foreach (var uid in mapSys.GetAnchoredEntities(grid, coords + (0, -1)))
+                yield return (Direction.South, uid);
+
+            foreach (var uid in mapSys.GetAnchoredEntities(grid, coords + (1, 0)))
+                yield return (Direction.East, uid);
+
+            foreach (var uid in mapSys.GetAnchoredEntities(grid, coords + (-1, 0)))
+                yield return (Direction.West, uid);
+        }
+
+        [Obsolete("Use the overload that takes Entity<MapGridComponent> and IEntityManager")]
         [SuppressMessage("ReSharper", "EnforceForeachStatementBraces")]
         public static IEnumerable<(Direction dir, EntityUid entity)> GetCardinalNeighborCells(
             MapGridComponent grid,
             Vector2i coords,
             bool includeSameTile = true)
         {
-            if (includeSameTile)
-            {
-                foreach (var uid in grid.GetAnchoredEntities(coords))
-                    yield return (Direction.Invalid, uid);
-            }
-
-            foreach (var uid in grid.GetAnchoredEntities(coords + (0, 1)))
-                yield return (Direction.North, uid);
-
-            foreach (var uid in grid.GetAnchoredEntities(coords + (0, -1)))
-                yield return (Direction.South, uid);
-
-            foreach (var uid in grid.GetAnchoredEntities(coords + (1, 0)))
-                yield return (Direction.East, uid);
-
-            foreach (var uid in grid.GetAnchoredEntities(coords + (-1, 0)))
-                yield return (Direction.West, uid);
+            return GetCardinalNeighborCells((grid.Owner, grid), coords, IoCManager.Resolve<IEntityManager>(), includeSameTile);
         }
     }
 }

--- a/Content.Server/NodeContainer/Nodes/NodeHelpers.cs
+++ b/Content.Server/NodeContainer/Nodes/NodeHelpers.cs
@@ -10,10 +10,9 @@ namespace Content.Server.NodeContainer.Nodes
     /// </summary>
     public static class NodeHelpers
     {
-        public static IEnumerable<Node> GetNodesInTile(EntityQuery<NodeContainerComponent> nodeQuery, Entity<MapGridComponent> grid, Vector2i coords, IEntityManager entMan)
+        public static IEnumerable<Node> GetNodesInTile(EntityQuery<NodeContainerComponent> nodeQuery, Entity<MapGridComponent> grid, Vector2i coords, SharedMapSystem mapSystem)
         {
-            var mapSys = entMan.System<SharedMapSystem>();
-            foreach (var entityUid in mapSys.GetAnchoredEntities(grid, coords))
+            foreach (var entityUid in mapSystem.GetAnchoredEntities(grid, coords))
             {
                 if (!nodeQuery.TryGetComponent(entityUid, out var container))
                     continue;
@@ -25,20 +24,20 @@ namespace Content.Server.NodeContainer.Nodes
             }
         }
 
-        [Obsolete("Use the overload that takes Entity<MapGridComponent> and IEntityManager")]
+        [Obsolete("Use the overload that passes in Entity<MapGridComponent> and SharedMapSystem")]
         public static IEnumerable<Node> GetNodesInTile(EntityQuery<NodeContainerComponent> nodeQuery, MapGridComponent grid, Vector2i coords)
         {
-            return GetNodesInTile(nodeQuery, (grid.Owner, grid), coords, IoCManager.Resolve<IEntityManager>());
+            return GetNodesInTile(nodeQuery, (grid.Owner, grid), coords, IoCManager.Resolve<IEntityManager>().System<SharedMapSystem>());
         }
 
         public static IEnumerable<(Direction dir, Node node)> GetCardinalNeighborNodes(
             EntityQuery<NodeContainerComponent> nodeQuery,
             Entity<MapGridComponent> grid,
             Vector2i coords,
-            IEntityManager entMan,
+            SharedMapSystem mapSystem,
             bool includeSameTile = true)
         {
-            foreach (var (dir, entityUid) in GetCardinalNeighborCells(grid, coords, entMan, includeSameTile))
+            foreach (var (dir, entityUid) in GetCardinalNeighborCells(grid, coords, mapSystem, includeSameTile))
             {
                 if (!nodeQuery.TryGetComponent(entityUid, out var container))
                     continue;
@@ -50,51 +49,50 @@ namespace Content.Server.NodeContainer.Nodes
             }
         }
 
-        [Obsolete("Use the overload that takes Entity<MapGridComponent> and IEntityManager")]
+        [Obsolete("Use the overload that passes in Entity<MapGridComponent> and SharedMapSystem")]
         public static IEnumerable<(Direction dir, Node node)> GetCardinalNeighborNodes(
             EntityQuery<NodeContainerComponent> nodeQuery,
             MapGridComponent grid,
             Vector2i coords,
             bool includeSameTile = true)
         {
-            return GetCardinalNeighborNodes(nodeQuery, (grid.Owner, grid), coords, IoCManager.Resolve<IEntityManager>(), includeSameTile);
+            return GetCardinalNeighborNodes(nodeQuery, (grid.Owner, grid), coords, IoCManager.Resolve<IEntityManager>().System<SharedMapSystem>(), includeSameTile);
         }
 
         [SuppressMessage("ReSharper", "EnforceForeachStatementBraces")]
         public static IEnumerable<(Direction dir, EntityUid entity)> GetCardinalNeighborCells(
             Entity<MapGridComponent> grid,
             Vector2i coords,
-            IEntityManager entMan,
+            SharedMapSystem mapSystem,
             bool includeSameTile = true)
         {
-            var mapSys = entMan.System<SharedMapSystem>();
             if (includeSameTile)
             {
-                foreach (var uid in mapSys.GetAnchoredEntities(grid, coords))
+                foreach (var uid in mapSystem.GetAnchoredEntities(grid, coords))
                     yield return (Direction.Invalid, uid);
             }
 
-            foreach (var uid in mapSys.GetAnchoredEntities(grid, coords + (0, 1)))
+            foreach (var uid in mapSystem.GetAnchoredEntities(grid, coords + (0, 1)))
                 yield return (Direction.North, uid);
 
-            foreach (var uid in mapSys.GetAnchoredEntities(grid, coords + (0, -1)))
+            foreach (var uid in mapSystem.GetAnchoredEntities(grid, coords + (0, -1)))
                 yield return (Direction.South, uid);
 
-            foreach (var uid in mapSys.GetAnchoredEntities(grid, coords + (1, 0)))
+            foreach (var uid in mapSystem.GetAnchoredEntities(grid, coords + (1, 0)))
                 yield return (Direction.East, uid);
 
-            foreach (var uid in mapSys.GetAnchoredEntities(grid, coords + (-1, 0)))
+            foreach (var uid in mapSystem.GetAnchoredEntities(grid, coords + (-1, 0)))
                 yield return (Direction.West, uid);
         }
 
-        [Obsolete("Use the overload that takes Entity<MapGridComponent> and IEntityManager")]
+        [Obsolete("Use the overload that passes in Entity<MapGridComponent> and SharedMapSystem")]
         [SuppressMessage("ReSharper", "EnforceForeachStatementBraces")]
         public static IEnumerable<(Direction dir, EntityUid entity)> GetCardinalNeighborCells(
             MapGridComponent grid,
             Vector2i coords,
             bool includeSameTile = true)
         {
-            return GetCardinalNeighborCells((grid.Owner, grid), coords, IoCManager.Resolve<IEntityManager>(), includeSameTile);
+            return GetCardinalNeighborCells((grid.Owner, grid), coords, IoCManager.Resolve<IEntityManager>().System<SharedMapSystem>(), includeSameTile);
         }
     }
 }

--- a/Content.Server/NodeContainer/Nodes/PortPipeNode.cs
+++ b/Content.Server/NodeContainer/Nodes/PortPipeNode.cs
@@ -10,15 +10,16 @@ namespace Content.Server.NodeContainer.Nodes
         public override IEnumerable<Node> GetReachableNodes(TransformComponent xform,
             EntityQuery<NodeContainerComponent> nodeQuery,
             EntityQuery<TransformComponent> xformQuery,
-            MapGridComponent? grid,
+            Entity<MapGridComponent>? grid,
             IEntityManager entMan)
         {
-            if (!xform.Anchored || grid == null)
+            if (!xform.Anchored || grid is not { } gridEnt)
                 yield break;
 
-            var gridIndex = grid.TileIndicesFor(xform.Coordinates);
+            var mapSystem = entMan.System<SharedMapSystem>();
+            var gridIndex = mapSystem.TileIndicesFor(gridEnt, xform.Coordinates);
 
-            foreach (var node in NodeHelpers.GetNodesInTile(nodeQuery, grid, gridIndex))
+            foreach (var node in NodeHelpers.GetNodesInTile(nodeQuery, gridEnt, gridIndex, mapSystem))
             {
                 if (node is PortablePipeNode)
                     yield return node;

--- a/Content.Server/NodeContainer/Nodes/PortablePipeNode.cs
+++ b/Content.Server/NodeContainer/Nodes/PortablePipeNode.cs
@@ -10,15 +10,16 @@ namespace Content.Server.NodeContainer.Nodes
         public override IEnumerable<Node> GetReachableNodes(TransformComponent xform,
             EntityQuery<NodeContainerComponent> nodeQuery,
             EntityQuery<TransformComponent> xformQuery,
-            MapGridComponent? grid,
+            Entity<MapGridComponent>? grid,
             IEntityManager entMan)
         {
-            if (!xform.Anchored || grid == null)
+            if (!xform.Anchored || grid is not { } gridEnt)
                 yield break;
 
-            var gridIndex = grid.TileIndicesFor(xform.Coordinates);
+            var mapSystem = entMan.System<SharedMapSystem>();
+            var gridIndex = mapSystem.TileIndicesFor(gridEnt, xform.Coordinates);
 
-            foreach (var node in NodeHelpers.GetNodesInTile(nodeQuery, grid, gridIndex))
+            foreach (var node in NodeHelpers.GetNodesInTile(nodeQuery, gridEnt, gridIndex, mapSystem))
             {
                 if (node is PortPipeNode)
                     yield return node;

--- a/Content.Server/Power/Generation/Teg/TegNodeGroup.cs
+++ b/Content.Server/Power/Generation/Teg/TegNodeGroup.cs
@@ -130,13 +130,14 @@ public sealed partial class TegNodeGenerator : Node
         TransformComponent xform,
         EntityQuery<NodeContainerComponent> nodeQuery,
         EntityQuery<TransformComponent> xformQuery,
-        MapGridComponent? grid,
+        Entity<MapGridComponent>? grid,
         IEntityManager entMan)
     {
-        if (!xform.Anchored || grid == null)
+        if (!xform.Anchored || grid is not { } gridEnt)
             yield break;
 
-        var gridIndex = grid.TileIndicesFor(xform.Coordinates);
+        var mapSystem = entMan.System<SharedMapSystem>();
+        var gridIndex = mapSystem.TileIndicesFor(gridEnt, xform.Coordinates);
 
         var dir = xform.LocalRotation.GetDir();
         var a = FindCirculator(dir);
@@ -152,7 +153,7 @@ public sealed partial class TegNodeGenerator : Node
         {
             var targetIdx = gridIndex.Offset(searchDir);
 
-            foreach (var node in NodeHelpers.GetNodesInTile(nodeQuery, grid, targetIdx))
+            foreach (var node in NodeHelpers.GetNodesInTile(nodeQuery, gridEnt, targetIdx, mapSystem))
             {
                 if (node is not TegNodeCirculator circulator)
                     continue;
@@ -182,19 +183,20 @@ public sealed partial class TegNodeCirculator : Node
         TransformComponent xform,
         EntityQuery<NodeContainerComponent> nodeQuery,
         EntityQuery<TransformComponent> xformQuery,
-        MapGridComponent? grid,
+        Entity<MapGridComponent>? grid,
         IEntityManager entMan)
     {
-        if (!xform.Anchored || grid == null)
+        if (!xform.Anchored || grid is not { } gridEnt)
             yield break;
 
-        var gridIndex = grid.TileIndicesFor(xform.Coordinates);
+        var mapSystem = entMan.System<SharedMapSystem>();
+        var gridIndex = mapSystem.TileIndicesFor(gridEnt, xform.Coordinates);
 
         var dir = xform.LocalRotation.GetDir();
         var searchDir = dir.GetClockwise90Degrees();
         var targetIdx = gridIndex.Offset(searchDir);
 
-        foreach (var node in NodeHelpers.GetNodesInTile(nodeQuery, grid, targetIdx))
+        foreach (var node in NodeHelpers.GetNodesInTile(nodeQuery, gridEnt, targetIdx, mapSystem))
         {
             if (node is not TegNodeGenerator generator)
                 continue;

--- a/Content.Server/Power/Nodes/CableDeviceNode.cs
+++ b/Content.Server/Power/Nodes/CableDeviceNode.cs
@@ -1,4 +1,3 @@
-using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.NodeContainer.Nodes;
 using Content.Shared.NodeContainer;
@@ -34,15 +33,16 @@ namespace Content.Server.Power.Nodes
         public override IEnumerable<Node> GetReachableNodes(TransformComponent xform,
             EntityQuery<NodeContainerComponent> nodeQuery,
             EntityQuery<TransformComponent> xformQuery,
-            MapGridComponent? grid,
+            Entity<MapGridComponent>? grid,
             IEntityManager entMan)
         {
-            if (!xform.Anchored || grid == null)
+            if (!xform.Anchored || grid is not { } gridEnt)
                 yield break;
 
-            var gridIndex = grid.TileIndicesFor(xform.Coordinates);
+            var mapSystem = entMan.System<SharedMapSystem>();
+            var gridIndex = mapSystem.TileIndicesFor(gridEnt, xform.Coordinates);
 
-            foreach (var node in NodeHelpers.GetNodesInTile(nodeQuery, grid, gridIndex))
+            foreach (var node in NodeHelpers.GetNodesInTile(nodeQuery, gridEnt, gridIndex, mapSystem))
             {
                 if (node is CableNode)
                     yield return node;

--- a/Content.Server/Power/Nodes/CableNode.cs
+++ b/Content.Server/Power/Nodes/CableNode.cs
@@ -1,7 +1,5 @@
-using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.Nodes;
 using Content.Shared.NodeContainer;
-using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 
 namespace Content.Server.Power.Nodes
@@ -12,20 +10,21 @@ namespace Content.Server.Power.Nodes
         public override IEnumerable<Node> GetReachableNodes(TransformComponent xform,
             EntityQuery<NodeContainerComponent> nodeQuery,
             EntityQuery<TransformComponent> xformQuery,
-            MapGridComponent? grid,
+            Entity<MapGridComponent>? grid,
             IEntityManager entMan)
         {
-            if (!xform.Anchored || grid == null)
+            if (!xform.Anchored || grid is not { } gridEnt)
                 yield break;
 
-            var gridIndex = grid.TileIndicesFor(xform.Coordinates);
+            var mapSystem = entMan.System<SharedMapSystem>();
+            var gridIndex = mapSystem.TileIndicesFor(gridEnt, xform.Coordinates);
 
             // While we go over adjacent nodes, we build a list of blocked directions due to
             // incoming or outgoing wire terminals.
             var terminalDirs = 0;
             List<(Direction, Node)> nodeDirs = new();
 
-            foreach (var (dir, node) in NodeHelpers.GetCardinalNeighborNodes(nodeQuery, grid, gridIndex))
+            foreach (var (dir, node) in NodeHelpers.GetCardinalNeighborNodes(nodeQuery, gridEnt, gridIndex, mapSystem))
             {
                 if (node is CableNode && node != this)
                 {

--- a/Content.Server/Power/Nodes/CableTerminalNode.cs
+++ b/Content.Server/Power/Nodes/CableTerminalNode.cs
@@ -12,18 +12,19 @@ namespace Content.Server.Power.Nodes
         public override IEnumerable<Node> GetReachableNodes(TransformComponent xform,
             EntityQuery<NodeContainerComponent> nodeQuery,
             EntityQuery<TransformComponent> xformQuery,
-            MapGridComponent? grid,
+            Entity<MapGridComponent>? grid,
             IEntityManager entMan)
         {
-            if (!xform.Anchored || grid == null)
+            if (!xform.Anchored || grid is not { } gridEnt)
                 yield break;
 
-            var gridIndex = grid.TileIndicesFor(xform.Coordinates);
+            var mapSystem = entMan.System<SharedMapSystem>();
+            var gridIndex = mapSystem.TileIndicesFor(gridEnt, xform.Coordinates);
 
             var dir = xform.LocalRotation.GetDir();
             var targetIdx = gridIndex.Offset(dir);
 
-            foreach (var node in NodeHelpers.GetNodesInTile(nodeQuery, grid, targetIdx))
+            foreach (var node in NodeHelpers.GetNodesInTile(nodeQuery, gridEnt, targetIdx, mapSystem))
             {
                 if (node is CableTerminalPortNode)
                     yield return node;

--- a/Content.Server/Power/Nodes/CableTerminalPortNode.cs
+++ b/Content.Server/Power/Nodes/CableTerminalPortNode.cs
@@ -1,7 +1,5 @@
-using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.Nodes;
 using Content.Shared.NodeContainer;
-using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 
 namespace Content.Server.Power.Nodes
@@ -12,15 +10,16 @@ namespace Content.Server.Power.Nodes
         public override IEnumerable<Node> GetReachableNodes(TransformComponent xform,
             EntityQuery<NodeContainerComponent> nodeQuery,
             EntityQuery<TransformComponent> xformQuery,
-            MapGridComponent? grid,
+            Entity<MapGridComponent>? grid,
             IEntityManager entMan)
         {
-            if (!xform.Anchored || grid == null)
+            if (!xform.Anchored || grid is not { } gridEnt)
                 yield break;
 
-            var gridIndex = grid.TileIndicesFor(xform.Coordinates);
+            var mapSystem = entMan.System<SharedMapSystem>();
+            var gridIndex = mapSystem.TileIndicesFor(gridEnt, xform.Coordinates);
 
-            var nodes = NodeHelpers.GetCardinalNeighborNodes(nodeQuery, grid, gridIndex, includeSameTile: false);
+            var nodes = NodeHelpers.GetCardinalNeighborNodes(nodeQuery, gridEnt, gridIndex, mapSystem, includeSameTile: false);
             foreach (var (_, node) in nodes)
             {
                 if (node is CableTerminalNode)

--- a/Content.Shared/NodeContainer/Node.cs
+++ b/Content.Shared/NodeContainer/Node.cs
@@ -95,6 +95,6 @@ public abstract partial class Node
     public abstract IEnumerable<Node> GetReachableNodes(TransformComponent xform,
         EntityQuery<NodeContainerComponent> nodeQuery,
         EntityQuery<TransformComponent> xformQuery,
-        MapGridComponent? grid,
+        Entity<MapGridComponent>? grid,
         IEntityManager entMan);
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Updated the API for `NodeHelpers` so the methods take `Entity<MapGridComponent>` instead of just `MapGridComponent`, as well as a reference to `SharedMapSystem`. This enables them to use `SharedMapSystem.GetAnchoredEntities` instead of the obsolete `MapGridComponent.GetAnchoredEntities`.

The old versions of the `NodeHelpers` methods were marked as obsolete. Cleaning up the uses of the old versions required a change to the abstract method `Node.GetReachableNodes`, so that it also takes an `Entity<MapGridComponent>` instead of a `MapGridComponent`. All classes that implement `GetReachableNodes` were updated to use the new signature.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
17 warnings for [PZW](https://github.com/space-wizards/space-station-14/issues/33279).
It's also just generally good to bring some old parts of the API up to more modern standards. Passing around components without references to their owner entities is funky.

## Technical details
<!-- Summary of code changes for easier review. -->


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- The abstract method `Node.GetReachableNodes` now takes an `Entity<MapGridComponent>?` instead of a `MapGridComponent?`. Classes that extend `Node` will need to be updated to override the new method signature.
- The methods of `NodeHelpers` now take an `Entity<MapGridComponent>` instead of just `MapGridComponent`, as well as a reference to `SharedMapSystem`.