### PR TITLE
Convert showgunspread and nodevis/nodevisfilter commands to LEC

### DIFF
--- a/Content.Client/NodeContainer/NodeVisCommand.cs
+++ b/Content.Client/NodeContainer/NodeVisCommand.cs
@@ -1,48 +1,36 @@
 ﻿using Content.Client.Administration.Managers;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 
 namespace Content.Client.NodeContainer
 {
-    public sealed class NodeVisCommand : IConsoleCommand
+    public sealed class NodeVisCommand : LocalizedEntityCommands
     {
-        [Dependency] private readonly IEntityManager _e = default!;
+        [Dependency] private readonly IClientAdminManager _admin = default!;
+        [Dependency] private readonly NodeGroupSystem _nodes = default!;
 
-        public string Command => "nodevis";
-        public string Description => "Toggles node group visualization";
-        public string Help => "";
+        public override string Command => "nodevis";
 
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            var adminMan = IoCManager.Resolve<IClientAdminManager>();
-            if (!adminMan.HasFlag(AdminFlags.Debug))
-            {
-                shell.WriteError("You need +DEBUG for this command");
-                return;
-            }
-
-            var sys = _e.System<NodeGroupSystem>();
-            sys.SetVisEnabled(!sys.VisEnabled);
+            if (!_admin.HasFlag(AdminFlags.Debug))
+                shell.WriteError(Loc.GetString($"cmd-nodevis-error"));
+            else
+                _nodes.SetVisEnabled(!_nodes.VisEnabled);
         }
     }
 
-    public sealed class NodeVisFilterCommand : IConsoleCommand
+    public sealed class NodeVisFilterCommand : LocalizedEntityCommands
     {
-        [Dependency] private readonly IEntityManager _e = default!;
+        [Dependency] private readonly NodeGroupSystem _nodes = default!;
 
-        public string Command => "nodevisfilter";
-        public string Description => "Toggles showing a specific group on nodevis";
-        public string Help => "Usage: nodevis [filter]\nOmit filter to list currently masked-off";
+        public override string Command => "nodevisfilter";
 
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            var sys = _e.System<NodeGroupSystem>();
-
             if (args.Length == 0)
             {
-                foreach (var filtered in sys.Filtered)
+                foreach (var filtered in _nodes.Filtered)
                 {
                     shell.WriteLine(filtered);
                 }
@@ -50,9 +38,9 @@ namespace Content.Client.NodeContainer
             else
             {
                 var filter = args[0];
-                if (!sys.Filtered.Add(filter))
+                if (!_nodes.Filtered.Add(filter))
                 {
-                    sys.Filtered.Remove(filter);
+                    _nodes.Filtered.Remove(filter);
                 }
             }
         }

--- a/Content.Client/Weapons/Ranged/Commands/ShowSpreadCommand.cs
+++ b/Content.Client/Weapons/Ranged/Commands/ShowSpreadCommand.cs
@@ -1,18 +1,17 @@
 using Content.Client.Weapons.Ranged.Systems;
 using Robust.Shared.Console;
 
-namespace Content.Client.Weapons.Ranged;
+namespace Content.Client.Weapons.Ranged.Commands;
 
-public sealed class ShowSpreadCommand : IConsoleCommand
+public sealed class ShowSpreadCommand : LocalizedEntityCommands
 {
-    public string Command => "showgunspread";
-    public string Description => $"Shows gun spread overlay for debugging";
-    public string Help => $"{Command}";
-    public void Execute(IConsoleShell shell, string argStr, string[] args)
-    {
-        var system = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<GunSystem>();
-        system.SpreadOverlay ^= true;
+    [Dependency] private readonly GunSystem _gun = default!;
 
-        shell.WriteLine($"Set spread overlay to {system.SpreadOverlay}");
+    public override string Command => "showgunspread";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        _gun.SpreadOverlay ^= true;
+        shell.WriteLine(Loc.GetString($"cmd-showgunspread-status", ("status", _gun.SpreadOverlay)));
     }
 }

--- a/Resources/Locale/en-US/commands/node-vis-commands
+++ b/Resources/Locale/en-US/commands/node-vis-commands
@@ -1,0 +1,6 @@
+﻿cmd-nodevis-desc = Toggles node group visualization.
+cmd-nodevisfilter-desc = Toggles showing a specific group on nodevis.
+cmd-nodevisfilter-help =
+    Usage: nodevis [filter]
+    Omit filter to list currently masked-off.
+cmd-nodevis-error = You need +DEBUG for this command.

--- a/Resources/Locale/en-US/commands/show-spread-command.ftl
+++ b/Resources/Locale/en-US/commands/show-spread-command.ftl
@@ -1,0 +1,2 @@
+﻿cmd-showgunspread-desc = Shows gun spread overlay for debugging.
+cmd-showgunspread-status = Set spread overlay to {$status}.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Converts the 3 named commands to localized entity commands. Removes any depends for EntityManager and replaces resolves with dependencies.

Question for the nodevis command. is the check for the debug flag necessary? no other overlays do this and if it were to protect something important I don't imagine it'd be on the client.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->