### PR TITLE
Cleanup `ChameleonJobLoadoutTest`

### DIFF
--- a/Content.IntegrationTests/Tests/Chameleon/ChameleonJobLoadoutTest.cs
+++ b/Content.IntegrationTests/Tests/Chameleon/ChameleonJobLoadoutTest.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Text;
-using Content.Client.Implants;
 using Content.IntegrationTests.Tests.Interaction;
 using Content.Shared.Clothing;
 using Content.Shared.Implants;
@@ -11,17 +9,17 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Chameleon;
 
 /// <summary>
-/// Ensures all round <see cref="IsProbablyRoundStartJob">"round start jobs"</see> have an associated chameleon loadout.
+/// Ensures all <see cref="IsProbablyRoundStartJob">"round start jobs"</see> have an associated chameleon loadout.
 /// </summary>
 public sealed class ChameleonJobLoadoutTest : InteractionTest
 {
-    private readonly List<ProtoId<JobPrototype>> JobBlacklist =
+    private static readonly List<ProtoId<JobPrototype>> JobBlacklist =
     [
 
     ];
 
     [Test]
-    public async Task CheckAllJobs()
+    public Task CheckAllJobs()
     {
         var alljobs = ProtoMan.EnumeratePrototypes<JobPrototype>();
 
@@ -47,24 +45,16 @@ public sealed class ChameleonJobLoadoutTest : InteractionTest
             validJobs[chameleon.Job.Value] += 1;
         }
 
-        var errorMessage = new StringBuilder();
-        errorMessage.AppendLine("The following job(s) have no chameleon prototype(s):");
-        var invalid = false;
-
-        // All round start jobs have a chameleon loadout
-        foreach (var job in validJobs)
+        Assert.Multiple(() =>
         {
-            if (job.Value != 0)
-                continue;
+            foreach (var job in validJobs)
+            {
+                Assert.That(job.Value, Is.Not.Zero,
+                    $"{job.Key} has no chameleonOutfit prototype.");
+            }
+        });
 
-            errorMessage.AppendLine(job.Key + " has no chameleonOutfit prototype.");
-            invalid = true;
-        }
-
-        if (!invalid)
-            return;
-
-        Assert.Fail(errorMessage.ToString());
+        return Task.CompletedTask;
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Cleans up 1 warning and makes a few adjustments to `ChameleonJobLoadoutTest`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279 and a little bit of test standardization.

## Technical details
<!-- Summary of code changes for easier review. -->
- Made `JobBlacklist` static.
- Removed `async` keyword from `CheckAllJobs` (this fixes the warning).
- Made the test return `Task.CompletedTask` (so the previous change doesn't cause an error).
- Swapped the `StringBuilder` and `invalid` tracking (used to report all errors instead of just the first) for just using `Assert.Multiple`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->