### PR TITLE
Added bulk cleanades crate

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
@@ -11,9 +11,8 @@
 - type: cargoProduct
   id: ServiceCleanerGrenades
   icon:
-    sprite: Objects/Storage/boxes.rsi
-    state: box
-    state: flashbang
+    sprite: Objects/Weapons/Grenades/janitor.rsi
+    state: icon
   product: CrateServiceCleanerGrenades
   cost: 400
   category: cargoproduct-category-name-service

--- a/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
@@ -9,6 +9,17 @@
   group: market
 
 - type: cargoProduct
+  id: ServiceCleanerGrenades
+  icon:
+    sprite: Objects/Storage/boxes.rsi
+    state: box
+    state: flashbang
+  product: CrateServiceCleanerGrenades
+  cost: 400
+  category: cargoproduct-category-name-service
+  group: market
+
+- type: cargoProduct
   id: ServiceLightsReplacement
   icon:
     sprite: Objects/Power/light_bulb.rsi

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -22,6 +22,17 @@
       - id: BoxCleanerGrenades
 
 - type: entity
+  id: CrateServiceCleanerGrenades
+  parent: CratePlastic
+  name: bulk cleanades crate
+  description: Contains two boxes of cleaner grenades, for those deeply-entrenched stains.
+  components:
+  - type: StorageFill
+    contents:
+      - id: BoxCleanerGrenades
+        amount: 2
+
+- type: entity
   id: CrateServiceReplacementLights
   parent: CrateGenericSteel
   name: replacement lights crate


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the bulk cleanades crate, containing two cleanade boxes for $400.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Cleanade boxes are already purchasable from cargo via the janitorial supplies crate ($560). However, the other contents of said crate are kind of useless unless a department really needs a full janitorial kit:
- Buckets, mops, trash bags, and wet floor signs are all printable via autolathe
- Space cleaner spray bottles are refillable, the janitor's space cleaner dispenser holds 5000u of space cleaner, chemistry can make even more space cleaner, and the spray bottles themselves can be printed via autolathe anyway
- Mop buckets, plungers, and soap can't be printed from an autolathe, but they're all infinite-use items (soap can technically be eaten or liquefied, but a janitor generally has no reason to do so)

When a janitorial supply crate is ordered, it's usually just for the single box of cleanades, which means the rest of the box's contents generally sit around in the cargo bay and take up space (unless someone remembers to sell them or give them to some other department or something). Having an explicit cleanades crate reduces clutter; if someone just wants cleanades, they can just buy the cleanades crate.

The price of the bulk cleanades crate was determined as follows:
- The janitorial supply crate costs $560, but is only actually worth $170 (including the price of the crate itself); i.e, the cost is about 3.3x the sale price.
- A plastic crate containing two cleanades would be worth $120 (including the price of the crate itself); 3.3x that is $396, which I rounded up to $400

## Technical details
<!-- Summary of code changes for easier review. -->
- Added CrateServiceCleanerGrenades to Resources\Prototypes\Catalog\Fills\Crates\service.yml
- Added ServiceCleanerGrenades to Resources\Prototypes\Catalog\Cargo\cargo_service.yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![moss-cleanadescrate 1](https://github.com/user-attachments/assets/4fa246d7-8d52-4956-9675-0c107eb7dbc9)
![moss-cleanadescrate 2](https://github.com/user-attachments/assets/17cda45b-f180-4535-8b5b-85d30dfacb38)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Cargo can now order the bulk cleanades crate, containing two cleanade boxes for $400.