### PR TITLE
Xenoborg jammer now ignores xenoborg associated frequencies

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkJammerSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkJammerSystem.cs
@@ -30,8 +30,8 @@ public sealed class DeviceNetworkJammerSystem : SharedDeviceNetworkJammerSystem
             if (!_jammer.GetJammableNetworks((uid, jammerComp)).Contains(ev.NetworkId))
                 continue;
 
-            if (jammerComp.ExcludedFrequencies != null &&
-                jammerComp.ExcludedFrequencies.Contains(ev.Frequency))
+            if (jammerComp.FrequenciesExcluded != null &&
+                jammerComp.FrequenciesExcluded.Contains(ev.Frequency))
                 continue;
 
             if (_transform.InRange(jammerXform.Coordinates, ev.SenderTransform.Coordinates, jammerComp.Range)

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkJammerSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkJammerSystem.cs
@@ -30,6 +30,10 @@ public sealed class DeviceNetworkJammerSystem : SharedDeviceNetworkJammerSystem
             if (!_jammer.GetJammableNetworks((uid, jammerComp)).Contains(ev.NetworkId))
                 continue;
 
+            if (jammerComp.ExcludedFrequencies != null &&
+                jammerComp.ExcludedFrequencies.Contains(ev.Frequency))
+                continue;
+
             if (_transform.InRange(jammerXform.Coordinates, ev.SenderTransform.Coordinates, jammerComp.Range)
                 || _transform.InRange(jammerXform.Coordinates, xform.Comp.Coordinates, jammerComp.Range))
             {

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -349,7 +349,7 @@ namespace Content.Server.DeviceNetwork.Systems
                 if (connection.Owner == packet.Sender)
                     continue;
 
-                BeforePacketSentEvent beforeEv = new(packet.Sender, xform, senderPos, connection.NetIdEnum.ToString());
+                BeforePacketSentEvent beforeEv = new(packet.Sender, xform, senderPos, connection.NetIdEnum.ToString(), packet.Frequency);
                 RaiseLocalEvent(connection.Owner, beforeEv, false);
 
                 if (!beforeEv.Cancelled)

--- a/Content.Server/Radio/EntitySystems/JammerSystem.cs
+++ b/Content.Server/Radio/EntitySystems/JammerSystem.cs
@@ -73,9 +73,14 @@ public sealed class JammerSystem : SharedJammerSystem
             _jammer.SetRange((ent, jammingComp), GetCurrentRange(ent));
             _jammer.AddJammableNetwork((ent, jammingComp), DeviceNetworkComponent.DeviceNetIdDefaults.Wireless.ToString());
 
-            // Copy excluded frequencies from RadioJammerComponent
+            // Add excluded frequencies using the system method
             if (ent.Comp.FrequenciesExcluded != null)
-                jammingComp.FrequenciesExcluded = new(ent.Comp.FrequenciesExcluded);
+            {
+                foreach (var freq in ent.Comp.FrequenciesExcluded)
+                {
+                    _jammer.AddExcludedFreequency((ent, jammingComp), (uint)freq);
+                }
+            }
         }
         else
         {

--- a/Content.Server/Radio/EntitySystems/JammerSystem.cs
+++ b/Content.Server/Radio/EntitySystems/JammerSystem.cs
@@ -78,7 +78,7 @@ public sealed class JammerSystem : SharedJammerSystem
             {
                 foreach (var freq in ent.Comp.FrequenciesExcluded)
                 {
-                    _jammer.AddExcludedFreequency((ent, jammingComp), (uint)freq);
+                    _jammer.AddExcludedFrequency((ent, jammingComp), (uint)freq);
                 }
             }
         }

--- a/Content.Server/Radio/EntitySystems/JammerSystem.cs
+++ b/Content.Server/Radio/EntitySystems/JammerSystem.cs
@@ -72,6 +72,10 @@ public sealed class JammerSystem : SharedJammerSystem
             EnsureComp<DeviceNetworkJammerComponent>(ent, out var jammingComp);
             _jammer.SetRange((ent, jammingComp), GetCurrentRange(ent));
             _jammer.AddJammableNetwork((ent, jammingComp), DeviceNetworkComponent.DeviceNetIdDefaults.Wireless.ToString());
+
+            // Copy excluded frequencies from RadioJammerComponent
+            if (ent.Comp.FrequenciesExcluded != null)
+                jammingComp.ExcludedFrequencies = new(ent.Comp.FrequenciesExcluded);
         }
         else
         {

--- a/Content.Server/Radio/EntitySystems/JammerSystem.cs
+++ b/Content.Server/Radio/EntitySystems/JammerSystem.cs
@@ -75,7 +75,7 @@ public sealed class JammerSystem : SharedJammerSystem
 
             // Copy excluded frequencies from RadioJammerComponent
             if (ent.Comp.FrequenciesExcluded != null)
-                jammingComp.ExcludedFrequencies = new(ent.Comp.FrequenciesExcluded);
+                jammingComp.FrequenciesExcluded = new(ent.Comp.FrequenciesExcluded);
         }
         else
         {

--- a/Content.Server/Radio/EntitySystems/JammerSystem.cs
+++ b/Content.Server/Radio/EntitySystems/JammerSystem.cs
@@ -96,19 +96,23 @@ public sealed class JammerSystem : SharedJammerSystem
 
     private void OnRadioSendAttempt(ref RadioSendAttemptEvent args)
     {
-        if (ShouldCancelSend(args.RadioSource))
+        if (ShouldCancelSend(args.RadioSource, args.Channel.Frequency))
         {
             args.Cancelled = true;
         }
     }
 
-    private bool ShouldCancelSend(EntityUid sourceUid)
+    private bool ShouldCancelSend(EntityUid sourceUid, int frequency)
     {
         var source = Transform(sourceUid).Coordinates;
         var query = EntityQueryEnumerator<ActiveRadioJammerComponent, RadioJammerComponent, TransformComponent>();
 
         while (query.MoveNext(out var uid, out _, out var jam, out var transform))
         {
+            // Check if this jammer excludes the frequency
+            if (jam.FrequenciesExcluded != null && jam.FrequenciesExcluded.Contains(frequency))
+                continue;
+
             if (_transform.InRange(source, transform.Coordinates, GetCurrentRange((uid, jam))))
             {
                 return true;

--- a/Content.Shared/DeviceNetwork/Components/DeviceNetworkJammerComponent.cs
+++ b/Content.Shared/DeviceNetwork/Components/DeviceNetworkJammerComponent.cs
@@ -23,6 +23,9 @@ public sealed partial class DeviceNetworkJammerComponent : Component
     [DataField, AutoNetworkedField]
     public HashSet<string> JammableNetworks = [];
 
+    /// <summary>
+    /// Device networks frequencies that wont be jammed.
+    /// </summary>
     [DataField]
     public HashSet<uint> FrequenciesExcluded = [];
 

--- a/Content.Shared/DeviceNetwork/Components/DeviceNetworkJammerComponent.cs
+++ b/Content.Shared/DeviceNetwork/Components/DeviceNetworkJammerComponent.cs
@@ -23,4 +23,7 @@ public sealed partial class DeviceNetworkJammerComponent : Component
     [DataField, AutoNetworkedField]
     public HashSet<string> JammableNetworks = [];
 
+    [DataField]
+    public HashSet<uint> FrequenciesExcluded = [];
+
 }

--- a/Content.Shared/DeviceNetwork/Events/BeforePacketSentEvent.cs
+++ b/Content.Shared/DeviceNetwork/Events/BeforePacketSentEvent.cs
@@ -25,11 +25,17 @@ public sealed class BeforePacketSentEvent : CancellableEntityEventArgs
     /// </summary>
     public readonly string NetworkId;
 
-    public BeforePacketSentEvent(EntityUid sender, TransformComponent xform, Vector2 senderPosition, string networkId)
+    /// <summary>
+    /// The frequency the packet is sent on.
+    /// </summary>
+    public readonly uint Frequency;
+
+    public BeforePacketSentEvent(EntityUid sender, TransformComponent xform, Vector2 senderPosition, string networkId, uint frequency)
     {
         Sender = sender;
         SenderTransform = xform;
         SenderPosition = senderPosition;
         NetworkId = networkId;
+        Frequency = frequency
     }
 }

--- a/Content.Shared/DeviceNetwork/Events/BeforePacketSentEvent.cs
+++ b/Content.Shared/DeviceNetwork/Events/BeforePacketSentEvent.cs
@@ -36,6 +36,6 @@ public sealed class BeforePacketSentEvent : CancellableEntityEventArgs
         SenderTransform = xform;
         SenderPosition = senderPosition;
         NetworkId = networkId;
-        Frequency = frequency
+        Frequency = frequency;
     }
 }

