### PR TITLE
fix dragon devour action

### DIFF
--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -417,15 +417,13 @@ public abstract class SharedActionsSystem : EntitySystem
             return comp.CanTargetSelf;
 
         var targetAction = Comp<TargetActionComponent>(uid);
-        var coords = Transform(target).Coordinates;
-        if (!ValidateBaseTarget(user, coords, (uid, targetAction)))
-        {
-            // if not just checking pure range, let stored entities be targeted by actions
-            // if it's out of range it probably isn't stored anyway...
-            return targetAction.CheckCanAccess && _interaction.CanAccessViaStorage(user, target);
-        }
+        // not using the ValidateBaseTarget logic since its raycast fails if the target is e.g. a wall
+        if (targetAction.CheckCanAccess)
+            return _interaction.InRangeAndAccessible(user, target, range: targetAction.Range);
 
-        return _interaction.InRangeAndAccessible(user, target, range: targetAction.Range);
+        // if not just checking pure range, let stored entities be targeted by actions
+        // if it's out of range it probably isn't stored anyway...
+        return _interaction.CanAccessViaStorage(user, target);
     }
 
     public bool ValidateWorldTarget(EntityUid user, EntityCoordinates target, Entity<WorldTargetActionComponent> ent)
@@ -436,7 +434,7 @@ public abstract class SharedActionsSystem : EntitySystem
 
     private bool ValidateBaseTarget(EntityUid user, EntityCoordinates coords, Entity<TargetActionComponent> ent)
     {
-        var (uid, comp) = ent;
+        var comp = ent.Comp;
         if (comp.CheckCanAccess)
             return _interaction.InRangeUnobstructed(user, coords, range: comp.Range);
 

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -253,9 +253,17 @@
   - type: Action
     icon: { sprite : Interface/Actions/devour.rsi, state: icon }
     iconOn: { sprite : Interface/Actions/devour.rsi, state: icon-on }
+    itemIconStyle: BigAction
     priority: 1
   - type: TargetAction
   - type: EntityTargetAction
+    canTargetSelf: false
+    whitelist:
+      components:
+      - MobState
+      - Door
+      tags:
+      - Wall
     event: !type:DevourActionEvent
 
 - type: entity


### PR DESCRIPTION
## About the PR
- fixed not being able to eat walls, fixes #37944
- fixed it not having a hand overlay because it never had one apparently
- fixed the action not having a whitelist so the green/red interaction outline is now correct except for mobs because for whatever reason they cant have one when not drag-dropping??
- can no longer target yourself it didnt work anyway due to being alive

## Media
the hand overlay is real
![11:08:07](https://github.com/user-attachments/assets/c5375d75-03cd-4976-bcae-7ef307b88092)

the outline is real
![11:08:26](https://github.com/user-attachments/assets/e0fde62d-3cf0-4732-bbb6-f8b683f59086)

eating bodies is still real
![11:09:28](https://github.com/user-attachments/assets/d936b3d3-3619-4336-af71-b8fe1f2c6855)

would cl for wall eating but its not on stable so