### PR TITLE
Make BODAs start with Russian accent.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1166,6 +1166,7 @@
     radius: 1.5
     energy: 1.6
     color: "#389690"
+  - type: RussianAccent
 
 - type: entity
   parent: VendingMachine


### PR DESCRIPTION
## About the PR
Now sentient BODA vending gets russian accent

## Why / Balance
tommorow I played on vulture, and someone pulled sentient BODA to the medbay, after this someone said in LOOC that will be cool if sentient BODAs get russian accent. I think that this is cool idea. So, why not? Anyway sentient machine event is pretty boring and rare.

## Technical details
I haven't touched chatcode/code of accent, just added component to the entproto. Should be fine with freeze.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.