### PR TITLE
HOTFIX Cryochem revert

### DIFF
--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -3661,33 +3661,6 @@
   url: https://github.com/space-wizards/space-station-14/pull/37069
 - author: ScarKy0
   changes:
-  - message: Added Stelloxadone! A cryochemical used to treat poison and radiation
-      damage in living patients as well as corpses, though it comes at a cost of genetic
-      damage.
-    type: Add
-  id: 8520
-  time: '2025-05-18T09:11:23.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37131
-- author: ScarKy0
-  changes:
-  - message: Cryoxadone now works on the dead.
-    type: Tweak
-  - message: Cryoxadone has been reworked. It no longer heals basic damage types.
-      Instead it heals asphyxiation, bloodloss and increases blood level.
-    type: Tweak
-  id: 8521
-  time: '2025-05-18T09:11:51.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37132
-- author: ScarKy0
-  changes:
-  - message: Added Traumoxadone! A cryochemical used to treat brute damage in living
-      patients as well as corpses.
-    type: Add
-  id: 8522
-  time: '2025-05-18T09:11:59.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37236
-- author: ScarKy0
-  changes:
   - message: Aloxadone has been tweaked. The recipe has been altered to be simplier
       to make and the healing values have been increased.
     type: Tweak

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -136,9 +136,6 @@ reagent-desc-necrosol = A necrotic substance that seems to be able to heal froze
 reagent-name-aloxadone = aloxadone
 reagent-desc-aloxadone = A cryogenics chemical. Used to treat severe burns and frostbite via regeneration of the affected tissue. Works regardless of the patient being alive or dead.
 
-reagent-name-traumoxadone = traumoxadone
-reagent-desc-traumoxadone = A cryogenics chemical. Used to treat severe trauma to tissues via patching them with tiny particles within the liquid. Works regardless of the patient being alive or dead.
-
 reagent-name-mannitol = mannitol
 reagent-desc-mannitol = Efficiently restores brain damage.
 

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -14,7 +14,7 @@ reagent-name-bicaridine = bicaridine
 reagent-desc-bicaridine = An analgesic which is highly effective at treating brute damage. It's useful for stabilizing people who have been severely beaten, as well as treating less life-threatening injuries.
 
 reagent-name-cryoxadone = cryoxadone
-reagent-desc-cryoxadone = Required for the proper function of cryogenics. Used to treat bloodloss and asphyxiation, as well as to restore bodily fluids such as blood. It can treat and rejuvenate plants when applied in small doses. Works regardless of the patient being alive or dead.
+reagent-desc-cryoxadone = Required for the proper function of cryogenics. Heals all standard types of damage, but only works in temperatures under 213K. It can treat and rejuvenate plants when applied in small doses.
 
 reagent-name-doxarubixadone = doxarubixadone
 reagent-desc-doxarubixadone = A cryogenics chemical. Heals cellular damage caused by dangerous gasses and chemicals.

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -147,6 +147,3 @@ reagent-desc-potassium-iodide = Will reduce the damaging effects of radiation by
 
 reagent-name-haloperidol = haloperidol
 reagent-desc-haloperidol = Removes most stimulating and hallucinogenic drugs. Reduces druggy effects and jitteriness. Causes drowsiness.
-
-reagent-name-stelloxadone = stelloxadone
-reagent-desc-stelloxadone = A cryogenics chemical. Used to aggressively dissolve toxins from the body. Works regardless of the patient being alive or dead.

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1287,25 +1287,6 @@
             Caustic: -1.5
 
 - type: reagent
-  id: Traumoxadone
-  name: reagent-name-traumoxadone
-  group: Medicine
-  desc: reagent-desc-traumoxadone
-  physicalDesc: reagent-physical-desc-cloudy
-  flavor: medicine
-  color: "#69304D"
-  worksOnTheDead: true
-  metabolisms:
-    Medicine:
-      effects:
-      - !type:EvenHealthChange
-        conditions:
-        - !type:Temperature
-          max: 213.0
-        damage:
-          Brute: -4
-
-- type: reagent
   id : Mannitol # currently this is just a way to create psicodine
   name: reagent-name-mannitol
   group: Medicine

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1428,27 +1428,3 @@
       - !type:AdjustReagent
         reagent: MindbreakerToxin
         amount: -3.0
-
-- type: reagent
-  id: Stelloxadone
-  name: reagent-name-stelloxadone
-  group: Medicine
-  desc: reagent-desc-stelloxadone
-  physicalDesc: reagent-physical-desc-murky
-  flavor: medicine
-  color: "#FFC683"
-  worksOnTheDead: true
-  metabolisms:
-    Medicine:
-      effects:
-      - !type:HealthChange
-        conditions:
-        - !type:Temperature
-          max: 213.0
-        damage:
-          groups:
-            Brute: 3
-            Genetic: 1
-          types:
-            Poison: -6
-            Radiation: -3

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -174,7 +174,6 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: medicine
   color: "#0091ff"
-  worksOnTheDead: true
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: -5
@@ -184,8 +183,6 @@
   metabolisms:
     Medicine:
       effects:
-        - !type:ModifyBloodLevel
-          amount: 4
         - !type:HealthChange
           conditions:
           - !type:Temperature
@@ -194,7 +191,10 @@
           damage:
           # todo scale with temp like SS13
             groups:
-              Airloss: -10
+              Airloss: -6
+              Brute: -4
+              Burn: -6
+              Toxin: -4
 
 - type: reagent
   id: Doxarubixadone

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -515,4 +515,3 @@
       amount: 1
   products:
     Tazinide: 1
-

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -515,3 +515,4 @@
       amount: 1
   products:
     Tazinide: 1
+

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -561,7 +561,7 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine: 
+    Cognizine:
       amount: 1
     Plasma:
       amount: 2

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -664,21 +664,6 @@
     Haloperidol: 5
 
 - type: reaction
-  id: Traumoxadone
-  impact: Medium
-  reactants:
-    Cryoxadone:
-      amount: 1
-    Bicaridine:
-      amount: 1
-    Fersilicite:
-      amount: 1
-    Lipozine:
-      amount: 1
-  products:
-    Traumoxadone: 3
-  
-- type: reaction
   id: Stelloxadone
   impact: Medium
   reactants:

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -561,7 +561,7 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine:
+    Cognizine: 
       amount: 1
     Plasma:
       amount: 2
@@ -662,18 +662,3 @@
       amount: 1
   products:
     Haloperidol: 5
-
-- type: reaction
-  id: Stelloxadone
-  impact: Medium
-  reactants:
-    Stellibinin:
-      amount: 5
-    Cryoxadone:
-      amount: 3
-    Arithrazine:
-      amount: 2
-  products:
-    Stelloxadone: 5
-    Water: 3
-    Fiber: 2


### PR DESCRIPTION
## About the PR
Reverts #37131 #37236 and #37132

## Why / Balance
Maintainer vote decided that the new chems should not work on the dead, however without that ability, there was little use to have them. Cryoxadone was also changed to work on the dead but also essentially nerfed to accomodate the new chemicals (and fill a new niche), so without them we need it back as it was, so that's also a revert rather than an edit.

## Technical details

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
