### PR TITLE
Rat King changed to Antag and NPC Zombies don't attack Initial Infected

### DIFF
--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -87,7 +87,7 @@ ghost-role-information-kobold-description = Be the little gremlin you are, yell 
 
 ghost-role-information-rat-king-name = Rat King
 
-ghost-role-information-rat-king-description = You are the Rat King, your interests are food, food, and more food. Cooperate with or fight against the station for food. Did I say food interests you?
+ghost-role-information-rat-king-description = You are the Rat King, your interests are food, food, and more food. Fight against the station for food. Did I say food interests you?
 
 ghost-role-information-rat-servant-name = Rat Servant
 ghost-role-information-rat-servant-description = You are a Rat Servant. You must follow your king's orders.

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -18,9 +18,9 @@
   - type: GhostRole
     name: ghost-role-information-rat-king-name
     description: ghost-role-information-rat-king-description
-    rules: ghost-role-information-freeagent-rules
+    rules: ghost-role-information-antagonist-rules
     mindRoles:
-    - MindRoleGhostRoleFreeAgent
+    - MindRoleGhostRoleAntag
     raffle:
       settings: default
   - type: GhostRoleMobSpawner

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -8,6 +8,10 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 3600 # 1h
+  components:
+  - type: NpcFactionMember
+    factions:
+    - Zombie
 
 - type: antag
   id: Zombie
@@ -16,3 +20,8 @@
   setPreference: false
   objective: roles-antag-zombie-objective
   guides: [ Zombies ]
+  components:
+  - type: NpcFactionMember
+    factions:
+    - Zombie
+

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -162,5 +162,5 @@
   - Xeno # rivalry
 
   # cause they are hostile to them
-  - SimpleHostile 
+  - SimpleHostile
   - AllHostile


### PR DESCRIPTION
ZOMBIES STILL ATTACK INITIAL INFECTED! WORKING ON IT

Rat King guide updated to show antag rules

Initial infected given zombie faction
Zombies given zombie faction too (not sure if redundant or not)

## About the PR
Rat Kings are now antagonists. Initial Infected are now a part of the zombie faction. Zombies are also in the zombie faction.

## Why / Balance
Needed for antag rework. Zombie NPCs now won't attack initial infected. Rat Kings are now clearly marked as evil.

## Technical details
Zombie faction added to InitialInfected and Zombie antag prototypes.

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: Rat King is now an antag.
- fix: Initial Infected won't be attacked by other npc zombies


