### PR TITLE
Tile-based variants of RulesSystem and it's associated classes

### DIFF
--- a/Content.Shared/Random/Rules/TileRules/OnEmptyTileRule.cs
+++ b/Content.Shared/Random/Rules/TileRules/OnEmptyTileRule.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Map;
+
+namespace Content.Shared.Random.Rules.TileRules;
+
+/// <summary>
+/// Rule for whether a specific tile is just empty space.
+/// </summary>
+public sealed partial class OnEmptyTileRule : TileRule
+{
+    public override bool Check(EntityManager entManager, EntityUid tileParentUid, TileRef tile, Vector2i position, HashSet<EntityUid> intersectingEntities)
+        => tile.Tile.IsEmpty ^ Inverted;
+}

--- a/Content.Shared/Random/Rules/TileRules/OnExposedSubfloorRule.cs
+++ b/Content.Shared/Random/Rules/TileRules/OnExposedSubfloorRule.cs
@@ -1,0 +1,13 @@
+using Content.Shared.Maps;
+using Robust.Shared.Map;
+
+namespace Content.Shared.Random.Rules.TileRules;
+
+/// <summary>
+/// Rule for whether a specific tile is an exposed (sub)floor (e.g. under-tile plating or lattice, but not on space itself).
+/// </summary>
+public sealed partial class OnExposedSubfloorTileRule : TileRule
+{
+    public override bool Check(EntityManager entManager, EntityUid tileParentUid, TileRef tile, Vector2i position, HashSet<EntityUid> intersectingEntities)
+        => tile.Tile.GetContentTileDefinition().IsSubFloor ^ Inverted;
+}

--- a/Content.Shared/Random/Rules/TileRules/OnExposedSubfloorRule.cs
+++ b/Content.Shared/Random/Rules/TileRules/OnExposedSubfloorRule.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Map;
 namespace Content.Shared.Random.Rules.TileRules;
 
 /// <summary>
