### PR TITLE
reduced the number of slots in bookshelves

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
+++ b/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
@@ -16,14 +16,14 @@
     # Randomly generated books
     - id: BookRandomStory
       amount: !type:RangeNumberSelector
-        range: 0, 6
+        range: 4, 8
     # Guidebooks
     - !type:NestedSelector
       tableId: RandomGuidebookTable
     # Handwritten books
     - !type:NestedSelector
       rolls: !type:RangeNumberSelector
-        range: 0, 3
+        range: 1, 3
       tableId: RandomHandwrittenBookTable
 
 - type: entityTable

--- a/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
+++ b/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
@@ -19,7 +19,10 @@
         range: 0, 8
     # Guidebooks
     - !type:NestedSelector
+      rolls: !type:RangeNumberSelector
+        range: 0, 2
       tableId: RandomGuidebookTable
+
     # Handwritten books
     - !type:NestedSelector
       rolls: !type:RangeNumberSelector

--- a/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
+++ b/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
@@ -16,14 +16,14 @@
     # Randomly generated books
     - id: BookRandomStory
       amount: !type:RangeNumberSelector
-        range: 2, 8
+        range: 0, 8
     # Guidebooks
     - !type:NestedSelector
       tableId: RandomGuidebookTable
     # Handwritten books
     - !type:NestedSelector
       rolls: !type:RangeNumberSelector
-        range: 1, 3
+        range: 0, 3
       tableId: RandomHandwrittenBookTable
 
 - type: entityTable

--- a/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
+++ b/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
@@ -22,7 +22,6 @@
       rolls: !type:RangeNumberSelector
         range: 0, 2
       tableId: RandomGuidebookTable
-
     # Handwritten books
     - !type:NestedSelector
       rolls: !type:RangeNumberSelector

--- a/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
+++ b/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
@@ -16,14 +16,14 @@
     # Randomly generated books
     - id: BookRandomStory
       amount: !type:RangeNumberSelector
-        range: 0, 4
+        range: 0, 6
     # Guidebooks
     - !type:NestedSelector
       tableId: RandomGuidebookTable
     # Handwritten books
     - !type:NestedSelector
       rolls: !type:RangeNumberSelector
-        range: 0, 2
+        range: 0, 3
       tableId: RandomHandwrittenBookTable
 
 - type: entityTable

--- a/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
+++ b/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
@@ -16,7 +16,7 @@
     # Randomly generated books
     - id: BookRandomStory
       amount: !type:RangeNumberSelector
-        range: 4, 8
+        range: 2, 8
     # Guidebooks
     - !type:NestedSelector
       tableId: RandomGuidebookTable

--- a/Resources/Prototypes/Entities/Structures/Furniture/bookshelf.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/bookshelf.yml
@@ -48,7 +48,7 @@
   - type: Occluder
   - type: Storage
     grid:
-    - 0,0,15,3
+    - 0,0,9,3
     maxItemSize: Normal
     whitelist:
       tags:


### PR DESCRIPTION
## About the PR
Currently, bookshelves have an absurd amount of slots, which is strange for something that can only hold books and paper. I reduced the slot-count to 40, and since one book takes up 2, and there are 20 fill-level sprites (not including empty) that corresponds to one sprite per book.

In addition, I also increased the number of books that randomly-filled bookcases contain. I did this so there will be fewer bookcases with just a couple, or even just one book in them. Now librarians will feel less compelled to dismantle all but one bookshelf.

## Why / Balance
It looked ugly honestly. Also I didn't like that adding/removing books to/from the shelf did not always correspond to a sprite change.

## Technical details


## Media
![books](https://github.com/user-attachments/assets/a5b1d144-c9f5-494b-9753-637dfd7eabd0)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
shouldn't be any

**Changelog**
:cl:
- tweak: Bookshelves now contain a more reasonable amount of books.
