### PR TITLE
remove explosions from destroying a explosive payload

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/payload.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/payload.yml
@@ -37,12 +37,6 @@
   - type: Destructible
     thresholds:
     - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 25
-      behaviors:
-      - !type:ExplodeBehavior
-    - trigger:
         !type:DamageTrigger
         damage: 50
       behaviors:


### PR DESCRIPTION
## About the PR
Payload stacking too good. Removed the explosive threshold and behavior from payloads. Modular grenades went untouched, so now "payload stacking" requires more effort.

## Why / Balance
Too often do you see nuclear operatives get decimated by toolboxes or bags full of payloads, which require a mere dip in the sec research tree. Being able to detonate them via damage/signal trigger/voice trigger remotely is absurdly strong, and can be used to kill/gib people instantenously with no counter-play.

## Technical details
Removed 6 lines of code in the payload.yml related to ExplodeBehavior

## Media
https://github.com/user-attachments/assets/7131332b-df23-46a3-ad58-844f9bf9f1be


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Explosive payloads no longer explode. Modular grenades with explosive payloads remain unchanged, and can still be used to stack explosions.
