### PR TITLE
Cleanup redundant `SpriteSystem` dependencies in `VisualizerSystem`s

### DIFF
--- a/Content.Client/Atmos/EntitySystems/FireVisualizerSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/FireVisualizerSystem.cs
@@ -11,7 +11,6 @@ namespace Content.Client.Atmos.EntitySystems;
 /// </summary>
 public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
     [Dependency] private readonly PointLightSystem _lights = default!;
 
     public override void Initialize()
@@ -33,9 +32,9 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
         // Need LayerMapTryGet because Init fails if there's no existing sprite / appearancecomp
         // which means in some setups (most frequently no AppearanceComp) the layer never exists.
         if (TryComp<SpriteComponent>(uid, out var sprite) &&
-            _sprite.LayerMapTryGet((uid, sprite), FireVisualLayers.Fire, out var layer, false))
+            SpriteSystem.LayerMapTryGet((uid, sprite), FireVisualLayers.Fire, out var layer, false))
         {
-            _sprite.RemoveLayer((uid, sprite), layer);
+            SpriteSystem.RemoveLayer((uid, sprite), layer);
         }
     }
 
@@ -44,11 +43,11 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
         if (!TryComp<SpriteComponent>(uid, out var sprite) || !TryComp(uid, out AppearanceComponent? appearance))
             return;
 
-        _sprite.LayerMapReserve((uid, sprite), FireVisualLayers.Fire);
-        _sprite.LayerSetVisible((uid, sprite), FireVisualLayers.Fire, false);
+        SpriteSystem.LayerMapReserve((uid, sprite), FireVisualLayers.Fire);
+        SpriteSystem.LayerSetVisible((uid, sprite), FireVisualLayers.Fire, false);
         sprite.LayerSetShader(FireVisualLayers.Fire, "unshaded");
         if (component.Sprite != null)
-            _sprite.LayerSetRsi((uid, sprite), FireVisualLayers.Fire, new ResPath(component.Sprite));
+            SpriteSystem.LayerSetRsi((uid, sprite), FireVisualLayers.Fire, new ResPath(component.Sprite));
 
         UpdateAppearance(uid, component, sprite, appearance);
     }
@@ -61,12 +60,12 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
 
     private void UpdateAppearance(EntityUid uid, FireVisualsComponent component, SpriteComponent sprite, AppearanceComponent appearance)
     {
-        if (!_sprite.LayerMapTryGet((uid, sprite), FireVisualLayers.Fire, out var index, false))
+        if (!SpriteSystem.LayerMapTryGet((uid, sprite), FireVisualLayers.Fire, out var index, false))
             return;
 
         AppearanceSystem.TryGetData<bool>(uid, FireVisuals.OnFire, out var onFire, appearance);
         AppearanceSystem.TryGetData<float>(uid, FireVisuals.FireStacks, out var fireStacks, appearance);
-        _sprite.LayerSetVisible((uid, sprite), index, onFire);
+        SpriteSystem.LayerSetVisible((uid, sprite), index, onFire);
 
         if (!onFire)
         {
@@ -80,9 +79,9 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
         }
 
         if (fireStacks > component.FireStackAlternateState && !string.IsNullOrEmpty(component.AlternateState))
-            _sprite.LayerSetRsiState((uid, sprite), index, component.AlternateState);
+            SpriteSystem.LayerSetRsiState((uid, sprite), index, component.AlternateState);
         else
-            _sprite.LayerSetRsiState((uid, sprite), index, component.NormalState);
+            SpriteSystem.LayerSetRsiState((uid, sprite), index, component.NormalState);
 
         component.LightEntity ??= Spawn(null, new EntityCoordinates(uid, default));
         var light = EnsureComp<PointLightComponent>(component.LightEntity.Value);

--- a/Content.Client/Atmos/Monitor/AtmosAlarmableVisualsSystem.cs
+++ b/Content.Client/Atmos/Monitor/AtmosAlarmableVisualsSystem.cs
@@ -7,11 +7,9 @@ namespace Content.Client.Atmos.Monitor;
 
 public sealed class AtmosAlarmableVisualsSystem : VisualizerSystem<AtmosAlarmableVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, AtmosAlarmableVisualsComponent component, ref AppearanceChangeEvent args)
     {
-        if (args.Sprite == null || !_sprite.LayerMapTryGet((uid, args.Sprite), component.LayerMap, out var layer, false))
+        if (args.Sprite == null || !SpriteSystem.LayerMapTryGet((uid, args.Sprite), component.LayerMap, out var layer, false))
             return;
 
         if (!args.AppearanceData.TryGetValue(PowerDeviceVisuals.Powered, out var poweredObject) ||
@@ -24,8 +22,8 @@ public sealed class AtmosAlarmableVisualsSystem : VisualizerSystem<AtmosAlarmabl
         {
             foreach (var visLayer in component.HideOnDepowered)
             {
-                if (_sprite.LayerMapTryGet((uid, args.Sprite), visLayer, out var powerVisibilityLayer, false))
-                    _sprite.LayerSetVisible((uid, args.Sprite), powerVisibilityLayer, powered);
+                if (SpriteSystem.LayerMapTryGet((uid, args.Sprite), visLayer, out var powerVisibilityLayer, false))
+                    SpriteSystem.LayerSetVisible((uid, args.Sprite), powerVisibilityLayer, powered);
             }
         }
 
@@ -33,8 +31,8 @@ public sealed class AtmosAlarmableVisualsSystem : VisualizerSystem<AtmosAlarmabl
         {
             foreach (var (setLayer, powerState) in component.SetOnDepowered)
             {
-                if (_sprite.LayerMapTryGet((uid, args.Sprite), setLayer, out var setStateLayer, false))
-                    _sprite.LayerSetRsiState((uid, args.Sprite), setStateLayer, new RSI.StateId(powerState));
+                if (SpriteSystem.LayerMapTryGet((uid, args.Sprite), setLayer, out var setStateLayer, false))
+                    SpriteSystem.LayerSetRsiState((uid, args.Sprite), setStateLayer, new RSI.StateId(powerState));
             }
         }
 
@@ -43,7 +41,7 @@ public sealed class AtmosAlarmableVisualsSystem : VisualizerSystem<AtmosAlarmabl
             && powered
             && component.AlarmStates.TryGetValue(alarmType, out var state))
         {
-            _sprite.LayerSetRsiState((uid, args.Sprite), layer, new RSI.StateId(state));
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), layer, new RSI.StateId(state));
         }
     }
 }

--- a/Content.Client/Atmos/Visualizers/PortableScrubberVisualsSystem.cs
+++ b/Content.Client/Atmos/Visualizers/PortableScrubberVisualsSystem.cs
@@ -9,8 +9,6 @@ namespace Content.Client.Atmos.Visualizers;
 /// </summary>
 public sealed class PortableScrubberSystem : VisualizerSystem<PortableScrubberVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, PortableScrubberVisualsComponent component, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
@@ -20,15 +18,15 @@ public sealed class PortableScrubberSystem : VisualizerSystem<PortableScrubberVi
             && AppearanceSystem.TryGetData<bool>(uid, PortableScrubberVisuals.IsRunning, out var isRunning, args.Component))
         {
             var runningState = isRunning ? component.RunningState : component.IdleState;
-            _sprite.LayerSetRsiState((uid, args.Sprite), PortableScrubberVisualLayers.IsRunning, runningState);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), PortableScrubberVisualLayers.IsRunning, runningState);
 
             var fullState = isFull ? component.FullState : component.ReadyState;
-            _sprite.LayerSetRsiState((uid, args.Sprite), PowerDeviceVisualLayers.Powered, fullState);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), PowerDeviceVisualLayers.Powered, fullState);
         }
 
         if (AppearanceSystem.TryGetData<bool>(uid, PortableScrubberVisuals.IsDraining, out var isDraining, args.Component))
         {
-            _sprite.LayerSetVisible((uid, args.Sprite), PortableScrubberVisualLayers.IsDraining, isDraining);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), PortableScrubberVisualLayers.IsDraining, isDraining);
         }
     }
 }

--- a/Content.Client/Botany/PlantHolderVisualizerSystem.cs
+++ b/Content.Client/Botany/PlantHolderVisualizerSystem.cs
@@ -7,8 +7,6 @@ namespace Content.Client.Botany;
 
 public sealed class PlantHolderVisualizerSystem : VisualizerSystem<PlantHolderVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -20,8 +18,8 @@ public sealed class PlantHolderVisualizerSystem : VisualizerSystem<PlantHolderVi
         if (!TryComp<SpriteComponent>(uid, out var sprite))
             return;
 
-        _sprite.LayerMapReserve((uid, sprite), PlantHolderLayers.Plant);
-        _sprite.LayerSetVisible((uid, sprite), PlantHolderLayers.Plant, false);
+        SpriteSystem.LayerMapReserve((uid, sprite), PlantHolderLayers.Plant);
+        SpriteSystem.LayerSetVisible((uid, sprite), PlantHolderLayers.Plant, false);
     }
 
     protected override void OnAppearanceChange(EntityUid uid, PlantHolderVisualsComponent component, ref AppearanceChangeEvent args)
