### PR TITLE
Station size armory fills

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -181,26 +181,24 @@
       tableId: FillRifleLecterLowPop
       conditions:
       - !type:PlayerCountCondition
-        min: 0
-        max: 29
+        max: 30
     - !type:NestedSelector
       tableId: FillRifleLecterMidPop
       conditions:
       - !type:PlayerCountCondition
-        min: 30
-        max: 49
+        min: 31
+        max: 50
     - !type:NestedSelector
       tableId: FillRifleLecterHighPop
       conditions:
       - !type:PlayerCountCondition
-        min: 50
-        max: 69
+        min: 51
+        max: 75
     - !type:NestedSelector
       tableId: FillRifleLecterMaxPop
       conditions:
       - !type:PlayerCountCondition
-        min: 70
-        max: 80
+        min: 76
 
 - type: entityTable
   id: FillRifleLecterLowPop
@@ -212,7 +210,7 @@
       amount: 4
 
 - type: entityTable
-  id: FillRifleLecterMedPop
+  id: FillRifleLecterMidPop
   table: !type:AllSelector
     children:
     - id: WeaponRifleLecter
@@ -248,54 +246,78 @@
       entity_storage: !type:NestedSelector
         tableId: BaseFillRifleLecter
 
-- type: entity
-  parent: [GunSafeBaseSecure, BaseSecurityContraband]
-  id: GunSafeSubMachineGunDrozd
-  suffix: LowPop
-  name: drozd safe
-  components:
-  - type: StorageFill
-    contents:
+- type: entityTable
+  id: BaseFillSubMachineGunDrozd
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: FillSubMachineGunDrozdLowPop
+      conditions:
+      - !type:PlayerCountCondition
+        max: 30
+    - !type:NestedSelector
+      tableId: FillSubMachineGunDrozdMidPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 31
+        max: 50
+    - !type:NestedSelector
+      tableId: FillSubMachineGunDrozdHighPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 51
+        max: 75
+    - !type:NestedSelector
+      tableId: FillSubMachineGunDrozdMaxPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 76
+
+- type: entityTable
+  id: FillSubMachineGunDrozdLowPop
+  table: !type:AllSelector
+    children:
     - id: WeaponSubMachineGunDrozd
       amount: 2
     - id: MagazinePistolSubMachineGun
       amount: 4
 
-- type: entity
-  parent: GunSafeSubMachineGunDrozd
-  id: GunSafeSubMachineGunDrozdMidPop
-  suffix: MidPop
-  components:
-  - type: StorageFill
-    contents:
-    - id: WeaponSubMachineGunDrozd
-      amount: 2
-    - id: MagazinePistolSubMachineGun
-      amount: 4
-
-- type: entity
-  parent: GunSafeSubMachineGunDrozd
-  id: GunSafeSubMachineGunDrozdHighPop
-  suffix: HighPop
-  components:
-  - type: StorageFill
-    contents:
+- type: entityTable
+  id: FillSubMachineGunDrozdMidPop
+  table: !type:AllSelector
+    children:
     - id: WeaponSubMachineGunDrozd
       amount: 3
     - id: MagazinePistolSubMachineGun
       amount: 6
 
-- type: entity
-  parent: GunSafeSubMachineGunDrozd
-  id: GunSafeSubMachineGunDrozdMaxPop
-  suffix: MaxPop
-  components:
-  - type: StorageFill
-    contents:
+- type: entityTable
+  id: FillSubMachineGunDrozdHighPop
+  table: !type:AllSelector
+    children:
     - id: WeaponSubMachineGunDrozd
       amount: 4
     - id: MagazinePistolSubMachineGun
       amount: 8
+
+- type: entityTable
+  id: FillSubMachineGunDrozdMaxPop
+  table: !type:AllSelector
+    children:
+    - id: WeaponSubMachineGunDrozd
+      amount: 5
+    - id: MagazinePistolSubMachineGun
+      amount: 10
+
+- type: entity
+  parent: [GunSafeBaseSecure, BaseSecurityContraband]
+  id: GunSafeSubMachineGunDrozd
+  name: drozd safe
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: BaseFillSubMachineGunDrozd
 
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
@@ -309,65 +331,78 @@
     - id: BoxLethalshot
       amount: 4
 
