### PR TITLE
Fix mops, rags, and towels interacting with drains

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
@@ -18,6 +18,9 @@
     unequipSound: 
   - type: Spillable
     solution: absorbed
+    spillWhenThrown: false
+  - type: DrainableSolution
+    solution: absorbed
   - type: Absorbent
     pickupAmount: 15
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -25,6 +25,9 @@
       collection: MetalThud
   - type: Spillable
     solution: absorbed
+    spillWhenThrown: false
+  - type: DrainableSolution
+    solution: absorbed
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -79,6 +82,9 @@
       soundHit:
          collection: MetalThud
     - type: Spillable
+      solution: absorbed
+      spillWhenThrown: false
+    - type: DrainableSolution
       solution: absorbed
     - type: Wieldable
     - type: IncreaseDamageOnWield
@@ -312,6 +318,9 @@
       maxFillLevels: 3
       fillBaseName: fill-
     - type: Spillable
+      solution: absorbed
+      spillWhenThrown: false
+    - type: DrainableSolution
       solution: absorbed
     - type: MeleeWeapon
       soundNoDamage:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Previously, mops, rags, and towels would have a verb to empty them when right clicking a drain, but would say they're empty when you tried to click it, regardless of solution status. Now you can actually squeeze them out!
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I think you should be able to squeeze out absorbant cleaning tools into a drain, seems realistic. 
## Technical details
<!-- Summary of code changes for easier review. -->
Added DrainableSolution component to mops, rags, and towels. Additionally changed the SpillWhenThrown flag to false for Spillable (Adding the DrainableSolution component suddenly made these items spill when thrown otherwise).
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
nope
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed mops, rags, and towels being unable to be properly emptied into drains
