### PR TITLE
Allow cargo request computers to send orders to the primary account

### DIFF
--- a/Content.Client/Cargo/UI/CargoConsoleMenu.xaml.cs
+++ b/Content.Client/Cargo/UI/CargoConsoleMenu.xaml.cs
@@ -203,6 +203,9 @@ namespace Content.Client.Cargo.UI
         /// </summary>
         public void PopulateOrders(IEnumerable<CargoOrderData> orders)
         {
+            if (!_orderConsoleQuery.TryComp(_owner, out var orderConsole))
+                return;
+
             Requests.DisposeAllChildren();
 
             foreach (var order in orders)
@@ -237,6 +240,7 @@ namespace Content.Client.Cargo.UI
                 row.Cancel.OnPressed += (args) => { OnOrderCanceled?.Invoke(args); };
 
                 // TODO: Disable based on access.
+                row.SetApproveVisible(orderConsole.Mode != CargoOrderConsoleMode.SendToPrimary);
                 row.Approve.OnPressed += (args) => { OnOrderApproved?.Invoke(args); };
                 Requests.AddChild(row);
             }
@@ -290,8 +294,8 @@ namespace Content.Client.Cargo.UI
                                            TransferSpinBox.Value > bankAccount.Accounts[orderConsole.Account] * orderConsole.TransferLimit ||
                                            _timing.CurTime < orderConsole.NextAccountActionTime;
 
-            OrdersSpacer.Visible = !orderConsole.SlipPrinter;
-            Orders.Visible = !orderConsole.SlipPrinter;
+            OrdersSpacer.Visible = orderConsole.Mode != CargoOrderConsoleMode.PrintSlip;
+            Orders.Visible = orderConsole.Mode != CargoOrderConsoleMode.PrintSlip;
         }
     }
 }

--- a/Content.Client/Cargo/UI/CargoOrderRow.xaml.cs
+++ b/Content.Client/Cargo/UI/CargoOrderRow.xaml.cs
@@ -14,5 +14,15 @@ namespace Content.Client.Cargo.UI
         {
             RobustXamlLoader.Load(this);
         }
+
+        public void SetApproveVisible(bool visible)
+        {
+            Approve.Visible = visible;
+
+            if (visible)
+                Cancel.AddStyleClass("OpenLeft");
+            else
+                Cancel.RemoveStyleClass("OpenLeft");
+        }
     }
 }

--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -100,7 +100,7 @@ namespace Content.Server.Cargo.Systems
             {
                 OnInteractUsingCash(uid, component, ref args);
             }
-            else if (TryComp<CargoSlipComponent>(args.Used, out var slip) && !component.SlipPrinter)
+            else if (TryComp<CargoSlipComponent>(args.Used, out var slip) && component.Mode == CargoOrderConsoleMode.DirectOrder)
             {
                 OnInteractUsingSlip((uid, component), ref args, slip);
             }
@@ -144,7 +144,7 @@ namespace Content.Server.Cargo.Systems
             if (args.Actor is not { Valid: true } player)
                 return;
 
-            if (component.SlipPrinter)
+            if (component.Mode != CargoOrderConsoleMode.DirectOrder)
                 return;
 
             if (!_accessReaderSystem.IsAllowed(player, uid))
@@ -181,7 +181,7 @@ namespace Content.Server.Cargo.Systems
                 return;
             }
 
-            var amount = GetOutstandingOrderCount(orderDatabase, order.Account);
+            var amount = GetOutstandingOrderCount((station.Value, orderDatabase), order.Account);
             var capacity = orderDatabase.Capacity;
 
             // Too many orders, avoid them getting spammed in the UI.
