### PR TITLE
Show TEG theoretical supply on inspect

### DIFF
--- a/Content.Server/Power/Generation/Teg/TegSystem.cs
+++ b/Content.Server/Power/Generation/Teg/TegSystem.cs
@@ -1,10 +1,7 @@
-﻿using Content.Server.Atmos;
-using Content.Server.Atmos.EntitySystems;
+﻿using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
 using Content.Server.Audio;
-using Content.Server.DeviceNetwork;
 using Content.Server.DeviceNetwork.Systems;
-using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.Power.Components;
 using Content.Shared.Atmos;
@@ -17,7 +14,6 @@ using Content.Shared.Power.EntitySystems;
 using Content.Shared.Power.Generation.Teg;
 using Content.Shared.Rounding;
 using Robust.Server.GameObjects;
-using Robust.Shared.Utility;
 
 namespace Content.Server.Power.Generation.Teg;
 
@@ -101,7 +97,12 @@ public sealed class TegSystem : EntitySystem
         else
         {
             var supplier = Comp<PowerSupplierComponent>(uid);
-            args.PushMarkup(Loc.GetString("teg-generator-examine-power", ("power", supplier.CurrentSupply)));
+
+            using (args.PushGroup(nameof(TegGeneratorComponent)))
+            {
+                args.PushMarkup(Loc.GetString("teg-generator-examine-power", ("power", supplier.CurrentSupply)));
+                args.PushMarkup(Loc.GetString("teg-generator-examine-power-max-output", ("power", supplier.MaxSupply)));
+            }
         }
     }
 
@@ -161,7 +162,7 @@ public sealed class TegSystem : EntitySystem
             // Reduce efficiency at low temperature differences to encourage burn chambers (instead
             // of just feeding the TEG room temperature gas from an infinite gas miner).
             var dT = Thot - Tcold;
-            N *= MathF.Tanh(dT/700); // https://www.wolframalpha.com/input?i=tanh(x/700)+from+0+to+1000
+            N *= MathF.Tanh(dT / 700); // https://www.wolframalpha.com/input?i=tanh(x/700)+from+0+to+1000
 
             var transfer = Wmax * N;
             electricalEnergy = transfer * component.PowerFactor;
@@ -297,7 +298,9 @@ public sealed class TegSystem : EntitySystem
         if (_pointLight.TryGetLight(ent, out var pointLight))
         {
             _pointLight.SetEnabled(ent, powered, pointLight);
-            _pointLight.SetColor(ent, speed == TegCirculatorSpeed.SpeedFast ? circ.LightColorFast : circ.LightColorSlow, pointLight);
+            _pointLight.SetColor(ent,
+                speed == TegCirculatorSpeed.SpeedFast ? circ.LightColorFast : circ.LightColorSlow,
+                pointLight);
         }
     }
 
@@ -357,8 +360,8 @@ public sealed class TegSystem : EntitySystem
     private (PipeNode inlet, PipeNode outlet) GetPipes(EntityUid uidCirculator)
     {
         var nodeContainer = _nodeContainerQuery.GetComponent(uidCirculator);
-        var inlet = (PipeNode) nodeContainer.Nodes[NodeNameInlet];
-        var outlet = (PipeNode) nodeContainer.Nodes[NodeNameOutlet];
+        var inlet = (PipeNode)nodeContainer.Nodes[NodeNameInlet];
+        var outlet = (PipeNode)nodeContainer.Nodes[NodeNameOutlet];
 
         return (inlet, outlet);
     }

--- a/Resources/Locale/en-US/power/teg.ftl
+++ b/Resources/Locale/en-US/power/teg.ftl
@@ -1,2 +1,3 @@
-﻿teg-generator-examine-power = It's generating [color=yellow]{ POWERWATTS($power) }[/color].
+﻿teg-generator-examine-power = It's currently supplying [color=yellow]{ POWERWATTS($power) }[/color].
+teg-generator-examine-power-max-output = It's capable of supplying [color=yellow]{ POWERWATTS($power) }[/color].
 teg-generator-examine-connection = To function, a [color=white]circulator[/color] must be attached on both sides.


### PR DESCRIPTION
## About the PR
Presents TEG theoretical power supply information alongside its current power supply on inspect.

## Why / Balance
This helps lower the bar for performing "grid matching", a practice where engineers throttle the TEG's working gas flow rate in order to match the TEG's theoretical power production to the current demand of the station. This saves fuel, and if you're doing manual burn chamber refills and relights, this reduces how often you'll do them.

Previously it was not super intuitive to do this: you had to isolate the TEG from the grid in order to multitool the HV net to get the TEG's theoretical supply information. If you didn't do this, you would likely get other information (from an active engine or otherwise) mixed in.

This just brings it into the inspect, allowing engineers to look at it real easy and just power accordingly.

This is a temporary measure until the TEG is reworked (see #37902), as it'll probably get a UI (or the sensor monitoring console might get some love? I'd have to see how I feel about it).

## Technical details
We just use PushGroup to push info on the TEG's current max supply.

Sorry for the import cleanup, Rider just does this. I can revert if necessary.

## Media
![Content Client_Kh3EH6g4Tp](https://github.com/user-attachments/assets/41afa2ce-ee2a-4cce-9ef6-b6958dfe5f06)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: The TEG now shows its capable peak power output on inspect, making it easier for engineers to match the TEG's power output with the current grid demand (to save fuel!).