### PR TITLE
Removes references to GetAnchoredEntitiesEnumerator(Vector2i)

### DIFF
--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -567,7 +567,7 @@ public abstract partial class SharedMoverController : VirtualController
 
         // If the coordinates have a FootstepModifier component
         // i.e. component that emit sound on footsteps emit that sound
-        var anchored = grid.GetAnchoredEntitiesEnumerator(position);
+        var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(uid, grid, position);
 
         while (anchored.MoveNext(out var maybeFootstep))
         {

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -567,7 +567,7 @@ public abstract partial class SharedMoverController : VirtualController
 
         // If the coordinates have a FootstepModifier component
         // i.e. component that emit sound on footsteps emit that sound
-        var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(uid, grid, position);
+        var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(xform.GridUid.Value, grid, position);
 
         while (anchored.MoveNext(out var maybeFootstep))
         {

--- a/Content.Shared/Random/Rules/NearbyTilesPercent.cs
+++ b/Content.Shared/Random/Rules/NearbyTilesPercent.cs
@@ -45,7 +45,7 @@ public sealed partial class NearbyTilesPercentRule : RulesRule
             // Only consider collidable anchored (for reasons some subfloor stuff has physics but non-collidable)
             if (IgnoreAnchored)
             {
-                var gridEnum = mapSys.GetAnchoredEntitiesEnumerator(uid, grid, tile.GridIndices);
+                var gridEnum = mapSys.GetAnchoredEntitiesEnumerator(xform.GridUid.Value, grid, tile.GridIndices);
                 var found = false;
 
                 while (gridEnum.MoveNext(out var ancUid))

--- a/Content.Shared/Random/Rules/NearbyTilesPercent.cs
+++ b/Content.Shared/Random/Rules/NearbyTilesPercent.cs
@@ -45,7 +45,7 @@ public sealed partial class NearbyTilesPercentRule : RulesRule
             // Only consider collidable anchored (for reasons some subfloor stuff has physics but non-collidable)
             if (IgnoreAnchored)
             {
-                var gridEnum = grid.GetAnchoredEntitiesEnumerator(tile.GridIndices);
+                var gridEnum = mapSys.GetAnchoredEntitiesEnumerator(uid, grid, tile.GridIndices);
                 var found = false;
 
                 while (gridEnum.MoveNext(out var ancUid))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
## About the PR
<!-- What did you change? -->
Title
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
#33279, `grid.GetAnchoredEntitiesEnumerator(Vector2i)` is Obsolete
## Technical details
<!-- Summary of code changes for easier review. -->
Replace places using `grid.GetAnchoredEntitiesEnumerator(Vector2i)` with `mapSystem.GetAnchoredEntitiesEnumerator(uid, grid, Vector2i)`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
