### PR TITLE
nerfed zombification speed from 0.4 to 0.35

### DIFF
--- a/Content.Shared/Zombies/PendingZombieComponent.cs
+++ b/Content.Shared/Zombies/PendingZombieComponent.cs
@@ -17,7 +17,7 @@ public sealed partial class PendingZombieComponent : Component
     {
         DamageDict = new ()
         {
-            { "Poison", 0.4 },
+            { "Poison", 0.35 },
         }
     };
 


### PR DESCRIPTION
## About the PR
I changed the zombification speed from 0.4 to 0.35. The change was made on line 20 of PendingZombieComponent.cs

## Why / Balance
Issue: #37445
The 0.4 damage rate from poison was slightly too powerful. Dropping the rate down to 0.35 still makes poison effective but not too over powered. It allows players slightly more time to find a cure. 

## Technical details
Changed the DamageDict for PendingZombieComponent.cs from 0.4 to 0.35

## Media
This is a small enough change that media is not required per the guidelines. 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
This PR does not include any breaking changes.

**Changelog**

:cl:
tweak: Zombification poison damage reduced from 0.4 to 0.35. Gives infected players a little more time to find a cure
