### PR TITLE
Combined syndicate contraband and magical contraband into "extreme contraband"

### DIFF
--- a/Resources/Locale/en-US/contraband/contraband-severity.ftl
+++ b/Resources/Locale/en-US/contraband/contraband-severity.ftl
@@ -3,8 +3,7 @@ contraband-examine-text-Restricted = [color=yellow]This item is departmentally r
 contraband-examine-text-Restricted-department = [color=yellow]This item is restricted to {$departments}, and may be considered contraband.[/color]
 contraband-examine-text-Major = [color=red]This item is considered major contraband.[/color]
 contraband-examine-text-GrandTheft = [color=red]This item is a highly valuable target for Syndicate agents![/color]
-contraband-examine-text-Syndicate = [color=crimson]This item is highly illegal Syndicate contraband![/color]
-contraband-examine-text-Magical = [color=#b337b3]This item is highly illegal Magical contraband![/color]
+contraband-examine-text-Foreign = [color=crimson]This item is highly illegal foreign contraband![/color]
 
 contraband-examine-text-avoid-carrying-around = [color=red][italic]You probably want to avoid visibly carrying this around without a good reason.[/italic][/color]
 contraband-examine-text-in-the-clear = [color=green][italic]You should be in the clear to visibly carry this around.[/italic][/color]

--- a/Resources/Locale/en-US/contraband/contraband-severity.ftl
+++ b/Resources/Locale/en-US/contraband/contraband-severity.ftl
@@ -3,7 +3,7 @@ contraband-examine-text-Restricted = [color=yellow]This item is departmentally r
 contraband-examine-text-Restricted-department = [color=yellow]This item is restricted to {$departments}, and may be considered contraband.[/color]
 contraband-examine-text-Major = [color=red]This item is considered major contraband.[/color]
 contraband-examine-text-GrandTheft = [color=red]This item is a highly valuable target for Syndicate agents![/color]
-contraband-examine-text-Foreign = [color=crimson]This item is highly illegal foreign contraband![/color]
+contraband-examine-text-Extreme = [color=crimson]This item is highly illegal extreme contraband![/color]
 
 contraband-examine-text-avoid-carrying-around = [color=red][italic]You probably want to avoid visibly carrying this around without a good reason.[/italic][/color]
 contraband-examine-text-in-the-clear = [color=green][italic]You should be in the clear to visibly carry this around.[/italic][/color]

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -371,7 +371,7 @@
 
 - type: entity
   name: syndicate encryption key box
-  parent: [BoxEncryptionKeyPassenger, BaseSyndicateContraband]
+  parent: [BoxEncryptionKeyPassenger, BaseForeignContraband]
   id: BoxEncryptionKeySyndie
   description: Two syndicate encryption keys for the price of one. Miniaturized for ease of use.
   components:

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -371,7 +371,7 @@
 
 - type: entity
   name: syndicate encryption key box
-  parent: [BoxEncryptionKeyPassenger, BaseForeignContraband]
+  parent: [BoxEncryptionKeyPassenger, BaseExtremeContraband]
   id: BoxEncryptionKeySyndie
   description: Two syndicate encryption keys for the price of one. Miniaturized for ease of use.
   components:

--- a/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: ElectricalDisruptionKit
-  parent: [BoxCardboard, BaseSyndicateContraband]
+  parent: [BoxCardboard, BaseForeignContraband]
   name: electrical disruption kit
   suffix: Filled
   components:
@@ -12,7 +12,7 @@
           amount: 1
 
 - type: entity
-  parent: [BoxVial, BaseSyndicateContraband]
+  parent: [BoxVial, BaseForeignContraband]
   id: ChemicalSynthesisKit
   name: chemical synthesis kit
   description: A starter kit for the aspiring chemist, includes two vials of vestine for all your criminal needs!
@@ -33,7 +33,7 @@
       - id: SyringeStimulants
 
 - type: entity
-  parent: [BoxCardboard, BaseSyndicateContraband]
+  parent: [BoxCardboard, BaseForeignContraband]
   id: ThrowingKnivesKit
   name: throwing knives kit
   description: A set of 4 syndicate branded throwing knives, perfect for embedding into the body of your victims.
@@ -52,7 +52,7 @@
 
 - type: entity
   name: deathrattle implant box
-  parent: [BoxCardboard, BaseSyndicateContraband]
+  parent: [BoxCardboard, BaseForeignContraband]
   id: BoxDeathRattleImplants
   description: Six deathrattle implants for the whole squad.
   components:
@@ -69,7 +69,7 @@
         amount: 6
 
 - type: entity
-  parent: [BoxCardboard, BaseSyndicateContraband]
+  parent: [BoxCardboard, BaseForeignContraband]
   id: CombatBakeryKit
   name: combat bakery kit
   description: A kit of clandestine baked weapons.

--- a/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: ElectricalDisruptionKit
-  parent: [BoxCardboard, BaseForeignContraband]
+  parent: [BoxCardboard, BaseExtremeContraband]
   name: electrical disruption kit
   suffix: Filled
   components:
@@ -12,7 +12,7 @@
           amount: 1
 
 - type: entity
-  parent: [BoxVial, BaseForeignContraband]
+  parent: [BoxVial, BaseExtremeContraband]
   id: ChemicalSynthesisKit
   name: chemical synthesis kit
   description: A starter kit for the aspiring chemist, includes two vials of vestine for all your criminal needs!
@@ -33,7 +33,7 @@
       - id: SyringeStimulants
 
 - type: entity
-  parent: [BoxCardboard, BaseForeignContraband]
+  parent: [BoxCardboard, BaseExtremeContraband]
   id: ThrowingKnivesKit
   name: throwing knives kit
   description: A set of 4 syndicate branded throwing knives, perfect for embedding into the body of your victims.
@@ -52,7 +52,7 @@
 
 - type: entity
   name: deathrattle implant box
-  parent: [BoxCardboard, BaseForeignContraband]
+  parent: [BoxCardboard, BaseExtremeContraband]
   id: BoxDeathRattleImplants
   description: Six deathrattle implants for the whole squad.
   components:
@@ -69,7 +69,7 @@
         amount: 6
 
 - type: entity
-  parent: [BoxCardboard, BaseForeignContraband]
+  parent: [BoxCardboard, BaseExtremeContraband]
   id: CombatBakeryKit
   name: combat bakery kit
   description: A kit of clandestine baked weapons.

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CrateSyndicateSurplusBundle
-  parent: [ CrateSyndicate, StorePresetUplink, BaseSyndicateContraband ]
+  parent: [ CrateSyndicate, StorePresetUplink, BaseForeignContraband ]
   name: Syndicate surplus crate
   description: Contains 50 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
   components:
@@ -24,7 +24,7 @@
 
 - type: entity
   id: CrateSyndicateSuperSurplusBundle
-  parent: [ CrateSyndicate, StorePresetUplink, BaseSyndicateContraband ]
+  parent: [ CrateSyndicate, StorePresetUplink, BaseForeignContraband ]
   name: Syndicate super surplus crate
   description: Contains 125 telecrystals worth of completely random Syndicate items.
   components:

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CrateSyndicateSurplusBundle
-  parent: [ CrateSyndicate, StorePresetUplink, BaseForeignContraband ]
+  parent: [ CrateSyndicate, StorePresetUplink, BaseExtremeContraband ]
   name: Syndicate surplus crate
   description: Contains 50 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
   components:
@@ -24,7 +24,7 @@
 
 - type: entity
   id: CrateSyndicateSuperSurplusBundle
-  parent: [ CrateSyndicate, StorePresetUplink, BaseForeignContraband ]
+  parent: [ CrateSyndicate, StorePresetUplink, BaseExtremeContraband ]
   name: Syndicate super surplus crate
   description: Contains 125 telecrystals worth of completely random Syndicate items.
   components:

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -269,7 +269,7 @@
 
 #Syndicate
 - type: entity
-  parent: [ClothingBackpack, BaseSyndicateContraband]
+  parent: [ClothingBackpack, BaseForeignContraband]
   id: ClothingBackpackSyndicate
   name: syndicate backpack
   description:

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -269,7 +269,7 @@
 
 #Syndicate
 - type: entity
-  parent: [ClothingBackpack, BaseForeignContraband]
+  parent: [ClothingBackpack, BaseExtremeContraband]
   id: ClothingBackpackSyndicate
   name: syndicate backpack
   description:

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -158,7 +158,7 @@
       sprite: Clothing/Back/Duffels/salvage.rsi
 
 - type: entity
-  parent: [ClothingBackpackDuffel, BaseSyndicateContraband]
+  parent: [ClothingBackpackDuffel, BaseForeignContraband]
   id: ClothingBackpackDuffelSyndicate
   name: syndicate duffel bag
   description: A large duffel bag for holding various traitor goods.

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -158,7 +158,7 @@
       sprite: Clothing/Back/Duffels/salvage.rsi
 
 - type: entity
-  parent: [ClothingBackpackDuffel, BaseForeignContraband]
+  parent: [ClothingBackpackDuffel, BaseExtremeContraband]
   id: ClothingBackpackDuffelSyndicate
   name: syndicate duffel bag
   description: A large duffel bag for holding various traitor goods.

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -596,7 +596,7 @@
     - 0,0,3,1
 
 - type: entity
-  parent: [ClothingBeltStorageBase, BaseSyndicateContraband]
+  parent: [ClothingBeltStorageBase, BaseForeignContraband]
   id: ClothingBeltSyndieHolster
   name: syndicate shoulder holster
   description: A deep shoulder holster capable of holding many types of ballistics.
@@ -653,7 +653,7 @@
     sprite: Clothing/Belt/salvagewebbing.rsi
 
 - type: entity
-  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseSyndicateContraband]
+  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseForeignContraband]
   id: ClothingBeltMilitaryWebbing
   name: chest rig
   description: A set of tactical webbing worn by Syndicate boarding parties.
@@ -709,7 +709,7 @@
     sprite: Clothing/Belt/suspenders_black.rsi
 
 - type: entity
-  parent: [ ClothingBeltStorageBase, BaseMagicalContraband ]
+  parent: [ ClothingBeltStorageBase, BaseForeignContraband ]
   id: ClothingBeltWand
   name: wand belt
   description: A belt designed to hold various rods of power. A veritable fanny pack of exotic magic.

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -596,7 +596,7 @@
     - 0,0,3,1
 
 - type: entity
-  parent: [ClothingBeltStorageBase, BaseForeignContraband]
+  parent: [ClothingBeltStorageBase, BaseExtremeContraband]
   id: ClothingBeltSyndieHolster
   name: syndicate shoulder holster
   description: A deep shoulder holster capable of holding many types of ballistics.
@@ -653,7 +653,7 @@
     sprite: Clothing/Belt/salvagewebbing.rsi
 
 - type: entity
-  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseForeignContraband]
+  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseExtremeContraband]
   id: ClothingBeltMilitaryWebbing
   name: chest rig
   description: A set of tactical webbing worn by Syndicate boarding parties.
@@ -709,7 +709,7 @@
     sprite: Clothing/Belt/suspenders_black.rsi
 
 - type: entity
-  parent: [ ClothingBeltStorageBase, BaseForeignContraband ]
+  parent: [ ClothingBeltStorageBase, BaseExtremeContraband ]
   id: ClothingBeltWand
   name: wand belt
   description: A belt designed to hold various rods of power. A veritable fanny pack of exotic magic.

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -290,7 +290,7 @@
       sprite: Clothing/Ears/Headsets/freelance.rsi
 
 - type: entity
-  parent: [ClothingHeadset, BaseMagicalContraband]
+  parent: [ClothingHeadset, BaseForeignContraband]
   id: ClothingHeadsetWizard
   name: wizard headset
   description: A headset used by the dreaded space wizards.

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -290,7 +290,7 @@
       sprite: Clothing/Ears/Headsets/freelance.rsi
 
 - type: entity
-  parent: [ClothingHeadset, BaseForeignContraband]
+  parent: [ClothingHeadset, BaseExtremeContraband]
   id: ClothingHeadsetWizard
   name: wizard headset
   description: A headset used by the dreaded space wizards.

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -122,7 +122,7 @@
     sprite: Clothing/Ears/Headsets/science.rsi
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseSyndicateContraband]
+  parent: [ClothingHeadsetAlt, BaseForeignContraband]
   id: ClothingHeadsetAltSyndicate
   name: blood-red over-ear headset
   description: An updated, modular syndicate intercom that fits over the head and takes encryption keys (there are 5 key slots.).
@@ -157,7 +157,7 @@
       sprite: Clothing/Ears/Headsets/freelance.rsi
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseMagicalContraband]
+  parent: [ClothingHeadsetAlt, BaseForeignContraband]
   id: ClothingHeadsetAltWizard
   name: wizard's over-ear headset
   components:

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -122,7 +122,7 @@
     sprite: Clothing/Ears/Headsets/science.rsi
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseForeignContraband]
+  parent: [ClothingHeadsetAlt, BaseExtremeContraband]
   id: ClothingHeadsetAltSyndicate
   name: blood-red over-ear headset
   description: An updated, modular syndicate intercom that fits over the head and takes encryption keys (there are 5 key slots.).
@@ -157,7 +157,7 @@
       sprite: Clothing/Ears/Headsets/freelance.rsi
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseForeignContraband]
+  parent: [ClothingHeadsetAlt, BaseExtremeContraband]
   id: ClothingHeadsetAltWizard
   name: wizard's over-ear headset
   components:

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -199,7 +199,7 @@
   - type: ShowSyndicateIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, BaseForeignContraband]
+  parent: [ClothingEyesBase, ShowSecurityIcons, BaseExtremeContraband]
   id: ClothingEyesHudSyndicate
   name: syndicate visor
   description: The syndicate's professional head-up display, designed for better detection of humanoids and their subsequent elimination.
@@ -211,7 +211,7 @@
   - type: ShowSyndicateIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, BaseForeignContraband]
+  parent: [ClothingEyesBase, ShowSecurityIcons, BaseExtremeContraband]
   id: ClothingEyesHudSyndicateAgent
   name: syndicate medical visor
   description: The Syndicate Corpsman's professional heads-up display, designed for quick diagnosis of their team's status.

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -199,7 +199,7 @@
   - type: ShowSyndicateIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, BaseSyndicateContraband]
+  parent: [ClothingEyesBase, ShowSecurityIcons, BaseForeignContraband]
   id: ClothingEyesHudSyndicate
   name: syndicate visor
   description: The syndicate's professional head-up display, designed for better detection of humanoids and their subsequent elimination.
@@ -211,7 +211,7 @@
   - type: ShowSyndicateIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, BaseSyndicateContraband]
+  parent: [ClothingEyesBase, ShowSecurityIcons, BaseForeignContraband]
   id: ClothingEyesHudSyndicateAgent
   name: syndicate medical visor
   description: The Syndicate Corpsman's professional heads-up display, designed for quick diagnosis of their team's status.

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -384,7 +384,7 @@
   - type: Unremoveable
 
 - type: entity
-  parent: [ClothingHandsButcherable, BaseSyndicateContraband]
+  parent: [ClothingHandsButcherable, BaseForeignContraband]
   id: ClothingHandsGlovesNorthStar
   name: gloves of the north star
   description: These gloves allow you to punch incredibly fast.
@@ -531,7 +531,7 @@
     stealGroup: ClothingHandsKnuckleDustersQM
 
 - type: entity
-  parent: [ClothingHandsBase, BaseSyndicateContraband]
+  parent: [ClothingHandsBase, BaseForeignContraband]
   id: ClothingHandsKnuckleDustersSyndicate
   name: syndicate knuckle dusters
   description: "Plastitanium knuckle dusters branded with the blood-red S. A real man beats someone to death with these."

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -384,7 +384,7 @@
   - type: Unremoveable
 
 - type: entity
-  parent: [ClothingHandsButcherable, BaseForeignContraband]
+  parent: [ClothingHandsButcherable, BaseExtremeContraband]
   id: ClothingHandsGlovesNorthStar
   name: gloves of the north star
   description: These gloves allow you to punch incredibly fast.
@@ -531,7 +531,7 @@
     stealGroup: ClothingHandsKnuckleDustersQM
 
 - type: entity
-  parent: [ClothingHandsBase, BaseForeignContraband]
+  parent: [ClothingHandsBase, BaseExtremeContraband]
   id: ClothingHandsKnuckleDustersSyndicate
   name: syndicate knuckle dusters
   description: "Plastitanium knuckle dusters branded with the blood-red S. A real man beats someone to death with these."

--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -28,7 +28,7 @@
 
 #Syndicate EVA Helmet
 - type: entity
-  parent: [ ClothingHeadEVAHelmetBase, BaseForeignContraband ]
+  parent: [ ClothingHeadEVAHelmetBase, BaseExtremeContraband ]
   id: ClothingHeadHelmetSyndicate
   name: syndicate EVA helmet
   description: A simple, stylish EVA helmet. Designed for maximum humble space-badassery.

