### PR TITLE
Cleanup 2 `SpriteComponent.GetPrototypeTextures` uses

### DIFF
--- a/Content.Client/Mapping/MappingState.cs
+++ b/Content.Client/Mapping/MappingState.cs
@@ -454,7 +454,7 @@ public sealed class MappingState : GameplayStateBase
         switch (prototype)
         {
             case EntityPrototype entity:
-                textures.AddRange(SpriteComponent.GetPrototypeTextures(entity, _resources).Select(t => t.Default));
+                textures.AddRange(_sprite.GetPrototypeTextures(entity).Select(t => t.Default));
                 break;
             case DecalPrototype decal:
                 textures.Add(_sprite.Frame0(decal.Sprite));

--- a/Content.IntegrationTests/Tests/DummyIconTest.cs
+++ b/Content.IntegrationTests/Tests/DummyIconTest.cs
@@ -16,6 +16,7 @@ namespace Content.IntegrationTests.Tests
             var client = pair.Client;
             var prototypeManager = client.ResolveDependency<IPrototypeManager>();
             var resourceCache = client.ResolveDependency<IResourceCache>();
+            var spriteSys = client.System<SpriteSystem>();
 
             await client.WaitAssertion(() =>
             {
@@ -26,7 +27,7 @@ namespace Content.IntegrationTests.Tests
 
                     Assert.DoesNotThrow(() =>
                     {
-                        var _ = SpriteComponent.GetPrototypeTextures(proto, resourceCache).ToList();
+                        var _ = spriteSys.GetPrototypeTextures(proto).ToList();
                     }, "Prototype {0} threw an exception when getting its textures.",
                         proto.ID);
                 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 2 warnings from uses of the obsolete `SpriteComponent.GetPrototypeTextures` method.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Now that https://github.com/space-wizards/RobustToolbox/pull/6001 has been merged and reached content, we have the replacement system method for `GetPrototypeTextures`. This PR fixes 2 of the 3 uses of it.
- In `MappingState`, we already have a reference to `SpriteSystem` in `_sprite`, so we just use that.
- In `DummyIconTest`, we use the `System` method of the client test instance to get `SpriteSystem` (the standard way of getting entsystem references in tests).

The third use is in `ConstructionPlacementHijack` and I have a fix for it, but it needs `PlacementManager.EntityManager` to be changed from `internal` to `public` (which https://github.com/space-wizards/RobustToolbox/pull/5994 happens to do for other reasons).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->