+- type: entityTable
+  id: BaseFillShotgunKammerer
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: FillShotgunKammererLowPop
+      conditions:
+      - !type:PlayerCountCondition
+        max: 30
+    - !type:NestedSelector
+      tableId: FillShotgunKammererMidPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 31
+        max: 50
+    - !type:NestedSelector
+      tableId: FillShotgunKammererHighPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 51
+        max: 75
+    - !type:NestedSelector
+      tableId: FillShotgunKammererMaxPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 76
+
+- type: entityTable
+  id: FillShotgunKammererLowPop
+  table: !type:AllSelector
+    children:
+    - id: WeaponShotgunKammerer
+      amount: 2
+    - id: BoxLethalshot
+      amount: 4
+
+- type: entityTable
+  id: FillShotgunKammererMidPop
+  table: !type:AllSelector
+    children:
+    - id: WeaponShotgunKammerer
+      amount: 3
+    - id: BoxLethalshot
+      amount: 6
+
+- type: entityTable
+  id: FillShotgunKammererHighPop
+  table: !type:AllSelector
+    children:
+    - id: WeaponShotgunKammerer
+      amount: 4
+    - id: BoxLethalshot
+      amount: 8
+
+- type: entityTable
+  id: FillShotgunKammererMaxPop
+  table: !type:AllSelector
+    children:
+    - id: WeaponShotgunKammerer
+      amount: 5
+    - id: BoxLethalshot
+      amount: 10
+
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
   id: GunSafeShotgunKammerer
   name: kammerer safe
-  suffix: LowPop
   components:
-  - type: StorageFill
-    contents:
-    - id: WeaponShotgunKammerer
-      amount: 2
-    - id: BoxLethalshot
-      amount: 2
-    - id: BoxShotgunSlug
-      amount: 2
-
-- type: entity
-  parent: [GunSafeBaseSecure, BaseSecurityContraband]
-  id: GunSafeShotgunKammererMidPop
-  name: kammerer safe
-  suffix: MidPop
-  components:
-  - type: StorageFill
-    contents:
-    - id: WeaponShotgunKammerer
-      amount: 2
-    - id: BoxLethalshot
-      amount: 2
-    - id: BoxShotgunSlug
-      amount: 2
-
-- type: entity
-  parent: [GunSafeBaseSecure, BaseSecurityContraband]
-  id: GunSafeShotgunKammererHighPop
-  name: kammerer safe
-  suffix: HighPop
-  components:
-  - type: StorageFill
-    contents:
-    - id: WeaponShotgunKammerer
-      amount: 3
-    - id: BoxLethalshot
-      amount: 3
-    - id: BoxShotgunSlug
-      amount: 3
-
-- type: entity
-  parent: [GunSafeBaseSecure, BaseSecurityContraband]
-  id: GunSafeShotgunKammererMaxPop
-  name: kammerer safe
-  suffix: MaxPop
-  components:
-  - type: StorageFill
-    contents:
-    - id: WeaponShotgunKammerer
-      amount: 4
-    - id: BoxLethalshot
-      amount: 4
-    - id: BoxShotgunSlug
-      amount: 4
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: BaseFillShotgunKammerer
 
 - type: entity
   id: GunSafeSubMachineGunWt550
@@ -382,43 +417,67 @@
     - id: MagazinePistolSubMachineGunTopMounted
       amount: 4
 
-- type: entity
-  parent: [GunSafeBaseSecure, BaseSecurityContraband]
-  id: GunSafeLaserCarbine
-  name: laser safe
-  suffix: LowPop
-  components:
-  - type: StorageFill
-    contents:
+- type: entityTable
+  id: BaseFillWeaponLaserCarbine
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: FillWeaponLaserCarbineLowPop
+      conditions:
+      - !type:PlayerCountCondition
+        max: 30
+    - !type:NestedSelector
+      tableId: FillWeaponLaserCarbineMidPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 31
+        max: 50
+    - !type:NestedSelector
+      tableId: FillWeaponLaserCarbineHighPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 51
+        max: 75
+    - !type:NestedSelector
+      tableId: FillWeaponLaserCarbineMaxPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 76
+
+- type: entityTable
+  id: FillWeaponLaserCarbineLowPop
+  table: !type:AllSelector
+    children:
     - id: WeaponLaserCarbine
       amount: 3
 