--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -28,7 +28,7 @@
 
 #Syndicate EVA Helmet
 - type: entity
-  parent: [ ClothingHeadEVAHelmetBase, BaseSyndicateContraband ]
+  parent: [ ClothingHeadEVAHelmetBase, BaseForeignContraband ]
   id: ClothingHeadHelmetSyndicate
   name: syndicate EVA helmet
   description: A simple, stylish EVA helmet. Designed for maximum humble space-badassery.

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -692,7 +692,7 @@
 
 - type: entity
   abstract: true
-  parent: [ ClothingHeadBase, BaseMagicalContraband ]
+  parent: [ ClothingHeadBase, BaseForeignContraband ]
   id: ClothingHeadHatWizardBase
   components:
   - type: WizardClothes
@@ -737,7 +737,7 @@
     sprite: Clothing/Head/Hats/truckershat.rsi
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseSyndicateContraband ]
+  parent: [ ClothingHeadBase, BaseForeignContraband ]
   id: ClothingHeadPyjamaSyndicateBlack
   name: syndicate black pyjama hat
   description: For keeping that traitor head of yours warm.
@@ -753,7 +753,7 @@
       HeadSide : HEAD
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseSyndicateContraband ]
+  parent: [ ClothingHeadBase, BaseForeignContraband ]
   id: ClothingHeadPyjamaSyndicatePink
   name: syndicate pink pyjama hat
   description: For keeping that traitor head of yours warm.
@@ -769,7 +769,7 @@
       HeadSide : HEAD
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseSyndicateContraband ]
+  parent: [ ClothingHeadBase, BaseForeignContraband ]
   id: ClothingHeadPyjamaSyndicateRed
   name: syndicate red pyjama hat
   description: For keeping that traitor head of yours warm.
@@ -968,7 +968,7 @@
         Caustic: 0.95
 
 - type: entity
-  parent: [ClothingHeadBase, BaseSyndicateContraband]
+  parent: [ClothingHeadBase, BaseForeignContraband]
   id: ClothingHeadHatSyndie
   name: syndicate hat
   description: A souvenir hat from "Syndieland", their production has already been closed.

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -692,7 +692,7 @@
 
 - type: entity
   abstract: true
-  parent: [ ClothingHeadBase, BaseForeignContraband ]
+  parent: [ ClothingHeadBase, BaseExtremeContraband ]
   id: ClothingHeadHatWizardBase
   components:
   - type: WizardClothes
@@ -737,7 +737,7 @@
     sprite: Clothing/Head/Hats/truckershat.rsi
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseForeignContraband ]
+  parent: [ ClothingHeadBase, BaseExtremeContraband ]
   id: ClothingHeadPyjamaSyndicateBlack
   name: syndicate black pyjama hat
   description: For keeping that traitor head of yours warm.
@@ -753,7 +753,7 @@
       HeadSide : HEAD
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseForeignContraband ]
+  parent: [ ClothingHeadBase, BaseExtremeContraband ]
   id: ClothingHeadPyjamaSyndicatePink
   name: syndicate pink pyjama hat
   description: For keeping that traitor head of yours warm.
@@ -769,7 +769,7 @@
       HeadSide : HEAD
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseForeignContraband ]
+  parent: [ ClothingHeadBase, BaseExtremeContraband ]
   id: ClothingHeadPyjamaSyndicateRed
   name: syndicate red pyjama hat
   description: For keeping that traitor head of yours warm.
@@ -968,7 +968,7 @@
         Caustic: 0.95
 
 - type: entity
-  parent: [ClothingHeadBase, BaseForeignContraband]
+  parent: [ClothingHeadBase, BaseExtremeContraband]
   id: ClothingHeadHatSyndie
   name: syndicate hat
   description: A souvenir hat from "Syndieland", their production has already been closed.

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -418,7 +418,7 @@
       Hair: HEAD
 
 - type: entity
-  parent: [ BaseSyndicateContraband, ClothingHeadHelmetBase ]
+  parent: [ BaseForeignContraband, ClothingHeadHelmetBase ]
   id: ClothingHeadHelmetRaid
   name: syndicate raid helmet
   description: An armored helmet for use with the syndicate raid suit. Very stylish.

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -418,7 +418,7 @@
       Hair: HEAD
 
 - type: entity
-  parent: [ BaseForeignContraband, ClothingHeadHelmetBase ]
+  parent: [ BaseExtremeContraband, ClothingHeadHelmetBase ]
   id: ClothingHeadHelmetRaid
   name: syndicate raid helmet
   description: An armored helmet for use with the syndicate raid suit. Very stylish.

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -204,7 +204,7 @@
     accent: MobsterAccent
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseForeignContraband ]
+  parent: [ ClothingHeadBase, BaseExtremeContraband ]
   id: ClothingHeadHatCatEars
   name: cat ears
   description: "NYAH!"

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -204,7 +204,7 @@
     accent: MobsterAccent
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseSyndicateContraband ]
+  parent: [ ClothingHeadBase, BaseForeignContraband ]
   id: ClothingHeadHatCatEars
   name: cat ears
   description: "NYAH!"

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -41,7 +41,7 @@
         Heat: 0.95
 
 - type: entity
-  parent: [ClothingMaskGas, BaseForeignContraband]
+  parent: [ClothingMaskGas, BaseExtremeContraband]
   id: ClothingMaskGasSyndicate
   name: syndicate gas mask
   description: A close-fitting tactical mask that can be connected to an air supply.

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -41,7 +41,7 @@
         Heat: 0.95
 
 - type: entity
-  parent: [ClothingMaskGas, BaseSyndicateContraband]
+  parent: [ClothingMaskGas, BaseForeignContraband]
   id: ClothingMaskGasSyndicate
   name: syndicate gas mask
   description: A close-fitting tactical mask that can be connected to an air supply.

--- a/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
@@ -9,13 +9,13 @@
     sprite: Clothing/Multiple/towel.rsi
   - type: Clothing
     sprite: Clothing/Multiple/towel.rsi
-    slots: 
+    slots:
     - BELT
     - INNERCLOTHING
     - HEAD
     femaleMask: UniformTop
-    equipSound: 
-    unequipSound: 
+    equipSound:
+    unequipSound:
   - type: Spillable
     solution: absorbed
   - type: Absorbent
@@ -160,7 +160,7 @@
         color: "#0089EF"
   - type: Fiber
     fiberColor: fibers-blue
-    
+
 - type: entity
   id: TowelColorDarkBlue
   name: dark blue towel
@@ -734,7 +734,7 @@
 - type: entity
   id: TowelColorSyndicate
   name: syndicate towel
-  parent: [ BaseTowel, BaseSyndicateContraband ]
+  parent: [ BaseTowel, BaseForeignContraband ]
   components:
   - type: Sprite
     layers:
@@ -763,4 +763,3 @@
         color: "#535353"
   - type: Fiber
     fiberColor: fibers-black
-    

--- a/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
@@ -734,7 +734,7 @@
 - type: entity
   id: TowelColorSyndicate
   name: syndicate towel
-  parent: [ BaseTowel, BaseForeignContraband ]
+  parent: [ BaseTowel, BaseExtremeContraband ]
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
@@ -87,7 +87,7 @@
       sprite: Clothing/Neck/Scarfs/purple.rsi
 
 - type: entity
-  parent: [ ClothingScarfBase, BaseSyndicateContraband ]
+  parent: [ ClothingScarfBase, BaseForeignContraband ]
   id: ClothingNeckScarfStripedSyndieGreen
   name: striped syndicate green scarf
   description: A stylish striped syndicate green scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.
@@ -100,7 +100,7 @@
       price: 500
 
 - type: entity
-  parent: [ ClothingScarfBase, BaseSyndicateContraband ]
+  parent: [ ClothingScarfBase, BaseForeignContraband ]
   id: ClothingNeckScarfStripedSyndieRed
   name: striped syndicate red scarf
   description: A stylish striped syndicate red scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.

--- a/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
@@ -87,7 +87,7 @@
       sprite: Clothing/Neck/Scarfs/purple.rsi
 
 - type: entity
-  parent: [ ClothingScarfBase, BaseForeignContraband ]
+  parent: [ ClothingScarfBase, BaseExtremeContraband ]
   id: ClothingNeckScarfStripedSyndieGreen
   name: striped syndicate green scarf
   description: A stylish striped syndicate green scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.
@@ -100,7 +100,7 @@
       price: 500
 
 - type: entity
-  parent: [ ClothingScarfBase, BaseForeignContraband ]
+  parent: [ ClothingScarfBase, BaseExtremeContraband ]
   id: ClothingNeckScarfStripedSyndieRed
   name: striped syndicate red scarf
   description: A stylish striped syndicate red scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -142,7 +142,7 @@
 
 #Web vest
 - type: entity
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseSyndicateContraband]
+  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseForeignContraband]
   id: ClothingOuterVestWeb
   name: web vest
   description: A synthetic armor vest. This one has added webbing and ballistic plates.
@@ -165,7 +165,7 @@
 
 #Elite web vest
 - type: entity
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseSyndicateContraband]
+  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseForeignContraband]
   id: ClothingOuterVestWebElite
   name: elite web vest
   description: A synthetic armor vest. This one has added webbing and heat resistant fibers.
@@ -217,7 +217,7 @@
 
 # Armor covering multiple body parts including limbs
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband ]
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseForeignContraband ]
   id: ClothingOuterArmorRaid
   name: syndicate raid suit
   description: A somewhat flexible and well-armored suit with a powerful shoulder mounted flashlight manufactured in the Gorlex Marauder's iconic blood-red color scheme, it does not protect its wearer from space.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -142,7 +142,7 @@
 
 #Web vest
 - type: entity
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseForeignContraband]
+  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseExtremeContraband]
   id: ClothingOuterVestWeb
   name: web vest
   description: A synthetic armor vest. This one has added webbing and ballistic plates.
@@ -165,7 +165,7 @@
 
 #Elite web vest
 - type: entity
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseForeignContraband]
+  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseExtremeContraband]
   id: ClothingOuterVestWebElite
   name: elite web vest
   description: A synthetic armor vest. This one has added webbing and heat resistant fibers.
@@ -217,7 +217,7 @@
 
 # Armor covering multiple body parts including limbs
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseForeignContraband ]
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseExtremeContraband ]
   id: ClothingOuterArmorRaid
   name: syndicate raid suit
   description: A somewhat flexible and well-armored suit with a powerful shoulder mounted flashlight manufactured in the Gorlex Marauder's iconic blood-red color scheme, it does not protect its wearer from space.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -377,7 +377,7 @@
     sprite: Clothing/OuterClothing/Coats/windbreaker_paramedic.rsi
 
 - type: entity
-  parent: [ClothingOuterStorageBase, BaseForeignContraband]
+  parent: [ClothingOuterStorageBase, BaseExtremeContraband]
   id: ClothingOuterCoatSyndieCap
   name: syndicate's coat
   description: The syndicate's coat is made of durable fabric, with gilded patterns.
@@ -388,7 +388,7 @@
     sprite: Clothing/OuterClothing/Coats/syndicate/coatsyndiecap.rsi
 
 - type: entity
-  parent: [BaseForeignContraband, ClothingOuterCoatHoSTrench] # BaseForeignContraband as first parent so contraband system takes that as priority, yeah I know
+  parent: [BaseExtremeContraband, ClothingOuterCoatHoSTrench] # BaseExtremeContraband as first parent so contraband system takes that as priority, yeah I know
   id: ClothingOuterCoatSyndieCapArmored
   name: syndicate's armored coat
   description: The syndicate's armored coat is made of durable fabric, with gilded patterns.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -377,7 +377,7 @@
     sprite: Clothing/OuterClothing/Coats/windbreaker_paramedic.rsi
 
 - type: entity
-  parent: [ClothingOuterStorageBase, BaseSyndicateContraband]
+  parent: [ClothingOuterStorageBase, BaseForeignContraband]
   id: ClothingOuterCoatSyndieCap
   name: syndicate's coat
   description: The syndicate's coat is made of durable fabric, with gilded patterns.
@@ -388,7 +388,7 @@
     sprite: Clothing/OuterClothing/Coats/syndicate/coatsyndiecap.rsi
 
 - type: entity
-  parent: [BaseSyndicateContraband, ClothingOuterCoatHoSTrench] # BaseSyndicateContraband as first parent so contraband system takes that as priority, yeah I know
+  parent: [BaseForeignContraband, ClothingOuterCoatHoSTrench] # BaseForeignContraband as first parent so contraband system takes that as priority, yeah I know
   id: ClothingOuterCoatSyndieCapArmored
   name: syndicate's armored coat
   description: The syndicate's armored coat is made of durable fabric, with gilded patterns.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -497,7 +497,7 @@
 #ANTAG HARDSUITS
 #Blood-red Hardsuit
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseSyndicateContraband ]
+  parent: [ ClothingOuterHardsuitBase, BaseForeignContraband ]
   id: ClothingOuterHardsuitSyndie
   name: blood-red hardsuit
   description: A heavily armored hardsuit designed for work in special operations. Property of Gorlex Marauders.
@@ -540,7 +540,7 @@
 
 # Syndicate Medic Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitSyndie, BaseSyndicateContraband]
+  parent: [ClothingOuterHardsuitSyndie, BaseForeignContraband]
   id: ClothingOuterHardsuitSyndieMedic
   name: blood-red medic hardsuit
   description: A heavily armored and agile advanced hardsuit specifically designed for field medic operations.
@@ -558,7 +558,7 @@
 
 #Syndicate Elite Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
+  parent: [ClothingOuterHardsuitBase, BaseForeignContraband]
   id: ClothingOuterHardsuitSyndieElite
   name: syndicate elite hardsuit
   description: An elite version of the blood-red hardsuit, with improved radiation resistance and fireproofing. Property of Gorlex Marauders.
@@ -599,7 +599,7 @@
 
 #Syndicate Commander Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
+  parent: [ClothingOuterHardsuitBase, BaseForeignContraband]
   id: ClothingOuterHardsuitSyndieCommander
   name: syndicate commander hardsuit
   description: A bulked up version of the blood-red hardsuit, purpose-built for the commander of a syndicate operative squad. Has significantly improved armor for those deadly front-lines firefights.
@@ -633,7 +633,7 @@
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
+  parent: [ClothingOuterHardsuitBase, BaseForeignContraband]
   id: ClothingOuterHardsuitJuggernaut
   name: cybersun juggernaut suit
   description: A suit made by the cutting edge R&D department at cybersun to be hyper resilient.
@@ -671,7 +671,7 @@
 
 #Wizard Hardsuit
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseMagicalContraband ]
+  parent: [ ClothingOuterHardsuitBase, BaseForeignContraband ]
   id: ClothingOuterHardsuitWizard
   name: wizard hardsuit
   description: A bizarre gem-encrusted suit that radiates magical energies.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -497,7 +497,7 @@
 #ANTAG HARDSUITS
 #Blood-red Hardsuit
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseForeignContraband ]
+  parent: [ ClothingOuterHardsuitBase, BaseExtremeContraband ]
   id: ClothingOuterHardsuitSyndie
   name: blood-red hardsuit
   description: A heavily armored hardsuit designed for work in special operations. Property of Gorlex Marauders.
@@ -540,7 +540,7 @@
 
 # Syndicate Medic Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitSyndie, BaseForeignContraband]
+  parent: [ClothingOuterHardsuitSyndie, BaseExtremeContraband]
   id: ClothingOuterHardsuitSyndieMedic
   name: blood-red medic hardsuit
   description: A heavily armored and agile advanced hardsuit specifically designed for field medic operations.
@@ -558,7 +558,7 @@
 
 #Syndicate Elite Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseForeignContraband]
+  parent: [ClothingOuterHardsuitBase, BaseExtremeContraband]
   id: ClothingOuterHardsuitSyndieElite
   name: syndicate elite hardsuit
   description: An elite version of the blood-red hardsuit, with improved radiation resistance and fireproofing. Property of Gorlex Marauders.
@@ -599,7 +599,7 @@
 
 #Syndicate Commander Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseForeignContraband]
+  parent: [ClothingOuterHardsuitBase, BaseExtremeContraband]
   id: ClothingOuterHardsuitSyndieCommander
   name: syndicate commander hardsuit
   description: A bulked up version of the blood-red hardsuit, purpose-built for the commander of a syndicate operative squad. Has significantly improved armor for those deadly front-lines firefights.
@@ -633,7 +633,7 @@
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseForeignContraband]
+  parent: [ClothingOuterHardsuitBase, BaseExtremeContraband]
   id: ClothingOuterHardsuitJuggernaut
   name: cybersun juggernaut suit
   description: A suit made by the cutting edge R&D department at cybersun to be hyper resilient.