@@ -34,12 +32,12 @@ public sealed class PlantHolderVisualizerSystem : VisualizerSystem<PlantHolderVi
         {
             var valid = !string.IsNullOrWhiteSpace(state);
 
-            _sprite.LayerSetVisible((uid, args.Sprite), PlantHolderLayers.Plant, valid);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), PlantHolderLayers.Plant, valid);
 
             if (valid)
             {
-                _sprite.LayerSetRsi((uid, args.Sprite), PlantHolderLayers.Plant, new ResPath(rsi));
-                _sprite.LayerSetRsiState((uid, args.Sprite), PlantHolderLayers.Plant, state);
+                SpriteSystem.LayerSetRsi((uid, args.Sprite), PlantHolderLayers.Plant, new ResPath(rsi));
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), PlantHolderLayers.Plant, state);
             }
         }
     }

--- a/Content.Client/Chat/TypingIndicator/TypingIndicatorVisualizerSystem.cs
+++ b/Content.Client/Chat/TypingIndicator/TypingIndicatorVisualizerSystem.cs
@@ -9,7 +9,6 @@ public sealed class TypingIndicatorVisualizerSystem : VisualizerSystem<TypingInd
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
-    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     protected override void OnAppearanceChange(EntityUid uid, TypingIndicatorComponent component, ref AppearanceChangeEvent args)
     {
@@ -34,24 +33,24 @@ public sealed class TypingIndicatorVisualizerSystem : VisualizerSystem<TypingInd
             return;
         }
 
-        var layerExists = _sprite.LayerMapTryGet((uid, args.Sprite), TypingIndicatorLayers.Base, out var layer, false);
+        var layerExists = SpriteSystem.LayerMapTryGet((uid, args.Sprite), TypingIndicatorLayers.Base, out var layer, false);
         if (!layerExists)
-            layer = _sprite.LayerMapReserve((uid, args.Sprite), TypingIndicatorLayers.Base);
+            layer = SpriteSystem.LayerMapReserve((uid, args.Sprite), TypingIndicatorLayers.Base);
 
-        _sprite.LayerSetRsi((uid, args.Sprite), layer, proto.SpritePath);
-        _sprite.LayerSetRsiState((uid, args.Sprite), layer, proto.TypingState);
+        SpriteSystem.LayerSetRsi((uid, args.Sprite), layer, proto.SpritePath);
+        SpriteSystem.LayerSetRsiState((uid, args.Sprite), layer, proto.TypingState);
         args.Sprite.LayerSetShader(layer, proto.Shader);
-        _sprite.LayerSetOffset((uid, args.Sprite), layer, proto.Offset);
+        SpriteSystem.LayerSetOffset((uid, args.Sprite), layer, proto.Offset);
 
         AppearanceSystem.TryGetData<TypingIndicatorState>(uid, TypingIndicatorVisuals.State, out var state);
-        _sprite.LayerSetVisible((uid, args.Sprite), layer, state != TypingIndicatorState.None);
+        SpriteSystem.LayerSetVisible((uid, args.Sprite), layer, state != TypingIndicatorState.None);
         switch (state)
         {
             case TypingIndicatorState.Idle:
-                _sprite.LayerSetRsiState((uid, args.Sprite), layer, proto.IdleState);
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), layer, proto.IdleState);
                 break;
             case TypingIndicatorState.Typing:
-                _sprite.LayerSetRsiState((uid, args.Sprite), layer, proto.TypingState);
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), layer, proto.TypingState);
                 break;
         }
     }

--- a/Content.Client/Chemistry/Visualizers/FoamVisualizerSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/FoamVisualizerSystem.cs
@@ -11,7 +11,6 @@ namespace Content.Client.Chemistry.Visualizers;
 public sealed class FoamVisualizerSystem : VisualizerSystem<FoamVisualsComponent>
 {
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -72,7 +71,7 @@ public sealed class FoamVisualizerSystem : VisualizerSystem<FoamVisualsComponent
             return;
 
         if (TryComp<SpriteComponent>(uid, out var sprite))
-            _sprite.SetVisible((uid, sprite), false);
+            SpriteSystem.SetVisible((uid, sprite), false);
     }
 }
 

--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -16,7 +16,6 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly ItemSystem _itemSystem = default!;
-    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -50,7 +49,7 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
         if (args.Sprite == null)
             return;
 
-        if (!_sprite.LayerMapTryGet((uid, args.Sprite), component.Layer, out var fillLayer, false))
+        if (!SpriteSystem.LayerMapTryGet((uid, args.Sprite), component.Layer, out var fillLayer, false))
             return;
 
         var maxFillLevels = component.MaxFillLevels;
@@ -68,9 +67,9 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
         }
         if (component.Metamorphic)
         {
-            if (_sprite.LayerMapTryGet((uid, args.Sprite), component.BaseLayer, out var baseLayer, false))
+            if (SpriteSystem.LayerMapTryGet((uid, args.Sprite), component.BaseLayer, out var baseLayer, false))
             {
-                var hasOverlay = _sprite.LayerMapTryGet((uid, args.Sprite), component.OverlayLayer, out var overlayLayer, false);
+                var hasOverlay = SpriteSystem.LayerMapTryGet((uid, args.Sprite), component.OverlayLayer, out var overlayLayer, false);
 
                 if (AppearanceSystem.TryGetData<string>(uid, SolutionContainerVisuals.BaseOverride,
                         out var baseOverride,
@@ -80,35 +79,35 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
 
                     if (reagentProto?.MetamorphicSprite is { } sprite)
                     {
-                        _sprite.LayerSetSprite((uid, args.Sprite), baseLayer, sprite);
+                        SpriteSystem.LayerSetSprite((uid, args.Sprite), baseLayer, sprite);
                         if (reagentProto.MetamorphicMaxFillLevels > 0)
                         {
-                            _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, true);
+                            SpriteSystem.LayerSetVisible((uid, args.Sprite), fillLayer, true);
                             maxFillLevels = reagentProto.MetamorphicMaxFillLevels;
                             fillBaseName = reagentProto.MetamorphicFillBaseName;
                             changeColor = reagentProto.MetamorphicChangeColor;
                             fillSprite = sprite;
                         }
                         else
-                            _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, false);
+                            SpriteSystem.LayerSetVisible((uid, args.Sprite), fillLayer, false);
 
                         if (hasOverlay)
-                            _sprite.LayerSetVisible((uid, args.Sprite), overlayLayer, false);
+                            SpriteSystem.LayerSetVisible((uid, args.Sprite), overlayLayer, false);
                     }
                     else
                     {
-                        _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, true);
+                        SpriteSystem.LayerSetVisible((uid, args.Sprite), fillLayer, true);
                         if (hasOverlay)
-                            _sprite.LayerSetVisible((uid, args.Sprite), overlayLayer, true);
+                            SpriteSystem.LayerSetVisible((uid, args.Sprite), overlayLayer, true);
                         if (component.MetamorphicDefaultSprite != null)
-                            _sprite.LayerSetSprite((uid, args.Sprite), baseLayer, component.MetamorphicDefaultSprite);
+                            SpriteSystem.LayerSetSprite((uid, args.Sprite), baseLayer, component.MetamorphicDefaultSprite);
                     }
                 }
             }
         }
         else
         {
-            _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, true);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), fillLayer, true);
         }
 
         var closestFillSprite = ContentHelpers.RoundToLevels(fraction, 1, maxFillLevels + 1);
@@ -120,25 +119,25 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
 
             var stateName = fillBaseName + closestFillSprite;
             if (fillSprite != null)
-                _sprite.LayerSetSprite((uid, args.Sprite), fillLayer, fillSprite);
-            _sprite.LayerSetRsiState((uid, args.Sprite), fillLayer, stateName);
+                SpriteSystem.LayerSetSprite((uid, args.Sprite), fillLayer, fillSprite);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), fillLayer, stateName);
 
             if (changeColor && AppearanceSystem.TryGetData<Color>(uid, SolutionContainerVisuals.Color, out var color, args.Component))
-                _sprite.LayerSetColor((uid, args.Sprite), fillLayer, color);
+                SpriteSystem.LayerSetColor((uid, args.Sprite), fillLayer, color);
             else
-                _sprite.LayerSetColor((uid, args.Sprite), fillLayer, Color.White);
+                SpriteSystem.LayerSetColor((uid, args.Sprite), fillLayer, Color.White);
         }
         else
         {
             if (component.EmptySpriteName == null)
-                _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, false);
+                SpriteSystem.LayerSetVisible((uid, args.Sprite), fillLayer, false);
             else
             {
-                _sprite.LayerSetRsiState((uid, args.Sprite), fillLayer, component.EmptySpriteName);
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), fillLayer, component.EmptySpriteName);
                 if (changeColor)
-                    _sprite.LayerSetColor((uid, args.Sprite), fillLayer, component.EmptySpriteColor);
+                    SpriteSystem.LayerSetColor((uid, args.Sprite), fillLayer, component.EmptySpriteColor);
                 else
-                    _sprite.LayerSetColor((uid, args.Sprite), fillLayer, Color.White);
+                    SpriteSystem.LayerSetColor((uid, args.Sprite), fillLayer, Color.White);
             }
         }
 

