### PR TITLE
Cleanup some misc warnings

### DIFF
--- a/Content.Client/TurretController/TurretControllerWindow.xaml.cs
+++ b/Content.Client/TurretController/TurretControllerWindow.xaml.cs
@@ -115,6 +115,7 @@ public sealed partial class TurretControllerWindow : BaseWindow
             TurretArmamentSetting.Safe => SafeButton,
             TurretArmamentSetting.Stun => StunButton,
             TurretArmamentSetting.Lethal => LethalButton,
+            _ => throw new NotImplementedException(),
         };
         setPressedOn.Pressed = true;
 

--- a/Content.Shared/Atmos/Monitor/AtmosAlarmThreshold.cs
+++ b/Content.Shared/Atmos/Monitor/AtmosAlarmThreshold.cs
@@ -348,6 +348,11 @@ public readonly partial struct AlarmThresholdSetting: IEquatable<AlarmThresholdS
         return true;
     }
 
+    public override bool Equals(object? obj)
+    {
+        return obj is AlarmThresholdSetting ats && Equals(ats);
+    }
+
     public static bool operator ==(AlarmThresholdSetting lhs, AlarmThresholdSetting rhs)
     {
         return lhs.Equals(rhs);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 2 warnings in 2 files.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
- **TurretControllerWindow:** `warning CS8524: The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value. For example, the pattern '(Content.Client.TurretController.TurretControllerWindow.TurretArmamentSetting)2' is not covered.`
Added a default condition.
- **AtmosAlarmThreshold:** `warning CS0660: 'AlarmThresholdSetting' defines operator == or operator != but does not override Object.Equals(object o)`
Now it does.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->