@@ -671,7 +671,7 @@
 
 #Wizard Hardsuit
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseForeignContraband ]
+  parent: [ ClothingOuterHardsuitBase, BaseExtremeContraband ]
   id: ClothingOuterHardsuitWizard
   name: wizard hardsuit
   description: A bizarre gem-encrusted suit that radiates magical energies.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -184,7 +184,7 @@
 
 - type: entity
   abstract: true
-  parent: [ ClothingOuterBase, AllowSuitStorageClothingGasTanks, BaseForeignContraband ]
+  parent: [ ClothingOuterBase, AllowSuitStorageClothingGasTanks, BaseExtremeContraband ]
   id: ClothingOuterWizardBase
   components:
   - type: WizardClothes

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -184,7 +184,7 @@
 
 - type: entity
   abstract: true
-  parent: [ ClothingOuterBase, AllowSuitStorageClothingGasTanks, BaseMagicalContraband ]
+  parent: [ ClothingOuterBase, AllowSuitStorageClothingGasTanks, BaseForeignContraband ]
   id: ClothingOuterWizardBase
   components:
   - type: WizardClothes

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -17,7 +17,7 @@
 
 #Syndicate EVA
 - type: entity
-  parent: [ ClothingOuterEVASuitBase, BaseForeignContraband ]
+  parent: [ ClothingOuterEVASuitBase, BaseExtremeContraband ]
   id: ClothingOuterEVASuitSyndicate
   name: syndicate EVA suit
   description: "Has a tag on the back that reads: 'Totally not property of an enemy corporation, honest!'"

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -17,7 +17,7 @@
 
 #Syndicate EVA
 - type: entity
-  parent: [ ClothingOuterEVASuitBase, BaseSyndicateContraband ]
+  parent: [ ClothingOuterEVASuitBase, BaseForeignContraband ]
   id: ClothingOuterEVASuitSyndicate
   name: syndicate EVA suit
   description: "Has a tag on the back that reads: 'Totally not property of an enemy corporation, honest!'"

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -759,7 +759,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterWarden
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseForeignContraband]
+  parent: [ClothingOuterWinterCoatToggleable, BaseExtremeContraband]
   id: ClothingOuterWinterSyndieCap
   name: syndicate's winter coat
   description: "The syndicate's winter coat is made of durable fabric, with gilded patterns, and coarse wool."
@@ -784,7 +784,7 @@
 
 ##############################################################
 - type: entity
-  parent: [ BaseForeignContraband, ClothingOuterWinterWarden ]
+  parent: [ BaseExtremeContraband, ClothingOuterWinterWarden ]
   id: ClothingOuterWinterSyndieCapArmored
   name: syndicate's armored winter coat
   description: "The syndicate's armored winter coat is made of durable fabric, with gilded patterns, and coarse wool."
@@ -798,7 +798,7 @@
 ##############################################################
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseForeignContraband]
+  parent: [ClothingOuterWinterCoatToggleable, BaseExtremeContraband]
   id: ClothingOuterWinterSyndie
   name: syndicate's winter coat
   description: Insulated winter coat, looks like a merch from "Syndieland".

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -759,7 +759,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterWarden
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseSyndicateContraband]
+  parent: [ClothingOuterWinterCoatToggleable, BaseForeignContraband]
   id: ClothingOuterWinterSyndieCap
   name: syndicate's winter coat
   description: "The syndicate's winter coat is made of durable fabric, with gilded patterns, and coarse wool."
@@ -784,7 +784,7 @@
 
 ##############################################################
 - type: entity
-  parent: [ BaseSyndicateContraband, ClothingOuterWinterWarden ]
+  parent: [ BaseForeignContraband, ClothingOuterWinterWarden ]
   id: ClothingOuterWinterSyndieCapArmored
   name: syndicate's armored winter coat
   description: "The syndicate's armored winter coat is made of durable fabric, with gilded patterns, and coarse wool."
@@ -798,7 +798,7 @@
 ##############################################################
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseSyndicateContraband]
+  parent: [ClothingOuterWinterCoatToggleable, BaseForeignContraband]
   id: ClothingOuterWinterSyndie
   name: syndicate's winter coat
   description: Insulated winter coat, looks like a merch from "Syndieland".

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -161,7 +161,7 @@
     sprite: Clothing/Shoes/Boots/winterbootssec.rsi
 
 - type: entity
-  parent: [ClothingShoesBaseWinterBoots, BaseSyndicateContraband]
+  parent: [ClothingShoesBaseWinterBoots, BaseForeignContraband]
   id: ClothingShoesBootsWinterSyndicate
   name: syndicate's winter boots
   description: Durable heavy boots, looks like merch from "Syndieland".

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -161,7 +161,7 @@
     sprite: Clothing/Shoes/Boots/winterbootssec.rsi
 
 - type: entity
-  parent: [ClothingShoesBaseWinterBoots, BaseForeignContraband]
+  parent: [ClothingShoesBaseWinterBoots, BaseExtremeContraband]
   id: ClothingShoesBootsWinterSyndicate
   name: syndicate's winter boots
   description: Durable heavy boots, looks like merch from "Syndieland".

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -88,7 +88,7 @@
     price: 3000
 
 - type: entity
-  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseForeignContraband]
+  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseExtremeContraband]
   id: ClothingShoesBootsMagSyndie
   name: blood-red magboots
   description: Reverse-engineered magnetic boots that have a heavy magnetic pull and integrated thrusters. It can hold 0.75 L of gas.

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -88,7 +88,7 @@
     price: 3000
 
 - type: entity
-  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband]
+  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseForeignContraband]
   id: ClothingShoesBootsMagSyndie
   name: blood-red magboots
   description: Reverse-engineered magnetic boots that have a heavy magnetic pull and integrated thrusters. It can hold 0.75 L of gas.

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -512,7 +512,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/hosformaldress.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformSkirtBase, BaseSyndicateContraband]
+  parent: [UnsensoredClothingUniformSkirtBase, BaseForeignContraband]
   id: ClothingUniformJumpskirtOperative
   name: operative jumpskirt
   description: Uniform for elite syndicate operatives performing tactical operations in deep space.
@@ -628,7 +628,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/lawyergood.rsi
 
 - type: entity
-  parent: [ ClothingUniformSkirtBase, BaseSyndicateContraband ]
+  parent: [ ClothingUniformSkirtBase, BaseForeignContraband ]
   id: ClothingUniformJumpskirtSyndieFormalDress
   name: syndicate formal dress
   description: "The syndicate's uniform is made in an elegant style, it's even a pity to do dirty tricks in this."

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -512,7 +512,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/hosformaldress.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformSkirtBase, BaseForeignContraband]
+  parent: [UnsensoredClothingUniformSkirtBase, BaseExtremeContraband]
   id: ClothingUniformJumpskirtOperative
   name: operative jumpskirt
   description: Uniform for elite syndicate operatives performing tactical operations in deep space.
@@ -628,7 +628,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/lawyergood.rsi
 
 - type: entity
-  parent: [ ClothingUniformSkirtBase, BaseForeignContraband ]
+  parent: [ ClothingUniformSkirtBase, BaseExtremeContraband ]
   id: ClothingUniformJumpskirtSyndieFormalDress
   name: syndicate formal dress
   description: "The syndicate's uniform is made in an elegant style, it's even a pity to do dirty tricks in this."

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -769,7 +769,7 @@
       sprite: Clothing/Uniforms/Jumpsuit/lawyergood.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseForeignContraband]
+  parent: [UnsensoredClothingUniformBase, BaseExtremeContraband]
   id: ClothingUniformJumpsuitPyjamaSyndicateBlack
   name: black syndicate pyjamas
   description: For those long nights in perma.
@@ -780,7 +780,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/pyjamasyndicateblack.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseForeignContraband]
+  parent: [UnsensoredClothingUniformBase, BaseExtremeContraband]
   id: ClothingUniformJumpsuitPyjamaSyndicatePink
   name: pink syndicate pyjamas
   description: For those long nights in perma.
@@ -791,7 +791,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/pyjamasyndicatepink.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseForeignContraband]
+  parent: [UnsensoredClothingUniformBase, BaseExtremeContraband]
   id: ClothingUniformJumpsuitPyjamaSyndicateRed
   name: red syndicate pyjamas
   description: For those long nights in perma.
@@ -846,7 +846,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hosformal.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseForeignContraband]
+  parent: [UnsensoredClothingUniformBase, BaseExtremeContraband]
   id: ClothingUniformJumpsuitOperative
   name: operative jumpsuit
   description: Uniform for elite syndicate operatives performing tactical operations in deep space.
@@ -1153,7 +1153,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hawaiyellow.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseForeignContraband]
+  parent: [ClothingUniformBase, BaseExtremeContraband]
   id: ClothingUniformJumpsuitSyndieFormal
   name: syndicate formal suit
   description: "The syndicate's uniform is made in an elegant style, it's even a pity to do dirty tricks in this."

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -769,7 +769,7 @@
       sprite: Clothing/Uniforms/Jumpsuit/lawyergood.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseSyndicateContraband]
+  parent: [UnsensoredClothingUniformBase, BaseForeignContraband]
   id: ClothingUniformJumpsuitPyjamaSyndicateBlack
   name: black syndicate pyjamas
   description: For those long nights in perma.
@@ -780,7 +780,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/pyjamasyndicateblack.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseSyndicateContraband]
+  parent: [UnsensoredClothingUniformBase, BaseForeignContraband]
   id: ClothingUniformJumpsuitPyjamaSyndicatePink
   name: pink syndicate pyjamas
   description: For those long nights in perma.
@@ -791,7 +791,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/pyjamasyndicatepink.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseSyndicateContraband]
+  parent: [UnsensoredClothingUniformBase, BaseForeignContraband]
   id: ClothingUniformJumpsuitPyjamaSyndicateRed
   name: red syndicate pyjamas
   description: For those long nights in perma.
@@ -846,7 +846,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hosformal.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseSyndicateContraband]
+  parent: [UnsensoredClothingUniformBase, BaseForeignContraband]
   id: ClothingUniformJumpsuitOperative
   name: operative jumpsuit
   description: Uniform for elite syndicate operatives performing tactical operations in deep space.
@@ -1153,7 +1153,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hawaiyellow.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseSyndicateContraband]
+  parent: [ClothingUniformBase, BaseForeignContraband]
   id: ClothingUniformJumpsuitSyndieFormal
   name: syndicate formal suit
   description: "The syndicate's uniform is made in an elegant style, it's even a pity to do dirty tricks in this."

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/ship_vs_ship.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/ship_vs_ship.yml
@@ -15,7 +15,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/recruit_nt.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseForeignContraband ]
+  parent: [ ClothingUniformBase, BaseExtremeContraband ]
   id: ClothingUniformJumpsuitRecruitSyndie
   name: syndicate recruit jumpsuit
   description: A dubious, dark-grey jumpsuit. As if passengers weren't dubious enough already.
@@ -38,7 +38,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/repairman_nt.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseForeignContraband ]
+  parent: [ ClothingUniformBase, BaseExtremeContraband ]
   id: ClothingUniformJumpsuitRepairmanSyndie
   name: syndicate repairman jumpsuit
   description: Functional, fashionable, and badass. Nanotrasen's engineers wish they could look as good as this.
@@ -61,7 +61,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/paramedic_nt.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseForeignContraband ]
+  parent: [ ClothingUniformBase, BaseExtremeContraband ]
   id: ClothingUniformJumpsuitParamedicSyndie
   name: syndicate paramedic jumpsuit
   description: For some reason, wearing this makes you feel like you're awfully close to violating the Geneva Convention.
@@ -85,7 +85,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/ce_nt.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseForeignContraband ]
+  parent: [ ClothingUniformBase, BaseExtremeContraband ]
   id: ClothingUniformJumpsuitChiefEngineerSyndie
   name: syndicate chief engineer jumpsuit
   description: An evil-looking jumpsuit with a reflective vest & red undershirt. #TODO: Write a better description for this once Ship vs. Ship is real and actual player habits begin forming

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/ship_vs_ship.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/ship_vs_ship.yml
@@ -15,7 +15,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/recruit_nt.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseSyndicateContraband ]
+  parent: [ ClothingUniformBase, BaseForeignContraband ]
   id: ClothingUniformJumpsuitRecruitSyndie
   name: syndicate recruit jumpsuit
   description: A dubious, dark-grey jumpsuit. As if passengers weren't dubious enough already.
@@ -38,7 +38,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/repairman_nt.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseSyndicateContraband ]
+  parent: [ ClothingUniformBase, BaseForeignContraband ]
   id: ClothingUniformJumpsuitRepairmanSyndie
   name: syndicate repairman jumpsuit
   description: Functional, fashionable, and badass. Nanotrasen's engineers wish they could look as good as this.
@@ -61,7 +61,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/paramedic_nt.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseSyndicateContraband ]
+  parent: [ ClothingUniformBase, BaseForeignContraband ]
   id: ClothingUniformJumpsuitParamedicSyndie
   name: syndicate paramedic jumpsuit
   description: For some reason, wearing this makes you feel like you're awfully close to violating the Geneva Convention.
@@ -85,7 +85,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/ce_nt.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseSyndicateContraband ]
+  parent: [ ClothingUniformBase, BaseForeignContraband ]
   id: ClothingUniformJumpsuitChiefEngineerSyndie
   name: syndicate chief engineer jumpsuit
   description: An evil-looking jumpsuit with a reflective vest & red undershirt. #TODO: Write a better description for this once Ship vs. Ship is real and actual player habits begin forming

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2285,7 +2285,7 @@
 
 - type: entity
   name: grenade penguin
-  parent: [ MobPenguin, MobCombat, BaseForeignContraband ]
+  parent: [ MobPenguin, MobCombat, BaseExtremeContraband ]
   id: MobGrenadePenguin
   description: A small penguin with a grenade strapped around its neck. Harvested by the Syndicate from icy shit-hole planets.
   components:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2285,7 +2285,7 @@
 
 - type: entity
   name: grenade penguin
-  parent: [ MobPenguin, MobCombat, BaseSyndicateContraband ]
+  parent: [ MobPenguin, MobCombat, BaseForeignContraband ]
   id: MobGrenadePenguin
   description: A small penguin with a grenade strapped around its neck. Harvested by the Syndicate from icy shit-hole planets.
   components:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -603,7 +603,7 @@
 
 - type: entity
   id: HappyHonkNukie
-  parent: [HappyHonk, BaseForeignContraband]
+  parent: [HappyHonk, BaseExtremeContraband]
   name: robust nukie meal
   description: A sus meal with a potentially explosive surprise.
   suffix: Toy Unsafe

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -277,7 +277,7 @@
       prob: 0.05
       orGroup: Pizza
     - id: KnifePlastic
-  
+
 - type: entity
   name: pizza box
   parent: FoodBoxPizzaFilled
@@ -603,7 +603,7 @@
 
 - type: entity
   id: HappyHonkNukie
-  parent: [HappyHonk, BaseSyndicateContraband]
+  parent: [HappyHonk, BaseForeignContraband]
   name: robust nukie meal
   description: A sus meal with a potentially explosive surprise.
   suffix: Toy Unsafe

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1854,7 +1854,7 @@
 
 - type: entity
   name: gatfruit
-  parent: [ FoodProduceBase, BaseForeignContraband ]
+  parent: [ FoodProduceBase, BaseExtremeContraband ]
   id: FoodGatfruit
   description: A delicious, gun-shaped fruit with a thick wooden stem.
   components:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1854,7 +1854,7 @@
 
 - type: entity
   name: gatfruit
-  parent: [ FoodProduceBase, BaseSyndicateContraband ]
+  parent: [ FoodProduceBase, BaseForeignContraband ]
   id: FoodGatfruit
   description: A delicious, gun-shaped fruit with a thick wooden stem.
   components:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -178,7 +178,7 @@
 
 - type: entity
   id: CigPackSyndicate
-  parent: [CigPackBase, BaseSyndicateContraband]
+  parent: [CigPackBase, BaseForeignContraband]
   name: Interdyne herbals packet
   description: Elite cigarettes for elite syndicate agents. Infused with medicine for when you need to do more than calm your nerves.
   components:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -178,7 +178,7 @@
 
 - type: entity
   id: CigPackSyndicate
-  parent: [CigPackBase, BaseForeignContraband]
+  parent: [CigPackBase, BaseExtremeContraband]
   name: Interdyne herbals packet
   description: Elite cigarettes for elite syndicate agents. Infused with medicine for when you need to do more than calm your nerves.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -355,7 +355,7 @@
       prototype: ComputerComms
 
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseSyndicateContraband ]
+  parent: [ BaseComputerCircuitboard, BaseForeignContraband ]
   id: SyndicateCommsComputerCircuitboard
   name: syndicate communications computer board
   description: A computer printed circuit board for a syndicate communications console.
@@ -366,7 +366,7 @@
     prototype: SyndicateComputerComms
 
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseSyndicateContraband ]
+  parent: [ BaseComputerCircuitboard, BaseForeignContraband ]
   id: WizardCommsComputerCircuitboard
   name: wizard communications computer board
   description: A computer printed circuit board for a wizard communications console.
