### PR TITLE
Fixes electropacks not ignoring insulation

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -152,7 +152,7 @@ namespace Content.Server.Explosion.EntitySystems
                 return;
             }
 
-            _electrocution.TryDoElectrocution(containerEnt, null, shockOnTrigger.Comp.Damage, shockOnTrigger.Comp.Duration, true);
+            _electrocution.TryDoElectrocution(containerEnt, null, shockOnTrigger.Comp.Damage, shockOnTrigger.Comp.Duration, true, ignoreInsulation: true);
             shockOnTrigger.Comp.NextTrigger = curTime + shockOnTrigger.Comp.Cooldown;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Electropacks used to not ignore insulation, now they do

## Why / Balance
This makes electropacking an engineer or john tider not a joke.
Yes there is a comment in SharedElectrocutionSystem that states that theres a problem with people being electrocuted gaining control over the mouse but this seems more niche of an issue compared to being able to bypass electropacks with insulated gloves
## Technical details
Yaml moment

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Electropacks now shock people regardless of if they have insulated gloves or not

