### PR TITLE
Cleanup warnings in `SalvageExpeditionConsoleBoundUserInterface`

### DIFF
--- a/Content.Client/Salvage/UI/SalvageExpeditionConsoleBoundUserInterface.cs
+++ b/Content.Client/Salvage/UI/SalvageExpeditionConsoleBoundUserInterface.cs
@@ -20,11 +20,15 @@ public sealed class SalvageExpeditionConsoleBoundUserInterface : BoundUserInterf
 
     [Dependency] private readonly IConfigurationManager _cfgManager = default!;
     [Dependency] private readonly IEntityManager _entManager = default!;
+    [Dependency] private readonly ILogManager _logManager = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
+
+    private readonly ISawmill _sawmill;
 
     public SalvageExpeditionConsoleBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
         IoCManager.InjectDependencies(this);
+        _sawmill = _logManager.GetSawmill("salvage.expedition.console");
     }
 
     protected override void Open()
@@ -111,7 +115,7 @@ public sealed class SalvageExpeditionConsoleBoundUserInterface : BoundUserInterf
 
             string LogAndReturnDefaultFactionDescription(string faction)
             {
-                Logger.Error($"Description is null or white space for SalvageFactionPrototype: {faction}");
+                _sawmill.Error($"Description is null or white space for SalvageFactionPrototype: {faction}");
                 return Loc.GetString(_protoManager.Index<SalvageFactionPrototype>(faction).ID);
             }
 
@@ -150,7 +154,7 @@ public sealed class SalvageExpeditionConsoleBoundUserInterface : BoundUserInterf
 
             string LogAndReturnDefaultBiomDescription(string biome)
             {
-                Logger.Error($"Description is null or white space for SalvageBiomeModPrototype: {biome}");
+                _sawmill.Error($"Description is null or white space for SalvageBiomeModPrototype: {biome}");
                 return Loc.GetString(_protoManager.Index<SalvageBiomeModPrototype>(biome).ID);
             }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 2 warnings in `SalvageExpeditionConsoleBoundUserInterface.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced static logger calls with a proper `ISawmill` setup.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->