### PR TITLE
diona version for basic operative bundle

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -259,6 +259,7 @@ uplink-super-surplus-bundle-desc = Contains 125 telecrystals worth of completely
 
 uplink-starter-kit-name = Basic Operative Bundle
 uplink-starter-kit-desc = Contains 40 telecrystals of basic operative gear. For those operatives who just don't know what they should buy.
+uplink-starter-kit-diona-name = Basic Operootive Bundle
 
 # Tools
 uplink-toolbox-name = Toolbox

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -344,3 +344,22 @@
       - id: EmpImplanter
       - id: ClothingShoesBootsMagSyndie
       - id: AgentIDCard
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateBundle
+  id: ClothingBackpackDuffelSyndicateFilledStarterKitDiona
+  name: basic operootive bundle
+  description: "Contains a weapon, medical supplies, breaching tools, spare ammo, and some simple utilities."
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponSubMachineGunC20r
+    - id: MagazinePistolSubMachineGun
+      amount: 4
+    - id: MagazinePistol
+    - id: SyndicateJawsOfLife
+    - id: C4
+      amount: 3
+    - id: MedkitCombatFilled
+    - id: EmpImplanter
+    - id: AgentIDCard

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1115,7 +1115,32 @@
       blacklist:
         components:
         - SurplusBundle
+    - !type:BuyerSpeciesCondition
+        blacklist:
+        - Diona
 
+- type: listing
+  parent: UplinkStarterKit
+  id: UplinkStarterKitDiona
+  name: uplink-starter-kit-diona-name
+  description: uplink-starter-kit-desc
+  productEntity: ClothingBackpackDuffelSyndicateFilledStarterKitDiona
+  cost:
+    Telecrystal: 40
+  categories:
+  - UplinkDisruption
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
+  - !type:BuyerSpeciesCondition
+    whitelist:
+    - Diona
 
 - type: listing
   id: UplinkSingarityBeacon


### PR DESCRIPTION
## About the PR
Diona nukies can no longer buy the basic operative bundle, instead they get an alternate version that does not have the magboots. It contains an extra C4 and magazine instead.

## Why / Balance
Diona can't use the magboots, so it's a waste of TC for them

## Technical details
just some yaml

## Media

![Screenshot_2025-05-28_185241](https://github.com/user-attachments/assets/27305fcc-a6d0-4d80-8298-519d2ef37947)

![Screenshot_2025-05-28_185229](https://github.com/user-attachments/assets/5ab15dcf-5a79-4389-b068-c2ea06cc5bc8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl: Errant
- tweak: Diona nukies no longer get magboots in the basic operative bundle. Instead, their bundle contains slightly more destruction.