-- type: entity
-  parent: GunSafeLaserCarbine
-  id: GunSafeLaserCarbineMidPop
-  suffix: MidPop
-  components:
-  - type: StorageFill
-    contents:
+- type: entityTable
+  id: FillWeaponLaserCarbineMidPop
+  table: !type:AllSelector
+    children:
     - id: WeaponLaserCarbine
       amount: 4
 
-- type: entity
-  parent: GunSafeLaserCarbine
-  id: GunSafeLaserCarbineHighPop
-  suffix: HighPop
-  components:
-  - type: StorageFill
-    contents:
+- type: entityTable
+  id: FillWeaponLaserCarbineHighPop
+  table: !type:AllSelector
+    children:
     - id: WeaponLaserCarbine
       amount: 5
 
-- type: entity
-  parent: GunSafeLaserCarbine
-  id: GunSafeLaserCarbineMaxPop
-  suffix: MaxPop
-  components:
-  - type: StorageFill
-    contents:
+- type: entityTable
+  id: FillWeaponLaserCarbineMaxPop
+  table: !type:AllSelector
+    children:
     - id: WeaponLaserCarbine
       amount: 6
+
+- type: entity
+  parent: [GunSafeBaseSecure, BaseSecurityContraband]
+  id: GunSafeWeaponLaserCarbine
+  name: laser safe
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: BaseFillWeaponLaserCarbine

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -159,7 +159,7 @@
   - type: StorageFill
     contents:
     - id: WeaponDisabler
-      amount: 5
+      amount: 6
 
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
@@ -177,6 +177,7 @@
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
   id: GunSafeRifleLecter
   name: lecter safe
+  suffix: LowPop
   components:
   - type: StorageFill
     contents:
@@ -186,8 +187,45 @@
       amount: 4
 
 - type: entity
+  parent: GunSafeRifleLecter
+  id: GunSafeRifleLecterMidPop
+  suffix: MidPop
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponRifleLecter
+      amount: 3
+    - id: MagazineRifle
+      amount: 6
+
+- type: entity
+  parent: GunSafeRifleLecter
+  id: GunSafeRifleLecterHighPop
+  suffix: HighPop
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponRifleLecter
+      amount: 4
+    - id: MagazineRifle
+      amount: 8
+
+- type: entity
+  parent: GunSafeRifleLecter
+  id: GunSafeRifleLecterMaxPop
+  suffix: MaxPop
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponRifleLecter
+      amount: 5
+    - id: MagazineRifle
+      amount: 10
+
+- type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
   id: GunSafeSubMachineGunDrozd
+  suffix: LowPop
   name: drozd safe
   components:
   - type: StorageFill
@@ -196,6 +234,42 @@
       amount: 2
     - id: MagazinePistolSubMachineGun
       amount: 4
+
+- type: entity
+  parent: GunSafeSubMachineGunDrozd
+  id: GunSafeSubMachineGunDrozdMidPop
+  suffix: MidPop
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponSubMachineGunDrozd
+      amount: 2
+    - id: MagazinePistolSubMachineGun
+      amount: 4
+
+- type: entity
+  parent: GunSafeSubMachineGunDrozd
+  id: GunSafeSubMachineGunDrozdHighPop
+  suffix: HighPop
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponSubMachineGunDrozd
+      amount: 3
+    - id: MagazinePistolSubMachineGun
+      amount: 6
+
+- type: entity
+  parent: GunSafeSubMachineGunDrozd
+  id: GunSafeSubMachineGunDrozdMaxPop
+  suffix: MaxPop
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponSubMachineGunDrozd
+      amount: 4
+    - id: MagazinePistolSubMachineGun
+      amount: 8
 
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
@@ -213,6 +287,7 @@
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
   id: GunSafeShotgunKammerer
   name: kammerer safe
+  suffix: LowPop
   components:
   - type: StorageFill
     contents:
@@ -220,6 +295,53 @@
       amount: 2
     - id: BoxLethalshot
       amount: 2
