### PR TITLE
ShowEmergencyShuttleCommand and MeleeSpreadCommand LEC conversion.

### DIFF
--- a/Content.Client/Shuttles/Commands/ShowEmergencyShuttleCommand.cs
+++ b/Content.Client/Shuttles/Commands/ShowEmergencyShuttleCommand.cs
@@ -3,15 +3,15 @@ using Robust.Shared.Console;
 
 namespace Content.Client.Shuttles.Commands;
 
-public sealed class ShowEmergencyShuttleCommand : IConsoleCommand
+public sealed class ShowEmergencyShuttleCommand : LocalizedEntityCommands
 {
-    public string Command => "showemergencyshuttle";
-    public string Description => "Shows the expected position of the emergency shuttle";
-    public string Help => $"{Command}";
-    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    [Dependency] private readonly ShuttleSystem _shuttle = default!;
+
+    public override string Command => "showemergencyshuttle";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        var tstalker = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ShuttleSystem>();
-        tstalker.EnableShuttlePosition ^= true;
-        shell.WriteLine($"Set emergency shuttle debug to {tstalker.EnableShuttlePosition}");
+        _shuttle.EnableShuttlePosition ^= true;
+        shell.WriteLine(Loc.GetString($"cmd-showemergencyshuttle-status", ("status", _shuttle.EnableShuttlePosition)));
     }
 }

--- a/Content.Client/Weapons/Melee/MeleeSpreadCommand.cs
+++ b/Content.Client/Weapons/Melee/MeleeSpreadCommand.cs
@@ -3,39 +3,33 @@ using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
 using Robust.Shared.Console;
-using Robust.Shared.Map;
 
 namespace Content.Client.Weapons.Melee;
 
-
-public sealed class MeleeSpreadCommand : IConsoleCommand
+public sealed class MeleeSpreadCommand : LocalizedEntityCommands
 {
-    public string Command => "showmeleespread";
-    public string Description => "Shows the current weapon's range and arc for debugging";
-    public string Help => $"{Command}";
-    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    [Dependency] private readonly IEyeManager _eyeManager = default!;
+    [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly IOverlayManager _overlay = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly MeleeWeaponSystem _meleeSystem = default!;
+    [Dependency] private readonly SharedCombatModeSystem _combatSystem = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+
+    public override string Command => "showmeleespread";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        var collection = IoCManager.Instance;
-
-        if (collection == null)
+        if (_overlay.RemoveOverlay<MeleeArcOverlay>())
             return;
 
-        var overlayManager = collection.Resolve<IOverlayManager>();
-
-        if (overlayManager.RemoveOverlay<MeleeArcOverlay>())
-        {
-            return;
-        }
-
-        var sysManager = collection.Resolve<IEntitySystemManager>();
-
-        overlayManager.AddOverlay(new MeleeArcOverlay(
-            collection.Resolve<IEntityManager>(),
-            collection.Resolve<IEyeManager>(),
-            collection.Resolve<IInputManager>(),
-            collection.Resolve<IPlayerManager>(),
-            sysManager.GetEntitySystem<MeleeWeaponSystem>(),
-            sysManager.GetEntitySystem<SharedCombatModeSystem>(),
-            sysManager.GetEntitySystem<SharedTransformSystem>()));
+        _overlay.AddOverlay(new MeleeArcOverlay(
+            EntityManager,
+            _eyeManager,
+            _inputManager,
+            _playerManager,
+            _meleeSystem,
+            _combatSystem,
+            _transformSystem));
     }
 }

--- a/Resources/Locale/en-US/commands/melee-spread-command.ftl
+++ b/Resources/Locale/en-US/commands/melee-spread-command.ftl
@@ -1,0 +1,1 @@
+﻿cmd-showmeleespread-desc = Shows the current weapon's range and arc for debugging.

--- a/Resources/Locale/en-US/commands/show-emergency-shuttle-command.ftl
+++ b/Resources/Locale/en-US/commands/show-emergency-shuttle-command.ftl
@@ -1,0 +1,2 @@
+﻿cmd-showemergencyshuttle-desc = Shows the expected position of the emergency shuttle.
+cmd-showemergencyshuttle-status = Set emergency shuttle debug to {$status}.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Yet another command conversion PR. Converts the two mentioned commands to localized commands and replaces their resolves with depends.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->