### PR TITLE
Added extreme contraband to guidebook

### DIFF
--- a/Resources/Locale/en-US/contraband/contraband-severity.ftl
+++ b/Resources/Locale/en-US/contraband/contraband-severity.ftl
@@ -3,6 +3,7 @@ contraband-examine-text-Restricted = [color=yellow]This item is departmentally r
 contraband-examine-text-Restricted-department = [color=yellow]This item is restricted to {$departments}, and may be considered contraband.[/color]
 contraband-examine-text-Major = [color=red]This item is considered major contraband.[/color]
 contraband-examine-text-GrandTheft = [color=red]This item is a highly valuable target for Syndicate agents![/color]
+contraband-examine-text-Extreme = [color=red]This item is highly illegal extreme contraband![/color]
 contraband-examine-text-Syndicate = [color=crimson]This item is highly illegal Syndicate contraband![/color]
 contraband-examine-text-Magical = [color=#b337b3]This item is highly illegal Magical contraband![/color]
 

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -1,4 +1,13 @@
-﻿# used by the unique items of xenoborgs (like modules and stuff)
+﻿# generic "extreme" contraband; Syndicate/magical contraband are equivalent under Space Law, so this is mostly a placeholder
+# for stuff that should be equally illegal but doesn't need its own unique contraband tier added
+- type: entity
+  id: BaseExtremeContraband
+  abstract: true
+  components:
+  - type: Contraband
+    severity: Extreme
+
+# used by the unique items of xenoborgs (like modules and stuff)
 - type: entity
   id: BaseXenoborgContraband
   abstract: true

--- a/Resources/Prototypes/contraband_severities.yml
+++ b/Resources/Prototypes/contraband_severities.yml
@@ -21,6 +21,11 @@
   id: GrandTheft
   examineText: contraband-examine-text-GrandTheft
 
+# This is extreme contraband and is illegal to own IC.
+- type: contrabandSeverity
+  id: Extreme
+  examineText: contraband-examine-text-Extreme
+
 # This is clear syndicate contraband and is illegal to own IC.
 - type: contrabandSeverity
   id: Syndicate

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
@@ -76,7 +76,7 @@
     </ColorBox>
     <ColorBox Color="#2f3832">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Possession: Syndicate (P)
+        Possession: Extreme (P)
       </Box>
     </ColorBox>
     <ColorBox>
@@ -570,17 +570,17 @@
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Possession/Use of Syndicate Contraband
+        Possession/Use of Extreme Contraband
       </Box>
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        To make, hold, or use Syndicate contraband.
+        To make, hold, or use extreme contraband.
       </Box>
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        Syndicate contraband may only be used in emergencies, and only to prevent death or gross bodily harm.
+        Extreme contraband includes Syndicate contraband and magical contraband. Without explicit authorization from Central Command, extreme contraband may only be used in emergencies, and only to prevent death or gross bodily harm.
       </Box>
     </ColorBox>
     <ColorBox>

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
@@ -41,7 +41,7 @@
 
   [color=#a4885c]Stackable Crimes:[/color] Crimes are to be considered 'stackable' in the sense that if you charge someone with two or more different crimes, you should combine the times you would give them for each crime. Linked crimes, shown in matching colors and suffixes on the Quick Crime Guide, can not be stacked and instead override each other, you should pick the highest crime that matches the case.
 
-  - Example: A suspect has committed a 2-01 (possession: major) and a 3-01 (possession: syndicate). The maximum sentence here would be 10 minutes due to them being linked crimes, and 3-01 is the greater crime.
+  - Example: A suspect has committed a 2-01 (possession: major) and a 3-01 (possession: extreme). The maximum sentence here would be 10 minutes due to them being linked crimes, and 3-01 is the greater crime.
   - Example 2: A suspect commits a 3-04 (Secure trespassing) and a 3-06 (manslaughter). Those crimes stack since they are not linked crimes. You could sentence for a maximum of 20 minutes, but context matters heavily, and maximum sentences should only be used for the worst offenders.
 
   [color=#a4885c]Repeater Offenders:[/color] Repeated crimes are when someone is released for a crime and then goes to commit the same crime within the same shift. Repeated crimes can be charged with tacked-on time; first repeat: 3:00, second repeat: 6:00, third repeat: permanent confinement. It should be noted each tacked-on time is directly linked to one type of crime, so for example, if someone does their first repeat of trespass and petty theft, you can charge them with an extra 6 minutes.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
"Posession/Use of Syndicate Contraband" in the crimes list has been replaced with "Posession/Use of Extreme Contraband", which covers both Syndicate contraband and magical contraband.

Additionally, a generic "extreme contraband" tier has been added to the current prototypes, to be used for any items that should be similarly illegal (i.e, only Central Command can approve their use) but don't fit into those two categories and don't warrant the creation of an entire new category.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Technically speaking, Space Law did not mention magical contraband at all. Having one "extreme contraband" law fixes this. Keeping the items themselves labelled as Syndicate/magical contraband (instead of just directly labeling them as extreme contraband) is important so that players are able to look at an item and tell "oh, this is a Syndicate item" or "oh, this is magical".

Having a generic extreme contraband law also allows for more items to be covered by it in the future. Ninja items could be moved to this tier, for instance, though ideally I'd want to get the actual framework in place first before making that change. (Plus, I don't actually know all the ninja items off the top of my head.) Likewise, Central Command uniforms / IDs / etc could be considered extreme contraband for anyone other than CentComm officials.

## Technical details
<!-- Summary of code changes for easier review. -->
- **Resources\ServerInfo\Guidebook\ServerRules\SpaceLaw\SLCrimeList.xml:** guidebook update
- **Resources\ServerInfo\Guidebook\ServerRules\SpaceLaw\SpaceLaw.xml:** guidebook update
- **Resources\Locale\en-US\contraband\contraband-severity.ftl:** added contraband-examine-text-Extreme
- **Resources\Prototypes\Entities\Objects\base_contraband.yml:** added BaseExtremeContraband
- **Resources\Prototypes\contraband_severities.yml:** added Extreme contraband severity

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![moss-extremecontraband](https://github.com/user-attachments/assets/50ec4a79-dbca-4379-a030-25801075dc4d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Space Law now considers both Syndicate contraband and magical contraband to collectively be "extreme contraband".