+    - id: BoxShotgunSlug
+      amount: 2
+
+- type: entity
+  parent: [GunSafeBaseSecure, BaseSecurityContraband]
+  id: GunSafeShotgunKammererMidPop
+  name: kammerer safe
+  suffix: MidPop
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponShotgunKammerer
+      amount: 2
+    - id: BoxLethalshot
+      amount: 2
+    - id: BoxShotgunSlug
+      amount: 2
+
+- type: entity
+  parent: [GunSafeBaseSecure, BaseSecurityContraband]
+  id: GunSafeShotgunKammererHighPop
+  name: kammerer safe
+  suffix: HighPop
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponShotgunKammerer
+      amount: 3
+    - id: BoxLethalshot
+      amount: 3
+    - id: BoxShotgunSlug
+      amount: 3
+
+- type: entity
+  parent: [GunSafeBaseSecure, BaseSecurityContraband]
+  id: GunSafeShotgunKammererMaxPop
+  name: kammerer safe
+  suffix: MaxPop
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponShotgunKammerer
+      amount: 4
+    - id: BoxLethalshot
+      amount: 4
+    - id: BoxShotgunSlug
+      amount: 4
 
 - type: entity
   id: GunSafeSubMachineGunWt550
@@ -238,8 +360,39 @@
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
   id: GunSafeLaserCarbine
   name: laser safe
+  suffix: LowPop
   components:
   - type: StorageFill
     contents:
     - id: WeaponLaserCarbine
       amount: 3
+
+- type: entity
+  parent: GunSafeLaserCarbine
+  id: GunSafeLaserCarbineMidPop
+  suffix: MidPop
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponLaserCarbine
+      amount: 4
+
+- type: entity
+  parent: GunSafeLaserCarbine
+  id: GunSafeLaserCarbineHighPop
+  suffix: HighPop
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponLaserCarbine
+      amount: 5
+
+- type: entity
+  parent: GunSafeLaserCarbine
+  id: GunSafeLaserCarbineMaxPop
+  suffix: MaxPop
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponLaserCarbine
+      amount: 6

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -173,54 +173,80 @@
     - id: MagazinePistol
       amount: 8
 
-- type: entity
-  parent: [GunSafeBaseSecure, BaseSecurityContraband]
-  id: GunSafeRifleLecter
-  name: lecter safe
-  suffix: LowPop
-  components:
-  - type: StorageFill
-    contents:
+- type: entityTable
+  id: BaseFillRifleLecter
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: FillRifleLecterLowPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 0
+        max: 29
+    - !type:NestedSelector
+      tableId: FillRifleLecterMidPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 30
+        max: 49
+    - !type:NestedSelector
+      tableId: FillRifleLecterHighPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 50
+        max: 69
+    - !type:NestedSelector
+      tableId: FillRifleLecterMaxPop
+      conditions:
+      - !type:PlayerCountCondition
+        min: 70
+        max: 80
+
+- type: entityTable
+  id: FillRifleLecterLowPop
+  table: !type:AllSelector
+    children:
     - id: WeaponRifleLecter
       amount: 2
     - id: MagazineRifle
       amount: 4
 
-- type: entity
-  parent: GunSafeRifleLecter
-  id: GunSafeRifleLecterMidPop
-  suffix: MidPop
-  components:
-  - type: StorageFill
-    contents:
+- type: entityTable
+  id: FillRifleLecterMedPop
+  table: !type:AllSelector
+    children:
     - id: WeaponRifleLecter
       amount: 3
     - id: MagazineRifle
       amount: 6
 
-- type: entity
-  parent: GunSafeRifleLecter
-  id: GunSafeRifleLecterHighPop
-  suffix: HighPop
-  components:
-  - type: StorageFill
-    contents:
+- type: entityTable
+  id: FillRifleLecterHighPop
+  table: !type:AllSelector
+    children:
     - id: WeaponRifleLecter
       amount: 4
     - id: MagazineRifle
       amount: 8
 
-- type: entity
-  parent: GunSafeRifleLecter
-  id: GunSafeRifleLecterMaxPop
-  suffix: MaxPop
-  components:
-  - type: StorageFill
-    contents:
+- type: entityTable
+  id: FillRifleLecterMaxPop
+  table: !type:AllSelector
+    children:
     - id: WeaponRifleLecter
       amount: 5
     - id: MagazineRifle
       amount: 10
