### PR TITLE
DoAfter support for Actions

### DIFF
--- a/Content.Shared/Actions/Events/ActionAttemptDoAfterEvent.cs
+++ b/Content.Shared/Actions/Events/ActionAttemptDoAfterEvent.cs
@@ -1,7 +1,11 @@
-﻿namespace Content.Shared.Actions.Events;
+﻿using Content.Shared.Actions.Components;
+
+namespace Content.Shared.Actions.Events;
 
 /// <summary>
 /// Raised when attempting to run a DoAfter on an Action, used to trigger a DoAfter on an Action (if it has the DoAfter component)
 /// </summary>
+/// <param name="Performer">The action performer</param>
+/// <param name="OriginalUseDelay">The original action use delay, used for repeating actions</param>
 [ByRefEvent]
-public record struct ActionAttemptDoAfterEvent(EntityUid User, RequestPerformActionEvent requestEvent);
+public record struct ActionAttemptDoAfterEvent(Entity<ActionsComponent?> Performer, TimeSpan? OriginalUseDelay);

--- a/Content.Shared/Actions/Events/ActionAttemptDoAfterEvent.cs
+++ b/Content.Shared/Actions/Events/ActionAttemptDoAfterEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace Content.Shared.Actions.Events;
+
+/// <summary>
+/// Raised when attempting to run a DoAfter on an Action, used to trigger a DoAfter on an Action (if it has the DoAfter component)
+/// </summary>
+[ByRefEvent]
+public record struct ActionAttemptDoAfterEvent(EntityUid User, RequestPerformActionEvent requestEvent);

--- a/Content.Shared/Actions/Events/ActionAttemptDoAfterEvent.cs
+++ b/Content.Shared/Actions/Events/ActionAttemptDoAfterEvent.cs
@@ -7,5 +7,6 @@ namespace Content.Shared.Actions.Events;
 /// </summary>
 /// <param name="Performer">The action performer</param>
 /// <param name="OriginalUseDelay">The original action use delay, used for repeating actions</param>
+/// <param name="Input">The original request, for validating</param>
 [ByRefEvent]
-public record struct ActionAttemptDoAfterEvent(Entity<ActionsComponent?> Performer, TimeSpan? OriginalUseDelay);
+public record struct ActionAttemptDoAfterEvent(Entity<ActionsComponent?> Performer, TimeSpan? OriginalUseDelay, RequestPerformActionEvent Input);