@@ -312,7 +312,7 @@ namespace Content.Server.Cargo.Systems
         {
             var station = _station.GetOwningStation(uid);
 
-            if (component.SlipPrinter)
+            if (component.Mode != CargoOrderConsoleMode.DirectOrder)
                 return;
 
             if (!TryGetOrderDatabase(station, out var orderDatabase))
@@ -367,6 +367,9 @@ namespace Content.Server.Cargo.Systems
             if (!TryGetOrderDatabase(stationUid, out var orderDatabase))
                 return;
 
+            if (!TryComp<StationBankAccountComponent>(stationUid, out var bank))
+                return;
+
             if (!_protoMan.TryIndex<CargoProductPrototype>(args.CargoProductId, out var product))
             {
                 Log.Error($"Tried to add invalid cargo product {args.CargoProductId} as order!");
@@ -376,15 +379,17 @@ namespace Content.Server.Cargo.Systems
             if (!GetAvailableProducts((uid, component)).Contains(args.CargoProductId))
                 return;
 
-            if (component.SlipPrinter)
+            if (component.Mode == CargoOrderConsoleMode.PrintSlip)
             {
                 OnAddOrderMessageSlipPrinter(uid, component, args, product);
                 return;
             }
 
+            var targetAccount = component.Mode == CargoOrderConsoleMode.SendToPrimary ? bank.PrimaryAccount : component.Account;
+
             var data = GetOrderData(args, product, GenerateOrderId(orderDatabase), component.Account);
 
-            if (!TryAddOrder(stationUid.Value, component.Account, data, orderDatabase))
+            if (!TryAddOrder(stationUid.Value, targetAccount, data, orderDatabase))
             {
                 PlayDenySound(uid, component);
                 return;
@@ -419,13 +424,31 @@ namespace Content.Server.Cargo.Systems
                     CargoConsoleUiKey.Orders,
                     new CargoConsoleInterfaceState(
                     MetaData(station.Value).EntityName,
-                    GetOutstandingOrderCount(orderDatabase, console.Account),
+                    GetOutstandingOrderCount((station!.Value, orderDatabase), console.Account),
                     orderDatabase.Capacity,
                     GetNetEntity(station.Value),
-                    orderDatabase.Orders[console.Account],
+                    RelevantOrders((station!.Value, orderDatabase), (consoleUid, console)),
                     GetAvailableProducts((consoleUid, console))
                 ));
             }
+        }
+
+        /// <summary>
+        /// Gets orders relevant to this account, i.e. orders on the account directly or orders on behalf of the account in the primary account.
+        /// </summary>
+        private List<CargoOrderData> RelevantOrders(Entity<StationCargoOrderDatabaseComponent> station, Entity<CargoOrderConsoleComponent> console)
+        {
+            if (!TryComp<StationBankAccountComponent>(station, out var bank))
+                return [];
+
+            var ourOrders = station.Comp.Orders[console.Comp.Account];
+
+            if (console.Comp.Account == bank.PrimaryAccount)
+                return ourOrders;
+
+            var otherOrders = station.Comp.Orders[bank.PrimaryAccount].Where(order => order.Account == console.Comp.Account);
+
+            return ourOrders.Concat(otherOrders).ToList();
         }
 
         private void ConsolePopup(EntityUid actor, string text)
@@ -447,12 +470,27 @@ namespace Content.Server.Cargo.Systems
             return new CargoOrderData(id, cargoProduct.Product, cargoProduct.Name, cargoProduct.Cost, args.Amount, args.Requester, args.Reason, account);
         }
 
