### PR TITLE
Belts render on top of PDA and outer clothing.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -90,10 +90,11 @@
       - map: ["enum.HumanoidVisualLayers.RHand"]
       - map: [ "gloves" ]
       - map: [ "shoes" ]
-      - map: [ "belt" ]
+      #- map: [ "belt" ] Moffstation (Belts Over Outerwear)
       - map: [ "id" ]
       - map: [ "outerClothing" ]
-      - map: [ "enum.HumanoidVisualLayers.Tail" ] # Mentioned in moth code: This needs renaming lol.
+      - map: [ "belt" ] # Moffstation (Belts Over Outerwear)
+      - map: [ "enum.HumanoidVisualLayers.Tail" ] # Mentioned in moth code: This needs renZming lol.
       - map: [ "back" ]
       - map: [ "neck" ]
       - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
@@ -128,7 +129,7 @@
   - type: HumanoidAppearance
     species: Arachnid
   - type: Inventory
-    speciesId: arachnid 
+    speciesId: arachnid
 
 
 #>88w88<

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -30,9 +30,10 @@
     - map: [ "shoes" ]
     - map: [ "ears" ]
     - map: [ "eyes" ]
-    - map: [ "belt" ]
+    #- map: [ "belt" ] Moffstation (Belts Over Outerwear)
     - map: [ "id" ]
     - map: [ "outerClothing" ]
+    - map: [ "belt" ] # Moffstation (Belts Over Outerwear)
     - map: [ "back" ]
     - map: [ "neck" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -99,9 +99,10 @@
       - map: [ "shoes" ]
       - map: [ "ears" ]
       - map: [ "eyes" ]
-      - map: [ "belt" ]
+    #- map: [ "belt" ] Moffstation (Belts Over Outerwear)
       - map: [ "id" ]
       - map: [ "outerClothing" ]
+      - map: [ "belt" ] # Moffstation (Belts Over Outerwear)
       - map: [ "enum.HumanoidVisualLayers.Tail" ] #in the utopian future we should probably have a wings enum inserted here so everyhting doesn't break
       - map: [ "back" ]
       - map: [ "neck" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -80,9 +80,10 @@
     - map: [ "shoes" ]
     - map: [ "ears" ]
     - map: [ "eyes" ]
-    - map: [ "belt" ]
+    #- map: [ "belt" ] Moffstation (Belts Over Outerwear)
     - map: [ "id" ]
     - map: [ "outerClothing" ]
+    - map: [ "belt" ] # Moffstation (Belts Over Outerwear)
     - map: [ "back" ]
     - map: [ "neck" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]


### PR DESCRIPTION
(cherry picked from commit a31b37d4e701dd089522dba2fdcb135e8a39ba6c)

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
As the name suggests, it makes belts appear on top of outer clothing and PDAs! This used to be the case, but was changed a while ago with the main goal seemingly being to make PDAs not render on top of outerwear?
By changing around the order slightly we can have the best of both worlds!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It looks so much nicer to see your belts and chest rigs.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/7ea2c898-c525-4dbb-b0e0-91aaa15a469a)
![image](https://github.com/user-attachments/assets/61453046-7ebe-4187-92cb-aca3c472072d)
![image](https://github.com/user-attachments/assets/fed64e9d-e1f6-4100-bbdc-a838a58b1e70)

its not perfect with coats, but I feel its worth it, and hopefully we can make a component which changes the sprite ordering at some point.
![image](https://github.com/user-attachments/assets/7bdb57be-4f70-40e7-85d7-1d87c4791d1d)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Nox38
- tweak: Belts once again appear over outerwear.
