### PR TITLE
Revert "Add hair back to hardhats (#38086)"

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -66,6 +66,11 @@
   - type: Tag
     tags:
     - WhitelistChameleon
+  - type: HideLayerClothing
+    layers:
+      Hair: HEAD
+      HeadTop: HEAD
+      HeadSide: HEAD
 
 - type: entity
   parent: ClothingHeadHatHardhatBase


### PR DESCRIPTION
This reverts commit 4cbfd1931285a80b5f390e62dc8ace1e409ae8a0. [38086]

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Revert "Add hair back to hardhats (#38086)"
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
That's not the way to do it. It makes the other characters look really weird, especially with their hair sticking out.

Until there's a better option, it's easier to accept that safety measures prohibit long hair
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
This is what different hair looks like now:
![2025-06-07_11-11](https://github.com/user-attachments/assets/f53f2ad6-c87f-462b-bac1-75e08419b6df)
![2025-06-07_11-11_1](https://github.com/user-attachments/assets/eac6a978-1c40-40ec-bc33-a26b9f766ff5)
![image](https://github.com/user-attachments/assets/e3159fe9-caa7-453a-9d5e-c7d8fff696c0)

That's why it was done in the first place:
![image](https://github.com/user-attachments/assets/e86a7da6-e903-466e-81d3-ab920bb97ba1)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