@@ -449,7 +449,7 @@
     prototype: ComputerShuttle
 
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseSyndicateContraband ]
+  parent: [ BaseComputerCircuitboard, BaseForeignContraband ]
   id: SyndicateShuttleConsoleCircuitboard
   name: syndicate shuttle console board
   description: A computer printed circuit board for a syndicate shuttle console.
@@ -482,7 +482,7 @@
       prototype: ComputerIFF
 
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseSyndicateContraband ]
+  parent: [ BaseComputerCircuitboard, BaseForeignContraband ]
   id: ComputerIFFSyndicateCircuitboard
   name: syndicate IFF console board
   description: Allows you to control the IFF and stealth characteristics of this vessel.

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -355,7 +355,7 @@
       prototype: ComputerComms
 
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseForeignContraband ]
+  parent: [ BaseComputerCircuitboard, BaseExtremeContraband ]
   id: SyndicateCommsComputerCircuitboard
   name: syndicate communications computer board
   description: A computer printed circuit board for a syndicate communications console.
@@ -366,7 +366,7 @@
     prototype: SyndicateComputerComms
 
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseForeignContraband ]
+  parent: [ BaseComputerCircuitboard, BaseExtremeContraband ]
   id: WizardCommsComputerCircuitboard
   name: wizard communications computer board
   description: A computer printed circuit board for a wizard communications console.
@@ -449,7 +449,7 @@
     prototype: ComputerShuttle
 
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseForeignContraband ]
+  parent: [ BaseComputerCircuitboard, BaseExtremeContraband ]
   id: SyndicateShuttleConsoleCircuitboard
   name: syndicate shuttle console board
   description: A computer printed circuit board for a syndicate shuttle console.
@@ -482,7 +482,7 @@
       prototype: ComputerIFF
 
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseForeignContraband ]
+  parent: [ BaseComputerCircuitboard, BaseExtremeContraband ]
   id: ComputerIFFSyndicateCircuitboard
   name: syndicate IFF console board
   description: Allows you to control the IFF and stealth characteristics of this vessel.

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
@@ -132,7 +132,7 @@
 
 - type: entity
   id: AntimovCircuitBoard
-  parent: [BaseElectronics, BaseForeignContraband]
+  parent: [BaseElectronics, BaseExtremeContraband]
   name: law board (Antimov)
   description: An electronics board containing the Antimov lawset.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
@@ -132,7 +132,7 @@
 
 - type: entity
   id: AntimovCircuitBoard
-  parent: [BaseElectronics, BaseSyndicateContraband]
+  parent: [BaseElectronics, BaseForeignContraband]
   name: law board (Antimov)
   description: An electronics board containing the Antimov lawset.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/camera_bug.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/camera_bug.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CameraBug
