### PR TITLE
make PacifiedComponent session specific

### DIFF
--- a/Content.Shared/CombatMode/Pacification/PacifiedComponent.cs
+++ b/Content.Shared/CombatMode/Pacification/PacifiedComponent.cs
@@ -17,33 +17,46 @@ namespace Content.Shared.CombatMode.Pacification;
 [Access(typeof(PacificationSystem))]
 public sealed partial class PacifiedComponent : Component
 {
+    /// <summary>
+    /// If true, this will prevent you from disarming opponents in combat.
+    /// </summary>
     [DataField]
     public bool DisallowDisarm = false;
 
     /// <summary>
-    ///  If true, this will disable combat entirely instead of only disallowing attacking living creatures and harmful things.
+    /// If true, this will disable combat entirely instead of only disallowing attacking living creatures and harmful things.
     /// </summary>
     [DataField]
     public bool DisallowAllCombat = false;
 
 
     /// <summary>
-    ///     When attempting attack against the same entity multiple times,
-    ///     don't spam popups every frame and instead have a cooldown.
+    /// When attempting attack against the same entity multiple times,
+    /// don't spam popups every frame and instead have a cooldown.
     /// </summary>
     [DataField]
     public TimeSpan PopupCooldown = TimeSpan.FromSeconds(3.0);
 
+    /// <summary>
+    /// Time at which the next popup can be shown.
+    /// </summary>
     [DataField]
     [AutoPausedField]
     public TimeSpan? NextPopupTime = null;
 
     /// <summary>
-    ///     The last entity attacked, used for popup purposes (avoid spam)
+    /// The last entity attacked, used for popup purposes (avoid spam)
     /// </summary>
     [DataField]
     public EntityUid? LastAttackedEntity = null;
 
+    /// <summary>
+    /// The alert to show to owners of this component.
+    /// </summary>
     [DataField]
     public ProtoId<AlertPrototype> PacifiedAlert = "Pacified";
+
+    // Prevent cheat clients from using this to identify thieves and players that cannot fight back.
+    // This should not matter for prediction reasons since it only blocks user input.
+    public override bool SendOnlyToOwner => true;
 }


### PR DESCRIPTION
## About the PR
Purely technical change, no gameplay impact.

## Why / Balance
No reason for other clients to know who is pacified. It only blocks user input for the component owner, so it cannot cause any mispredicts for other clients.

## Technical details
Just set the bool to true.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`PacifiedComponent` is now session specific and only networked to the component owner.

**Changelog**
nah