--- a/Content.Shared/Actions/Events/ActionDoAfterEvent.cs
+++ b/Content.Shared/Actions/Events/ActionDoAfterEvent.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.DoAfter;
+﻿using Content.Shared.Actions.Components;
+using Content.Shared.DoAfter;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Actions.Events;
@@ -9,11 +10,15 @@ namespace Content.Shared.Actions.Events;
 [Serializable, NetSerializable]
 public sealed partial class ActionDoAfterEvent : DoAfterEvent
 {
-    public readonly RequestPerformActionEvent RequestEvent;
+    [NonSerialized]
+    public readonly Entity<ActionsComponent?> Performer;
 
-    public ActionDoAfterEvent(RequestPerformActionEvent requestEvent)
+    public readonly TimeSpan? OriginalUseDelay;
+
+    public ActionDoAfterEvent(Entity<ActionsComponent?> performer, TimeSpan? originalUseDelay)
     {
-        RequestEvent = requestEvent;
+        Performer = performer;
+        OriginalUseDelay = originalUseDelay;
     }
 
     public override DoAfterEvent Clone() => this;

--- a/Content.Shared/Actions/Events/ActionDoAfterEvent.cs
+++ b/Content.Shared/Actions/Events/ActionDoAfterEvent.cs
@@ -1,0 +1,20 @@
+﻿using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Actions.Events;
+
+/// <summary>
+/// The event that triggers when an action doafter is completed or cancelled
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class ActionDoAfterEvent : DoAfterEvent
+{
+    public readonly RequestPerformActionEvent RequestEvent;
+
+    public ActionDoAfterEvent(RequestPerformActionEvent requestEvent)
+    {
+        RequestEvent = requestEvent;
+    }
+
+    public override DoAfterEvent Clone() => this;
+}

--- a/Content.Shared/Actions/Events/ActionDoAfterEvent.cs
+++ b/Content.Shared/Actions/Events/ActionDoAfterEvent.cs
@@ -10,15 +10,27 @@ namespace Content.Shared.Actions.Events;
 [Serializable, NetSerializable]
 public sealed partial class ActionDoAfterEvent : DoAfterEvent
 {
+    /// <summary>
+    /// <inheritdoc cref="ActionAttemptDoAfterEvent.Performer"/>
+    /// </summary>
     [NonSerialized]
     public readonly Entity<ActionsComponent?> Performer;
 
+    /// <summary>
+    /// <inheritdoc cref="ActionAttemptDoAfterEvent.OriginalUseDelay"/>
+    /// </summary>
     public readonly TimeSpan? OriginalUseDelay;
 
-    public ActionDoAfterEvent(Entity<ActionsComponent?> performer, TimeSpan? originalUseDelay)
+    /// <summary>
+    /// <inheritdoc cref="ActionAttemptDoAfterEvent.Input"/>
+    /// </summary>
+    public readonly RequestPerformActionEvent Input;
+
+    public ActionDoAfterEvent(Entity<ActionsComponent?> performer, TimeSpan? originalUseDelay, RequestPerformActionEvent input)
     {
         Performer = performer;
         OriginalUseDelay = originalUseDelay;
+        Input = input;
     }
 
     public override DoAfterEvent Clone() => this;

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -121,7 +121,7 @@ public abstract class SharedActionsSystem : EntitySystem
         if (TryPerformAction(args.Input, args.Performer, skipDoActionRequest: true))
             return;
 
-        // TODO: This fixes the mispredicting but it doesn't fix the extra repeat
+        // This fixes the mispredicting but it doesn't fix the extra repeat
         if (_netMan.IsClient)
             return;
 

--- a/Content.Shared/Charges/Systems/SharedChargesSystem.cs
+++ b/Content.Shared/Charges/Systems/SharedChargesSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Actions.Events;
 using Content.Shared.Charges.Components;
+using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using JetBrains.Annotations;
 using Robust.Shared.Timing;
@@ -20,9 +21,18 @@ public abstract class SharedChargesSystem : EntitySystem
 
         SubscribeLocalEvent<LimitedChargesComponent, ExaminedEvent>(OnExamine);
 
+        SubscribeLocalEvent<LimitedChargesComponent, DoAfterAttemptEvent<ActionDoAfterEvent>>(OnActionDoAfterAttempt);
         SubscribeLocalEvent<LimitedChargesComponent, ActionAttemptEvent>(OnChargesAttempt);
         SubscribeLocalEvent<LimitedChargesComponent, MapInitEvent>(OnChargesMapInit);
         SubscribeLocalEvent<LimitedChargesComponent, ActionPerformedEvent>(OnChargesPerformed);
+    }
+
+    private void OnActionDoAfterAttempt(Entity<LimitedChargesComponent> ent, ref DoAfterAttemptEvent<ActionDoAfterEvent> args)
+    {
+        var charges = GetCurrentCharges((ent.Owner, ent.Comp, null));
+
+        if (charges <= 0)
+            args.Cancel();
     }
 
     private void OnExamine(EntityUid uid, LimitedChargesComponent comp, ExaminedEvent args)

--- a/Content.Shared/DoAfter/DoAfterArgs.cs
+++ b/Content.Shared/DoAfter/DoAfterArgs.cs
@@ -319,6 +319,7 @@ public enum DuplicateConditions : byte
     All = SameTool | SameTarget | SameEvent,
 }
 