-  parent: [ BaseItem, BaseSyndicateContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   name: camera bug
   description: An illegal syndicate device that allows you to hack into the station's camera network.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/camera_bug.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/camera_bug.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CameraBug
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   name: camera bug
   description: An illegal syndicate device that allows you to hack into the station's camera network.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/chimp_upgrade_kit.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/chimp_upgrade_kit.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: C.H.I.M.P. handcannon upgrade chip
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   id: WeaponPistolCHIMPUpgradeKit
   description: An experimental upgrade kit for the C.H.I.M.P.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/chimp_upgrade_kit.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/chimp_upgrade_kit.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: C.H.I.M.P. handcannon upgrade chip
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   id: WeaponPistolCHIMPUpgradeKit
   description: An experimental upgrade kit for the C.H.I.M.P.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/guardian_activators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/guardian_activators.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: holoparasite injector
   id: HoloparasiteInjector
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   description: A complex artwork of handheld machinery allowing the user to host a holoparasite guardian.
   components:
   - type: Sprite
@@ -34,7 +34,7 @@
 
 - type: entity
   name: holoparasite box
-  parent: [BoxCardboard, BaseSyndicateContraband]
+  parent: [BoxCardboard, BaseForeignContraband]
   id: BoxHoloparasite
   description: A box containing a holoparasite injector.
   components:
@@ -50,7 +50,7 @@
 
 - type: entity
   name: holoclown box
-  parent: [BoxCardboard, BaseSyndicateContraband]
+  parent: [BoxCardboard, BaseForeignContraband]
   id: BoxHoloclown
   description: A box containing a holoclown injector.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/guardian_activators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/guardian_activators.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: holoparasite injector
   id: HoloparasiteInjector
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   description: A complex artwork of handheld machinery allowing the user to host a holoparasite guardian.
   components:
   - type: Sprite
@@ -34,7 +34,7 @@
 
 - type: entity
   name: holoparasite box
-  parent: [BoxCardboard, BaseForeignContraband]
+  parent: [BoxCardboard, BaseExtremeContraband]
   id: BoxHoloparasite
   description: A box containing a holoparasite injector.
   components:
@@ -50,7 +50,7 @@
 
 - type: entity
   name: holoclown box
-  parent: [BoxCardboard, BaseForeignContraband]
+  parent: [BoxCardboard, BaseExtremeContraband]
   id: BoxHoloclown
   description: A box containing a holoclown injector.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   abstract: true
   id: ReinforcementRadio
   name: syndicate reinforcement radio

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   abstract: true
   id: ReinforcementRadio
   name: syndicate reinforcement radio

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: SingularityBeacon
-  parent: [BaseMachinePowered, BaseForeignContraband]
+  parent: [BaseMachinePowered, BaseExtremeContraband]
   name: singularity beacon
   description: A syndicate device that attracts the singularity. If it's loose and you're seeing this, run.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: SingularityBeacon
-  parent: [BaseMachinePowered, BaseSyndicateContraband]
+  parent: [BaseMachinePowered, BaseForeignContraband]
   name: singularity beacon
   description: A syndicate device that attracts the singularity. If it's loose and you're seeing this, run.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   id: ChameleonProjector
   name: chameleon projector
   description: Holoparasite technology used to create a hard-light replica of any object around you. Disguise is destroyed when picked up or deactivated.

--- a/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   id: ChameleonProjector
   name: chameleon projector
   description: Holoparasite technology used to create a hard-light replica of any object around you. Disguise is destroyed when picked up or deactivated.

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -166,7 +166,7 @@
     - Xenoborg
 
 - type: entity
-  parent: [ DoorRemoteDefault, BaseForeignContraband ]
+  parent: [ DoorRemoteDefault, BaseExtremeContraband ]
   id: DoorRemoteXenoborg
   name: xenoborg door remote
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -166,7 +166,7 @@
     - Xenoborg
 
 - type: entity
-  parent: [ DoorRemoteDefault, BaseXenoborgContraband ]
+  parent: [ DoorRemoteDefault, BaseForeignContraband ]
   id: DoorRemoteXenoborg
   name: xenoborg door remote
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -224,7 +224,7 @@
     - EncryptionService
 
 - type: entity
-  parent: [ EncryptionKey, BaseSyndicateContraband ]
+  parent: [ EncryptionKey, BaseForeignContraband ]
   id: EncryptionKeySyndie
   name: blood-red encryption key
   description: An encryption key used by... wait... Who is the owner of this chip?
@@ -256,7 +256,7 @@
     - state: ai_label
 
 - type: entity
-  parent: [ EncryptionKey, BaseSyndicateContraband ]
+  parent: [ EncryptionKey, BaseForeignContraband ]
   id: EncryptionKeyBinarySyndicate
   name: binary translator key
   description: A syndicate encryption key that translates binary signals used by silicons.

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -224,7 +224,7 @@
     - EncryptionService
 
 - type: entity
-  parent: [ EncryptionKey, BaseForeignContraband ]
+  parent: [ EncryptionKey, BaseExtremeContraband ]
   id: EncryptionKeySyndie
   name: blood-red encryption key
   description: An encryption key used by... wait... Who is the owner of this chip?
@@ -256,7 +256,7 @@
     - state: ai_label
 
 - type: entity
-  parent: [ EncryptionKey, BaseForeignContraband ]
+  parent: [ EncryptionKey, BaseExtremeContraband ]
   id: EncryptionKeyBinarySyndicate
   name: binary translator key
   description: A syndicate encryption key that translates binary signals used by silicons.

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1062,7 +1062,7 @@
     - DoorBumpOpener
 
 - type: entity
-  parent: [ BasePDA, BaseForeignContraband ]
+  parent: [ BasePDA, BaseExtremeContraband ]
   id: SyndiPDA
   name: syndicate PDA
   description: Ok, time to be a productive member of- oh cool I'm a bad guy time to kill people!
@@ -1435,7 +1435,7 @@
     state: pda-pirate
 
 - type: entity
-  parent: [ BaseMedicalPDA, BaseForeignContraband ]
+  parent: [ BaseMedicalPDA, BaseExtremeContraband ]
   id: SyndiAgentPDA
   name: syndicate corpsman PDA
   description: For those days when healing normal syndicates aren't enough, try healing nuclear operatives instead!

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1062,7 +1062,7 @@
     - DoorBumpOpener
 
 - type: entity
-  parent: [ BasePDA, BaseSyndicateContraband ]
+  parent: [ BasePDA, BaseForeignContraband ]
   id: SyndiPDA
   name: syndicate PDA
   description: Ok, time to be a productive member of- oh cool I'm a bad guy time to kill people!
@@ -1435,7 +1435,7 @@
     state: pda-pirate
 
 - type: entity
-  parent: [ BaseMedicalPDA, BaseSyndicateContraband ]
+  parent: [ BaseMedicalPDA, BaseForeignContraband ]
   id: SyndiAgentPDA
   name: syndicate corpsman PDA
   description: For those days when healing normal syndicates aren't enough, try healing nuclear operatives instead!

--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -52,7 +52,7 @@
   name: syndicate pinpointer
   description: Produced specifically for nuclear operative missions, get that disk!
   id: PinpointerSyndicateNuclear
-  parent: [ PinpointerBase, BaseSyndicateContraband ]
+  parent: [ PinpointerBase, BaseForeignContraband ]
   components:
   - type: Sprite
     layers:
@@ -110,7 +110,7 @@
     targetName: the station
 
 - type: entity
-  parent: [ PinpointerBase, BaseXenoborgContraband ]
+  parent: [ PinpointerBase, BaseForeignContraband ]
   id: PinpointerMothership
   name: core pinpointer
   suffix: Mothership

--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -52,7 +52,7 @@
   name: syndicate pinpointer
   description: Produced specifically for nuclear operative missions, get that disk!
   id: PinpointerSyndicateNuclear
-  parent: [ PinpointerBase, BaseForeignContraband ]
+  parent: [ PinpointerBase, BaseExtremeContraband ]
   components:
   - type: Sprite
     layers:
@@ -110,7 +110,7 @@
     targetName: the station
 
 - type: entity
-  parent: [ PinpointerBase, BaseForeignContraband ]
+  parent: [ PinpointerBase, BaseExtremeContraband ]
   id: PinpointerMothership
   name: core pinpointer
   suffix: Mothership

--- a/Resources/Prototypes/Entities/Objects/Fun/darts.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/darts.yml
@@ -191,7 +191,7 @@
         acts: [ "Destruction" ]
 
 - type: entity
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   id: HypoDartBox
   name: hypodart box
   suffix: HypoDart

--- a/Resources/Prototypes/Entities/Objects/Fun/darts.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/darts.yml
@@ -191,7 +191,7 @@
         acts: [ "Destruction" ]
 
 - type: entity
-  parent: [ BaseItem, BaseSyndicateContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   id: HypoDartBox
   name: hypodart box
   suffix: HypoDart

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -95,7 +95,7 @@
         - WrappedParcel
 
 - type: entity
-  parent: [ PersonalAI, BaseForeignContraband]
+  parent: [ PersonalAI, BaseExtremeContraband]
   id: SyndicatePersonalAI
   name: syndicate personal ai device
   description: Your Syndicate pal who's fun to be with!

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -95,7 +95,7 @@
         - WrappedParcel
 
 - type: entity
-  parent: [ PersonalAI, BaseSyndicateContraband]
+  parent: [ PersonalAI, BaseForeignContraband]
   id: SyndicatePersonalAI
   name: syndicate personal ai device
   description: Your Syndicate pal who's fun to be with!

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1665,7 +1665,7 @@
         volume: -10
 
 - type: entity
-  parent: [ BaseItem, BaseMagicalContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   id: PonderingOrb
   name: pondering orb
   description: Ponderous, man... Really ponderous.

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1665,7 +1665,7 @@
         volume: -10
 
 - type: entity
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   id: PonderingOrb
   name: pondering orb
   description: Ponderous, man... Really ponderous.

--- a/Resources/Prototypes/Entities/Objects/Magic/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/books.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: BaseSpellbook
   name: spellbook
-  parent: [ BaseItem, BaseMagicalContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   abstract: true
   components:
     - type: Sprite
@@ -25,7 +25,7 @@
   id: WizardsGrimoire
   name: wizards grimoire
   suffix: Wizard
-  parent: [ BaseItem, StorePresetSpellbook, BaseMagicalContraband ]
+  parent: [ BaseItem, StorePresetSpellbook, BaseForeignContraband ]
   components:
     - type: Sprite
       sprite: Objects/Misc/books.rsi

--- a/Resources/Prototypes/Entities/Objects/Magic/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/books.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: BaseSpellbook
   name: spellbook
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   abstract: true
   components:
     - type: Sprite
@@ -25,7 +25,7 @@
   id: WizardsGrimoire
   name: wizards grimoire
   suffix: Wizard
-  parent: [ BaseItem, StorePresetSpellbook, BaseForeignContraband ]
+  parent: [ BaseItem, StorePresetSpellbook, BaseExtremeContraband ]
   components:
     - type: Sprite
       sprite: Objects/Misc/books.rsi

--- a/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
@@ -306,7 +306,7 @@
 
 - type: entity
   id: BedsheetSyndie
-  parent: [ BedsheetBase, BaseSyndicateContraband ]
+  parent: [ BedsheetBase, BaseForeignContraband ]
   name: syndicate bedsheet
   description: It has a syndicate emblem and it has an aura of evil.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
@@ -306,7 +306,7 @@
 
 - type: entity
   id: BedsheetSyndie
-  parent: [ BedsheetBase, BaseForeignContraband ]
+  parent: [ BedsheetBase, BaseExtremeContraband ]
   name: syndicate bedsheet
   description: It has a syndicate emblem and it has an aura of evil.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/business_card.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/business_card.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: SyndicateBusinessCard
   name: syndicate business card
-  parent: [ Paper, BaseSyndicateContraband ]
+  parent: [ Paper, BaseForeignContraband ]
   description: A black card with the syndicate's logo. There's something written on the back.
   components:
     - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Misc/business_card.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/business_card.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: SyndicateBusinessCard
   name: syndicate business card
-  parent: [ Paper, BaseForeignContraband ]
+  parent: [ Paper, BaseExtremeContraband ]
   description: A black card with the syndicate's logo. There's something written on the back.
   components:
     - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -142,7 +142,7 @@
 
 # used for a engi xenoborg module
 - type: entity
-  parent: [ FireExtinguisher, BaseForeignContraband ]
+  parent: [ FireExtinguisher, BaseExtremeContraband ]
   id: SelfRechargingFireExtinguisher
   name: self-recharging fire extinguisher
   description: It extinguishes fires. it slowly refills with water.

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -142,7 +142,7 @@
 
 # used for a engi xenoborg module
 - type: entity
-  parent: [ FireExtinguisher, BaseXenoborgContraband ]
+  parent: [ FireExtinguisher, BaseForeignContraband ]
   id: SelfRechargingFireExtinguisher
   name: self-recharging fire extinguisher
   description: It extinguishes fires. it slowly refills with water.

--- a/Resources/Prototypes/Entities/Objects/Misc/handy_flags.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handy_flags.yml
@@ -23,7 +23,7 @@
     sprite: Objects/Misc/Handy_Flags/NT_handy_flag.rsi
 
 - type: entity
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   id: SyndieHandyFlag
   name: syndicate handheld flag
   description: "For truly rebellious patriots. Death to NT!"

--- a/Resources/Prototypes/Entities/Objects/Misc/handy_flags.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handy_flags.yml
@@ -23,7 +23,7 @@
     sprite: Objects/Misc/Handy_Flags/NT_handy_flag.rsi
 
 - type: entity
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   id: SyndieHandyFlag
   name: syndicate handheld flag
   description: "For truly rebellious patriots. Death to NT!"

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -637,7 +637,7 @@
     job: AtmosphericTechnician
 
 - type: entity
-  parent: [ IDCardStandard, BaseForeignContraband ]
+  parent: [ IDCardStandard, BaseExtremeContraband ]
   id: SyndicateIDCard
   name: syndicate ID card
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -637,7 +637,7 @@
     job: AtmosphericTechnician
 
 - type: entity
-  parent: [ IDCardStandard, BaseSyndicateContraband ]
+  parent: [ IDCardStandard, BaseForeignContraband ]
   id: SyndicateIDCard
   name: syndicate ID card
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -122,7 +122,7 @@
 
 - type: entity
   id: BaseImplantOnlyImplanterSyndi
-  parent: [BaseImplantOnlyImplanter, BaseSyndicateContraband]
+  parent: [BaseImplantOnlyImplanter, BaseForeignContraband]
   name: syndicate implanter
   description: A compact disposable syringe exclusively designed for the injection of subdermal implants. Make sure to scrub it with soap or a rag to remove residual DNA after use!
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -122,7 +122,7 @@
 
 - type: entity
   id: BaseImplantOnlyImplanterSyndi
-  parent: [BaseImplantOnlyImplanter, BaseForeignContraband]
+  parent: [BaseImplantOnlyImplanter, BaseExtremeContraband]
   name: syndicate implanter
   description: A compact disposable syringe exclusively designed for the injection of subdermal implants. Make sure to scrub it with soap or a rag to remove residual DNA after use!
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -368,7 +368,7 @@
   - type: NukeCodePaper
 
 - type: entity
-  parent: [Paper, BaseSyndicateContraband] # eat or burn your damn piece of paper damn thieves
+  parent: [Paper, BaseForeignContraband] # eat or burn your damn piece of paper damn thieves
   id: TraitorCodePaper
   name: syndicate codeword
   description: A leaked codeword to possibly get in touch with the Syndicate.
@@ -377,7 +377,7 @@
   - type: TraitorCodePaper
 
 - type: entity
-  parent: [Paper, BaseSyndicateContraband]
+  parent: [Paper, BaseForeignContraband]
   id: AllTraitorCodesPaper
   name: syndicate codewords registry
   description: A registry of all active Syndicate codewords.

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -368,7 +368,7 @@
   - type: NukeCodePaper
 
 - type: entity
-  parent: [Paper, BaseForeignContraband] # eat or burn your damn piece of paper damn thieves
+  parent: [Paper, BaseExtremeContraband] # eat or burn your damn piece of paper damn thieves
   id: TraitorCodePaper
   name: syndicate codeword
   description: A leaked codeword to possibly get in touch with the Syndicate.
@@ -377,7 +377,7 @@
   - type: TraitorCodePaper
 
 - type: entity
-  parent: [Paper, BaseForeignContraband]
+  parent: [Paper, BaseExtremeContraband]
   id: AllTraitorCodesPaper
   name: syndicate codewords registry
   description: A registry of all active Syndicate codewords.

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -82,7 +82,7 @@
 
 - type: entity
   name: Cybersun pen
-  parent: [BaseAdvancedPen, BaseSyndicateContraband]
+  parent: [BaseAdvancedPen, BaseForeignContraband]
   id: CyberPen
   description: A high-tech pen straight from Cybersun's legal department, capable of refracting hard-light at impossible angles through its diamond tip in order to write. So powerful, it's even able to rewrite officially stamped documents should the need arise.
   components:
@@ -124,7 +124,7 @@
 
 - type: entity
   name: wizard's magical pen
-  parent: [ PenEmbeddable, BaseMagicalContraband ]
+  parent: [ PenEmbeddable, BaseForeignContraband ]
   id: PenWiz
   description: A luxurious fountain pen. Seems to have a magical crystal eraser.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -82,7 +82,7 @@
 
 - type: entity
   name: Cybersun pen
-  parent: [BaseAdvancedPen, BaseForeignContraband]
+  parent: [BaseAdvancedPen, BaseExtremeContraband]
   id: CyberPen
   description: A high-tech pen straight from Cybersun's legal department, capable of refracting hard-light at impossible angles through its diamond tip in order to write. So powerful, it's even able to rewrite officially stamped documents should the need arise.
   components:
@@ -124,7 +124,7 @@
 
 - type: entity
   name: wizard's magical pen
-  parent: [ PenEmbeddable, BaseForeignContraband ]
+  parent: [ PenEmbeddable, BaseExtremeContraband ]
   id: PenWiz
   description: A luxurious fountain pen. Seems to have a magical crystal eraser.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
@@ -211,7 +211,7 @@
 
 - type: entity
   name: syndicate rubber stamp
-  parent: [RubberStampBase, BaseForeignContraband]
+  parent: [RubberStampBase, BaseExtremeContraband]
   id: RubberStampSyndicate
   categories: [ DoNotMap ]
   components:
@@ -303,7 +303,7 @@
 
 - type: entity
   name: wizard's rubber stamp
-  parent: [RubberStampBase, BaseForeignContraband]
+  parent: [RubberStampBase, BaseExtremeContraband]
   id: RubberStampWizard
   description: A chaotic wizard stamp for serving unchaotic paperwork, how ironic.
   categories: [ DoNotMap ]

--- a/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
@@ -211,7 +211,7 @@
 
 - type: entity
   name: syndicate rubber stamp
-  parent: [RubberStampBase, BaseSyndicateContraband]
+  parent: [RubberStampBase, BaseForeignContraband]
   id: RubberStampSyndicate
   categories: [ DoNotMap ]
   components:
@@ -303,7 +303,7 @@
 
 - type: entity
   name: wizard's rubber stamp
-  parent: [RubberStampBase, BaseMagicalContraband]
+  parent: [RubberStampBase, BaseForeignContraband]
   id: RubberStampWizard
   description: A chaotic wizard stamp for serving unchaotic paperwork, how ironic.
   categories: [ DoNotMap ]

--- a/Resources/Prototypes/Entities/Objects/Power/powersink.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powersink.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: PowerSink
-  parent: [BaseMachine, BaseForeignContraband]
+  parent: [BaseMachine, BaseExtremeContraband]
   name: power sink
   description: Drains immense amounts of electricity from the grid.
   components:

--- a/Resources/Prototypes/Entities/Objects/Power/powersink.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powersink.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: PowerSink
-  parent: [BaseMachine, BaseSyndicateContraband]
+  parent: [BaseMachine, BaseForeignContraband]
   name: power sink
   description: Drains immense amounts of electricity from the grid.
   components:

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -320,7 +320,7 @@
 
 - type: entity
   name: mirror shield
-  parent: [ BaseShield, BaseForeignContraband ]
+  parent: [ BaseShield, BaseExtremeContraband ]
   id: MirrorShield
   description: Eerily glows red... you hear the geometer whispering
   components:
@@ -368,7 +368,7 @@
 
 - type: entity
   name: energy shield
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   id: EnergyShield
   description: Exotic energy shield, when folded, can even fit in your pocket.
   components:

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -320,7 +320,7 @@
 
 - type: entity
   name: mirror shield
-  parent: [ BaseShield, BaseMagicalContraband ]
+  parent: [ BaseShield, BaseForeignContraband ]
   id: MirrorShield
   description: Eerily glows red... you hear the geometer whispering
   components:
@@ -368,7 +368,7 @@
 
 - type: entity
   name: energy shield
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   id: EnergyShield
   description: Exotic energy shield, when folded, can even fit in your pocket.
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -56,7 +56,7 @@
     stealGroup: Bible
 
 - type: entity
-  parent: [Bible, BaseForeignContraband]
+  parent: [Bible, BaseExtremeContraband]
   name: necronomicon
   description: "There's a note: Klatuu, Verata, Nikto -- Don't forget it again!"
   id: BibleNecronomicon

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -56,7 +56,7 @@
     stealGroup: Bible
 
 - type: entity
-  parent: [Bible, BaseSyndicateContraband]
+  parent: [Bible, BaseForeignContraband]
   name: necronomicon
   description: "There's a note: Klatuu, Verata, Nikto -- Don't forget it again!"
   id: BibleNecronomicon

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -529,7 +529,7 @@
       sprite: Objects/Specific/Hydroponics/fly_amanita.rsi
 
 - type: entity
-  parent: [SeedBase, BaseSyndicateContraband]
+  parent: [SeedBase, BaseForeignContraband]
   name: packet of gatfruit seeds
   description: "These are no peashooters."
   id: GatfruitSeeds

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -529,7 +529,7 @@
       sprite: Objects/Specific/Hydroponics/fly_amanita.rsi
 
 - type: entity
-  parent: [SeedBase, BaseForeignContraband]
+  parent: [SeedBase, BaseExtremeContraband]
   name: packet of gatfruit seeds
   description: "These are no peashooters."
   id: GatfruitSeeds

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -117,7 +117,7 @@
 - type: entity
   name: soap
   id: SoapSyndie
-  parent: [Soap, BaseForeignContraband]
+  parent: [Soap, BaseExtremeContraband]
   description: An untrustworthy bar of soap. Smells of fear.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -117,7 +117,7 @@
 - type: entity
   name: soap
   id: SoapSyndie
-  parent: [Soap, BaseSyndicateContraband]
+  parent: [Soap, BaseForeignContraband]
   description: An untrustworthy bar of soap. Smells of fear.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -97,7 +97,7 @@
 
 - type: entity
   id: DefibrillatorSyndicate
-  parent: [ DefibrillatorCompact, BaseForeignContraband ]
+  parent: [ DefibrillatorCompact, BaseExtremeContraband ]
   name: interdyne defibrillator
   description: Doubles as a self-defense weapon against war-crime inclined tiders.
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -97,7 +97,7 @@
 
 - type: entity
   id: DefibrillatorSyndicate
-  parent: [ DefibrillatorCompact, BaseSyndicateContraband ]
+  parent: [ DefibrillatorCompact, BaseForeignContraband ]
   name: interdyne defibrillator
   description: Doubles as a self-defense weapon against war-crime inclined tiders.
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -520,7 +520,7 @@
 
 - type: entity
   name: hyperzine injector
-  parent: [ChemicalMedipen, BaseForeignContraband]
+  parent: [ChemicalMedipen, BaseExtremeContraband]
   id: Stimpack
   description: Contains enough hyperzine for you to have the chemical's effect for 30 seconds. Use it when you're sure you're ready to throw down.
   components:
@@ -564,7 +564,7 @@
 
 - type: entity
   name: hyperzine microinjector
-  parent: [ChemicalMedipen, BaseForeignContraband]
+  parent: [ChemicalMedipen, BaseExtremeContraband]
   id: StimpackMini
   description: A microinjector of hyperzine that give you about 15 seconds of the chemical's effects.
   components:
@@ -603,7 +603,7 @@
 
 - type: entity
   name: combat medipen
-  parent: [ChemicalMedipen, BaseForeignContraband]
+  parent: [ChemicalMedipen, BaseExtremeContraband]
   id: CombatMedipen
   description: A single-use medipen containing chemicals that regenerate most types of damage.
   components:
@@ -671,7 +671,7 @@
     handle: false # don't want the sound to stop the self-inject from triggering
 
 - type: entity
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   id: HypopenBox
   name: hypopen box
   description: A small box containing a hypopen. Packaging disintegrates when opened, leaving no evidence behind.

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -520,7 +520,7 @@
 
 - type: entity
   name: hyperzine injector
-  parent: [ChemicalMedipen, BaseSyndicateContraband]
+  parent: [ChemicalMedipen, BaseForeignContraband]
   id: Stimpack
   description: Contains enough hyperzine for you to have the chemical's effect for 30 seconds. Use it when you're sure you're ready to throw down.
   components:
@@ -564,7 +564,7 @@
 
 - type: entity
   name: hyperzine microinjector
-  parent: [ChemicalMedipen, BaseSyndicateContraband]
+  parent: [ChemicalMedipen, BaseForeignContraband]
   id: StimpackMini
   description: A microinjector of hyperzine that give you about 15 seconds of the chemical's effects.
   components:
@@ -603,7 +603,7 @@
 
 - type: entity
   name: combat medipen
-  parent: [ChemicalMedipen, BaseSyndicateContraband]
+  parent: [ChemicalMedipen, BaseForeignContraband]
   id: CombatMedipen
   description: A single-use medipen containing chemicals that regenerate most types of damage.
   components:
@@ -671,7 +671,7 @@
     handle: false # don't want the sound to stop the self-inject from triggering
 
 - type: entity
-  parent: [ BaseItem, BaseSyndicateContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   id: HypopenBox
   name: hypopen box
   description: A small box containing a hypopen. Packaging disintegrates when opened, leaving no evidence behind.

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -227,7 +227,7 @@
 - type: entity
   name: advanced circular saw
   id: SawAdvanced
-  parent: [ SawElectric, BaseForeignContraband ]
+  parent: [ SawElectric, BaseExtremeContraband ]
   description: Interdyne's state-of-the-art surgical saw. Guaranteed to stay spotless and sterile, no matter how messy the job.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -227,7 +227,7 @@
 - type: entity
   name: advanced circular saw
   id: SawAdvanced
-  parent: [ SawElectric, BaseSyndicateContraband ]
+  parent: [ SawElectric, BaseForeignContraband ]
   description: Interdyne's state-of-the-art surgical saw. Guaranteed to stay spotless and sterile, no matter how messy the job.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -901,7 +901,7 @@
 #syndicate modules
 - type: entity
   id: BorgModuleSyndicateWeapon
-  parent: [ BaseBorgModule, BaseProviderBorgModule, BaseSyndicateContraband ]
+  parent: [ BaseBorgModule, BaseProviderBorgModule, BaseForeignContraband ]
   name: weapon cyborg module
   components:
   - type: Sprite
@@ -937,7 +937,7 @@
 
 - type: entity
   id: BorgModuleOperative
-  parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule, BaseSyndicateContraband ]
+  parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule, BaseForeignContraband ]
   name: operative cyborg module
   description: A module that comes with a crowbar, an Emag, an Access Breaker and a syndicate pinpointer.
   components:
@@ -956,7 +956,7 @@
 
 - type: entity
   id: BorgModuleEsword
-  parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule, BaseSyndicateContraband ]
+  parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule, BaseForeignContraband ]
   name: energy sword cyborg module
   description: A module that comes with a double energy sword.
   components:
@@ -973,7 +973,7 @@
 
 - type: entity
   id: BorgModuleL6C
-  parent: [ BaseBorgModuleSyndicateAssault, BaseProviderBorgModule, BaseSyndicateContraband ]
+  parent: [ BaseBorgModuleSyndicateAssault, BaseProviderBorgModule, BaseForeignContraband ]
   name: L6C ROW cyborg module
   description: A module that comes with a L6C.
   components:
@@ -990,7 +990,7 @@
 
 - type: entity
   id: BorgModuleMartyr
-  parent: [ BaseBorgModule, BaseProviderBorgModule, BaseSyndicateContraband ]
+  parent: [ BaseBorgModule, BaseProviderBorgModule, BaseForeignContraband ]
   name: martyr cyborg module
   description: "A module that comes with an explosive you probably don't want to handle yourself."
   components:
@@ -1026,7 +1026,7 @@
 
 # xenoborg modules
 - type: entity
-  parent: [ BaseXenoborgModuleGeneric, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleGeneric, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleBasic
   name: basic xenoborg module
   description: Essential items for any xenoborg.
@@ -1044,7 +1044,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-basic-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleGeneric, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleGeneric, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleTool
   name: tool xenoborg module
   description: Simple tools for most xenoborgs.
@@ -1065,7 +1065,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-tool-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleEngi, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleEngi, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleAccessBreaker
   name: access breaker xenoborg module
   description: Module with a access breaker.
@@ -1081,7 +1081,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-access-breaker-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleEngi, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleEngi, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleFireExtinguisher
   name: fire extinguisher xenoborg module
   description: Module with a self-refueling fire extinguisher.
@@ -1097,7 +1097,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-extinguisher-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleHeavy, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleHeavy, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleJammer
   name: jammer xenoborg module
   description: Module with a communication jammer.
@@ -1113,7 +1113,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-jammer-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleHeavy, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleHeavy, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleLaser
   name: laser xenoborg module
   description: Module with a laser gun.
@@ -1129,7 +1129,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-laser-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleHeavy, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleHeavy, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleHeavyLaser
   name: heavy laser xenoborg module
   description: Module with a heavy laser gun.
@@ -1145,7 +1145,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-laser2-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleScout, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleScout, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleSpaceMovement
   name: space movement xenoborg module
   description: Module that helps a xenoborg move better in space.
@@ -1165,7 +1165,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-space-movement-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleScout, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleScout, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleSword
   name: sword xenoborg module
   description: Module with a kukri knife.
@@ -1182,7 +1182,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-sword-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleScout, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleScout, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleEnergySword
   name: energy sword xenoborg module
   description: Module with an energy dagger.
@@ -1199,7 +1199,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-sword2-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleHypo
   name: nocturine hypo xenoborg module
   description: Module with a self-refilling nocturine hypo.
@@ -1215,7 +1215,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-hypo-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleChameleonProjector
   name: chameleon projector xenoborg module
   description: Module with a chameleon projector.
@@ -1231,7 +1231,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-projector-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseXenoborgContraband ]
+  parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseForeignContraband ]
   id: XenoborgModuleCloakDevice
   name: cloaking device xenoborg module
   description: Module with a device that allows xenoborgs to become invisible for some time.

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -901,7 +901,7 @@
 #syndicate modules
 - type: entity
   id: BorgModuleSyndicateWeapon
