### PR TITLE
Cleanup warnings in `TileAtmosCollectionSerializer`

### DIFF
--- a/Content.Server/Atmos/Serialization/TileAtmosCollectionSerializer.cs
+++ b/Content.Server/Atmos/Serialization/TileAtmosCollectionSerializer.cs
@@ -26,7 +26,7 @@ public sealed partial class TileAtmosCollectionSerializer : ITypeSerializer<Dict
         ISerializationManager.InstantiationDelegate<Dictionary<Vector2i, TileAtmosphere>>? instanceProvider = null)
     {
         node.TryGetValue("version", out var versionNode);
-        var version = ((ValueDataNode?) versionNode)?.AsInt() ?? 1;
+        var version = ((ValueDataNode?)versionNode)?.AsInt() ?? 1;
         Dictionary<Vector2i, TileAtmosphere> tiles = new();
 
         // Backwards compatability
@@ -48,7 +48,8 @@ public sealed partial class TileAtmosCollectionSerializer : ITypeSerializer<Dict
                     }
                     catch (ArgumentOutOfRangeException)
                     {
-                        Logger.Error(
+                        var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                        sawmill.Error(
                             $"Error during atmos serialization! Tile at {indices} points to an unique mix ({mix}) out of range!");
                     }
                 }
@@ -56,7 +57,7 @@ public sealed partial class TileAtmosCollectionSerializer : ITypeSerializer<Dict
         }
         else
         {
-            var dataNode = (MappingDataNode) node["data"];
+            var dataNode = (MappingDataNode)node["data"];
             var chunkSize = serializationManager.Read<int>(dataNode["chunkSize"], hookCtx, context);
 
             dataNode.TryGet("uniqueMixes", out var mixNode);
@@ -64,7 +65,7 @@ public sealed partial class TileAtmosCollectionSerializer : ITypeSerializer<Dict
 
             if (unique != null)
             {
-                var tileNode = (MappingDataNode) dataNode["tiles"];
+                var tileNode = (MappingDataNode)dataNode["tiles"];
                 foreach (var (chunkNode, valueNode) in tileNode)
                 {
                     var chunkOrigin = serializationManager.Read<Vector2i>(tileNode.GetKeyNode(chunkNode), hookCtx, context);
@@ -76,7 +77,7 @@ public sealed partial class TileAtmosCollectionSerializer : ITypeSerializer<Dict
                         {
                             for (var y = 0; y < chunkSize; y++)
                             {
-                                var flag = data & (uint) (1 << (x + y * chunkSize));
+                                var flag = data & (uint)(1 << (x + y * chunkSize));
 
                                 if (flag == 0)
                                     continue;
@@ -91,7 +92,8 @@ public sealed partial class TileAtmosCollectionSerializer : ITypeSerializer<Dict
                                 }
                                 catch (ArgumentOutOfRangeException)
                                 {
-                                    Logger.Error(
+                                    var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                                    sawmill.Error(
                                         $"Error during atmos serialization! Tile at {indices} points to an unique mix ({mix}) out of range!");
                                 }
                             }
@@ -128,7 +130,7 @@ public sealed partial class TileAtmosCollectionSerializer : ITypeSerializer<Dict
             var indices = SharedMapSystem.GetChunkRelative(gridIndices, chunkSize);
 
             var mixFlag = tileChunk.Data.GetOrNew(mixIndex);
-            mixFlag |= (uint) 1 << (indices.X + indices.Y * chunkSize);
+            mixFlag |= (uint)1 << (indices.X + indices.Y * chunkSize);
             tileChunk.Data[mixIndex] = mixFlag;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 2 warnings in `TileAtmosCollectionSerializer.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaces static logger calls with properly getting an `ISawmill` instance.
This is the content version of https://github.com/space-wizards/RobustToolbox/pull/5966.

Also fixes a bit of formatting.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->