### PR TITLE
Change potassium-water explosion scaling

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -112,7 +112,7 @@
   effects:
     - !type:ExplosionReactionEffect
       explosionType: Default
-      intensityPerUnit: 0.2 # 50+50 reagent for maximum explosion
+      intensityPerUnit: 0.25
       maxTotalIntensity: 100
       intensitySlope: 4
       maxIntensity: 7

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -112,10 +112,10 @@
   effects:
     - !type:ExplosionReactionEffect
       explosionType: Default
-      maxIntensity: 100
-      intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
-      intensitySlope: 4
+      intensityPerUnit: 0.2 # 50+50 reagent for maximum explosion
       maxTotalIntensity: 100
+      intensitySlope: 4
+      maxIntensity: 7
 
 - type: reaction
   id: Smoke


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR changes the Potassium-Water explosion properties, flattening out the explosion curve to spread out damage across an rea for large-quantity explosions, and requiring larger damage to reach the max damage capacity.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Potassium + Water = Explosion is fun! If we can't have FNAF in the game, at the very least we can give unassuming Janitors explosion jumpscares. 

Both potassium and water are fairly common chemicals, and the reaction is trivial (unlike CLF3, which both contain rare chemicals *and* has a heat requirement). It also has low unit requirements to reach the 100 damage crit threshold (30u potassium), where its scaling quickly evens out (e.g. 100u potassium = 150 damage, 200u = 180 damage). This means potassium + water is a fairly effective aggressive weapon option; simple to create, a lot of damage. This has also resulted in  combining potassium with space cleaner which, when thrown and splashed on the ground, uses the space cleaner's effect to create water on the spot. Due to the factors mentioned above, these can be very potent and are in my opinion overtuned.

The values in this PR changes the curve to require more reagents to reach the scaling softcap, and flattens the cap such that damage is spread out in a wider area. The maximum damage a potassium explosion can deal is now 105 (whereas before it was effectively uncapped).

Images below show how the changes look for some reagent quantities, with the damage dealt edited in at the bottom of each tile. 

15u Potassium:
![image](https://github.com/user-attachments/assets/43005103-2f84-428e-a8a7-df1afbf7505e)

30u Potassium:
![image](https://github.com/user-attachments/assets/635717d2-fe46-4a4f-8f88-d3d0b776c07a)

100u Potassium:
![image](https://github.com/user-attachments/assets/1954aa4f-c7f6-425d-ab97-de578e390500)

200u Potassium:
![image](https://github.com/user-attachments/assets/4c7fc83c-8fee-4e28-9a36-44bb0a5fa903)

If you wonder about mopping: Puddles tend to even out at 20u, so a janitor mopping a potassium puddle now takes 75 damage instead of 90 damage.

## Technical details
<!-- Summary of code changes for easier review. -->

Just yaml!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Potassium-water explosion damage scaling has been tweaked to be less potent.