-  parent: [ BaseBorgModule, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseBorgModule, BaseProviderBorgModule, BaseExtremeContraband ]
   name: weapon cyborg module
   components:
   - type: Sprite
@@ -937,7 +937,7 @@
 
 - type: entity
   id: BorgModuleOperative
-  parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule, BaseExtremeContraband ]
   name: operative cyborg module
   description: A module that comes with a crowbar, an Emag, an Access Breaker and a syndicate pinpointer.
   components:
@@ -956,7 +956,7 @@
 
 - type: entity
   id: BorgModuleEsword
-  parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule, BaseExtremeContraband ]
   name: energy sword cyborg module
   description: A module that comes with a double energy sword.
   components:
@@ -973,7 +973,7 @@
 
 - type: entity
   id: BorgModuleL6C
-  parent: [ BaseBorgModuleSyndicateAssault, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseBorgModuleSyndicateAssault, BaseProviderBorgModule, BaseExtremeContraband ]
   name: L6C ROW cyborg module
   description: A module that comes with a L6C.
   components:
@@ -990,7 +990,7 @@
 
 - type: entity
   id: BorgModuleMartyr
-  parent: [ BaseBorgModule, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseBorgModule, BaseProviderBorgModule, BaseExtremeContraband ]
   name: martyr cyborg module
   description: "A module that comes with an explosive you probably don't want to handle yourself."
   components:
@@ -1026,7 +1026,7 @@
 
 # xenoborg modules
 - type: entity
-  parent: [ BaseXenoborgModuleGeneric, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleGeneric, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleBasic
   name: basic xenoborg module
   description: Essential items for any xenoborg.
@@ -1044,7 +1044,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-basic-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleGeneric, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleGeneric, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleTool
   name: tool xenoborg module
   description: Simple tools for most xenoborgs.
@@ -1065,7 +1065,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-tool-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleEngi, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleEngi, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleAccessBreaker
   name: access breaker xenoborg module
   description: Module with a access breaker.
@@ -1081,7 +1081,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-access-breaker-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleEngi, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleEngi, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleFireExtinguisher
   name: fire extinguisher xenoborg module
   description: Module with a self-refueling fire extinguisher.
@@ -1097,7 +1097,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-extinguisher-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleHeavy, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleHeavy, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleJammer
   name: jammer xenoborg module
   description: Module with a communication jammer.
@@ -1113,7 +1113,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-jammer-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleHeavy, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleHeavy, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleLaser
   name: laser xenoborg module
   description: Module with a laser gun.
@@ -1129,7 +1129,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-laser-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleHeavy, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleHeavy, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleHeavyLaser
   name: heavy laser xenoborg module
   description: Module with a heavy laser gun.
@@ -1145,7 +1145,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-laser2-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleScout, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleScout, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleSpaceMovement
   name: space movement xenoborg module
   description: Module that helps a xenoborg move better in space.
@@ -1165,7 +1165,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-space-movement-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleScout, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleScout, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleSword
   name: sword xenoborg module
   description: Module with a kukri knife.
@@ -1182,7 +1182,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-sword-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleScout, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleScout, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleEnergySword
   name: energy sword xenoborg module
   description: Module with an energy dagger.
@@ -1199,7 +1199,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-sword2-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleHypo
   name: nocturine hypo xenoborg module
   description: Module with a self-refilling nocturine hypo.
@@ -1215,7 +1215,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-hypo-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleChameleonProjector
   name: chameleon projector xenoborg module
   description: Module with a chameleon projector.
@@ -1231,7 +1231,7 @@
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-projector-module }
 
 - type: entity
-  parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseForeignContraband ]
+  parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseExtremeContraband ]
   id: XenoborgModuleCloakDevice
   name: cloaking device xenoborg module
   description: Module with a device that allows xenoborgs to become invisible for some time.

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/cloaking_device.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/cloaking_device.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   id: CloakingDevice
   name: cloaking device
   description: A device that allows xenoborgs to go invisible.

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/cloaking_device.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/cloaking_device.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseItem, BaseXenoborgContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   id: CloakingDevice
   name: cloaking device
   description: A device that allows xenoborgs to go invisible.

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/material_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/material_bag.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseStorageItem, BaseForeignContraband ]
+  parent: [ BaseStorageItem, BaseExtremeContraband ]
   id: MaterialBag
   name: material bag
   description: A robust bag for xenoborgs to carry large amounts of materials.

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/material_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/material_bag.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseStorageItem, BaseXenoborgContraband ]
+  parent: [ BaseStorageItem, BaseForeignContraband ]
   id: MaterialBag
   name: material bag
   description: A robust bag for xenoborgs to carry large amounts of materials.

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/nocturine_hypo.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/nocturine_hypo.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BorgHypo, BaseXenoborgContraband ]
+  parent: [ BorgHypo, BaseForeignContraband ]
   id: NocturineHypo
   name: nocturine hypo
   description: A self-refilling injector for rapid administration of nocturine to victms.

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/nocturine_hypo.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoborg/nocturine_hypo.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BorgHypo, BaseForeignContraband ]
+  parent: [ BorgHypo, BaseExtremeContraband ]
   id: NocturineHypo
   name: nocturine hypo
   description: A self-refilling injector for rapid administration of nocturine to victms.

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -187,7 +187,7 @@
 # It inherits FoodComponent from PlushieCarp, but is de-facto inedible
 # PlushieCarp has requiresSpecialDigestion:true, and this one is not whitelisted anywhere, so it behaves like it's not edible
 - type: entity
-  parent: [PlushieCarp, RehydratableItem, BaseForeignContraband]
+  parent: [PlushieCarp, RehydratableItem, BaseExtremeContraband]
   id: DehydratedSpaceCarp
   name: dehydrated space carp
   description: Looks like a plush toy carp, but just add water and it becomes a real-life space carp!

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -187,7 +187,7 @@
 # It inherits FoodComponent from PlushieCarp, but is de-facto inedible
 # PlushieCarp has requiresSpecialDigestion:true, and this one is not whitelisted anywhere, so it behaves like it's not edible
 - type: entity
-  parent: [PlushieCarp, RehydratableItem, BaseSyndicateContraband]
+  parent: [PlushieCarp, RehydratableItem, BaseForeignContraband]
   id: DehydratedSpaceCarp
   name: dehydrated space carp
   description: Looks like a plush toy carp, but just add water and it becomes a real-life space carp!

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -1,7 +1,7 @@
 
 - type: entity
   name: telecrystal
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   id: Telecrystal
   suffix: 20 TC
   description: It seems to be pulsing with suspiciously enticing energies.
@@ -49,7 +49,7 @@
 
 # Uplinks
 - type: entity
-  parent: [BaseItem, StorePresetUplink, BaseForeignContraband]
+  parent: [BaseItem, StorePresetUplink, BaseExtremeContraband]
   id: BaseUplinkRadio
   name: syndicate uplink
   description: Suspiciously looking old radio...

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -1,7 +1,7 @@
 
 - type: entity
   name: telecrystal
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   id: Telecrystal
   suffix: 20 TC
   description: It seems to be pulsing with suspiciously enticing energies.
@@ -49,7 +49,7 @@
 
 # Uplinks
 - type: entity
-  parent: [BaseItem, StorePresetUplink, BaseSyndicateContraband]
+  parent: [BaseItem, StorePresetUplink, BaseForeignContraband]
   id: BaseUplinkRadio
   name: syndicate uplink
   description: Suspiciously looking old radio...

--- a/Resources/Prototypes/Entities/Objects/Tools/access_breaker.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_breaker.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   id: AccessBreakerUnlimited
   suffix: Unlimited
   name: authentication disruptor

--- a/Resources/Prototypes/Entities/Objects/Tools/access_breaker.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_breaker.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   id: AccessBreakerUnlimited
   suffix: Unlimited
   name: authentication disruptor

--- a/Resources/Prototypes/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/emag.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   id: EmagUnlimited
   suffix: Unlimited
   name: cryptographic sequencer

--- a/Resources/Prototypes/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/emag.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   id: EmagUnlimited
   suffix: Unlimited
   name: cryptographic sequencer

--- a/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: radio jammer
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   id: RadioJammer
   description: This device will disrupt any nearby outgoing radio communication as well as suit sensors when activated.
   components:
@@ -52,7 +52,7 @@
     price: 1500
 
 - type: entity
-  parent: [RadioJammer, BaseForeignContraband]
+  parent: [RadioJammer, BaseExtremeContraband]
   id: XenoborgRadioJammer
   name: xenoborg radio jammer
   components:

--- a/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: radio jammer
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   id: RadioJammer
   description: This device will disrupt any nearby outgoing radio communication as well as suit sensors when activated.
   components:
@@ -52,7 +52,7 @@
     price: 1500
 
 - type: entity
-  parent: [RadioJammer, BaseXenoborgContraband]
+  parent: [RadioJammer, BaseForeignContraband]
   id: XenoborgRadioJammer
   name: xenoborg radio jammer
   components:

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -52,7 +52,7 @@
 
 - type: entity
   name: syndicate jaws of life
-  parent: [JawsOfLife, BaseForeignContraband]
+  parent: [JawsOfLife, BaseExtremeContraband]
   id: SyndicateJawsOfLife
   description: Useful for entering the station or its departments.
   components:

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -52,7 +52,7 @@
 
 - type: entity
   name: syndicate jaws of life
-  parent: [JawsOfLife, BaseSyndicateContraband]
+  parent: [JawsOfLife, BaseForeignContraband]
   id: SyndicateJawsOfLife
   description: Useful for entering the station or its departments.
   components:

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -114,7 +114,7 @@
 #Empty black
 - type: entity
   id: JetpackBlack
-  parent: [BaseJetpack, BaseSyndicateContraband]
+  parent: [BaseJetpack, BaseForeignContraband]
   name: jetpack
   suffix: Empty
   components:
@@ -296,7 +296,7 @@
 
 # Infinite jetpack
 - type: entity
-  parent: [ JetpackBlack, BaseXenoborgContraband ]
+  parent: [ JetpackBlack, BaseForeignContraband ]
   id: JetpackXenoborg
   name: xenoborg jetpack
   suffix: Infinite

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -114,7 +114,7 @@
 #Empty black
 - type: entity
   id: JetpackBlack
-  parent: [BaseJetpack, BaseForeignContraband]
+  parent: [BaseJetpack, BaseExtremeContraband]
   name: jetpack
   suffix: Empty
   components:
@@ -296,7 +296,7 @@
 
 # Infinite jetpack
 - type: entity
-  parent: [ JetpackBlack, BaseForeignContraband ]
+  parent: [ JetpackBlack, BaseExtremeContraband ]
   id: JetpackXenoborg
   name: xenoborg jetpack
   suffix: Infinite

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -118,7 +118,7 @@
 
 - type: entity
   name: suspicious toolbox
-  parent: [ToolboxBase, BaseForeignContraband]
+  parent: [ToolboxBase, BaseExtremeContraband]
   id: ToolboxSyndicate
   description: A sinister looking toolbox filled with elite syndicate tools.
   components:

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -118,7 +118,7 @@
 
 - type: entity
   name: suspicious toolbox
-  parent: [ToolboxBase, BaseSyndicateContraband]
+  parent: [ToolboxBase, BaseForeignContraband]
   id: ToolboxSyndicate
   description: A sinister looking toolbox filled with elite syndicate tools.
   components:

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -202,7 +202,7 @@
     color: orange
 
 - type: entity
-  parent: [ Welder, BaseForeignContraband ]
+  parent: [ Welder, BaseExtremeContraband ]
   id: RefuelingWelder
   name: refuling welding tool
   description: "An slow welder that can refuel itself over time."

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -202,7 +202,7 @@
     color: orange
 
 - type: entity
-  parent: [ Welder, BaseXenoborgContraband ]
+  parent: [ Welder, BaseForeignContraband ]
   id: RefuelingWelder
   name: refuling welding tool
   description: "An slow welder that can refuel itself over time."

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/funny.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/funny.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: hot potato
   description: Once activated, you can't drop this time bomb - hit someone else with it to save yourself! Don't burn your hands!
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   id: HotPotato
   components:
     - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/funny.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/funny.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: hot potato
   description: Once activated, you can't drop this time bomb - hit someone else with it to save yourself! Don't burn your hands!
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   id: HotPotato
   components:
     - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
@@ -24,7 +24,7 @@
     handle: false # don't want the sound to stop the explosion from triggering
 
 - type: entity
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   id: PenExplodingBox
   name: exploding pen box
   description: A small box containing an exploding pen. Packaging disintegrates when opened, leaving no evidence behind.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
@@ -24,7 +24,7 @@
     handle: false # don't want the sound to stop the explosion from triggering
 
 - type: entity
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   id: PenExplodingBox
   name: exploding pen box
   description: A small box containing an exploding pen. Packaging disintegrates when opened, leaving no evidence behind.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_staff.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_staff.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: WeaponStaffBase
   abstract: true
