### PR TITLE
Better robotics console

### DIFF
--- a/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml.cs
+++ b/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml.cs
@@ -28,6 +28,8 @@ public sealed partial class RoboticsConsoleWindow : FancyWindow
 
     public EntityUid Entity;
 
+    private bool _allowBorgControl = true;
+
     public RoboticsConsoleWindow()
     {
         RobustXamlLoader.Load(this);
@@ -72,6 +74,7 @@ public sealed partial class RoboticsConsoleWindow : FancyWindow
     public void UpdateState(RoboticsConsoleState state)
     {
         _cyborgs = state.Cyborgs;
+        _allowBorgControl = state.AllowBorgControl;
 
         // clear invalid selection
         if (_selected is {} selected && !_cyborgs.ContainsKey(selected))
@@ -85,8 +88,8 @@ public sealed partial class RoboticsConsoleWindow : FancyWindow
         PopulateData();
 
         var locked = _lock.IsLocked(Entity);
-        DangerZone.Visible = !locked;
-        LockedMessage.Visible = locked;
+        DangerZone.Visible = !locked && _allowBorgControl;
+        LockedMessage.Visible = locked && _allowBorgControl; // Only show if locked AND control is allowed
     }
 
     private void PopulateCyborgs()
@@ -137,7 +140,9 @@ public sealed partial class RoboticsConsoleWindow : FancyWindow
         BorgInfo.SetMessage(text);
 
         // how the turntables
-        DisableButton.Disabled = !(data.HasBrain && data.CanDisable);
+        DisableButton.Disabled = !_allowBorgControl || !(data.HasBrain && data.CanDisable);
+        DestroyButton.Disabled = !_allowBorgControl;
+        DangerZone.Visible = _allowBorgControl; // <-- Hide the whole button area if not allowed
     }
 
     protected override void FrameUpdate(FrameEventArgs args)

--- a/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml.cs
+++ b/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml.cs
@@ -130,11 +130,20 @@ public sealed partial class RoboticsConsoleWindow : FancyWindow
             _ => "blue"
         };
 
+        var hpPercentColor = data.HpPercent switch {
+            < 0.2f => "red",
+            < 0.4f => "orange",
+            < 0.6f => "yellow",
+            < 0.8f => "green",
+            _ => "blue"
+        };
+
         var text = new FormattedMessage();
         text.AddMarkupOrThrow($"{Loc.GetString("robotics-console-model", ("name", model))}\n");
         text.AddMarkupOrThrow(Loc.GetString("robotics-console-designation"));
         text.AddText($" {data.Name}\n"); // prevent players trolling by naming borg [color=red]satan[/color]
         text.AddMarkupOrThrow($"{Loc.GetString("robotics-console-battery", ("charge", (int)(data.Charge * 100f)), ("color", batteryColor))}\n");
+        text.AddMarkupOrThrow($"{Loc.GetString("robotics-console-hp", ("hp", (int)(data.HpPercent * 100f)), ("color", hpPercentColor))}\n");
         text.AddMarkupOrThrow($"{Loc.GetString("robotics-console-brain", ("brain", data.HasBrain))}\n");
         text.AddMarkupOrThrow(Loc.GetString("robotics-console-modules", ("count", data.ModuleCount)));
         BorgInfo.SetMessage(text);

--- a/Content.Server/Robotics/Systems/RoboticsConsoleSystem.cs
+++ b/Content.Server/Robotics/Systems/RoboticsConsoleSystem.cs
@@ -139,7 +139,7 @@ public sealed class RoboticsConsoleSystem : SharedRoboticsConsoleSystem
 
     private void UpdateUserInterface(Entity<RoboticsConsoleComponent> ent)
     {
-        var state = new RoboticsConsoleState(ent.Comp.Cyborgs);
+        var state = new RoboticsConsoleState(ent.Comp.Cyborgs, ent.Comp.AllowBorgControl);
         _ui.SetUiState(ent.Owner, RoboticsConsoleUiKey.Key, state);
     }
 }

--- a/Content.Server/Silicons/Borgs/BorgSystem.Transponder.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Transponder.cs
@@ -49,11 +49,11 @@ public sealed partial class BorgSystem
             var hpPercent = 1f;
 
             // gaze upon the horrible if ladder
