### PR TITLE
added new sign-snapping option

### DIFF
--- a/Resources/ServerInfo/Sandbox.txt
+++ b/Resources/ServerInfo/Sandbox.txt
@@ -14,3 +14,4 @@
 [color=#a4885c]AlignTileDense[/color] colliders must be in the target tile.
 [color=#a4885c]AlignWall[/color] snaps to vertical halftiles.
 [color=#a4885c]AlignWallProper[/color] snaps the entity to the middle of the tile edges
+[color=#a4885c]AlignWallSigns[/color] used for snapping directional hallway signs to walls.


### PR DESCRIPTION
## About the PR
All this PR does is update sandbox.txt, but it goes along with https://github.com/space-wizards/RobustToolbox/pull/5987 which actually is what adds the afformentioned sign-snapping option

## Why / Balance
Manually aligning signs sucks

## Technical details
see https://github.com/space-wizards/RobustToolbox/pull/5987

## Media
https://github.com/user-attachments/assets/258b2de7-5ea0-4faf-9ed2-b6f1687326ed

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
shouldn't be any

**Changelog**
no