### PR TITLE
HOTFIX: Stop AI turrets from causing flickering lights

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
@@ -97,7 +97,7 @@
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRifle
     capacity: 500
-      
+
 - type: entity
   parent: BaseWeaponTurret
   id: BaseWeaponEnergyTurret
@@ -129,7 +129,7 @@
   - type: ApcPowerReceiverBattery
     idleLoad: 5
     batteryRechargeRate: 200
-    batteryRechargeEfficiency: 1.225
+    batteryRechargeEfficiency: 0.0 # temporarily no power draw because this was causing potentially seizure inducing light flickering
   - type: ApcPowerReceiver
     powerLoad: 5
   - type: ExtensionCableReceiver


### PR DESCRIPTION
Temporary bandaid because this may cause seizures for some players.
We set the power draw to 0 so the APC has no load.
The turrets still require a powered APC to recharge, so they are still functional.