### PR TITLE
Fix noir shader in compability mode

### DIFF
--- a/Resources/Textures/Shaders/noir.swsl
+++ b/Resources/Textures/Shaders/noir.swsl
@@ -3,7 +3,7 @@
 
 uniform sampler2D SCREEN_TEXTURE;
 // Sensitivity, in degrees.
-const highp float RedHueRange = 5;
+const highp float RedHueRange = 5.0;
 const highp float MinSaturation = 0.4;
 
 // https://en.wikipedia.org/wiki/HSL_and_HSV#From_RGB


### PR DESCRIPTION
## About the PR
Fixes the
` ---> Robust.Client.Graphics.Clyde.ShaderCompilationException: ERROR: 0:234: '=' : cannot convert from 'const int' to 'const highp float'`
error when starting the game in compability mode. Use
`dotnet run --project Content.Client --cvar display.compat=true` for testing.

## Why / Balance
critical bugfix

## Technical details
change a int to a float
we really need an integration test for the compability mode

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none
**Changelog**
:cl:
- fix: Fixed the game not launching in compability mode.
