### PR TITLE
Fix electrified grilles under directional windows

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -57,6 +57,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
     [Dependency] private readonly SharedStutteringSystem _stuttering = default!;
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
 
     [ValidatePrototypeId<StatusEffectPrototype>]
     private const string StatusEffectKey = "Electrocution";
@@ -135,19 +136,6 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
     {
         if (!electrified.Enabled)
             return false;
-        if (electrified.NoWindowInTile)
-        {
-            var tileRef = transform.Coordinates.GetTileRef(EntityManager, _mapManager);
-
-            if (tileRef != null)
-            {
-                foreach (var entity in _entityLookup.GetLocalEntitiesIntersecting(tileRef.Value, flags: LookupFlags.StaticSundries))
-                {
-                    if (_tag.HasTag(entity, WindowTag))
-                        return false;
-                }
-            }
-        }
         if (electrified.UsesApcPower)
         {
             if (!this.IsPowered(uid, EntityManager))
@@ -161,7 +149,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
 
     private void OnElectrifiedStartCollide(EntityUid uid, ElectrifiedComponent electrified, ref StartCollideEvent args)
     {
-        if (electrified.OnBump)
+        if (electrified.OnBump && _interaction.InRangeUnobstructed(args.OurEntity, args.OtherEntity, overlapCheck: false))
             TryDoElectrifiedAct(uid, args.OtherEntity, 1, electrified);
     }
 

--- a/Content.Shared/Electrocution/Components/ElectrifiedComponent.cs
+++ b/Content.Shared/Electrocution/Components/ElectrifiedComponent.cs
@@ -25,12 +25,6 @@ public sealed partial class ElectrifiedComponent : Component
     public bool OnAttacked = true;
 
     /// <summary>
-    /// When true - disables power if a window is present in the same tile
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public bool NoWindowInTile = false;
-
-    /// <summary>
     /// Should player get damage on interact with empty hand
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Resources/Prototypes/Entities/Structures/Walls/fence_metal.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/fence_metal.yml
@@ -52,7 +52,6 @@
     showInMonitor: false
   - type: Electrified
     requirePower: true
-    noWindowInTile: true
     highVoltageNode: high
     mediumVoltageNode: medium
     lowVoltageNode: low

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -36,7 +36,6 @@
       damageModifierSet: PerforatedMetallic
     - type: Electrified
       requirePower: true
-      noWindowInTile: true
       highVoltageNode: high
       mediumVoltageNode: medium
       lowVoltageNode: low


### PR DESCRIPTION
## About the PR

Fixes #27660. Directional windows over electrified grilles no longer entirely disable them, and you cannot hit a grille through a directional window.

## Why / Balance

Bug fix

## Technical details

I removed the `noWindowInTile` `DataField`. This was only used on grilles and fences, and in electrocution system it would add an additional check for entities with tag `Window` and disable the power to the electrified entity.

Instead, when the grille is bumped, also do a raycast to check that the ray between the player and the center of the grille is unobstructed. This allows directional windows to block this interaction.

## Media

I'm on my laptop so I can't really take a video but:

Bump against directional window, NO SHOCK
![2025-06-03_21-14](https://github.com/user-attachments/assets/6d169f54-d820-4221-b4fe-60c3e7a83b66)

Bump against grille side, SHOCK
![2025-06-03_21-14_1](https://github.com/user-attachments/assets/03676d7b-65ac-4dc7-b8d8-c8b4cc1bc5ab)

Bump against plain grill, SHOCK of course
![2025-06-03_21-15](https://github.com/user-attachments/assets/ec69bf4e-50e5-43e3-96c2-77e7e920a8db)

Bump against grille under window, NO SHOCK
![2025-06-03_21-15_1](https://github.com/user-attachments/assets/cc50317f-c265-4c4d-9868-78e9aec3e0a1)

Cannot hit grille with baseball bat on directional window side.
![2025-06-03_21-16](https://github.com/user-attachments/assets/1bd3b130-60d6-4424-b390-aba6a409272b)


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

`DataField` `NoWindowInTile` on `ElectrifiedComponent` has been removed.

**Changelog**

:cl:
- fix: Directional windows no longer cause electrified grilles to stop working

