### PR TITLE
Update locker storage to entity tables

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/biohazard.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/biohazard.yml
@@ -1,49 +1,84 @@
- - type: entity
-   id: ClosetL3Filled
-   suffix: Filled, Generic
-   parent: ClosetL3
-   components:
-   - type: StorageFill
-     contents:
-       - id: ClothingOuterBioGeneral
-       - id: ClothingHeadHatHoodBioGeneral
+- type: entity
+  id: ClosetL3Filled
+  suffix: Filled, Generic
+  parent: ClosetL3
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillBiohazardGearGeneric
 
- - type: entity
-   id: ClosetL3VirologyFilled
-   suffix: Filled, Virology
-   parent: ClosetL3Virology
-   components:
-   - type: StorageFill
-     contents:
-       - id: ClothingOuterBioVirology
-       - id: ClothingHeadHatHoodBioVirology
+- type: entityTable
+  id: FillBiohazardGearGeneric
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterBioGeneral
+    - id: ClothingHeadHatHoodBioGeneral
 
- - type: entity
-   id: ClosetL3SecurityFilled
-   suffix: Filled, Security
-   parent: ClosetL3Security
-   components:
-   - type: StorageFill
-     contents:
-       - id: ClothingOuterBioSecurity
-       - id: ClothingHeadHatHoodBioSecurity
+- type: entity
+  id: ClosetL3VirologyFilled
+  suffix: Filled, Virology
+  parent: ClosetL3Virology
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillBiohazardGearVirology
 
- - type: entity
-   id: ClosetL3JanitorFilled
-   suffix: Filled, Janitor
-   parent: ClosetL3Janitor
-   components:
-   - type: StorageFill
-     contents:
-       - id: ClothingOuterBioJanitor
-       - id: ClothingHeadHatHoodBioJanitor
+- type: entityTable
+  id: FillBiohazardGearVirology
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterBioVirology
+    - id: ClothingHeadHatHoodBioVirology
 
- - type: entity
-   id: ClosetL3ScienceFilled
-   suffix: Filled, Science
-   parent: ClosetL3Science
-   components:
-   - type: StorageFill
-     contents:
-       - id: ClothingOuterBioScientist
-       - id: ClothingHeadHatHoodBioScientist
+- type: entity
+  id: ClosetL3SecurityFilled
+  suffix: Filled, Security
+  parent: ClosetL3Security
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillBiohazardGearSecurity
+
+- type: entityTable
+  id: FillBiohazardGearSecurity
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterBioSecurity
+    - id: ClothingHeadHatHoodBioSecurity
+
+- type: entity
+  id: ClosetL3JanitorFilled
+  suffix: Filled, Janitor
+  parent: ClosetL3Janitor
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillBiohazardGearJanitor
+
+- type: entityTable
+  id: FillBiohazardGearJanitor
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterBioJanitor
+    - id: ClothingHeadHatHoodBioJanitor
+
+- type: entity
+  id: ClosetL3ScienceFilled
+  suffix: Filled, Science
+  parent: ClosetL3Science
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillBiohazardGearScience
+
+- type: entityTable
+  id: FillBiohazardGearScience
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterBioScientist
+    - id: ClothingHeadHatHoodBioScientist

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -3,60 +3,83 @@
   parent: ClosetTool
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingOuterVestHazard
-        prob: 0.4
-      - id: FlashlightLantern
-        prob: 0.7
-      - id: Screwdriver
-        prob: 0.7
-      - id: Wrench
-        prob: 0.7
-      - id: Welder
-        prob: 0.7
-      - id: Crowbar
-        prob: 0.7
-      - id: Wirecutter
-        prob: 0.7
-      - id: Multitool
-        prob: 0.2
-      - id: trayScanner
-        prob: 0.7
-      - id: GasAnalyzer
-        prob: 0.7
-      - id: ClothingBeltUtility
-        prob: 0.2
-      - id: ClothingHandsGlovesColorYellow
-        prob: 0.05
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillToolCloset
+
+- type: entityTable
+  id: FillToolCloset
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterVestHazard
+      prob: 0.4
+    - id: FlashlightLantern
+      prob: 0.7
+    - id: Screwdriver
+      prob: 0.7
+    - id: Wrench
+      prob: 0.7
+    - id: Welder
+      prob: 0.7
+    - id: Crowbar
+      prob: 0.7
+    - id: Wirecutter
+      prob: 0.7
+    - id: Multitool
+      prob: 0.2
+    - id: trayScanner
+      prob: 0.7
+    - id: GasAnalyzer
+      prob: 0.7
+    - id: ClothingBeltUtility
+      prob: 0.2
+    - id: ClothingHandsGlovesColorYellow
+      prob: 0.05
+    - !type:GroupSelector
+      prob: 0.4
+      children:
       - id: ClothingHeadHatHardhatRed
