### PR TITLE
Use SharedMapSystem for GridTileToLocal

### DIFF
--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -306,7 +306,7 @@ public sealed partial class PathfindingSystem
         {
             for (var y = Math.Floor(mapGrid.LocalAABB.Bottom); y <= Math.Ceiling(mapGrid.LocalAABB.Top + ChunkSize); y += ChunkSize)
             {
-                DirtyChunk(ev.EntityUid, mapGrid.GridTileToLocal(new Vector2i((int) x, (int) y)));
+                DirtyChunk(ev.EntityUid, _maps.GridTileToLocal(ev.EntityUid, mapGrid, new Vector2i((int)x, (int)y)));
             }
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes one (1) obsolete component method use in the pathfinding system.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
One less warning for [PZW](https://github.com/space-wizards/space-station-14/issues/33279).

## Technical details
<!-- Summary of code changes for easier review. -->
Converts a use of the `MapGridComponent.GridTileToLocal` method to use the equivalent `SharedMapSystem.GridTileToLocal` method.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
