### PR TITLE
Add hair back to hardhats

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -66,11 +66,6 @@
   - type: Tag
     tags:
     - WhitelistChameleon
-  - type: HideLayerClothing
-    layers:
-      Hair: HEAD
-      HeadTop: HEAD
-      HeadSide: HEAD
 
 - type: entity
   parent: ClothingHeadHatHardhatBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reverts one of the changes made in #36818 to make hardhats stop hiding hair
## Why / Balance
While I understand why the change was done, hardhats now make most characters pretty ugly

## Technical details
simple yaml removal

## Media
![hardhat](https://github.com/user-attachments/assets/467e1954-7112-40ed-a4c4-f3ce0ed801de)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
The original PR didn't explicitly mention hardhats so I don't think CL is needed