### PR TITLE
Standardized running and walking speed debuffs for equipped gear.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -418,7 +418,7 @@
         Heat: 0.9
         Radiation: 0.8
   - type: ClothingSpeedModifier
-    walkModifier: 0.7
+    walkModifier: 0.65
     sprintModifier: 0.65
   - type: HeldSpeedModifier
   - type: ExplosionResistance
@@ -445,6 +445,7 @@
         Piercing: 0.4
   - type: ClothingSpeedModifier
     walkModifier: 0.8
+    sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ExplosionResistance
     damageCoefficient: 0.4

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -114,7 +114,7 @@
     heatingCoefficient: 0.01
     coolingCoefficient: 0.01
   - type: ClothingSpeedModifier
-    walkModifier: 0.4
+    walkModifier: 0.6
     sprintModifier: 0.6
   - type: HeldSpeedModifier
   - type: Item

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -17,7 +17,7 @@
     zombificationResistanceCoefficient: 0.35
   - type: GroupExamine
   - type: ClothingSpeedModifier
-    walkModifier: 1
+    walkModifier: 0.95
     sprintModifier: 0.95
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -92,7 +92,7 @@
         Radiation: 0.3 #salv is supposed to have radiation hazards in the future
         Caustic: 0.8
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
+    walkModifier: 0.8
     sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
@@ -352,7 +352,7 @@
         Radiation: 0.0
         Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
+    walkModifier: 0.8
     sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
@@ -379,7 +379,7 @@
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.4
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
+    walkModifier: 0.95
     sprintModifier: 0.95
   - type: HeldSpeedModifier
   - type: ToggleableClothing
@@ -488,7 +488,7 @@
         Radiation: 0.5
         Caustic: 0.8
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
+    walkModifier: 0.9
     sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
@@ -589,7 +589,7 @@
   - type: Item
     size: Huge
   - type: ClothingSpeedModifier
-    walkModifier: 1.0
+    walkModifier: 0.9
     sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
@@ -657,7 +657,7 @@
         Radiation: 0.2
         Caustic: 0.2
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
+    walkModifier: 0.65
     sprintModifier: 0.65
   - type: HeldSpeedModifier
   - type: ToggleableClothing

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -64,7 +64,7 @@
         Heat: 0.8
         Cold: 0.8
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
+    walkModifier: 0.7
     sprintModifier: 0.7
   - type: HeldSpeedModifier
   - type: GroupExamine

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -24,7 +24,7 @@
     prefixOn: on
   - type: Magboots
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
+    walkModifier: 0.8
     sprintModifier: 0.8
   - type: Appearance
   - type: GenericVisualizer
@@ -82,8 +82,8 @@
   description: These would look fetching on a fetcher like you.
   components:
   - type: ClothingSpeedModifier
-    walkModifier: 1.10 #PVS isn't too much of an issue when you are blind...
-    sprintModifier: 1.10
+    walkModifier: 1.1 #PVS isn't too much of an issue when you are blind...
+    sprintModifier: 1.1
   - type: StaticPrice
     price: 3000
 
@@ -99,7 +99,7 @@
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.95
+    walkModifier: 0.9
     sprintModifier: 0.9
   - type: GasTank
     outputPressure: 42.6

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -135,7 +135,7 @@
   - type: Magboots # always have gravity because le suction cups
   - type: ClothingSpeedModifier
     # ninja are masters of sneaking around relatively quickly, won't break cloak
-    walkModifier: 1.1
+    walkModifier: 1.3
     sprintModifier: 1.3
   - type: FootstepModifier
     footstepSoundCollection: null
@@ -259,7 +259,7 @@
     size: Small
     sprite: Clothing/Shoes/Specific/large_clown.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
+    walkModifier: 0.8
     sprintModifier: 0.8
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Power/powersink.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powersink.yml
@@ -8,8 +8,8 @@
       size: Huge
     - type: MultiHandedItem
     - type: HeldSpeedModifier #verrryy heavy
-      walkModifier: 0.60
-      sprintModifier: 0.60
+      walkModifier: 0.6
+      sprintModifier: 0.6
     - type: NodeContainer
       examinable: true
       nodes:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
All equipped clothing and gear that imposes a debuff on movement speed has been standardized. Equipped items no longer have separate values for running and walk speed debuffs - instead they are now debuffed equally.

## Why / Balance
There is no standardization among equipped gear in regards to walking and running speed debuffs. Some gear debuffs running more heavily than walking - some does the opposite. Some gear only debuffs running, and some only debuffs walking.

Having separate lines on inspect for running and walking speed debuffs is extra clutter for the already often cluttered item stats popup.

By standardizing the movement debuff to a single flat number, we can make speed debuffs easier to understand intuitively. If you wear clothing with a movement speed debuff, you'll know that both your running and walking speed are being debuffed by the same amount. Simple, straightforwards, easy.

Bigger rant on the issue here (with pictures!): https://github.com/space-wizards/space-station-14/issues/37823

## Technical details
All yaml changes. A full list of gear that has had it's speed changed by this PR follows. All gear has had it's walking speed debuff changed to match the sprint speed debuff.

Hardsuits: ClothingOuterHardsuitBase, ClothingOuterHardsuitSpatio, ClothingOuterHardsuitEngineeringWhite, ClothingOuterHardsuitMedical, ClothingOuterHardsuitLuxury, ClothingOuterHardsuitSyndieElite, ClothingOuterHardsuitJuggernaut, 

Other Outerwear: ClothingOuterBioGeneral, ClothingOuterArmorChangeling, ClothingOuterArmorBone, ClothingOuterSuitFire,

Shoes: ClothingShoesBootsMagBase, ClothingShoesBootsMagSyndie, ClothingShoesSpaceNinja, ClothingShoesClownLarge

Didn't touch: Duffel bags (They only slow you down while running, which seems like a unique differentiation for a backpack to have), XenoArtifactSpeedUp (Affects move speed while holding artifacts with the speed ability, outside the scope of the PR as it isn't equipped)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The running and walking speed debuffs on equipped gear have been standardized.