### PR TITLE
Restore Gas Pipe Naming in Construction Menu

### DIFF
--- a/Resources/Locale/en-US/recipes/tags.ftl
+++ b/Resources/Locale/en-US/recipes/tags.ftl
@@ -55,7 +55,7 @@ construction-graph-tag-super-compact-ai-chip = a super-compact AI chip
 # other
 construction-graph-tag-light-bulb = light bulb
 construction-graph-tag-radio = radio
-construction-graph-tag-pipe = pipe
+construction-graph-tag-pipe = gas pipe
 construction-graph-tag-human-head = human head
 construction-graph-tag-bucket = bucket
 construction-graph-tag-borg-arm = borg arm

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -2,7 +2,7 @@
   abstract: true
   id: GasPipeBase
   parent: BaseItem
-  name: pipe
+  name: gas pipe
   description: Holds gas.
   placement:
     mode: SnapgridCenter


### PR DESCRIPTION
## About the PR
Restored the atmos gas pipe naming conventions previously used in the construction menu.

## Why / Balance
Prior to #32339 being merged, you could see most of the atmos construction items if you just searched "gas" in the search bar. They were changed to just be named "pipe" after the merge. This is annoying if you're playing atmos.

## Technical details
Literally just changed 2 lines to use the name "gas pipe" instead of "pipe"

## Media
<img width="913" alt="gas" src="https://github.com/user-attachments/assets/76dc5c6b-5dd1-4f2d-998c-14c1e26919d4" />
<img width="807" alt="recipe" src="https://github.com/user-attachments/assets/b209ecfb-4a45-4d29-acbe-5abea97864da" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Gas Pipes are now named as such in the construction menu.