-  parent: [ BaseItem, BaseMagicalContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Basic/staves.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_staff.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_staff.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: WeaponStaffBase
   abstract: true
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Basic/staves.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wand.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wand.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: WeaponWandBase
   abstract: true
-  parent: [ BaseItem, BaseMagicalContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Basic/wands.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wand.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wand.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: WeaponWandBase
   abstract: true
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Basic/wands.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -706,7 +706,7 @@
 
 - type: entity
   name: experimental C.H.I.M.P. handcannon
-  parent: [WeaponPistolCHIMP, BaseSyndicateContraband]
+  parent: [WeaponPistolCHIMP, BaseForeignContraband]
   id: WeaponPistolCHIMPUpgraded
   description: This C.H.I.M.P. seems to have a greater punch than is usual...
   components:
@@ -850,12 +850,12 @@
 
 - type: entity
   name: xenoborg laser gun
-  parent: [ WeaponAdvancedLaser, BaseXenoborgContraband ]
+  parent: [ WeaponAdvancedLaser, BaseForeignContraband ]
   id: XenoborgLaserGun
 
 - type: entity
   name: xenoborg heavy laser gun
-  parent: [ WeaponAdvancedLaser, BaseXenoborgContraband ]
+  parent: [ WeaponAdvancedLaser, BaseForeignContraband ]
   id: XenoborgHeavyLaserGun
   components:
   - type: HitscanBatteryAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -706,7 +706,7 @@
 
 - type: entity
   name: experimental C.H.I.M.P. handcannon
-  parent: [WeaponPistolCHIMP, BaseForeignContraband]
+  parent: [WeaponPistolCHIMP, BaseExtremeContraband]
   id: WeaponPistolCHIMPUpgraded
   description: This C.H.I.M.P. seems to have a greater punch than is usual...
   components:
@@ -850,12 +850,12 @@
 
 - type: entity
   name: xenoborg laser gun
-  parent: [ WeaponAdvancedLaser, BaseForeignContraband ]
+  parent: [ WeaponAdvancedLaser, BaseExtremeContraband ]
   id: XenoborgLaserGun
 
 - type: entity
   name: xenoborg heavy laser gun
-  parent: [ WeaponAdvancedLaser, BaseForeignContraband ]
+  parent: [ WeaponAdvancedLaser, BaseExtremeContraband ]
   id: XenoborgHeavyLaserGun
   components:
   - type: HitscanBatteryAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -68,7 +68,7 @@
 - type: entity
   name: L6 SAW
   id: WeaponLightMachineGunL6
-  parent: [BaseWeaponLightMachineGun, BaseForeignContraband]
+  parent: [BaseWeaponLightMachineGun, BaseExtremeContraband]
   description: Developed by Waffle Corp, the L6 Squad Automatic Weapon is a deadly light machine gun often used by the Gorlex Marauders. Although bulky and cumbersome, its heavy barrel and high ammo capacity make it perfect for suppressing combatants with a hail of bullets. Feeds from .30 ammo belts.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -68,7 +68,7 @@
 - type: entity
   name: L6 SAW
   id: WeaponLightMachineGunL6
-  parent: [BaseWeaponLightMachineGun, BaseSyndicateContraband]
+  parent: [BaseWeaponLightMachineGun, BaseForeignContraband]
   description: Developed by Waffle Corp, the L6 Squad Automatic Weapon is a deadly light machine gun often used by the Gorlex Marauders. Although bulky and cumbersome, its heavy barrel and high ammo capacity make it perfect for suppressing combatants with a hail of bullets. Feeds from .30 ammo belts.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -22,7 +22,7 @@
 
 - type: entity
   name: china lake
-  parent: [BaseWeaponLauncher, BaseGunWieldable, BaseSyndicateContraband]
+  parent: [BaseWeaponLauncher, BaseGunWieldable, BaseForeignContraband]
   id: WeaponLauncherChinaLake
   description: PLOOP.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -22,7 +22,7 @@
 
 - type: entity
   name: china lake
-  parent: [BaseWeaponLauncher, BaseGunWieldable, BaseForeignContraband]
+  parent: [BaseWeaponLauncher, BaseGunWieldable, BaseExtremeContraband]
   id: WeaponLauncherChinaLake
   description: PLOOP.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -70,7 +70,7 @@
 
 - type: entity
   name: viper
-  parent: [BaseWeaponPistol, BaseSyndicateContraband]
+  parent: [BaseWeaponPistol, BaseForeignContraband]
   id: WeaponPistolViper
   description: A common handgun illegally modified by the Syndicate. The Viper sports a selector switch between semi-auto and ‘rock and roll’. The standard sidearm for any soldier who fights under the three serpents. Feeds from .35 pistol magazines.
   components:
@@ -105,7 +105,7 @@
 
 - type: entity
   name: echis
-  parent: [ BaseItem, BaseSyndicateContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   id: WeaponPistolEchis
   description: A cyborg-mounted weapon system based on the Viper pistol. Creates ammunition on the fly from an internal fabricator, which slowly self-charges.
   components:
@@ -140,7 +140,7 @@
 
 - type: entity
   name: cobra
-  parent: [ BaseWeaponPistol, BaseSyndicateContraband ]
+  parent: [ BaseWeaponPistol, BaseForeignContraband ]
   id: WeaponPistolCobra
   description: Integrally suppressed semi-automatic pistol used by the Syndicate, firing caseless subsonic rounds. Favored by any agent who likes to keep things quiet and leave no evidence behind. Feeds from .25 pistol magazines.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -70,7 +70,7 @@
 
 - type: entity
   name: viper
-  parent: [BaseWeaponPistol, BaseForeignContraband]
+  parent: [BaseWeaponPistol, BaseExtremeContraband]
   id: WeaponPistolViper
   description: A common handgun illegally modified by the Syndicate. The Viper sports a selector switch between semi-auto and ‘rock and roll’. The standard sidearm for any soldier who fights under the three serpents. Feeds from .35 pistol magazines.
   components:
@@ -105,7 +105,7 @@
 
 - type: entity
   name: echis
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   id: WeaponPistolEchis
   description: A cyborg-mounted weapon system based on the Viper pistol. Creates ammunition on the fly from an internal fabricator, which slowly self-charges.
   components:
@@ -140,7 +140,7 @@
 
 - type: entity
   name: cobra
-  parent: [ BaseWeaponPistol, BaseForeignContraband ]
+  parent: [ BaseWeaponPistol, BaseExtremeContraband ]
   id: WeaponPistolCobra
   description: Integrally suppressed semi-automatic pistol used by the Syndicate, firing caseless subsonic rounds. Favored by any agent who likes to keep things quiet and leave no evidence behind. Feeds from .25 pistol magazines.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -118,7 +118,7 @@
 
 - type: entity
   name: Python
-  parent: [BaseWeaponRevolver, BaseForeignContraband]
+  parent: [BaseWeaponRevolver, BaseExtremeContraband]
   id: WeaponRevolverPython
   description: A powerful double-action revolver manufactured by the Syndicate. Loud and flashy, perfect for any agent looking to make a statement. Loads 6 rounds of .45 magnum.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -118,7 +118,7 @@
 
 - type: entity
   name: Python
-  parent: [BaseWeaponRevolver, BaseSyndicateContraband]
+  parent: [BaseWeaponRevolver, BaseForeignContraband]
   id: WeaponRevolverPython
   description: A powerful double-action revolver manufactured by the Syndicate. Loud and flashy, perfect for any agent looking to make a statement. Loads 6 rounds of .45 magnum.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -102,7 +102,7 @@
 
 - type: entity
   name: M-90gl
-  parent: [BaseWeaponRifle, BaseSyndicateContraband]
+  parent: [BaseWeaponRifle, BaseForeignContraband]
   id: WeaponRifleM90GrenadeLauncher
   description: An older bullpup carbine model, with an attached underbarrel grenade launcher. Uses .20 rifle ammo.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -102,7 +102,7 @@
 
 - type: entity
   name: M-90gl
-  parent: [BaseWeaponRifle, BaseForeignContraband]
+  parent: [BaseWeaponRifle, BaseExtremeContraband]
   id: WeaponRifleM90GrenadeLauncher
   description: An older bullpup carbine model, with an attached underbarrel grenade launcher. Uses .20 rifle ammo.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -83,7 +83,7 @@
 
 - type: entity
   name: C-20r submachine gun
-  parent: [BaseWeaponSubMachineGun, BaseForeignContraband]
+  parent: [BaseWeaponSubMachineGun, BaseExtremeContraband]
   id: WeaponSubMachineGunC20r
   description: A classic and widespread submachine gun, infamous for its use by the Gorlex Marauders. One of the first homegrown Waffle Corp. designs, it remains in service today. Feeds from .35 SMG magazines.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -83,7 +83,7 @@
 
 - type: entity
   name: C-20r submachine gun
-  parent: [BaseWeaponSubMachineGun, BaseSyndicateContraband]
+  parent: [BaseWeaponSubMachineGun, BaseForeignContraband]
   id: WeaponSubMachineGunC20r
   description: A classic and widespread submachine gun, infamous for its use by the Gorlex Marauders. One of the first homegrown Waffle Corp. designs, it remains in service today. Feeds from .35 SMG magazines.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -46,7 +46,7 @@
 - type: entity
   name: Bulldog
   # Don't parent to BaseWeaponShotgun because it differs significantly
-  parent: [BaseItem, BaseGunWieldable, BaseForeignContraband]
+  parent: [BaseItem, BaseGunWieldable, BaseExtremeContraband]
   id: WeaponShotgunBulldog
   description: An automatic magazine-fed shotgun for close-quarters combat. Kicks like a mule on steroids. Uses .50 shotgun shells.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -46,7 +46,7 @@
 - type: entity
   name: Bulldog
   # Don't parent to BaseWeaponShotgun because it differs significantly
-  parent: [BaseItem, BaseGunWieldable, BaseSyndicateContraband]
+  parent: [BaseItem, BaseGunWieldable, BaseForeignContraband]
   id: WeaponShotgunBulldog
   description: An automatic magazine-fed shotgun for close-quarters combat. Kicks like a mule on steroids. Uses .50 shotgun shells.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -52,7 +52,7 @@
 
 - type: entity
   name: Hristov
-  parent: [BaseWeaponSniper, BaseGunWieldable, BaseSyndicateContraband]
+  parent: [BaseWeaponSniper, BaseGunWieldable, BaseForeignContraband]
   id: WeaponSniperHristov
   description: A portable anti-materiel rifle. Fires armor piercing 14.5mm shells. Uses .60 anti-materiel ammo.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -52,7 +52,7 @@
 
 - type: entity
   name: Hristov
-  parent: [BaseWeaponSniper, BaseGunWieldable, BaseForeignContraband]
+  parent: [BaseWeaponSniper, BaseGunWieldable, BaseExtremeContraband]
   id: WeaponSniperHristov
   description: A portable anti-materiel rifle. Fires armor piercing 14.5mm shells. Uses .60 anti-materiel ammo.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseWeaponBallisticTurret, BaseForeignContraband]
+  parent: [BaseWeaponBallisticTurret, BaseExtremeContraband]
   id: WeaponTurretSyndicate
   suffix: Syndicate
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseWeaponBallisticTurret, BaseSyndicateContraband]
+  parent: [BaseWeaponBallisticTurret, BaseForeignContraband]
   id: WeaponTurretSyndicate
   suffix: Syndicate
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
@@ -28,7 +28,7 @@
 
 - type: entity
   name: cane blade
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   id: CaneBlade
   description: A sharp blade with a cane shaped hilt.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
@@ -28,7 +28,7 @@
 
 - type: entity
   name: cane blade
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   id: CaneBlade
   description: A sharp blade with a cane shaped hilt.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -75,7 +75,7 @@
 
 - type: entity
   name: energy sword
-  parent: [BaseMeleeWeaponEnergy, BaseForeignContraband]
+  parent: [BaseMeleeWeaponEnergy, BaseExtremeContraband]
   id: EnergySword
   description: A very loud & dangerous sword with a beam made of pure, concentrated plasma. Cuts through unarmored targets like butter.
   components:
@@ -95,7 +95,7 @@
 
 - type: entity
   name: energy dagger
-  parent: [BaseMeleeWeaponEnergy, BaseForeignContraband]
+  parent: [BaseMeleeWeaponEnergy, BaseExtremeContraband]
   id: EnergyDaggerLoud
   description: A not as loud and dangerous dagger with a beam made of pure, concentrated plasma. This one is completely undisguised.
   components:
@@ -196,7 +196,7 @@
     - type: Execution
       doAfterDuration: 4.0
     - type: Contraband
-      severity: Foreign
+      severity: Extreme
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_dagger.rsi
     layers:
@@ -227,7 +227,7 @@
     - Write
 
 - type: entity
-  parent: [BaseItem, BaseForeignContraband]
+  parent: [BaseItem, BaseExtremeContraband]
   id: EnergyDaggerBox
   name: e-dagger box
   suffix: E-Dagger
@@ -270,7 +270,7 @@
 
 - type: entity
   name: double-bladed energy sword
-  parent: [BaseMeleeWeaponEnergy, BaseForeignContraband]
+  parent: [BaseMeleeWeaponEnergy, BaseExtremeContraband]
   id: EnergySwordDouble
   description: Syndicate Command Interns thought that having one blade on the energy sword was not enough. This can be stored in pockets.
   components:
@@ -397,7 +397,7 @@
     freeHandsRequired: 0 # because borg has no off-hand to wield with.  Without this, it will be unable to activate the esword
 
 - type: entity
-  parent: [ EnergyDaggerLoud, BaseForeignContraband ]
+  parent: [ EnergyDaggerLoud, BaseExtremeContraband ]
   id: EnergyDaggerLoudBlue
   suffix: blue
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -75,7 +75,7 @@
 
 - type: entity
   name: energy sword
-  parent: [BaseMeleeWeaponEnergy, BaseSyndicateContraband]
+  parent: [BaseMeleeWeaponEnergy, BaseForeignContraband]
   id: EnergySword
   description: A very loud & dangerous sword with a beam made of pure, concentrated plasma. Cuts through unarmored targets like butter.
   components:
@@ -95,7 +95,7 @@
 
 - type: entity
   name: energy dagger
-  parent: [BaseMeleeWeaponEnergy, BaseSyndicateContraband]
+  parent: [BaseMeleeWeaponEnergy, BaseForeignContraband]
   id: EnergyDaggerLoud
   description: A not as loud and dangerous dagger with a beam made of pure, concentrated plasma. This one is completely undisguised.
   components:
@@ -227,7 +227,7 @@
     - Write
 
 - type: entity
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseForeignContraband]
   id: EnergyDaggerBox
   name: e-dagger box
   suffix: E-Dagger
@@ -270,7 +270,7 @@
 
 - type: entity
   name: double-bladed energy sword
-  parent: [BaseMeleeWeaponEnergy, BaseSyndicateContraband]
+  parent: [BaseMeleeWeaponEnergy, BaseForeignContraband]
   id: EnergySwordDouble
   description: Syndicate Command Interns thought that having one blade on the energy sword was not enough. This can be stored in pockets.
   components:
@@ -397,7 +397,7 @@
     freeHandsRequired: 0 # because borg has no off-hand to wield with.  Without this, it will be unable to activate the esword
 
 - type: entity
-  parent: [ EnergyDaggerLoud, BaseXenoborgContraband ]
+  parent: [ EnergyDaggerLoud, BaseForeignContraband ]
   id: EnergyDaggerLoudBlue
   suffix: blue
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -196,7 +196,7 @@
     - type: Execution
       doAfterDuration: 4.0
     - type: Contraband
-      severity: Syndicate
+      severity: Foreign
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_dagger.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -53,7 +53,7 @@
 - type: entity
   id: FireAxeFlaming
   name: fire axe
-  parent: [ BaseSyndicateContraband, FireAxe ]
+  parent: [ BaseForeignContraband, FireAxe ]
   description: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle!
   components:
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -53,7 +53,7 @@
 - type: entity
   id: FireAxeFlaming
   name: fire axe
-  parent: [ BaseForeignContraband, FireAxe ]
+  parent: [ BaseExtremeContraband, FireAxe ]
   description: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle!
   components:
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
@@ -26,7 +26,7 @@
 
 - type: entity
   id: Mjollnir