--- a/Content.Client/Damage/DamageVisualsSystem.cs
+++ b/Content.Client/Damage/DamageVisualsSystem.cs
@@ -27,7 +27,6 @@ namespace Content.Client.Damage;
 public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponent>
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -229,7 +228,7 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
             // the layer key just doesn't exist, we skip it.
             foreach (var key in damageVisComp.TargetLayers)
             {
-                if (!_sprite.LayerMapTryGet((entity, spriteComponent), key, out var index, false))
+                if (!SpriteSystem.LayerMapTryGet((entity, spriteComponent), key, out var index, false))
                 {
                     Log.Warning($"Layer at key {key} was invalid for entity {entity}.");
                     continue;
@@ -254,7 +253,7 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
             foreach (var layer in damageVisComp.TargetLayerMapKeys)
             {
                 var layerCount = spriteComponent.AllLayers.Count();
-                var index = _sprite.LayerMapGet((entity, spriteComponent), layer);
+                var index = SpriteSystem.LayerMapGet((entity, spriteComponent), layer);
                 // var layerState = spriteComponent.LayerGetState(index).ToString()!;
 
                 if (index + 1 != layerCount)
@@ -325,17 +324,17 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
     /// </summary>
     private void AddDamageLayerToSprite(Entity<SpriteComponent?> spriteEnt, DamageVisualizerSprite sprite, string state, string mapKey, int? index = null)
     {
-        var newLayer = _sprite.AddLayer(
+        var newLayer = SpriteSystem.AddLayer(
             spriteEnt,
             new SpriteSpecifier.Rsi(
                 new(sprite.Sprite), state
             ),
             index
         );
-        _sprite.LayerMapSet(spriteEnt, mapKey, newLayer);
+        SpriteSystem.LayerMapSet(spriteEnt, mapKey, newLayer);
         if (sprite.Color != null)
-            _sprite.LayerSetColor(spriteEnt, newLayer, Color.FromHex(sprite.Color));
-        _sprite.LayerSetVisible(spriteEnt, newLayer, false);
+            SpriteSystem.LayerSetColor(spriteEnt, newLayer, Color.FromHex(sprite.Color));
+        SpriteSystem.LayerSetVisible(spriteEnt, newLayer, false);
     }
 
     protected override void OnAppearanceChange(EntityUid uid, DamageVisualsComponent damageVisComp, ref AppearanceChangeEvent args)
@@ -410,7 +409,7 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
             damageVisComp.DisabledLayers[layer] = disabled;
             if (damageVisComp.TrackAllDamage)
             {
-                _sprite.LayerSetVisible((uid, spriteComponent), $"{layer}trackDamage", !disabled);
+                SpriteSystem.LayerSetVisible((uid, spriteComponent), $"{layer}trackDamage", !disabled);
                 continue;
             }
 
@@ -419,7 +418,7 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
 
             foreach (var damageGroup in damageVisComp.DamageOverlayGroups.Keys)
             {
-                _sprite.LayerSetVisible((uid, spriteComponent), $"{layer}{damageGroup}", !disabled);
+                SpriteSystem.LayerSetVisible((uid, spriteComponent), $"{layer}{damageGroup}", !disabled);
             }
         }
     }
@@ -462,20 +461,20 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
 
     private void ReorderOverlaySprite(Entity<SpriteComponent> spriteEnt, DamageVisualsComponent damageVisComp, DamageVisualizerSprite sprite, string key, string statePrefix, FixedPoint2 threshold)
     {
-        _sprite.LayerMapTryGet(spriteEnt.AsNullable(), key, out var spriteLayer, false);
+        SpriteSystem.LayerMapTryGet(spriteEnt.AsNullable(), key, out var spriteLayer, false);
         var visibility = spriteEnt.Comp[spriteLayer].Visible;
-        _sprite.RemoveLayer(spriteEnt.AsNullable(), spriteLayer);
+        SpriteSystem.RemoveLayer(spriteEnt.AsNullable(), spriteLayer);
         if (threshold == FixedPoint2.Zero) // these should automatically be invisible
             threshold = damageVisComp.Thresholds[1];
-        spriteLayer = _sprite.AddLayer(
+        spriteLayer = SpriteSystem.AddLayer(
             spriteEnt.AsNullable(),
             new SpriteSpecifier.Rsi(
                 new(sprite.Sprite),
                 $"{statePrefix}_{threshold}"
             ),
             spriteLayer);
-        _sprite.LayerMapSet(spriteEnt.AsNullable(), key, spriteLayer);
-        _sprite.LayerSetVisible(spriteEnt.AsNullable(), spriteLayer, visibility);
+        SpriteSystem.LayerMapSet(spriteEnt.AsNullable(), key, spriteLayer);
+        SpriteSystem.LayerSetVisible(spriteEnt.AsNullable(), spriteLayer, visibility);
         // this is somewhat iffy since it constantly reallocates
         damageVisComp.TopMostLayerKey = key;
     }
@@ -610,7 +609,7 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
             if (!damageVisComp.DisabledLayers[layerMapKey])
             {
                 var layerState = damageVisComp.LayerMapKeyStates[layerMapKey];
-                _sprite.LayerMapTryGet(spriteEnt.AsNullable(), $"{layerMapKey}trackDamage", out var spriteLayer, false);
+                SpriteSystem.LayerMapTryGet(spriteEnt.AsNullable(), $"{layerMapKey}trackDamage", out var spriteLayer, false);
 
                 UpdateDamageLayerState(spriteEnt,
                     spriteLayer,
@@ -621,7 +620,7 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
         else if (!damageVisComp.Overlay)
         {
             var layerState = damageVisComp.LayerMapKeyStates[layerMapKey];
-            _sprite.LayerMapTryGet(spriteEnt.AsNullable(), $"{layerMapKey}", out var spriteLayer, false);
+            SpriteSystem.LayerMapTryGet(spriteEnt.AsNullable(), $"{layerMapKey}", out var spriteLayer, false);
 
             UpdateDamageLayerState(spriteEnt,
                 spriteLayer,
@@ -643,7 +642,7 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
             if (damageVisComp.DamageOverlayGroups.ContainsKey(damageGroup) && !damageVisComp.DisabledLayers[layerMapKey])
             {
                 var layerState = damageVisComp.LayerMapKeyStates[layerMapKey];
-                _sprite.LayerMapTryGet((entity, spriteComponent), $"{layerMapKey}{damageGroup}", out var spriteLayer, false);
+                SpriteSystem.LayerMapTryGet((entity, spriteComponent), $"{layerMapKey}{damageGroup}", out var spriteLayer, false);
 
                 UpdateDamageLayerState(
                     (entity, spriteComponent),
@@ -655,7 +654,7 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
         else if (!damageVisComp.Overlay)
         {
             var layerState = damageVisComp.LayerMapKeyStates[layerMapKey];
-            _sprite.LayerMapTryGet((entity, spriteComponent), $"{layerMapKey}", out var spriteLayer, false);
+            SpriteSystem.LayerMapTryGet((entity, spriteComponent), $"{layerMapKey}", out var spriteLayer, false);
 
             UpdateDamageLayerState(
                 (entity, spriteComponent),
@@ -670,7 +669,7 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
     /// </summary>
     private void UpdateOverlay(Entity<SpriteComponent> spriteEnt, FixedPoint2 threshold)
     {
-        _sprite.LayerMapTryGet(spriteEnt.AsNullable(), $"DamageOverlay", out var spriteLayer, false);
+        SpriteSystem.LayerMapTryGet(spriteEnt.AsNullable(), $"DamageOverlay", out var spriteLayer, false);
 
         UpdateDamageLayerState(spriteEnt,
             spriteLayer,
@@ -690,7 +689,7 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
         {
             if (damageVisComp.DamageOverlayGroups.ContainsKey(damageGroup))
             {
-                _sprite.LayerMapTryGet((entity, spriteComponent), $"DamageOverlay{damageGroup}", out var spriteLayer, false);
+                SpriteSystem.LayerMapTryGet((entity, spriteComponent), $"DamageOverlay{damageGroup}", out var spriteLayer, false);
 
                 UpdateDamageLayerState(
                     (entity, spriteComponent),
@@ -711,15 +710,15 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
     {
         if (threshold == 0)
         {
-            _sprite.LayerSetVisible(spriteEnt.AsNullable(), spriteLayer, false);
+            SpriteSystem.LayerSetVisible(spriteEnt.AsNullable(), spriteLayer, false);
         }
         else
         {
             if (!spriteEnt.Comp[spriteLayer].Visible)
             {
-                _sprite.LayerSetVisible(spriteEnt.AsNullable(), spriteLayer, true);
+                SpriteSystem.LayerSetVisible(spriteEnt.AsNullable(), spriteLayer, true);
             }
-            _sprite.LayerSetRsiState(spriteEnt.AsNullable(), spriteLayer, $"{statePrefix}_{threshold}");
+            SpriteSystem.LayerSetRsiState(spriteEnt.AsNullable(), spriteLayer, $"{statePrefix}_{threshold}");
         }
     }
 }

--- a/Content.Client/DamageState/DamageStateVisualizerSystem.cs
+++ b/Content.Client/DamageState/DamageStateVisualizerSystem.cs
@@ -6,8 +6,6 @@ namespace Content.Client.DamageState;
 
 public sealed class DamageStateVisualizerSystem : VisualizerSystem<DamageStateVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, DamageStateVisualsComponent component, ref AppearanceChangeEvent args)
     {
         var sprite = args.Sprite;
@@ -25,18 +23,18 @@ public sealed class DamageStateVisualizerSystem : VisualizerSystem<DamageStateVi
         // Brain no worky rn so this was just easier.
         foreach (var key in new[] { DamageStateVisualLayers.Base, DamageStateVisualLayers.BaseUnshaded })
         {
-            if (!_sprite.LayerMapTryGet((uid, sprite), key, out _, false)) continue;
+            if (!SpriteSystem.LayerMapTryGet((uid, sprite), key, out _, false)) continue;
 
-            _sprite.LayerSetVisible((uid, sprite), key, false);
+            SpriteSystem.LayerSetVisible((uid, sprite), key, false);
         }
 
         foreach (var (key, state) in layers)
         {
             // Inheritance moment.
-            if (!_sprite.LayerMapTryGet((uid, sprite), key, out _, false)) continue;
+            if (!SpriteSystem.LayerMapTryGet((uid, sprite), key, out _, false)) continue;
 
-            _sprite.LayerSetVisible((uid, sprite), key, true);
-            _sprite.LayerSetRsiState((uid, sprite), key, state);
+            SpriteSystem.LayerSetVisible((uid, sprite), key, true);
+            SpriteSystem.LayerSetRsiState((uid, sprite), key, state);
         }
 
         // So they don't draw over mobs anymore
@@ -45,12 +43,12 @@ public sealed class DamageStateVisualizerSystem : VisualizerSystem<DamageStateVi
             if (sprite.DrawDepth > (int)DrawDepth.DeadMobs)
             {
                 component.OriginalDrawDepth = sprite.DrawDepth;
-                _sprite.SetDrawDepth((uid, sprite), (int)DrawDepth.DeadMobs);
+                SpriteSystem.SetDrawDepth((uid, sprite), (int)DrawDepth.DeadMobs);
             }
         }
         else if (component.OriginalDrawDepth != null)
         {
-            _sprite.SetDrawDepth((uid, sprite), component.OriginalDrawDepth.Value);
+            SpriteSystem.SetDrawDepth((uid, sprite), component.OriginalDrawDepth.Value);
             component.OriginalDrawDepth = null;
         }
     }

--- a/Content.Client/Electrocution/ElectrocutionHUDVisualizerSystem.cs
+++ b/Content.Client/Electrocution/ElectrocutionHUDVisualizerSystem.cs
@@ -11,7 +11,6 @@ namespace Content.Client.Electrocution;
 public sealed class ElectrocutionHUDVisualizerSystem : VisualizerSystem<ElectrocutionHUDVisualsComponent>
 {
     [Dependency] private readonly IPlayerManager _playerMan = default!;
-    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -59,7 +58,7 @@ public sealed class ElectrocutionHUDVisualizerSystem : VisualizerSystem<Electroc
             if (!AppearanceSystem.TryGetData<bool>(uid, ElectrifiedVisuals.IsElectrified, out var electrified, appearanceComp))
                 continue;
 
-            _sprite.LayerSetVisible((uid, spriteComp), ElectrifiedLayers.HUD, electrified);
+            SpriteSystem.LayerSetVisible((uid, spriteComp), ElectrifiedLayers.HUD, electrified);
         }
     }
 
@@ -70,7 +69,7 @@ public sealed class ElectrocutionHUDVisualizerSystem : VisualizerSystem<Electroc
         var electrifiedQuery = AllEntityQuery<ElectrocutionHUDVisualsComponent, AppearanceComponent, SpriteComponent>();
         while (electrifiedQuery.MoveNext(out var uid, out _, out _, out var spriteComp))
         {
-            _sprite.LayerSetVisible((uid, spriteComp), ElectrifiedLayers.HUD, false);
+            SpriteSystem.LayerSetVisible((uid, spriteComp), ElectrifiedLayers.HUD, false);
         }
     }
 
@@ -84,6 +83,6 @@ public sealed class ElectrocutionHUDVisualizerSystem : VisualizerSystem<Electroc
             return;
 
         var player = _playerMan.LocalEntity;
-        _sprite.LayerSetVisible((uid, args.Sprite), ElectrifiedLayers.HUD, electrified && HasComp<ShowElectrocutionHUDComponent>(player));
+        SpriteSystem.LayerSetVisible((uid, args.Sprite), ElectrifiedLayers.HUD, electrified && HasComp<ShowElectrocutionHUDComponent>(player));
     }
 }

--- a/Content.Client/Light/EntitySystems/EmergencyLightSystem.cs
+++ b/Content.Client/Light/EntitySystems/EmergencyLightSystem.cs
@@ -6,8 +6,6 @@ namespace Content.Client.Light.EntitySystems;
 
 public sealed class EmergencyLightSystem : VisualizerSystem<EmergencyLightComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, EmergencyLightComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
@@ -16,13 +14,13 @@ public sealed class EmergencyLightSystem : VisualizerSystem<EmergencyLightCompon
         if (!AppearanceSystem.TryGetData<bool>(uid, EmergencyLightVisuals.On, out var on, args.Component))
             on = false;
 
-        _sprite.LayerSetVisible((uid, args.Sprite), EmergencyLightVisualLayers.LightOff, !on);
-        _sprite.LayerSetVisible((uid, args.Sprite), EmergencyLightVisualLayers.LightOn, on);
+        SpriteSystem.LayerSetVisible((uid, args.Sprite), EmergencyLightVisualLayers.LightOff, !on);
+        SpriteSystem.LayerSetVisible((uid, args.Sprite), EmergencyLightVisualLayers.LightOn, on);
 
         if (AppearanceSystem.TryGetData<Color>(uid, EmergencyLightVisuals.Color, out var color, args.Component))
         {
-            _sprite.LayerSetColor((uid, args.Sprite), EmergencyLightVisualLayers.LightOn, color);
-            _sprite.LayerSetColor((uid, args.Sprite), EmergencyLightVisualLayers.LightOff, color);
+            SpriteSystem.LayerSetColor((uid, args.Sprite), EmergencyLightVisualLayers.LightOn, color);
+            SpriteSystem.LayerSetColor((uid, args.Sprite), EmergencyLightVisualLayers.LightOff, color);
         }
     }
 }

--- a/Content.Client/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Client/Light/EntitySystems/ExpendableLightSystem.cs
@@ -10,7 +10,6 @@ public sealed class ExpendableLightSystem : VisualizerSystem<ExpendableLightComp
     [Dependency] private readonly PointLightSystem _pointLightSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly LightBehaviorSystem _lightBehavior = default!;
-    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -54,37 +53,37 @@ public sealed class ExpendableLightSystem : VisualizerSystem<ExpendableLightComp
                 comp.PlayingStream = _audioSystem.PlayPvs(
                     comp.LoopedSound, uid)?.Entity;
 
-                if (_sprite.LayerMapTryGet((uid, args.Sprite), ExpendableLightVisualLayers.Overlay, out var layerIdx, true))
+                if (SpriteSystem.LayerMapTryGet((uid, args.Sprite), ExpendableLightVisualLayers.Overlay, out var layerIdx, true))
                 {
                     if (!string.IsNullOrWhiteSpace(comp.IconStateLit))
-                        _sprite.LayerSetRsiState((uid, args.Sprite), layerIdx, comp.IconStateLit);
+                        SpriteSystem.LayerSetRsiState((uid, args.Sprite), layerIdx, comp.IconStateLit);
                     if (!string.IsNullOrWhiteSpace(comp.SpriteShaderLit))
                         args.Sprite.LayerSetShader(layerIdx, comp.SpriteShaderLit);
                     else
                         args.Sprite.LayerSetShader(layerIdx, null, null);
                     if (comp.GlowColorLit.HasValue)
-                        _sprite.LayerSetColor((uid, args.Sprite), layerIdx, comp.GlowColorLit.Value);
-                    _sprite.LayerSetVisible((uid, args.Sprite), layerIdx, true);
+                        SpriteSystem.LayerSetColor((uid, args.Sprite), layerIdx, comp.GlowColorLit.Value);
+                    SpriteSystem.LayerSetVisible((uid, args.Sprite), layerIdx, true);
                 }
 
                 if (comp.GlowColorLit.HasValue)
-                    _sprite.LayerSetColor((uid, args.Sprite), ExpendableLightVisualLayers.Glow, comp.GlowColorLit.Value);
-                _sprite.LayerSetVisible((uid, args.Sprite), ExpendableLightVisualLayers.Glow, true);
+                    SpriteSystem.LayerSetColor((uid, args.Sprite), ExpendableLightVisualLayers.Glow, comp.GlowColorLit.Value);
+                SpriteSystem.LayerSetVisible((uid, args.Sprite), ExpendableLightVisualLayers.Glow, true);
 
                 break;
             case ExpendableLightState.Dead:
                 comp.PlayingStream = _audioSystem.Stop(comp.PlayingStream);
-                if (_sprite.LayerMapTryGet((uid, args.Sprite), ExpendableLightVisualLayers.Overlay, out layerIdx, true))
+                if (SpriteSystem.LayerMapTryGet((uid, args.Sprite), ExpendableLightVisualLayers.Overlay, out layerIdx, true))
                 {
                     if (!string.IsNullOrWhiteSpace(comp.IconStateSpent))
-                        _sprite.LayerSetRsiState((uid, args.Sprite), layerIdx, comp.IconStateSpent);
+                        SpriteSystem.LayerSetRsiState((uid, args.Sprite), layerIdx, comp.IconStateSpent);
                     if (!string.IsNullOrWhiteSpace(comp.SpriteShaderSpent))
                         args.Sprite.LayerSetShader(layerIdx, comp.SpriteShaderSpent);
                     else
                         args.Sprite.LayerSetShader(layerIdx, null, null);
                 }
 
-                _sprite.LayerSetVisible((uid, args.Sprite), ExpendableLightVisualLayers.Glow, false);
+                SpriteSystem.LayerSetVisible((uid, args.Sprite), ExpendableLightVisualLayers.Glow, false);
                 break;
         }
     }

--- a/Content.Client/Light/EntitySystems/LightBulbSystem.cs
+++ b/Content.Client/Light/EntitySystems/LightBulbSystem.cs
@@ -5,8 +5,6 @@ namespace Content.Client.Light.Visualizers;
 
 public sealed class LightBulbSystem : VisualizerSystem<LightBulbComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, LightBulbComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
@@ -18,13 +16,13 @@ public sealed class LightBulbSystem : VisualizerSystem<LightBulbComponent>
             switch (state)
             {
                 case LightBulbState.Normal:
-                    _sprite.LayerSetRsiState((uid, args.Sprite), LightBulbVisualLayers.Base, comp.NormalSpriteState);
+                    SpriteSystem.LayerSetRsiState((uid, args.Sprite), LightBulbVisualLayers.Base, comp.NormalSpriteState);
                     break;
                 case LightBulbState.Broken:
-                    _sprite.LayerSetRsiState((uid, args.Sprite), LightBulbVisualLayers.Base, comp.BrokenSpriteState);
+                    SpriteSystem.LayerSetRsiState((uid, args.Sprite), LightBulbVisualLayers.Base, comp.BrokenSpriteState);
                     break;
                 case LightBulbState.Burned:
-                    _sprite.LayerSetRsiState((uid, args.Sprite), LightBulbVisualLayers.Base, comp.BurnedSpriteState);
+                    SpriteSystem.LayerSetRsiState((uid, args.Sprite), LightBulbVisualLayers.Base, comp.BurnedSpriteState);
                     break;
             }
         }
@@ -32,7 +30,7 @@ public sealed class LightBulbSystem : VisualizerSystem<LightBulbComponent>
         // also update sprites color
         if (AppearanceSystem.TryGetData<Color>(uid, LightBulbVisuals.Color, out var color, args.Component))
         {
-            _sprite.SetColor((uid, args.Sprite), color);
+            SpriteSystem.SetColor((uid, args.Sprite), color);
         }
     }
 }

--- a/Content.Client/Light/Visualizers/PoweredLightVisualizerSystem.cs
+++ b/Content.Client/Light/Visualizers/PoweredLightVisualizerSystem.cs
@@ -11,7 +11,6 @@ public sealed class PoweredLightVisualizerSystem : VisualizerSystem<PoweredLight
 {
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -28,16 +27,16 @@ public sealed class PoweredLightVisualizerSystem : VisualizerSystem<PoweredLight
             return;
 
         if (comp.SpriteStateMap.TryGetValue(state, out var spriteState))
-            _sprite.LayerSetRsiState((uid, args.Sprite), PoweredLightLayers.Base, spriteState);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), PoweredLightLayers.Base, spriteState);
 
-        if (_sprite.LayerExists((uid, args.Sprite), PoweredLightLayers.Glow))
+        if (SpriteSystem.LayerExists((uid, args.Sprite), PoweredLightLayers.Glow))
         {
             if (TryComp<PointLightComponent>(uid, out var light))
             {
-                _sprite.LayerSetColor((uid, args.Sprite), PoweredLightLayers.Glow, light.Color);
+                SpriteSystem.LayerSetColor((uid, args.Sprite), PoweredLightLayers.Glow, light.Color);
             }
 
-            _sprite.LayerSetVisible((uid, args.Sprite), PoweredLightLayers.Glow, state == PoweredLightState.On);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), PoweredLightLayers.Glow, state == PoweredLightState.On);
         }
 
         SetBlinkingAnimation(

--- a/Content.Client/Lock/Visualizers/LockVisualizerSystem.cs
+++ b/Content.Client/Lock/Visualizers/LockVisualizerSystem.cs
@@ -6,8 +6,6 @@ namespace Content.Client.Lock.Visualizers;
 
 public sealed class LockVisualizerSystem : VisualizerSystem<LockVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, LockVisualsComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null
@@ -22,14 +20,14 @@ public sealed class LockVisualizerSystem : VisualizerSystem<LockVisualsComponent
 
         if (AppearanceSystem.TryGetData<bool>(uid, StorageVisuals.Open, out var open, args.Component))
         {
-            _sprite.LayerSetVisible((uid, args.Sprite), LockVisualLayers.Lock, !open);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), LockVisualLayers.Lock, !open);
         }
         else if (!(bool)unlockedStateExist!)
