### PR TITLE
Cleanup some easy-to-fix static logger warnings

### DIFF
--- a/Content.Server/Administration/Commands/DepartmentBanCommand.cs
+++ b/Content.Server/Administration/Commands/DepartmentBanCommand.cs
@@ -16,6 +16,9 @@ public sealed class DepartmentBanCommand : IConsoleCommand
     [Dependency] private readonly IPlayerLocator _locator = default!;
     [Dependency] private readonly IBanManager _banManager = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly ILogManager _log = default!;
+
+    private ISawmill? _sawmill;
 
     public string Command => "departmentban";
     public string Description => Loc.GetString("cmd-departmentban-desc");
@@ -29,7 +32,8 @@ public sealed class DepartmentBanCommand : IConsoleCommand
         uint minutes;
         if (!Enum.TryParse(_cfg.GetCVar(CCVars.DepartmentBanDefaultSeverity), out NoteSeverity severity))
         {
-            Logger.WarningS("admin.department_ban", "Department ban severity could not be parsed from config! Defaulting to medium.");
+            _sawmill ??= _log.GetSawmill("admin.department_ban");
+            _sawmill.Warning("Department ban severity could not be parsed from config! Defaulting to medium.");
             severity = NoteSeverity.Medium;
         }
 

--- a/Content.Server/Administration/Commands/RoleBanCommand.cs
+++ b/Content.Server/Administration/Commands/RoleBanCommand.cs
@@ -17,7 +17,10 @@ public sealed class RoleBanCommand : IConsoleCommand
     [Dependency] private readonly IPlayerLocator _locator = default!;
     [Dependency] private readonly IBanManager _bans = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly ILogManager _log = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    private ISawmill? _sawmill;
 
     public string Command => "roleban";
     public string Description => Loc.GetString("cmd-roleban-desc");
@@ -31,7 +34,8 @@ public sealed class RoleBanCommand : IConsoleCommand
         uint minutes;
         if (!Enum.TryParse(_cfg.GetCVar(CCVars.RoleBanDefaultSeverity), out NoteSeverity severity))
         {
-            Logger.WarningS("admin.role_ban", "Role ban severity could not be parsed from config! Defaulting to medium.");
+            _sawmill ??= _log.GetSawmill("admin.role_ban");
+            _sawmill.Warning("Role ban severity could not be parsed from config! Defaulting to medium.");
             severity = NoteSeverity.Medium;
         }
 
@@ -81,7 +85,7 @@ public sealed class RoleBanCommand : IConsoleCommand
 
         if (!_proto.HasIndex<JobPrototype>(job))
         {
-            shell.WriteError(Loc.GetString("cmd-roleban-job-parse",("job", job)));
+            shell.WriteError(Loc.GetString("cmd-roleban-job-parse", ("job", job)));
             return;
         }
 

--- a/Content.Server/Administration/Notes/UserNotesEui.cs
+++ b/Content.Server/Administration/Notes/UserNotesEui.cs
@@ -13,16 +13,19 @@ public sealed class UserNotesEui : BaseEui
 {
     [Dependency] private readonly IAdminNotesManager _notesMan = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly ILogManager _log = default!;
     private readonly bool _seeOwnNotes;
+    private readonly ISawmill _sawmill;
 
     public UserNotesEui()
     {
         IoCManager.InjectDependencies(this);
+        _sawmill = _log.GetSawmill("admin.notes");
         _seeOwnNotes = _cfg.GetCVar(CCVars.SeeOwnNotes);
 
         if (!_seeOwnNotes)
         {
-            Logger.WarningS("admin.notes", "User notes initialized when see_own_notes set to false");
+            _sawmill.Warning("User notes initialized when see_own_notes set to false");
         }
     }
 
@@ -39,7 +42,7 @@ public sealed class UserNotesEui : BaseEui
     {
         if (!_seeOwnNotes)
         {
-            Logger.WarningS("admin.notes", $"User {Player.Name} with ID {Player.UserId} tried to update their own user notes when see_own_notes was set to false");
+            _sawmill.Warning($"User {Player.Name} with ID {Player.UserId} tried to update their own user notes when see_own_notes was set to false");
             return;
         }
 

--- a/Content.Server/EUI/EuiManager.cs
+++ b/Content.Server/EUI/EuiManager.cs
@@ -9,8 +9,11 @@ namespace Content.Server.EUI
 {
     public sealed class EuiManager : IPostInjectInit
     {
+        [Dependency] private readonly ILogManager _log = default!;
         [Dependency] private readonly IPlayerManager _players = default!;
         [Dependency] private readonly IServerNetManager _net = default!;
+
+        private ISawmill? _sawmill;
 
         private readonly Dictionary<ICommonSession, PlayerEuiData> _playerData =
             new();
@@ -34,6 +37,7 @@ namespace Content.Server.EUI
             _net.RegisterNetMessage<MsgEuiCtl>();
             _net.RegisterNetMessage<MsgEuiState>();
             _net.RegisterNetMessage<MsgEuiMessage>(RxMsgMessage);
+            _sawmill = _log.GetSawmill("eui");
         }
 
         public void SendUpdates()
@@ -99,7 +103,7 @@ namespace Content.Server.EUI
 
             if (!dat.OpenUIs.TryGetValue(message.Id, out var eui))
             {
-                Logger.WarningS("eui", $"Got EUI message from player {ply} for non-existing UI {message.Id}");
+                _sawmill?.Warning($"Got EUI message from player {ply} for non-existing UI {message.Id}");
                 return;
             }
 

--- a/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
@@ -55,7 +55,7 @@ namespace Content.Server.Preferences.Managers
 
             if (!_cachedPlayerPrefs.TryGetValue(userId, out var prefsData) || !prefsData.PrefsLoaded)
             {
-                Logger.WarningS("prefs", $"User {userId} tried to modify preferences before they loaded.");
+                _sawmill.Warning($"User {userId} tried to modify preferences before they loaded.");
                 return;
             }
 
@@ -141,7 +141,7 @@ namespace Content.Server.Preferences.Managers
 
             if (!_cachedPlayerPrefs.TryGetValue(userId, out var prefsData) || !prefsData.PrefsLoaded)
             {
-                Logger.WarningS("prefs", $"User {userId} tried to modify preferences before they loaded.");
+                _sawmill.Warning($"User {userId} tried to modify preferences before they loaded.");
                 return;
             }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 7 warnings from static `Logger` calls.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced static `Logger` calls by getting proper Sawmill instances using `ILogManager`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->