-            if (_entityManager.TryGetComponent(uid, out DamageableComponent? damageable))
+            if (_entityManager.TryGetComponent<DamageableComponent>(uid, out var damageable))
             {
-                if (_entityManager.TryGetComponent(uid, out MobStateComponent? mobState))
+                if (_entityManager.TryGetComponent<MobStateComponent>(uid, out var mobState))
                 {
-                    if (_entityManager.TryGetComponent(uid, out MobThresholdsComponent? mobThresholds))
+                    if (_entityManager.TryGetComponent<MobThresholdsComponent>(uid, out var mobThresholds))
                     {
                         if (CalcProgress(uid, mobState, damageable, mobThresholds) is not { } deathProgress)
                             hpPercent = 0f;

--- a/Content.Shared/Robotics/Components/RoboticsConsoleComponent.cs
+++ b/Content.Shared/Robotics/Components/RoboticsConsoleComponent.cs
@@ -50,4 +50,10 @@ public sealed partial class RoboticsConsoleComponent : Component
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoNetworkedField, AutoPausedField]
     public TimeSpan NextDestroy = TimeSpan.Zero;
+
+    /// <summary>
+    /// If false, disables the disable/destroy buttons in the UI.
+    /// </summary>
+    [DataField]
+    public bool AllowBorgControl = true;
 }

--- a/Content.Shared/Robotics/RoboticsConsoleUi.cs
+++ b/Content.Shared/Robotics/RoboticsConsoleUi.cs
@@ -18,10 +18,12 @@ public sealed class RoboticsConsoleState : BoundUserInterfaceState
     /// Map of device network addresses to cyborg data.
     /// </summary>
     public Dictionary<string, CyborgControlData> Cyborgs;
+    public bool AllowBorgControl;
 
-    public RoboticsConsoleState(Dictionary<string, CyborgControlData> cyborgs)
+    public RoboticsConsoleState(Dictionary<string, CyborgControlData> cyborgs, bool allowBorgControl)
     {
         Cyborgs = cyborgs;
+        AllowBorgControl = allowBorgControl;
     }
 }
 

--- a/Content.Shared/Robotics/RoboticsConsoleUi.cs
+++ b/Content.Shared/Robotics/RoboticsConsoleUi.cs
@@ -87,6 +87,12 @@ public partial record struct CyborgControlData
     public float Charge;
 
     /// <summary>
+    /// HP level from 0 to 1.
+    /// </summary>
+    [DataField]
+    public float HpPercent; // 0.0 to 1.0
+
+    /// <summary>
     /// How many modules this borg has, just useful information for roboticists.
     /// Lets them keep track of the latejoin borgs that need new modules and stuff.
     /// </summary>
@@ -113,12 +119,13 @@ public partial record struct CyborgControlData
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan Timeout = TimeSpan.Zero;
 
-    public CyborgControlData(SpriteSpecifier? chassisSprite, string chassisName, string name, float charge, int moduleCount, bool hasBrain, bool canDisable)
+    public CyborgControlData(SpriteSpecifier? chassisSprite, string chassisName, string name, float charge, float hpPercent, int moduleCount, bool hasBrain, bool canDisable)
     {
         ChassisSprite = chassisSprite;
         ChassisName = chassisName;
         Name = name;
         Charge = charge;
+        HpPercent = hpPercent;
         ModuleCount = moduleCount;
         HasBrain = hasBrain;
         CanDisable = canDisable;

--- a/Resources/Locale/en-US/research/components/robotics-console.ftl
+++ b/Resources/Locale/en-US/research/components/robotics-console.ftl
@@ -6,6 +6,7 @@ robotics-console-model = [color=gray]Model:[/color] {$name}
 # name is not formatted to prevent players trolling
 robotics-console-designation = [color=gray]Designation:[/color]
 robotics-console-battery = [color=gray]Battery charge:[/color] [color={$color}]{$charge}[/color]%
+robotics-console-hp = [color=gray]HP:[/color] [color={$color}]{$hp}[/color]%
 robotics-console-modules = [color=gray]Modules installed:[/color] {$count}
 robotics-console-brain = [color=gray]Brain installed:[/color] [color={$brain ->
     [true] green]Yes

--- a/Resources/Locale/en-US/research/components/robotics-console.ftl
+++ b/Resources/Locale/en-US/research/components/robotics-console.ftl
@@ -6,7 +6,7 @@ robotics-console-model = [color=gray]Model:[/color] {$name}
 # name is not formatted to prevent players trolling
 robotics-console-designation = [color=gray]Designation:[/color]
 robotics-console-battery = [color=gray]Battery charge:[/color] [color={$color}]{$charge}[/color]%
-robotics-console-hp = [color=gray]HP:[/color] [color={$color}]{$hp}[/color]%
+robotics-console-hp = [color=gray]Integrity:[/color] [color={$color}]{$hp}[/color]%
 robotics-console-modules = [color=gray]Modules installed:[/color] {$count}
 robotics-console-brain = [color=gray]Brain installed:[/color] [color={$brain ->
     [true] green]Yes


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a option in the RoboticsConsoleComponent to disable the control buttons.
Added a HP gauge to the robotics console UI.
Empty MMI wont count as having a brain in the robotics console UI.
<!-- What did you change? -->

## Why / Balance
The option to disable the control buttons is gonna be useful for my xenoborgs later since I only want the xenoborg computer to be useful to check the status of the xenoborgs and not actually destroy them.
The HP gauge is a quality of life.
I believe if a borg has a empty MMI inside it shouldn't broadcast that it has a brain installed, is just confusing.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
New boolean datafield in RoboticsConsoleComponent that is used to determine the visibility of the buttons in the UI.
The BorgTransponder system now calculates the HP percentage similar to the show health overlay and send that data via network to the robotics console just like the charge data and then is displayed with similar text format.
The BorgTransponder system now also checks to see if the brain entity has a brain-slot and if it's empty, it returns that it doesn't have a brain installed.
<!-- Summary of code changes for easier review. -->

## Media
![image](https://github.com/user-attachments/assets/2dc69917-1b57-479b-90aa-3e2b0673abdc)
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Samuka
- fix: The Robotics Console now correctly displays the brain installed information if the borg has a empty MMI
- tweak: The Robotics Console now shows the borg physical integrity
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
