### PR TITLE
Add WieldingBlockerComponent

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Relay.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Relay.cs
@@ -4,6 +4,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Wieldable;
 
 namespace Content.Shared.Hands.EntitySystems;
 
@@ -19,6 +20,8 @@ public abstract partial class SharedHandsSystem
         SubscribeLocalEvent<HandsComponent, ExtinguishEvent>(RefRelayEvent);
         SubscribeLocalEvent<HandsComponent, ProjectileReflectAttemptEvent>(RefRelayEvent);
         SubscribeLocalEvent<HandsComponent, HitScanReflectAttemptEvent>(RefRelayEvent);
+        SubscribeLocalEvent<HandsComponent, WieldAttemptEvent>(RefRelayEvent);
+        SubscribeLocalEvent<HandsComponent, UnwieldAttemptEvent>(RefRelayEvent);
     }
 
     private void RelayEvent<T>(Entity<HandsComponent> entity, ref T args) where T : EntityEventArgs

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -24,6 +24,7 @@ using Content.Shared.Strip.Components;
 using Content.Shared.Temperature;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Wieldable;
 using Content.Shared.Zombies;
 
 namespace Content.Shared.Inventory;
@@ -63,6 +64,8 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, ProjectileReflectAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, HitScanReflectAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, GetContrabandDetailsEvent>(RefRelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, WieldAttemptEvent>(RefRelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, UnwieldAttemptEvent>(RefRelayInventoryEvent);
 
         // Eye/vision events
         SubscribeLocalEvent<InventoryComponent, CanSeeAttemptEvent>(RelayInventoryEvent);

--- a/Content.Shared/Wieldable/Components/WieldingBlockerComponent.cs
+++ b/Content.Shared/Wieldable/Components/WieldingBlockerComponent.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Wieldable.Components;
+
+/// <summary>
+/// Blocks an entity from wielding items.
+/// When added to an item, it will block wielding when held in hand or equipped.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class WieldingBlockerComponent : Component
+{
+    /// <summary>
+    /// Block wielding when this item is held in a hand?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool BlockInHand = true;
+
+    /// <summary>
+    /// Block wielding when this item is equipped?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool BlockEquipped = true;
+}

--- a/Content.Shared/Wieldable/Events.cs
+++ b/Content.Shared/Wieldable/Events.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Inventory;
+
 namespace Content.Shared.Wieldable;
 
 /// <summary>
@@ -14,12 +16,18 @@ public readonly record struct ItemWieldedEvent(EntityUid User);
 public readonly record struct ItemUnwieldedEvent(EntityUid User, bool Force);
 
 /// <summary>
-/// Raised directed on an item before a user tries to wield it.
+/// Raised directed on an user and all the items in their inventory and hands before they wield an item.
 /// If this event is cancelled wielding will not happen.
 /// </summary>
 [ByRefEvent]
-public record struct WieldAttemptEvent(EntityUid User, bool Cancelled = false)
+public record struct WieldAttemptEvent(EntityUid User, EntityUid Wielded, bool Cancelled = false) : IInventoryRelayEvent
 {
+    /// <summary>
+    /// Popup message for the user to tell them why they cannot wield if Cancelled
+    /// </summary>
+    public string? Message;
+
+    SlotFlags IInventoryRelayEvent.TargetSlots => SlotFlags.WITHOUT_POCKET;
     public void Cancel()
     {
         Cancelled = true;
@@ -27,15 +35,21 @@ public record struct WieldAttemptEvent(EntityUid User, bool Cancelled = false)
 }
 
 /// <summary>
-/// Raised directed on an item before a user tries to stop wielding it willingly.
+/// Raised directed on an user and all the items in their inventory and hands before they unwield an item willingly.
 /// If this event is cancelled unwielding will not happen.
 /// </summary>
 /// <remarks>
 /// This event is not raised if the user is forced to unwield the item.
 /// </remarks>
 [ByRefEvent]
-public record struct UnwieldAttemptEvent(EntityUid User, bool Cancelled = false)
+public record struct UnwieldAttemptEvent(EntityUid User, EntityUid Wielded, bool Cancelled = false) : IInventoryRelayEvent
 {
+    /// <summary>
+    /// Popup message for the user to tell them why they cannot unwield if Cancelled
+    /// </summary>
+    public string? Message;
+
+    SlotFlags IInventoryRelayEvent.TargetSlots => SlotFlags.WITHOUT_POCKET;
     public void Cancel()
     {
         Cancelled = true;

--- a/Resources/Locale/en-US/wieldable/wieldable-component.ftl
+++ b/Resources/Locale/en-US/wieldable/wieldable-component.ftl
@@ -7,6 +7,7 @@ wieldable-component-successful-wield = You wield { THE($item) }.
 wieldable-component-failed-wield = You unwield { THE($item) }.
 wieldable-component-successful-wield-other = { CAPITALIZE(THE($user)) } wields { THE($item) }.
 wieldable-component-failed-wield-other = { CAPITALIZE(THE($user)) } unwields { THE($item) }.
+wieldable-component-blocked-wield = { CAPITALIZE(THE($blocker)) } blocks you from wielding { THE($item) }.
 
 wieldable-component-no-hands = You don't have enough hands!
 wieldable-component-not-enough-free-hands = {$number ->


### PR DESCRIPTION
## About the PR
Purely technical addition, no gameplay changes yet
We already had a `WieldAttemptEvent`, but it was never used.
When added to a mob `WieldingBlockerComponent` will block them from wielding any item.
When added to a clothing item `WieldingBlockerComponent` will block the wearer from wielding if `BlockEquipped` is true.
When added to an item `WieldingBlockerComponent` and `BlockInHand` is true it will block anyone holding the item from wielding other items, no matter if they have free hands or not.

## Why / Balance
Should be useful in the future.
I'm planning on doing some more playtests with 4-handed arachnids. One of the biggest problems is that they can use shields and wield a gun at the same time, which is a huge combat advantage. Adding a wielding blocker when holding shields would be a simple way to keep this more balanced.

## Technical details
`WieldAttemptEvent` and `UnwieldAttemptEvent` were previously only raised on the item to be wielded. I changed it to be a relay event that gets raised on all inventory and hand items instead (which includes the item since it is held in hand).
We allow the event to add a popup message to tell the player why the wielding failed.
The event was currently not used anywhere.

## Media
How to test:
- use the `addhand` command to give yourself extra hands
- use VV to add `WieldingblockerComponent` to a clothing item and set `BlockInHand` to false
- use VV to add `WieldingblockerComponent` to a shield


https://github.com/user-attachments/assets/1adc27dc-82b2-487f-b360-4eb581d65ac2

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`WieldAttemptEvent` and `UnwieldAttemptEvent` now get raised on wielder and relayed to their inventory and all their held items instead of only on the item to be wielded. If you want to keep the previous functionality, then subscribe to the hand relay event and add a `if (uid == args.Wielded)` check in your subscription.

**Changelog**
no player facing changes