+
+- type: entity
+  parent: [GunSafeBaseSecure, BaseSecurityContraband]
+  id: GunSafeRifleLecter
+  name: lecter safe
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: BaseFillRifleLecter
 
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -474,7 +474,7 @@
 
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
-  id: GunSafeWeaponLaserCarbine
+  id: GunSafeLaserCarbine
   name: laser safe
   components:
   - type: EntityTableContainerFill

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -173,69 +173,6 @@
     - id: MagazinePistol
       amount: 8
 
-- type: entityTable
-  id: BaseFillRifleLecter
-  table: !type:AllSelector
-    children:
-    - !type:NestedSelector
-      tableId: FillRifleLecterLowPop
-      conditions:
-      - !type:PlayerCountCondition
-        max: 30
-    - !type:NestedSelector
-      tableId: FillRifleLecterMidPop
-      conditions:
-      - !type:PlayerCountCondition
-        min: 31
-        max: 50
-    - !type:NestedSelector
-      tableId: FillRifleLecterHighPop
-      conditions:
-      - !type:PlayerCountCondition
-        min: 51
-        max: 75
-    - !type:NestedSelector
-      tableId: FillRifleLecterMaxPop
-      conditions:
-      - !type:PlayerCountCondition
-        min: 76
-
-- type: entityTable
-  id: FillRifleLecterLowPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponRifleLecter
-      amount: 2
-    - id: MagazineRifle
-      amount: 4
-
-- type: entityTable
-  id: FillRifleLecterMidPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponRifleLecter
-      amount: 3
-    - id: MagazineRifle
-      amount: 6
-
-- type: entityTable
-  id: FillRifleLecterHighPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponRifleLecter
-      amount: 4
-    - id: MagazineRifle
-      amount: 8
-
-- type: entityTable
-  id: FillRifleLecterMaxPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponRifleLecter
-      amount: 5
-    - id: MagazineRifle
-      amount: 10
-
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
   id: GunSafeRifleLecter
@@ -244,70 +181,89 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: BaseFillRifleLecter
+        tableId: GunSafeRifleLecterFill
+
+- type: entityTable
+  id: GunSafeRifleLecterFill
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: BaseFillRifleLecter
+      rolls: 2
+      conditions:
+      - !type:PlayerCountCondition
+        min: 0
+        max: 2
+    - !type:NestedSelector
+      tableId: BaseFillRifleLecter
+      rolls: 3
+      conditions:
+      - !type:PlayerCountCondition
+        min: 3
+        max: 4
+    - !type:NestedSelector
+      tableId: BaseFillRifleLecter
+      rolls: 4
+      conditions:
+      - !type:PlayerCountCondition
+        min: 5
+        max: 6
+    - !type:NestedSelector
+      tableId: BaseFillRifleLecter
+      rolls: 5
+      conditions:
+      - !type:PlayerCountCondition
+        min: 7
+        max: 8
+
+- type: entityTable
+  id: BaseFillRifleLecter
+  table: !type:AllSelector
+    children:
+    - id: WeaponRifleLecter
+    - id: MagazineRifle
+      amount: 2
+
+- type: entityTable
+  id: GunSafeSubMachineGunDrozdFill
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: BaseFillSubMachineGunDrozd
+      rolls: 2
+      conditions:
+      - !type:PlayerCountCondition
+        min: 0
+        max: 2
+    - !type:NestedSelector
+      tableId: BaseFillSubMachineGunDrozd
+      rolls: 3
+      conditions:
+      - !type:PlayerCountCondition
+        min: 3
+        max: 4
+    - !type:NestedSelector
+      tableId: BaseFillSubMachineGunDrozd
+      rolls: 3
+      conditions:
+      - !type:PlayerCountCondition
+        min: 5
+        max: 6
+    - !type:NestedSelector
+      tableId: BaseFillSubMachineGunDrozd
+      rolls: 4
+      conditions:
+      - !type:PlayerCountCondition
+        min: 7
+        max: 8
 
 - type: entityTable
   id: BaseFillSubMachineGunDrozd
   table: !type:AllSelector
     children:
