### PR TITLE
Make `TryGetWires<T>` actually work.

### DIFF
--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -579,14 +579,14 @@ public sealed class WiresSystem : SharedWiresSystem
     ///     Tries to get all the wires on this entity by the wire action type.
     /// </summary>
     /// <returns>Enumerator of all wires in this entity according to the given type.</returns>
-    public IEnumerable<Wire> TryGetWires<T>(EntityUid uid, WiresComponent? wires = null)
+    public IEnumerable<Wire> TryGetWires<T>(EntityUid uid, WiresComponent? wires = null) where T: IWireAction
     {
         if (!Resolve(uid, ref wires))
             yield break;
 
         foreach (var wire in wires.WiresList)
         {
-            if (wire.GetType() == typeof(T))
+            if (wire.Action?.GetType() == typeof(T))
             {
                 yield return wire;
             }


### PR DESCRIPTION
## About the PR

Fixes the function `WiresSystem.TryGetWires<T>(...)`

## Why / Balance

fix

## Technical details

It's two lines, just restrict T and actually compare to the action type

## Media

nada

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
d

## Breaking changes

negative, this function isn't even used anywhere currently, but I'm using it for integration tests in future PRs

**Changelog**

nope
