### PR TITLE
emergency shuttle emergency lockers

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -159,7 +159,8 @@
 - type: entity
   parent: LockerBase
   id: LockerEvacRepair
-  name: evac repair locker
+  name: emergency shuttle emergency locker
+  description: It's emergencies all the way down.
   components:
   - type: Appearance
   - type: EntityStorageVisuals

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/wall_lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/wall_lockers.yml
@@ -180,7 +180,8 @@
 - type: entity
   parent: BaseWallLocker
   id: LockerWallEvacRepair
-  name: evac repair wall locker
+  name: emergency shuttle emergency wall locker
+  description: It's emergencies all the way down.
   components:
   - type: Appearance
   - type: EntityStorageVisuals


### PR DESCRIPTION
## About the PR
Change the name and description of the new evac repair lockers

## Why / Balance
It's an emergency locker on the emergency shuttle, the joke practically writes itself. Adds a bit of background humor to the game

## Technical details
weh

## Media

![Screenshot_2025-06-06_092754](https://github.com/user-attachments/assets/b8258009-0556-4c55-bde2-01cef77fc0dc)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
Not necessary
