### PR TITLE
Split codewords into its own system

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -123,6 +123,8 @@ namespace Content.Client.Entry
             _prototypeManager.RegisterIgnore("alertLevels");
             _prototypeManager.RegisterIgnore("nukeopsRole");
             _prototypeManager.RegisterIgnore("ghostRoleRaffleDecider");
+            _prototypeManager.RegisterIgnore("codewordGenerator");
+            _prototypeManager.RegisterIgnore("codewordFaction");
 
             _componentFactory.GenerateNetIds();
             _adminManager.Initialize();

--- a/Content.Server/Codewords/CodewordComponent.cs
+++ b/Content.Server/Codewords/CodewordComponent.cs
@@ -1,0 +1,14 @@
+﻿namespace Content.Server.Codewords;
+
+/// <summary>
+/// Container for generated codewords.
+/// </summary>
+[RegisterComponent, Access(typeof(CodewordSystem))]
+public sealed partial class CodewordComponent : Component
+{
+    /// <summary>
+    /// The codewords that were generated.
+    /// </summary>
+    [DataField]
+    public string[] Codewords = [];
+}

--- a/Content.Server/Codewords/CodewordFaction.cs
+++ b/Content.Server/Codewords/CodewordFaction.cs
@@ -1,0 +1,14 @@
+﻿using Robust.Shared.Prototypes;
+
+namespace Content.Server.Codewords;
+
+/// <summary>
+/// This is a prototype for easy access to codewords using identifiers instead of magic strings.
+/// </summary>
+[Prototype("codewordFaction")]
+public sealed partial class CodewordFaction : IPrototype
+{
+    /// <inheritdoc/>
+    [IdDataField]
+    public string ID { get; } = default!;
+}

--- a/Content.Server/Codewords/CodewordGenerator.cs
+++ b/Content.Server/Codewords/CodewordGenerator.cs
@@ -1,0 +1,33 @@
+﻿using Content.Shared.Dataset;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Codewords;
+
+/// <summary>
+/// This is a prototype for specifying codeword generation
+/// </summary>
+[Prototype("codewordGenerator")]
+public sealed partial class CodewordGenerator : IPrototype
+{
+    /// <inheritdoc/>
+    [IdDataField]
+    public string ID { get; } = default!;
+
+    /// <summary>
+    /// The adjectives to be used by the generator
+    /// </summary>
+    [DataField]
+    public ProtoId<LocalizedDatasetPrototype> CodewordAdjectives = "Adjectives";
+
+    /// <summary>
+    /// The verbs to be used by the generator
+    /// </summary>
+    [DataField]
+    public ProtoId<LocalizedDatasetPrototype> CodewordVerbs = "Verbs";
+
+    /// <summary>
+    /// How many codewords should be generated?
+    /// </summary>
+    [DataField]
+    public int Amount = 3;
+}

--- a/Content.Server/Codewords/CodewordRuleComponent.cs
+++ b/Content.Server/Codewords/CodewordRuleComponent.cs
@@ -1,0 +1,22 @@
+﻿using Robust.Shared.Prototypes;
+
+namespace Content.Server.Codewords;
+
+/// <summary>
+/// Component that defines <see cref="CodewordGenerator"/> to use and keeps track of generated codewords.
+/// </summary>
+[RegisterComponent, Access(typeof(CodewordSystem))]
+public sealed partial class CodewordRuleComponent : Component
+{
+    /// <summary>
+    /// The generators available.
+    /// </summary>
+    [DataField(required: true)]
+    public Dictionary<ProtoId<CodewordFaction>, ProtoId<CodewordGenerator>> Generators = new();
+
+    /// <summary>
+    /// The generated codewords. The value contains the entity that has the <see cref="CodewordComponent"/>
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public readonly Dictionary<ProtoId<CodewordFaction>, EntityUid> Codewords = new();
+}

