### PR TITLE
Increased Borg Density (Drag Speeds)

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -25,7 +25,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.35
-        density: 150
+        density: 300
         mask:
         - MobMask
         layer:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I changed Borg density universally, to allow them to drag faster & consequently be dragged slower, equivalent to a Diona's drag speed.

## Why / Balance
This was changed due to Borgs being extremely reliant on dragging, yet having a drag speed lower than that of a regular human, (in-between a dwarfs drag speed & a humans drag speed) making for a frustrating experience as several Borg types, when they were obligated to drag something (ie. crit crew, corpses, ordered to drag a heavy object) and had to spend several minutes moving at a snails-pace.
Currently, Borgs are lighter than even humans, which doesn't make too much sense given their larger size & robotic, steel bodies, so I thought to change this.

This is unlikely to have any drastic balance concerns; it raises a Borgs capabilities somewhat, and lets them move faster whilst moving an object/corpse to med-bay or other places, but is no stronger than what a Diona is capable of.

## Technical details
I changed Borg chassis density from 150 to 300, equivalent to Diona.

## Media
old speeds:

https://github.com/user-attachments/assets/5fd17752-4ca5-4264-8ab4-60995e51e32a

https://github.com/user-attachments/assets/50dcb25e-8434-43a0-843e-26d1a7a9b06d

--------------------------
new speeds:

https://github.com/user-attachments/assets/5919a536-680c-4ce0-aa48-5728b51f83d2

https://github.com/user-attachments/assets/befa270b-0bf8-4406-9449-d99a6a8e83a3





## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Increased borg drag speed, equivalent to Diona speeds.
