### PR TITLE
Fix serialization of `SunShadowCycleComponent`

### DIFF
--- a/Content.Shared/Light/Components/SunShadowCycleComponent.cs
+++ b/Content.Shared/Light/Components/SunShadowCycleComponent.cs
@@ -35,7 +35,7 @@ public sealed partial class SunShadowCycleComponent : Component
 };
 
 [DataDefinition]
-[Serializable]
+[Serializable, NetSerializable]
 public partial record struct SunShadowCycleDirection
 {
     [DataField]

--- a/Content.Shared/Light/Components/SunShadowCycleComponent.cs
+++ b/Content.Shared/Light/Components/SunShadowCycleComponent.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Numerics;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Light.Components;
 

--- a/Content.Shared/Light/Components/SunShadowCycleComponent.cs
+++ b/Content.Shared/Light/Components/SunShadowCycleComponent.cs
@@ -38,14 +38,19 @@ public sealed partial class SunShadowCycleComponent : Component
 [Serializable]
 public partial record struct SunShadowCycleDirection
 {
+    [DataField]
+    public float Ratio;
+
+    [DataField]
+    public Vector2 Direction;
+
+    [DataField]
+    public float Alpha;
+
     public SunShadowCycleDirection(float ratio, Vector2 direction, float alpha)
     {
         Ratio = ratio;
         Direction = direction;
         Alpha = alpha;
     }
-
-    public float Ratio;
-    public Vector2 Direction;
-    public float Alpha;
 };

--- a/Content.Shared/Light/Components/SunShadowCycleComponent.cs
+++ b/Content.Shared/Light/Components/SunShadowCycleComponent.cs
@@ -25,11 +25,27 @@ public sealed partial class SunShadowCycleComponent : Component
     /// Time to have each direction applied. Will lerp from the current value to the next one.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public List<(float Ratio, Vector2 Direction, float Alpha)> Directions = new()
+    public List<SunShadowCycleDirection> Directions = new()
     {
-        (0f, new Vector2(0f, 3f), 0f),
-        (0.25f, new Vector2(-3f, -0.1f), 0.5f),
-        (0.5f, new Vector2(0f, -3f), 0.8f),
-        (0.75f, new Vector2(3f, -0.1f), 0.5f),
+        new SunShadowCycleDirection(0f, new Vector2(0f, 3f), 0f),
+        new SunShadowCycleDirection(0.25f, new Vector2(-3f, -0.1f), 0.5f),
+        new SunShadowCycleDirection(0.5f, new Vector2(0f, -3f), 0.8f),
+        new SunShadowCycleDirection(0.75f, new Vector2(3f, -0.1f), 0.5f),
     };
-}
+};
+
+[DataDefinition]
+[Serializable]
+public partial record struct SunShadowCycleDirection
+{
+    public SunShadowCycleDirection(float ratio, Vector2 direction, float alpha)
+    {
+        Ratio = ratio;
+        Direction = direction;
+        Alpha = alpha;
+    }
+
+    public float Ratio;
+    public Vector2 Direction;
+    public float Alpha;
+};


### PR DESCRIPTION
## About the PR

If you map on master, planets are failing to save due to `SunShadowCycleComponent`

## Why / Balance

bugfix

## Technical details

I turn the `Directions` elements from the tuple into a serializable struct

This is the resultant serialization in the saved map:

```yml
- type: SunShadowCycle
  directions:
  - direction: 0,3
  - alpha: 0.5
    direction: -3,-0.1
    ratio: 0.25
  - alpha: 0.8
    direction: 0,-3
    ratio: 0.5
  - alpha: 0.5
    direction: 3,-0.1
    ratio: 0.75
```

## Media

nope

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

nope

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
