### PR TITLE
Added a Metal Toolbox and autolathe recipe

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -147,3 +147,15 @@
     state: icon
   - type: Item
     sprite: Objects/Tools/Toolboxes/toolbox_gold.rsi
+
+- type: entity
+  name: metal toolbox
+  parent: ToolboxBase
+  id: ToolboxMetal
+  description: A shiny toolbox, perfect for storing everything you want.
+  components:
+  - type: Sprite
+    sprite: Objects/Tools/Toolboxes/toolbox_red.rsi
+    state: icon
+  - type: Item
+    sprite: Objects/Tools/Toolboxes/toolbox_red.rsi

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -20,6 +20,7 @@
   - HandheldStationMap
   - ClothingHeadHatWelding
   - ClothingHeadHatCone
+  - ToolboxMetal
 
 - type: latheRecipePack
   id: AtmosStatic

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -216,3 +216,11 @@
     Steel: 750
     Plasma: 150
     Uranium: 150
+
+- type: latheRecipe
+  parent: BaseToolRecipe
+  id: ToolboxMetal
+  result: ToolboxMetal
+  completetime: 8 #John McTider stares you down for an awkwardly long amount of time
+  materials:
+    Steel: 2000


### PR DESCRIPTION
## About the PR
This adds the metal toolbox... it's a metal toolbox perfect for beating up all of security with how ROBUST you are with your nice insuls and best damn gas mask in the station you tidester.

## Why / Balance
Toolboxes being limited in number has always made certain bounties impossible to complete without salvages help, not to mention other jobs like engineering makes hauling large amount of materials without taking up bag space is always very nice.

The high recipe price is to prevent revs from swarming with toolboxes and to hopefully make it a last ditch for the toolbox bounty (120 steel for 6 toolboxes so they'll make a profit but not enough to be enticing)
## Technical details
All yaml

## Media
Soon TM

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [  ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added a new autolathe recipe for a metal toolbox, for all your tiding needs!