-    - !type:NestedSelector
-      tableId: FillSubMachineGunDrozdLowPop
-      conditions:
-      - !type:PlayerCountCondition
-        max: 30
-    - !type:NestedSelector
-      tableId: FillSubMachineGunDrozdMidPop
-      conditions:
-      - !type:PlayerCountCondition
-        min: 31
-        max: 50
-    - !type:NestedSelector
-      tableId: FillSubMachineGunDrozdHighPop
-      conditions:
-      - !type:PlayerCountCondition
-        min: 51
-        max: 75
-    - !type:NestedSelector
-      tableId: FillSubMachineGunDrozdMaxPop
-      conditions:
-      - !type:PlayerCountCondition
-        min: 76
-
-- type: entityTable
-  id: FillSubMachineGunDrozdLowPop
-  table: !type:AllSelector
-    children:
     - id: WeaponSubMachineGunDrozd
+    - id: MagazinePistolSubMachineGun
       amount: 2
-    - id: MagazinePistolSubMachineGun
-      amount: 4
-
-- type: entityTable
-  id: FillSubMachineGunDrozdMidPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponSubMachineGunDrozd
-      amount: 3
-    - id: MagazinePistolSubMachineGun
-      amount: 6
-
-- type: entityTable
-  id: FillSubMachineGunDrozdHighPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponSubMachineGunDrozd
-      amount: 4
-    - id: MagazinePistolSubMachineGun
-      amount: 8
-
-- type: entityTable
-  id: FillSubMachineGunDrozdMaxPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponSubMachineGunDrozd
-      amount: 5
-    - id: MagazinePistolSubMachineGun
-      amount: 10
 
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
@@ -317,7 +273,7 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: BaseFillSubMachineGunDrozd
+        tableId: GunSafeSubMachineGunDrozdFill
 
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
@@ -332,67 +288,45 @@
       amount: 4
 
 - type: entityTable
+  id: GunSafeShotgunKammererFill
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: BaseFillShotgunKammerer
+      rolls: 2
+      conditions:
+      - !type:PlayerCountCondition
+        min: 0
+        max: 2
+    - !type:NestedSelector
+      tableId: BaseFillShotgunKammerer
+      rolls: 3
+      conditions:
+      - !type:PlayerCountCondition
+        min: 3
+        max: 4
+    - !type:NestedSelector
+      tableId: BaseFillShotgunKammerer
+      rolls: 3
+      conditions:
+      - !type:PlayerCountCondition
+        min: 5
+        max: 6
+    - !type:NestedSelector
+      tableId: BaseFillShotgunKammerer
+      rolls: 4
+      conditions:
+      - !type:PlayerCountCondition
+        min: 7
+        max: 8
+
+- type: entityTable
   id: BaseFillShotgunKammerer
   table: !type:AllSelector
     children:
-    - !type:NestedSelector
-      tableId: FillShotgunKammererLowPop
-      conditions:
-      - !type:PlayerCountCondition
-        max: 30
-    - !type:NestedSelector
-      tableId: FillShotgunKammererMidPop
-      conditions:
-      - !type:PlayerCountCondition
-        min: 31
-        max: 50
-    - !type:NestedSelector
-      tableId: FillShotgunKammererHighPop
-      conditions:
-      - !type:PlayerCountCondition
-        min: 51
-        max: 75
-    - !type:NestedSelector
-      tableId: FillShotgunKammererMaxPop
-      conditions:
-      - !type:PlayerCountCondition
-        min: 76
-
-- type: entityTable
-  id: FillShotgunKammererLowPop
-  table: !type:AllSelector
-    children:
     - id: WeaponShotgunKammerer
+    - id: BoxLethalshot
       amount: 2
-    - id: BoxLethalshot
-      amount: 4
-
-- type: entityTable
-  id: FillShotgunKammererMidPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponShotgunKammerer
-      amount: 3
-    - id: BoxLethalshot
-      amount: 6
-
-- type: entityTable
-  id: FillShotgunKammererHighPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponShotgunKammerer
-      amount: 4
-    - id: BoxLethalshot
-      amount: 8
-
-- type: entityTable
-  id: FillShotgunKammererMaxPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponShotgunKammerer
-      amount: 5
-    - id: BoxLethalshot
-      amount: 10
 
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
@@ -402,7 +336,7 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: BaseFillShotgunKammerer
+        tableId: GunSafeShotgunKammererFill
 
 - type: entity
   id: GunSafeSubMachineGunWt550
