### PR TITLE
Limit survivor event spell purchases to after 30 minutes

### DIFF
--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -305,6 +305,7 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   disableRefund: true
+  restockTime: 1800
 
 - type: listing
   id: SpellbookEventSummonMagic
@@ -319,6 +320,7 @@
   - !type:ListingLimitedStockCondition
     stock: 1
   disableRefund: true
+  restockTime: 1800
 
 # Upgrades
 - type: listing


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The 2 wizard survivor event spells (Summon Magic & Summon Guns) can now only be purchased starting 30 minutes in, in line with what the syndicate bomb requires.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Everyone getting free agent status pretty much signals what is going to end up ending the round. While this is fine, it shouldn't happen 5 minutes into the round. 30 minutes was chosen to match the timer on the syndicate bomb.
## Technical details
<!-- Summary of code changes for easier review. -->
The time restriction on syndicate bombs was copied to the event spells.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Screenshot showing the survivor event spells having a delay](https://github.com/user-attachments/assets/293027cb-e450-46b9-b5c2-eb5a786a8ec2)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: WarPigeon

- tweak: Summon Magic and Summon Guns can now only be purchased from the spellbook after the round is 30 minutes in.

