### PR TITLE
Add pause to runclient

### DIFF
--- a/runclient-Tools.bat
+++ b/runclient-Tools.bat
@@ -1,2 +1,3 @@
 @echo off
 dotnet run --project Content.Client --configuration Tools
+pause

--- a/runclient.bat
+++ b/runclient.bat
@@ -1,2 +1,3 @@
 @echo off
 dotnet run --project Content.Client
+pause


### PR DESCRIPTION
## About the PR
Add pause to `runclient.bat` and `runclient-Tools.bat`

## Why / Balance
- If client crashes, the console will not close, allowing you to see the error
- There is already a pause in `runclient.sh` and `runclient-Tools.sh` files

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
