### PR TITLE
Cleanup logging in guidebook embeds

### DIFF
--- a/Content.Client/Guidebook/Controls/GuideEntityEmbed.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideEntityEmbed.xaml.cs
@@ -28,11 +28,14 @@ public sealed partial class GuideEntityEmbed : BoxContainer, IDocumentTag
 {
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IEntitySystemManager _systemManager = default!;
+    [Dependency] private readonly ILogManager _logManager = default!;
     [Dependency] private readonly IUserInterfaceManager _ui = default!;
 
     private readonly TagSystem _tagSystem;
     private readonly ExamineSystem _examineSystem;
     private readonly GuidebookSystem _guidebookSystem;
+
+    private readonly ISawmill _sawmill;
 
     public bool Interactive;
 
@@ -53,6 +56,7 @@ public sealed partial class GuideEntityEmbed : BoxContainer, IDocumentTag
         _tagSystem = _systemManager.GetEntitySystem<TagSystem>();
         _examineSystem = _systemManager.GetEntitySystem<ExamineSystem>();
         _guidebookSystem = _systemManager.GetEntitySystem<GuidebookSystem>();
+        _sawmill = _logManager.GetSawmill("guidebook.entity");
         MouseFilter = MouseFilterMode.Stop;
     }
 
@@ -135,7 +139,7 @@ public sealed partial class GuideEntityEmbed : BoxContainer, IDocumentTag
     {
         if (!args.TryGetValue("Entity", out var proto))
         {
-            Logger.Error("Entity embed tag is missing entity prototype argument");
+            _sawmill.Error("Entity embed tag is missing entity prototype argument");
             control = null;
             return false;
         }

--- a/Content.Client/Guidebook/Controls/GuideMicrowaveEmbed.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideMicrowaveEmbed.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class GuideMicrowaveEmbed : PanelContainer, IDocumentTag, 
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly ILogManager _logManager = default!;
 
-    private ISawmill _sawmill = default!;
+    private readonly ISawmill _sawmill = default!;
 
     public IPrototype? RepresentedPrototype { get; private set; }
 
@@ -34,7 +34,7 @@ public sealed partial class GuideMicrowaveEmbed : PanelContainer, IDocumentTag, 
         IoCManager.InjectDependencies(this);
         MouseFilter = MouseFilterMode.Stop;
 
-        _sawmill = _logManager.GetSawmill("guidemicrowaveembed");
+        _sawmill = _logManager.GetSawmill("guidebook.microwave");
     }
 
     public GuideMicrowaveEmbed(string recipe) : this()