--- a/Content.Shared/DeviceNetwork/Systems/SharedDeviceNetworkJammerSystem.cs
+++ b/Content.Shared/DeviceNetwork/Systems/SharedDeviceNetworkJammerSystem.cs
@@ -60,4 +60,34 @@ public abstract class SharedDeviceNetworkJammerSystem : EntitySystem
         ent.Comp.JammableNetworks.Clear();
         Dirty(ent);
     }
+
+    /// <summary>
+    /// Enables this entity to stop packets with the specified frequency from being jammmed.
+    /// </summary>
+    public void AddExcludedFreequency(Entity<DeviceNetworkJammerComponent> ent, uint frequency)
+    {
+        if (ent.Comp.FrequenciesExcluded.Add(frequency))
+            Dirty(ent);
+    }
+
+    /// <summary>
+    /// Stops this entity to stop packets with the specified frequency from being jammmed.
+    /// </summary>
+    public void RemoveExcludedFreequency(Entity<DeviceNetworkJammerComponent> ent, uint frequency)
+    {
+        if (ent.Comp.FrequenciesExcluded.Remove(frequency))
+            Dirty(ent);
+    }
+
+    /// <summary>
+    /// Stops this entity to stop packets with any frequency from being jammmed.
+    /// </summary>
+    public void ClearExcludedFreequency(Entity<DeviceNetworkJammerComponent> ent)
+    {
+        if (ent.Comp.FrequenciesExcluded.Count == 0)
+            return;
+
+        ent.Comp.FrequenciesExcluded.Clear();
+        Dirty(ent);
+    }
 }

