### PR TITLE
Add various commands for playing localized sounds

### DIFF
--- a/Content.Server/Administration/Commands/PlayGlobalSoundCommand.cs
+++ b/Content.Server/Administration/Commands/PlayGlobalSoundCommand.cs
@@ -88,7 +88,8 @@ public sealed class PlayGlobalSoundCommand : IConsoleCommand
         }
 
         audio = audio.AddVolume(-8);
-        _entManager.System<ServerGlobalSoundSystem>().PlayAdminGlobal(filter, args[0], audio, replay);
+        var path = new ResolvedPathSpecifier(args[0]);
+        _entManager.System<ServerGlobalSoundSystem>().PlayAdminGlobal(filter, path, audio, replay);
     }
 
     public CompletionResult GetCompletion(IConsoleShell shell, string[] args)

--- a/Content.Server/Administration/Commands/PlayLocalSoundCommand.cs
+++ b/Content.Server/Administration/Commands/PlayLocalSoundCommand.cs
@@ -1,0 +1,129 @@
+using Content.Shared.Administration;
+using Robust.Server.Player;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Console;
+using Robust.Shared.ContentPack;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Fun)]
+public sealed class PlayLocalSoundCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IPrototypeManager _protoManager = default!;
+    [Dependency] private readonly IResourceManager _res = default!;
+
+    public string Command => "playlocalsound";
+    public string Description => Loc.GetString("play-local-sound-command-description");
+    public string Help => Loc.GetString("play-local-sound-command-help");
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var filter = Filter.Empty();
+        var audio = AudioParams.Default;
+
+        var replay = true;
+        var followRunner = false;
+
+        var playerEntity = shell.Player?.AttachedEntity;
+        if (playerEntity == null)
+        {
+            shell.WriteLine(Loc.GetString("play-local-sound-command-no-entity"));
+            return;
+        }
+
+        if (args.Length == 0) // No arguments, show command help.
+        {
+            shell.WriteLine(Loc.GetString("play-local-sound-command-help"));
+            return;
+        }
+
+        // No players specified, so set filter here
+        if (args.Length <= 3)
+        {
+            // Filter.Broadcast does resolves IPlayerManager, so use this instead.
+            filter = Filter.Empty().AddAllPlayers(_playerManager);
+        }
+
+        // At least <path> [volume] specified
+        if (args.Length >= 2)
+        {
+            if (int.TryParse(args[1], out var volume))
+            {
+                audio = audio.WithVolume(volume);
+            }
+            else
+            {
+                shell.WriteError(Loc.GetString("play-local-sound-command-volume-parse", ("volume", args[1])));
+                return;
+            }
+        }
+
+        // <path> [volume] [follow] specified
+        if (args.Length >= 3 && !bool.TryParse(args[2], out followRunner))
+        {
+            shell.WriteError(Loc.GetString("shell-invalid-bool"));
+            return;
+        }
+
+        // One or more users specified.
+        if (args.Length >= 4)
+        {
+            replay = false;
+            // <path> [volume] [follow] >[players...]
+            for (var i = 3; i < args.Length; i++)
+            {
+                var username = args[i];
+
+                if (!_playerManager.TryGetSessionByUsername(username, out var session))
+                {
+                    shell.WriteError(Loc.GetString("play-local-sound-command-player-not-found",
+                        ("username", username)));
+                    continue; // Still use remaining names
+                }
+
+                filter.AddPlayer(session);
+            }
+        }
+
+        audio = audio.AddVolume(-8); // Matching /playglobalsound
+        var sound = new SoundPathSpecifier(args[0], audio);
+
+        var sysMan = IoCManager.Resolve<IEntitySystemManager>();
+        var audioSys = sysMan.GetEntitySystem<SharedAudioSystem>();
+        if (followRunner)
+        {
+            // Note: if playerEntity isn't in a client's PVS (the runner could be a ghost), they will
+            // never hear this. This is not true if followRunner is false. This is not totally ideal.
+            audioSys.PlayEntity(sound, filter, playerEntity.Value, replay);
+        }
+        else
+        {
+            // Whatever the runner's parent is is /probably/ what we want to be stationary to.
+            var coords = _entManager.GetComponent<TransformComponent>(playerEntity.Value).Coordinates;
+            audioSys.PlayStatic(sound, filter, coords, replay);
+        }
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        return args.Length switch
+        {
+            1 => CompletionResult.FromHintOptions(CompletionHelper.AudioFilePath(args[0], _protoManager, _res),
+                Loc.GetString("play-local-sound-command-arg-path")),
+
+            2 => CompletionResult.FromHint(Loc.GetString("play-local-sound-command-arg-volume")),
+
+            3 => CompletionResult.FromHint(Loc.GetString("play-local-sound-command-arg-follow")),
+
+            >= 4 => CompletionResult.FromHintOptions(CompletionHelper.SessionNames(),
+                Loc.GetString("play-local-sound-command-arg-usern", ("user", args.Length - 3))),
+
+            _ => CompletionResult.Empty,
+        };
+    }
+}

