### PR TITLE
De-hardcode shuttle docking messages/audio

### DIFF
--- a/Content.Server/Shuttles/Components/StationEmergencyShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/StationEmergencyShuttleComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server.Shuttles.Systems;
+using Robust.Shared.Audio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations;
 using Robust.Shared.Utility;
 
@@ -21,4 +22,39 @@ public sealed partial class StationEmergencyShuttleComponent : Component
     /// </summary>
     [DataField("emergencyShuttlePath", customTypeSerializer: typeof(ResPathSerializer))]
     public ResPath EmergencyShuttlePath { get; set; } = new("/Maps/Shuttles/emergency.yml");
+
+    /// <summary>
+    /// The announcement made when the shuttle has successfully docked with the station.
+    /// </summary>
+    public LocId DockedAnnouncement = "emergency-shuttle-docked";
+
+    /// <summary>
+    /// Sound played when the shuttle has successfully docked with the station.
+    /// </summary>
+    public SoundSpecifier DockedAudio = new SoundPathSpecifier("/Audio/Announcements/shuttle_dock.ogg");
+
+    /// <summary>
+    /// The announcement made when the shuttle is unable to dock and instead parks in nearby space.
+    /// </summary>
+    public LocId NearbyAnnouncement = "emergency-shuttle-nearby";
+
+    /// <summary>
+    /// Sound played when the shuttle is unable to dock and instead parks in nearby space.
+    /// </summary>
+    public SoundSpecifier NearbyAudio = new SoundPathSpecifier("/Audio/Misc/notice1.ogg");
+
+    /// <summary>
+    /// The announcement made when the shuttle is unable to find a station.
+    /// </summary>
+    public LocId FailureAnnouncement = "emergency-shuttle-good-luck";
+
+    /// <summary>
+    /// Sound played when the shuttle is unable to find a station.
+    /// </summary>
+    public SoundSpecifier FailureAudio = new SoundPathSpecifier("/Audio/Misc/notice1.ogg");
+
+    /// <summary>
+    /// Text appended to the docking announcement if the launch time has been extended.
+    /// </summary>
+    public LocId LaunchExtendedMessage = "emergency-shuttle-extended";
 }

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -323,6 +323,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
     /// </summary>
     public void AnnounceShuttleDock(ShuttleDockResult result, bool extended)
     {
+        var stationShuttleComp = result.Station.Comp;
         var shuttle = result.Station.Comp.EmergencyShuttle;
 
         DebugTools.Assert(shuttle != null);
@@ -331,11 +332,11 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         {
             _chatSystem.DispatchStationAnnouncement(
                 result.Station,
-                Loc.GetString("emergency-shuttle-good-luck"),
+                Loc.GetString(stationShuttleComp.FailureAnnouncement),
                 playDefaultSound: false);
 
             // TODO: Need filter extensions or something don't blame me.
-            _audio.PlayGlobal("/Audio/Misc/notice1.ogg", Filter.Broadcast(), true);
+            _audio.PlayGlobal(stationShuttleComp.FailureAudio, Filter.Broadcast(), true);
             return;
         }
 
@@ -354,10 +355,10 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         var location = FormattedMessage.RemoveMarkupPermissive(
             _navMap.GetNearestBeaconString((shuttle.Value, Transform(shuttle.Value))));
 
-        var extendedText = extended ? Loc.GetString("emergency-shuttle-extended") : "";
+        var extendedText = extended ? Loc.GetString(stationShuttleComp.LaunchExtendedMessage) : "";
         var locKey = result.ResultType == ShuttleDockResultType.NoDock
-            ? "emergency-shuttle-nearby"
-            : "emergency-shuttle-docked";
+            ? stationShuttleComp.NearbyAnnouncement
+            : stationShuttleComp.DockedAnnouncement;
 
         _chatSystem.DispatchStationAnnouncement(
             result.Station,
@@ -390,8 +391,8 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         // Play announcement audio.
 
         var audioFile = result.ResultType == ShuttleDockResultType.NoDock
-            ? "/Audio/Misc/notice1.ogg"
-            : "/Audio/Announcements/shuttle_dock.ogg";
+            ? stationShuttleComp.NearbyAudio
+            : stationShuttleComp.DockedAudio;
 
         // TODO: Need filter extensions or something don't blame me.
         _audio.PlayGlobal(audioFile, Filter.Broadcast(), true);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Moved the text and audio for shuttle docking messages from `EmergencyShuttleSystem` into `StationEmergencyShuttleComponent`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes 2 warnings for [PZW](https://github.com/space-wizards/space-station-14/issues/33279) and allows stations to customize these announcements if they want to.

## Technical details
<!-- Summary of code changes for easier review. -->
- Added `LocId` and `SoundSpecifier` datafields to `StationEmergencyShuttleComponent`, defaulting the the previously-hardcoded values.
- Modified `EmergencyShuttleSystem` to use the component's values instead of hardcoding them.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->