+[Serializable, NetSerializable]
 public enum AttemptFrequency : byte
 {
     /// <summary>

--- a/Content.Shared/DoAfter/DoAfterComponent.cs
+++ b/Content.Shared/DoAfter/DoAfterComponent.cs
@@ -9,11 +9,23 @@ namespace Content.Shared.DoAfter;
 [Access(typeof(SharedDoAfterSystem))]
 public sealed partial class DoAfterComponent : Component
 {
-    [DataField("nextId")]
+    /// <summary>
+    /// The id of the next doafter
+    /// </summary>
+    [DataField]
     public ushort NextId;
 
-    [DataField("doAfters")]
+    /// <summary>
+    /// collection of id + doafter
+    /// </summary>
+    [DataField]
     public Dictionary<ushort, DoAfter> DoAfters = new();
+
+    /// <summary>
+    /// What should the delay be reduced to after completion?
+    /// </summary>
+    [DataField]
+    public TimeSpan? DelayReduction;
 
     // This region of fields are for setting parameters for a do after
     // Eventually DoAfterArgs should be completely merged with this class
@@ -124,10 +136,12 @@ public sealed class DoAfterComponentState : ComponentState
 {
     public readonly ushort NextId;
     public readonly Dictionary<ushort, DoAfter> DoAfters;
+    public readonly TimeSpan? DelayReduction;
 
     public DoAfterComponentState(IEntityManager entManager, DoAfterComponent component)
     {
         NextId = component.NextId;
+        DelayReduction = component.DelayReduction;
 
         // Cursed test bugs - See CraftingTests.CancelCraft
         // The following is wrapped in an if DEBUG. This is tests don't (de)serialize net messages and just copy objects

--- a/Content.Shared/DoAfter/DoAfterComponent.cs
+++ b/Content.Shared/DoAfter/DoAfterComponent.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.DoAfter;
 
+// TODO: This needs a rework to modern standards & a check if autogeneratestate would work
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedDoAfterSystem))]
 public sealed partial class DoAfterComponent : Component

--- a/Content.Shared/DoAfter/DoAfterComponent.cs
+++ b/Content.Shared/DoAfter/DoAfterComponent.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 
@@ -13,6 +14,106 @@ public sealed partial class DoAfterComponent : Component
 
     [DataField("doAfters")]
     public Dictionary<ushort, DoAfter> DoAfters = new();
+
+    // This region of fields are for setting parameters for a do after
+    // Eventually DoAfterArgs should be completely merged with this class
+    // Still requires some setup currently, but this way it hardcodes doafters a lot less
+    #region DoAfterArgsSettings
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.AttemptFrequency"/>
+    /// </summary>
+    [DataField]
+    public AttemptFrequency AttemptFrequency;
+
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.Broadcast"/>
+    /// </summary>
+    [DataField]
+    public bool Broadcast;
+
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.Delay"/>
+    /// </summary>
+    [DataField]
+    public TimeSpan Delay = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.Hidden"/>
+    /// </summary>
+    [DataField]
+    public bool Hidden;
+
+    /// <summary>
+    /// Should this DoAfter repeat after being completed?
+    /// </summary>
+    [DataField]
+    public bool Repeat;
+
+    #region Break/Cancellation Options
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.NeedHand"/>
+    /// </summary>
+    [DataField]
+    public bool NeedHand;
+
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.BreakOnHandChange"/>
+    /// </summary>
+    [DataField]
+    public bool BreakOnHandChange = true;
+
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.BreakOnDropItem"/>
+    /// </summary>
+    [DataField]
+    public bool BreakOnDropItem = true;
+
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.BreakOnMove"/>
+    /// </summary>
+    [DataField]
+    public bool BreakOnMove;
+
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.BreakOnWeightlessMove"/>
+    /// </summary>
+    [DataField]
+    public bool BreakOnWeightlessMove = true;
+
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.MovementThreshold"/>
+    /// </summary>
+    [DataField]
+    public float MovementThreshold = 0.3f;
+
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.DistanceThreshold"/>
+    /// </summary>
+    [DataField]
+    public float? DistanceThreshold;
+
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.BreakOnDamage"/>
+    /// </summary>
+    [DataField]
+    public bool BreakOnDamage;
+
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.DamageThreshold"/>
+    /// </summary>
+    [DataField]
+    public FixedPoint2 DamageThreshold = 1;
+
+    /// <summary>
+    /// <inheritdoc cref="DoAfterArgs.RequireCanInteract"/>
+    /// </summary>
+    [DataField]
+    public bool RequireCanInteract = true;
+    // End Break/Cancellation Options
+    #endregion
+
+    // End DoAfterArgsSettings
+    #endregion
 
     // Used by obsolete async do afters
     public readonly Dictionary<ushort, TaskCompletionSource<DoAfterStatus>> AwaitedDoAfters = new();

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -48,7 +48,6 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
 
         var actionDoAfter = ent.Comp;
 
-        // TODO: Attempt Start delay (aka casting delay) and repeat delay (shorter)
         var delay = actionDoAfter.Delay;
 
         var actionDoAfterEvent = new ActionDoAfterEvent(args.Performer, args.OriginalUseDelay, args.Input);
@@ -161,6 +160,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         }
 
         comp.NextId = state.NextId;
+        comp.DelayReduction = state.DelayReduction;
         DebugTools.Assert(!comp.DoAfters.ContainsKey(comp.NextId));
 
         if (comp.DoAfters.Count == 0)

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -353,16 +353,16 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
     /// <summary>
     ///     Cancels an active DoAfter.
     /// </summary>
