### PR TITLE
Normal and Cotton Dough Slices/Ropes can be cooked using heat

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bagel.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bagel.yml
@@ -53,7 +53,7 @@
           Quantity: 5
 
 - type: entity
-  id: FoodBagelCotton
+  id: FoodCottonBagel
   parent: FoodBagelBase
   name: cotton bagel
   description: A delicious bagel made with cotton dough.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bagel.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bagel.yml
@@ -25,6 +25,10 @@
   id: FoodBagel
   name: bagel
   parent: FoodBagelBase
+  components:
+  - type: Construction
+    graph: CookingDough
+    node: cookedBagel
 
 - type: entity
   id: FoodBagelPoppy
@@ -54,6 +58,9 @@
   name: cotton bagel
   description: A delicious bagel made with cotton dough.
   components:
+  - type: Construction
+    graph: CookingCottonDough
+    node: cookedCottonBagel
   - type: FlavorProfile
     flavors:
     - bread

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -19,6 +19,10 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 6.66 # 1/3 of a loaf of bread, technically losing 0.01 nutriment per batch of three buns over making bread loaves/slices
+  - type: Construction
+    graph: CookingDough
+    node: cookedBun
+
   - type: Butcherable
     butcherDelay: 1
     spawned:
@@ -31,10 +35,10 @@
   id: FoodBreadBunBottom
   parent: FoodBreadSliceBase
   name: bottom bun
-  description: It's time to start building the burger tower. 
+  description: It's time to start building the burger tower.
   components:
   - type: Item
-    size: Normal #patch until there is an adequate resizing system in place 
+    size: Normal #patch until there is an adequate resizing system in place
   - type: Food
   - type: Sprite
     drawdepth: Mobs
@@ -83,7 +87,7 @@
   - type: FoodSequenceElement
     entries:
       Burger: BunTopBurger
-  
+
 # Base
 
 - type: entity
@@ -687,7 +691,7 @@
   description: An elusive rib shaped burger with limited availability across the galaxy. Not as good as you remember it.
   components:
   - type: Food
-    trash: 
+    trash:
     - FoodKebabSkewer
   - type: FlavorProfile
     flavors:
@@ -987,4 +991,4 @@
   - type: Tag
     tags:
     - Meat
-    
+

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/cottonburger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/cottonburger.yml
@@ -6,6 +6,9 @@
   name: cotton bun
   description: A cotton hamburger bun. Soft, round and convenient to hold.
   components:
+  - type: Construction
+    graph: CookingCottonDough
+    node: CookedCottonBun
   - type: Food
     requiresSpecialDigestion: true
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -261,6 +261,7 @@
 
 # Baking
 
+#only bake goods have temperature for now. Needed to be able to cook food without microwave recipe
 - type: entity
   abstract: true
   parent: FoodBase
@@ -269,6 +270,11 @@
   components:
   - type: Sprite
     sprite: Objects/Consumable/Food/ingredients.rsi
+  - type: Temperature
+    currentTemperature: 290
+  - type: InternalTemperature
+    thickness: 0.02
+    area: 0.02
   - type: SolutionContainerManager
     solutions:
       food:
@@ -313,7 +319,7 @@
     tags:
     - Slice
   - type: Construction
-    graph: DoughRope
+    graph: CookingDough
     node: start
   - type: SolutionContainerManager
     solutions:
@@ -335,7 +341,7 @@
   - type: Sprite
     state: dough-rope
   - type: Construction
-    graph: DoughRope
+    graph: CookingDough
     node: rolled
   - type: SolutionContainerManager
     solutions:
@@ -477,7 +483,7 @@
     - Slice
     - ClothMade
   - type: Construction
-    graph: DoughRopeCotton
+    graph: CookingCottonDough
     node: start
   - type: SolutionContainerManager
     solutions:
@@ -502,7 +508,7 @@
   - type: Sprite
     state: cotton-dough-rope
   - type: Construction
-    graph: DoughRopeCotton
+    graph: CookingCottonDough
     node: rolled
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/food/doughrope.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/food/doughrope.yml
@@ -1,5 +1,10 @@
+#
+# This will contain all food trees for doughs
+# This should include normal and cotton, but not cakes
+# Bun should be moved from burger.yml to here
+
 - type: constructionGraph
-  id: DoughRope
+  id: CookingDough
   start: start
   graph:
   - node: start
@@ -9,11 +14,27 @@
       steps:
       - tool: Rolling
         doAfter: 1
+    - to: cookedBun
+      steps:
+      - minTemperature: 330
+
   - node: rolled
     entity: FoodDoughRope
+    edges:
+    - to: cookedBagel
+      steps:
+      - minTemperature: 330
+
+  - node: cookedBun
+    entity: FoodBreadBun
+
+  - node: cookedBagel
+    entity: FoodBagel
+
+
 
 - type: constructionGraph
-  id: DoughRopeCotton
+  id: CookingCottonDough
   start: start
   graph:
   - node: start
@@ -23,5 +44,13 @@
       steps:
       - tool: Rolling
         doAfter: 1
+    - to: cookedCottonBun
+      steps:
+      - minTemperature: 330
+
   - node: rolled
     entity: FoodDoughCottonRope
+  - node: cookedCottonBun
+    entity: FoodCottonBun
+  - node: cookedCottonBagel
+    entity: FoodCottonBagel

--- a/Resources/Prototypes/Recipes/Construction/Graphs/food/doughrope.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/food/doughrope.yml
@@ -50,7 +50,13 @@
 
   - node: rolled
     entity: FoodDoughCottonRope
+    edges:
+    - to: cookedCottonBagel
+      steps:
+      - minTemperature: 330
+
   - node: cookedCottonBun
     entity: FoodCottonBun
+
   - node: cookedCottonBagel
     entity: FoodCottonBagel


### PR DESCRIPTION
## About the PR
Buns and Bagels (normal and cotton) can now be cooked using heat

## Why / Balance
In order to allow Chef to become more interactive, we should try to move away from relying entirely on microwaves. Heat means that Chef can cook using ANY source of heat.

## Technical details
Dough slices and ropes have had their construction tree expanded to incorporate most of the products in its production chain. I didn't move the tree to include loaves of bread to simplify how many things needed to be changed for refactoring considerations.

Temperature and InternalTemperature was added to FoodBakingBase, InternalTemperature is the main component that allows the cooking trigger to work.

I renamed the cooking trees from DoughRope and CottonDoughRope to CookingDough and CookingCottonDough. I would like to expand these trees to include loaves as well, and to refactor how the recipes/cooking is organised. Currently it is very messy and does not make logical sense (however this would be future stepped PRs)

Currently I set the baking temperature to 330, this is the same temperature to turn Raw Meat into Steaks. This should be adjusted to something more appropriate later.

## Media
![cookinBreads](https://github.com/user-attachments/assets/8f09ff61-381d-4366-972c-807ad17e4a1a)


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
Some names were changed here, however I was unable to find any conflicts. I have no tested what happens if I make 100 dough pieces, and then set a trit fire. This may cause everything to trigger at once.

**Changelog**
<!--
:cl:
- add: Added the ability to use heat to cook buns and bagels (both normal and cotton).
-->