-        public static int GetOutstandingOrderCount(StationCargoOrderDatabaseComponent component, ProtoId<CargoAccountPrototype> account)
+        public int GetOutstandingOrderCount(Entity<StationCargoOrderDatabaseComponent> station, ProtoId<CargoAccountPrototype> account)
         {
             var amount = 0;
 
-            foreach (var order in component.Orders[account])
+            if (!TryComp<StationBankAccountComponent>(station, out var bank))
+                return amount;
+
+            foreach (var order in station.Comp.Orders[account])
             {
+                if (!order.Approved)
+                    continue;
+                amount += order.OrderQuantity - order.NumDispatched;
+            }
+
+            if (account == bank.PrimaryAccount)
+                return amount;
+
+            foreach (var order in station.Comp.Orders[bank.PrimaryAccount])
+            {
+                if (order.Account != account)
+                    continue;
                 if (!order.Approved)
                     continue;
                 amount += order.OrderQuantity - order.NumDispatched;

--- a/Content.Server/StationEvents/Events/CargoGiftsRule.cs
+++ b/Content.Server/StationEvents/Events/CargoGiftsRule.cs
@@ -53,7 +53,7 @@ public sealed class CargoGiftsRule : StationEventSystem<CargoGiftsRuleComponent>
         }
 
         // Add some presents
-        var outstanding = CargoSystem.GetOutstandingOrderCount(cargoDb, component.Account);
+        var outstanding = _cargoSystem.GetOutstandingOrderCount((station.Value, cargoDb), component.Account);
         while (outstanding < cargoDb.Capacity - component.OrderSpaceToLeave && component.Gifts.Count > 0)
         {
             // I wish there was a nice way to pop this

--- a/Content.Shared/Cargo/Components/CargoOrderConsoleComponent.cs
+++ b/Content.Shared/Cargo/Components/CargoOrderConsoleComponent.cs
@@ -104,10 +104,10 @@ public sealed partial class CargoOrderConsoleComponent : Component
     public static readonly ProtoId<RadioChannelPrototype> BaseAnnouncementChannel = "Supply";
 
     /// <summary>
-    /// If set to true, restricts this console from ordering and has it print slips instead
+    /// The behaviour of the cargo console regarding orders
     /// </summary>
     [DataField]
-    public bool SlipPrinter;
+    public CargoOrderConsoleMode Mode = CargoOrderConsoleMode.DirectOrder;
 
     /// <summary>
     /// The time at which the console will be able to print a slip again.
@@ -144,6 +144,26 @@ public sealed partial class CargoOrderConsoleComponent : Component
     /// </summary>
     [DataField]
     public TimeSpan DenySoundDelay = TimeSpan.FromSeconds(2);
+}
+
+/// <summary>
+/// The behaviour of the cargo order console
+/// </summary>
+[Serializable, NetSerializable]
+public enum CargoOrderConsoleMode : byte
+{
+    /// <summary>
+    /// Place orders directly
+    /// </summary>
+    DirectOrder,
+    /// <summary>
+    /// Print a slip to be inserted into a DirectOrder console
+    /// </summary>
+    PrintSlip,
+    /// <summary>
+    /// Transfers the order to the primary account
+    /// </summary>
+    SendToPrimary,
 }
 
 /// <summary>

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -931,7 +931,7 @@
     account: Engineering
     announcementChannel: Engineering
     removeLimitAccess: [ "ChiefEngineer" ]
-    slipPrinter: true
+    mode: SendToPrimary
   - type: ActiveRadio
     channels:
     - Engineering
@@ -964,7 +964,7 @@
     account: Medical
     announcementChannel: Medical
     removeLimitAccess: [ "ChiefMedicalOfficer" ]
-    slipPrinter: true
+    mode: SendToPrimary
   - type: ActiveRadio
     channels:
     - Medical
@@ -997,7 +997,7 @@
     account: Science
     announcementChannel: Science
     removeLimitAccess: [ "ResearchDirector" ]
-    slipPrinter: true
+    mode: SendToPrimary
   - type: ActiveRadio
     channels:
     - Science
@@ -1030,7 +1030,7 @@
     account: Security
     announcementChannel: Security
     removeLimitAccess: [ "HeadOfSecurity" ]
-    slipPrinter: true
+    mode: SendToPrimary
   - type: ActiveRadio
     channels:
     - Security
@@ -1063,7 +1063,7 @@
     account: Service
     announcementChannel: Service
     removeLimitAccess: [ "HeadOfPersonnel" ]
-    slipPrinter: true
+    mode: SendToPrimary
   - type: ActiveRadio
     channels:
     - Service


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This adds a third mode of operation for cargo request computers, Send To Primary.

## Why / Balance
- Cargo having a say in orders is desirable i.e. "we have 500 steel from salvagers, don't waste your money on that and let us deliver you some materials"
- People not having to walk up to Cargo to place an order is desirable
- Conclusion: Allow people to place orders in their department's request computers, but still give Cargo the final say.

## Technical details
- replace `SlipPrinter` with `Mode` because I couldn't figure out an elegant way to handle mutually incompatible behaviour between being a slip printer and being an order console that sends to primary
- hide Approve button on non-DirectOrder consoles on the client side
- change order enumeration + counting to consider orders on behalf of the account present in the primary account

## Media
![grafik](https://github.com/user-attachments/assets/43e8882f-02be-408f-88ed-9a60c3f6a0c3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- `CargoOrderConsoleComponent#SlipPrinter` has been replaced with `CargoOrderConsoleComponent#Mode` that specifies console behavior. Specify `DirectOrder` for `false`, `PrintSlip` for `true`, or `SendToPrimary` to match existing non-Cargo request computers and use the new behaviour.
- `CargoSystem#GetOutstandingOrderCount` is no longer static and expects to be passed an `Entity<StationCargoOrderDatabaseComponent>` and not just the plain component.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Departmental request computers now send their orders directly to Cargo, instead of requiring paper slips be brought to Cargo for insertion
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
