### PR TITLE
SVALINN GOOD

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -105,7 +105,7 @@
   name: svalinn laser pistol
   parent: [ BaseWeaponPowerCellSmall, BaseSecurityContraband ]
   id: WeaponLaserSvalinn
-  description: A cheap and widely used laser pistol.
+  description: A cheap and widely used laser pistol. Prone to overheating when rapidly fired, losing accuracy.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
@@ -115,8 +115,19 @@
     - state: mag-unshaded-4
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
-  - type: Item
+  - type: Gun
+    minAngle: 1
+    maxAngle: 20
+    angleIncrease: 2.2
+    angleDecay: 4
     sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
+    fireRate: 2 
+    burstFireRate: 8
+    availableModes:
+    - Burst
+    - SemiAuto
+    shotsPerBurst: 4
+    burstCooldown: 0.6
   - type: MagazineVisuals
     magState: mag
     steps: 5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made the Svalinn be able to fire a 4 round burst. However, the Svalinn now becomes inaccurate after prolonged rapid fire, or overheating.
The 4 round burst is twice as fast as semi auto. Semi auto will still overheat, however it will be significantly more controlled than the burst mode.

Note that I'm open to suggestions, especially the description. Although I tested some numbers (using the scientific method of guess and check) and I feel that these are good. You can still get a lucky hit at moderate inaccuracy, but it's very unlikely to get a mid range hit at high inaccuracy.

## Why / Balance
The Svalinn is a boring gun (according to some people), so this gives it a coat of paint. 
The Svalinn is better when you're moving towards the enemy (or when they're approaching you!) as the accuracy becomes less of a penalty, and the faster RoF becomes more of a boon.
The Svalinn can still be used in long range combat, but not as well. 
Imagine the Svalinn like a flintlock pistol for a pirate. You fire one shot, or one battery, and then move in closer to do proper combat against the enemy with your cutlass, rifle, shotgun. Or, you can draw another flintlock or Svalinn and keep at it... 

Also if this gets merged you should totally also merge #37724
## Technical details

1 minAngle. For reference, this is the same as a single shot with the WT550
20 maxAngle, meaning the gun will be mostly luck at far range during rapid fire.
2.2 angleIncrease, meaning the gun won't gain too much inaccuracy per shot. It's the rapid shots that do in the accuracy.
4 angleDecay, meaning this gun will dissipate it's max 20 accuracy in 4.75 seconds of not shooting. 
2 fireRate
8 burstFireRate, meaning the gun fires four times as fast when under burst mode. It fires its entire 4 round burst in half a second.
4 shotsPerBurst. Yeah, self explanatory. 
0.6 burstCooldown, meaning once you click the mouse, you'll need to wait 0.6 seconds before firing another burst. 

I mostly ripped off the Drozid and WT550.

Also, the Svalinn used to be an item. Now, it's a gun. I don't know what this changes honestly, but I don't think it breaks anything.
Note I am not a programmer. I don't think I did anything wrong, but I could have.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
NOTE. I USED THE WRONG DESCRIPTION IN ONE OF THE VIDEOS. THE DESCRIPTION IS "A cheap and widely used laser pistol. Prone to overheating when rapidly fired, losing accuracy."
And sorry for the bad video quality and using medal. I hate medal, but I don't have anything else I can upload to :3

https://medal.tv/games/space-station-14/clips/klB5oQZ56Bo6BlQBn?invite=cr-MSxNNHksMTE0ODEzMjI2
https://medal.tv/games/space-station-14/clips/klAVP292e6JElDd7E?invite=cr-MSw4T3YsMTE0ODEzMjI2

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The Svalinn now has a rapid-fire 4 round burst mode. 
- tweak: The Svalinn now becomes inaccurate under prolonged fire. 

