### PR TITLE
Make structures, crates, harder to break. Adjust structure damage values

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -13,17 +13,17 @@
 - type: damageModifierSet
   id: StructuralMetallicStrong
   coefficients:
-    Blunt: 0.5
-    Slash: 0.5
-    Piercing: 0.5
+    Blunt: 0.75
+    Slash: 0.75
+    Piercing: 0.75
     Shock: 1.2
-    Structural: 0.25
+    Structural: 0.5
   flatReductions:
-    Blunt: 10
-    Slash: 10
-    Piercing: 10
-    Heat: 10
-    Structural: 10
+    Blunt: 25 # TODO: reduce this once PKA damage is reduced.
+    Slash: 20
+    Piercing: 20
+    Heat: 15
+    Structural: 25
 
 - type: damageModifierSet
   id: StructuralMetallic
@@ -36,7 +36,7 @@
     Slash: 10
     Piercing: 10
     Heat: 10
-    Structural: 10
+    Structural: 15
 
 - type: damageModifierSet
   id: Rock

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -335,7 +335,8 @@
 #   soundHit:  Waiting on serv3
     damage:
       types:
-        Heat: 14
+        Heat: 15
+        Structural: 35
   # mining laser real
   - type: GatheringProjectile
   - type: Tag
@@ -497,7 +498,7 @@
     damage:
       types:
         Blunt: 25
-        Structural: 30
+        Structural: 20
   # Short lifespan
   - type: TimedDespawn
     lifetime: 0.22 # roughly 5.5 tiles

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -26,7 +26,7 @@
       groups:
         Brute: 10
       types:
-        Structural: 30
+        Structural: 20
   - type: Item
     size: Normal
     shape:
@@ -160,7 +160,7 @@
       types:
         Blunt: 2.5
         Slash: 2.5
-        Structural: 30
+        Structural: 25
   - type: GunRequiresWield
   - type: DisarmMalus
   - type: Prying

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -43,7 +43,7 @@
     isPlaceable: false # defaults to closed.
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: Metallic
+    damageModifierSet: StructuralMetallic
   - type: Destructible
     thresholds:
     - trigger:
@@ -132,7 +132,7 @@
       map: ["enum.PaperLabelVisuals.Layer"]
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallic
+    damageModifierSet: StructuralMetallicStrong
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -48,6 +48,10 @@
           path: /Audio/Effects/break_stone.ogg
           params:
             volume: -6
+  - type: Gatherable
+    toolWhitelist:
+      tags:
+      - Pickaxe
   - type: Fixtures
     fixtures:
       fix1:
@@ -92,6 +96,9 @@
     intensitySlope: 2.5
     maxIntensity: 10
     canCreateVacuum: false
+  - type: Gatherable # nasty hack to cover the fact that this needs to not be single-hit destruction.
+    toolWhitelist:
+      tags: [ ]
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adjusts the `StructuralMetallicStrong` to have higher flat resistances so you can't whittle things down.
Additionally reduces the structural damage on a lot of mining equipment. The only reason a lot of it exists is for 1-hit rock mining, which we can emulate anyways with gatherable code. There's no point in the value really being so high.

The buff to emitter damage is just meant to facilitate a more Classic:tm: way of busting crates now that the most common methods aren't a thing.


also there's a todo on one of the flat resistances because the pka does 25 burst damage which is insanity that fucks everything up. there's gonna be a fix soon but its a larger mob/salv rebalance so its gonna take a minute.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The general goal of this PR is to make breaking through secure structures like rwalls, secure crates, airlocks, etc more difficult. A lot of mining-based tools make this incredibly trivial to do, which enables cargo to steal things like nobody's goddamn business. 

With the proposed changes, they are forced to either invest in high-damage weapons like upgraded pkas or diamond drills, or resort to loud and dangerous methods like seismic charges and emitters.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Strong metallic structures (reinforced walls, airlocks, firelocks) are now harder to destroy.
- tweak: Increased strength of reinforced crates.
- tweak: Decreased structural damage on various weapons.
- tweak: Added structural damage to emitter bolts.

