### PR TITLE
Fix the ability to hit and break overlapping walls

### DIFF
--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -91,6 +91,7 @@ namespace Content.Shared.Interaction
         public const string RateLimitKey = "Interaction";
 
         private static readonly ProtoId<TagPrototype> BypassInteractionRangeChecksTag = "BypassInteractionRangeChecks";
+        private static readonly ProtoId<TagPrototype> WallTag = "Wall";
 
         public delegate bool Ignored(EntityUid entity);
 
@@ -888,6 +889,18 @@ namespace Content.Shared.Interaction
 
                 if (ignoreAnchored && _mapManager.TryFindGridAt(targetCoords, out var gridUid, out var grid))
                     ignored.UnionWith(_map.GetAnchoredEntities((gridUid, grid), targetCoords));
+            }
+            else if (_tagSystem.HasTag(target, WallTag))
+            {
+                if (_mapManager.TryFindGridAt(targetCoords, out var gridUid, out var grid))
+                {
+                    // If the target is a wall, it should ignore collision with other walls at the same coordinates
+                    // This fixes the bug of not being able to target or break walls when they are overlapping
+                    //   like those spawned by rock anomalies
+                    var wallIgnored = _map.GetAnchoredEntities((gridUid, grid), targetCoords)
+                        .Where(e => _tagSystem.HasTag(e, WallTag));
+                    ignored.UnionWith(wallIgnored);
+                }
             }
 
             Ignored combinedPredicate = e => e == target || (predicate?.Invoke(e) ?? false) || ignored.Contains(e);


### PR DESCRIPTION
## About the PR

Allows you to break walls that are overlapping on top of each other, like those created by rock anomaly pulses.

## Why / Balance

Bugfix / regression

## Technical details

Added a predicate in `SharedInteractionSystem.GetPredicate`.

This predicate checks the target for `Wall` tag, and will then add other `Wall` tagged entities on the same exact coordinates to the set of entities that are ignored for a user to interact with it.

## Media

https://github.com/user-attachments/assets/99397921-0b9c-4a12-83e2-1a13791f4e74


## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

Negatory

**Changelog**

:cl:
- fix: You can break overlapping walls with melee weapons again!

