### PR TITLE
Blood-Red Magboots now correctly show if magboots are active

### DIFF
--- a/Content.Client/Movement/Systems/JetpackSystem.cs
+++ b/Content.Client/Movement/Systems/JetpackSystem.cs
@@ -34,10 +34,6 @@ public sealed class JetpackSystem : SharedJetpackSystem
     {
         Appearance.TryGetData<bool>(uid, JetpackVisuals.Enabled, out var enabled, args.Component);
 
-        var state = "icon" + (enabled ? "-on" : "");
-        if (args.Sprite != null)
-            _sprite.LayerSetRsiState((uid, args.Sprite), 0, state);
-
         if (TryComp<ClothingComponent>(uid, out var clothing))
             _clothing.SetEquippedPrefix(uid, enabled ? "on" : null, clothing);
     }

--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -202,4 +202,5 @@ public abstract class SharedJetpackSystem : EntitySystem
 public enum JetpackVisuals : byte
 {
     Enabled,
+    Layer
 }

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -45,7 +45,7 @@
     sprite: Objects/Tanks/Jetpacks/blue.rsi
     quickEquip: false
     slots:
-      - Back
+    - Back
   - type: GasTank
     outputPressure: 21.3
     air:
@@ -58,8 +58,8 @@
     visuals:
       enum.JetpackVisuals.Enabled:
         enum.JetpackVisuals.Layer:
-            True: {state: icon-on}
-            False: {state: icon}
+          True: {state: icon-on}
+          False: {state: icon}
   - type: StaticPrice
     price: 100
 

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -25,35 +25,43 @@
   name: jetpack
   description: It's a jetpack. It can hold 5 L of gas.
   components:
-    - type: Sprite
-      sprite: Objects/Tanks/Jetpacks/blue.rsi
-      state: icon
-    - type: Item
-      sprite: Objects/Tanks/Jetpacks/blue.rsi
-      size: Huge
-    - type: UserInterface
-      interfaces:
-        enum.SharedGasTankUiKey.Key:
-          type: GasTankBoundUserInterface
-    - type: UseDelay
-      delays:
-        gasTank:
-          length: 1.0
-    - type: Clothing
-      sprite: Objects/Tanks/Jetpacks/blue.rsi
-      quickEquip: false
-      slots:
-        - Back
-    - type: GasTank
-      outputPressure: 21.3
-      air:
-        volume: 5
-        temperature: 293.15
-    - type: Jetpack
-      moleUsage: 0.00085
-    - type: Appearance
-    - type: StaticPrice
-      price: 100
+  - type: Sprite
+    sprite: Objects/Tanks/Jetpacks/blue.rsi
+    layers:
+    - state: icon
+      map: ["enum.JetpackVisuals.Layer"]
+  - type: Item
+    sprite: Objects/Tanks/Jetpacks/blue.rsi
+    size: Huge
+  - type: UserInterface
+    interfaces:
+      enum.SharedGasTankUiKey.Key:
+        type: GasTankBoundUserInterface
+  - type: UseDelay
+    delays:
+      gasTank:
+        length: 1.0
+  - type: Clothing
+    sprite: Objects/Tanks/Jetpacks/blue.rsi
+    quickEquip: false
+    slots:
+      - Back
+  - type: GasTank
+    outputPressure: 21.3
+    air:
+      volume: 5
+      temperature: 293.15
+  - type: Jetpack
+    moleUsage: 0.00085
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.JetpackVisuals.Enabled:
+        enum.JetpackVisuals.Layer:
+            True: {state: icon-on}
+            False: {state: icon}
+  - type: StaticPrice
+    price: 100
 
 - type: entity
   parent: BaseAction


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed the icon state overriding with Blood-Red Magboots. Now, when you activate the blood-red magboots, the inventory item state will show green to show that the mag tractors are active. 

Activating the Jetpack functionality no longer updates the item state with the "green" traction lights.

Jetpacks still have their icons updating as normal.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Fixes #36573
- Fixes #28355 

## Technical details
<!-- Summary of code changes for easier review. -->
This PR changes the way the Jetpacks update their own item icon states. It removes the icon-overriding behaviour in AppearanceChangeEvent which was forcing an incorrect visual on the Blood-Red Magboots.

By setting up the visual on another sprite-layer, and using a Generic Visualizer, I managed to stop the jetpack active behaviour from affecting the Magboots active effect.

The .yml also had the indentation adjusted for the jetpack.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Magboots on:
![image](https://github.com/user-attachments/assets/0875cbcb-f185-4933-870c-d32506db7303)

Magboots off:
![image](https://github.com/user-attachments/assets/cca89940-63f6-49a5-b932-90be70894e0e)

Jetpack On:
![image](https://github.com/user-attachments/assets/6e90b9f3-3408-4635-a5a2-cc7c37c551e3)

Jetpack Off:
![image](https://github.com/user-attachments/assets/e2f15a23-6536-42e2-947a-7c8171930948)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking Changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Just a visual change - and a minor one :)
