### PR TITLE
Cleanup warnings in `CableVisSystem`

### DIFF
--- a/Content.Server/Power/EntitySystems/CableVisSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableVisSystem.cs
@@ -13,6 +13,7 @@ namespace Content.Server.Power.EntitySystems
     {
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
+        [Dependency] private readonly SharedMapSystem _map = default!;
 
         public override void Initialize()
         {
@@ -31,7 +32,7 @@ namespace Content.Server.Power.EntitySystems
                 return;
 
             var mask = WireVisDirFlags.None;
-            var tile = grid.TileIndicesFor(transform.Coordinates);
+            var tile = _map.TileIndicesFor((transform.GridUid.Value, grid), transform.Coordinates);
 
             foreach (var reachable in node.ReachableNodes)
             {
@@ -39,7 +40,7 @@ namespace Content.Server.Power.EntitySystems
                     continue;
 
                 var otherTransform = Transform(reachable.Owner);
-                var otherTile = grid.TileIndicesFor(otherTransform.Coordinates);
+                var otherTile = _map.TileIndicesFor((transform.GridUid.Value, grid), otherTransform.Coordinates);
                 var diff = otherTile - tile;
 
                 mask |= diff switch


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 2 warnings in `CableVisSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced `MapGridComponent.TileIndicesFor` with `SharedMapSystem.TileIndicesFor`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->