### PR TITLE
Cleanup chat highlighting code

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -107,7 +107,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
             // that make sure the words to match are separated by spaces or punctuation.
             // NOTE: The reason why we don't use \b tags is that \b doesn't match reverse slash characters "\" so
             // a pre-sanitized (see 1.) string like "\[test]" wouldn't get picked up by the \b.
-            if (keyword.Count(c => (c == '"')) > 0)
+            if (keyword.Any(c => c == '"'))
             {
                 // Matches the last double quote character.
                 keyword = StartDoubleQuote.Replace(keyword, "(?!\\w)");

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -14,6 +14,7 @@ namespace Content.Client.UserInterface.Systems.Chat;
 /// </summary>
 public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSystem>
 {
+    [Dependency] private readonly ILocalizationManager _loc = default!;
     [UISystemDependency] private readonly CharacterInfoSystem _characterInfo = default!;
 
     private static readonly Regex StartDoubleQuote = new("\"$");
@@ -150,7 +151,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         // Convert the job title to kebab-case and use it as a key for the loc file.
         string jobKey = job.Replace(' ', '-').ToLower();
 
-        if (Loc.TryGetString($"highlights-{jobKey}", out var jobMatches))
+        if (_loc.TryGetString($"highlights-{jobKey}", out var jobMatches))
             newHighlights += '\n' + jobMatches.Replace(", ", "\n");
 
         UpdateHighlights(newHighlights);

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -16,6 +16,10 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
 {
     [UISystemDependency] private readonly CharacterInfoSystem _characterInfo = default!;
 
+    private static readonly Regex StartDoubleQuote = new("\"$");
+    private static readonly Regex EndDoubleQuote = new("^\"|(?<=^@)\"");
+    private static readonly Regex StartAtSign = new("^@");
+
     /// <summary>
     ///     The list of words to be highlighted in the chatbox.
     /// </summary>
@@ -105,14 +109,14 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
             if (keyword.Count(c => (c == '"')) > 0)
             {
                 // Matches the last double quote character.
-                keyword = Regex.Replace(keyword, "\"$", "(?!\\w)");
+                keyword = StartDoubleQuote.Replace(keyword, "(?!\\w)");
                 // When matching for the first double quote character we also consider the possibility
                 // of the double quote being preceded by a @ character.
-                keyword = Regex.Replace(keyword, "^\"|(?<=^@)\"", "(?<!\\w)");
+                keyword = EndDoubleQuote.Replace(keyword, "(?<!\\w)");
             }
 
             // Make sure any name tagged as ours gets highlighted only when others say it.
-            keyword = Regex.Replace(keyword, "^@", "(?<=(?<=/name.*)|(?<=,.*\"\".*))");
+            keyword = StartAtSign.Replace(keyword, "(?<=(?<=/name.*)|(?<=,.*\"\".*))");
 
             _highlights.Add(keyword);
         }

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -24,7 +24,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
     /// <summary>
     ///     The list of words to be highlighted in the chatbox.
     /// </summary>
-    private List<string> _highlights = new();
+    private readonly List<string> _highlights = new();
 
     /// <summary>
     ///     The string holding the hex color used to highlight words.

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -47,7 +47,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         _config.OnValueChanged(CCVars.ChatHighlightsColor, (value) => { _highlightsColor = value; }, true);
 
         // Load highlights if any were saved.
-        string highlights = _config.GetCVar(CCVars.ChatHighlights);
+        var highlights = _config.GetCVar(CCVars.ChatHighlights);
 
         if (!string.IsNullOrEmpty(highlights))
         {
@@ -89,12 +89,12 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
 
         // We first subdivide the highlights based on newlines to prevent replacing
         // a valid "\n" tag and adding it to the final regex.
-        string[] splittedHighlights = newHighlights.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var splittedHighlights = newHighlights.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-        for (int i = 0; i < splittedHighlights.Length; i++)
+        for (var i = 0; i < splittedHighlights.Length; i++)
         {
             // Replace every "\" character with a "\\" to prevent "\n", "\0", etc...
-            string keyword = splittedHighlights[i].Replace(@"\", @"\\");
+            var keyword = splittedHighlights[i].Replace(@"\", @"\\");
 
             // Escape the keyword to prevent special characters like "(" and ")" to be considered valid regex.
             keyword = Regex.Escape(keyword);
@@ -137,7 +137,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         var (_, job, _, _, entityName) = data;
 
         // Mark this entity's name as our character name for the "UpdateHighlights" function.
-        string newHighlights = "@" + entityName;
+        var newHighlights = "@" + entityName;
 
         // Subdivide the character's name based on spaces or hyphens so that every word gets highlighted.
         if (newHighlights.Count(c => (c == ' ' || c == '-')) == 1)
@@ -149,7 +149,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
             newHighlights = newHighlights.Split('-')[0] + "\n@" + newHighlights.Split('-')[^1];
 
         // Convert the job title to kebab-case and use it as a key for the loc file.
-        string jobKey = job.Replace(' ', '-').ToLower();
+        var jobKey = job.Replace(' ', '-').ToLower();
 
         if (_loc.TryGetString($"highlights-{jobKey}", out var jobMatches))
             newHighlights += '\n' + jobMatches.Replace(", ", "\n");


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 4 warnings and a few other minor code style issues in `ChatUIController.Highlighting.cs`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
- Regexes are now cached as `private static readonly` fields (fixes 3 instances of `warning RA0026: Usage of a static Regex function that takes in a pattern string. This can cause constant re-parsing of the pattern`).
- Use of the static method `Loc.TryGetString` was replaced with adding an `ILocalizationManager` dependency and using its non-static `TryGetString` method (Fixes 1 `warning CS0618 (Obsolete)`).
- A use of the LINQ `Count` method was changed to use `Any`. This isn't a compiler warning, but I do get a suggestion to change it in vscode. I assume that `Any` is able to shortcut and return true at the first instance that passes, whereas checking that `Count` is greater than 0 requires evaluating all instances.
- Explicitly-typed variables were changed to use `var` (standard practice for this repo).
- The `_highlights` field was marked `readonly`. This is just to satisfy the suggested change in vscode, but there's no reason _not_ to do it. It is only ever added, cleared, or read, so this causes no problems.

Each of the above changes was done as a separate commit for easier review.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->