### PR TITLE
Cleanup warning in `SpiderSystem`

### DIFF
--- a/Content.Server/Spider/SpiderSystem.cs
+++ b/Content.Server/Spider/SpiderSystem.cs
@@ -9,6 +9,7 @@ namespace Content.Server.Spider;
 
 public sealed class SpiderSystem : SharedSpiderSystem
 {
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
 
     public override void Initialize()
@@ -66,7 +67,7 @@ public sealed class SpiderSystem : SharedSpiderSystem
 
     private bool IsTileBlockedByWeb(EntityCoordinates coords)
     {
-        foreach (var entity in coords.GetEntitiesInTile())
+        foreach (var entity in _lookup.GetEntitiesIntersecting(coords))
         {
             if (HasComp<SpiderWebObjectComponent>(entity))
                 return true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 1 warning in `SpiderSystem.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaces `EntityCoordinates.GetEntitiesInTile` with `EntityLookupSystem.GetEntitiesIntersecting`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Shiva making some webs:
<img width="312" alt="Screenshot 2025-05-24 at 1 30 05 PM" src="https://github.com/user-attachments/assets/aebefd97-b32e-4489-87ec-e633c9a4eaa6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->