### PR TITLE
comment out slotblocker yaml

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -109,8 +109,9 @@
   id: ClothingHeadEVAHelmetBase
   name: base space helmet
   components:
-  - type: SlotBlock
-    slots: [ears, eyes, mask]
+# SlotBlocker blocked until UI change
+#  - type: SlotBlock
+#    slots: [ears, eyes, mask]
   - type: BreathMask
   - type: Item
     size: Normal
@@ -146,8 +147,9 @@
   name: base hardsuit helmet
   categories: [ HideSpawnMenu ]
   components:
-  - type: SlotBlock
-    slots: [ears, eyes, mask]
+ # SlotBlocker blocked until UI change
+#  - type: SlotBlock
+#    slots: [ears, eyes, mask]
   - type: BreathMask
   - type: Sprite
     state: icon # default state used by most inheritors
@@ -194,8 +196,9 @@
   name: base hardsuit helmet with light
   categories: [ HideSpawnMenu ]
   components:
-  - type: SlotBlock
-    slots: [ears, eyes, mask]
+# SlotBlocker blocked until UI change
+#  - type: SlotBlock
+#    slots: [ears, eyes, mask]
   - type: Sprite
     layers:
     - state: icon

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -147,7 +147,7 @@
   name: base hardsuit helmet
   categories: [ HideSpawnMenu ]
   components:
- # SlotBlocker blocked until UI change
+# SlotBlocker blocked until UI change
 #  - type: SlotBlock
 #    slots: [ears, eyes, mask]
   - type: BreathMask

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -105,8 +105,9 @@
   id: ClothingOuterHardsuitBase
   name: base hardsuit
   components:
-  - type: SlotBlock
-    slots: [innerclothing, feet]
+# SlotBlocker blocked until UI change
+#  - type: SlotBlock
+#    slots: [innerclothing, feet]
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
@@ -151,8 +152,9 @@
   id: ClothingOuterEVASuitBase
   name: base EVA Suit
   components:
-  - type: SlotBlock
-    slots: [innerclothing, feet]
+# SlotBlocker blocked until UI change
+#  - type: SlotBlock
+#    slots: [innerclothing, feet]
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000


### PR DESCRIPTION
## About the PR
Turn off the #35172 feature's yaml parts for now

## Why / Balance
By maintainer vote, feature should be kept inactive until the inventory system makes it more clear when a slot is blocked. Visually display some overlay/blocker icon on those slots?

## Technical details
just some yaml

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Slot blocking has been removed from entities for now.
