### PR TITLE
show reflection prob on examine

### DIFF
--- a/Content.Shared/Weapons/Reflect/ReflectComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectComponent.cs
@@ -54,6 +54,33 @@ public sealed partial class ReflectComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier? SoundOnReflect = new SoundPathSpecifier("/Audio/Weapons/Guns/Hits/laser_sear_wall.ogg", AudioParams.Default.WithVariation(0.05f));
+
+    #region Locs
+    /// <summary>
+    /// Probability for a projectile to be reflected.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string ExamineLoc = "reflect-examine-value";
+
+    /// <summary>
+    /// Probability for a projectile to be reflected.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string EnergyTypeLoc = "reflect-examine-energy-type";
+
+    /// <summary>
+    /// Probability for a projectile to be reflected.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string NonEnergyTypeLoc = "reflect-examine-nonenergy-type";
+
+    /// <summary>
+    /// Probability for a projectile to be reflected.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string BothTypeLoc = "reflect-examine-both-type";
+
+    #endregion
 }
 
 [Flags, Serializable, NetSerializable]

--- a/Content.Shared/Weapons/Reflect/ReflectComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectComponent.cs
@@ -54,33 +54,6 @@ public sealed partial class ReflectComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier? SoundOnReflect = new SoundPathSpecifier("/Audio/Weapons/Guns/Hits/laser_sear_wall.ogg", AudioParams.Default.WithVariation(0.05f));
-
-    #region Locs
-    /// <summary>
-    /// Probability for a projectile to be reflected.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public string ExamineLoc = "reflect-examine-value";
-
-    /// <summary>
-    /// Probability for a projectile to be reflected.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public string EnergyTypeLoc = "reflect-examine-energy-type";
-
-    /// <summary>
-    /// Probability for a projectile to be reflected.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public string NonEnergyTypeLoc = "reflect-examine-nonenergy-type";
-
-    /// <summary>
-    /// Probability for a projectile to be reflected.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public string BothTypeLoc = "reflect-examine-both-type";
-
-    #endregion
 }
 
 [Flags, Serializable, NetSerializable]

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
-using Content.Shared.Armor;
 using Content.Shared.Hands;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
@@ -16,7 +15,7 @@ using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
-using Content.Shared.Verbs;
+using Content.Shared.Examine;
 
 namespace Content.Shared.Weapons.Reflect;
 
@@ -47,7 +46,7 @@ public sealed class ReflectSystem : EntitySystem
         SubscribeLocalEvent<ReflectComponent, GotUnequippedEvent>(OnReflectUnequipped);
         SubscribeLocalEvent<ReflectComponent, GotEquippedHandEvent>(OnReflectHandEquipped);
         SubscribeLocalEvent<ReflectComponent, GotUnequippedHandEvent>(OnReflectHandUnequipped);
-        SubscribeLocalEvent<ReflectComponent, GetVerbsEvent<ExamineVerb>>(OnExamine);
+        SubscribeLocalEvent<ReflectComponent, ExaminedEvent>(OnExamine);
     }
 
     private void OnReflectUserCollide(Entity<ReflectComponent> ent, ref ProjectileReflectAttemptEvent args)
@@ -205,33 +204,33 @@ public sealed class ReflectSystem : EntitySystem
     }
 
     #region Examine
