### PR TITLE
Fix missing bike horn implant cooldown

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -330,6 +330,7 @@
   components:
   - type: Action
     icon: { sprite: Objects/Fun/bikehorn.rsi, state: icon }
+    useDelay: 1
 
 - type: entity
   parent: BaseAction


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds a cooldown to the bike horn implant action.

I noticed that the cooldown was missing when I ordered a bunch from cargo as a goof. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

There used to be one. It looks like it was accidentally removed during the ECS action refactor a couple weeks back.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:

https://github.com/user-attachments/assets/bdb58e13-8247-46c1-b6fb-58e05468f097

After: 

https://github.com/user-attachments/assets/e152c93d-659b-42bd-863c-d32a6f1e9513

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Returned the cooldown for bike horn implants