-            _sprite.LayerSetVisible((uid, args.Sprite), LockVisualLayers.Lock, locked);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), LockVisualLayers.Lock, locked);
 
         if (!open && (bool)unlockedStateExist!)
         {
-            _sprite.LayerSetRsiState((uid, args.Sprite), LockVisualLayers.Lock, locked ? comp.StateLocked : comp.StateUnlocked);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), LockVisualLayers.Lock, locked ? comp.StateLocked : comp.StateUnlocked);
         }
     }
 }

--- a/Content.Client/PDA/PdaVisualizerSystem.cs
+++ b/Content.Client/PDA/PdaVisualizerSystem.cs
@@ -6,20 +6,19 @@ namespace Content.Client.PDA;
 
 public sealed class PdaVisualizerSystem : VisualizerSystem<PdaVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
     protected override void OnAppearanceChange(EntityUid uid, PdaVisualsComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
             return;
 
         if (AppearanceSystem.TryGetData<string>(uid, PdaVisuals.PdaType, out var pdaType, args.Component))
-            _sprite.LayerSetRsiState((uid, args.Sprite), PdaVisualLayers.Base, pdaType);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), PdaVisualLayers.Base, pdaType);
 
         if (AppearanceSystem.TryGetData<bool>(uid, UnpoweredFlashlightVisuals.LightOn, out var isFlashlightOn, args.Component))