--- a/Content.Server/Codewords/CodewordSystem.cs
+++ b/Content.Server/Codewords/CodewordSystem.cs
@@ -1,0 +1,74 @@
+﻿using System.Linq;
+using Content.Server.Administration.Logs;
+using Content.Server.GameTicking.Rules;
+using Content.Shared.Database;
+using Content.Shared.GameTicking.Components;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server.Codewords;
+
+/// <summary>
+/// Gamerule that provides codewords for other gamerules that rely on them.
+/// </summary>
+public sealed class CodewordSystem : GameRuleSystem<CodewordRuleComponent>
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+
+    /// <summary>
+    /// Retrieves codewords for the faction specified.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when no codewords have been generated for that faction.</exception>
+    public string[] GetCodewords(ProtoId<CodewordFaction> faction)
+    {
+        var query = EntityQueryEnumerator<CodewordRuleComponent, GameRuleComponent>();
+        while (query.MoveNext(out var uid, out var codewordRuleComponent, out var gameRuleComponent))
+        {
+            if (!GameTicker.IsGameRuleActive(uid, gameRuleComponent))
+                continue;
+
+            if (!codewordRuleComponent.Codewords.TryGetValue(faction, out var codewordEntity))
+                continue;
+
+            return Comp<CodewordComponent>(codewordEntity).Codewords;
+        }
+
+        throw new InvalidOperationException($"Tried to index codewords for faction {faction}, but no codewords were generated for that faction.");
+    }
+
+    protected override void Added(EntityUid uid, CodewordRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
+    {
+        base.Added(uid, component, gameRule, args);
+
+        foreach (var (id, generatorId) in component.Generators)
+        {
+            var codewords = GenerateCodewords(generatorId);
+            var codewordsContainer = EntityManager.Spawn(protoName:null, MapCoordinates.Nullspace);
+            EnsureComp<CodewordComponent>(codewordsContainer)
+                .Codewords = codewords;
+            component.Codewords[id] = codewordsContainer;
+            _adminLogger.Add(LogType.EventStarted, LogImpact.Low, $"Codewords generated for faction {id}: {string.Join(", ", component.Codewords)}");
+        }
+    }
+
+    /// <summary>
+    /// Generates codewords as specified by the <see cref="CodewordGenerator"/> codeword generator.
+    /// </summary>
+    public string[] GenerateCodewords(ProtoId<CodewordGenerator> generatorId)
+    {
+        var generator = _prototypeManager.Index(generatorId);
+
+        var adjectives = _prototypeManager.Index(generator.CodewordAdjectives).Values;
+        var verbs = _prototypeManager.Index(generator.CodewordVerbs).Values;
+        var codewordPool = adjectives.Concat(verbs).ToList();
+        var finalCodewordCount = Math.Min(generator.Amount, codewordPool.Count);
+        var codewords = new string[finalCodewordCount];
+        for (var i = 0; i < finalCodewordCount; i++)
+        {
+            codewords[i] = Loc.GetString(RobustRandom.PickAndTake(codewordPool));
+        }
+        return codewords;
+    }
+}

--- a/Content.Server/Codewords/CodewordSystem.cs
+++ b/Content.Server/Codewords/CodewordSystem.cs
@@ -49,7 +49,7 @@ public sealed class CodewordSystem : GameRuleSystem<CodewordRuleComponent>
             EnsureComp<CodewordComponent>(codewordsContainer)
                 .Codewords = codewords;
             component.Codewords[id] = codewordsContainer;
-            _adminLogger.Add(LogType.EventStarted, LogImpact.Low, $"Codewords generated for faction {id}: {string.Join(", ", component.Codewords)}");
+            _adminLogger.Add(LogType.EventStarted, LogImpact.Low, $"Codewords generated for faction {id}: {string.Join(", ", codewords)}");
         }
     }
 

--- a/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
@@ -1,6 +1,7 @@
+using Content.Server.Codewords;
 using Content.Shared.Dataset;
 using Content.Shared.FixedPoint;
-﻿using Content.Shared.NPC.Prototypes;
+using Content.Shared.NPC.Prototypes;
 using Content.Shared.Random;
 using Content.Shared.Roles;
 using Robust.Shared.Audio;