-  parent: [ BaseItem, BaseMagicalContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   name: Mjollnir
   description: A weapon worthy of a god, able to strike with the force of a lightning bolt. It crackles with barely contained energy.
   components:
@@ -69,7 +69,7 @@
 
 - type: entity
   id: SingularityHammer
-  parent: [ BaseItem, BaseMagicalContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   name: Singularity Hammer
   description: The pinnacle of close combat technology, the hammer harnesses the power of a miniaturized singularity to deal crushing blows.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
@@ -26,7 +26,7 @@
 
 - type: entity
   id: Mjollnir
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   name: Mjollnir
   description: A weapon worthy of a god, able to strike with the force of a lightning bolt. It crackles with barely contained energy.
   components:
@@ -69,7 +69,7 @@
 
 - type: entity
   id: SingularityHammer
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   name: Singularity Hammer
   description: The pinnacle of close combat technology, the hammer harnesses the power of a miniaturized singularity to deal crushing blows.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -271,7 +271,7 @@
 
 - type: entity
   name: throwing knife
-  parent: [BaseKnife, BaseForeignContraband]
+  parent: [BaseKnife, BaseExtremeContraband]
   id: ThrowingKnife
   description: This blood-red knife is very aerodynamic and easy to throw, but good luck trying to fight someone hand-to-hand.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -271,7 +271,7 @@
 
 - type: entity
   name: throwing knife
-  parent: [BaseKnife, BaseSyndicateContraband]
+  parent: [BaseKnife, BaseForeignContraband]
   id: ThrowingKnife
   description: This blood-red knife is very aerodynamic and easy to throw, but good luck trying to fight someone hand-to-hand.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -42,7 +42,7 @@
 - type: entity
   name: explosive grenade
   description: Grenade that creates a small but devastating explosion.
-  parent: [GrenadeBase, BaseForeignContraband]
+  parent: [GrenadeBase, BaseExtremeContraband]
   id: ExGrenade
   components:
   - type: ExplodeOnTrigger
@@ -108,7 +108,7 @@
 - type: entity
   name: syndicate minibomb
   description: A syndicate-manufactured explosive used to stow destruction and cause chaos.
-  parent: [GrenadeBase, BaseForeignContraband]
+  parent: [GrenadeBase, BaseExtremeContraband]
   id: SyndieMiniBomb
   components:
   - type: Sprite
@@ -171,7 +171,7 @@
 
 
 - type: entity
-  parent: [ GrenadeBase, BaseForeignContraband ]
+  parent: [ GrenadeBase, BaseExtremeContraband ]
   id: SingularityGrenade
   name: singularity grenade
   description: Grenade that simulates the power of a singularity, pulling things in a heap.
@@ -360,7 +360,7 @@
 - type: entity
   name: EMP grenade
   description: A grenade designed to wreak havoc on electronic systems.
-  parent: [GrenadeBase, BaseForeignContraband]
+  parent: [GrenadeBase, BaseExtremeContraband]
   id: EmpGrenade
   components:
   - type: Sprite
@@ -379,7 +379,7 @@
 - type: entity
   name: holy hand grenade
   description: O Lord, bless this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits, in thy mercy.
-  parent: [GrenadeBase, BaseForeignContraband]
+  parent: [GrenadeBase, BaseExtremeContraband]
   id: HolyHandGrenade
   components:
   - type: Sprite
@@ -527,7 +527,7 @@
 - type: entity
   name: syndicate trickybomb
   description: A syndicate-manufactured explosive used to make an excellent distraction.
-  parent: [GrenadeDummy, BaseForeignContraband]
+  parent: [GrenadeDummy, BaseExtremeContraband]
   id: SyndieTrickyBomb
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -42,7 +42,7 @@
 - type: entity
   name: explosive grenade
   description: Grenade that creates a small but devastating explosion.
-  parent: [GrenadeBase, BaseSyndicateContraband]
+  parent: [GrenadeBase, BaseForeignContraband]
   id: ExGrenade
   components:
   - type: ExplodeOnTrigger
@@ -108,7 +108,7 @@
 - type: entity
   name: syndicate minibomb
   description: A syndicate-manufactured explosive used to stow destruction and cause chaos.
-  parent: [GrenadeBase, BaseSyndicateContraband]
+  parent: [GrenadeBase, BaseForeignContraband]
   id: SyndieMiniBomb
   components:
   - type: Sprite
@@ -171,7 +171,7 @@
 
 
 - type: entity
-  parent: [ GrenadeBase, BaseSyndicateContraband ]
+  parent: [ GrenadeBase, BaseForeignContraband ]
   id: SingularityGrenade
   name: singularity grenade
   description: Grenade that simulates the power of a singularity, pulling things in a heap.
@@ -360,7 +360,7 @@
 - type: entity
   name: EMP grenade
   description: A grenade designed to wreak havoc on electronic systems.
-  parent: [GrenadeBase, BaseSyndicateContraband]
+  parent: [GrenadeBase, BaseForeignContraband]
   id: EmpGrenade
   components:
   - type: Sprite
@@ -379,7 +379,7 @@
 - type: entity
   name: holy hand grenade
   description: O Lord, bless this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits, in thy mercy.
-  parent: [GrenadeBase, BaseSyndicateContraband]
+  parent: [GrenadeBase, BaseForeignContraband]
   id: HolyHandGrenade
   components:
   - type: Sprite
@@ -527,7 +527,7 @@
 - type: entity
   name: syndicate trickybomb
   description: A syndicate-manufactured explosive used to make an excellent distraction.
-  parent: [GrenadeDummy, BaseSyndicateContraband]
+  parent: [GrenadeDummy, BaseForeignContraband]
   id: SyndieTrickyBomb
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -57,7 +57,7 @@
       path: /Audio/Effects/countdown.ogg
 
 - type: entity
-  parent: [ProjectileGrenadeBase, BaseForeignContraband]
+  parent: [ProjectileGrenadeBase, BaseExtremeContraband]
   id: GrenadeIncendiary
   name: incendiary grenade
   description: Guaranteed to light up the mood.
@@ -85,7 +85,7 @@
     price: 1500
 
 - type: entity
-  parent: [ProjectileGrenadeBase, BaseForeignContraband]
+  parent: [ProjectileGrenadeBase, BaseExtremeContraband]
   id: GrenadeShrapnel
   name: shrapnel grenade
   description: Releases a deadly spray of shrapnel that causes severe bleeding.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -57,7 +57,7 @@
       path: /Audio/Effects/countdown.ogg
 
 - type: entity
-  parent: [ProjectileGrenadeBase, BaseSyndicateContraband]
+  parent: [ProjectileGrenadeBase, BaseForeignContraband]
   id: GrenadeIncendiary
   name: incendiary grenade
   description: Guaranteed to light up the mood.
@@ -85,7 +85,7 @@
     price: 1500
 
 - type: entity
-  parent: [ProjectileGrenadeBase, BaseSyndicateContraband]
+  parent: [ProjectileGrenadeBase, BaseForeignContraband]
   id: GrenadeShrapnel
   name: shrapnel grenade
   description: Releases a deadly spray of shrapnel that causes severe bleeding.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
@@ -75,7 +75,7 @@
       path: "/Audio/Machines/door_lock_off.ogg"
 
 - type: entity
-  parent: [ScatteringGrenadeBase, BaseForeignContraband]
+  parent: [ScatteringGrenadeBase, BaseExtremeContraband]
   id: ClusterGrenade
   name: clustergrenade
   description: Why use one grenade when you can use three at once!
@@ -102,7 +102,7 @@
     price: 2500
 
 - type: entity
-  parent: [ScatteringGrenadeBase, BaseForeignContraband]
+  parent: [ScatteringGrenadeBase, BaseExtremeContraband]
   id: ClusterBananaPeel
   name: cluster banana peel
   description: Splits into 6 explosive banana peels after throwing, guaranteed fun!
@@ -124,7 +124,7 @@
       path: "/Audio/Items/bikehorn.ogg"
 
 - type: entity
-  parent: [SoapSyndie, ScatteringGrenadeBase, BaseForeignContraband]
+  parent: [SoapSyndie, ScatteringGrenadeBase, BaseExtremeContraband]
   id: SlipocalypseClusterSoap
   name: slipocalypse clustersoap
   description: Spreads small pieces of syndicate soap over an area upon landing on the floor.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
@@ -75,7 +75,7 @@
       path: "/Audio/Machines/door_lock_off.ogg"
 
 - type: entity
-  parent: [ScatteringGrenadeBase, BaseSyndicateContraband]
+  parent: [ScatteringGrenadeBase, BaseForeignContraband]
   id: ClusterGrenade
   name: clustergrenade
   description: Why use one grenade when you can use three at once!
@@ -102,7 +102,7 @@
     price: 2500
 
 - type: entity
-  parent: [ScatteringGrenadeBase, BaseSyndicateContraband]
+  parent: [ScatteringGrenadeBase, BaseForeignContraband]
   id: ClusterBananaPeel
   name: cluster banana peel
   description: Splits into 6 explosive banana peels after throwing, guaranteed fun!
@@ -124,7 +124,7 @@
       path: "/Audio/Items/bikehorn.ogg"
 
 - type: entity
-  parent: [SoapSyndie, ScatteringGrenadeBase, BaseSyndicateContraband]
+  parent: [SoapSyndie, ScatteringGrenadeBase, BaseForeignContraband]
   id: SlipocalypseClusterSoap
   name: slipocalypse clustersoap
   description: Spreads small pieces of syndicate soap over an area upon landing on the floor.

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -1,26 +1,11 @@
-﻿# used by the unique items of xenoborgs (like modules and stuff)
+﻿# any item used by foreign invaders (e.g non-stealth syndicate stuff, wizards' magical items, ninja gear, xenoborg modules),
+# i.e stuff that crew members are not to use without explicit CentComm approval barring extreme life-or-death situations
 - type: entity
-  id: BaseXenoborgContraband
+  id: BaseForeignContraband
   abstract: true
   components:
   - type: Contraband
-    severity: Major # placeholder until they make a better severity
-
-# any type of magical items used by wizards and similiar
-- type: entity
-  id: BaseMagicalContraband
-  abstract: true
-  components:
-  - type: Contraband
-    severity: Magical
-
-# non-stealth syndicate stuff
-- type: entity
-  id: BaseSyndicateContraband
-  abstract: true
-  components:
-  - type: Contraband
-    severity: Syndicate
+    severity: Foreign
 
 # minor contraband not departmentally restricted -- improvised weapons etc
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -1,11 +1,12 @@
-﻿# any item used by foreign invaders (e.g non-stealth syndicate stuff, wizards' magical items, ninja gear, xenoborg modules),
-# i.e stuff that crew members are not to use without explicit CentComm approval barring extreme life-or-death situations
+﻿# any item that crew members are not to use without explicit CentComm approval outside of extreme life-or-death situations
+# covers the items used by foreign invaders (e.g non-stealth syndicate stuff, wizards' magical items, xenoborg modules)
+# theoretically could also cover items restricted to Central Command only, though that'd need to be implemented later
 - type: entity
-  id: BaseForeignContraband
+  id: BaseExtremeContraband
   abstract: true
   components:
   - type: Contraband
-    severity: Foreign
+    severity: Extreme
 
 # minor contraband not departmentally restricted -- improvised weapons etc
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -92,7 +92,7 @@
       disposable: false
 
 - type: entity
-  parent: [BaseHardBomb, BaseForeignContraband]
+  parent: [BaseHardBomb, BaseExtremeContraband]
   id: SyndicateBomb
   name: syndicate bomb
   description: A bomb for Syndicate operatives and agents alike. The real deal, no more training, get to it!

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -92,7 +92,7 @@
       disposable: false
 
 - type: entity
-  parent: [BaseHardBomb, BaseSyndicateContraband]
+  parent: [BaseHardBomb, BaseForeignContraband]
   id: SyndicateBomb
   name: syndicate bomb
   description: A bomb for Syndicate operatives and agents alike. The real deal, no more training, get to it!

--- a/Resources/Prototypes/Magic/staves.yml
+++ b/Resources/Prototypes/Magic/staves.yml
@@ -39,7 +39,7 @@
 
 - type: entity
   id: AnimationStaff
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   name: staff of animation
   description: Brings inanimate objects to life!
   components:

--- a/Resources/Prototypes/Magic/staves.yml
+++ b/Resources/Prototypes/Magic/staves.yml
@@ -39,7 +39,7 @@
 
 - type: entity
   id: AnimationStaff
-  parent: [ BaseItem, BaseMagicalContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   name: staff of animation
   description: Brings inanimate objects to life!
   components:

--- a/Resources/Prototypes/Magic/teleport_scroll.yml
+++ b/Resources/Prototypes/Magic/teleport_scroll.yml
@@ -2,7 +2,7 @@
   id: WizardTeleportScroll
   name: teleport scroll
   suffix: Wizard
-  parent: [ BaseItem, BaseMagicalContraband ]
+  parent: [ BaseItem, BaseForeignContraband ]
   components:
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Magic/teleport_scroll.yml
+++ b/Resources/Prototypes/Magic/teleport_scroll.yml
@@ -2,7 +2,7 @@
   id: WizardTeleportScroll
   name: teleport scroll
   suffix: Wizard
-  parent: [ BaseItem, BaseForeignContraband ]
+  parent: [ BaseItem, BaseExtremeContraband ]
   components:
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/contraband_severities.yml
+++ b/Resources/Prototypes/contraband_severities.yml
@@ -21,12 +21,7 @@
   id: GrandTheft
   examineText: contraband-examine-text-GrandTheft
 
-# This is clear syndicate contraband and is illegal to own IC.
+# This is clear foreign contraband (syndicate, magical, etc) and is illegal to own/use IC.
 - type: contrabandSeverity
-  id: Syndicate
-  examineText: contraband-examine-text-Syndicate
-
-# This is magical contraband and not permitted to be used IC.
-- type: contrabandSeverity
-  id: Magical
-  examineText: contraband-examine-text-Magical
+  id: Foreign
+  examineText: contraband-examine-text-Foreign

--- a/Resources/Prototypes/contraband_severities.yml
+++ b/Resources/Prototypes/contraband_severities.yml
@@ -21,7 +21,7 @@
   id: GrandTheft
   examineText: contraband-examine-text-GrandTheft
 
-# This is clear foreign contraband (syndicate, magical, etc) and is illegal to own/use IC.
+# This is clear extreme contraband (syndicate, magical, etc) and is illegal to own/use IC.
 - type: contrabandSeverity
-  id: Foreign
-  examineText: contraband-examine-text-Foreign
+  id: Extreme
+  examineText: contraband-examine-text-Extreme

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
@@ -76,7 +76,7 @@
     </ColorBox>
     <ColorBox Color="#2f3832">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Possession: Foreign (P)
+        Possession: Extreme (P)
       </Box>
     </ColorBox>
     <ColorBox>
@@ -570,17 +570,17 @@
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Possession/Use of Foreign Contraband
+        Possession/Use of Extreme Contraband
       </Box>
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        To make, hold, or use foreign contraband.
+        To make, hold, or use extreme contraband.
       </Box>
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Foreign contraband may only be used in emergencies, and only to prevent death or gross bodily harm.
+        Extreme contraband may only be used in emergencies, and only to prevent death or gross bodily harm.
       </Box>
     </ColorBox>
     <ColorBox>

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
@@ -76,7 +76,7 @@
     </ColorBox>
     <ColorBox Color="#2f3832">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Possession: Syndicate (P)
+        Possession: Foreign (P)
       </Box>
     </ColorBox>
     <ColorBox>
@@ -570,17 +570,17 @@
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Possession/Use of Syndicate Contraband
+        Possession/Use of Foreign Contraband
       </Box>
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        To make, hold, or use Syndicate contraband.
+        To make, hold, or use foreign contraband.
       </Box>
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Syndicate contraband may only be used in emergencies, and only to prevent death or gross bodily harm.
+        Foreign contraband may only be used in emergencies, and only to prevent death or gross bodily harm.
       </Box>
     </ColorBox>
     <ColorBox>

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
@@ -41,7 +41,7 @@
 
   [color=#a4885c]Stackable Crimes:[/color] Crimes are to be considered 'stackable' in the sense that if you charge someone with two or more different crimes, you should combine the times you would give them for each crime. Linked crimes, shown in matching colors and suffixes on the Quick Crime Guide, can not be stacked and instead override each other, you should pick the highest crime that matches the case.
 
-  - Example: A suspect has committed a 2-01 (possession: major) and a 3-01 (possession: syndicate). The maximum sentence here would be 10 minutes due to them being linked crimes, and 3-01 is the greater crime.
+  - Example: A suspect has committed a 2-01 (possession: major) and a 3-01 (possession: foreign). The maximum sentence here would be 10 minutes due to them being linked crimes, and 3-01 is the greater crime.
   - Example 2: A suspect commits a 3-04 (Secure trespassing) and a 3-06 (manslaughter). Those crimes stack since they are not linked crimes. You could sentence for a maximum of 20 minutes, but context matters heavily, and maximum sentences should only be used for the worst offenders.
 
   [color=#a4885c]Repeater Offenders:[/color] Repeated crimes are when someone is released for a crime and then goes to commit the same crime within the same shift. Repeated crimes can be charged with tacked-on time; first repeat: 3:00, second repeat: 6:00, third repeat: permanent confinement. It should be noted each tacked-on time is directly linked to one type of crime, so for example, if someone does their first repeat of trespass and petty theft, you can charge them with an extra 6 minutes.

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
@@ -41,7 +41,7 @@
 
   [color=#a4885c]Stackable Crimes:[/color] Crimes are to be considered 'stackable' in the sense that if you charge someone with two or more different crimes, you should combine the times you would give them for each crime. Linked crimes, shown in matching colors and suffixes on the Quick Crime Guide, can not be stacked and instead override each other, you should pick the highest crime that matches the case.
 
-  - Example: A suspect has committed a 2-01 (possession: major) and a 3-01 (possession: foreign). The maximum sentence here would be 10 minutes due to them being linked crimes, and 3-01 is the greater crime.
+  - Example: A suspect has committed a 2-01 (possession: major) and a 3-01 (possession: extreme). The maximum sentence here would be 10 minutes due to them being linked crimes, and 3-01 is the greater crime.
   - Example 2: A suspect commits a 3-04 (Secure trespassing) and a 3-06 (manslaughter). Those crimes stack since they are not linked crimes. You could sentence for a maximum of 20 minutes, but context matters heavily, and maximum sentences should only be used for the worst offenders.
 
   [color=#a4885c]Repeater Offenders:[/color] Repeated crimes are when someone is released for a crime and then goes to commit the same crime within the same shift. Repeated crimes can be charged with tacked-on time; first repeat: 3:00, second repeat: 6:00, third repeat: permanent confinement. It should be noted each tacked-on time is directly linked to one type of crime, so for example, if someone does their first repeat of trespass and petty theft, you can charge them with an extra 6 minutes.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
All items that were formely syndicate contraband or magical contraband are now in a collective "extreme contraband" tier.

(Xenoborg contraband has also been included, though since Xenoborgs are still in development that's not a player-facing change.)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
These items having separate contraband "types" was confusing for some players; technically speaking, Space Law did not mention magical contraband at all. Merging all extreme contraband into one tier makes identifying it, and arresting people for it, easier.

Having a single extreme contraband tier also allows for more items to be added to it in the future. Ninja items could be moved to this tier, for instance, though ideally I'd want to get the actual framework in place first before making that change. (Plus, I don't actually know all the ninja items off the top of my head.) Likewise, Central Command uniforms / IDs / etc could be considered extreme contraband for anyone other than CentComm officials.

## Technical details
<!-- Summary of code changes for easier review. -->
- **Resources\ServerInfo\Guidebook\ServerRules\SpaceLaw\SLCrimeList.xml:** guidebook update
- **Resources\ServerInfo\Guidebook\ServerRules\SpaceLaw\SpaceLaw.xml:** guidebook update
- **Resources\Locale\en-US\contraband\contraband-severity.ftl:** replaced contraband-examine-text-Syndicate and contraband-examine-text-Magical with contraband-examine-text-Extreme
- **Resources\Prototypes\Entities\Objects\base_contraband.yml:** replaced BaseSyndicateContraband, BaseMagicalContraband, and BaseXenoborgContraband prototypes with BaseExtremeContraband
- **Resources\Prototypes\contraband_severities.yml:** replaced Syndicate and Magical contraband severities with Extreme contraband severity
- Performed a broad find-and-replace for BaseSyndicateContraband, BaseMagicalContraband, and BaseXenoborgContraband to replace them with BaseExtremeContraband

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![moss-foreigncontraband 1](https://github.com/user-attachments/assets/c0e9d1e9-7fef-447c-be54-8c79a099a71b)
![moss-foreigncontraband 2](https://github.com/user-attachments/assets/00a71a0c-5994-486a-81f4-326c038b3eac)
![moss-foreigncontraband 3](https://github.com/user-attachments/assets/21850a1f-6e94-46ba-81f6-097072efb92c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Syndicate/Magical/Xenoborg contraband tiers have been removed entirely in favor of Extreme contraband. All existing items _should_ already be updated to Extreme contraband, but this was done via find-and-replace so there may be some slip-ups.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Syndicate contraband and magical contraband have been merged into an "extreme contraband" tier.
