### PR TITLE
Allow actions to specify if they want to rotate the user when targeting

### DIFF
--- a/Content.Shared/Actions/Components/EntityTargetActionComponent.cs
+++ b/Content.Shared/Actions/Components/EntityTargetActionComponent.cs
@@ -1,5 +1,4 @@
-using Content.Shared.Actions;
-﻿using Content.Shared.Whitelist;
+using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
@@ -45,4 +44,10 @@ public sealed partial class EntityTargetActionComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool CanTargetSelf = true;
+
+    /// <summary>
+    /// Whether to make the user face towards the direction where they targeted this action.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool RotateOnUse = true;
 }

--- a/Content.Shared/Actions/Components/WorldTargetActionComponent.cs
+++ b/Content.Shared/Actions/Components/WorldTargetActionComponent.cs
@@ -1,5 +1,4 @@
-using Content.Shared.Actions;
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Actions.Components;
@@ -13,6 +12,7 @@ namespace Content.Shared.Actions.Components;
 /// </remarks>
 [RegisterComponent, NetworkedComponent, Access(typeof(SharedActionsSystem))]
 [EntityCategory("Actions")]
+[AutoGenerateComponentState]
 public sealed partial class WorldTargetActionComponent : Component
 {
     /// <summary>
@@ -20,4 +20,10 @@ public sealed partial class WorldTargetActionComponent : Component
     /// </summary>
     [DataField(required: true), NonSerialized]
     public WorldTargetActionEvent? Event;
+
+    /// <summary>
+    /// Whether to make the user face towards the direction where they targeted this action.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool RotateOnUse = true;
 }

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions.Components;
 using Content.Shared.Actions.Events;
@@ -607,7 +608,7 @@ public abstract class SharedActionsSystem : EntitySystem
         return AddAction(performer, ref actionId, out _, actionPrototypeId, container, component);
     }
 
-    /// <inheritdoc cref="AddAction(Robust.Shared.GameObjects.EntityUid,ref System.Nullable{Robust.Shared.GameObjects.EntityUid},string?,Robust.Shared.GameObjects.EntityUid,Content.Shared.Actions.ActionsComponent?)"/>
+    /// <inheritdoc cref="AddAction(Robust.Shared.GameObjects.EntityUid,ref System.Nullable{Robust.Shared.GameObjects.EntityUid},string?,Robust.Shared.GameObjects.EntityUid,ActionsComponent?)"/>
     public bool AddAction(EntityUid performer,
         [NotNullWhen(true)] ref EntityUid? actionId,
         [NotNullWhen(true)] out ActionComponent? action,

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions.Components;
 using Content.Shared.Actions.Events;
@@ -348,7 +347,9 @@ public abstract class SharedActionsSystem : EntitySystem
         var target = GetEntity(netTarget);
 
         var targetWorldPos = _transform.GetWorldPosition(target);
-        _rotateToFace.TryFaceCoordinates(user, targetWorldPos);
+
+        if (ent.Comp.RotateOnUse)
+            _rotateToFace.TryFaceCoordinates(user, targetWorldPos);
 
         if (!ValidateEntityTarget(user, target, ent))
             return;
@@ -369,7 +370,9 @@ public abstract class SharedActionsSystem : EntitySystem
 
         var user = args.User;
         var target = GetCoordinates(netTarget);
-        _rotateToFace.TryFaceCoordinates(user, target.ToMapPos(EntityManager, _transform));
+
+        if (ent.Comp.RotateOnUse)
+            _rotateToFace.TryFaceCoordinates(user, _transform.ToMapCoordinates(target).Position);
 
         if (!ValidateWorldTarget(user, target, ent))
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a boolean field RotateOnUse to both EntityTargetActionComponent and WorldTargetActionComponent

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
RMC-14 charger crusher uses this for example for an action that lets you dash but only to the sides

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/ff0a087e-fd68-4b14-b789-6cd6405026d8


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

