### PR TITLE
Fix obsolete method warning in SimpleFloorPlanPopulatorSystem

### DIFF
--- a/Content.Server/Worldgen/Systems/Debris/SimpleFloorPlanPopulatorSystem.cs
+++ b/Content.Server/Worldgen/Systems/Debris/SimpleFloorPlanPopulatorSystem.cs
@@ -29,7 +29,7 @@ public sealed class SimpleFloorPlanPopulatorSystem : BaseWorldSystem
         var enumerator = _map.GetAllTilesEnumerator(uid, grid);
         while (enumerator.MoveNext(out var tile))
         {
-            var coords = grid.GridTileToLocal(tile.Value.GridIndices);
+            var coords = _map.GridTileToLocal(uid, grid, tile.Value.GridIndices);
             var selector = tile.Value.Tile.GetContentTileDefinition(_tileDefinition).ID;
             if (!component.Caches.TryGetValue(selector, out var cache))
                 continue;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a single obsolete component method call in `SimpleFloorPlanPopulatorSystem`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
One less warning for [PZW](https://github.com/space-wizards/space-station-14/issues/33279).

## Technical details
<!-- Summary of code changes for easier review. -->
Converts one call to the obsolete `MapGridComponent.GridTileToLocal` method to call the equivalent `SharedMapSystem.GridTileToLocal` method.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