-        prob: 0.4
-      - id: CableApcStack
-        prob: 0.3
-      - id: CableApcStack
-        prob: 0.3
-      - id: CableApcStack
-        prob: 0.3
-      - id: SprayPainter
-        prob: 0.7
+      - id: ClothingHeadHatHardhatBlue
+      - id: ClothingHeadHatHardhatOrange
+      - id: ClothingHeadHatHardhatWhite
+      - id: ClothingHeadHatHardhatYellow
+      - id: ClothingHeadHatHardhatYellowDark
+    - id: CableApcStack
+      prob: 0.3
+      rolls: !type:ConstantNumberSelector
+        value: 3
+    - id: SprayPainter
+      prob: 0.7
 
 - type: entity
   id: LockerElectricalSuppliesFilled
   suffix: Filled
   parent: LockerElectricalSupplies
   components:
-  - type: StorageFill
-    contents:
-      - id: ToolboxElectricalFilled
-        prob: 0.7
-      - id: FirelockElectronics
-        prob: 0.05
-      - id: APCElectronics
-        prob: 0.1
-      - id: CableMVStack
-        prob: 0.2
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillElectricalSupplies
+
+- type: entityTable
+  id: FillElectricalSupplies
+  table: !type:AllSelector
+    children:
+    - id: ToolboxElectricalFilled
+      prob: 0.7
+    - id: FirelockElectronics
+      prob: 0.05
+    - id: APCElectronics
+      prob: 0.1
+    - !type:GroupSelector
+      prob: 0.5
+      children:
       - id: CableApcStack
-        prob: 0.3
+        weight: 5
+      - id: CableMVStack
+      - id: CableHVStack
+        weight: 0.5
 
 - type: entity
   id: LockerWeldingSuppliesFilled
@@ -104,73 +127,108 @@
   suffix: Filled, Hardsuit
   parent: LockerAtmospherics
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingOuterHardsuitAtmos
-      - id: ClothingMaskGasAtmos
-      - id: ClothingOuterSuitAtmosFire
-      - id: ClothingHeadHelmetAtmosFire
-      - id: GasAnalyzer
-      - id: MedkitOxygenFilled
-      - id: HolofanProjector
-      - id: RCD
-      - id: RCDAmmo
-      - id: AirGrenade
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - !type:NestedSelector
+          tableId: FillAtmosphericsLocker
+        - !type:NestedSelector
+          tableId: FillAtmosphericsHardsuit
 
 - type: entity
   id: LockerAtmosphericsFilled
   suffix: Filled
   parent: LockerAtmospherics
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingMaskGasAtmos
-      - id: ClothingOuterSuitAtmosFire
-      - id: ClothingHeadHelmetAtmosFire
-      - id: GasAnalyzer
-      - id: MedkitOxygenFilled
-      - id: HolofanProjector
-      - id: RCD
-      - id: RCDAmmo
-      - id: AirGrenade
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillAtmosphericsLocker
+
+- type: entityTable
+  id: FillAtmosphericsLocker
+  table: !type:AllSelector
+    children:
+    - id: ClothingMaskGasAtmos
+    - id: ClothingOuterSuitAtmosFire
+    - id: ClothingHeadHelmetAtmosFire
+    - id: GasAnalyzer
+    - id: MedkitOxygenFilled
+    - id: HolofanProjector
+    - id: RCD
+    - id: RCDAmmo
+    - id: AirGrenade
+
+- type: entityTable
+  id: FillAtmosphericsHardsuit
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterHardsuitAtmos
+    - id: OxygenTankFilled
+    - id: ClothingMaskBreath
 
 - type: entity
   id: LockerEngineerFilledHardsuit
   suffix: Filled, Hardsuit
   parent: LockerEngineer
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingOuterHardsuitEngineering
-      - id: ClothingHandsGlovesColorYellow
-      - id: ClothingMaskGas
-      - id: ClothingShoesBootsMag
-      - id: RCD
-      - id: RCDAmmo
-      - id: MetalFoamGrenade
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - !type:NestedSelector
+          tableId: FillEngineerLocker
+        - !type:NestedSelector
+          tableId: FillEngineerHardsuit
 
 - type: entity
   id: LockerEngineerFilled
   suffix: Filled
   parent: LockerEngineer
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingHandsGlovesColorYellow
-      - id: ClothingMaskGas
-      - id: trayScanner
-      - id: RCD
-      - id: RCDAmmo
-      - id: MetalFoamGrenade
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillEngineerLocker
+
+- type: entityTable
+  id: FillEngineerLocker
+  table: !type:AllSelector
+    children:
+    - id: ClothingHandsGlovesColorYellow
+    - id: ClothingMaskGas
+    - id: trayScanner
+    - id: RCD
+    - id: RCDAmmo
+    - id: MetalFoamGrenade
+
+- type: entityTable
+  id: FillEngineerHardsuit
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterHardsuitEngineering
+    - id: OxygenTankFilled
+    - id: ClothingShoesBootsMag
+    - id: ClothingMaskBreath
 
 - type: entity
   id: ClosetRadiationSuitFilled
   parent: ClosetRadiationSuit
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingOuterSuitRad
-        amount: 2
-      - id: GeigerCounter
-        amount: 2
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillRadiationSuit
+
+- type: entityTable
+  id: FillRadiationSuit
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterSuitRad
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: GeigerCounter
+      amount: !type:ConstantNumberSelector
+        value: 2

