### PR TITLE
Add test that all construction recipes have unique display names

### DIFF
--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -76,6 +76,35 @@ namespace Content.Client.Construction
             return false;
         }
 
+        /// <summary>
+        /// Attempts to get the display name used for the given construction prototype.
+        /// This will be <see cref="ConstructionPrototype.Name"/> if it is not null, or the resulting entity's name as a fallback.
+        /// </summary>
+        /// <param name="constructionProtoId">ID of the construction prototype.</param>
+        /// <param name="name">Display name for the construction prototype.</param>
+        /// <returns>true if it was possible to get a name, otherwise false.</returns>
+        public bool TryGetRecipeName(ProtoId<ConstructionPrototype> constructionProtoId, [NotNullWhen(true)] out string? name)
+        {
+            name = null;
+
+            if (!PrototypeManager.TryIndex(constructionProtoId, out var recipe))
+                return false;
+
+            name ??= recipe.Name;
+
+            if (name != null)
+                return true;
+
+            if (!TryGetRecipePrototype(constructionProtoId, out var targetProtoId))
+                return false;
+
+            if (!PrototypeManager.TryIndex(targetProtoId, out var entProto))
+                return false;
+
+            name = entProto.Name;
+            return true;
+        }
+
         private void WarmupRecipesCache()
         {
             foreach (var constructionProto in PrototypeManager.EnumeratePrototypes<ConstructionPrototype>())

--- a/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
@@ -188,8 +188,26 @@ namespace Content.IntegrationTests.Tests.Construction
                 if (!constructionSys.TryGetRecipeName(recipe.ID, out var name))
                     continue;
 
-                // Track this use
                 var users = nameUsers.GetOrNew(name);
+
+                // Don't track this if it's a mirror of one we're already tracking
+                if (recipe.Mirror is { } mirrorProto && users.Contains(mirrorProto))
+                    continue;
+
+                // Don't track this if it's an alternative version of one we're already tracking
+                var isAlternative = false;
+                foreach (var alterativeProto in recipe.AlternativePrototypes)
+                {
+                    if (users.Contains(alterativeProto))
+                    {
+                        isAlternative = true;
+                        break;
+                    }
+                }
+                if (isAlternative)
+                    continue;
+
+                // Track this use
                 users.Add(recipe);
             }
 

--- a/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
@@ -1,10 +1,13 @@
+using System.Collections.Generic;
 using System.Numerics;
+using Content.Client.Construction;
 using Content.Server.Construction.Components;
 using Content.Shared.Construction.Prototypes;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.IntegrationTests.Tests.Construction
 {
@@ -111,7 +114,7 @@ namespace Content.IntegrationTests.Tests.Construction
                     if (proto.Abstract || pair.IsTestPrototype(proto) || !proto.Components.TryGetValue(name, out var reg))
                         continue;
 
-                    var comp = (ConstructionComponent) reg.Component;
+                    var comp = (ConstructionComponent)reg.Component;
                     var target = comp.DeconstructionNode;
                     if (target == null)
                         continue;
@@ -155,6 +158,48 @@ namespace Content.IntegrationTests.Tests.Construction
                     Assert.That(entity.Components.ContainsKey("Construction"),
                         $"The next node ({next.Name}) in the path from the start node ({start}) to the target node ({target}) specified an entity prototype ({next.Entity}) without a ConstructionComponent.");
 #pragma warning restore NUnit2045
+                }
+            });
+
+            await pair.CleanReturnAsync();
+        }
+
+        /// <summary>
+        /// Checks that every construction prototype has a unique display name in the construction window.
+        /// </summary>
+        [Test]
+        public async Task TestUniqueNames()
+        {
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings()
+            {
+                Connected = true,
+            });
+            var client = pair.Client;
+
+            var protoMan = client.ProtoMan;
+            var constructionSys = client.System<ConstructionSystem>();
+
+            // Create a dictionary mapping display names to prototypes that have that name
+            Dictionary<string, List<ProtoId<ConstructionPrototype>>> nameUsers = [];
+
+            // Populate the dictionary
+            foreach (var recipe in protoMan.EnumeratePrototypes<ConstructionPrototype>())
+            {
+                if (!constructionSys.TryGetRecipeName(recipe.ID, out var name))
+                    continue;
+
+                // Track this use
+                var users = nameUsers.GetOrNew(name);
+                users.Add(recipe);
+            }
+
+            Assert.Multiple(() =>
+            {
+                foreach (var (displayName, recipeList) in nameUsers)
+                {
+                    // Make sure that each name only has one use
+                    Assert.That(recipeList, Has.Count.EqualTo(1),
+                        $"Multiple construction prototypes have the display name {displayName}: {string.Join(", ", recipeList)}");
                 }
             });
 

