### PR TITLE
Access Reader Refactor

### DIFF
--- a/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
+++ b/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
@@ -25,7 +25,7 @@ namespace Content.IntegrationTests.Tests.Access
                 var system = entityManager.System<AccessReaderSystem>();
 
                 // test empty
-                var reader = new AccessReaderComponent();
+                var reader = new Entity<AccessReaderComponent>();
                 Assert.Multiple(() =>
                 {
                     Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "Foo" }, reader), Is.True);
@@ -34,8 +34,8 @@ namespace Content.IntegrationTests.Tests.Access
                 });
 
                 // test deny
-                reader = new AccessReaderComponent();
-                reader.DenyTags.Add("A");
+                reader = new Entity<AccessReaderComponent>();
+                system.AddDenyTag(reader, "A");
                 Assert.Multiple(() =>
                 {
                     Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "Foo" }, reader), Is.True);
@@ -45,8 +45,8 @@ namespace Content.IntegrationTests.Tests.Access
                 });
 
                 // test one list
-                reader = new AccessReaderComponent();
-                reader.AccessLists.Add(new HashSet<ProtoId<AccessLevelPrototype>> { "A" });
+                reader = new Entity<AccessReaderComponent>();
+                system.AddAccess(reader, "A");
                 Assert.Multiple(() =>
                 {
                     Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.True);
@@ -56,8 +56,8 @@ namespace Content.IntegrationTests.Tests.Access
                 });
 
                 // test one list - two items
-                reader = new AccessReaderComponent();
-                reader.AccessLists.Add(new HashSet<ProtoId<AccessLevelPrototype>> { "A", "B" });
+                reader = new Entity<AccessReaderComponent>();
+                system.AddAccess(reader, new HashSet<ProtoId<AccessLevelPrototype>> { "A", "B" });
                 Assert.Multiple(() =>
                 {
                     Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.False);
@@ -67,9 +67,12 @@ namespace Content.IntegrationTests.Tests.Access
                 });
 
                 // test two list
-                reader = new AccessReaderComponent();
-                reader.AccessLists.Add(new HashSet<ProtoId<AccessLevelPrototype>> { "A" });
-                reader.AccessLists.Add(new HashSet<ProtoId<AccessLevelPrototype>> { "B", "C" });
+                reader = new Entity<AccessReaderComponent>();
+                var accesses = new List<HashSet<ProtoId<AccessLevelPrototype>>>() {
+                    new HashSet<ProtoId<AccessLevelPrototype>> () { "A" },
+                    new HashSet<ProtoId<AccessLevelPrototype>> () { "B", "C" }
+                };
+                system.AddAccesses(reader, accesses);
                 Assert.Multiple(() =>
                 {
                     Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.True);
@@ -81,9 +84,9 @@ namespace Content.IntegrationTests.Tests.Access
                 });
 
                 // test deny list
-                reader = new AccessReaderComponent();
-                reader.AccessLists.Add(new HashSet<ProtoId<AccessLevelPrototype>> { "A" });
-                reader.DenyTags.Add("B");
+                reader = new Entity<AccessReaderComponent>();
+                system.AddAccess(reader, new HashSet<ProtoId<AccessLevelPrototype>> { "A" });
+                system.AddDenyTag(reader, "B");
                 Assert.Multiple(() =>
                 {
                     Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.True);

--- a/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
+++ b/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
-using System.Linq;
 using Content.Shared.Access;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.Access
@@ -12,6 +12,15 @@ namespace Content.IntegrationTests.Tests.Access
     [TestOf(typeof(AccessReaderComponent))]
     public sealed class AccessReaderTest
     {
+        [TestPrototypes]
+        private const string Prototypes = @"
+- type: entity
+  id: TestAccessReader
+  name: access reader
+  components:
+  - type: AccessReader
+";
+
         [Test]
         public async Task TestTags()
         {
@@ -19,13 +28,13 @@ namespace Content.IntegrationTests.Tests.Access
             var server = pair.Server;
             var entityManager = server.ResolveDependency<IEntityManager>();
 
-
             await server.WaitAssertion(() =>
             {
                 var system = entityManager.System<AccessReaderSystem>();
+                var ent = entityManager.SpawnEntity("TestAccessReader", MapCoordinates.Nullspace);
+                var reader = new Entity<AccessReaderComponent>(ent, entityManager.GetComponent<AccessReaderComponent>(ent));
 
                 // test empty
-                var reader = new Entity<AccessReaderComponent>();
                 Assert.Multiple(() =>
                 {
                     Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "Foo" }, reader), Is.True);
@@ -34,7 +43,6 @@ namespace Content.IntegrationTests.Tests.Access
                 });
 
                 // test deny
-                reader = new Entity<AccessReaderComponent>();
                 system.AddDenyTag(reader, "A");
                 Assert.Multiple(() =>
                 {
@@ -43,9 +51,9 @@ namespace Content.IntegrationTests.Tests.Access
                     Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "Foo" }, reader), Is.False);
                     Assert.That(system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.True);
                 });
