### PR TITLE
reduced motion flash effect version 3

### DIFF
--- a/Content.Client/Flash/FlashOverlay.cs
+++ b/Content.Client/Flash/FlashOverlay.cs
@@ -24,8 +24,8 @@ namespace Content.Client.Flash
 
         public override OverlaySpace Space => OverlaySpace.WorldSpace;
         private readonly ShaderInstance _shader;
-        private bool _reducedMotion = false;
-        public float PercentComplete = 0.0f;
+        private bool _reducedMotion;
+        public float PercentComplete;
         public Texture? ScreenshotTexture;
 
         public FlashOverlay()
@@ -82,6 +82,10 @@ namespace Content.Client.Flash
             var worldHandle = args.WorldHandle;
             if (_reducedMotion)
             {
+                // TODO: This is a very simple placeholder.
+                // Replace it with a proper shader once we come up with something good.
+                // Turns out making an effect that is supposed to be a bright, sudden, and disorienting flash 
+                // not do any of that while also being equivalent in terms of game balance is hard.
                 var alpha = 1 - MathF.Pow(PercentComplete, 8f); // similar falloff curve to the flash shader
                 worldHandle.DrawRect(args.WorldBounds, new Color(0f, 0f, 0f, alpha));
             }

--- a/Content.Client/Flash/FlashOverlay.cs
+++ b/Content.Client/Flash/FlashOverlay.cs
@@ -1,8 +1,10 @@
+using Content.Shared.CCVar;
 using Content.Shared.Flash;
 using Content.Shared.Flash.Components;
 using Content.Shared.StatusEffect;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -15,12 +17,14 @@ namespace Content.Client.Flash
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
+        [Dependency] private readonly IConfigurationManager _configManager = default!;
 
         private readonly SharedFlashSystem _flash;
         private readonly StatusEffectsSystem _statusSys;
 
         public override OverlaySpace Space => OverlaySpace.WorldSpace;
         private readonly ShaderInstance _shader;
+        private bool _reducedMotion = false;
         public float PercentComplete = 0.0f;
         public Texture? ScreenshotTexture;
 
@@ -30,6 +34,8 @@ namespace Content.Client.Flash
             _shader = _prototypeManager.Index<ShaderPrototype>("FlashedEffect").InstanceUnique();
             _flash = _entityManager.System<SharedFlashSystem>();
             _statusSys = _entityManager.System<StatusEffectsSystem>();
+
+            _configManager.OnValueChanged(CCVars.ReducedMotion, (b) => { _reducedMotion = b; }, invokeImmediately: true);
         }
 
         protected override void FrameUpdate(FrameEventArgs args)
@@ -47,8 +53,8 @@ namespace Content.Client.Flash
                 return;
 
             var curTime = _timing.CurTime;
-            var lastsFor = (float) (time.Value.Item2 - time.Value.Item1).TotalSeconds;
-            var timeDone = (float) (curTime - time.Value.Item1).TotalSeconds;
+            var lastsFor = (float)(time.Value.Item2 - time.Value.Item1).TotalSeconds;
+            var timeDone = (float)(curTime - time.Value.Item1).TotalSeconds;
 
             PercentComplete = timeDone / lastsFor;
         }
@@ -74,10 +80,18 @@ namespace Content.Client.Flash
                 return;
 
             var worldHandle = args.WorldHandle;
-            _shader.SetParameter("percentComplete", PercentComplete);
-            worldHandle.UseShader(_shader);
-            worldHandle.DrawTextureRectRegion(ScreenshotTexture, args.WorldBounds);
-            worldHandle.UseShader(null);
+            if (_reducedMotion)
+            {
+                var alpha = 1 - MathF.Pow(PercentComplete, 8f); // similar falloff curve to the flash shader
+                worldHandle.DrawRect(args.WorldBounds, new Color(0f, 0f, 0f, alpha));
+            }
+            else
+            {
+                _shader.SetParameter("percentComplete", PercentComplete);
+                worldHandle.UseShader(_shader);
+                worldHandle.DrawTextureRectRegion(ScreenshotTexture, args.WorldBounds);
+                worldHandle.UseShader(null);
+            }
         }
 
         protected override void DisposeBehavior()


### PR DESCRIPTION
## About the PR
See https://github.com/space-wizards/space-station-14/pull/36288 and https://github.com/space-wizards/space-station-14/pull/37583
Since the previous PRs all had someone who did not like how the effect looked like I made another very simple alternative effect that we can merge in the meantime until a better shader has been made. This should allow the affected players to be able to play in Revolutionary mode again for now.

The effect is a simple black overlay with the same falloff curve as used in the shader, so it should be comparable concerning combat balance.

In the past the flash shader was bugged for quite a while, causing it to look like this (see https://github.com/space-wizards/space-station-14/pull/27369). So we already know that this works from a gameplay perspective.

## Why / Balance
accessibility

## Technical details
If the reduced motion cvar is enabled, just draw a black color rectangle over the screen instead of the shader.
The alpha value is chosen from the same falloff curve used for blending the flash shader.

## Media

https://github.com/user-attachments/assets/5e96677c-5da7-4b3f-853b-c86f216ca514

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Quantum-cross, slarticodefast
- add: The flash effect is now replaced with a reduced motion variant if the accessibility setting is enabled in the game options.
