### PR TITLE
Add FixedPoint2TypeParser

### DIFF
--- a/Content.Shared/FixedPoint/FixedPoint2.cs
+++ b/Content.Shared/FixedPoint/FixedPoint2.cs
@@ -303,15 +303,7 @@ namespace Content.Shared.FixedPoint
 
         public readonly int CompareTo(FixedPoint2 other)
         {
-            if (other.Value > Value)
-            {
-                return -1;
-            }
-            if (other.Value < Value)
-            {
-                return 1;
-            }
-            return 0;
+            return Value.CompareTo(other.Value);
         }
 
     }

--- a/Content.Shared/Toolshed/TypeParsers/FixedPoint2TypeParser.cs
+++ b/Content.Shared/Toolshed/TypeParsers/FixedPoint2TypeParser.cs
@@ -1,0 +1,36 @@
+﻿using Content.Shared.FixedPoint;
+using Robust.Shared.Console;
+using Robust.Shared.Toolshed;
+using Robust.Shared.Toolshed.Syntax;
+using Robust.Shared.Toolshed.TypeParsers;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Toolshed.TypeParsers;
+
+public sealed class FixedPoint2TypeParser : TypeParser<FixedPoint2>
+{
+    public override bool TryParse(ParserContext ctx, out FixedPoint2 result)
+    {
+        if (Toolshed.TryParse(ctx, out int? value))
+        {
+            result =  FixedPoint2.New(value.Value);
+            return true;
+        }
+
+        if (Toolshed.TryParse(ctx, out float? fValue))
+        {
+            result = FixedPoint2.New(fValue.Value);
+            return true;
+        }
+
+        // Toolshed's number parser (NumberBaseTypeParser) should have assigned ctx.Error so we don't have to.
+        DebugTools.AssertNotNull(ctx.Error);
+        result = FixedPoint2.Zero;
+        return false;
+    }
+
+    public override CompletionResult? TryAutocomplete(ParserContext parserContext, CommandArgument? arg)
+    {
+        return CompletionResult.FromHint(GetArgHint(arg));
+    }
+}


### PR DESCRIPTION
## About the PR
Adds a Toolshed type parser for FixedPoint2.

The parser actually requires [an engine PR](https://github.com/space-wizards/RobustToolbox/pull/6014) to work, but as the parser is currently unused IMO its fine to just merge w/o the engine PR.