--- a/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
@@ -3,13 +3,20 @@
   suffix: Filled
   parent: LockerScientist
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingHandsGlovesLatex
-      - id: ClothingHeadsetScience
-      - id: ClothingMaskSterile
-      - id: ClothingOuterCoatRnd
-      - id: AnomalyScanner
-      - id: NodeScanner
-      - id: NetworkConfigurator
-        prob: 0.5
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillScientistLocker
+
+- type: entityTable
+  id: FillScientistLocker
+  table: !type:AllSelector
+    children:
+    - id: ClothingHandsGlovesLatex
+    - id: ClothingHeadsetScience
+    - id: ClothingMaskSterile
+    - id: ClothingOuterCoatRnd
+    - id: AnomalyScanner
+    - id: NodeScanner
+    - id: NetworkConfigurator
+      prob: 0.5

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -97,10 +97,8 @@
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:AllSelector
-        children:
-        - !type:NestedSelector
-          tableId: FillEngineerHardsuit
+      entity_storage: !type:NestedSelector
+        tableId: FillEngineerHardsuit
   - type: AccessReader
     access: [["Engineering"]]
 
@@ -112,10 +110,8 @@
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:AllSelector
-        children:
-        - !type:NestedSelector
-          tableId: FillAtmosphericsHardsuit
+      entity_storage: !type:NestedSelector
+        tableId: FillAtmosphericsHardsuit
   - type: AccessReader
     access: [["Atmospherics"]]
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -95,12 +95,12 @@
   parent: SuitStorageBase
   suffix: Station Engineer
   components:
-  - type: StorageFill
-    contents:
-        - id: OxygenTankFilled
-        - id: ClothingShoesBootsMag
-        - id: ClothingOuterHardsuitEngineering
-        - id: ClothingMaskBreath
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - !type:NestedSelector
+          tableId: FillEngineerHardsuit
   - type: AccessReader
     access: [["Engineering"]]
 
@@ -110,11 +110,12 @@
   parent: SuitStorageBase
   suffix: Atmospheric Technician
   components:
-  - type: StorageFill
-    contents:
-        - id: OxygenTankFilled
-        - id: ClothingOuterHardsuitAtmos
-        - id: ClothingMaskBreath
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - !type:NestedSelector
+          tableId: FillAtmosphericsHardsuit
   - type: AccessReader
     access: [["Atmospherics"]]
 


### PR DESCRIPTION
## About the PR
Updates a few more storages in the `Lockers` folder to entity tables.
Lockers Already Done:
- Cargo
- Heads
- Medical
- Misc
- Suit Storage(partial)

This PR Updates:
- Biohazard
- Engineer
- Science
- Suit Storage(partial)

Files Still Needed:
- Dressers
- Security
- Service
- Space_Ruin
- Suit Storage(the rest)
- Wardrobe_Colors
- Wardrobe_Job
 
## Why / Balance
Is necessary 

## Technical details
Too tired to do any more tonight

## Media
n/a

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
n/a
