### PR TITLE
high-vis vest is now dimmer

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -13,6 +13,8 @@
     - state: icon
     - state: icon-unshaded
       shader: unshaded
+    - state: icon-unshaded
+      shader: shaded
   - type: Clothing
     sprite: Clothing/OuterClothing/Vests/hazard.rsi
     clothingVisuals:
@@ -20,6 +22,8 @@
       - state: equipped-OUTERCLOTHING
       - state: equipped-OUTERCLOTHING-unshaded
         shader: unshaded
+      - state: equipped-OUTERCLOTHING-unshaded
+        shader: shaded
   - type: Tag
     tags:
     - HiViz


### PR DESCRIPTION
## About the PR
The high-vis vest currently is absolutely *dazzling* in its brightness. You are a fucking spotlight in all but the brightest areas. So I made it less bright

## Technical details
As you may already know, we do not have emissive maps. Things are "unshaded" in order to glow, and unshaded means FULLBRIGHT, no lighting. I found a hack though. You see, you can have a transparent sprite that *is* shaded, over the top of an unshaded sprite, and it will occlude, including partially. I also discovered that the high-vis vests unshaded sprite is already transparent (probably because it came from TG where they do have working emissive maps), so I just put it over top of itself; and voila. I basically hacked in an emissive map, though admittedly the emissive level is inverted (but I didn't change it because I like how it looks already)

So now, you can make things that are unshaded have an "emissive map", just add an alpha channel to the unshaded sprite, and whatever emissiveness you want, invert that (since it works subtractively, not additively). then have two layers of this sprite, with one being unshaded and the one on top of it being shaded.

I'm sure there are problems with this approach but I haven't found them ~~so lets go get some technical debt aylmao~~

## Media
![image](https://github.com/user-attachments/assets/31883459-c307-441a-be54-7350010c337d)
![image](https://github.com/user-attachments/assets/bd647510-449b-46f4-ab66-7f6189439026)
![image](https://github.com/user-attachments/assets/4add0f15-8e9d-4b51-a740-2c634ead8b5d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
shouldn't be any

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: high-vis vests are dimmer now.