### PR TITLE
Fix missing weight property in Chief Medical Officer job prototype

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -15,6 +15,7 @@
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 36000 #10 hrs
+  weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"
   supervisors: job-supervisors-captain


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed missing weight property for Chief Medical Officer job prototype.  The weight was removed (presumably by accident) in #36666.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Per the definition in [JobPrototype.cs](https://github.com/space-wizards/space-station-14/blob/af736eb93daf47f71b704cca850c65271d97c25a/Content.Shared/Roles/JobPrototype.cs#L88), the `weight` is the importance of this job.  If this number is large, the job system will assign this job before assigning other jobs.  The `weight` property is also used to sort jobs in the user interface, like the crew manifest.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds `weight: 10` back to chief_medical_officer.yml, after the `requirements` property and before `startingGear` property.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Not applicable.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The Chief Medical Officer should now appear with the correct precedence in the crew manifest.
