### PR TITLE
Minor revisions to planet and setmapatmos commands

### DIFF
--- a/Content.Server/Atmos/Commands/SetMapAtmosCommand.cs
+++ b/Content.Server/Atmos/Commands/SetMapAtmosCommand.cs
@@ -14,10 +14,7 @@ public sealed class AddMapAtmosCommand : LocalizedEntityCommands
     [Dependency] private readonly IEntityManager _entities = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
 
-    private const string _cmd = "cmd-set-map-atmos";
     public override string Command => "setmapatmos";
-    public override string Description => Loc.GetString($"{_cmd}-desc");
-    public override string Help => Loc.GetString($"{_cmd}-help");
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
@@ -44,7 +41,7 @@ public sealed class AddMapAtmosCommand : LocalizedEntityCommands
         if (space || args.Length < 4)
         {
             _entities.RemoveComponent<MapAtmosphereComponent>(map);
-            shell.WriteLine(Loc.GetString($"{_cmd}-removed", ("map", id)));
+            shell.WriteLine(Loc.GetString($"cmd-setmapatmos-removed", ("map", id)));
             return;
         }
 
@@ -71,24 +68,24 @@ public sealed class AddMapAtmosCommand : LocalizedEntityCommands
 
         var atmos = _entities.EntitySysManager.GetEntitySystem<AtmosphereSystem>();
         atmos.SetMapAtmosphere(map, space, mix);
-        shell.WriteLine(Loc.GetString($"{_cmd}-updated", ("map", id)));
+        shell.WriteLine(Loc.GetString($"cmd-setmapatmos-updated", ("map", id)));
     }
 
     public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
     {
         if (args.Length == 1)
-            return CompletionResult.FromHintOptions(CompletionHelper.MapIds(_entities), Loc.GetString($"{_cmd}-hint-map"));
+            return CompletionResult.FromHintOptions(CompletionHelper.MapIds(_entities), Loc.GetString($"cmd-setmapatmos-hint-map"));
 
         if (args.Length == 2)
-            return CompletionResult.FromHintOptions(new[] { "false", "true" }, Loc.GetString($"{_cmd}-hint-space"));
+            return CompletionResult.FromHintOptions(new[] { "false", "true" }, Loc.GetString($"cmd-setmapatmos-hint-space"));
 
         if (!bool.TryParse(args[1], out var space) || space)
             return CompletionResult.Empty;
 
         if (args.Length == 3)
-            return CompletionResult.FromHint(Loc.GetString($"{_cmd}-hint-temp"));
+            return CompletionResult.FromHint(Loc.GetString($"cmd-setmapatmos-hint-temp"));
 
         var gas = (Gas)args.Length - 4;
-        return CompletionResult.FromHint(Loc.GetString($"{_cmd}-hint-gas", ("gas", gas.ToString())));
+        return CompletionResult.FromHint(Loc.GetString($"cmd-setmapatmos-hint-gas", ("gas", gas.ToString())));
     }
 }

--- a/Content.Server/Atmos/Commands/SetMapAtmosCommand.cs
+++ b/Content.Server/Atmos/Commands/SetMapAtmosCommand.cs
@@ -11,7 +11,7 @@ namespace Content.Server.Atmos.Commands;
 [AdminCommand(AdminFlags.Admin)]
 public sealed class AddMapAtmosCommand : LocalizedEntityCommands
 {
-    [Dependency] private readonly IEntityManager _entities = default!;
+    [Dependency] private readonly AtmosphereSystem _atmos = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
 
     public override string Command => "setmapatmos";
@@ -40,7 +40,7 @@ public sealed class AddMapAtmosCommand : LocalizedEntityCommands
 
         if (space || args.Length < 4)
         {
-            _entities.RemoveComponent<MapAtmosphereComponent>(map);
+            EntityManager.RemoveComponent<MapAtmosphereComponent>(map);
             shell.WriteLine(Loc.GetString($"cmd-setmapatmos-removed", ("map", id)));
             return;
         }
@@ -66,15 +66,14 @@ public sealed class AddMapAtmosCommand : LocalizedEntityCommands
             mix.AdjustMoles(i, moles);
         }
 