-            _sprite.LayerSetVisible((uid, args.Sprite), PdaVisualLayers.Flashlight, isFlashlightOn);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), PdaVisualLayers.Flashlight, isFlashlightOn);
 
         if (AppearanceSystem.TryGetData<bool>(uid, PdaVisuals.IdCardInserted, out var isCardInserted, args.Component))
-            _sprite.LayerSetVisible((uid, args.Sprite), PdaVisualLayers.IdLight, isCardInserted);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), PdaVisualLayers.IdLight, isCardInserted);
     }
 
     public enum PdaVisualLayers : byte

--- a/Content.Client/Paper/EnvelopeSystem.cs
+++ b/Content.Client/Paper/EnvelopeSystem.cs
@@ -5,8 +5,6 @@ namespace Content.Client.Paper;
 
 public sealed class EnvelopeSystem : VisualizerSystem<EnvelopeComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -23,9 +21,9 @@ public sealed class EnvelopeSystem : VisualizerSystem<EnvelopeComponent>
         if (!Resolve(ent.Owner, ref sprite))
             return;
 
-        _sprite.LayerSetVisible((ent.Owner, sprite), EnvelopeVisualLayers.Open, ent.Comp.State == EnvelopeComponent.EnvelopeState.Open);
-        _sprite.LayerSetVisible((ent.Owner, sprite), EnvelopeVisualLayers.Sealed, ent.Comp.State == EnvelopeComponent.EnvelopeState.Sealed);
-        _sprite.LayerSetVisible((ent.Owner, sprite), EnvelopeVisualLayers.Torn, ent.Comp.State == EnvelopeComponent.EnvelopeState.Torn);
+        SpriteSystem.LayerSetVisible((ent.Owner, sprite), EnvelopeVisualLayers.Open, ent.Comp.State == EnvelopeComponent.EnvelopeState.Open);
+        SpriteSystem.LayerSetVisible((ent.Owner, sprite), EnvelopeVisualLayers.Sealed, ent.Comp.State == EnvelopeComponent.EnvelopeState.Sealed);
+        SpriteSystem.LayerSetVisible((ent.Owner, sprite), EnvelopeVisualLayers.Torn, ent.Comp.State == EnvelopeComponent.EnvelopeState.Torn);
     }
 
     public enum EnvelopeVisualLayers : byte

--- a/Content.Client/Paper/UI/PaperVisualizerSystem.cs
+++ b/Content.Client/Paper/UI/PaperVisualizerSystem.cs
@@ -6,26 +6,24 @@ namespace Content.Client.Paper.UI;
 
 public sealed class PaperVisualizerSystem : VisualizerSystem<PaperVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, PaperVisualsComponent component, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
             return;
 
         if (AppearanceSystem.TryGetData<PaperStatus>(uid, PaperVisuals.Status, out var writingStatus, args.Component))
-            _sprite.LayerSetVisible((uid, args.Sprite), PaperVisualLayers.Writing, writingStatus == PaperStatus.Written);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), PaperVisualLayers.Writing, writingStatus == PaperStatus.Written);
 
         if (AppearanceSystem.TryGetData<string>(uid, PaperVisuals.Stamp, out var stampState, args.Component))
         {
             if (stampState != string.Empty)
             {
-                _sprite.LayerSetRsiState((uid, args.Sprite), PaperVisualLayers.Stamp, stampState);
-                _sprite.LayerSetVisible((uid, args.Sprite), PaperVisualLayers.Stamp, true);
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), PaperVisualLayers.Stamp, stampState);
+                SpriteSystem.LayerSetVisible((uid, args.Sprite), PaperVisualLayers.Stamp, true);
             }
             else
             {
-                _sprite.LayerSetVisible((uid, args.Sprite), PaperVisualLayers.Stamp, false);
+                SpriteSystem.LayerSetVisible((uid, args.Sprite), PaperVisualLayers.Stamp, false);
             }
 
         }

--- a/Content.Client/ParticleAccelerator/ParticleAcceleratorPartVisualizerSystem.cs
+++ b/Content.Client/ParticleAccelerator/ParticleAcceleratorPartVisualizerSystem.cs
@@ -5,14 +5,12 @@ namespace Content.Client.ParticleAccelerator;
 
 public sealed class ParticleAcceleratorPartVisualizerSystem : VisualizerSystem<ParticleAcceleratorPartVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, ParticleAcceleratorPartVisualsComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
             return;
 
