### PR TITLE
Fix bar mailing unit tag on plasma

### DIFF
--- a/Resources/Maps/plasma.yml
+++ b/Resources/Maps/plasma.yml
@@ -128141,6 +128141,11 @@ entities:
     - type: Transform
       pos: -69.5,-24.5
       parent: 2
+    - type: MailingUnit
+      tag: Bar
+    - type: Configuration
+      config:
+        tag: Bar
   - uid: 18699
     components:
     - type: Transform


### PR DESCRIPTION
## About the PR

untagged mailing unit

## Why / Balance

fix / oversight

## Technical details

tag no there, tag there now

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes


**Changelog**

:cl:
- fix: The bartender's mailing unit on plasma is properly configured.
