### PR TITLE
Cleanup warnings in AI wire actions

### DIFF
--- a/Content.Server/Silicons/StationAi/AiInteractWireAction.cs
+++ b/Content.Server/Silicons/StationAi/AiInteractWireAction.cs
@@ -22,13 +22,13 @@ public sealed partial class AiInteractWireAction : ComponentWireAction<StationAi
     public override bool Cut(EntityUid user, Wire wire, StationAiWhitelistComponent component)
     {
         return EntityManager.System<SharedStationAiSystem>()
-            .SetWhitelistEnabled((component.Owner, component), false, announce: true);
+            .SetWhitelistEnabled((wire.Owner, component), false, announce: true);
     }
 
     public override bool Mend(EntityUid user, Wire wire, StationAiWhitelistComponent component)
     {
         return EntityManager.System<SharedStationAiSystem>()
-            .SetWhitelistEnabled((component.Owner, component), true);
+            .SetWhitelistEnabled((wire.Owner, component), true);
     }
 
     public override void Pulse(EntityUid user, Wire wire, StationAiWhitelistComponent component)

--- a/Content.Server/Silicons/StationAi/AiVisionWireAction.cs
+++ b/Content.Server/Silicons/StationAi/AiVisionWireAction.cs
@@ -23,13 +23,13 @@ public sealed partial class AiVisionWireAction : ComponentWireAction<StationAiVi
     public override bool Cut(EntityUid user, Wire wire, StationAiVisionComponent component)
     {
         return EntityManager.System<SharedStationAiSystem>()
-            .SetVisionEnabled((component.Owner, component), false, announce: true);
+            .SetVisionEnabled((wire.Owner, component), false, announce: true);
     }
 
     public override bool Mend(EntityUid user, Wire wire, StationAiVisionComponent component)
     {
         return EntityManager.System<SharedStationAiSystem>()
-            .SetVisionEnabled((component.Owner, component), true);
+            .SetVisionEnabled((wire.Owner, component), true);
     }
 
     public override void Pulse(EntityUid user, Wire wire, StationAiVisionComponent component)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 4 warnings in AI wire actions code.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
`wire.Owner` lets us get the owning entity uid without having to use `Component.Owner`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->