-/// Rule for whether a specific tile is an exposed (sub)floor (e.g. under-tile plating or lattice, but not on space itself).
+/// Rule for whether a specific tile is a subfloor by tile definition (e.g. under-tile plating or lattice, but not space itself).
 /// </summary>
 public sealed partial class OnExposedSubfloorTileRule : TileRule
 {

--- a/Content.Shared/Random/Rules/TileRules/TileRulesSystem.cs
+++ b/Content.Shared/Random/Rules/TileRules/TileRulesSystem.cs
@@ -31,7 +31,11 @@ public abstract partial class TileRule
     [DataField]
     public bool Inverted;
 
-    /// <summary>Checks whether this rule is valid, based on a tile and it's parent grid or map.</summary>
+    /// <summary>
+    /// Checks whether this rule is valid, based on a tile and it's parent grid or map. If <paramref name="intersectingEntities"/>
+    ///     is in use to check if this rule is true, then <see cref="TakesIntersecting"/> should be true, otherwise the set of
+    ///     intersecting entities may not have been evaluated.
+    /// </summary>
     /// <remarks>Always pure.</remarks>
     /// <param name="tileParentUid">The <see cref="EntityUid"/> (such as map or grid) that contains the specified tile.</param>
     /// <param name="intersectingEntities">

--- a/Content.Shared/Random/Rules/TileRules/TileRulesSystem.cs
+++ b/Content.Shared/Random/Rules/TileRules/TileRulesSystem.cs
@@ -25,7 +25,7 @@ public sealed partial class TileRulesPrototype : IPrototype
 public abstract partial class TileRule
 {
     /// <summary>Does this rule take intersecting entities as an input when checking it?</summary>
-    // This is done so that intersecting entities aren't calculated for every single TileRule, but only for those that actually need it.
+    // This is done so that intersecting entities aren't evaluated for every single TileRule, but only for those that actually need it.
     public virtual bool TakesIntersecting => false;
 
     [DataField]
@@ -49,7 +49,7 @@ public sealed class TileRulesSystem : EntitySystem
     /// Checks if a given set of <see cref="TileRule"/>s is valid. Optionally takes
     ///     a list of entities intersecting the tile, resolving it with
     ///     <see cref="DefaultIntersectionEnlargement"/> as long as at least one rule
-    ///     needs to calculate any intersecting entities.
+    ///     needs to evaluate any intersecting entities.
     /// </summary>
     /// <param name="tileParentUid">The <see cref="EntityUid"/> (such as map or grid) that contains the specified tile.</param>
     /// <seealso cref="TileRule.TakesIntersecting"/>

--- a/Content.Shared/Random/Rules/TileRules/TileRulesSystem.cs
+++ b/Content.Shared/Random/Rules/TileRules/TileRulesSystem.cs
@@ -34,7 +34,11 @@ public abstract partial class TileRule
     /// <summary>Checks whether this rule is valid, based on a tile and it's parent grid or map.</summary>
     /// <remarks>Always pure.</remarks>
     /// <param name="tileParentUid">The <see cref="EntityUid"/> (such as map or grid) that contains the specified tile.</param>
-    /// <param name="intersectingEntities">The entities intersecting with the tile, with an enlargement of <see cref="TileRulesSystem.IntersectionOffset"/>.</param>
+    /// <param name="intersectingEntities">
+    /// The entities intersecting with the tile, with an enlargement of <see cref="TileRulesSystem.IntersectionOffset"/>.
+    ///     Will not be guaranteed to have been evaluated (i.e., it would've stayed empty) unless <see cref="TakesIntersecting"/>
+    ///     is true.
+    /// </param>
     public abstract bool Check(EntityManager entManager, EntityUid tileParentUid, TileRef tile, Vector2i position, HashSet<EntityUid> intersectingEntities);
 }
 

--- a/Content.Shared/Random/Rules/TileRules/TileRulesSystem.cs
+++ b/Content.Shared/Random/Rules/TileRules/TileRulesSystem.cs
@@ -60,6 +60,7 @@ public sealed class TileRulesSystem : EntitySystem
 
         foreach (var rule in rules.Rules)
         {
+            // Only if a rule NEEDs a list of intersecting entities -- and if we need to re-evaluate them, then do so.
             if (rule.TakesIntersecting && reEvaluateIntersecting)
             {
                 _lookup.GetLocalEntitiesIntersecting(tileParentUid, position, intersectingEntities, DefaultIntersectionEnlargement, LookupFlags.Uncontained);

--- a/Content.Shared/Random/Rules/TileRules/TileRulesSystem.cs
+++ b/Content.Shared/Random/Rules/TileRules/TileRulesSystem.cs
@@ -1,0 +1,76 @@
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Random.Rules.TileRules;
+
+
+/// <summary>
+/// Rules-based conditional selection. Variant of <see cref="RulesPrototype"/>, but is in terms of
+///     individual grid tiles, rather than only their entities.
+/// </summary>
+[Prototype]
+public sealed partial class TileRulesPrototype : IPrototype
+{
+    [IdDataField] public string ID { get; private set; } = string.Empty;
+
+    [DataField("rules", required: true)]
+    public List<TileRule> Rules = new();
+}
+
+/// <summary>
+/// Variant of <see cref="RulesRule"/>, but is applied to individual grid tiles
+///     rather than entities.
+/// </summary>
+[ImplicitDataDefinitionForInheritors]
+public abstract partial class TileRule
+{
+    /// <summary>Does this rule take intersecting entities as an input when checking it?</summary>
+    // This is done so that intersecting entities aren't calculated for every single TileRule, but only for those that actually need it.
+    public virtual bool TakesIntersecting => false;
+
+    [DataField]
+    public bool Inverted;
+
+    /// <summary>Checks whether this rule is valid, based on a tile and it's parent grid or map.</summary>
+    /// <remarks>Always pure.</remarks>
+    /// <param name="tileParentUid">The <see cref="EntityUid"/> (such as map or grid) that contains the specified tile.</param>
+    /// <param name="intersectingEntities">The entities intersecting with the tile, with an enlargement of <see cref="TileRulesSystem.IntersectionOffset"/>.</param>
+    public abstract bool Check(EntityManager entManager, EntityUid tileParentUid, TileRef tile, Vector2i position, HashSet<EntityUid> intersectingEntities);
+}
+
+public sealed class TileRulesSystem : EntitySystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+
+    // The enlargement used when getting the default intersecting entities of a tile.
+    public const float DefaultIntersectionEnlargement = -0.05f;
+
+    /// <summary>
+    /// Checks if a given set of <see cref="TileRule"/>s is valid. Optionally takes
+    ///     a list of entities intersecting the tile, resolving it with
+    ///     <see cref="DefaultIntersectionEnlargement"/> as long as at least one rule
+    ///     needs to calculate any intersecting entities.
+    /// </summary>
+    /// <param name="tileParentUid">The <see cref="EntityUid"/> (such as map or grid) that contains the specified tile.</param>
+    /// <seealso cref="TileRule.TakesIntersecting"/>
+    public bool IsTrue(EntityUid tileParentUid, TileRulesPrototype rules, TileRef tile, Vector2i position, HashSet<EntityUid>? intersectingEntities = null)
+    {
+        // `intersectingEntities` will always be resolved, as long as at least one rule needs it.
+        var tookIntersectingEntities = false;
+        intersectingEntities ??= new();
+
+        foreach (var rule in rules.Rules)
+        {
+            if (rule.TakesIntersecting && !tookIntersectingEntities)
+            {
+                _lookup.GetLocalEntitiesIntersecting(tileParentUid, position, intersectingEntities, DefaultIntersectionEnlargement, LookupFlags.Uncontained);
+                tookIntersectingEntities = true;
+            }
+
+            if (!rule.Check(EntityManager, tileParentUid, tile, position, intersectingEntities))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/Random/Rules/TileRules/TileRulesSystem.cs
+++ b/Content.Shared/Random/Rules/TileRules/TileRulesSystem.cs
@@ -47,24 +47,23 @@ public sealed class TileRulesSystem : EntitySystem
 
     /// <summary>
     /// Checks if a given set of <see cref="TileRule"/>s is valid. Optionally takes
-    ///     a list of entities intersecting the tile, resolving it with
-    ///     <see cref="DefaultIntersectionEnlargement"/> as long as at least one rule
-    ///     needs to evaluate any intersecting entities.
+    ///     a list of entities intersecting the tile, that should be resolved with
+    ///     <see cref="DefaultIntersectionEnlargement"/>.
     /// </summary>
     /// <param name="tileParentUid">The <see cref="EntityUid"/> (such as map or grid) that contains the specified tile.</param>
     /// <seealso cref="TileRule.TakesIntersecting"/>
     public bool IsTrue(EntityUid tileParentUid, TileRulesPrototype rules, TileRef tile, Vector2i position, HashSet<EntityUid>? intersectingEntities = null)
     {
-        // `intersectingEntities` will always be resolved, as long as at least one rule needs it.
-        var tookIntersectingEntities = false;
+        // If we were already provided with an array of intersecting entities, we don't need to evaluate it again.
+        var reEvaluateIntersecting = intersectingEntities == null;
         intersectingEntities ??= new();
 
         foreach (var rule in rules.Rules)
         {
-            if (rule.TakesIntersecting && !tookIntersectingEntities)
+            if (rule.TakesIntersecting && reEvaluateIntersecting)
             {
                 _lookup.GetLocalEntitiesIntersecting(tileParentUid, position, intersectingEntities, DefaultIntersectionEnlargement, LookupFlags.Uncontained);
-                tookIntersectingEntities = true;
+                reEvaluateIntersecting = false;
             }
 
             if (!rule.Check(EntityManager, tileParentUid, tile, position, intersectingEntities))

--- a/Content.Shared/Random/Rules/TileRules/TileSupportsWindowsRule.cs
+++ b/Content.Shared/Random/Rules/TileRules/TileSupportsWindowsRule.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Random.Rules.TileRules;
 
 /// <summary>
 /// Rule for whether a window can be placed on a specific tile, based on whether an
-///     entity on that tiles has  a<see cref="SharedCanBuildWindowOnTopComponent"/>.
+///     entity on that tiles has a <see cref="SharedCanBuildWindowOnTopComponent"/>.
 /// </summary>
 public sealed partial class TileSupportsWindowsRule : TileRule
 {

--- a/Content.Shared/Random/Rules/TileRules/TileSupportsWindowsRule.cs
+++ b/Content.Shared/Random/Rules/TileRules/TileSupportsWindowsRule.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+using Content.Shared.Construction;
+using Robust.Shared.Map;
+
+namespace Content.Shared.Random.Rules.TileRules;
+
+/// <summary>
+/// Rule for whether a window can be placed on a specific tile, based on whether an
+///     entity on that tiles has  a<see cref="SharedCanBuildWindowOnTopComponent"/>.
+/// </summary>
+public sealed partial class TileSupportsWindowsRule : TileRule
+{
+    public override bool TakesIntersecting => true;
+
+    public override bool Check(EntityManager entManager, EntityUid tileParentUid, TileRef tile, Vector2i position, HashSet<EntityUid> intersectingEntities)
+        => intersectingEntities.Any(entManager.HasComponent<SharedCanBuildWindowOnTopComponent>) ^ Inverted;
+}


### PR DESCRIPTION
## About the PR
Added variants to RulesSystem, RulesRules, & RulesPrototype that, instead of using `EntityUid`s, use tiles.

## Why
https://github.com/space-wizards/space-station-14/blob/766bade68f53d1dbd156e9dc47af75cb261f1348/Content.Shared/RCD/RCDPrototype.cs#L126-L134
And obviously it's not ideal to use `EntityUid`s for tiles, so...

## Technical details
Added `TileRulesSystem`, `TileRule`, and `TileRulesPrototype`.

`TileRule`s may sometimes need a list of entities intersecting with the tile. The default constant enlargement for the intersection calculation is -0.05 (TileRulesSystem.DefaultIntersectionEnlargement). 

`IsTrue()` on `TileRulesSystem` can optionally take a set of intersecting entities, or define an empty one if no set is specified. Each `TileRule` has a `TakesIntersecting` bool to save performance, so that a list of intersecting entities is *only* evaluated as long as it wasn't specified in `IsTrue()`, and when it is actually needed to be used.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
N/A
