### PR TITLE
Revise ShowAccessReadersCommand as LocalizedEntityCommands

### DIFF
--- a/Content.Client/Access/Commands/ShowAccessReadersCommand.cs
+++ b/Content.Client/Access/Commands/ShowAccessReadersCommand.cs
@@ -4,39 +4,25 @@ using Robust.Shared.Console;
 
 namespace Content.Client.Access.Commands;
 
-public sealed class ShowAccessReadersCommand : IConsoleCommand
+public sealed class ShowAccessReadersCommand : LocalizedEntityCommands
 {
-    public string Command => "showaccessreaders";
+    [Dependency] private readonly IOverlayManager _overlay = default!;
+    [Dependency] private readonly IResourceCache _cache = default!;
+    [Dependency] private readonly SharedTransformSystem _xform = default!;
 
-    public string Description => "Toggles showing access reader permissions on the map";
-    public string Help => """
-        Overlay Info:
-        -Disabled | The access reader is disabled
-        +Unrestricted | The access reader has no restrictions
-        +Set [Index]: [Tag Name]| A tag in an access set (accessor needs all tags in the set to be allowed by the set)
-        +Key [StationUid]: [StationRecordKeyId] | A StationRecordKey that is allowed
-        -Tag [Tag Name] | A tag that is not allowed (takes priority over other allows)
-        """;
-    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    public override string Command => "showaccessreaders";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         var collection = IoCManager.Instance;
 
         if (collection == null)
             return;
 
-        var overlay = collection.Resolve<IOverlayManager>();
+        var existing = _overlay.RemoveOverlay<AccessOverlay>();
+        if (!existing)
+            _overlay.AddOverlay(new AccessOverlay(EntityManager, _cache, _xform));
 
-        if (overlay.RemoveOverlay<AccessOverlay>())
-        {
-            shell.WriteLine($"Set access reader debug overlay to false");
-            return;
-        }
-
-        var entManager = collection.Resolve<IEntityManager>();
-        var cache = collection.Resolve<IResourceCache>();
-        var xform = entManager.System<SharedTransformSystem>();
-
-        overlay.AddOverlay(new AccessOverlay(entManager, cache, xform));
-        shell.WriteLine($"Set access reader debug overlay to true");
+        shell.WriteLine(Loc.GetString($"cmd-showaccessreaders-status", ("status", !existing)));
     }
 }

--- a/Resources/Locale/en-US/commands/show-access-readers-command.ftl
+++ b/Resources/Locale/en-US/commands/show-access-readers-command.ftl
@@ -1,0 +1,9 @@
+﻿cmd-showaccessreaders-desc = Toggles showing access reader permissions on the map
+cmd-showaccessreaders-help =
+    Overlay Info:
+    -Disabled | The access reader is disabled
+    +Unrestricted | The access reader has no restrictions
+    +Set [Index]: [Tag Name]| A tag in an access set (accessor needs all tags in the set to be allowed by the set)
+    +Key [StationUid]: [StationRecordKeyId] | A StationRecordKey that is allowed
+    -Tag [Tag Name] | A tag that is not allowed (takes priority over other allows)
+cmd-showaccessreaders-status = Set access reader debug overlay to {$status}.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Converted the ShowAccessReadersCommand to LocalizedEntityCommands and replaced resolves with dependencies. Also localized the command and made a minor simplification. Partial progress towards #13099.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->