### PR TITLE
Fixes the telescopic shield visual bug

### DIFF
--- a/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
+++ b/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Toggleable;
 using Robust.Client.GameObjects;
 using Robust.Shared.Utility;
 using System.Linq;
+using Content.Shared.Item.ItemToggle.Components;
 
 namespace Content.Client.Toggleable;
 
@@ -15,12 +16,14 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
 {
     [Dependency] private readonly SharedItemSystem _itemSys = default!;
     [Dependency] private readonly SharedPointLightSystem _lights = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<ToggleableLightVisualsComponent, GetInhandVisualsEvent>(OnGetHeldVisuals, after: new[] { typeof(ItemSystem) });
         SubscribeLocalEvent<ToggleableLightVisualsComponent, GetEquipmentVisualsEvent>(OnGetEquipmentVisuals, after: new[] { typeof(ClientClothingSystem) });
+        SubscribeLocalEvent<ToggleableLightVisualsComponent, ItemToggledEvent>(OnItemToggled);
     }
 
     protected override void OnAppearanceChange(EntityUid uid, ToggleableLightVisualsComponent component, ref AppearanceChangeEvent args)
@@ -51,6 +54,14 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
 
         // update clothing & in-hand visuals.
         _itemSys.VisualsChanged(uid);
+    }
+
+    /// <summary>
+    ///     Toggle the visuals of the item when the ItemToggledEvent is raised.
+    /// </summary>
+    private void OnItemToggled(EntityUid uid, ToggleableLightVisualsComponent component, ItemToggledEvent args)
+    {
+        _appearance.SetData(uid, ToggleableLightVisuals.Enabled, args.Activated);
     }
 
     /// <summary>

--- a/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
+++ b/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
@@ -8,7 +8,6 @@ using Content.Shared.Toggleable;
 using Robust.Client.GameObjects;
 using Robust.Shared.Utility;
 using System.Linq;
-using Content.Shared.Item.ItemToggle.Components;
 
 namespace Content.Client.Toggleable;
 

--- a/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
+++ b/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
@@ -16,14 +16,12 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
 {
     [Dependency] private readonly SharedItemSystem _itemSys = default!;
     [Dependency] private readonly SharedPointLightSystem _lights = default!;
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<ToggleableLightVisualsComponent, GetInhandVisualsEvent>(OnGetHeldVisuals, after: new[] { typeof(ItemSystem) });
         SubscribeLocalEvent<ToggleableLightVisualsComponent, GetEquipmentVisualsEvent>(OnGetEquipmentVisuals, after: new[] { typeof(ClientClothingSystem) });
-        SubscribeLocalEvent<ToggleableLightVisualsComponent, ItemToggledEvent>(OnItemToggled);
     }
 
     protected override void OnAppearanceChange(EntityUid uid, ToggleableLightVisualsComponent component, ref AppearanceChangeEvent args)
@@ -54,14 +52,6 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
 
         // update clothing & in-hand visuals.
         _itemSys.VisualsChanged(uid);
-    }
-
-    /// <summary>
-    ///     Toggle the visuals of the item when the ItemToggledEvent is raised.
-    /// </summary>
-    private void OnItemToggled(EntityUid uid, ToggleableLightVisualsComponent component, ItemToggledEvent args)
-    {
-        _appearance.SetData(uid, ToggleableLightVisuals.Enabled, args.Activated);
     }
 
     /// <summary>

--- a/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
@@ -283,6 +283,7 @@ public sealed class ItemToggleSystem : EntitySystem
         if (TryComp(ent, out AppearanceComponent? appearance))
         {
             _appearance.SetData(ent, ToggleVisuals.Toggled, ent.Comp.Activated, appearance);
+            _appearance.SetData(ent, ToggleableLightVisuals.Enabled, ent.Comp.Activated, appearance);
         }
     }
 

--- a/Content.Shared/Light/EntitySystems/ItemTogglePointLightSystem.cs
+++ b/Content.Shared/Light/EntitySystems/ItemTogglePointLightSystem.cs
@@ -10,7 +10,6 @@ namespace Content.Shared.Light.EntitySystems;
 /// </summary>
 public sealed class ItemTogglePointLightSystem : EntitySystem
 {
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedPointLightSystem _light = default!;
     [Dependency] private readonly SharedHandheldLightSystem _handheldLight = default!;
 
@@ -25,7 +24,6 @@ public sealed class ItemTogglePointLightSystem : EntitySystem
         if (!_light.TryGetLight(ent.Owner, out var light))
             return;
 
-        _appearance.SetData(ent, ToggleableLightVisuals.Enabled, args.Activated);
         _light.SetEnabled(ent.Owner, args.Activated, comp: light);
         if (TryComp<HandheldLightComponent>(ent.Owner, out var handheldLight))
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed a bug where the telescopic shield's sprite would not change when you toggle it.

## Technical details
TLDR: The `ToggleableLightVisualsSystem` is in a bad spot right now, as it does a lot more than just lights.
There is a proper pr #35341 to uncouple the system but that is 3 months old and not jet merged - and I realised I could very quickly fix the telescopic shield bug in an afternoon by changing 2 lines of code.

The telescopic shield and the energy sword work the exact same way, via the `ToggleableLightVisualsSystem`, and they both change sprite when toggled. Yet the energy sword works and the telescopic shield does not. Why is this?

In order for the item to change it needs the `ToggleLightsVisuals.Enabled` appearance data to be set. It is set a few times in the code (like when people get set on fire, another of the many many things this one system does :grimacing:). But what we need is it to be set in response to an item being toggled, and this only happens at once place. In the `ItemTogglePointLightSystem`, and only for items with point lights. The energy sword has a point light but the telescopic shield doesn't. That's it, that's the bug.

So the bug is that the `ToggleLightsVisuals.Enabled` is set in the wrong place in the code for some items and not others. So I removed the line that sets it from `ItemTogglePointLightSystem`, but I didn't know where to put it. My first thought was for it to be in the `ToggleableLightVisualsSystem` but that is Client and the data has to be set in Shared or it will mispredict. So I set it in the `UpdateVisuals` method in the `ItemToggleSystem` alongside where `ToggleVisuals.Toggle` is set. I think it makes the most sense there.

When I first tried to fix this bug I thought I should refactor it to use `ToggleVisuals.Toggled` instead of `ToggleableLightVisuals.Enabled` - but that can't work because this stuff is also used for people burning. Refactoring it so people who are burning alive are *toggled on* is an utterly insane idea and one I abandoned.

This whole thing needs a big proper refactor which is already in progress via #35341. However that pr is taking a very long time to review and I was playing yesterday and the teleshield bug was bugging me so I just fixed it with two lines of code.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Here are images of the telescopic shield working! Hallelujah!
![Screenshot from 2025-05-26 18-12-30](https://github.com/user-attachments/assets/23c71a50-a058-4cbe-aa50-cb056e8c7982)
![Screenshot from 2025-05-26 18-12-37](https://github.com/user-attachments/assets/e17e4215-baf1-4777-91b9-a12a0068273b)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the telescopic shield visual bug - it now changes sprite when toggled!
