### PR TITLE
Omega map fixes

### DIFF
--- a/Resources/Maps/omega.yml
+++ b/Resources/Maps/omega.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 260.2.0
   forkId: ""
   forkVersion: ""
-  time: 05/26/2025 05:54:23
+  time: 05/26/2025 06:31:46
   entityCount: 14203
 maps:
 - 473
@@ -6827,6 +6827,13 @@ entities:
     - type: Transform
       pos: 25.5,-34.5
       parent: 4812
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        917:
+        - - DoorStatus
+          - DoorBolt
   - uid: 10406
     components:
     - type: Transform
@@ -6998,6 +7005,13 @@ entities:
     - type: Transform
       pos: 25.5,-37.5
       parent: 4812
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        6594:
+        - - DoorStatus
+          - DoorBolt
   - uid: 2737
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Adds missing sec hardsuits to Omega armory
- Added vacuum tile markers for pockets in asteroid rocks around the map
- Replaced SE maints doors leading to asteroids with locked external doors, replaced CC mask, syndicate EVA helmet and emergency EVA with explorer mask, normal EVA respectively
- Replaced one instance of explorer mask in hidden pocket with welding gas mask

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes #37838 by adding suits to Omega armory. Verified with mapinit command.

Replaced easy access into space with external-locked doors to make space-faring and spacing maints harder.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/5664292a-14b2-40d8-8025-a2028ebb9785)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

Mapping cl:
- fix: Omega armory now contains security hardsuits.