### PR TITLE
Improve some `BinSystem` functionality

### DIFF
--- a/Content.Shared/Storage/Components/BinComponent.cs
+++ b/Content.Shared/Storage/Components/BinComponent.cs
@@ -21,6 +21,12 @@ public sealed partial class BinComponent : Component
     public Container ItemContainer = default!;
 
     /// <summary>
+    /// ID of the container used to hold the items in the bin.
+    /// </summary>
+    [DataField]
+    public string ContainerId = "bin-container";
+
+    /// <summary>
     /// A list representing the order in which
     /// all the entities are stored in the bin.
     /// </summary>

--- a/Content.Shared/Storage/EntitySystems/BinSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/BinSystem.cs
@@ -24,13 +24,12 @@ public sealed class BinSystem : EntitySystem
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
-    public const string BinContainerId = "bin-container";
-
     /// <inheritdoc/>
     public override void Initialize()
     {
         SubscribeLocalEvent<BinComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<BinComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<BinComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
         SubscribeLocalEvent<BinComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
         SubscribeLocalEvent<BinComponent, InteractHandEvent>(OnInteractHand, before: new[] { typeof(SharedItemSystem) });
         SubscribeLocalEvent<BinComponent, AfterInteractUsingEvent>(OnAfterInteractUsing);
@@ -45,7 +44,7 @@ public sealed class BinSystem : EntitySystem
 
     private void OnStartup(EntityUid uid, BinComponent component, ComponentStartup args)
     {
-        component.ItemContainer = _container.EnsureContainer<Container>(uid, BinContainerId);
+        component.ItemContainer = _container.EnsureContainer<Container>(uid, component.ContainerId);
     }
 
     private void OnMapInit(EntityUid uid, BinComponent component, MapInitEvent args)
@@ -64,6 +63,11 @@ public sealed class BinSystem : EntitySystem
                 return;
             }
         }
+    }
+
+    private void OnEntInserted(Entity<BinComponent> ent, ref EntInsertedIntoContainerMessage args)
+    {
+        ent.Comp.Items.Add(args.Entity);
     }
 
     private void OnEntRemoved(EntityUid uid, BinComponent component, EntRemovedFromContainerMessage args)
@@ -96,7 +100,7 @@ public sealed class BinSystem : EntitySystem
         if (args.Using != null)
         {
             var canReach = args.CanAccess && args.CanInteract;
-            InsertIntoBin(args.User, args.Target, (EntityUid) args.Using, component, false, canReach);
+            InsertIntoBin(args.User, args.Target, (EntityUid)args.Using, component, false, canReach);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes two small improvements to `BinSystem`:
- The bin now tracks items that get inserted in any way, instead of only tracking items that are inserted by hand through `BinSystem` itself. This allows other systems to interact with the container without breaking the bin's behavior - for example, you could use `ThrowInsertContainer` to throw items into a bin and still be able to take them back out by clicking on it.
- The container ID can now be specified on the component instead of being hardcoded as "bin-container". For compatibility, "bin-container" is the default value.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- I want the bin insert/remove functionality for something that I'm working on, but I need another system to be able to interact with the same container.
- Being able to specify the container ID is just a bit nicer, and matches the functionality of other systems that interact with containers.

## Technical details
<!-- Summary of code changes for easier review. -->
- Added an `EntInsertedIntoContainerMessage` subscription to `BinSystem` which adds the entity to the `BinComponent`'s list.
- Deleted the `BinContainerId` constant and added a `ContainerId` DataField to `BinComponent`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->