--- a/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
@@ -199,7 +199,7 @@ namespace Content.IntegrationTests.Tests.Construction
                 {
                     // Make sure that each name only has one use
                     Assert.That(recipeList, Has.Count.EqualTo(1),
-                        $"Multiple construction prototypes have the display name {displayName}: {string.Join(", ", recipeList)}");
+                        $"Multiple construction prototypes have the display name '{displayName}': {string.Join(", ", recipeList)}");
                 }
             });
 

--- a/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
@@ -190,22 +190,10 @@ namespace Content.IntegrationTests.Tests.Construction
 
                 var users = nameUsers.GetOrNew(name);
 
-                // Don't track this if it's a mirror of one we're already tracking
-                if (recipe.Mirror is { } mirrorProto && users.Contains(mirrorProto))
+                // We don't care about recipes that aren't shown in the menu
+                if (recipe.Hide)
                     continue;
 
-                // Don't track this if it's an alternative version of one we're already tracking
-                var isAlternative = false;
-                foreach (var alterativeProto in recipe.AlternativePrototypes)
-                {
-                    if (users.Contains(alterativeProto))
-                    {
-                        isAlternative = true;
-                        break;
-                    }
-                }
-                if (isAlternative)
-                    continue;
 
                 // Track this use
                 users.Add(recipe);

--- a/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
@@ -204,7 +204,7 @@ namespace Content.IntegrationTests.Tests.Construction
                 foreach (var (displayName, recipeList) in nameUsers)
                 {
                     // Make sure that each name only has one use
-                    Assert.That(recipeList, Has.Count.EqualTo(1),
+                    Assert.That(recipeList, Has.Count.AtMost(1),
                         $"Multiple construction prototypes have the display name '{displayName}': {string.Join(", ", recipeList)}");
                 }
             });


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds an integration test that makes sure that every entry in the construction window has a unique name.

**This test is going to fail on master right now! Do not merge this until https://github.com/space-wizards/space-station-14/issues/38153 is resolved!**

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/38153 suggested a test for this purpose, and I thought it seemed like a good idea. Having a test will help to find the instances that need to be fixed.

Having a unique name for each entry will make it easier to select the correct recipe, clear up ambiguity in cases where entries also have identical sprites, and make it easier to search for recipes.

## Technical details
<!-- Summary of code changes for easier review. -->
- Adds a method to Client's `ConstructionSystem` that gets the display name for a given `ConstructionPrototype` ID.
- The test itself enumerates all `ConstructionPrototype`s and uses the new method to get their display names. A dictionary uses the display names as keys and keeps a list of every `ConstructionPrototype` with the same display name. After the all prototypes are processed, the dictionary is checked and any entries that have more than one `ConstructionPrototype` fail the test. The error message displays the IDs of all `ConstructionPrototypes` with the same display name:
```
1)   Multiple construction prototypes have the display name 'chain link fence': FenceMetalCorner, FenceMetal, FenceMetalEnd
Assert.That(recipeList, Has.Count.EqualTo(1))
  Expected: property Count equal to 1
  But was:  3
```

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Construction recipes are now required to have unique display names in the construction window. By default, recipes use the entity name of the resulting entity, but `name` can be specified for in `ConstructionPrototype` YAML files to override the display name.