### PR TITLE
Change smoke/foam/explosion chemistry reaction order & energy transfer

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -104,6 +104,7 @@
   id: PotassiumExplosion
   impact: High
   priority: 20
+  conserveEnergy: false
   reactants:
     Water:
       amount: 1
@@ -119,8 +120,9 @@
 
 - type: reaction
   id: Smoke
-  priority: 10
+  priority: -10
   impact: High
+  conserveEnergy: false
   reactants:
     Phosphorus:
       amount: 1
@@ -137,8 +139,9 @@
 
 - type: reaction
   id: Foam
-  priority: 10
+  priority: -10
   impact: High
+  conserveEnergy: false
   reactants:
     Fluorosurfactant:
       amount: 1
@@ -154,7 +157,8 @@
 - type: reaction
   id: IronMetalFoam
   impact: High
-  priority: 10
+  priority: -10
+  conserveEnergy: false
   reactants:
     Iron:
       amount: 3
@@ -172,7 +176,8 @@
 - type: reaction
   id: AluminiumMetalFoam
   impact: High
-  priority: 10
+  priority: -10
+  conserveEnergy: false
   reactants:
     Aluminium:
       amount: 3
@@ -191,6 +196,7 @@
   id: UraniumEmpExplosion
   impact: High
   priority: 20
+  conserveEnergy: false
   reactants:
     Iron:
       amount: 1
@@ -209,6 +215,7 @@
   id: Flash
   impact: High
   priority: 20
+  conserveEnergy: false
   reactants:
     Aluminium:
       amount: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR does two things:

1. Foam and smoke effects have been changed to trigger *after* all other reactions.
2. Foams, smokes and explosion reactions that can eliminate all reagents no longer transfer the reagents' energy to the solution (i.e. no longer heats the container).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

1. Foam and smoke effects have been changed to trigger after all other reactions. 

Due to foam and smoke reactions previously having priority over normal mix reactions, there was a strange behavior that could occur where, due to foam/smoke not allowing reagent reactions, a mix of chemicals that should normally react wouldn't do so until inhaled. Not only is this unintuitive (all reagents are in the cloud, yet somehow not mixing), but it allowed for certain inhalation mixes that wouldn't trigger effects until inhaled (most notably "bee bombs"). 

2. Foams, smokes and explosion reactions that can eliminate all reagents no longer transfer reagents' energy to the solution (i.e. no longer heats the container).

The chemistry system runs on a type of largely simplified exothermic/endothermic reaction system that, while nifty, causes some issues when bumping up against the limitations of the simulation. Due to foams/smokes/explosions having potential to delete all reagents involved in the reaction, any remaining reagents in the solution take on the full heat energy of what was deleted, regardless of how little actually remains. 

E.g. a fluorosurfactant/water mix with 99.99u of each, with 0.01u of a random other reagent, after reacting results in that other reagent becoming hotter than the core of the sun by 3 magnitudes.   

Because of this, the heat system could be used to rapidly trigger heat-induced chemical reactions. Since the energy is meant to go into the act of creating the foam/smoke/explosion itself, removing it feels like an okay alternative. Foam/smoke still transfers the heat of the original container they were in (and due to change 1, exo/endothermic reactions happen before the foam/smoke).

It is worth noting that if a more exact heat simulation system is introduced in the future, the behavior could be properly tweaked back in.

## Technical details
<!-- Summary of code changes for easier review. -->

Surprisingly... Just yaml!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Chemistry foam and smoke reactions now trigger after regular mix reactions.
- tweak: Foam, smoke and explosion reactions no longer transfer the reagents' energies to the container.