-        if (!_sprite.LayerMapTryGet((uid, args.Sprite), ParticleAcceleratorVisualLayers.Unlit, out var index, false))
+        if (!SpriteSystem.LayerMapTryGet((uid, args.Sprite), ParticleAcceleratorVisualLayers.Unlit, out var index, false))
             return;
 
         if (!AppearanceSystem.TryGetData<ParticleAcceleratorVisualState>(uid, ParticleAcceleratorVisuals.VisualState, out var state, args.Component))
@@ -22,12 +20,12 @@ public sealed class ParticleAcceleratorPartVisualizerSystem : VisualizerSystem<P
 
         if (state != ParticleAcceleratorVisualState.Unpowered)
         {
-            _sprite.LayerSetVisible((uid, args.Sprite), index, true);
-            _sprite.LayerSetRsiState((uid, args.Sprite), index, comp.StateBase + comp.StatesSuffixes[state]);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), index, true);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), index, comp.StateBase + comp.StatesSuffixes[state]);
         }
         else
         {
-            _sprite.LayerSetVisible((uid, args.Sprite), index, false);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), index, false);
         }
     }
 }

--- a/Content.Client/Power/APC/ApcVisualizerSystem.cs
+++ b/Content.Client/Power/APC/ApcVisualizerSystem.cs
@@ -6,7 +6,6 @@ namespace Content.Client.Power.APC;
 public sealed class ApcVisualizerSystem : VisualizerSystem<ApcVisualsComponent>
 {
     [Dependency] private readonly SharedPointLightSystem _lights = default!;
-    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     protected override void OnAppearanceChange(EntityUid uid, ApcVisualsComponent comp, ref AppearanceChangeEvent args)
     {
@@ -14,8 +13,8 @@ public sealed class ApcVisualizerSystem : VisualizerSystem<ApcVisualsComponent>
             return;
 
         // get the mapped layer index of the first lock layer and the first channel layer
-        var lockIndicatorOverlayStart = _sprite.LayerMapGet((uid, args.Sprite), ApcVisualLayers.InterfaceLock);
-        var channelIndicatorOverlayStart = _sprite.LayerMapGet((uid, args.Sprite), ApcVisualLayers.Equipment);
+        var lockIndicatorOverlayStart = SpriteSystem.LayerMapGet((uid, args.Sprite), ApcVisualLayers.InterfaceLock);
+        var channelIndicatorOverlayStart = SpriteSystem.LayerMapGet((uid, args.Sprite), ApcVisualLayers.Equipment);
 
         // Handle APC screen overlay:
         if (!AppearanceSystem.TryGetData<ApcChargeState>(uid, ApcVisuals.ChargeState, out var chargeState, args.Component))
@@ -23,7 +22,7 @@ public sealed class ApcVisualizerSystem : VisualizerSystem<ApcVisualsComponent>
 
         if (chargeState >= 0 && chargeState < ApcChargeState.NumStates)
         {
-            _sprite.LayerSetRsiState((uid, args.Sprite), ApcVisualLayers.ChargeState, $"{comp.ScreenPrefix}-{comp.ScreenSuffixes[(sbyte)chargeState]}");
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), ApcVisualLayers.ChargeState, $"{comp.ScreenPrefix}-{comp.ScreenSuffixes[(sbyte)chargeState]}");
 
             // LockState does nothing currently. The backend doesn't exist.
             if (AppearanceSystem.TryGetData<byte>(uid, ApcVisuals.LockState, out var lockStates, args.Component))
@@ -32,8 +31,8 @@ public sealed class ApcVisualizerSystem : VisualizerSystem<ApcVisualsComponent>
                 {
                     var layer = (byte)lockIndicatorOverlayStart + i;
                     var lockState = (sbyte)((lockStates >> (i << (sbyte)ApcLockState.LogWidth)) & (sbyte)ApcLockState.All);
-                    _sprite.LayerSetRsiState((uid, args.Sprite), layer, $"{comp.LockPrefix}{i}-{comp.LockSuffixes[lockState]}");
-                    _sprite.LayerSetVisible((uid, args.Sprite), layer, true);
+                    SpriteSystem.LayerSetRsiState((uid, args.Sprite), layer, $"{comp.LockPrefix}{i}-{comp.LockSuffixes[lockState]}");
+                    SpriteSystem.LayerSetVisible((uid, args.Sprite), layer, true);
                 }
             }
 
@@ -44,8 +43,8 @@ public sealed class ApcVisualizerSystem : VisualizerSystem<ApcVisualsComponent>
                 {
                     var layer = (byte)channelIndicatorOverlayStart + i;
                     var channelState = (sbyte)((channelStates >> (i << (sbyte)ApcChannelState.LogWidth)) & (sbyte)ApcChannelState.All);
-                    _sprite.LayerSetRsiState((uid, args.Sprite), layer, $"{comp.ChannelPrefix}{i}-{comp.ChannelSuffixes[channelState]}");
-                    _sprite.LayerSetVisible((uid, args.Sprite), layer, true);
+                    SpriteSystem.LayerSetRsiState((uid, args.Sprite), layer, $"{comp.ChannelPrefix}{i}-{comp.ChannelSuffixes[channelState]}");
+                    SpriteSystem.LayerSetVisible((uid, args.Sprite), layer, true);
                 }
             }
 
@@ -57,16 +56,16 @@ public sealed class ApcVisualizerSystem : VisualizerSystem<ApcVisualsComponent>
         else
         {
             /// Overrides all of the lock and channel indicators.
-            _sprite.LayerSetRsiState((uid, args.Sprite), ApcVisualLayers.ChargeState, comp.EmaggedScreenState);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), ApcVisualLayers.ChargeState, comp.EmaggedScreenState);
             for (var i = 0; i < comp.LockIndicators; ++i)
             {
                 var layer = (byte)lockIndicatorOverlayStart + i;
-                _sprite.LayerSetVisible((uid, args.Sprite), layer, false);
+                SpriteSystem.LayerSetVisible((uid, args.Sprite), layer, false);
             }
             for (var i = 0; i < comp.ChannelIndicators; ++i)
             {
                 var layer = (byte)channelIndicatorOverlayStart + i;
-                _sprite.LayerSetVisible((uid, args.Sprite), layer, false);
+                SpriteSystem.LayerSetVisible((uid, args.Sprite), layer, false);
             }
 
             if (TryComp<PointLightComponent>(uid, out var light))

--- a/Content.Client/Power/SMES/SmesSystem.cs
+++ b/Content.Client/Power/SMES/SmesSystem.cs
@@ -6,8 +6,6 @@ namespace Content.Client.Power.SMES;
 
 public sealed class SmesVisualizerSystem : VisualizerSystem<SmesComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, SmesComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
@@ -15,12 +13,12 @@ public sealed class SmesVisualizerSystem : VisualizerSystem<SmesComponent>
 
         if (!AppearanceSystem.TryGetData<int>(uid, SmesVisuals.LastChargeLevel, out var level, args.Component) || level == 0)
         {
-            _sprite.LayerSetVisible((uid, args.Sprite), SmesVisualLayers.Charge, false);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), SmesVisualLayers.Charge, false);
         }
         else
         {
-            _sprite.LayerSetVisible((uid, args.Sprite), SmesVisualLayers.Charge, true);
-            _sprite.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Charge, $"{comp.ChargeOverlayPrefix}{level}");
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), SmesVisualLayers.Charge, true);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Charge, $"{comp.ChargeOverlayPrefix}{level}");
         }
 
         if (!AppearanceSystem.TryGetData<ChargeState>(uid, SmesVisuals.LastChargeState, out var state, args.Component))
@@ -29,16 +27,16 @@ public sealed class SmesVisualizerSystem : VisualizerSystem<SmesComponent>
         switch (state)
         {
             case ChargeState.Still:
-                _sprite.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Input, $"{comp.InputOverlayPrefix}0");
-                _sprite.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Output, $"{comp.OutputOverlayPrefix}1");
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Input, $"{comp.InputOverlayPrefix}0");
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Output, $"{comp.OutputOverlayPrefix}1");
                 break;
             case ChargeState.Charging:
-                _sprite.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Input, $"{comp.InputOverlayPrefix}1");
-                _sprite.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Output, $"{comp.OutputOverlayPrefix}1");
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Input, $"{comp.InputOverlayPrefix}1");
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Output, $"{comp.OutputOverlayPrefix}1");
                 break;
             case ChargeState.Discharging:
-                _sprite.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Input, $"{comp.InputOverlayPrefix}0");
-                _sprite.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Output, $"{comp.OutputOverlayPrefix}2");
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Input, $"{comp.InputOverlayPrefix}0");
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), SmesVisualLayers.Output, $"{comp.OutputOverlayPrefix}2");
                 break;
         }
     }

--- a/Content.Client/PowerCell/PowerChargerVisualizerSystem.cs
+++ b/Content.Client/PowerCell/PowerChargerVisualizerSystem.cs
@@ -5,8 +5,6 @@ namespace Content.Client.PowerCell;
 
 public sealed class PowerChargerVisualizerSystem : VisualizerSystem<PowerChargerVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, PowerChargerVisualsComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