+                system.ClearDenyTags(reader);
 
                 // test one list
-                reader = new Entity<AccessReaderComponent>();
                 system.AddAccess(reader, "A");
                 Assert.Multiple(() =>
                 {
@@ -54,9 +62,9 @@ namespace Content.IntegrationTests.Tests.Access
                     Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "B" }, reader), Is.True);
                     Assert.That(system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.False);
                 });
+                system.ClearAccesses(reader);
 
                 // test one list - two items
-                reader = new Entity<AccessReaderComponent>();
                 system.AddAccess(reader, new HashSet<ProtoId<AccessLevelPrototype>> { "A", "B" });
                 Assert.Multiple(() =>
                 {
@@ -65,9 +73,9 @@ namespace Content.IntegrationTests.Tests.Access
                     Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "B" }, reader), Is.True);
                     Assert.That(system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.False);
                 });
+                system.ClearAccesses(reader);
 
                 // test two list
-                reader = new Entity<AccessReaderComponent>();
                 var accesses = new List<HashSet<ProtoId<AccessLevelPrototype>>>() {
                     new HashSet<ProtoId<AccessLevelPrototype>> () { "A" },
                     new HashSet<ProtoId<AccessLevelPrototype>> () { "B", "C" }
@@ -82,9 +90,9 @@ namespace Content.IntegrationTests.Tests.Access
                     Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "C", "B", "A" }, reader), Is.True);
                     Assert.That(system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.False);
                 });
+                system.ClearAccesses(reader);
 
                 // test deny list
-                reader = new Entity<AccessReaderComponent>();
                 system.AddAccess(reader, new HashSet<ProtoId<AccessLevelPrototype>> { "A" });
                 system.AddDenyTag(reader, "B");
                 Assert.Multiple(() =>
@@ -94,6 +102,8 @@ namespace Content.IntegrationTests.Tests.Access
                     Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "B" }, reader), Is.False);
                     Assert.That(system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.False);
                 });
+                system.ClearAccesses(reader);
+                system.ClearDenyTags(reader);
             });
             await pair.CleanReturnAsync();
         }

--- a/Content.Server/Access/AccessWireAction.cs
+++ b/Content.Server/Access/AccessWireAction.cs
@@ -25,14 +25,13 @@ public sealed partial class AccessWireAction : ComponentWireAction<AccessReaderC
     {
         WiresSystem.TryCancelWireAction(wire.Owner, PulseTimeoutKey.Key);
         EntityManager.System<AccessReaderSystem>().SetActive((wire.Owner, comp), false);
-        EntityManager.Dirty(wire.Owner, comp);
+
         return true;
     }
 
     public override bool Mend(EntityUid user, Wire wire, AccessReaderComponent comp)
     {
         EntityManager.System<AccessReaderSystem>().SetActive((wire.Owner, comp), true);
-        EntityManager.Dirty(wire.Owner, comp);
 
         return true;
     }
@@ -40,7 +39,6 @@ public sealed partial class AccessWireAction : ComponentWireAction<AccessReaderC
     public override void Pulse(EntityUid user, Wire wire, AccessReaderComponent comp)
     {
         EntityManager.System<AccessReaderSystem>().SetActive((wire.Owner, comp), false);
-        EntityManager.Dirty(wire.Owner, comp);
         WiresSystem.StartWireAction(wire.Owner, _pulseTimeout, PulseTimeoutKey.Key, new TimedWireEvent(AwaitPulseCancel, wire));
     }
 
@@ -59,7 +57,6 @@ public sealed partial class AccessWireAction : ComponentWireAction<AccessReaderC
             if (EntityManager.TryGetComponent<AccessReaderComponent>(wire.Owner, out var access))
             {
                 EntityManager.System<AccessReaderSystem>().SetActive((wire.Owner, access), true);
-                EntityManager.Dirty(wire.Owner, access);
             }
         }
     }

