### PR TITLE
Fix for obsolete method warning in AtmosphericsSystem

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -682,7 +682,7 @@ namespace Content.Server.Atmos.EntitySystems
             adj.MonstermosInfo[idx.ToOppositeDir()] -= amount;
         }
 
-        private void HandleDecompressionFloorRip(MapGridComponent mapGrid, TileAtmosphere tile, float sum)
+        private void HandleDecompressionFloorRip(Entity<MapGridComponent> mapGrid, TileAtmosphere tile, float sum)
         {
             if (!MonstermosRipTiles)
                 return;
@@ -691,6 +691,12 @@ namespace Content.Server.Atmos.EntitySystems
 
             if (sum > 20 && _random.Prob(chance))
                 PryTile(mapGrid, tile.GridIndices);
+        }
+
+        [Obsolete("This method is obsolete, please use the Entity<T> override")]
+        private void HandleDecompressionFloorRip(MapGridComponent mapGrid, TileAtmosphere tile, float sum)
+        {
+            HandleDecompressionFloorRip((mapGrid.Owner, mapGrid), tile, sum);
         }
 
         private sealed class TileAtmosphereComparer : IComparer<TileAtmosphere?>

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -550,7 +550,7 @@ namespace Content.Server.Atmos.EntitySystems
                 }
 
                 InvalidateVisuals(ent, otherTile);
-                HandleDecompressionFloorRip(mapGrid, otherTile, otherTile.MonstermosInfo.CurrentTransferAmount);
+                HandleDecompressionFloorRip((owner, mapGrid), otherTile, otherTile.MonstermosInfo.CurrentTransferAmount);
             }
 
             if (GridImpulse && tileCount > 0)

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -693,12 +693,6 @@ namespace Content.Server.Atmos.EntitySystems
                 PryTile(mapGrid, tile.GridIndices);
         }
 
-        [Obsolete("This method is obsolete, please use the Entity<T> override")]
-        private void HandleDecompressionFloorRip(MapGridComponent mapGrid, TileAtmosphere tile, float sum)
-        {
-            HandleDecompressionFloorRip((mapGrid.Owner, mapGrid), tile, sum);
-        }
-
         private sealed class TileAtmosphereComparer : IComparer<TileAtmosphere?>
         {
             public int Compare(TileAtmosphere? a, TileAtmosphere? b)

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -28,7 +28,8 @@ public partial class AtmosphereSystem
 
         // Pay more for gas canisters that are more pure
         float purity = 1;
-        if (totalMoles > 0) {
+        if (totalMoles > 0)
+        {
             purity = maxComponent / totalMoles;
         }
 
@@ -88,7 +89,7 @@ public partial class AtmosphereSystem
 
             fixVacuum |= airtight.FixVacuum;
 
-            if(!airtight.AirBlocked)
+            if (!airtight.AirBlocked)
                 continue;
 
             blockedDirs |= airtight.AirBlockedDirection;
@@ -106,11 +107,18 @@ public partial class AtmosphereSystem
     /// </summary>
     /// <param name="mapGrid">The grid in question.</param>
     /// <param name="tile">The indices of the tile.</param>
-    private void PryTile(MapGridComponent mapGrid, Vector2i tile)
+    private void PryTile(Entity<MapGridComponent> mapGrid, Vector2i tile)
     {
-        if (!mapGrid.TryGetTileRef(tile, out var tileRef))
+        if (!_mapSystem.TryGetTileRef(mapGrid.Owner, mapGrid.Comp, tile, out var tileRef))
             return;
 
         _tile.PryTile(tileRef);
+    }
+
+    /// <inheritdoc cref="PryTile(Entity{MapGridComponent}, Vector2i)"/>
+    [Obsolete("please use the Entity<MapGridComponent> override")]
+    private void PryTile(MapGridComponent mapGrid, Vector2i tile)
+    {
+        PryTile((mapGrid.Owner, mapGrid), tile);
     }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -114,11 +114,4 @@ public partial class AtmosphereSystem
 
         _tile.PryTile(tileRef);
     }
-
-    /// <inheritdoc cref="PryTile(Entity{MapGridComponent}, Vector2i)"/>
-    [Obsolete("please use the Entity<MapGridComponent> override")]
-    private void PryTile(MapGridComponent mapGrid, Vector2i tile)
-    {
-        PryTile((mapGrid.Owner, mapGrid), tile);
-    }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a single obsolete component method warning in `AtmosphericsSystem`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
One less warning for [PZW](https://github.com/space-wizards/space-station-14/issues/33279).

## Technical details
<!-- Summary of code changes for easier review. -->
Converts one use of the `MapGridComponent.TryGetTileRef` method to use the equivalent `SharedMapSystem.TryGetTileRef` method. Also converts the calling private functions to take `Entity<MapGridComponent` instead of a raw `MapGridComponent` so it has the necessary `EntityUid`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
