### PR TITLE
Remove omnizine from unwarmed honk pockets, honk pockets make you honk

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donkpocket.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donkpocket.yml
@@ -228,6 +228,8 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
+        - ReagentId: Honk
+          Quantity: 0.50
   - type: Sprite
     state: banana
 
@@ -247,6 +249,8 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 10
+        - ReagentId: Honk
+          Quantity: 1
         - ReagentId: Omnizine
           Quantity: 2
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donkpocket.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donkpocket.yml
@@ -228,8 +228,6 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
-        - ReagentId: Omnizine
-          Quantity: 2
   - type: Sprite
     state: banana
 


### PR DESCRIPTION
## About the PR

We all know clowns are abominations but they shouldn't get special treatment in that their variant of donk pockets don't need to be warmed to activate the omnizine

## Why / Balance

I think this was an oversight.

## Technical details

yml

## Media

nah

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

nope

**Changelog**

:cl:
- fix: Unwarmed honk pockets no longer contain omnizine
- fix: Honk pockets make you honk