--- a/Content.Server/Access/AccessWireAction.cs
+++ b/Content.Server/Access/AccessWireAction.cs
@@ -1,6 +1,7 @@
 using Content.Server.Wires;
 using Content.Shared.Access;
 using Content.Shared.Access.Components;
+using Content.Shared.Access.Systems;
 using Content.Shared.Wires;
 
 namespace Content.Server.Access;
@@ -23,14 +24,14 @@ public sealed partial class AccessWireAction : ComponentWireAction<AccessReaderC
     public override bool Cut(EntityUid user, Wire wire, AccessReaderComponent comp)
     {
         WiresSystem.TryCancelWireAction(wire.Owner, PulseTimeoutKey.Key);
-        comp.Enabled = false;
+        EntityManager.System<AccessReaderSystem>().SetActive((wire.Owner, comp), false);
         EntityManager.Dirty(wire.Owner, comp);
         return true;
     }
 
     public override bool Mend(EntityUid user, Wire wire, AccessReaderComponent comp)
     {
-        comp.Enabled = true;
+        EntityManager.System<AccessReaderSystem>().SetActive((wire.Owner, comp), true);
         EntityManager.Dirty(wire.Owner, comp);
 
         return true;
@@ -38,7 +39,7 @@ public sealed partial class AccessWireAction : ComponentWireAction<AccessReaderC
 
     public override void Pulse(EntityUid user, Wire wire, AccessReaderComponent comp)
     {
-        comp.Enabled = false;
+        EntityManager.System<AccessReaderSystem>().SetActive((wire.Owner, comp), false);
         EntityManager.Dirty(wire.Owner, comp);
         WiresSystem.StartWireAction(wire.Owner, _pulseTimeout, PulseTimeoutKey.Key, new TimedWireEvent(AwaitPulseCancel, wire));
     }
@@ -57,7 +58,7 @@ public sealed partial class AccessWireAction : ComponentWireAction<AccessReaderC
         {
             if (EntityManager.TryGetComponent<AccessReaderComponent>(wire.Owner, out var access))
             {
-                access.Enabled = true;
+                EntityManager.System<AccessReaderSystem>().SetActive((wire.Owner, access), true);
                 EntityManager.Dirty(wire.Owner, access);
             }
         }

--- a/Content.Server/Access/AddAccessLogCommand.cs
+++ b/Content.Server/Access/AddAccessLogCommand.cs
@@ -1,8 +1,8 @@
 using Content.Server.Administration;
 using Content.Shared.Access.Components;
+using Content.Shared.Access.Systems;
 using Content.Shared.Administration;
 using Robust.Shared.Toolshed;
-using Robust.Shared.Toolshed.Syntax;
 
 namespace Content.Server.Access;
 
@@ -19,7 +19,7 @@ public sealed class AddAccessLogCommand : ToolshedCommand
             ctx.WriteLine($"WARNING: Surpassing the limit of the log by {accessLogCount - accessReader.AccessLogLimit+1} entries!");
 
         var accessTime = TimeSpan.FromSeconds(seconds);
-        accessReader.AccessLog.Enqueue(new AccessRecord(accessTime, accessor));
+        EntityManager.System<AccessReaderSystem>().LogAccess((input, accessReader), accessor, accessTime, true);
         ctx.WriteLine($"Successfully added access log to {input} with this information inside:\n " +
                       $"Time of access: {accessTime}\n " +
                       $"Accessed by: {accessor}");

--- a/Content.Server/Access/LogWireAction.cs
+++ b/Content.Server/Access/LogWireAction.cs
@@ -38,7 +38,7 @@ public sealed partial class LogWireAction : ComponentWireAction<AccessReaderComp
     {
         WiresSystem.TryCancelWireAction(wire.Owner, PulseTimeoutKey.Key);
         EntityManager.System<AccessReaderSystem>().SetLoggingActive((wire.Owner, comp), false);
-        EntityManager.Dirty(wire.Owner, comp);
+
         return true;
     }
 

--- a/Content.Server/Access/LogWireAction.cs
+++ b/Content.Server/Access/LogWireAction.cs
@@ -37,21 +37,21 @@ public sealed partial class LogWireAction : ComponentWireAction<AccessReaderComp
     public override bool Cut(EntityUid user, Wire wire, AccessReaderComponent comp)
     {
         WiresSystem.TryCancelWireAction(wire.Owner, PulseTimeoutKey.Key);
-        comp.LoggingDisabled = true;
+        EntityManager.System<AccessReaderSystem>().SetLoggingActive((wire.Owner, comp), false);
         EntityManager.Dirty(wire.Owner, comp);
         return true;
     }
 
     public override bool Mend(EntityUid user, Wire wire, AccessReaderComponent comp)
     {
-        comp.LoggingDisabled = false;
+        EntityManager.System<AccessReaderSystem>().SetLoggingActive((wire.Owner, comp), true);
         return true;
     }
 
     public override void Pulse(EntityUid user, Wire wire, AccessReaderComponent comp)
     {
         _access.LogAccess((wire.Owner, comp), Loc.GetString(PulseLog));
-        comp.LoggingDisabled = true;
+        EntityManager.System<AccessReaderSystem>().SetLoggingActive((wire.Owner, comp), false);
         WiresSystem.StartWireAction(wire.Owner, PulseTimeout, PulseTimeoutKey.Key, new TimedWireEvent(AwaitPulseCancel, wire));
     }
 
@@ -64,7 +64,7 @@ public sealed partial class LogWireAction : ComponentWireAction<AccessReaderComp
     private void AwaitPulseCancel(Wire wire)
     {
         if (!wire.IsCut && EntityManager.TryGetComponent<AccessReaderComponent>(wire.Owner, out var comp))
-            comp.LoggingDisabled = false;
+            EntityManager.System<AccessReaderSystem>().SetLoggingActive((wire.Owner, comp), true);
     }
 
     private enum PulseTimeoutKey : byte

--- a/Content.Server/Access/Systems/AccessOverriderSystem.cs
+++ b/Content.Server/Access/Systems/AccessOverriderSystem.cs
@@ -233,8 +233,6 @@ public sealed class AccessOverriderSystem : SharedAccessOverriderSystem
 
         var ev = new OnAccessOverriderAccessUpdatedEvent(player);
         RaiseLocalEvent(component.TargetAccessReaderId, ref ev);
-
-        Dirty(accessReaderEnt.Value);
     }
 
     /// <summary>

