### PR TITLE
Added the Touchy Quirk

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -150,6 +150,9 @@ namespace Content.Shared.Examine
 
                 if (TryComp<BlurryVisionComponent>(examiner, out var blurry))
                     return Math.Clamp(ExamineRange - blurry.Magnitude * ExamineBlurrinessMult, 2, ExamineRange);
+
+                if (TryComp<TouchyComponent>(examiner, out var touchyComponent))
+                    return Math.Clamp(InteractionRange, 2, ExamineRange);
             }
             return ExamineRange;
         }

--- a/Content.Shared/Examine/TouchyComponent.cs
+++ b/Content.Shared/Examine/TouchyComponent.cs
@@ -1,0 +1,12 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Examine;
+
+/// <summary>
+/// This is used for the touchy trait.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class TouchyComponent : Component
+{
+
+}

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -62,3 +62,6 @@ trait-spanish-desc = Hola señor, donde esta la biblioteca.
 
 trait-painnumbness-name = Numb
 trait-painnumbness-desc = You lack any sense of feeling pain, being unaware of how hurt you may be.
+
+trait-touchy-name = Touchy
+trait-touchy-desc = You're more hands on than most, and must be within arms reach of something to examine it.

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -23,6 +23,7 @@
   - PainNumbness
   - Paracusia
   - PermanentBlindness
+  - Touchy
   - Snoring
   - Unrevivable
   # job specific

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -24,3 +24,11 @@
   category: Quirks
   components:
   - type: Snoring
+
+- type: trait
+  id: Touchy
+  name: trait-touchy-name
+  description: trait-touchy-desc
+  category: Quirks
+  components:
+  - type: Touchy


### PR DESCRIPTION
## About the PR
Added the Touchy quirk which prevents you from examining things outside of grab range

## Why / Balance
I dont know what person would want this outside of "why not" and i guess extreme kleptos but frankly i find it really funny that to truly grasp the true nature of a singuloth they have to touch it

## Technical details
Added the Touchy Component and put it into clone.yml

## Media
![image](https://github.com/user-attachments/assets/2c1533aa-6cb6-4aaf-ab5e-1a87a18a388a)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added a new quirk called: "Touchy" which only lets you examine things within grab range