@@ -18,16 +19,13 @@ public sealed partial class TraitorRuleComponent : Component
     public ProtoId<AntagPrototype> TraitorPrototypeId = "Traitor";
 
     [DataField]
+    public ProtoId<CodewordFaction> CodewordFactionPrototypeId = "Traitor";
+
+    [DataField]
     public ProtoId<NpcFactionPrototype> NanoTrasenFaction = "NanoTrasen";
 
     [DataField]
     public ProtoId<NpcFactionPrototype> SyndicateFaction = "Syndicate";
-
-    [DataField]
-    public ProtoId<LocalizedDatasetPrototype> CodewordAdjectives = "Adjectives";
-
-    [DataField]
-    public ProtoId<LocalizedDatasetPrototype> CodewordVerbs = "Verbs";
 
     [DataField]
     public ProtoId<LocalizedDatasetPrototype> ObjectiveIssuers = "TraitorCorporations";
@@ -51,7 +49,6 @@ public sealed partial class TraitorRuleComponent : Component
     public bool GiveBriefing = true;
 
     public int TotalTraitors => TraitorMinds.Count;
-    public string[] Codewords = new string[3];
 
     public enum SelectionState
     {
@@ -76,12 +73,6 @@ public sealed partial class TraitorRuleComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier GreetSoundNotification = new SoundPathSpecifier("/Audio/Ambience/Antag/traitor_start.ogg");
-
-    /// <summary>
-    /// The amount of codewords that are selected.
-    /// </summary>
-    [DataField]
-    public int CodewordCount = 4;
 
     /// <summary>
     /// The amount of TC traitors start with.

--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Linq;
 using System.Text;
+using Content.Server.Codewords;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -37,6 +38,7 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
     [Dependency] private readonly SharedRoleCodewordSystem _roleCodewordSystem = default!;
     [Dependency] private readonly SharedRoleSystem _roleSystem = default!;
     [Dependency] private readonly UplinkSystem _uplink = default!;
+    [Dependency] private readonly CodewordSystem _codewordSystem = default!;
 
     public override void Initialize()
     {
@@ -48,41 +50,17 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         SubscribeLocalEvent<TraitorRuleComponent, ObjectivesTextPrependEvent>(OnObjectivesTextPrepend);
     }
 
-    protected override void Added(EntityUid uid, TraitorRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
-    {
-        base.Added(uid, component, gameRule, args);
-        SetCodewords(component, args.RuleEntity);
-    }
-
     private void AfterEntitySelected(Entity<TraitorRuleComponent> ent, ref AfterAntagEntitySelectedEvent args)
     {
         Log.Debug($"AfterAntagEntitySelected {ToPrettyString(ent)}");
         MakeTraitor(args.EntityUid, ent);
     }
 
-    private void SetCodewords(TraitorRuleComponent component, EntityUid ruleEntity)
-    {
-        component.Codewords = GenerateTraitorCodewords(component);
-        _adminLogger.Add(LogType.EventStarted, LogImpact.Low, $"Codewords generated for game rule {ToPrettyString(ruleEntity)}: {string.Join(", ", component.Codewords)}");
-    }
-
-    public string[] GenerateTraitorCodewords(TraitorRuleComponent component)
-    {
-        var adjectives = _prototypeManager.Index(component.CodewordAdjectives).Values;
-        var verbs = _prototypeManager.Index(component.CodewordVerbs).Values;
-        var codewordPool = adjectives.Concat(verbs).ToList();
-        var finalCodewordCount = Math.Min(component.CodewordCount, codewordPool.Count);
-        string[] codewords = new string[finalCodewordCount];
-        for (var i = 0; i < finalCodewordCount; i++)
-        {
-            codewords[i] = Loc.GetString(_random.PickAndTake(codewordPool));
-        }
-        return codewords;
-    }
-
     public bool MakeTraitor(EntityUid traitor, TraitorRuleComponent component)
     {
         Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - start");
+
+        var factionCodewords = _codewordSystem.GetCodewords(component.CodewordFactionPrototypeId);
 
         //Grab the mind if it wasn't provided
         if (!_mindSystem.TryGetMind(traitor, out var mindId, out var mind))
@@ -96,7 +74,7 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         if (component.GiveCodewords)
         {
             Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - added codewords flufftext to briefing");
-            briefing = Loc.GetString("traitor-role-codewords-short", ("codewords", string.Join(", ", component.Codewords)));
+            briefing = Loc.GetString("traitor-role-codewords-short", ("codewords", string.Join(", ", factionCodewords)));
         }
 
         var issuer = _random.Pick(_prototypeManager.Index(component.ObjectiveIssuers));
@@ -129,7 +107,7 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         if (component.GiveCodewords)
         {
             Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - set codewords from component");
-            codewords = component.Codewords;
+            codewords = factionCodewords;
         }
 
         if (component.GiveBriefing)
@@ -161,7 +139,7 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         var color = TraitorCodewordColor; // Fall back to a dark red Syndicate color if a prototype is not found
 
         RoleCodewordComponent codewordComp = EnsureComp<RoleCodewordComponent>(mindId);
-        _roleCodewordSystem.SetRoleCodewords(codewordComp, "traitor", component.Codewords.ToList(), color);
+        _roleCodewordSystem.SetRoleCodewords(codewordComp, "traitor", factionCodewords.ToList(), color);
 
         // Change the faction
         Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - Change faction");
@@ -211,7 +189,7 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
     private void OnObjectivesTextPrepend(EntityUid uid, TraitorRuleComponent comp, ref ObjectivesTextPrependEvent args)
     {
         if(comp.GiveCodewords)
-            args.Text += "\n" + Loc.GetString("traitor-round-end-codewords", ("codewords", string.Join(", ", comp.Codewords)));
+            args.Text += "\n" + Loc.GetString("traitor-round-end-codewords", ("codewords", string.Join(", ", _codewordSystem.GetCodewords(comp.CodewordFactionPrototypeId))));
     }
 
     // TODO: figure out how to handle this? add priority to briefing event?

--- a/Content.Server/Traitor/Components/TraitorCodePaperComponent.cs
+++ b/Content.Server/Traitor/Components/TraitorCodePaperComponent.cs
@@ -1,3 +1,6 @@
+using Content.Server.Codewords;
+using Robust.Shared.Prototypes;
+
 namespace Content.Server.Traitor.Components;
 
 /// <summary>
@@ -6,6 +9,18 @@ namespace Content.Server.Traitor.Components;
 [RegisterComponent]
 public sealed partial class TraitorCodePaperComponent : Component
 {
+    /// <summary>
+    /// The faction to get codewords for.
+    /// </summary>
+    [DataField]
+    public ProtoId<CodewordFaction> CodewordFaction = "Traitor";
+
+    /// <summary>
+    /// The generator to use for the fake words.
+    /// </summary>
+    [DataField]
+    public ProtoId<CodewordGenerator> CodewordGenerator = "TraitorCodewordGenerator";
+
     /// <summary>
     /// The number of codewords that should be generated on this paper.
     /// Will not extend past the max number of available codewords.

--- a/Content.Server/Traitor/Systems/TraitorCodePaperSystem.cs
+++ b/Content.Server/Traitor/Systems/TraitorCodePaperSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.Traitor.Components;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using System.Linq;
+using Content.Server.Codewords;
 using Content.Shared.Paper;
 
 namespace Content.Server.Traitor.Systems;
@@ -17,6 +18,7 @@ public sealed class TraitorCodePaperSystem : EntitySystem
     [Dependency] private readonly TraitorRuleSystem _traitorRuleSystem = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly PaperSystem _paper = default!;
+    [Dependency] private readonly CodewordSystem _codewordSystem = default!;
 
     public override void Initialize()
     {
@@ -48,7 +50,7 @@ public sealed class TraitorCodePaperSystem : EntitySystem
         traitorCode = null;
 
         var codesMessage = new FormattedMessage();
-        List<string> codeList = new();
+        var codeList = _codewordSystem.GetCodewords(component.CodewordFaction).ToList();
         // Find the first nuke that matches the passed location.
         if (_gameTicker.IsGameRuleAdded<TraitorRuleComponent>())
         {
@@ -57,14 +59,13 @@ public sealed class TraitorCodePaperSystem : EntitySystem
             {
                 if (TryComp(ruleEnt, out TraitorRuleComponent? traitorComp))
                 {
-                    codeList.AddRange(traitorComp.Codewords.ToList());
                 }
             }
         }
         if (codeList.Count == 0)
         {
             if (component.FakeCodewords)
-                codeList = _traitorRuleSystem.GenerateTraitorCodewords(new TraitorRuleComponent()).ToList();
+                codeList = _codewordSystem.GenerateCodewords(component.CodewordGenerator).ToList();
             else
                 codeList = [Loc.GetString("traitor-codes-none")];
         }

--- a/Content.Server/Traitor/Systems/TraitorCodePaperSystem.cs
+++ b/Content.Server/Traitor/Systems/TraitorCodePaperSystem.cs
@@ -51,17 +51,7 @@ public sealed class TraitorCodePaperSystem : EntitySystem
 
         var codesMessage = new FormattedMessage();
         var codeList = _codewordSystem.GetCodewords(component.CodewordFaction).ToList();
-        // Find the first nuke that matches the passed location.
-        if (_gameTicker.IsGameRuleAdded<TraitorRuleComponent>())
-        {
-            var ruleEnts = _gameTicker.GetAddedGameRules();
-            foreach (var ruleEnt in ruleEnts)
-            {
-                if (TryComp(ruleEnt, out TraitorRuleComponent? traitorComp))
-                {
-                }
-            }
-        }
+
         if (codeList.Count == 0)
         {
             if (component.FakeCodewords)

--- a/Resources/Prototypes/Codewords/codeword_factions.yml
+++ b/Resources/Prototypes/Codewords/codeword_factions.yml
@@ -1,0 +1,2 @@
+﻿- type: codewordFaction
+  id: Traitor

--- a/Resources/Prototypes/Codewords/codeword_generators.yml
+++ b/Resources/Prototypes/Codewords/codeword_generators.yml
@@ -1,0 +1,5 @@
+﻿- type: codewordGenerator
+  id: TraitorCodewordGenerator
+  codewordAdjectives: Adjectives
+  codewordVerbs: Verbs
+  amount: 4

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -449,3 +449,11 @@
       prob: 0.90
     - id: SolarPanelDamageVariationPass
     - id: SolarPanelEmptyVariationPass
+
+- type: entity
+  parent: BaseGameRule
+  id: CodewordRule
+  components:
+  - type: CodewordRule
+    generators:
+      Traitor: TraitorCodewordGenerator

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -6,6 +6,7 @@
   showInVote: false # secret
   description: survival-description
   rules:
+    - CodewordRule
     - MeteorSwarmScheduler
     - RampingStationEventScheduler
     - SpaceTrafficControlEventScheduler
@@ -22,6 +23,7 @@
   showInVote: false # secret
   description: kessler-syndrome-description
   rules:
+    - CodewordRule
     - KesslerSyndromeScheduler
     - RampingStationEventScheduler
     - SpaceTrafficControlEventScheduler
@@ -35,6 +37,7 @@
   description: all-at-once-description
   showInVote: false
   rules:
+    - CodewordRule
     - Nukeops
     - Traitor
     - Revolutionary
@@ -56,6 +59,7 @@
   description: aller-at-once-description
   showInVote: false #Please god dont do this
   rules:
+    - CodewordRule
     - Nukeops
     - Traitor
     - Revolutionary
@@ -79,6 +83,7 @@
   showInVote: false #2boring2vote
   description: extended-description
   rules:
+  - CodewordRule
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -93,6 +98,7 @@
   showInVote: false #4boring4vote
   description: greenshift-description
   rules:
+  - CodewordRule
   - SpaceTrafficControlFriendlyEventScheduler
   - BasicRoundstartVariation
 
@@ -105,6 +111,7 @@
   showInVote: true
   description: secret-description
   rules:
+    - CodewordRule
     - Secret
 
 - type: gamePreset
@@ -115,6 +122,7 @@
   showInVote: false #Admin Use
   description: secret-description
   rules:
+    - CodewordRule
     - BasicStationEventScheduler
     - MeteorSwarmScheduler
     - SpaceTrafficControlEventScheduler
@@ -128,6 +136,7 @@
   showInVote: false #Admin Use
   description: secret-description
   rules:
+  - CodewordRule
   - SpaceTrafficControlFriendlyEventScheduler
   - BasicRoundstartVariation
 
@@ -140,6 +149,7 @@
   showInVote: false # Not suitable for use without admin intervention, since entity spamming can quickly crash a server
   maxPlayers: 5
   rules:
+    - CodewordRule
     - Sandbox
 
 - type: gamePreset
@@ -151,6 +161,7 @@
   description: traitor-description
   showInVote: false
   rules:
+  - CodewordRule
   - DummyNonAntagChance
   - Traitor
   - SubGamemodesRule
@@ -180,6 +191,7 @@
   description: nukeops-description
   showInVote: false
   rules:
+  - CodewordRule
   - Nukeops
   - DummyNonAntagChance
   - SubGamemodesRule
@@ -198,6 +210,7 @@
   description: rev-description
   showInVote: false
   rules:
+  - CodewordRule
   - DummyNonAntagChance
   - Revolutionary
   - SubGamemodesRule
@@ -214,6 +227,7 @@
   description: wizard-description
   showInVote: false
   rules:
+  - CodewordRule
   - Wizard
   - DummyNonAntagChance
   - SubGamemodesRuleNoWizard #No Dual Wizards at the start, midround is fine
@@ -234,6 +248,7 @@
   description: zombie-description
   showInVote: false
   rules:
+  - CodewordRule
   - Zombie
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
@@ -250,6 +265,7 @@
   description: zombieteors-description
   showInVote: false
   rules:
+  - CodewordRule
   - Zombie
   - BasicStationEventScheduler
   - KesslerSyndromeScheduler


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR splits codewords into its own system for general use in more than just traitors. It also fixes the issue where sleeper agents have different codewords than the round start traitors. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #29876

Codewords being baked into the Traitor system was also bad code design.

## Technical details
<!-- Summary of code changes for easier review. -->
Created 2 new prototypes: `CodewordGenerator` and `CodewordFaction`.
`CodewordGenerator` is responsible for defining what dataset to use and how many codewords to generate.
`CodewordFaction` is a simple identifier for different sets of codewords. I used this instead of a magic const because magic const values are generally not good.

For generating the codewords I added a gamerule `CodewordSystem`.
This gamerule (once added, it should always be added before any codewords are requested) takes the Dictionary of `<CodewordFaction, CodewordGenerator>` given in the rule component and uses it to generate the codewords as specified in the `CodewordGenerator`. The codewords are stored in a nullspaced entity containing the `CodewordComponent` which has the array of codewords. A referenece to the EntityUid is kept in the rule component.

Retrieving codewords is done by calling `CodewordSystem::GetCodewords(ProtoId<CodewordFaction>)` . This method will search all codeword gamerules for the requested faction. If no codewords are found for this faction, the method throws an error.

Some small changes had to be made to `TraitorCodePaperSystem` to ensure it still works with the central codeword system.

For `game_presets.yml` I had to add the gamerule at the first position always, even in modes that do not call for codewords, in case an admin adds traitors midround. I am unsure if there is a better way to do this.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
Round Start Traitor:
![image](https://github.com/user-attachments/assets/01a0c615-ec88-42c0-9f85-058bd8ca3118)
Sleeper Agent:
![image](https://github.com/user-attachments/assets/115cc187-76a7-4587-8b82-a1dbe1f04399)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Simyon
- fix: Sleeper agents no longer have different codewords than round-start traitors.