### PR TITLE
Bar sign AlignTile version and fixtures for bar signs

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
@@ -98,7 +98,7 @@
 #- type: entity
 #  id: LargeBarSign
 #  name: large bar sign
-#  categories: [HideSpawnMenu ]
+#  categories: [ HideSpawnMenu ]
 #  components:
 #  - type: Clickable
 #  - type: InteractionOutline

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
@@ -1,7 +1,6 @@
 ﻿- type: entity
   id: BaseBarSign
   parent: BaseStructure
-  name: bar sign
   abstract: true
   components:
   - type: MeleeSound
@@ -15,7 +14,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.45,-0.45,1.45,0.45"
+          bounds: "-0.95,-0.45,0.95,0.45"
         density: 60
         mask:
         - MachineMask
@@ -23,7 +22,6 @@
         - MidImpassable
         - LowImpassable
   - type: Sprite
-    offset: 0.5,0
     drawdepth: WallMountedItems
     sprite: Structures/Wallmounts/barsign.rsi
     state: empty
@@ -64,16 +62,43 @@
     layoutId: BarSign
 
 - type: entity
+  id: BaseBarSignAlignTile
+  parent: BaseBarSign
+  sufix: AlignTile
+  abstract: true
+  components:
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,1.45,0.45"
+        density: 60
+        mask:
+        - MachineMask
+        layer:
+        - MidImpassable
+        - LowImpassable
+  - type: Sprite
+    offset: 0.5,0
+
+- type: entity
   parent: BaseBarSign
   id: BarSign
   name: bar sign
   suffix: Random
 
+- type: entity
+  parent: BaseBarSignAlignTile
+  id: BarSignAlignTile
+  name: bar sign
+  suffix: Random, AlignTile
+
 # Missing appearance components & various other sprite issues.
 #- type: entity
 #  id: LargeBarSign
 #  name: large bar sign
-#  categories: [ HideSpawnMenu ]
+#  categories: [HideSpawnMenu ]
 #  components:
 #  - type: Clickable
 #  - type: InteractionOutline
@@ -95,6 +120,11 @@
     current: ComboCafe
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignComboCafe]
+  id: BarSignComboCafeAlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignEmergencyRumParty
   name: Emergency Rum Party
@@ -102,6 +132,11 @@
   components:
   - type: BarSign
     current: EmergencyRumParty
+
+- type: entity
+  parent: [BaseBarSignAlignTile, BarSignEmergencyRumParty]
+  id: BarSignEmergencyRumPartyAlignTile
+  suffix: AlignTile
 
 - type: entity
   parent: BaseBarSign
@@ -113,6 +148,11 @@
     current: LV426
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignLV426]
+  id: BarSignLV426AlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignMaidCafe
   name: Maid Cafe
@@ -120,6 +160,11 @@
   components:
   - type: BarSign
     current: MaidCafe
+
+- type: entity
+  parent: [BaseBarSignAlignTile, BarSignMaidCafe]
+  id: BarSignMaidCafeAlignTile
+  suffix: AlignTile
 
 - type: entity
   parent: BaseBarSign
@@ -131,6 +176,11 @@
     current: MalteseFalcon
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignMalteseFalcon]
+  id: BarSignMalteseFalconAlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignOfficerBeersky
   name: Officer Beersky
@@ -138,6 +188,11 @@
   components:
   - type: BarSign
     current: OfficerBeersky
+
+- type: entity
+  parent: [BaseBarSignAlignTile, BarSignOfficerBeersky]
+  id: BarSignOfficerBeerskyAlignTile
+  suffix: AlignTile
 
 - type: entity
   parent: BaseBarSign
@@ -149,6 +204,11 @@
     current: RobustaCafe
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignRobustaCafe]
+  id: BarSignRobustaCafeAlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignTheAleNath
   name: The Ale Nath
@@ -156,6 +216,11 @@
   components:
   - type: BarSign
     current: TheAleNath
+
+- type: entity
+  parent: [BaseBarSignAlignTile, BarSignTheAleNath]
+  id: BarSignTheAleNathAlignTile
+  suffix: AlignTile
 
 - type: entity
   parent: BaseBarSign
@@ -167,6 +232,11 @@
     current: TheBirdCage
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignTheBirdCage]
+  id: BarSignTheBirdCageAlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignTheCoderbus
   name: The Coderbus
@@ -174,6 +244,11 @@
   components:
   - type: BarSign
     current: TheCoderbus
+
+- type: entity
+  parent: [BaseBarSignAlignTile, BarSignTheCoderbus]
+  id: BarSignTheCoderbusAlignTile
+  suffix: AlignTile
 
 - type: entity
   parent: BaseBarSign
