### PR TITLE
Fix small issues with Text Highlighting

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -112,7 +112,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
             }
 
             // Make sure any name tagged as ours gets highlighted only when others say it.
-            keyword = Regex.Replace(keyword, "^@", "(?<=(?<=/name.*)|(?<=,.*\"\".*))");
+            keyword = Regex.Replace(keyword, "^@", @"(?<=(?<=,.*"".*)|(?<!\[Name].*))");
 
             _highlights.Add(keyword);
         }

--- a/Resources/Locale/en-US/chat/ui/chat-box.ftl
+++ b/Resources/Locale/en-US/chat/ui/chat-box.ftl
@@ -37,6 +37,6 @@ hud-chatbox-highlights-button = Submit
 hud-chatbox-highlights-tooltip = The words need to be separated by a newline,
                                  if wrapped around " they will be highlighted
                                  only if separated by spaces or punctuation.
-hud-chatbox-highlights-placeholder = McHands
+hud-chatbox-highlights-placeholder = @McHands
                                      "Judge"
                                      Medical

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -50,8 +50,8 @@ ui-options-interface-label = Interface
 
 
 ui-options-auto-fill-highlights = Auto-fill the highlights with the character's information
-ui-options-highlights-color = Highlighs color:
-ui-options-highlights-color-example = This is an highlighted text!
+ui-options-highlights-color = Highlights color:
+ui-options-highlights-color-example = This is a highlighted text!
 ui-options-show-held-item = Show held item next to cursor
 ui-options-show-combat-mode-indicators = Show combat mode indicators with cursor
 ui-options-opaque-storage-window = Opaque storage window


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This is a small PR to fix some mistakes left by the [text highlighting PR](https://github.com/space-wizards/space-station-14/pull/31442).

## Technical details
<!-- Summary of code changes for easier review. -->
Other than grammatical errors, this PR also **changes the regex in charge of highlighting user-excluding keywords** (keywords that start with a @). 

The old regex didn't count for cases where the keyword in question would appear without a [Name] tag present (eg. station announcements), so the keyword in that case wouldn't get highlighted.

The new regex checks if there are some double quotes before the keyword or if there isn't a [Name] tag.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:
<img src="https://github.com/user-attachments/assets/bea82a64-2d00-48bb-b566-6e04fbbcf2cb" width=350>
After:
<img src="https://github.com/user-attachments/assets/c8ab3488-d40b-4773-86f2-b76bd96f71f9" width=350>


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