-    private void OnExamine(Entity<ReflectComponent> ent, ref GetVerbsEvent<ExamineVerb> args)
+    private void OnExamine(Entity<ReflectComponent> ent, ref ExaminedEvent args)
     {
+        // This isn't examine verb or something just because it looks too much bad.
+        // Trust me, universal verb for the potential weapons, armor and walls looks awful.
         var value = MathF.Round(ent.Comp.ReflectProb * 100, 1);
 
-        if (value == 0 || ent.Comp.Reflects == ReflectType.None)
+        if (!_toggle.IsActivated(ent.Owner) || value == 0 || ent.Comp.Reflects == ReflectType.None)
             return;
 
         string type;
 
-        args.Msg.PushNewline();
         switch (ent.Comp.Reflects)
         {
             case ReflectType.Energy | ReflectType.NonEnergy:
                 type = Loc.GetString("reflect-examine-type-both");
-                args.Msg.AddMarkupOrThrow(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
+                args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
                 break;
 
             case ReflectType.Energy:
                 type = Loc.GetString("reflect-examine-type-energy");
-                args.Msg.AddMarkupOrThrow(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
+                args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
                 break;
 
             case ReflectType.NonEnergy:
                 type = Loc.GetString("reflect-examine-type-nonenergy");
-                args.Msg.AddMarkupOrThrow(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
+                args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
                 break;
-
         }
     }
     #endregion

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -220,7 +220,7 @@ public sealed class ReflectSystem : EntitySystem
 
         for (var i = 0; i < compTypes.Length; i++)
         {
-            var type = ("reflect-component-" + Loc.GetString(compTypes[i])).ToLower();
+            var type = Loc.GetString(("reflect-component-" + compTypes[i]).ToLower());
             typeList.Add(type);
         }
 

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -216,7 +216,7 @@ public sealed class ReflectSystem : EntitySystem
 
         var compTypes = ent.Comp.Reflects.ToString().Split(", ");
 
-        List<string> typeList = [];
+        List<string> typeList = new(compTypes.Length);
 
         for (var i = 0; i < compTypes.Length; i++)
         {

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -213,25 +213,12 @@ public sealed class ReflectSystem : EntitySystem
         if (!_toggle.IsActivated(ent.Owner) || value == 0 || ent.Comp.Reflects == ReflectType.None)
             return;
 
-        string type;
+        var type = ent.Comp.Reflects.ToString();
 
-        switch (ent.Comp.Reflects)
-        {
-            case ReflectType.Energy | ReflectType.NonEnergy:
-                type = "both";
-                args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
-                break;
-
-            case ReflectType.Energy:
-                type = "energy";
-                args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
-                break;
-
-            case ReflectType.NonEnergy:
-                type = "nonenergy";
-                args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
-                break;
-        }
+        // SOOOOOOOOOOO, DEPENDING ON THE HOW FTL SELECTOR WORKS THIS IS ONLY WAY TO DO IT PROPERLY.
+        // YES. THIS SENDS TO THE SELECTOR NON-CAMEL CASE SHIT AND REMOVES ANY ", " SO
+        // "Energy, Nonenergy" turs into "EnergyNonenergy"
+        args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", type.Replace(", ", null))));
     }
     #endregion
 }

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -47,7 +47,7 @@ public sealed class ReflectSystem : EntitySystem
         SubscribeLocalEvent<ReflectComponent, GotUnequippedEvent>(OnReflectUnequipped);
         SubscribeLocalEvent<ReflectComponent, GotEquippedHandEvent>(OnReflectHandEquipped);
         SubscribeLocalEvent<ReflectComponent, GotUnequippedHandEvent>(OnReflectHandUnequipped);
-        SubscribeLocalEvent<ReflectComponent, ArmorExamineEvent>(OnExamine);
+        SubscribeLocalEvent<ReflectComponent, GetVerbsEvent<ExamineVerb>>(OnExamine);
     }
 
     private void OnReflectUserCollide(Entity<ReflectComponent> ent, ref ProjectileReflectAttemptEvent args)
@@ -205,9 +205,9 @@ public sealed class ReflectSystem : EntitySystem
     }
 
     #region Examine
