### PR TITLE
Fix the sensor monitoring console forcing a GC every 3 seconds

### DIFF
--- a/Content.Client/SensorMonitoring/SensorMonitoringWindow.xaml.cs
+++ b/Content.Client/SensorMonitoring/SensorMonitoringWindow.xaml.cs
@@ -25,6 +25,29 @@ public sealed partial class SensorMonitoringWindow : FancyWindow, IComputerWindo
     private TimeSpan _retentionTime;
     private readonly Dictionary<int, SensorData> _sensorData = new();
 
+    /// <summary>
+    /// <para>A shared array used to store vertices for drawing graphs in <see cref="GraphView"/>.
+    /// Prevents excessive allocations by reusing the same array across multiple graph views.</para>
+    /// <para>This effectively makes it so that each <see cref="SensorMonitoringWindow"/> has its own pooled array.</para>
+    /// </summary>
+    private Vector2[] _sharedVertices = [];
+
+    /// <summary>
+    /// Retrieves a shared array of vertices, ensuring that it has at least the requested size.
+    /// Assigns a new array of the requested size if the current shared array is smaller than the requested size.
+    /// </summary>
+    /// <param name="requestedSize">The minimum number of vertices required in the shared array.</param>
+    /// <returns>An array of <see cref="System.Numerics.Vector2"/> representing the shared vertices.</returns>
+    /// <remarks>This does not prevent other threads from accessing the same shared pool.</remarks>
+    public Vector2[] GetSharedVertices(int requestedSize)
+    {
+        if (_sharedVertices.Length < requestedSize)
+        {
+            _sharedVertices = new Vector2[requestedSize];
+        }
+        return _sharedVertices;
+    }
+
     public SensorMonitoringWindow()
     {
         RobustXamlLoader.Load(this);
@@ -145,7 +168,7 @@ public sealed partial class SensorMonitoringWindow : FancyWindow, IComputerWindo
                     }
                 });
 
-                Asdf.AddChild(new GraphView(stream.Samples, startTime, curTime, maxValue * 1.1f) { MinHeight = 150 });
+                Asdf.AddChild(new GraphView(stream.Samples, startTime, curTime, maxValue * 1.1f, this) { MinHeight = 150 });
                 Asdf.AddChild(new PanelContainer { StyleClasses = { StyleBase.ClassLowDivider } });
             }
         }
@@ -193,23 +216,25 @@ public sealed partial class SensorMonitoringWindow : FancyWindow, IComputerWindo
 
     private sealed class GraphView : Control
     {
-        // Shared static buffer for all instances of GraphView to reduce allocations.
-        // Need to use this because ArrayPool violates sandbox.
-        private static Vector2[] _sharedVertices = [];
-        private static readonly object SharedVerticesLock = new();
-
         private readonly Queue<SensorSample> _samples;
         private readonly TimeSpan _startTime;
         private readonly TimeSpan _curTime;
         private readonly float _maxY;
+        private readonly SensorMonitoringWindow _parentWindow;
+        private readonly object _bufferLock = new();
 
-        public GraphView(Queue<SensorSample> samples, TimeSpan startTime, TimeSpan curTime, float maxY)
+        public GraphView(Queue<SensorSample> samples,
+            TimeSpan startTime,
+            TimeSpan curTime,
+            float maxY,
+            SensorMonitoringWindow parentWindow)
         {
             _samples = samples;
             _startTime = startTime;
             _curTime = curTime;
             _maxY = maxY;
             RectClipContent = true;
+            _parentWindow = parentWindow;
         }
 
         protected override void Draw(DrawingHandleScreen handle)
@@ -220,18 +245,12 @@ public sealed partial class SensorMonitoringWindow : FancyWindow, IComputerWindo
             var countVtx = 0;
 
             var lastPoint = new Vector2(float.NaN, float.NaN);
+            var requiredVertices = 6 * (_samples.Count - 1);
 
-            // Lock the shared buffer to ensure thread safety.
-            lock (SharedVerticesLock)
+            // We're now performing operations on the shared vertices array.
+            lock (_bufferLock)
             {
-                // Expand the shared buffer *as needed*.
-                // We don't use Array.Resize here because it would allocate and copy over
-                // garbage data that we don't need.
-                var requiredVertices = 6 * (_samples.Count - 1);
-                if (_sharedVertices.Length < requiredVertices)
-                {
-                    _sharedVertices = new Vector2[requiredVertices];
-                }
+                var vertices = _parentWindow.GetSharedVertices(requiredVertices);
 
                 foreach (var (time, sample) in _samples)
                 {
@@ -246,18 +265,19 @@ public sealed partial class SensorMonitoringWindow : FancyWindow, IComputerWindo
                     {
                         handle.DrawLine(lastPoint, newPoint, Color.White);
 
-                        _sharedVertices[countVtx++] = lastPoint;
-                        _sharedVertices[countVtx++] = lastPoint with { Y = PixelHeight };
-                        _sharedVertices[countVtx++] = newPoint;
-                        _sharedVertices[countVtx++] = newPoint;
-                        _sharedVertices[countVtx++] = lastPoint with { Y = PixelHeight };
-                        _sharedVertices[countVtx++] = newPoint with { Y = PixelHeight };
+                        vertices[countVtx++] = lastPoint;
+                        vertices[countVtx++] = lastPoint with { Y = PixelHeight };
+                        vertices[countVtx++] = newPoint;
+                        vertices[countVtx++] = newPoint;
+                        vertices[countVtx++] = lastPoint with { Y = PixelHeight };
+                        vertices[countVtx++] = newPoint with { Y = PixelHeight };
                     }
 
                     lastPoint = newPoint;
                 }
-
-                handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, _sharedVertices.AsSpan(0, countVtx), Color.White.WithAlpha(0.1f));
+                handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList,
+                    vertices.AsSpan(0, countVtx),
+                    Color.White.WithAlpha(0.1f));
             }
         }
     }


### PR DESCRIPTION
## About the PR
Fixes the sensor monitoring console forcing a garbage collect every 3 seconds.

## Why / Balance
Holy shit I was pissed when I was doing TEG testing.
## Technical details
Previously, every single draw call we were creating a new Vector2 array with 25000 elements.
This allocated something like 130-145 KiB per frame and caused my game to do a GC every 3 seconds.

Instead, we do the following:
- We first allocate a new vertices array in the constructor.
	- Because we know how big `_samples` is, and that each line segment needs 6 vertices to form 2 triangles, we can simply make an array that's the size that we need.
- This array is populated like normal.
	- If the array is too small, it is simply doubled (however this shouldn't happen).
- For the next draw call, `_verticies` remains allocated and the data is simply overwritten as the draw call logic will start at the beginning of the array. Any extra data beyond the amount of elements in `countVtx` is simply ignored when we go to draw primitives (as it only draws up to `countVtx`).

Allocations per frame are about 20-23 KiB without looking at the console, ~50 KiB while looking at the console.
And it doesn't do a SOH garbage collect every 3 seconds.

## Media
Before the implementation
![rider64_RpEgwnLor6](https://github.com/user-attachments/assets/a3d6dbe0-7a75-43d1-a26e-0db66d94be93)

After
![rider64_RxCqODrUwT](https://github.com/user-attachments/assets/76f52711-76b8-49e7-8f26-1a1cda075e9f)
![rider64_67FhJtZiC7](https://github.com/user-attachments/assets/0ac0a3a9-58bc-444a-90e8-dd5b63f654b8)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
no CL no fun
