### PR TITLE
Convert `TimedSpawnerComponent` to use an Update loop

### DIFF
--- a/Content.Server/Spawners/Components/TimedSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/TimedSpawnerComponent.cs
@@ -1,6 +1,6 @@
-﻿using System.Threading;
-using Robust.Shared.Prototypes;
+﻿using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Spawners.Components;
 
@@ -10,6 +10,7 @@ namespace Content.Server.Spawners.Components;
 /// and min/max number of entities to spawn.
 /// </summary>
 [RegisterComponent, EntityCategory("Spawner")]
+[AutoGenerateComponentPause]
 public sealed partial class TimedSpawnerComponent : Component, ISerializationHooks
 {
     /// <summary>
@@ -30,7 +31,7 @@ public sealed partial class TimedSpawnerComponent : Component, ISerializationHoo
     /// Length of the interval between spawn attempts.
     /// </summary>
     [DataField]
-    public int IntervalSeconds = 60;
+    public TimeSpan IntervalSeconds = TimeSpan.FromSeconds(60);
 
     /// <summary>
     /// The minimum number of entities that can be spawned when an interval elapses.
@@ -44,7 +45,11 @@ public sealed partial class TimedSpawnerComponent : Component, ISerializationHoo
     [DataField]
     public int MaximumEntitiesSpawned = 1;
 
-    public CancellationTokenSource? TokenSource;
+    /// <summary>
+    /// The time at which the current interval will have elapsed and entities may be spawned.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
+    public TimeSpan NextFire = TimeSpan.Zero;
 
     void ISerializationHooks.AfterDeserialization()
     {

--- a/Content.Server/Spawners/EntitySystems/SpawnerSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/SpawnerSystem.cs
@@ -1,25 +1,41 @@
-using System.Threading;
 using Content.Server.Spawners.Components;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Spawners.EntitySystems;
 
 public sealed class SpawnerSystem : EntitySystem
 {
+    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<TimedSpawnerComponent, ComponentInit>(OnSpawnerInit);
-        SubscribeLocalEvent<TimedSpawnerComponent, ComponentShutdown>(OnTimedSpawnerShutdown);
+
+        SubscribeLocalEvent<TimedSpawnerComponent, MapInitEvent>(OnMapInit);
     }
 
-    private void OnSpawnerInit(EntityUid uid, TimedSpawnerComponent component, ComponentInit args)
+    public override void Update(float frameTime)
     {
-        component.TokenSource?.Cancel();
-        component.TokenSource = new CancellationTokenSource();
-        uid.SpawnRepeatingTimer(TimeSpan.FromSeconds(component.IntervalSeconds), () => OnTimerFired(uid, component), component.TokenSource.Token);
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        var query = EntityQueryEnumerator<TimedSpawnerComponent>();
+        while (query.MoveNext(out var uid, out var timedSpawner))
+        {
+            if (timedSpawner.NextFire > curTime)
+                continue;
+
+            OnTimerFired(uid, timedSpawner);
+
+            timedSpawner.NextFire += timedSpawner.IntervalSeconds;
+        }
+    }
+
+    private void OnMapInit(Entity<TimedSpawnerComponent> ent, ref MapInitEvent args)
+    {
+        ent.Comp.NextFire = _timing.CurTime + ent.Comp.IntervalSeconds;
     }
 
     private void OnTimerFired(EntityUid uid, TimedSpawnerComponent component)
@@ -35,10 +51,5 @@ public sealed class SpawnerSystem : EntitySystem
             var entity = _random.Pick(component.Prototypes);
             SpawnAtPosition(entity, coordinates);
         }
-    }
-
-    private void OnTimedSpawnerShutdown(EntityUid uid, TimedSpawnerComponent component, ComponentShutdown args)
-    {
-        component.TokenSource?.Cancel();
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Modernizes `TimedSpawnerComponent` and `SpawnerSystem` code.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
`SpawnRepeatingTimer` is bad.
1 more warning for [PZW](https://github.com/space-wizards/space-station-14/issues/33279)

## Technical details
<!-- Summary of code changes for easier review. -->
Removed all the nasty timer and threading code and replaced it with a standard `Update` loop and auto-paused datafield.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`TimedSpawnerComponent.IntervalSeconds` is now a `TimeSpan` instead of an `int`. Thanks to the way `TimeSpan`s are serialized, this requires no YAML changes, but code that uses it will need to be adjusted.