### PR TITLE
nerf cheese prices, part 2: electronics

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/misc.yml
@@ -12,5 +12,3 @@
   - type: Tag
     tags:
       - StationMapElectronics
-  - type: StaticPrice
-    price: 30

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
@@ -10,8 +10,6 @@
   - type: Sprite
     sprite: Objects/Misc/module.rsi
     state: generic
-  - type: StaticPrice
-    price: 100
   - type: PhysicalComposition
     materialComposition:
       Glass: 200

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/disposal.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/disposal.yml
@@ -10,5 +10,3 @@
     - type: Tag
       tags:
         - MailingUnitElectronics
-    - type: StaticPrice
-      price: 55

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
@@ -11,8 +11,6 @@
       tags:
         - DoorElectronics
     - type: DoorElectronics
-    - type: StaticPrice
-      price: 55
     - type: AccessReader
     - type: ActivatableUI
       key: enum.DoorElectronicsConfigurationUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/misc.yml
@@ -11,5 +11,3 @@
     tags:
       - FreezerElectronics
   - type: DoorElectronics
-  - type: StaticPrice
-    price: 55


### PR DESCRIPTION
## About the PR
nerfed cost of biggest part of electronics

## Why / Balance
See #38230
Mass media console costs 150 for some reason that allows create everlasting printers of money.
Same with others changed electronics they costs more than should be and can be used to make really bad things.
Removed static price component from baseelectronics. Now price of electronics calculates via material composition

## Technical details
removed door electronics component from the freezer because it even doesn't have UI comp.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.