### PR TITLE
Lets angry AI gorillas pry open doors, smash things, and vault tables

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1199,6 +1199,21 @@
   - type: HTN
     rootTask:
       task: SimpleHostileCompound
+    blackboard:
+      NavClimb: !type:Bool
+        true
+      NavInteract: !type:Bool
+        true
+      NavPry: !type:Bool
+        true
+      NavSmash: !type:Bool
+        true
+  - type: Prying
+    pryPowered: true
+    force: true
+    speedModifier: 1.5
+    useSound:
+      path: /Audio/Items/crowbar.ogg
 
 - type: entity
   name: kangaroo


### PR DESCRIPTION
## About the PR
Added the ability for pissed off gorillas to climb, pry, and smash

## Why / Balance
Gorillas are huge scary monsters that are absolutely ripped, they should absolutely be able to pry open doors. Their description also says that they smash, so now they smash.

## Technical details
added NavClimb, NavInteract, NavPry, and NavSmash blackboard to gorilla

## Media

https://github.com/user-attachments/assets/03b8eda2-d7f2-4e31-bc8b-0cff2e679afd



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: NPC Gorillas can now pry open doors and vault/smash tables!