### PR TITLE
Add player autofill to rename command.

### DIFF
--- a/Content.Server/Mind/Commands/RenameCommand.cs
+++ b/Content.Server/Mind/Commands/RenameCommand.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Content.Server.Administration;
-using Content.Server.Administration.Systems;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Robust.Server.Player;

--- a/Content.Server/Mind/Commands/RenameCommand.cs
+++ b/Content.Server/Mind/Commands/RenameCommand.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Server.Administration;
-using Content.Shared.Access.Components;
+using Content.Server.Administration.Systems;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Robust.Server.Player;
@@ -59,5 +60,17 @@ public sealed class RenameCommand : LocalizedEntityCommands
 
         entityUid = EntityUid.Invalid;
         return false;
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            var players = _playerManager.Sessions.OrderBy(c => c.Name).Select(c => c.Name).ToArray();
+
+            return CompletionResult.FromHintOptions(players, Help);
+        }
+
+        return CompletionResult.Empty;
     }
 }

--- a/Content.Server/Mind/Commands/RenameCommand.cs
+++ b/Content.Server/Mind/Commands/RenameCommand.cs
@@ -65,11 +65,7 @@ public sealed class RenameCommand : LocalizedEntityCommands
     public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
     {
         if (args.Length == 1)
-        {
-            var players = _playerManager.Sessions.OrderBy(c => c.Name).Select(c => c.Name).ToArray();
-
-            return CompletionResult.FromHintOptions(players, Help);
-        }
+            return CompletionResult.FromOptions(CompletionHelper.SessionNames());
 
         return CompletionResult.Empty;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Resolves #38060. Simple approach, just took what was done in KickCommand and copied it over. That said, I feel like it'd be better to have some way of getting player names in IPlayerManager as it seems to be done commonly enough. Could reduce duplication but thats just my input. 

Note, I was going to add admin logging to this as well but I wasn't really sure how to go about it. I stopped when I noticed the kick command also didn't have logging. Probably should be an issue opened for that.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->