@@ -16,22 +14,22 @@ public sealed class PowerChargerVisualizerSystem : VisualizerSystem<PowerCharger
         if (AppearanceSystem.TryGetData<bool>(uid, CellVisual.Occupied, out var occupied, args.Component) && occupied)
         {
             // TODO: don't throw if it doesn't have a full state
-            _sprite.LayerSetRsiState((uid, args.Sprite), PowerChargerVisualLayers.Base, comp.OccupiedState);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), PowerChargerVisualLayers.Base, comp.OccupiedState);
         }
         else
         {
-            _sprite.LayerSetRsiState((uid, args.Sprite), PowerChargerVisualLayers.Base, comp.EmptyState);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), PowerChargerVisualLayers.Base, comp.EmptyState);
         }
 
         // Update lighting
         if (AppearanceSystem.TryGetData<CellChargerStatus>(uid, CellVisual.Light, out var status, args.Component)
             && comp.LightStates.TryGetValue(status, out var lightState))
         {
-            _sprite.LayerSetRsiState((uid, args.Sprite), PowerChargerVisualLayers.Light, lightState);
-            _sprite.LayerSetVisible((uid, args.Sprite), PowerChargerVisualLayers.Light, true);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), PowerChargerVisualLayers.Light, lightState);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), PowerChargerVisualLayers.Light, true);
         }
         else
-            _sprite.LayerSetVisible((uid, args.Sprite), PowerChargerVisualLayers.Light, false);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), PowerChargerVisualLayers.Light, false);
     }
 }
 

--- a/Content.Client/Shuttles/ThrusterSystem.cs
+++ b/Content.Client/Shuttles/ThrusterSystem.cs
@@ -8,8 +8,6 @@ namespace Content.Client.Shuttles;
 /// </summary>
 public sealed class ThrusterSystem : VisualizerSystem<ThrusterComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     /// <summary>
     /// Updates whether or not the thruster is visibly active/thrusting.
     /// </summary>
@@ -19,7 +17,7 @@ public sealed class ThrusterSystem : VisualizerSystem<ThrusterComponent>
         || !AppearanceSystem.TryGetData<bool>(uid, ThrusterVisualState.State, out var state, args.Component))
             return;
 
-        _sprite.LayerSetVisible((uid, args.Sprite), ThrusterVisualLayers.ThrustOn, state);
+        SpriteSystem.LayerSetVisible((uid, args.Sprite), ThrusterVisualLayers.ThrustOn, state);
         SetThrusting(
             uid,
             state && AppearanceSystem.TryGetData<bool>(uid, ThrusterVisualState.Thrusting, out var thrusting, args.Component) && thrusting,
@@ -32,14 +30,14 @@ public sealed class ThrusterSystem : VisualizerSystem<ThrusterComponent>
     /// </summary>
     private void SetThrusting(EntityUid uid, bool value, SpriteComponent sprite)
     {
-        if (_sprite.LayerMapTryGet((uid, sprite), ThrusterVisualLayers.Thrusting, out var thrustingLayer, false))
+        if (SpriteSystem.LayerMapTryGet((uid, sprite), ThrusterVisualLayers.Thrusting, out var thrustingLayer, false))
         {
-            _sprite.LayerSetVisible((uid, sprite), thrustingLayer, value);
+            SpriteSystem.LayerSetVisible((uid, sprite), thrustingLayer, value);
         }
 
-        if (_sprite.LayerMapTryGet((uid, sprite), ThrusterVisualLayers.ThrustingUnshaded, out var unshadedLayer, false))
+        if (SpriteSystem.LayerMapTryGet((uid, sprite), ThrusterVisualLayers.ThrustingUnshaded, out var unshadedLayer, false))
         {
-            _sprite.LayerSetVisible((uid, sprite), unshadedLayer, value);
+            SpriteSystem.LayerSetVisible((uid, sprite), unshadedLayer, value);
         }
     }
 }

--- a/Content.Client/Storage/Systems/StorageContainerVisualsSystem.cs
+++ b/Content.Client/Storage/Systems/StorageContainerVisualsSystem.cs
@@ -8,8 +8,6 @@ namespace Content.Client.Storage.Systems;
 /// <inheritdoc cref="StorageContainerVisualsComponent"/>
 public sealed class StorageContainerVisualsSystem : VisualizerSystem<StorageContainerVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, StorageContainerVisualsComponent component, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
@@ -23,7 +21,7 @@ public sealed class StorageContainerVisualsSystem : VisualizerSystem<StorageCont
 
         var fraction = used / (float)capacity;
 
-        if (!_sprite.LayerMapTryGet((uid, args.Sprite), component.FillLayer, out var fillLayer, false))
+        if (!SpriteSystem.LayerMapTryGet((uid, args.Sprite), component.FillLayer, out var fillLayer, false))
             return;
 
         var closestFillSprite = Math.Min(ContentHelpers.RoundToNearestLevels(fraction, 1, component.MaxFillLevels + 1),
@@ -34,13 +32,13 @@ public sealed class StorageContainerVisualsSystem : VisualizerSystem<StorageCont
             if (component.FillBaseName == null)
                 return;
 
-            _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, true);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), fillLayer, true);
             var stateName = component.FillBaseName + closestFillSprite;
-            _sprite.LayerSetRsiState((uid, args.Sprite), fillLayer, stateName);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), fillLayer, stateName);
         }
         else
         {
-            _sprite.LayerSetVisible((uid, args.Sprite), fillLayer, false);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), fillLayer, false);
         }
     }
 }

--- a/Content.Client/Storage/Visualizers/EntityStorageVisualizerSystem.cs
+++ b/Content.Client/Storage/Visualizers/EntityStorageVisualizerSystem.cs
@@ -5,8 +5,6 @@ namespace Content.Client.Storage.Visualizers;
 
 public sealed class EntityStorageVisualizerSystem : VisualizerSystem<EntityStorageVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -25,7 +23,7 @@ public sealed class EntityStorageVisualizerSystem : VisualizerSystem<EntityStora
         if (!TryComp<SpriteComponent>(uid, out var sprite))
             return;
 
-        _sprite.LayerSetRsiState((uid, sprite), StorageVisualLayers.Base, comp.StateBaseClosed);
+        SpriteSystem.LayerSetRsiState((uid, sprite), StorageVisualLayers.Base, comp.StateBaseClosed);
     }
 
     protected override void OnAppearanceChange(EntityUid uid, EntityStorageVisualsComponent comp, ref AppearanceChangeEvent args)
@@ -35,41 +33,41 @@ public sealed class EntityStorageVisualizerSystem : VisualizerSystem<EntityStora
             return;
 
         // Open/Closed state for the storage entity.
-        if (_sprite.LayerMapTryGet((uid, args.Sprite), StorageVisualLayers.Door, out _, false))
+        if (SpriteSystem.LayerMapTryGet((uid, args.Sprite), StorageVisualLayers.Door, out _, false))
         {
             if (open)
             {
                 if (comp.OpenDrawDepth != null)
-                    _sprite.SetDrawDepth((uid, args.Sprite), comp.OpenDrawDepth.Value);
+                    SpriteSystem.SetDrawDepth((uid, args.Sprite), comp.OpenDrawDepth.Value);
 
                 if (comp.StateDoorOpen != null)
                 {
-                    _sprite.LayerSetRsiState((uid, args.Sprite), StorageVisualLayers.Door, comp.StateDoorOpen);
-                    _sprite.LayerSetVisible((uid, args.Sprite), StorageVisualLayers.Door, true);
+                    SpriteSystem.LayerSetRsiState((uid, args.Sprite), StorageVisualLayers.Door, comp.StateDoorOpen);
+                    SpriteSystem.LayerSetVisible((uid, args.Sprite), StorageVisualLayers.Door, true);
                 }
                 else
                 {
-                    _sprite.LayerSetVisible((uid, args.Sprite), StorageVisualLayers.Door, false);
+                    SpriteSystem.LayerSetVisible((uid, args.Sprite), StorageVisualLayers.Door, false);
                 }
 
                 if (comp.StateBaseOpen != null)
-                    _sprite.LayerSetRsiState((uid, args.Sprite), StorageVisualLayers.Base, comp.StateBaseOpen);
+                    SpriteSystem.LayerSetRsiState((uid, args.Sprite), StorageVisualLayers.Base, comp.StateBaseOpen);
             }
             else
             {
                 if (comp.ClosedDrawDepth != null)
-                    _sprite.SetDrawDepth((uid, args.Sprite), comp.ClosedDrawDepth.Value);
+                    SpriteSystem.SetDrawDepth((uid, args.Sprite), comp.ClosedDrawDepth.Value);
 
                 if (comp.StateDoorClosed != null)
                 {
-                    _sprite.LayerSetRsiState((uid, args.Sprite), StorageVisualLayers.Door, comp.StateDoorClosed);
-                    _sprite.LayerSetVisible((uid, args.Sprite), StorageVisualLayers.Door, true);
+                    SpriteSystem.LayerSetRsiState((uid, args.Sprite), StorageVisualLayers.Door, comp.StateDoorClosed);
+                    SpriteSystem.LayerSetVisible((uid, args.Sprite), StorageVisualLayers.Door, true);
                 }
                 else
-                    _sprite.LayerSetVisible((uid, args.Sprite), StorageVisualLayers.Door, false);
+                    SpriteSystem.LayerSetVisible((uid, args.Sprite), StorageVisualLayers.Door, false);
 
                 if (comp.StateBaseClosed != null)
-                    _sprite.LayerSetRsiState((uid, args.Sprite), StorageVisualLayers.Base, comp.StateBaseClosed);
+                    SpriteSystem.LayerSetRsiState((uid, args.Sprite), StorageVisualLayers.Base, comp.StateBaseClosed);
             }
         }
     }

