### PR TITLE
Add Security tag and Bar tag to untagged mailing units on Plasma station

### DIFF
--- a/Resources/Maps/plasma.yml
+++ b/Resources/Maps/plasma.yml
@@ -127064,11 +127064,21 @@ entities:
     - type: Transform
       pos: -69.5,-24.5
       parent: 2
+    - type: MailingUnit
+      tag: Bar
+    - type: Configuration
+      config:
+        tag: Bar
   - uid: 18474
     components:
     - type: Transform
       pos: -93.5,-25.5
       parent: 2
+    - type: MailingUnit
+      tag: Security
+    - type: Configuration
+      config:
+        tag: Security
   - uid: 23233
     components:
     - type: Transform


### PR DESCRIPTION
## About the PR

These two mailing units had no tag, making for a very sad cargo tech trying to deliver mail to security.

## Why / Balance

Fix / oversight

## Technical details

Tag no there, tag there now

## Media

"" -> "Security"
"" -> "Bar"

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

Now cargo technicians don't have an excuse to enter security to fix security's mailing unit 🤔 

**Changelog**

:cl:
- fix: Fix untagged mailing units on Plasma Station

