### PR TITLE
Tweak for the visual coverage granted to station AIs by holopads

### DIFF
--- a/Content.Shared/Silicons/StationAi/StationAiVisionComponent.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiVisionComponent.cs
@@ -6,14 +6,26 @@ namespace Content.Shared.StationAi;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(SharedStationAiSystem))]
 public sealed partial class StationAiVisionComponent : Component
 {
+    /// <summary>
+    /// Determines whether the entity is actively providing vision to the station AI.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public bool Enabled = true;
 
+    /// <summary>
+    /// Determines whether the entity's vision is blocked by walls.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public bool Occluded = true;
 
     /// <summary>
-    /// Range in tiles
+    /// Determines whether the entity needs to be receiving power to provide vision to the station AI.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool NeedsPower = false;
+
+    /// <summary>
+    /// Vision range in tiles.
     /// </summary>
     [DataField, AutoNetworkedField]
     public float Range = 7.5f;

--- a/Content.Shared/Silicons/StationAi/StationAiVisionComponent.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiVisionComponent.cs
@@ -3,6 +3,9 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.StationAi;
 
+/// <summary>
+/// Attached to entities that grant vision to the station AI, such as cameras.
+/// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(SharedStationAiSystem))]
 public sealed partial class StationAiVisionComponent : Component
 {
@@ -23,6 +26,12 @@ public sealed partial class StationAiVisionComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool NeedsPower = false;
+
+    /// <summary>
+    /// Determines whether the entity needs to be anchored to provide vision to the station AI.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool NeedsAnchoring = false;
 
     /// <summary>
     /// Vision range in tiles.

--- a/Content.Shared/Silicons/StationAi/StationAiVisionSystem.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiVisionSystem.cs
@@ -87,6 +87,9 @@ public sealed class StationAiVisionSystem : EntitySystem
             if (seed.Comp.NeedsPower && !_power.IsPowered(seed.Owner))
                 continue;
 
+            if (seed.Comp.NeedsAnchoring && !Transform(seed.Owner).Anchored)
+                continue;
+
             _job.Data.Add(seed);
         }
 
@@ -169,6 +172,9 @@ public sealed class StationAiVisionSystem : EntitySystem
                 continue;
 
             if (seed.Comp.NeedsPower && !_power.IsPowered(seed.Owner))
+                continue;
+
+            if (seed.Comp.NeedsAnchoring && !Transform(seed.Owner).Anchored)
                 continue;
 
             _job.Data.Add(seed);

--- a/Content.Shared/Silicons/StationAi/StationAiVisionSystem.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiVisionSystem.cs
@@ -1,8 +1,8 @@
+using Content.Shared.Power.EntitySystems;
 using Content.Shared.StationAi;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Threading;
-using Robust.Shared.Utility;
 
 namespace Content.Shared.Silicons.StationAi;
 
@@ -18,6 +18,7 @@ public sealed class StationAiVisionSystem : EntitySystem
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedMapSystem _maps = default!;
     [Dependency] private readonly SharedTransformSystem _xforms = default!;
+    [Dependency] private readonly SharedPowerReceiverSystem _power = default!;
 
     private SeedJob _seedJob;
     private ViewJob _job;
@@ -81,6 +82,9 @@ public sealed class StationAiVisionSystem : EntitySystem
         foreach (var seed in _seeds)
         {
             if (!seed.Comp.Enabled)
+                continue;
+
+            if (seed.Comp.NeedsPower && !_power.IsPowered(seed.Owner))
                 continue;
 
             _job.Data.Add(seed);
@@ -162,6 +166,9 @@ public sealed class StationAiVisionSystem : EntitySystem
         foreach (var seed in _seeds)
         {
             if (!seed.Comp.Enabled)
+                continue;
+
+            if (seed.Comp.NeedsPower && !_power.IsPowered(seed.Owner))
                 continue;
 
             _job.Data.Add(seed);

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -17,6 +17,8 @@
   - type: ApcPowerReceiver
     powerLoad: 300
   - type: StationAiVision
+    range: 1
+    needsPower: true
   - type: Sprite
     sprite: Structures/Machines/holopad.rsi
     drawdepth: HighFloorObjects

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -18,7 +18,7 @@
     powerLoad: 300
   - type: StationAiVision
     range: 1
-    needsPower: true
+    needsAnchoring: true
   - type: Sprite
     sprite: Structures/Machines/holopad.rsi
     drawdepth: HighFloorObjects


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Holopads now provide less visual coverage to station AIs (1 tile radius, down from 7.5). Holopads must also be anchored to provide vision.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The station AI needs to be able to see a holopad to interact with it, so holopads grant the AI vision just like cameras do. However, the amount of vision coverage that they grant is excessive for this need. Reducing the vision range is also helpful for antags trying to avoid detection.

Also, since holopads aren't functional when not anchored, they don't need to provide vision when they are unanchored. This also prevents unanchored holopads from acting as mobile cameras.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

The new visual coverage granted to the station AI by holopads
![aivision1](https://github.com/user-attachments/assets/f1b13cbb-f66f-412a-a3a2-385984a5f2b3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Holopads now provide less visual coverage to station AIs (1 tile radius, down from 7.5). Holopads must also be anchored to the floor to provide vision.