### PR TITLE
Fix displacement map rendering in UI

### DIFF
--- a/Content.Client/Holopad/HolopadSystem.cs
+++ b/Content.Client/Holopad/HolopadSystem.cs
@@ -107,7 +107,7 @@ public sealed class HolopadSystem : SharedHolopadSystem
         // Remove shading from all layers (except displacement maps)
         for (var i = 0; i < hologramSprite.AllLayers.Count(); i++)
         {
-            if (_sprite.TryGetLayer((hologram, hologramSprite), i, out var layer, false) && layer.ShaderPrototype != "DisplacedStencilDraw")
+            if (_sprite.TryGetLayer((hologram, hologramSprite), i, out var layer, false) && layer.ShaderPrototype != "DisplacedDraw")
                 hologramSprite.LayerSetShader(i, "unshaded");
         }
 

--- a/Content.Shared/DisplacementMap/DisplacementData.cs
+++ b/Content.Shared/DisplacementMap/DisplacementData.cs
@@ -10,5 +10,5 @@ public sealed partial class DisplacementData
     public Dictionary<int, PrototypeLayerData> SizeMaps = new();
 
     [DataField]
-    public string? ShaderOverride = "DisplacedStencilDraw";
+    public string? ShaderOverride = "DisplacedDraw";
 }

--- a/Resources/Prototypes/Shaders/displacement.yml
+++ b/Resources/Prototypes/Shaders/displacement.yml
@@ -8,3 +8,10 @@
     func: NotEqual
   params:
     displacementSize: 127
+
+- type: shader
+  id: DisplacedDraw
+  kind: source
+  path: "/Textures/Shaders/displacement.swsl"
+  params:
+    displacementSize: 127


### PR DESCRIPTION
918709cb4742d02e9822a651cf8e74727ba997de changed the way humans work to completely remove the stencil mask thing for clothing cutouts, in favor of displacement maps. Except it didn't actually remove the stencil parameters from the shader prototype, so this caused the shader to render incorrectly in SpriteView instances.

I introduced a new DisplacedDraw shader that doesn't have the stencil in use, as removing the old one would probably be a more annoying breaking change.

Fixes #37629
Fixes #35363

## Breaking changes
`DisplacementData` now defaults to `DisplacedDraw`, not `DisplacedStencilDraw`.

**Changelog**
:cl:
- fix: Fixed various worn clothing items being invisible when seen through UI, such as the examine popups.