-    public void Cancel(DoAfterId? id, DoAfterComponent? comp = null)
+    public void Cancel(DoAfterId? id, DoAfterComponent? comp = null, bool force = false)
     {
         if (id != null)
-            Cancel(id.Value.Uid, id.Value.Index, comp);
+            Cancel(id.Value.Uid, id.Value.Index, comp, force);
     }
 
     /// <summary>
     ///     Cancels an active DoAfter.
     /// </summary>
-    public void Cancel(EntityUid entity, ushort id, DoAfterComponent? comp = null)
+    public void Cancel(EntityUid entity, ushort id, DoAfterComponent? comp = null, bool force = false)
     {
         if (!Resolve(entity, ref comp, false))
             return;
@@ -373,13 +373,13 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             return;
         }
 
-        InternalCancel(doAfter, comp);
+        InternalCancel(doAfter, comp, force: force);
         Dirty(entity, comp);
     }
 
-    private void InternalCancel(DoAfter doAfter, DoAfterComponent component)
+    private void InternalCancel(DoAfter doAfter, DoAfterComponent component, bool force = false)
     {
-        if (doAfter.Cancelled || doAfter.Completed)
+        if (doAfter.Cancelled || (doAfter.Completed && !force))
             return;
 
         // Caller is responsible for dirtying the component.

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -43,7 +43,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
     private void OnActionDoAfterAttempt(Entity<DoAfterComponent> ent, ref ActionAttemptDoAfterEvent args)
     {
         // relay to user
-        if (!TryComp<DoAfterComponent>(args.User, out var userDoAfter))
+        if (!TryComp<DoAfterComponent>(args.Performer, out var userDoAfter))
             return;
 
         var actionDoAfter = ent.Comp;
@@ -51,15 +51,11 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         // TODO: Attempt Start delay (aka casting delay) and repeat delay (shorter)
         var delay = actionDoAfter.Delay;
 
-        var actionDoAfterEvent = new ActionDoAfterEvent(args.requestEvent)
-        {
-            Repeat = actionDoAfter.Repeat,
-        };
+        var actionDoAfterEvent = new ActionDoAfterEvent(args.Performer, args.OriginalUseDelay);
 
         // TODO: Should add a raise on used in the attemptactiondoafterevent or something to add a conditional item or w/e
 
-        // TODO: Should probably make an "AttemptActionDoAfter" event to trigger this instead of action attempt event
-        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, delay, actionDoAfterEvent, ent.Owner, args.User)
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.Performer, delay, actionDoAfterEvent, ent.Owner, args.Performer)
         {
             AttemptFrequency = actionDoAfter.AttemptFrequency,
             Broadcast = actionDoAfter.Broadcast,

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -51,7 +51,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         // TODO: Attempt Start delay (aka casting delay) and repeat delay (shorter)
         var delay = actionDoAfter.Delay;
 
-        var actionDoAfterEvent = new ActionDoAfterEvent(args.Performer, args.OriginalUseDelay);
+        var actionDoAfterEvent = new ActionDoAfterEvent(args.Performer, args.OriginalUseDelay, args.Input);
 
         // TODO: Should add a raise on used in the attemptactiondoafterevent or something to add a conditional item or w/e
 

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -7,6 +7,14 @@
   components:
   - type: Action
 
+# base proto for an action that requires a DoAfter
+- type: entity
+  abstract: true
+  parent: BaseAction
+  id: BaseDoAfterAction
+  components:
+  - type: DoAfter
+
 # an action that is done all in le head and cant be prevented by any means
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Actions now have DoAfter support! Just slap a DoAfter Component on an action and fill in the details!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

DoAfter support for actions was a long time coming. You can do a lot of interesting things with it such as:
- Cast Times
- Repeating actions
  - Repeating actions that have a lower doafter time

## Technical details
<!-- Summary of code changes for easier review. -->

- DoAfter Arg fields were also added to the DoAfterComponent so they can be relayed.
- AttemptFrequency was given serialization/netserialization
- DelayReduction was also added to the doafter component - to set a repeat delay to a lower time
- A force option was added to the doafter cancel method so we can cancel even if the doafter was completed.
- ActionDoAfterEvent was added to pass action info back to the action class after the doafter completes, so we can try to do another action
- LimitedChargesComponent also handles doafter cancellation if there's no more charges left on the action
- Doaftersystem handles the relay for actions
- A base DoAfter Action entity was added
- 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/c65c2974-b5a0-4963-8712-c35a8126954b

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
