### PR TITLE
Disposal tagger and router pre-filled with Trash tag

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
@@ -153,11 +153,11 @@
 
 - type: entity
   parent: DisposalTagger
-  id: DisposalTaggerWaste
-  suffix: waste
+  id: DisposalTaggerTrash
+  suffix: trash
   components:
   - type: DisposalTagger
-    tag: Waste
+    tag: Trash
 
 - type: entity
   id: DisposalSignaller
@@ -282,12 +282,12 @@
 
 - type: entity
   parent: DisposalRouter
-  id: DisposalRouterWaste
-  suffix: waste
+  id: DisposalRouterTrash
+  suffix: trash
   components:
   - type: DisposalRouter
     tags:
-    - Waste
+    - Trash
 
 - type: entity
   id: DisposalRouterFlipped
@@ -332,12 +332,12 @@
 
 - type: entity
   parent: DisposalRouterFlipped
-  id: DisposalRouterFlippedWaste
-  suffix: flipped, waste
+  id: DisposalRouterFlippedTrash
+  suffix: flipped, trash
   components:
   - type: DisposalRouter
     tags:
-    - Waste
+    - Trash
 
 - type: entity
   id: DisposalJunction


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Adds a variant of the disposal tagger and router that starts with the 'Trash' tag

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I wanted to copy Elkridge's disposal layout onto existing maps but ran into two problems:
1. You can't change taggers and routers beneath tiles.
2. Entering or changing tags is extremely repetitive.

I've added a disposal tagger and router that begins with the 'waste' tag to avoid both these issues while mapping. 

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![dotnet_epoTnQPOow](https://github.com/user-attachments/assets/6fbaa8bb-0d47-4e47-92c8-f3492a0cd088)
Outdated: replaced 'Waste' with 'Trash' tag

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

Not player-facing.