### PR TITLE
fix tile placement not being blocked by walls

### DIFF
--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -106,7 +106,7 @@ public sealed class FloorTileSystem : EntitySystem
         // otherwise check it isn't blocked by a wall
         if (!canAccessCenter)
         {
-            foreach (var ent in location.GetEntitiesInTile(lookupSystem: _lookup))
+            foreach (var ent in _lookup.GetEntitiesInRange(location, 0.05f))
             {
                 if (physicQuery.TryGetComponent(ent, out var phys) &&
                     phys.BodyType == BodyType.Static &&


### PR DESCRIPTION
## About the PR
It's no longer possible to place tiles under anchored walls/windows/grilles (anything with the Impassable collisiongroup)

## Why / Balance
This was actually not meant to be possible, but the check that tested for this broke at some point.
This broken test was by now also obsolete, so the fix also removes an obsolete call, line goes down!
This was also annoying engineers, who could lose tiles by accidentally clicking on the wall, and then not be able to get it back without partially deconstructing the wall.

## Technical details
FloorTileSystem used an obsolete call to query every entity on the tile, and then check if they were walls/fully blocking. However, this query no longer returns any results (I did not bother to investigate why, because the call is also obsolete), so it never sees the walls. It has now been replaced with a short-range GetEntitiesInRange

## Media
https://github.com/user-attachments/assets/1ccd63c9-b7ad-4aa7-8e2c-9b5ee69836ed

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: Errant
- fix: Tiles can no longer be placed under existing walls, so they will no longer eat your steel if you misclick.
