### PR TITLE
Chameleon Projector Physics Fix

### DIFF
--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -9,6 +9,7 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Physics;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -57,6 +58,7 @@ namespace Content.Shared.Movement.Systems
             SubscribeLocalEvent<InputMoverComponent, ComponentGetState>(OnMoverGetState);
             SubscribeLocalEvent<InputMoverComponent, ComponentHandleState>(OnMoverHandleState);
             SubscribeLocalEvent<InputMoverComponent, EntParentChangedMessage>(OnInputParentChange);
+            SubscribeLocalEvent<InputMoverComponent, AnchorStateChangedEvent>(OnAnchorState);
 
             SubscribeLocalEvent<FollowedComponent, EntParentChangedMessage>(OnFollowedParentChange);
 
@@ -294,6 +296,12 @@ namespace Content.Shared.Movement.Systems
 
             entity.Comp.LerpTarget = TimeSpan.FromSeconds(InputMoverComponent.LerpTime) + Timing.CurTime;
             Dirty(entity.Owner, entity.Comp);
+        }
+
+        private void OnAnchorState(Entity<InputMoverComponent> entity, ref AnchorStateChangedEvent args)
+        {
+            if (!args.Anchored)
+                PhysicsSystem.SetBodyType(entity, BodyType.KinematicController);
         }
 
         private void HandleDirChange(EntityUid entity, Direction dir, ushort subTick, bool state)

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -92,7 +92,6 @@ public abstract partial class SharedMoverController : VirtualController
         MapQuery = GetEntityQuery<MapComponent>();
 
         SubscribeLocalEvent<MovementSpeedModifierComponent, TileFrictionEvent>(OnTileFriction);
-        SubscribeLocalEvent<InputMoverComponent, AnchorStateChangedEvent>(OnAnchorState);
 
         InitializeInput();
         InitializeRelay();
@@ -626,11 +625,5 @@ public abstract partial class SharedMoverController : VirtualController
             args.Modifier *= ent.Comp.BaseWeightlessFriction;
         else
             args.Modifier *= ent.Comp.BaseFriction;
-    }
-
-    private void OnAnchorState(Entity<InputMoverComponent> entity, ref AnchorStateChangedEvent args)
-    {
-        if (!args.Anchored)
-            PhysicsSystem.SetBodyType(entity, BodyType.KinematicController);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed Chameleon Projector changing a player's BodyType from KinematicController to Dynamic upon anchoring and unanchoring while disguised.

Fixes: #37956

## Why / Balance
Lead to some physics issues involving speed and acceleration due and could easily lead to more in the right circumstances.

I chose this approach since it covers a lot more bases since there are other systems which unanchor and anchor entities and having handlers for players inside all of them would be inefficient. 

This approach helps with: #37955 by forcing KinematicController on entities that should always be KinematicControllers

## Technical details
Added a Subscriber for the InputMoverComponent to the SharedMoverController to override the setting of BodyType in Unanchoring to be Kinematic Controller instead of Dynamic.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Chameleon Projector will no longer cause you to be permanently slowed down

