### PR TITLE
Make RunVerbAs take and return EntityUids

### DIFF
--- a/Content.Server/Toolshed/Commands/Verbs/RunVerbAsCommand.cs
+++ b/Content.Server/Toolshed/Commands/Verbs/RunVerbAsCommand.cs
@@ -14,9 +14,9 @@ public sealed class RunVerbAsCommand : ToolshedCommand
     private SharedVerbSystem? _verb;
 
     [CommandImplementation]
-    public IEnumerable<NetEntity> RunVerbAs(
+    public IEnumerable<EntityUid> RunVerbAs(
             IInvocationContext ctx,
-            [PipedArgument] IEnumerable<NetEntity> input,
+            [PipedArgument] IEnumerable<EntityUid> input,
             EntityUid runner,
             string verb
         )
@@ -24,7 +24,7 @@ public sealed class RunVerbAsCommand : ToolshedCommand
         _verb ??= GetSys<SharedVerbSystem>();
         verb = verb.ToLowerInvariant();
 
-        foreach (var i in input)
+        foreach (var eId in input)
         {
             if (EntityManager.Deleted(runner) && runner.IsValid())
                 ctx.ReportError(new DeadEntity(runner));
@@ -32,7 +32,6 @@ public sealed class RunVerbAsCommand : ToolshedCommand
             if (ctx.GetErrors().Any())
                 yield break;
 
-            var eId = EntityManager.GetEntity(i);
             var verbs = _verb.GetLocalVerbs(eId, runner, Verb.VerbTypes, true);
 
             // if the "verb name" is actually a verb-type, try run any verb of that type.
@@ -43,7 +42,7 @@ public sealed class RunVerbAsCommand : ToolshedCommand
                 if (verbTy != null)
                 {
                     _verb.ExecuteVerb(verbTy, runner, eId, forced: true);
-                    yield return i;
+                    yield return eId;
                 }
             }
 
@@ -52,7 +51,7 @@ public sealed class RunVerbAsCommand : ToolshedCommand
                 if (verbTy.Text.ToLowerInvariant() == verb)
                 {
                     _verb.ExecuteVerb(verbTy, runner, eId, forced: true);
-                    yield return i;
+                    yield return eId;
                 }
             }
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made the toolshed command RunVerbAs take EntityIds instead of NetEntities.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As far as I can tell there's no way to pass around a NetEntity in toolshed, so this command wasn't usable.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Running verb with separate runner and targets works:

![image](https://github.com/user-attachments/assets/c851b262-df66-4df1-8b50-30d6d544dc3c)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
ADMIN:
- fix: The runverbas command should now work better with other toolshed commands.