--- a/Content.Server/Access/Systems/AccessOverriderSystem.cs
+++ b/Content.Server/Access/Systems/AccessOverriderSystem.cs
@@ -168,21 +168,6 @@ public sealed class AccessOverriderSystem : SharedAccessOverriderSystem
         return accessList;
     }
 
-    private List<HashSet<ProtoId<AccessLevelPrototype>>> ConvertAccessListToHashSet(List<ProtoId<AccessLevelPrototype>> accessList)
-    {
-        List<HashSet<ProtoId<AccessLevelPrototype>>> accessHashsets = new List<HashSet<ProtoId<AccessLevelPrototype>>>();
-
-        if (accessList != null && accessList.Any())
-        {
-            foreach (ProtoId<AccessLevelPrototype> access in accessList)
-            {
-                accessHashsets.Add(new HashSet<ProtoId<AccessLevelPrototype>>() { access });
-            }
-        }
-
-        return accessHashsets;
-    }
-
     /// <summary>
     /// Called whenever an access button is pressed, adding or removing that access requirement from the target access reader.
     /// </summary>
@@ -244,7 +229,7 @@ public sealed class AccessOverriderSystem : SharedAccessOverriderSystem
         _adminLogger.Add(LogType.Action, LogImpact.High,
             $"{ToPrettyString(player):player} has modified {ToPrettyString(accessReaderEnt.Value):entity} with the following allowed access level holders: [{string.Join(", ", addedTags.Union(removedTags))}] [{string.Join(", ", newAccessList)}]");
 
-        accessReaderEnt.Value.Comp.AccessLists = ConvertAccessListToHashSet(newAccessList);
+        _accessReader.SetAccesses(accessReaderEnt.Value, newAccessList);
 
         var ev = new OnAccessOverriderAccessUpdatedEvent(player);
         RaiseLocalEvent(component.TargetAccessReaderId, ref ev);

