### PR TITLE
Remove from evac pod acces

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -1190,20 +1190,6 @@
     containers:
       board: [ DoorElectronicsExternal ]
 
-- type: entity
-  parent: AirlockGlassShuttle
-  id: AirlockExternalGlassShuttleEscape
-  suffix: External, Escape 3x4, Glass, Docking
-  components:
-  - type: GridFill
-    addComponents:
-    - type: IFF
-      flags:
-      - HideLabel
-  - type: ContainerFill
-    containers:
-      board: [ DoorElectronicsExternal ]
-
 #HighSecDoors
 - type: entity
   parent: HighSecDoor

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -326,3 +326,11 @@
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Glass/centcomm.rsi
+
+- type: entity
+  parent: AirlockGlassShuttle
+  id: AirlockExternalGlassShuttleEscape
+  suffix: External, Escape 3x4, Glass, Docking
+  components:
+    - type: Sprite
+      sprite: Structures/Doors/Airlocks/Glass/shuttle.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I removed the external access requirements from the evac pods.

## Why / Balance
Greytides can now be evacuated on evac pods. No downside.

## Technical details
AirlockExternalGlassShuttleEscape moved to airlocks.yml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl: 
- fix: Now everyone has access to evacuation pods.
