### PR TITLE
You now can only change chameleon clothing with an implant

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
@@ -122,7 +122,13 @@ public abstract class SharedChameleonClothingSystem : EntitySystem
 
     private void OnVerb(Entity<ChameleonClothingComponent> ent, ref GetVerbsEvent<InteractionVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract || ent.Comp.User != args.User)
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        var ev = new CanAccessChameleonClothingEvent();
+        RaiseLocalEvent(args.User, ref ev);
+
+        if (!ev.CanAccess)
             return;
 
         // Can't pass args from a ref event inside of lambdas
@@ -213,4 +219,10 @@ public abstract class SharedChameleonClothingSystem : EntitySystem
             }
         }
     }
+}
+
+[ByRefEvent]
+public sealed class CanAccessChameleonClothingEvent : EntityEventArgs
+{
+    public bool CanAccess = false;
 }

--- a/Content.Shared/Implants/SharedChameleonControllerSystem.cs
+++ b/Content.Shared/Implants/SharedChameleonControllerSystem.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Prototypes;
+﻿using Content.Shared.Clothing.EntitySystems;
 
 namespace Content.Shared.Implants;
 
@@ -11,6 +11,7 @@ public abstract partial class SharedChameleonControllerSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<ChameleonControllerOpenMenuEvent>(OpenUI);
+        SubscribeLocalEvent<ChameleonControllerImplantComponent, ImplantRelayEvent<CanAccessChameleonClothingEvent>>(OnCanAccessRelay);
     }
 
     private void OpenUI(ChameleonControllerOpenMenuEvent ev)
@@ -24,5 +25,10 @@ public abstract partial class SharedChameleonControllerSystem : EntitySystem
             return;
 
         _uiSystem.OpenUi(implant.Value, ChameleonControllerKey.Key, ev.Performer);
+    }
+
+    private void OnCanAccessRelay(Entity<ChameleonControllerImplantComponent> ent, ref ImplantRelayEvent<CanAccessChameleonClothingEvent> args)
+    {
+        args.Event.CanAccess = true;
     }
 }

--- a/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
+++ b/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
@@ -9,6 +9,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using System.Linq;
+using Content.Shared.Clothing.EntitySystems;
 
 namespace Content.Shared.Implants;
 
@@ -33,6 +34,7 @@ public abstract class SharedSubdermalImplantSystem : EntitySystem
         SubscribeLocalEvent<ImplantedComponent, MobStateChangedEvent>(RelayToImplantEvent);
         SubscribeLocalEvent<ImplantedComponent, AfterInteractUsingEvent>(RelayToImplantEvent);
         SubscribeLocalEvent<ImplantedComponent, SuicideEvent>(RelayToImplantEvent);
+        SubscribeLocalEvent<ImplantedComponent, CanAccessChameleonClothingEvent>(RelayToImplantEvent);
     }
 
     private void OnInsert(EntityUid uid, SubdermalImplantComponent component, EntGotInsertedIntoContainerMessage args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title, you now have to be implanted with the chameleon controller implant to be able to control chameleon clothing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The main reason for this PR is to reduce metagaming of security officers. Now they can freely interact with chameleon clothing and it wont reveal itself unless you have the implant! Also to clarify: You can still manually edit specific pieces of clothing you aren't forced to use the preset outfits.

This does reduce the fun of randomly finding a piece of chameleon clothing as crew and then being able to play dressup with it but I personally think the tradeoff is worth it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: You can now only interact with chameleon clothing if you are implanted with a chameleon controller implant.