--- a/Content.Server/Administration/Toolshed/PlaySoundCommand.cs
+++ b/Content.Server/Administration/Toolshed/PlaySoundCommand.cs
@@ -1,0 +1,71 @@
+using System.Linq;
+using Content.Shared.Administration;
+using Content.Shared.Coordinates;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Toolshed;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Administration.Toolshed;
+
+/// <summary>
+/// Toolshed version of PlayLocalSound
+/// </summary>
+[ToolshedCommand, AdminCommand(AdminFlags.Fun)]
+public sealed class PlaySoundCommand : ToolshedCommand
+{
+    private SharedAudioSystem? _audioSystem;
+
+    [CommandImplementation("at")]
+    public EntityUid? PlaySoundAt([PipedArgument] EntityCoordinates target,
+        ResPath resPath,
+        float volume = 0)
+    {
+        _audioSystem ??= GetSys<SharedAudioSystem>();
+
+        var audioParams = AudioParams.Default.WithVolume(volume);
+        var sound = new SoundPathSpecifier(resPath, audioParams);
+        return _audioSystem.PlayPvs(sound, target)?.Entity;
+    }
+
+    [CommandImplementation("at")]
+    public IEnumerable<EntityUid?> PlaySoundAt([PipedArgument] IEnumerable<EntityCoordinates> targets,
+        ResPath resPath,
+        float volume = 0)
+    {
+        return targets.Select(x => PlaySoundAt(x, resPath, volume));
+    }
+
+    [CommandImplementation("on")]
+    public EntityUid? PlaySoundOn([PipedArgument] EntityUid target,
+        ResPath resPath,
+        float volume = 0)
+    {
+        return PlaySoundAt(Transform(target).Coordinates, resPath, volume);
+    }
+
+    [CommandImplementation("on")]
+    public IEnumerable<EntityUid?> PlaySoundOn([PipedArgument] IEnumerable<EntityUid> targets,
+        ResPath resPath,
+        float volume = 0)
+    {
+        return targets.Select(x => PlaySoundOn(x, resPath, volume));
+    }
+
+    [CommandImplementation("attached")]
+    public EntityUid? PlaySoundAttached([PipedArgument] EntityUid target,
+        ResPath resPath,
+        float volume = 0)
+    {
+        return PlaySoundAt(target.ToCoordinates(), resPath, volume);
+    }
+
+    [CommandImplementation("attached")]
+    public IEnumerable<EntityUid?> PlaySoundAttached([PipedArgument] IEnumerable<EntityUid> targets,
+        ResPath resPath,
+        float volume = 0)
+    {
+        return targets.Select(x => PlaySoundAttached(x, resPath, volume));
+    }
+}

--- a/Resources/Locale/en-US/administration/commands/play-local-sound-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/play-local-sound-command.ftl
@@ -1,0 +1,9 @@
+play-local-sound-command-description = Plays a localized sound from your current position for the specified players or for every nearby player if no players are specified.
+play-local-sound-command-help = playlocalsound <path> [volume] [follow] [user 1] ... [user n]
+play-local-sound-command-no-entity = You have no attached entity and you must play sounds.
+play-local-sound-command-player-not-found = Player "{$username}" not found.
+play-local-sound-command-volume-parse = Invalid volume of {$volume} specified.
+play-local-sound-command-arg-path = <path>
+play-local-sound-command-arg-follow = [follow]
+play-local-sound-command-arg-volume = [volume]
+play-local-sound-command-arg-usern = [user {$user}]

--- a/Resources/Locale/en-US/commands/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/commands/toolshed-commands.ftl
@@ -56,6 +56,12 @@ command-description-marked =
     Returns the value of $marked as a List<EntityUid>.
 command-description-rejuvenate =
     Rejuvenates the given entities, restoring them to full health, clearing status effects, etc.
+command-description-playsound-at =
+    Plays a sound at the given coordinates.
+command-description-playsound-on =
+    Plays a sound on the given entity, at its coordinates.
+command-description-playsound-attached =
+    Plays a sound on the given entity, following it if it moves.
 command-description-tag-list =
     Lists tags on the given entities.
 command-description-tag-with =


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This adds two new commands—one toolshed, one... not, for playing sound at a given location or playing a sound from your attached entity respectively.
1. `/playlocalsound <path> [volume] [follow=false] [users...]` works like `/playglobalsound`, except it has a `follow` argument that controls if the played sound is parented to the command's runner. It additionally can take a filter of users who are able to hear the sound.
2. `playsound:` as a family of toolshed commands, with similar subcommands to `spawn:`. Note that the toolshed variant does not allow user filtering.

I also drive-by fixed a warning in PlayGlobalSound.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I uh. Like haunting my friends.

## Technical details
<!-- Summary of code changes for easier review. -->
Pretty standard, but a few notes—
1. Sounds that are played "attached" to an entity are still subject to PVS visibility restrictions. This effectively means that you cannot, as a ghost, play audio that is attached to yourself and audible to non-ghost-seeing clients. I don't /love/ this, but I'm not sure how to get around it in a simple way. I'm not sure if this is where a PVS override or how to do that. Alternatively, just changing the visibilitymask on the spawned audio entity could be done, but that feels similarly janky.
2. No ResPath completion in Toolshed :(
3. I couldn't decide if the toolshed implementation should return the created audio entities or if it should pass through its input... I did the former for now since technically you can always `tee` around it if you need the latter behavior.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/5d735de4-300e-422f-85ac-d8c87d40953d" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
ADMIN:
- add: /playlocalsound has been added for playing localized sounds. (+FUN)
- add: Toolshed commands for playing sounds at a point have been added. (+FUN)