@@ -418,59 +352,43 @@
       amount: 4
 
 - type: entityTable
-  id: BaseFillWeaponLaserCarbine
+  id: GunSafeLaserCarbineFill
   table: !type:AllSelector
     children:
     - !type:NestedSelector
-      tableId: FillWeaponLaserCarbineLowPop
+      tableId: BaseFillLaserCarbine
+      rolls: 3
       conditions:
       - !type:PlayerCountCondition
-        max: 30
+        min: 0
+        max: 2
     - !type:NestedSelector
-      tableId: FillWeaponLaserCarbineMidPop
+      tableId: BaseFillLaserCarbine
+      rolls: 4
       conditions:
       - !type:PlayerCountCondition
-        min: 31
-        max: 50
+        min: 3
+        max: 4
     - !type:NestedSelector
-      tableId: FillWeaponLaserCarbineHighPop
+      tableId: BaseFillLaserCarbine
+      rolls: 5
       conditions:
       - !type:PlayerCountCondition
-        min: 51
-        max: 75
+        min: 5
+        max: 6
     - !type:NestedSelector
-      tableId: FillWeaponLaserCarbineMaxPop
+      tableId: BaseFillLaserCarbine
+      rolls: 6
       conditions:
       - !type:PlayerCountCondition
-        min: 76
+        min: 7
+        max: 8
 
 - type: entityTable
-  id: FillWeaponLaserCarbineLowPop
+  id: BaseFillLaserCarbine
   table: !type:AllSelector
     children:
     - id: WeaponLaserCarbine
-      amount: 3
-
-- type: entityTable
-  id: FillWeaponLaserCarbineMidPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponLaserCarbine
-      amount: 4
-
-- type: entityTable
-  id: FillWeaponLaserCarbineHighPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponLaserCarbine
-      amount: 5
-
-- type: entityTable
-  id: FillWeaponLaserCarbineMaxPop
-  table: !type:AllSelector
-    children:
-    - id: WeaponLaserCarbine
-      amount: 6
 
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]
@@ -480,4 +398,4 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: BaseFillWeaponLaserCarbine
+        tableId: GunSafeLaserCarbineFill

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -119,13 +119,15 @@
 - type: entity
   id: SuitStorageSec
   parent: SuitStorageBase
-  suffix: Security
+  suffix: Security, Double
   components:
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitSecurity
-        - id: ClothingMaskBreath
+          amount: 2
+        - id: JetpackSecurity
   - type: AccessReader
     access: [["Security"]]
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -12,6 +12,22 @@
         - id: ClothingHeadHelmetEVA
         - id: ClothingMaskBreath
 
+- type: entity
+  id: SuitStorageEVADouble
+  parent: SuitStorageBase
+  suffix: EVA, Double
+  components:
+  - type: StorageFill
+    contents:
+    - id: OxygenTankFilled
+    - id: NitrogenTankFilled
+    - id: ClothingOuterHardsuitEVA
+      amount: 2
+    - id: ClothingHeadHelmetEVA
+      amount: 2
+    - id: ClothingMaskBreath
+      amount: 2
+
 #Basic EVA (Big Ass Helmet)
 - type: entity
   id: SuitStorageEVAAlternate

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -143,6 +143,8 @@
         - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitSecurity
           amount: 2
+        - id: ClothingMaskGasSecurity
+          amount: 2
         - id: JetpackSecurity
   - type: AccessReader
     access: [["Security"]]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added entitytables to automatically fill gun safes for Kammerers, Lecters, Drozds, and Lasers. The number of guns inserted is based on total playercount.
Changed security suit storage units to fill with two hardsuits, a O2 and N2 tank, and a security jetpack.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This allows the number of guns in a map's armory to be balanced to map/security team size without the current method of manually adding more guns in the map, allowing balancing changes to be made fully through yaml. 
The current values are as follows, with the number of guns listed being the number of each type of gun, except lasers which following tradition have one extra.
LowPop: 0-30 players, standard fills (2 guns)
MidPop: 31-50 players, 3 guns
HighPop: 51-75 players, 4 guns
MaxPop: 76+ players, 5 guns

Following the merging of this PR I will remove the manually fills from each station armory.
## Technical details
<!-- Summary of code changes for easier review. -->
Simply added new prototypes which are parented to the base gun safes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
