### PR TITLE
Fix directional window inconsistencies

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -93,6 +93,8 @@
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks_directional.rsi
+  - type: Damageable
+    damageModifierSet: RGlass
   - type: RadiationBlocker
     resistance: 2
   - type: Destructible

--- a/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
@@ -55,7 +55,7 @@
 
 - type: entity
   id: UraniumReinforcedWindowDirectional
-  parent: WindowDirectional
+  parent: WindowDirectionalRCDResistant
   name: directional reinforced uranium window
   description: Don't smudge up the glass down there.
   placement:
@@ -79,6 +79,8 @@
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks_directional.rsi
+  - type: Damageable
+    damageModifierSet: RGlass
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ReinforcedUraniumWindow
   name: reinforced uranium window
-  parent: WindowDirectionalRCDResistant
+  parent: WindowRCDResistant
   components:
   - type: Sprite
     drawdepth: WallTops

--- a/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ReinforcedUraniumWindow
   name: reinforced uranium window
-  parent: WindowRCDResistant
+  parent: WindowDirectionalRCDResistant
   components:
   - type: Sprite
     drawdepth: WallTops

--- a/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
@@ -53,7 +53,7 @@
 
 - type: entity
   id: UraniumWindowDirectional
-  parent: WindowRCDResistant
+  parent: WindowDirectionalRCDResistant
   name: directional uranium window
   description: Don't smudge up the glass down there.
   placement:

--- a/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
@@ -53,7 +53,7 @@
 
 - type: entity
   id: UraniumWindowDirectional
-  parent: WindowDirectional
+  parent: WindowRCDResistant
   name: directional uranium window
   description: Don't smudge up the glass down there.
   placement:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made plasma and uranium thindows more resistant.
Uranium window no longer RCD deconstructible.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Most likely a bug. They were both using the Glass damage modifier, while the reinforced glass was using a RGlass damage modifier.
Uranium window being breakable by an RCD is definitely not intended.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed some parents and made modifier sets use RGlass instead of Glass.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
### Before
https://github.com/user-attachments/assets/a828608b-c344-481c-b182-558669bbe96d

### After
https://github.com/user-attachments/assets/32269067-14ad-4798-93b6-704e64df7da6


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Directional reinforced plasma and uranium windows are now correctly more durable than regular directional reinforced windows.
- fix: Directional uranium windows can no longer be deconstructed with an RCD.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
