### PR TITLE
Basilisk Nerfs for Gameplay

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -374,12 +374,12 @@
       Dead:
         Base: basilisk_dead
   - type: MovementSpeedModifier
-    baseWalkSpeed : 3
-    baseSprintSpeed : 3.5
+    baseWalkSpeed : 2
+    baseSprintSpeed : 3
   - type: MobThresholds
     thresholds:
       0: Alive
-      80: Dead
+      75: Dead
   - type: MeleeWeapon
     angle: 0
     animation: WeaponArcBite
@@ -391,6 +391,7 @@
         Piercing: 5
   - type: Gun
     fireRate: 0.75
+    projectileSpeed: 15.0
     selectedMode: SemiAuto
     showExamineText: false
     availableModes: [ SemiAuto ]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -391,7 +391,7 @@
         Piercing: 5
   - type: Gun
     fireRate: 0.75
-    projectileSpeed: 15.0
+    projectileSpeed: 10.0 # When we get predicted guns and projectiles this should be raised to like 15, 15 mis-predicts too much right now unfortunately.
     selectedMode: SemiAuto
     showExamineText: false
     availableModes: [ SemiAuto ]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -461,7 +461,7 @@
       projectile:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.2,-0.2,0.2,0.2"
+          bounds: "-0.05,-0.05,0.05,0.05"
         hard: false
         mask:
         - Opaque


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the basilisk to be overall weaker and hopefully more fun to fight.

Sprinting speed was reduced so you can outrun the basilisk so long as you don't get hit by its freezing ray (If you get hit once you can no longer outrun it).

Projectile speed was reduced so you can actually dodge the projectile (Had to reduce it to 10 because it mispredicts super hard at 15) and reduced the projectile size.

Reduced the Basilisk's health from 80 -> 75

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Basilisks right now are really unfun to fight at the moment. They outrange you and their projectile slows and ignores armor while not being dodgable at PTK ranges due to NPCs not having a shooting delay. 

This results in basilisks having very little counter-play outside of straight cheese (filling the VGRoid with glass maze walls). Currently they are the worst mob to deal with at higher levels of salvage play since there's not really a fun strategy to fighting them. 

This effectively means every basilisk fight boils down to: Take 20-25 damage -> They come into melee -> You out DPS them with a crusher or dagger -> You use half of your ointment and some bandages to heal off the damage.

The excessive usage of ointment is a real pain because you can't replenish ointment on the VGRoid like you can with gauze and there's no healing options on the VGRoid for heat damage (Crushers don't work, hivelord remains don't work).

Being so slow you can't move means melee fights are entirely a DPS check which is also really not fun and is made even worse if there's more than one enemy. 

Regarding these issues, I lowered the basilisk speed so that you can run and reposition if needed (although you're only slightly faster in a spationaught so you'll have to be tactical with the movement you spend dodging). 

Projectile speed so you can try to dodge their ranged attacks and succeed if you're smart and careful with your strafing (Although it's notably still difficult in the tight hallways of the VGRoid).

This adds skill and fun to bobbing and weaving getting shots in trying to fight them with getting hit still being just as punishing as before.

In addition their health was reduced by 5 so that 3 PTK shots kill rather than 4 (It was technically 3 before if you counted bleedout). This doesn't affect the number of hits it takes to kill with any other salvage melee weapon I checked (Crushers are still 4 hits, Daggers are still 7 hits)

## Technical details
YAML only changes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Basilisk projectile speed and movement speed has been reduced and is slightly weaker
