### PR TITLE
Adds a new font tag for small text

### DIFF
--- a/Content.Client/Paper/UI/PaperWindow.xaml.cs
+++ b/Content.Client/Paper/UI/PaperWindow.xaml.cs
@@ -44,6 +44,7 @@ namespace Content.Client.Paper.UI
             typeof(BulletTag),
             typeof(ColorTag),
             typeof(HeadingTag),
+            typeof(SmallTag),
             typeof(ItalicTag),
             typeof(MonoTag)
         };

--- a/Resources/ServerInfo/Guidebook/Writing.xml
+++ b/Resources/ServerInfo/Guidebook/Writing.xml
@@ -11,6 +11,8 @@ You can use the following sigils:
 - [color=tan]\[head=n\]\[\/head\][/color] — where [italic]n[/italic] is the heading level (1 – 3)
 - [color=tan]\[bullet\/\][/color] — to insert a bullet point (useful for lists)
 - [color=tan][bold]\[bold\]\[\/bold\][/bold][/color], [color=tan][italic]\[italic\]\[\/italic\][/italic][/color] — for emphasis
+- [color=tan]\[small=n\]\[\/head\][/color] — to add small text, where [italic]n[/italic] is the smallness level (1 – 3)
+- [color=tan][mono]\[mono\]\[\/mono\][/mono][/color] — to create monospaced text, useful for things that must be aligned.
 
 You can combine [bold][italic]bold and italic[/italic][/bold] tags, or use the shortcut [color=tan][bolditalic]\[bolditalic\][/bolditalic][/color].
 


### PR DESCRIPTION
## About the PR
I added the [small=n] tag, for making text smaller. the smallest size (level 3) is only 70% of normal font size, so they aren't *that* small. I intentionally didn't want to make anything too hard to read.

In addition, I added a note about it to the guidebook.
![image](https://github.com/user-attachments/assets/a404cb24-7a1f-4d51-991c-6a30fa309a3f)
I *also* added a note about [mono] because I didn't even know it existed until I was working on this pr.

## Why / Balance
It would be nice to be able to make small text for things like disclaimers, fitting more words into a space, or for higher resolution art. See media for a demonstration.

## Technical details
### Requires https://github.com/space-wizards/RobustToolbox/pull/5968
I go more into detail with the details in that PR as well. but basically, I copied the existing HeaderTag but made it make text smaller instead. The only real changes in this PR is just adding it to allowed tags, and also amending the guidebook.

## Media
![2025-05-25_02-08](https://github.com/user-attachments/assets/8dbbec39-ccc8-4617-aab2-807f9d55bdab)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
There shouldn't be any, but this IS my first engine PR.

**Changelog**
:cl:
- add: Added the new [small] tag, useful for making text smaller!