--- a/Content.Server/Doors/Electronics/Systems/DoorElectronicsSystem.cs
+++ b/Content.Server/Doors/Electronics/Systems/DoorElectronicsSystem.cs
@@ -48,7 +48,7 @@ public sealed class DoorElectronicsSystem : EntitySystem
         DoorElectronicsUpdateConfigurationMessage args)
     {
         var accessReader = EnsureComp<AccessReaderComponent>(uid);
-        _accessReader.SetAccesses(uid, accessReader, args.AccessList);
+        _accessReader.SetAccesses((uid, accessReader), args.AccessList);
     }
 
     private void OnAccessReaderChanged(

--- a/Content.Shared/Access/Components/AccessReaderComponent.cs
+++ b/Content.Shared/Access/Components/AccessReaderComponent.cs
@@ -1,8 +1,8 @@
+using Content.Shared.Access.Systems;
 using Content.Shared.StationRecords;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
 
 namespace Content.Shared.Access.Components;
 
@@ -11,10 +11,11 @@ namespace Content.Shared.Access.Components;
 /// and allows checking if something or somebody is authorized with these access levels.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
+[Access(typeof(AccessReaderSystem))]
 public sealed partial class AccessReaderComponent : Component
 {
     /// <summary>
-    /// Whether or not the accessreader is enabled.
+    /// Whether or not the access reader is enabled.
     /// If not, it will always let people through.
     /// </summary>
     [DataField]
@@ -23,7 +24,6 @@ public sealed partial class AccessReaderComponent : Component
     /// <summary>
     /// The set of tags that will automatically deny an allowed check, if any of them are present.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
     public HashSet<ProtoId<AccessLevelPrototype>> DenyTags = new();
 
@@ -31,12 +31,11 @@ public sealed partial class AccessReaderComponent : Component
     /// List of access groups that grant access to this reader. Only a single matching group is required to gain access.
     /// A group matches if it is a subset of the set being checked against.
     /// </summary>
-    [DataField("access")] [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("access")]
     public List<HashSet<ProtoId<AccessLevelPrototype>>> AccessLists = new();
 
     /// <summary>
-    /// A list of <see cref="StationRecordKey"/>s that grant access. Only a single matching key is required to gain
-    /// access.
+    /// A list of <see cref="StationRecordKey"/>s that grant access. Only a single matching key is required to gain access.
     /// </summary>
     [DataField]
     public HashSet<StationRecordKey> AccessKeys = new();
@@ -54,7 +53,7 @@ public sealed partial class AccessReaderComponent : Component
     public string? ContainerAccessProvider;
 
     /// <summary>
-    /// A list of past authentications
+    /// A list of past authentications.
     /// </summary>
     [DataField]
     public Queue<AccessRecord> AccessLog = new();
@@ -62,7 +61,7 @@ public sealed partial class AccessReaderComponent : Component
     /// <summary>
     /// A limit on the max size of <see cref="AccessLog"/>
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public int AccessLogLimit = 20;
 
     /// <summary>
@@ -95,15 +94,10 @@ public readonly partial record struct AccessRecord(
 public sealed class AccessReaderComponentState : ComponentState
 {
     public bool Enabled;
-
     public HashSet<ProtoId<AccessLevelPrototype>> DenyTags;
-
     public List<HashSet<ProtoId<AccessLevelPrototype>>> AccessLists;
-
     public List<(NetEntity, uint)> AccessKeys;
-
     public Queue<AccessRecord> AccessLog;
-
     public int AccessLogLimit;
 
     public AccessReaderComponentState(bool enabled, HashSet<ProtoId<AccessLevelPrototype>> denyTags, List<HashSet<ProtoId<AccessLevelPrototype>>> accessLists, List<(NetEntity, uint)> accessKeys, Queue<AccessRecord> accessLog, int accessLogLimit)
@@ -117,9 +111,4 @@ public sealed class AccessReaderComponentState : ComponentState
     }
 }
 
-public sealed class AccessReaderConfigurationChangedEvent : EntityEventArgs
-{
-    public AccessReaderConfigurationChangedEvent()
-    {
-    }
-}
+public sealed class AccessReaderConfigurationChangedEvent : EntityEventArgs;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
AccessReaderSystem has been refactored. The following changes have been made:
- Access to AccessReaderComponent is now restricted to AccessReaderSystem
- To interact with the fields on AccessReaderComponent, external systems must now use the new public methods that have been added to AccessReaderSystem
- AccessReaderSystem.SetAccesses has been updated to require an Entity<AccessReaderComponent> as an input, rather than a EntityUid and AccessReaderComponent
- Added missing documentation to the public methods in AccessReaderSystem

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
N/A

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
AccessReaderSystem has been refactored. The following changes have been made:
- Access to AccessReaderComponent is now restricted to AccessReaderSystem
- To interact with the fields on AccessReaderComponent, external systems must now use the new public methods that have been added to AccessReaderSystem
- AccessReaderSystem.SetAccesses has been updated to require an Entity<AccessReaderComponent> as an input, rather than a EntityUid and AccessReaderComponent

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
N/A