--- a/Content.Client/Guidebook/Controls/GuideMicrowaveGroupEmbed.cs
+++ b/Content.Client/Guidebook/Controls/GuideMicrowaveGroupEmbed.cs
@@ -15,12 +15,16 @@ namespace Content.Client.Guidebook.Controls;
 [UsedImplicitly]
 public sealed partial class GuideMicrowaveGroupEmbed : BoxContainer, IDocumentTag
 {
+    [Dependency] private readonly ILogManager _logManager = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+
+    private readonly ISawmill _sawmill;
 
     public GuideMicrowaveGroupEmbed()
     {
         Orientation = LayoutOrientation.Vertical;
         IoCManager.InjectDependencies(this);
+        _sawmill = _logManager.GetSawmill("guidebook.microwave_group");
         MouseFilter = MouseFilterMode.Stop;
     }
 
@@ -34,7 +38,7 @@ public sealed partial class GuideMicrowaveGroupEmbed : BoxContainer, IDocumentTa
         control = null;
         if (!args.TryGetValue("Group", out var group))
         {
-            Logger.Error("Microwave group embed tag is missing group argument");
+            _sawmill.Error("Microwave group embed tag is missing group argument");
             return false;
         }
 

--- a/Content.Client/Guidebook/Controls/GuideReagentEmbed.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideReagentEmbed.xaml.cs
@@ -25,9 +25,11 @@ namespace Content.Client.Guidebook.Controls;
 public sealed partial class GuideReagentEmbed : BoxContainer, IDocumentTag, ISearchableControl, IPrototypeRepresentationControl
 {
     [Dependency] private readonly IEntitySystemManager _systemManager = default!;
+    [Dependency] private readonly ILogManager _logManager = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
 
     private readonly ChemistryGuideDataSystem _chemistryGuideData;
+    private readonly ISawmill _sawmill;
 
     public IPrototype? RepresentedPrototype { get; private set; }
 
@@ -35,6 +37,7 @@ public sealed partial class GuideReagentEmbed : BoxContainer, IDocumentTag, ISea
     {
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
+        _sawmill = _logManager.GetSawmill("guidebook.reagent");
         _chemistryGuideData = _systemManager.GetEntitySystem<ChemistryGuideDataSystem>();
         MouseFilter = MouseFilterMode.Stop;
     }
@@ -64,13 +67,13 @@ public sealed partial class GuideReagentEmbed : BoxContainer, IDocumentTag, ISea
         control = null;
         if (!args.TryGetValue("Reagent", out var id))
         {
-            Logger.Error("Reagent embed tag is missing reagent prototype argument");
+            _sawmill.Error("Reagent embed tag is missing reagent prototype argument");
             return false;
         }
 
         if (!_prototype.TryIndex<ReagentPrototype>(id, out var reagent))
         {
-            Logger.Error($"Specified reagent prototype \"{id}\" is not a valid reagent prototype");
+            _sawmill.Error($"Specified reagent prototype \"{id}\" is not a valid reagent prototype");
             return false;
         }
 

--- a/Content.Client/Guidebook/Controls/GuideReagentGroupEmbed.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideReagentGroupEmbed.xaml.cs
@@ -17,12 +17,16 @@ namespace Content.Client.Guidebook.Controls;
 [UsedImplicitly, GenerateTypedNameReferences]
 public sealed partial class GuideReagentGroupEmbed : BoxContainer, IDocumentTag
 {
+    [Dependency] private readonly ILogManager _logManager = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+
+    private readonly ISawmill _sawmill;
 
     public GuideReagentGroupEmbed()
     {
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
+        _sawmill = _logManager.GetSawmill("guidebook.reagent_group");
         MouseFilter = MouseFilterMode.Stop;
     }
 
@@ -42,7 +46,7 @@ public sealed partial class GuideReagentGroupEmbed : BoxContainer, IDocumentTag
         control = null;
         if (!args.TryGetValue("Group", out var group))
         {
-            Logger.Error("Reagent group embed tag is missing group argument");
+            _sawmill.Error("Reagent group embed tag is missing group argument");
             return false;
         }
 

--- a/Content.Client/Guidebook/Controls/GuideTechDisciplineEmbed.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideTechDisciplineEmbed.xaml.cs
@@ -17,12 +17,16 @@ namespace Content.Client.Guidebook.Controls;
 [UsedImplicitly, GenerateTypedNameReferences]
 public sealed partial class GuideTechDisciplineEmbed : BoxContainer, IDocumentTag
 {
+    [Dependency] private readonly ILogManager _logManager = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+
+    private readonly ISawmill _sawmill;
 
     public GuideTechDisciplineEmbed()
     {
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
+        _sawmill = _logManager.GetSawmill("guidebook.tech_discipline");
         MouseFilter = MouseFilterMode.Stop;
     }
 
@@ -42,7 +46,7 @@ public sealed partial class GuideTechDisciplineEmbed : BoxContainer, IDocumentTa
         control = null;
         if (!args.TryGetValue("Discipline", out var group))
         {
-            Logger.Error("Technology discipline embed tag is missing discipline argument");
+            _sawmill.Error("Technology discipline embed tag is missing discipline argument");
             return false;
         }
 

--- a/Content.Client/Guidebook/Controls/GuideTechnologyEmbed.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideTechnologyEmbed.xaml.cs
@@ -22,10 +22,12 @@ namespace Content.Client.Guidebook.Controls;
 public sealed partial class GuideTechnologyEmbed : BoxContainer, IDocumentTag, ISearchableControl
 {
     [Dependency] private readonly IEntitySystemManager _systemManager = default!;
+    [Dependency] private readonly ILogManager _logManager = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
 
     private readonly ResearchSystem _research;
     private readonly SpriteSystem _sprite;
+    private readonly ISawmill _sawmill;
 
     public GuideTechnologyEmbed()
     {
@@ -33,6 +35,7 @@ public sealed partial class GuideTechnologyEmbed : BoxContainer, IDocumentTag, I
         IoCManager.InjectDependencies(this);
         _research = _systemManager.GetEntitySystem<ResearchSystem>();
         _sprite = _systemManager.GetEntitySystem<SpriteSystem>();
+        _sawmill = _logManager.GetSawmill("guidebook.technology");
         MouseFilter = MouseFilterMode.Stop;
     }
 
@@ -61,13 +64,13 @@ public sealed partial class GuideTechnologyEmbed : BoxContainer, IDocumentTag, I
         control = null;
         if (!args.TryGetValue("Technology", out var id))
         {
-            Logger.Error("Technology embed tag is missing technology prototype argument");
+            _sawmill.Error("Technology embed tag is missing technology prototype argument");
             return false;
         }
 
         if (!_prototype.TryIndex<TechnologyPrototype>(id, out var technology))
         {
-            Logger.Error($"Specified technology prototype \"{id}\" is not a valid technology prototype");
+            _sawmill.Error($"Specified technology prototype \"{id}\" is not a valid technology prototype");
             return false;
         }
 

--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
@@ -31,7 +31,7 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
     {
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
-        _sawmill = Logger.GetSawmill("Guidebook");
+        _sawmill = Logger.GetSawmill("guidebook");
 
         Tree.OnSelectedItemChanged += OnSelectionChanged;
 
@@ -225,7 +225,7 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
         {
             // TODO GUIDEBOOK Maybe allow duplicate entries?
             // E.g., for adding medicine under both chemicals & the chemist job
-            Logger.Error($"Adding duplicate guide entry: {id}");
+            _sawmill.Error($"Adding duplicate guide entry: {id}");
             return null;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removes static logger calls in guidebook embed classes by using `ILogManager` dependencies to get proper `ISawmill` instances.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
9 warnings for [PZW](https://github.com/space-wizards/space-station-14/issues/33279)

## Technical details
<!-- Summary of code changes for easier review. -->
- Adds `ILogManager` dependencies to various guidebook embed classes and uses them to get `ISawmill` instances.
- Unifies guidebook-related sawmill names to follow the same format: `guidebook.entity` for entity embeds, `guidebook.reagent` for reagent embeds, etc.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->