### PR TITLE
Dwarf Accent for All

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -60,5 +60,8 @@ trait-french-desc = Your accent seems to have a certain «je ne sais quoi».
 trait-spanish-name = Spanish accent
 trait-spanish-desc = Hola señor, donde esta la biblioteca.
 
+trait-dwarfaccent-name = Dwarven accent
+trait-dwarfaccent-desc = You cannae help speaking like ae proud Dorf.
+
 trait-painnumbness-name = Numb
 trait-painnumbness-desc = You lack any sense of feeling pain, being unaware of how hurt you may be.

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -93,6 +93,16 @@
   - type: ReplacementAccent
     accent: liar
 
+- type: trait
+  id: DwarfAccent
+  name: trait-dwarfaccent-name
+  description: trait-dwarfaccent-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: ReplacementAccent
+    accent: dwarf
+
 # 2 Cost
 
 - type: trait


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Dwarf accent has been added to the character customization screen for all species.
This does not effect Dwarf itself.

## Why / Balance
The Dwarf accent is closer to a regional dialect as opposed to a genetic way of talking, such as Lizard's dragged S.
As a Scottish person who inherently talks like a SS14 Dwarf IRL I thought it was a bit odd that the accent was restricted behind a species as opposed to being generally available like German or Spanish.
Additionally with frequent talk about Dwarf getting the axe for being too similar to humans, making this accent generally available better future-proofs it.
It'd also just be quite nice to add as another option for RP character customization due to how distinct and oddly content-packed this accent is.

## Technical details
All YML

## Media
![dwarf3](https://github.com/user-attachments/assets/72b66c5a-25da-4643-bee0-1eab0f8f1359)
![dwarf1](https://github.com/user-attachments/assets/c3f53896-a69a-45ca-a3c8-2636c6bb645a)
![dwarf2](https://github.com/user-attachments/assets/bc9b479b-f4bd-4579-85ce-e48b09e50e4a)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The Dwarf accent has been added to Character Customization for all species, Dwarves themselves are unchanged.
