### PR TITLE
Make gas tank UI a bit more network-happy

### DIFF
--- a/Content.Client/UserInterface/Systems/Atmos/GasTank/GasTankWindow.cs
+++ b/Content.Client/UserInterface/Systems/Atmos/GasTank/GasTankWindow.cs
@@ -207,7 +207,9 @@ public sealed class GasTankWindow
         _btnInternals.Disabled = !canConnectInternals;
         _lblInternals.SetMarkup(Loc.GetString("gas-tank-window-internal-text",
             ("status", Loc.GetString(internalsConnected ? "gas-tank-window-internal-connected" : "gas-tank-window-internal-disconnected"))));
-        _spbPressure.Value = outputPressure;
+        if (!_spbPressure.HasKeyboardFocus())
+            // Don't update release pressure if we're currently editing it
+            _spbPressure.Value = outputPressure;
     }
 
     protected override void FrameUpdate(FrameEventArgs args)

--- a/Content.Shared/Atmos/Components/GasTankComponent.cs
+++ b/Content.Shared/Atmos/Components/GasTankComponent.cs
@@ -44,7 +44,7 @@ public sealed partial class GasTankComponent : Component, IGasMixtureHolder
     /// <summary>
     ///     Distributed pressure.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float OutputPressure = DefaultOutputPressure;
 
     /// <summary>

--- a/Content.Shared/Atmos/EntitySystems/SharedGasTankSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedGasTankSystem.cs
@@ -52,6 +52,7 @@ public abstract class SharedGasTankSystem : EntitySystem
 
         ent.Comp.OutputPressure = pressure;
         Dirty(ent);
+        UpdateUserInterface(ent);
     }
 
     public virtual void UpdateUserInterface(Entity<GasTankComponent> ent)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This fixes two issues:
1. Gas tank release pressure wasn't being networked, so on a full state reset any manually set release pressure would be visually reset to the default on the client. This makes that field networked, and also updates the UI on changes to it to release pressure to avoid a mispredict of the old release pressure flashing for a moment.
2. The scroller field for the release pressure would clobber user input when internals were enabled due to GasTankWindow.Update being called to update the tank pressure label (via the BUI's update state, that is). This fixes that by just not modifying the scroller field if it's being edited.
 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Disconnect gaming.

## Technical details
<!-- Summary of code changes for easier review. -->
To reproduce the network issue, change a gas tanks release pressure and relog or run /fullstaterefresh.
To reproduce the editing issue, try changing the release pressure field while its being used as internals.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
