### PR TITLE
Fix: Allow energy shotgun lethal projectiles to hit holos

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1226,6 +1226,7 @@
           bounds: "-0.15,-0.3,0.15,0.3"
         hard: false
         mask:
+        - Opaque
         - Impassable
         - BulletImpassable
       fly-by: *flybyfixture


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Allow energy shotgun lethal projectiles to hit holo enemies (holoparasites and holocarp)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Seems to be an oversight considering other energy projectiles can hit holo targets.

Does not affect energy shotgun's inability to shoot through glass.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

### Hitting holo mobs
![dotnet_onBqBsOhpH](https://github.com/user-attachments/assets/de7f570f-e6c5-4a8f-bbdd-fc740c4e74e7)
![dotnet_Q9DbXXli3X](https://github.com/user-attachments/assets/b1b200e3-c879-4c18-bfa0-9fc6c13de7fa)

### Retaining inability to shoot through glass
![dotnet_YS5WDLFPGb](https://github.com/user-attachments/assets/746523c2-00ec-4d62-8c6c-b7544e8668e4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Energy shotgun lethal projectiles can now hit holo mobs.