-        var atmos = _entities.EntitySysManager.GetEntitySystem<AtmosphereSystem>();
-        atmos.SetMapAtmosphere(map, space, mix);
+        _atmos.SetMapAtmosphere(map, space, mix);
         shell.WriteLine(Loc.GetString($"cmd-setmapatmos-updated", ("map", id)));
     }
 
     public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
     {
         if (args.Length == 1)
-            return CompletionResult.FromHintOptions(CompletionHelper.MapIds(_entities), Loc.GetString($"cmd-setmapatmos-hint-map"));
+            return CompletionResult.FromHintOptions(CompletionHelper.MapIds(EntityManager), Loc.GetString($"cmd-setmapatmos-hint-map"));
 
         if (args.Length == 2)
             return CompletionResult.FromHintOptions(new[] { "false", "true" }, Loc.GetString($"cmd-setmapatmos-hint-space"));

--- a/Content.Server/Maps/PlanetCommand.cs
+++ b/Content.Server/Maps/PlanetCommand.cs
@@ -1,20 +1,11 @@
 using System.Linq;
 using Content.Server.Administration;
-using Content.Server.Atmos;
-using Content.Server.Atmos.Components;
-using Content.Server.Atmos.EntitySystems;
 using Content.Server.Parallax;
 using Content.Shared.Administration;
-using Content.Shared.Atmos;
-using Content.Shared.Gravity;
-using Content.Shared.Movement.Components;
 using Content.Shared.Parallax.Biomes;
-using Robust.Shared.Audio;
 using Robust.Shared.Console;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
 
 namespace Content.Server.Maps;
 

--- a/Content.Server/Maps/PlanetCommand.cs
+++ b/Content.Server/Maps/PlanetCommand.cs
@@ -29,8 +29,7 @@ public sealed class PlanetCommand : LocalizedEntityCommands
     [Dependency] private readonly SharedMapSystem _map = default!;
 
     public override string Command => "planet";
-    public override string Description => Loc.GetString("cmd-planet-desc");
-    public override string Help => Loc.GetString("cmd-planet-help", ("command", Command));
+
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         if (args.Length != 2)

--- a/Content.Server/Maps/PlanetCommand.cs
+++ b/Content.Server/Maps/PlanetCommand.cs
@@ -15,8 +15,8 @@ namespace Content.Server.Maps;
 [AdminCommand(AdminFlags.Mapping)]
 public sealed class PlanetCommand : LocalizedEntityCommands
 {
-    [Dependency] private readonly IEntityManager _entManager = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
+    [Dependency] private readonly BiomeSystem _biome = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
 
     public override string Command => "planet";
@@ -48,9 +48,8 @@ public sealed class PlanetCommand : LocalizedEntityCommands
             return;
         }
 
-        var biomeSystem = _entManager.System<BiomeSystem>();
         var mapUid = _map.GetMapOrInvalid(mapId);
-        biomeSystem.EnsurePlanet(mapUid, biomeTemplate);
+        _biome.EnsurePlanet(mapUid, biomeTemplate);
 
         shell.WriteLine(Loc.GetString("cmd-planet-success", ("mapId", mapId)));
     }
@@ -58,7 +57,7 @@ public sealed class PlanetCommand : LocalizedEntityCommands
     public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
     {
         if (args.Length == 1)
-            return CompletionResult.FromHintOptions(CompletionHelper.MapIds(_entManager), "Map Id");
+            return CompletionResult.FromHintOptions(CompletionHelper.MapIds(EntityManager), "Map Id");
 
         if (args.Length == 2)
         {

--- a/Resources/Locale/en-US/atmos/commands.ftl
+++ b/Resources/Locale/en-US/atmos/commands.ftl
@@ -1,8 +1,0 @@
-cmd-set-map-atmos-desc = Sets a map's atmosphere
-cmd-set-map-atmos-help = setmapatmos <mapid> <space> [<temperature> [moles...]]
-cmd-set-map-atmos-removed = Atmosphere removed from map {$map}
-cmd-set-map-atmos-updated = Atmosphere set for map {$map}
-cmd-set-map-atmos-hint-map = <mapid>
-cmd-set-map-atmos-hint-space = <space>
-cmd-set-map-atmos-hint-temp = <temperature> (float)
-cmd-set-map-atmos-hint-gas = <{$gas} moles> (float)

--- a/Resources/Locale/en-US/commands/planet-command.ftl
+++ b/Resources/Locale/en-US/commands/planet-command.ftl
@@ -1,5 +1,5 @@
 cmd-planet-desc = Converts the supplied map into a planet with some specific biome.
-cmd-planet-help = {$command} <mapid> <biome>.
+cmd-planet-help = planet <mapid> <biome>.
 cmd-planet-args = Requires 2 args only.
 cmd-planet-map = Unable to parse {$map} as an existing map.
 cmd-planet-map-prototype = Unable to index {$prototype} as an existing biome template prototype.

--- a/Resources/Locale/en-US/commands/set-map-atmos-command.ftl
+++ b/Resources/Locale/en-US/commands/set-map-atmos-command.ftl
@@ -1,0 +1,8 @@
+cmd-setmapatmos-desc = Sets a map's atmosphere
+cmd-setmapatmos-help = setmapatmos <mapid> <space> [<temperature> [moles...]]
+cmd-setmapatmos-removed = Atmosphere removed from map {$map}
+cmd-setmapatmos-updated = Atmosphere set for map {$map}
+cmd-setmapatmos-hint-map = <mapid>
+cmd-setmapatmos-hint-space = <space>
+cmd-setmapatmos-hint-temp = <temperature> (float)
+cmd-setmapatmos-hint-gas = <{$gas} moles> (float)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made some changes to setmapatmos and planet commands to make them consistent with other LECs. Also moved their respective ftl files to the commands locale folder and renamed them accordingly. The persistence locale folder has been sent to the big recycle bin in the sky.

Some questions:
First, there is another ftl in the maps locale folder called gamemap.ftl with a locale string (gamemap-could-not-use-map-error) that does not appear to be used anywhere, or at least I couldn't find any usages of it. Can this be removed?

Secondly, do we have a preference for using EntityManager.System or dependencies? I see some inconsistencies with how these are used such as in PlanetCommand.cs where SharedMapSystem is brought in as a depen but BiomeSystem is brought in with EntManager or is there a reasoning behind the differences?

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->