### PR TITLE
SkinColor Hues Minimum Saturation

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1113,8 +1113,9 @@ namespace Content.Client.Lobby.UI
                         RgbSkinColorContainer.Visible = true;
                     }
 
-                    Markings.CurrentSkinColor = _rgbSkinColorSelector.Color;
-                    Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(_rgbSkinColorSelector.Color));
+                    var color = SkinColor.MakeHueValid(_rgbSkinColorSelector.Color);
+                    Markings.CurrentSkinColor = color;
+                    Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(color));
                     break;
                 }
                 case HumanoidSkinColor.TintedHues:
@@ -1333,7 +1334,6 @@ namespace Content.Client.Lobby.UI
                     }
 
                     Skin.Value = SkinColor.HumanSkinToneFromColor(Profile.Appearance.SkinColor);
-
                     break;
                 }
                 case HumanoidSkinColor.Hues:
@@ -1344,8 +1344,7 @@ namespace Content.Client.Lobby.UI
                         RgbSkinColorContainer.Visible = true;
                     }
 
-                    // set the RGB values to the direct values otherwise
-                    _rgbSkinColorSelector.Color = Profile.Appearance.SkinColor;
+                    _rgbSkinColorSelector.Color = SkinColor.MakeHueValid(Profile.Appearance.SkinColor);
                     break;
                 }
                 case HumanoidSkinColor.TintedHues:
@@ -1356,8 +1355,7 @@ namespace Content.Client.Lobby.UI
                         RgbSkinColorContainer.Visible = true;
                     }
 
-                    // set the RGB values to the direct values otherwise
-                    _rgbSkinColorSelector.Color = Profile.Appearance.SkinColor;
+                    _rgbSkinColorSelector.Color = SkinColor.TintedHues(Profile.Appearance.SkinColor);
                     break;
                 }
                 case HumanoidSkinColor.VoxFeathers:

--- a/Content.Shared/Humanoid/SkinColor.cs
+++ b/Content.Shared/Humanoid/SkinColor.cs
@@ -9,6 +9,7 @@ public static class SkinColor
     public const float MinTintedHuesLightness = 0.85f;
 
     public const float MinHuesLightness = 0.175f;
+    public const float MinHuesSaturation = 0.1f;
 
     public const float MinFeathersHue = 29f / 360;
     public const float MaxFeathersHue = 174f / 360;
@@ -212,6 +213,7 @@ public static class SkinColor
     public static Color MakeHueValid(Color color)
     {
         var manipulatedColor = Color.ToHsv(color);
+        manipulatedColor.Y = Math.Max(manipulatedColor.Y, MinHuesSaturation);
         manipulatedColor.Z = Math.Max(manipulatedColor.Z, MinHuesLightness);
         return Color.FromHsv(manipulatedColor);
     }


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- add Saturation axis minimum to the HSV vector

- Modify the frontend to actively use the valid colorscape for Hues and TintedHues

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
0,0,0 skincolor characters using Hue would look like Locked characters, able to hide in fully shaded areas.
Simply clamping them to a grey gives them a better and more discernable profile without fully removing black scales/moth fluff as an option
## Technical details
<!-- Summary of code changes for easier review. -->
Added a 0.1f MathMax to the Saturation (y) axis on the HSV for hues, as well as actually made Hues/TintedHues use that Clamping function during character creation
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:
![000-noclamp](https://github.com/user-attachments/assets/acd28950-cd87-479c-b070-c5ec13346342)

After:
![Content Client_2025-06-09_02-20-51](https://github.com/user-attachments/assets/738ee0d1-450d-4d12-83cb-089c3f4ab58a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Kickguy223
- fix: added a Minimum saturation to the skin skin color of Arachnids, Diona, Moth, Reptilians, and Slimes.
