### PR TITLE
Move PriceCalculationEvent and EstimatedPriceCalculationEvent to shared

### DIFF
--- a/Content.Server/Anomaly/Effects/AnomalyCoreSystem.cs
+++ b/Content.Server/Anomaly/Effects/AnomalyCoreSystem.cs
@@ -1,5 +1,5 @@
-using Content.Server.Cargo.Systems;
 using Content.Shared.Anomaly.Components;
+using Content.Shared.Cargo;
 using Robust.Shared.Timing;
 
 namespace Content.Server.Anomaly.Effects;

--- a/Content.Server/Armor/ArmorSystem.cs
+++ b/Content.Server/Armor/ArmorSystem.cs
@@ -1,5 +1,5 @@
-using Content.Server.Cargo.Systems;
 using Content.Shared.Armor;
+using Content.Shared.Cargo;
 using Robust.Shared.Prototypes;
 using Content.Shared.Damage.Prototypes;
 

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -1,8 +1,8 @@
-using Content.Server.Cargo.Systems;
 using Content.Server.Explosion.EntitySystems;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Atmos.EntitySystems;
+using Content.Shared.Cargo;
 using Content.Shared.Throwing;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
@@ -1,6 +1,5 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
-using Content.Server.Cargo.Systems;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.NodeContainer.NodeGroups;
 using Content.Server.NodeContainer.Nodes;
@@ -8,6 +7,7 @@ using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Atmos.Piping.Binary.Components;
 using Content.Shared.Atmos.Piping.Unary.Systems;
+using Content.Shared.Cargo;
 using Content.Shared.Database;
 using Content.Shared.NodeContainer;
 using GasCanisterComponent = Content.Shared.Atmos.Piping.Unary.Components.GasCanisterComponent;

--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Cargo.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Administration;
 using Content.Shared.Body.Components;
+using Content.Shared.Cargo;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Materials;
@@ -183,10 +184,7 @@ public sealed class PricingSystem : EntitySystem
     /// </summary>
     public double GetEstimatedPrice(EntityPrototype prototype)
     {
-        var ev = new EstimatedPriceCalculationEvent()
-        {
-            Prototype = prototype,
-        };
+        var ev = new EstimatedPriceCalculationEvent(prototype);
 
         RaiseLocalEvent(ref ev);
 
@@ -398,40 +396,4 @@ public sealed class PricingSystem : EntitySystem
 
         return price;
     }
-}
-
-/// <summary>
-/// A directed by-ref event fired on an entity when something needs to know it's price. This value is not cached.
-/// </summary>
-[ByRefEvent]
-public record struct PriceCalculationEvent()
-{
-    /// <summary>
-    /// The total price of the entity.
-    /// </summary>
-    public double Price = 0;
-
-    /// <summary>
-    /// Whether this event was already handled.
-    /// </summary>
-    public bool Handled = false;
-}
-
-/// <summary>
-/// Raised broadcast for an entity prototype to determine its estimated price.
-/// </summary>
-[ByRefEvent]
-public record struct EstimatedPriceCalculationEvent()
-{
-    public required EntityPrototype Prototype;
-
-    /// <summary>
-    /// The total price of the entity.
-    /// </summary>
-    public double Price = 0;
-
-    /// <summary>
-    /// Whether this event was already handled.
-    /// </summary>
-    public bool Handled = false;
 }

--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -1,9 +1,8 @@
-using Content.Server.Cargo.Systems;
 using Content.Server.Emp;
 using Content.Server.Power.Components;
+using Content.Shared.Cargo;
 using Content.Shared.Examine;
 using Content.Shared.Rejuvenate;
-using Content.Shared.Timing;
 using JetBrains.Annotations;
 using Robust.Shared.Utility;
 using Robust.Shared.Timing;

--- a/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
+++ b/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Cargo.Systems;
 using Content.Server.Storage.Components;
+using Content.Shared.Cargo;
 using Content.Shared.Database;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction.Events;

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Cargo.Systems;
 using Content.Server.Emp;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
+using Content.Shared.Cargo;
 using Content.Shared.Damage;
 using Content.Shared.Destructible;
 using Content.Shared.DoAfter;

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -1,8 +1,8 @@
 using System.Linq;
 using System.Numerics;
 using Content.Server.Cargo.Systems;
-using Content.Server.Power.EntitySystems;
 using Content.Server.Weapons.Ranged.Components;
+using Content.Shared.Cargo;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
@@ -22,7 +22,6 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using Robust.Shared.Containers;
-using Content.Server.PowerCell;
 
 namespace Content.Server.Weapons.Ranged.Systems;
 

--- a/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.cs
@@ -1,4 +1,4 @@
-using Content.Server.Cargo.Systems;
+using Content.Shared.Cargo;
 using Content.Shared.Xenoarchaeology.Artifact;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 

--- a/Content.Shared/Cargo/PriceCalculationEvent.cs
+++ b/Content.Shared/Cargo/PriceCalculationEvent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Cargo;
 
 /// <summary>
-/// A directed by-ref event fired on an entity when something needs to know it's price. This value is not cached.
+/// A directed by-ref event fired on an entity when something needs to know its price. This value is not cached.
 /// </summary>
 [ByRefEvent]
 public record struct PriceCalculationEvent()

--- a/Content.Shared/Cargo/PriceCalculationEvent.cs
+++ b/Content.Shared/Cargo/PriceCalculationEvent.cs
@@ -1,0 +1,38 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Cargo;
+
+/// <summary>
+/// A directed by-ref event fired on an entity when something needs to know it's price. This value is not cached.
+/// </summary>
+[ByRefEvent]
+public record struct PriceCalculationEvent()
+{
+    /// <summary>
+    /// The total price of the entity.
+    /// </summary>
+    public double Price = 0;
+
+    /// <summary>
+    /// Whether this event was already handled.
+    /// </summary>
+    public bool Handled = false;
+}
+
+/// <summary>
+/// Raised broadcast for an entity prototype to determine its estimated price.
+/// </summary>
+/// <param name="Prototype">The prototype to estimate the price for.</param>
+[ByRefEvent]
+public record struct EstimatedPriceCalculationEvent(EntityPrototype Prototype)
+{
+    /// <summary>
+    /// The total price of the entity.
+    /// </summary>
+    public double Price = 0;
+
+    /// <summary>
+    /// Whether this event was already handled.
+    /// </summary>
+    public bool Handled = false;
+}


### PR DESCRIPTION
## About the PR
Title.
I am reviving https://github.com/space-wizards/space-station-14/pull/36709 and I would rather move the event to Shared than a system to Server.

## Why / Balance
Events like this should always be in shared to begin with to make predicting systems later easier.

## Technical details
Move two structs
Fix namespaces
use primary constructor for `EstimatedPriceCalculationEvent`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`PriceCalculationEvent` and `EstimatedPriceCalculationEvent` have been moved to `Content.Shared.Cargo`.

**Changelog**
none
