### PR TITLE
Add technology to tech disk names

### DIFF
--- a/Content.Shared/Research/TechnologyDisk/Systems/TechnologyDiskSystem.cs
+++ b/Content.Shared/Research/TechnologyDisk/Systems/TechnologyDiskSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Lathe;
+using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Research.Components;
@@ -20,6 +21,7 @@ public sealed class TechnologyDiskSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedResearchSystem _research = default!;
     [Dependency] private readonly SharedLatheSystem _lathe = default!;
+    [Dependency] private readonly NameModifierSystem _nameModifier = default!;
 
     public override void Initialize()
     {
@@ -28,6 +30,7 @@ public sealed class TechnologyDiskSystem : EntitySystem
         SubscribeLocalEvent<TechnologyDiskComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<TechnologyDiskComponent, AfterInteractEvent>(OnAfterInteract);
         SubscribeLocalEvent<TechnologyDiskComponent, ExaminedEvent>(OnExamine);
+        SubscribeLocalEvent<TechnologyDiskComponent, RefreshNameModifiersEvent>(OnRefreshNameModifiers);
     }
 
     private void OnMapInit(Entity<TechnologyDiskComponent> ent, ref MapInitEvent args)
@@ -55,6 +58,7 @@ public sealed class TechnologyDiskSystem : EntitySystem
         ent.Comp.Recipes = [];
         ent.Comp.Recipes.Add(_random.Pick(techs));
         Dirty(ent);
+        _nameModifier.RefreshNameModifiers(ent.Owner);
     }
 
     private void OnAfterInteract(Entity<TechnologyDiskComponent> ent, ref AfterInteractEvent args)
@@ -89,5 +93,17 @@ public sealed class TechnologyDiskSystem : EntitySystem
                 message += " " + Loc.GetString("tech-disk-examine-more");
         }
         args.PushMarkup(message);
+    }
+
+    private void OnRefreshNameModifiers(Entity<TechnologyDiskComponent> entity, ref RefreshNameModifiersEvent args)
+    {
+        if (entity.Comp.Recipes != null)
+        {
+            foreach (var recipe in entity.Comp.Recipes)
+            {
+                var proto = _protoMan.Index(recipe);
+                args.AddModifier("tech-disk-name-format", extraArgs: ("technology", _lathe.GetRecipeName(proto)));
+            }
+        }
     }
 }

--- a/Resources/Locale/en-US/research/components/technology-disk.ftl
+++ b/Resources/Locale/en-US/research/components/technology-disk.ftl
@@ -2,6 +2,7 @@ tech-disk-inserted = You insert the disk, adding a new recipe to the server.
 tech-disk-examine-none = The label is blank.
 tech-disk-examine = The label has a small dot matrix printed image depicting a {$result}.
 tech-disk-examine-more = There are more images printed, but they're too small to discern.
+tech-disk-name-format = {$baseName} ({$technology})
 
 tech-disk-ui-name = technology disk terminal
 tech-disk-ui-total-label = There are {$amount} points on the selected server


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Minor QOL fix - adds technology name to tech disks.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Technology disks are a bit of a pain to use right now; you tend to make a bunch of them all at once, then have to detailed-examine each of the disks to find what technology they contain, then pickup and move the disk into an "interesting" or "not interesting" pile.

Doing this a bunch is pretty tedious and easy to make a mistake requiring you to sort through the whole pile again. By adding the technology to the disk name, you can now right-click a pile and much more easily scan through it to pick up the interesting ones.


## Technical details
<!-- Summary of code changes for easier review. -->

Nothing terribly exciting; hooking up some already-extant systems.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:
![2025-06-08_20-23](https://github.com/user-attachments/assets/d50084bb-5e55-4930-ba17-08defa635ca7)
After:
![2025-06-08_20-18](https://github.com/user-attachments/assets/5ee36208-3906-491c-b3fc-23220103cd99)
(In this screenshot, I've also used a hand labeler to add a label to a disk, just to test that this PR doesn't interfere with that system)  

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->Real
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Technology disks will now show the tech they contain in their name.
