### PR TITLE
Slimepeople poisoned by nitrous oxide, sleepy by carbon dioxide

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -210,12 +210,22 @@
         - !type:OrganType
           type: Vox
           shouldHave: false
+        - !type:OrganType
+          type: Slime
+          shouldHave: false
         scaleByQuantity: true
         ignoreResistances: true
         damage:
           types:
             Poison:
               0.8
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Slime
+        damage:
+          types:
+            Poison: 2
       - !type:Oxygenate
         conditions:
         - !type:OrganType
@@ -236,6 +246,9 @@
         - !type:OrganType
           type: Vox
           shouldHave: false
+        - !type:OrganType
+          type: Slime
+          shouldHave: false
         # Don't want people to get toxin damage from the gas they just
         # exhaled, right?
         - !type:ReagentThreshold
@@ -246,6 +259,13 @@
           types:
             Poison:
               0.8
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Slime
+        damage:
+          types:
+            Poison: 2
       - !type:Oxygenate # carbon dioxide displaces oxygen from the bloodstream, causing asphyxiation
         conditions:
         - !type:OrganType
@@ -255,6 +275,57 @@
       # We need a metabolism effect on reagent removal
       #- !type:AdjustAlert
       #  alertType: CarbonDioxide
+      - !type:Emote
+        conditions:
+        - !type:ReagentThreshold
+          reagent: CarbonDioxide
+          min: 0.2
+        - !type:OrganType
+          type: Slime
+        emote: Laugh
+        showInChat: true
+        probability: 0.1
+      - !type:Emote
+        conditions:
+        - !type:ReagentThreshold
+          reagent: CarbonDioxide
+          min: 0.2
+        - !type:OrganType
+          type: Slime
+        emote: Scream
+        showInChat: true
+        probability: 0.01
+      - !type:PopupMessage
+        conditions:
+        - !type:ReagentThreshold
+          reagent: CarbonDioxide
+          min: 0.5
+        - !type:OrganType
+          type: Slime
+        type: Local
+        visualType: Medium
+        messages: [ "effect-sleepy" ]
+        probability: 0.1
+      - !type:MovespeedModifier
+        conditions:
+        - !type:ReagentThreshold
+          reagent: CarbonDioxide
+          min: 1
+        - !type:OrganType
+          type: Slime
+        walkSpeedModifier: 0.65
+        sprintSpeedModifier: 0.65
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          reagent: CarbonDioxide
+          min: 1.8
+        - !type:OrganType
+          type: Slime
+        key: ForcedSleep
+        component: ForcedSleeping
+        time: 3
+        type: Add
 
 - type: reagent
   id: Nitrogen

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -382,11 +382,44 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Slime
+        scaleByQuantity: true
+        ignoreResistances: true
+        damage:
+          types:
+            Poison:
+              0.8
+      - !type:HealthChange
         damage:
           types:
             Poison: 2
     Gas:
       effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Slime
+        # Don't want people to get toxin damage from the gas they just
+        # exhaled, right?
+        - !type:ReagentThreshold
+          min: 0.5
+        scaleByQuantity: true
+        ignoreResistances: true
+        damage:
+          types:
+            Poison:
+              0.8
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 2
+      - !type:Oxygenate # nitrous oxide displaces nitrogen from the slime bloodstream, causing asphyxiation
+        conditions:
+        - !type:OrganType
+          type: Slime
+        factor: -4
       - !type:Emote
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Makes slimepeople poisoned by nitrous oxide, sleepy by carbon dioxide
  - Identical damage and sleepiness to carbon dioxide poisoning, nitrous oxide sleepiness respectively

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Mirrors oxygen-breathing species where they're poisoned by carbon dioxide and made sleepy by nitrous oxide. Specifically, nitrous oxide is a waste product of slime gas sac respiration and poisonous to slimes, just like how carbon dioxide is a waste product of lungs and poisonous to humans.

No changes to vox yet as they exhale ammonia.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
### Nitrous oxide poisoning
![dotnet_8AXwXeihhq](https://github.com/user-attachments/assets/c71c0505-890d-46c5-b53e-0ef9dc02fb05)

### Carbon dioxide sleepiness
![dotnet_dj5hDmmnz2](https://github.com/user-attachments/assets/58924768-3cc2-44fb-91fd-b5ae30ab79ba)
![image](https://github.com/user-attachments/assets/22d92140-90f8-4cdd-9c8b-d4e31db5c129)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Slimepeople are now poisoned by nitrous oxide and made sleepy by carbon dioxide.