-    private void OnExamine(Entity<ReflectComponent> ent, ref ArmorExamineEvent args)
+    private void OnExamine(Entity<ReflectComponent> ent, ref GetVerbsEvent<ExamineVerb> args)
     {
-        var value = MathF.Round((1f - ent.Comp.ReflectProb) * 100, 1);
+        var value = MathF.Round(ent.Comp.ReflectProb * 100, 1);
 
         if (value == 0 || ent.Comp.Reflects == ReflectType.None)
             return;
@@ -218,19 +218,20 @@ public sealed class ReflectSystem : EntitySystem
         switch (ent.Comp.Reflects)
         {
             case ReflectType.Energy | ReflectType.NonEnergy:
-                type = Loc.GetString(ent.Comp.BothTypeLoc);
-                args.Msg.AddMarkupOrThrow(Loc.GetString(ent.Comp.ExamineLoc, ("value", value), ("type", type)));
+                type = Loc.GetString("reflect-examine-type-both");
+                args.Msg.AddMarkupOrThrow(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
                 break;
 
             case ReflectType.Energy:
-                type = Loc.GetString(ent.Comp.EnergyTypeLoc);
-                args.Msg.AddMarkupOrThrow(Loc.GetString(ent.Comp.ExamineLoc, ("value", value), ("type", type)));
+                type = Loc.GetString("reflect-examine-type-energy");
+                args.Msg.AddMarkupOrThrow(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
                 break;
 
             case ReflectType.NonEnergy:
-                type = Loc.GetString(ent.Comp.NonEnergyTypeLoc);
-                args.Msg.AddMarkupOrThrow(Loc.GetString(ent.Comp.ExamineLoc, ("value", value), ("type", type)));
+                type = Loc.GetString("reflect-examine-type-nonenergy");
+                args.Msg.AddMarkupOrThrow(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
                 break;
+
         }
     }
     #endregion

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -220,13 +220,13 @@ public sealed class ReflectSystem : EntitySystem
 
         for (var i = 0; i < compTypes.Length; i++)
         {
-            var type = Loc.GetString(compTypes[i]);
+            var type = ("reflect-component-" + Loc.GetString(compTypes[i])).ToLower();
             typeList.Add(type);
         }
 
         var msg = ContentLocalizationManager.FormatList(typeList);
 
-        args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", msg)));
+        args.PushMarkup(Loc.GetString("reflect-component-examine", ("value", value), ("type", msg)));
     }
     #endregion
 }

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -218,17 +218,17 @@ public sealed class ReflectSystem : EntitySystem
         switch (ent.Comp.Reflects)
         {
             case ReflectType.Energy | ReflectType.NonEnergy:
-                type = Loc.GetString("reflect-examine-type-both");
+                type = "both";
                 args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
                 break;
 
             case ReflectType.Energy:
-                type = Loc.GetString("reflect-examine-type-energy");
+                type = "energy";
                 args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
                 break;
 
             case ReflectType.NonEnergy:
-                type = Loc.GetString("reflect-examine-type-nonenergy");
+                type = "nonenergy";
                 args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", type)));
                 break;
         }

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -16,6 +16,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
 using Content.Shared.Examine;
+using Content.Shared.Localizations;
 
 namespace Content.Shared.Weapons.Reflect;
 
@@ -213,12 +214,19 @@ public sealed class ReflectSystem : EntitySystem
         if (!_toggle.IsActivated(ent.Owner) || value == 0 || ent.Comp.Reflects == ReflectType.None)
             return;
 
-        var type = ent.Comp.Reflects.ToString();
+        var compTypes = ent.Comp.Reflects.ToString().Split(", ");
 
-        // SOOOOOOOOOOO, DEPENDING ON THE HOW FTL SELECTOR WORKS THIS IS ONLY WAY TO DO IT PROPERLY.
-        // YES. THIS SENDS TO THE SELECTOR NON-CAMEL CASE SHIT AND REMOVES ANY ", " SO
-        // "Energy, Nonenergy" turs into "EnergyNonenergy"
-        args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", type.Replace(", ", null))));
+        List<string> typeList = [];
+
+        for (var i = 0; i < compTypes.Length; i++)
+        {
+            var type = Loc.GetString(compTypes[i]);
+            typeList.Add(type);
+        }
+
+        var msg = ContentLocalizationManager.FormatList(typeList);
+
+        args.PushMarkup(Loc.GetString("reflect-examine", ("value", value), ("type", msg)));
     }
     #endregion
 }

--- a/Resources/Locale/en-US/reflect/reflect-component.ftl
+++ b/Resources/Locale/en-US/reflect/reflect-component.ftl
@@ -1,6 +1,6 @@
 reflect-examine = It has a [color=lightblue]{$value}%[/color] to [color=cyan]reflect[/color] { $type ->
-    [both] energy bolts and bullets
-    [energy] energy bolts
-    [nonenergy] bullets
+    [NonEnergyEnergy] energy bolts and bullets
+    [Energy] energy bolts
+    [NonEnergy] bullets
     *[other] unknown
 }.