--- a/Content.Shared/DeviceNetwork/Systems/SharedDeviceNetworkJammerSystem.cs
+++ b/Content.Shared/DeviceNetwork/Systems/SharedDeviceNetworkJammerSystem.cs
@@ -64,7 +64,7 @@ public abstract class SharedDeviceNetworkJammerSystem : EntitySystem
     /// <summary>
     /// Enables this entity to stop packets with the specified frequency from being jammmed.
     /// </summary>
-    public void AddExcludedFreequency(Entity<DeviceNetworkJammerComponent> ent, uint frequency)
+    public void AddExcludedFrequency(Entity<DeviceNetworkJammerComponent> ent, uint frequency)
     {
         if (ent.Comp.FrequenciesExcluded.Add(frequency))
             Dirty(ent);
@@ -73,7 +73,7 @@ public abstract class SharedDeviceNetworkJammerSystem : EntitySystem
     /// <summary>
     /// Stops this entity to stop packets with the specified frequency from being jammmed.
     /// </summary>
-    public void RemoveExcludedFreequency(Entity<DeviceNetworkJammerComponent> ent, uint frequency)
+    public void RemoveExcludedFrequency(Entity<DeviceNetworkJammerComponent> ent, uint frequency)
     {
         if (ent.Comp.FrequenciesExcluded.Remove(frequency))
             Dirty(ent);
@@ -82,7 +82,7 @@ public abstract class SharedDeviceNetworkJammerSystem : EntitySystem
     /// <summary>
     /// Stops this entity to stop packets with any frequency from being jammmed.
     /// </summary>
-    public void ClearExcludedFreequency(Entity<DeviceNetworkJammerComponent> ent)
+    public void ClearExcludedFrequency(Entity<DeviceNetworkJammerComponent> ent)
     {
         if (ent.Comp.FrequenciesExcluded.Count == 0)
             return;

--- a/Content.Shared/Radio/Components/ActiveRadioJammerComponent.cs
+++ b/Content.Shared/Radio/Components/ActiveRadioJammerComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Radio.Components;
 
 /// <summary>
-/// Prevents almost all radio in range from sending messages
+/// Prevents all non whitelisted radios from sending messages
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedJammerSystem))]

--- a/Content.Shared/Radio/Components/ActiveRadioJammerComponent.cs
+++ b/Content.Shared/Radio/Components/ActiveRadioJammerComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Radio.Components;
 
 /// <summary>
-/// Prevents all radio in range from sending messages
+/// Prevents almost all radio in range from sending messages
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedJammerSystem))]

--- a/Content.Shared/Radio/Components/RadioJammerComponent.cs
+++ b/Content.Shared/Radio/Components/RadioJammerComponent.cs
@@ -47,6 +47,12 @@ public sealed partial class RadioJammerComponent : Component
     public RadioJamSetting[] Settings;
 
     /// <summary>
+    /// Frequencies that are NOT jammed by this jammer.
+    /// </summary>
+    [DataField]
+    public HashSet<int> FrequenciesExcluded = [];
+
+    /// <summary>
     /// Index of the currently selected setting.
     /// </summary>
     [DataField]

--- a/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
@@ -56,10 +56,10 @@
   components:
   - type: RadioJammer
     frequenciesExcluded:
-    - 2002
-    - 2003
-    - 2004
-    - 2005
+    - 2002 # xenoborg radio
+    - 2003 # mothership radio
+    - 2004 # xenoborg network
+    - 2005 # mothership network
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
@@ -58,6 +58,8 @@
     frequenciesExcluded:
     - 2002
     - 2003
+    - 2004
+    - 2005
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
@@ -54,6 +54,10 @@
   id: XenoborgRadioJammer
   name: xenoborg radio jammer
   components:
+  - type: RadioJammer
+    frequenciesExcluded:
+    - 2002
+    - 2003
   - type: ItemSlots
     slots:
       cell_slot:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The xenoborg jammer now has a list of frequencies to ignore, those being the xenoborg radio and network frequencies
<!-- What did you change? -->

## Why / Balance
So it is actually useful for the xenoborgs that now can still use their radio while a heavy has the jammer on nearby
This will also make so heavy xenoborg doesn't block the signal that will allow the mothership core from checking the status of the xenoborgs
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Added a new field to the jammer component that has a list of frequencies to not block, then I passed those along until the game checks whenever to block a message, if it has that frequency, it doesn't block it
<!-- Summary of code changes for easier review. -->

## Media

https://github.com/user-attachments/assets/d817f8eb-fa2c-4eeb-9203-7b80a034a1f9

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
No changelog since xenoborgs haven't been added yet, if they get added before this PR is merged, i will add a changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
