### PR TITLE
Fix living things being destroyed on devour

### DIFF
--- a/Content.Server/Devour/DevourSystem.cs
+++ b/Content.Server/Devour/DevourSystem.cs
@@ -27,17 +27,17 @@ public sealed class DevourSystem : SharedDevourSystem
 
         var ichorInjection = new Solution(component.Chemical, component.HealRate);
 
-        // If the devoured thing has the capacity for life, add it to the stomach
-        if (component.ShouldStoreDevoured && args.Args.Target is not null && HasComp<MobStateComponent>(args.Args.Target))
-        {
-            ContainerSystem.Insert(args.Args.Target.Value, component.Stomach);
-        }
-
         // Grant ichor if the devoured thing meets the dragon's food preference
         if (component.FoodPreference == FoodPreference.All ||
             (component.FoodPreference == FoodPreference.Humanoid && HasComp<HumanoidAppearanceComponent>(args.Args.Target)))
         {
             _bloodstreamSystem.TryAddToChemicals(uid, ichorInjection);
+        }
+
+        // If the devoured thing has the capacity for life, add it to the stomach
+        if (component.ShouldStoreDevoured && args.Args.Target is not null && HasComp<MobStateComponent>(args.Args.Target))
+        {
+            ContainerSystem.Insert(args.Args.Target.Value, component.Stomach);
         }
         //TODO: Figure out a better way of removing structures via devour that still entails standing still and waiting for a DoAfter. Somehow.
         //If it's not alive, it must be a structure


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Decoupled entities being stored in a devourer's (space dragon, for instance) stomach from their food preference.  Before, the dragon would eat things like Ian, Renault, or Cyborgs; some of which may be player-controlled.  Instead of storing the bodies, they got round-removed.  This is because the code coupled storing eaten entities to the dragon's food preference.
Now, if the thing eaten is a living thing or has the capacity for differentiating between 'alive' and 'dead', it will be stored in the stomach.  Ian, Renault, corgified people, space carp, whatever.  It'll be part of the loot piñata when the dragon is cut open.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Cyborgs being eaten is an immediate concern.  If they're eaten they're just deleted.  Furthermore, relevant round mobs like Ian are also destroyed, preventing corgi meat from being obtained.  An outstanding PR of mine has the capacity to change players into corgis and on playtest of this reagent, some corgi'd people have been eaten by the dragon and round-removed.  I want to make these victims recoverable.

## Technical details
<!-- Summary of code changes for easier review. -->
Devourer.FoodPreference has been decoupled from the logic that determines if an eaten thing can be stored in the stomach.  Now, anything with a MobState is stored in the stomach and FoodPreference only really matters toward ichor injection for the dragon.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/b17316bb-f164-4518-a48c-f997528f164c



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Dragons no longer destroy non-humanoid mobs upon eating them.