### PR TITLE
Adding a new trait: Monochromacy!

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -15,6 +15,9 @@ permanent-blindness-trait-examined = [color=lightblue]{CAPITALIZE(POSS-ADJ($targ
 trait-lightweight-name = Lightweight drunk
 trait-lightweight-desc = Alcohol has a stronger effect on you.
 
+trait-monochromancy-name = Monochromancy
+trait-monochromancy-desc = You are fully colorblind, everything you perceive ranges from blacks to whites.
+
 trait-muted-name = Muted
 trait-muted-desc = You can't speak.
 

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -17,6 +17,7 @@
   # traits
   # - LegsParalyzed (you get healed)
   - LightweightDrunk
+  - Monochromacy
   - Muted
   - Narcolepsy
   - Pacified

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -45,6 +45,14 @@
       cloneable: true
 
 - type: trait
+  id: Monochromancy
+  name: trait-monochromancy-name
+  description: trait-monochromancy-desc
+  category: Disabilities
+  components:
+  - type: BlackAndWhiteOverlay
+
+- type: trait
   id: Muted
   name: trait-muted-name
   description: trait-muted-desc


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This adds the Trait Monochromacy a new trait (or disability depending on who you ask) that makes you see in black and white

## Why / Balance
The honest reason was i saw it on the TG wiki and I LOVE sight related disabilities (Blindness my beloved) and after a bit of research I noticed that it would be really simple to add since the noir glasses PR added a black and white filter

## Technical details
oops all yaml

## Media
![image](https://github.com/user-attachments/assets/3c882a17-75d0-409c-b3f0-11522d0855b2)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added a new disability called Monochromacy, total colorblindness.