--- a/Resources/Locale/en-US/reflect/reflect-component.ftl
+++ b/Resources/Locale/en-US/reflect/reflect-component.ftl
@@ -1,4 +1,4 @@
-reflect-examine-value = It has [color=lightblue]{$value}%[/color] to [color=cyan]reflect[/color] {$type}.
-reflect-examine-energy-type = energy bolts
-reflect-examine-nonenergy-type = bullets
-reflect-examine-both = energy bolts and bullets
+reflect-examine = It has [color=lightblue]{$value}%[/color] to [color=cyan]reflect[/color] {$type}.
+reflect-examine-type-both = energy bolts and bullets
+reflect-examine-type-energy = energy bolts
+reflect-examine-type-nonenergy = bullets

--- a/Resources/Locale/en-US/reflect/reflect-component.ftl
+++ b/Resources/Locale/en-US/reflect/reflect-component.ftl
@@ -1,3 +1,3 @@
-reflect-examine = It has a [color=lightblue]{$value}%[/color] to [color=cyan]reflect[/color] {$type}.
-NonEnergy = bullets
-Energy = energy bolts
+reflect-component-examine = It has a [color=lightblue]{$value}%[/color] to [color=cyan]reflect[/color] {$type}.
+reflect-component-nonenergy = bullets
+reflect-component-energy = energy bolts

--- a/Resources/Locale/en-US/reflect/reflect-component.ftl
+++ b/Resources/Locale/en-US/reflect/reflect-component.ftl
@@ -1,3 +1,3 @@
-reflect-component-examine = It has a [color=lightblue]{$value}%[/color] to [color=cyan]reflect[/color] {$type}.
+reflect-component-examine = It has a [color=lightblue]{$value}%[/color] chance to [color=cyan]reflect[/color] {$type}.
 reflect-component-nonenergy = bullets
 reflect-component-energy = energy bolts

--- a/Resources/Locale/en-US/reflect/reflect-component.ftl
+++ b/Resources/Locale/en-US/reflect/reflect-component.ftl
@@ -1,6 +1,3 @@
-reflect-examine = It has a [color=lightblue]{$value}%[/color] to [color=cyan]reflect[/color] { $type ->
-    [NonEnergyEnergy] energy bolts and bullets
-    [Energy] energy bolts
-    [NonEnergy] bullets
-    *[other] unknown
-}.
+reflect-examine = It has a [color=lightblue]{$value}%[/color] to [color=cyan]reflect[/color] {$type}.
+NonEnergy = bullets
+Energy = energy bolts

--- a/Resources/Locale/en-US/reflect/reflect-component.ftl
+++ b/Resources/Locale/en-US/reflect/reflect-component.ftl
@@ -1,0 +1,4 @@
+reflect-examine-value = It has [color=lightblue]{$value}%[/color] to [color=cyan]reflect[/color] {$type}.
+reflect-examine-energy-type = energy bolts
+reflect-examine-nonenergy-type = bullets
+reflect-examine-both = energy bolts and bullets

--- a/Resources/Locale/en-US/reflect/reflect-component.ftl
+++ b/Resources/Locale/en-US/reflect/reflect-component.ftl
@@ -1,4 +1,6 @@
-reflect-examine = It has [color=lightblue]{$value}%[/color] to [color=cyan]reflect[/color] {$type}.
-reflect-examine-type-both = energy bolts and bullets
-reflect-examine-type-energy = energy bolts
-reflect-examine-type-nonenergy = bullets
+reflect-examine = It has a [color=lightblue]{$value}%[/color] to [color=cyan]reflect[/color] { $type ->
+    [both] energy bolts and bullets
+    [energy] energy bolts
+    [nonenergy] bullets
+    *[other] unknown
+}.


### PR DESCRIPTION
## About the PR
shows prob of reflection with examine
works with ANY entities
yes, pens-daggers protected from metagaming.

## Why / Balance
we should remove need in looking into prototypes/code of the game just for random numbers in proto.

## Media
![awdszawsawa](https://github.com/user-attachments/assets/dcf3059b-45aa-4df1-b2b4-f7094ee6b802)
![swadswsdw](https://github.com/user-attachments/assets/cc459c20-99a9-4882-b4cf-041bf0ba4ad3)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Reflection chances are examinable now.