### PR TITLE
Bring back low pressure damage to its unnerfed value

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -320,8 +320,7 @@ namespace Content.Shared.Atmos
         ///     (The pressure threshold is so low that it doesn't make sense to do any calculations,
         ///     so it just applies this flat value).
         /// </summary>
-        // Original value is 4, buff back when we have proper ways for players to deal with breaches.
-        public const int LowPressureDamage = 1;
+        public const int LowPressureDamage = 4;
 
         public const float WindowHeatTransferCoefficient = 0.1f;
 


### PR DESCRIPTION
## About the PR
This brings low pressure damage back to its unnerfed value. it was previously nerfed to be 1/4th of its default value.

## Why / Balance
The reasons behind the pressure damage nerf were centered around Engineering and Atmospherics not having the tools available to them to stop spacing damage on the Evac shuttle. This has now been alleviated in several ways:
- I have added Air Grenades.
- I have fixed Metal Foam Grenades.
- I have tweaked air canister volumes to be larger.
- KDynamic has added the air fill markers, which allow us to give shuttles high pressure air tanks.
- Spanky has restructured all shuttles. They now are designed around compartmentalization, have a robust atmos setup, and come with the new emergency shuttle emergency locker, which contains the aforementioned items plus some other stuff.
- EmoGarbage has made evac shuttle repair possible.

As such, I think it is OK to make spacing actually relevant again.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Spacing damage has been brought back to its unnerfed value, as Atmospherics and Engineering now have better tools to combat spacing.