@@ -185,6 +260,11 @@
     current: TheDrunkCarp
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignTheDrunkCarp]
+  id: BarSignTheDrunkCarpAlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignEngineChange
   name: The Engine Change
@@ -192,6 +272,11 @@
   components:
   - type: BarSign
     current: EngineChange
+
+- type: entity
+  parent: [BaseBarSignAlignTile, BarSignEngineChange]
+  id: BarSignEngineChangeAlignTile
+  suffix: AlignTile
 
 - type: entity
   parent: BaseBarSign
@@ -203,6 +288,11 @@
     current: Harmbaton
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignTheHarmbaton]
+  id: BarSignTheHarmbatonAlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignTheLightbulb
   name: The Lightbulb
@@ -210,6 +300,11 @@
   components:
   - type: BarSign
     current: TheLightbulb
+
+- type: entity
+  parent: [BaseBarSignAlignTile, BarSignTheLightbulb]
+  id: BarSignTheLightbulbAlignTile
+  suffix: AlignTile
 
 - type: entity
   parent: BaseBarSign
@@ -221,6 +316,11 @@
     current: Goose
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignTheLooseGoose]
+  id: BarSignTheLooseGooseAlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignTheNet
   name: The Net
@@ -228,6 +328,11 @@
   components:
   - type: BarSign
     current: TheNet
+
+- type: entity
+  parent: [BaseBarSignAlignTile, BarSignTheNet]
+  id: BarSignTheNetAlignTile
+  suffix: AlignTile
 
 - type: entity
   parent: BaseBarSign
@@ -239,6 +344,11 @@
     current: TheOuterSpess
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignTheOuterSpess]
+  id: BarSignTheOuterSpessAlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignTheSingulo
   name: The Singulo
@@ -246,6 +356,11 @@
   components:
   - type: BarSign
     current: TheSingulo
+
+- type: entity
+  parent: [BaseBarSignAlignTile, BarSignTheSingulo]
+  id: BarSignTheSinguloAlignTile
+  suffix: AlignTile
 
 - type: entity
   parent: BaseBarSign
@@ -257,6 +372,11 @@
     current: TheSun
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignTheSun]
+  id: BarSignTheSunAlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignWiggleRoom
   name: Wiggle Room
@@ -264,6 +384,11 @@
   components:
   - type: BarSign
     current: WiggleRoom
+
+- type: entity
+  parent: [BaseBarSignAlignTile, BarSignWiggleRoom]
+  id: BarSignWiggleRoomAlignTile
+  suffix: AlignTile
 
 - type: entity
   parent: BaseBarSign
@@ -275,6 +400,11 @@
     current: Zocalo
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignZocalo]
+  id: BarSignZocaloAlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignEmprah
   name: 4 The Emprah
@@ -282,6 +412,11 @@
   components:
   - type: BarSign
     current: Emprah
+
+- type: entity
+  parent: [BaseBarSignAlignTile, BarSignEmprah]
+  id: BarSignEmprahAlignTile
+  suffix: AlignTile
 
 - type: entity
   parent: BaseBarSign
@@ -293,6 +428,11 @@
     current: Spacebucks
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignSpacebucks]
+  id: BarSignSpacebucksAlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignMaltroach
   name: The Maltroach
@@ -302,6 +442,11 @@
     current: Maltroach
 
 - type: entity
+  parent: [BaseBarSignAlignTile, BarSignMaltroach]
+  id: BarSignMaltroachAlignTile
+  suffix: AlignTile
+
+- type: entity
   parent: BaseBarSign
   id: BarSignWhiskeyEchoes
   name: Whiskey Echoes
@@ -309,3 +454,8 @@
   components:
   - type: BarSign
     current: WhiskeyEchoes
+
+- type: entity
+  parent: [BaseBarSignAlignTile, BarSignWhiskeyEchoes]
+  id: BarSignWhiskeyEchoesAlignTile
+  suffix: AlignTile

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
@@ -10,7 +10,20 @@
         collection: GlassSmash
   - type: WallMount
     arc: 360
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,1.45,0.45"
+        density: 60
+        mask:
+        - MachineMask
+        layer:
+        - MidImpassable
+        - LowImpassable
   - type: Sprite
+    offset: 0.5,0
     drawdepth: WallMountedItems
     sprite: Structures/Wallmounts/barsign.rsi
     state: empty


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Now there is version of bar sign that takes full 2 tiles. I've also changed its fixtures.

## Why / Balance
#6476 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/9a91e4ec-a3f5-4983-8f79-dc5901216c5b)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->


:cl:
- add: Tile-aligned bar sign version was added.
- fix: Bar signs now have proper collision.