### PR TITLE
Added Hemophilia Trait

### DIFF
--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -51,6 +51,12 @@ namespace Content.Server.Body.Components
         public float BleedReductionAmount = 0.33f;
 
         /// <summary>
+        ///     How much should bleeding be reduced every update interval for the hemophilia trait?
+        /// </summary>
+        [DataField]
+        public float HemophiliacBleedReductionAmount = 0.10f;
+
+        /// <summary>
         ///     How high can <see cref="BleedAmount"/> go?
         /// </summary>
         [DataField]

--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -51,12 +51,6 @@ namespace Content.Server.Body.Components
         public float BleedReductionAmount = 0.33f;
 
         /// <summary>
-        ///     How much should bleeding be reduced every update interval for the hemophilia trait?
-        /// </summary>
-        [DataField]
-        public float HemophiliacBleedReductionAmount = 0.10f;
-
-        /// <summary>
         ///     How high can <see cref="BleedAmount"/> go?
         /// </summary>
         [DataField]

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -134,16 +134,8 @@ public sealed class BloodstreamSystem : EntitySystem
                 // Blood is removed from the bloodstream at a 1-1 rate with the bleed amount
                 TryModifyBloodLevel(uid, (-bloodstream.BleedAmount), bloodstream);
 
-                if (!HasComp<HemophiliaComponent>(uid))
-                {
-                    // Bleed rate is reduced by the bleed reduction amount in the bloodstream component.
-                    TryModifyBleedAmount(uid, -bloodstream.BleedReductionAmount, bloodstream);
-                }
-                else
-                {
-                    TryModifyBleedAmount(uid, -bloodstream.HemophiliacBleedReductionAmount, bloodstream);
-                }
-            }
+                // The rate in which stacks are reduced. Think of it like the rate at which your blood clots
+                TryModifyBleedAmount(uid, -bloodstream.BleedReductionAmount, bloodstream);
 
             // deal bloodloss damage if their blood level is below a threshold.
             var bloodPercentage = GetBloodLevelPercentage(uid, bloodstream);

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Speech.EntitySystems;
+using Content.Shared.Traits.Assorted;
 using Robust.Server.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -132,8 +133,16 @@ public sealed class BloodstreamSystem : EntitySystem
             {
                 // Blood is removed from the bloodstream at a 1-1 rate with the bleed amount
                 TryModifyBloodLevel(uid, (-bloodstream.BleedAmount), bloodstream);
-                // Bleed rate is reduced by the bleed reduction amount in the bloodstream component.
-                TryModifyBleedAmount(uid, -bloodstream.BleedReductionAmount, bloodstream);
+
+                if (!HasComp<HemophiliaComponent>(uid))
+                {
+                    // Bleed rate is reduced by the bleed reduction amount in the bloodstream component.
+                    TryModifyBleedAmount(uid, -bloodstream.BleedReductionAmount, bloodstream);
+                }
+                else
+                {
+                    TryModifyBleedAmount(uid, -bloodstream.HemophiliacBleedReductionAmount, bloodstream);
+                }
             }
 
             // deal bloodloss damage if their blood level is below a threshold.

--- a/Content.Shared/Traits/Assorted/HemophiliaComponent.cs
+++ b/Content.Shared/Traits/Assorted/HemophiliaComponent.cs
@@ -4,7 +4,13 @@ namespace Content.Shared.Traits.Assorted;
 
 /// <summary>
 /// This component is used for the Hemophilia Trait, it reduces the passive bleed stack reduction amount so entities with it bleed for longer.
-/// The reduction SHOULD be located in BloodstreamComponent.cs as HemophiliacBleedReductionAmount
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class HemophiliaComponent : Component;
+public sealed partial class HemophiliaComponent : Component
+{
+    /// <summary>
+    ///     How much should bleeding be reduced every update interval for the hemophilia trait?
+    /// </summary>
+    [DataField]
+    public float HemophiliacBleedReductionAmount = 0.10f;
+}

--- a/Content.Shared/Traits/Assorted/HemophiliaComponent.cs
+++ b/Content.Shared/Traits/Assorted/HemophiliaComponent.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Traits.Assorted;
+
+/// <summary>
+/// This component is used for the Hemophilia Trait, it reduces the passive bleed stack reduction amount so entities with it bleed for longer.
+/// The reduction SHOULD be located in BloodstreamComponent.cs as HemophiliacBleedReductionAmount
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class HemophiliaComponent : Component;

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -65,3 +65,6 @@ trait-spanish-desc = Hola señor, donde esta la biblioteca.
 
 trait-painnumbness-name = Numb
 trait-painnumbness-desc = You lack any sense of feeling pain, being unaware of how hurt you may be.
+
+trait-hemophilia-name = Hemophilia
+trait-hemophilia-desc = Your body fails to make blood clots.

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -16,6 +16,7 @@
   - NpcFactionMember
   # traits
   # - LegsParalyzed (you get healed)
+  - Hemophilia
   - LightweightDrunk
   - Monochromacy
   - Muted

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -83,3 +83,11 @@
   category: Disabilities
   components:
   - type: PainNumbness
+
+- type: trait
+  id: Hemophilia
+  name: trait-hemophilia-name
+  description: trait-hemophilia-desc
+  category: Disabilities
+  components:
+  - type: Hemophilia


### PR DESCRIPTION
## About the PR
Added the Hemophilia Trait, people with this trait will now bleed even longer and may have to think about making gauze or tourniquets with them... and maybe some garlic too.

## Why / Balance
It was one of the few traits when I first stared playing that I was surprised to not see.
Hopefully in the future someone will code specific blood intervals in which people will faint so it's not just "chug some more dex and saline and you'll be fine"

## Technical details
Added a new cs file in Shared/Traits (Where traits aught to go instead of literally everywhere but)
Added a couple lines in Bloodstream.cs and added a thing into the component itself

## Media
![image](https://github.com/user-attachments/assets/a034f5c8-ef0c-48d6-94d4-b3887f4f66ca)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added a new trait: Hemophilia! 