--- a/Content.Client/TextScreen/TextScreenSystem.cs
+++ b/Content.Client/TextScreen/TextScreenSystem.cs
@@ -27,7 +27,6 @@ namespace Content.Client.TextScreen;
 public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsComponent>
 {
     [Dependency] private readonly IGameTiming _gameTiming = default!;
-    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     /// <summary>
     ///     Contains char/state Key/Value pairs. <br/>
@@ -90,11 +89,11 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
 
         for (var i = 0; i < screen.RowLength; i++)
         {
-            _sprite.LayerMapReserve((uid, sprite), TimerMapKey + i);
+            SpriteSystem.LayerMapReserve((uid, sprite), TimerMapKey + i);
             timer.LayerStatesToDraw.Add(TimerMapKey + i, null);
-            _sprite.LayerSetRsi((uid, sprite), TimerMapKey + i, new ResPath(TextPath));
-            _sprite.LayerSetColor((uid, sprite), TimerMapKey + i, screen.Color);
-            _sprite.LayerSetRsiState((uid, sprite), TimerMapKey + i, DefaultState);
+            SpriteSystem.LayerSetRsi((uid, sprite), TimerMapKey + i, new ResPath(TextPath));
+            SpriteSystem.LayerSetColor((uid, sprite), TimerMapKey + i, screen.Color);
+            SpriteSystem.LayerSetRsiState((uid, sprite), TimerMapKey + i, DefaultState);
         }
     }
 
@@ -154,7 +153,7 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
             return;
 
         foreach (var key in timer.LayerStatesToDraw.Keys)
-            _sprite.RemoveLayer((uid, sprite), key);
+            SpriteSystem.RemoveLayer((uid, sprite), key);
 
         RemComp<TextScreenTimerComponent>(uid);
 
@@ -190,7 +189,7 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
             return;
 
         foreach (var key in component.LayerStatesToDraw.Keys)
-            _sprite.RemoveLayer((uid, sprite), key);
+            SpriteSystem.RemoveLayer((uid, sprite), key);
 
         component.LayerStatesToDraw.Clear();
 
@@ -198,11 +197,11 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
             for (var i = 0; i < component.RowLength; i++)
             {
                 var key = TextMapKey + row + i;
-                _sprite.LayerMapReserve((uid, sprite), key);
+                SpriteSystem.LayerMapReserve((uid, sprite), key);
                 component.LayerStatesToDraw.Add(key, null);
-                _sprite.LayerSetRsi((uid, sprite), key, new ResPath(TextPath));
-                _sprite.LayerSetColor((uid, sprite), key, component.Color);
-                _sprite.LayerSetRsiState((uid, sprite), key, DefaultState);
+                SpriteSystem.LayerSetRsi((uid, sprite), key, new ResPath(TextPath));
+                SpriteSystem.LayerSetColor((uid, sprite), key, component.Color);
+                SpriteSystem.LayerSetRsiState((uid, sprite), key, DefaultState);
             }
     }
 
@@ -228,7 +227,7 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
             for (var chr = 0; chr < min; chr++)
             {
                 component.LayerStatesToDraw[TextMapKey + rowIdx + chr] = GetStateFromChar(row[chr]);
-                _sprite.LayerSetOffset(
+                SpriteSystem.LayerSetOffset(
                     (uid, sprite),
                     TextMapKey + rowIdx + chr,
                     Vector2.Multiply(
@@ -259,7 +258,7 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
         for (var i = 0; i < min; i++)
         {
             timer.LayerStatesToDraw[TimerMapKey + i] = GetStateFromChar(time[i]);
-            _sprite.LayerSetOffset(
+            SpriteSystem.LayerSetOffset(
                 (uid, sprite),
                 TimerMapKey + i,
                 Vector2.Multiply(
@@ -279,7 +278,7 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
             return;
 
         foreach (var (key, state) in layerStates.Where(pairs => pairs.Value != null))
-            _sprite.LayerSetRsiState((uid, sprite), key, state);
+            SpriteSystem.LayerSetRsiState((uid, sprite), key, state);
     }
 
     public override void Update(float frameTime)

--- a/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
+++ b/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
@@ -15,7 +15,6 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
 {
     [Dependency] private readonly SharedItemSystem _itemSys = default!;
     [Dependency] private readonly SharedPointLightSystem _lights = default!;
-    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     public override void Initialize()
     {
@@ -32,11 +31,11 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
         var modulate = AppearanceSystem.TryGetData<Color>(uid, ToggleableLightVisuals.Color, out var color, args.Component);
 
         // Update the item's sprite
-        if (args.Sprite != null && component.SpriteLayer != null && _sprite.LayerMapTryGet((uid, args.Sprite), component.SpriteLayer, out var layer, false))
+        if (args.Sprite != null && component.SpriteLayer != null && SpriteSystem.LayerMapTryGet((uid, args.Sprite), component.SpriteLayer, out var layer, false))
         {
-            _sprite.LayerSetVisible((uid, args.Sprite), layer, enabled);
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), layer, enabled);
             if (modulate)
-                _sprite.LayerSetColor((uid, args.Sprite), layer, color);
+                SpriteSystem.LayerSetColor((uid, args.Sprite), layer, color);
         }
 
         // Update any point-lights

--- a/Content.Client/Wires/Visualizers/WiresVisualizerSystem.cs
+++ b/Content.Client/Wires/Visualizers/WiresVisualizerSystem.cs
@@ -5,24 +5,22 @@ namespace Content.Client.Wires.Visualizers
 {
     public sealed class WiresVisualizerSystem : VisualizerSystem<WiresVisualsComponent>
     {
-        [Dependency] private readonly SpriteSystem _sprite = default!;
-
         protected override void OnAppearanceChange(EntityUid uid, WiresVisualsComponent component, ref AppearanceChangeEvent args)
         {
             if (args.Sprite == null)
                 return;
 
-            var layer = _sprite.LayerMapReserve((uid, args.Sprite), WiresVisualLayers.MaintenancePanel);
+            var layer = SpriteSystem.LayerMapReserve((uid, args.Sprite), WiresVisualLayers.MaintenancePanel);
 
             if (args.AppearanceData.TryGetValue(WiresVisuals.MaintenancePanelState, out var panelStateObject) &&
                 panelStateObject is bool panelState)
             {
-                _sprite.LayerSetVisible((uid, args.Sprite), layer, panelState);
+                SpriteSystem.LayerSetVisible((uid, args.Sprite), layer, panelState);
             }
             else
             {
                 //Mainly for spawn window
-                _sprite.LayerSetVisible((uid, args.Sprite), layer, false);
+                SpriteSystem.LayerSetVisible((uid, args.Sprite), layer, false);
             }
         }
     }

--- a/Content.Client/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
+++ b/Content.Client/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
@@ -5,8 +5,6 @@ namespace Content.Client.Xenoarchaeology.XenoArtifacts;
 
 public sealed class RandomArtifactSpriteSystem : VisualizerSystem<RandomArtifactSpriteComponent>
 {
-    [Dependency] private readonly SpriteSystem _sprite = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, RandomArtifactSpriteComponent component, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
@@ -25,24 +23,24 @@ public sealed class RandomArtifactSpriteSystem : VisualizerSystem<RandomArtifact
         var spritePrefix = isUnlocking ? "_on" : "";
 
         // layered artifact sprite
-        if (_sprite.LayerMapTryGet((uid, args.Sprite), ArtifactsVisualLayers.UnlockingEffect, out var layer, false))
+        if (SpriteSystem.LayerMapTryGet((uid, args.Sprite), ArtifactsVisualLayers.UnlockingEffect, out var layer, false))
         {
             var spriteState = "ano" + spriteIndexStr;
-            _sprite.LayerSetRsiState((uid, args.Sprite), ArtifactsVisualLayers.Base, spriteState);
-            _sprite.LayerSetRsiState((uid, args.Sprite), layer, spriteState + "_on");
-            _sprite.LayerSetVisible((uid, args.Sprite), layer, isUnlocking);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), ArtifactsVisualLayers.Base, spriteState);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), layer, spriteState + "_on");
+            SpriteSystem.LayerSetVisible((uid, args.Sprite), layer, isUnlocking);
 
-            if (_sprite.LayerMapTryGet((uid, args.Sprite), ArtifactsVisualLayers.ActivationEffect, out var activationEffectLayer, false))
+            if (SpriteSystem.LayerMapTryGet((uid, args.Sprite), ArtifactsVisualLayers.ActivationEffect, out var activationEffectLayer, false))
             {
-                _sprite.LayerSetRsiState((uid, args.Sprite), activationEffectLayer, "artifact-activation");
-                _sprite.LayerSetVisible((uid, args.Sprite), activationEffectLayer, isActivated);
+                SpriteSystem.LayerSetRsiState((uid, args.Sprite), activationEffectLayer, "artifact-activation");
+                SpriteSystem.LayerSetVisible((uid, args.Sprite), activationEffectLayer, isActivated);
             }
         }
         // non-layered
         else
         {
             var spriteState = "ano" + spriteIndexStr + spritePrefix;
-            _sprite.LayerSetRsiState((uid, args.Sprite), ArtifactsVisualLayers.Base, spriteState);
+            SpriteSystem.LayerSetRsiState((uid, args.Sprite), ArtifactsVisualLayers.Base, spriteState);
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Updates every `VisualizerSystem`-derived class to use the base class' `SpriteSystem` dependency.

## Why/Technical details
<!-- Summary of code changes for easier review. -->
`VisualizerSystem` now has a `protected SpriteSystem` dependency for convenience.
These classes all used their own private dependency. Now they use the inherited one instead.

It's a bunch of changes, but they're dead simple.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->