### PR TITLE
Fix storage fastpath logical oversight

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1326,7 +1326,7 @@ public abstract class SharedStorageSystem : EntitySystem
         // This uses a faster path than the typical codepaths
         // as we can cache a bunch more data and re-use it to avoid a bunch of component overhead.
 
-        // So if we have an item that occupies 0,0 we can assume that the tile itself we're checking
+        // So if we have an item that occupies 0,0 and is a single rectangle we can assume that the tile itself we're checking
         // is always in its shapes regardless of angle. This matches virtually every item in the game and
         // means we can skip getting the item's rotated shape at all if the tile is occupied.
         // This mostly makes heavy checks (e.g. area insert) much, much faster.
@@ -1334,14 +1334,8 @@ public abstract class SharedStorageSystem : EntitySystem
         var itemShape = ItemSystem.GetItemShape(itemEnt);
         var fastAngles = itemShape.Count == 1;
 
-        foreach (var shape in itemShape)
-        {
-            if (shape.Contains(Vector2i.Zero))
-            {
-                fastPath = true;
-                break;
-            }
-        }
+        if (itemShape.Count == 1 && itemShape[0].Contains(Vector2i.Zero))
+            fastPath = true;
 
         var chunkEnumerator = new ChunkIndicesEnumerator(storageBounding, StorageComponent.ChunkSize);
         var angles = new ValueList<Angle>();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Second fix for #37694

fixes issues where some weirdly shaped objects (mostly guns) would not fit in storage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
The logical precondition for the fastpath is that the item being placed will always occupy the top-left spot in storage. This was being checked by seeing if any of the rectangles in the item's shape occupy 0,0. 

This doesn't actually verify correctly, however. If an item has an L-shape, then the item can be oriented such that the "cutout" of the L is in the top-left spot. This causes the fastpath logic to run, which is incorrect in this situation.

What we actually need to do is verify that the shape is concave (which i do by checking just the shape being a plain rectangle)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed a bug that would stop guns and other irregularly shaped objects from fitting into storage.
