### PR TITLE
Fix space-wizards#35663: Prevent clipping of hovered sprites on rotation

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/chemistry_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/chemistry_machines.yml
@@ -54,6 +54,7 @@
     - Electrolysis
   - type: Sprite
     sprite: Structures/Machines/Medical/electrolysis.rsi
+    noRot: true
     offset: "0.0,0.4"
     layers:
     - state: base
@@ -93,6 +94,7 @@
     - Centrifuge
   - type: Sprite
     sprite: Structures/Machines/Medical/centrifuge.rsi
+    noRot: true
     offset: "0.0,0.4"
     layers:
     - state: base


### PR DESCRIPTION
This fix addresses an issue where hovered tabletop machines (such as the grinder and electrolysis machine) had their sprites clipped when the camera was rotated. The problem was fixed by setting noRot: true.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This fix addresses an issue where hovered tabletop machines (such as the grinder and electrolysis machine) had their sprites clipped when the camera was rotated.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/35663

## Technical details
<!-- Summary of code changes for easier review. -->
This issue is fixed by setting noRot: true.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://streamable.com/bjeyon

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
-fix: Fix hovered tabletop machines (such as the grinder and electrolysis machine) that had their sprites clipped when the camera was rotated.
