### PR TITLE
Reagent Fires [DRAFT]

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
@@ -311,6 +311,23 @@ public partial class AtmosphereSystem
         return true;
     }
 
+    public void SetFlammableAtTile(Entity<TransformComponent?> ent, int flammability = 0)
+    {
+        if(!Resolve(ent, ref ent.Comp)) return;
+        var grid = ent.Comp.GridUid;
+        var position = _transformSystem.GetGridTilePositionOrDefault((ent, ent.Comp));
+        SetFlammableAtTile(position, grid, flammability);
+    }
+
+    public void SetFlammableAtTile(Vector2i position, Entity<GridAtmosphereComponent?>? grid, int flammability = 0)
+    {
+        if (grid is { } gridEnt && Resolve(gridEnt, ref gridEnt.Comp, false) && gridEnt.Comp.Tiles.TryGetValue(position, out var atmosTile))
+        {
+            atmosTile.SolutionFlammability = flammability;
+        }
+
+    }
+
     [ByRefEvent] private record struct SetSimulatedGridMethodEvent
         (EntityUid Grid, bool Simulated, bool Handled = false);
 

--- a/Content.Server/Atmos/TileAtmosphere.cs
+++ b/Content.Server/Atmos/TileAtmosphere.cs
@@ -130,6 +130,12 @@ namespace Content.Server.Atmos
         public bool TrimQueued;
 
         /// <summary>
+        /// An integer representing the flammibility of tile based on the solutions within it.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public int SolutionFlammability = 0;
+
+        /// <summary>
         /// Cached information about airtight entities on this tile. This gets updated anytime a tile gets invalidated
         /// (i.e., gets added to <see cref="GridAtmosphereComponent.InvalidatedCoords"/>).
         /// </summary>

--- a/Content.Shared/Atmos/TileFireEvent.cs
+++ b/Content.Shared/Atmos/TileFireEvent.cs
@@ -1,4 +1,4 @@
-﻿namespace Content.Server.Atmos
+﻿namespace Content.Shared.Atmos
 {
     /// <summary>
     ///     Event raised directed to an entity when it is standing on a tile that's on fire.

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -512,6 +512,15 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
         return true;
     }
 
+    public void BurnFlammableReagents(Entity<SolutionComponent> soln, float fraction)
+    {
+        var (uid, comp) = soln;
+        var solution = comp.Solution;
+
+        solution.BurnFlammableReagents(fraction, PrototypeManager);
+        UpdateChemicals(soln);
+    }
+
     /// <summary>
     ///     Removes reagent from a container.
     /// </summary>

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -88,6 +88,13 @@ namespace Content.Shared.Chemistry.Reagent
         [DataField]
         public float? MeltingPoint { get; private set; }
 
+        /// <summary>
+        /// How likely this reagent is to burst into flames.
+        /// Modeled loosely off NFPA 704.
+        /// </summary>
+        [DataField]
+        public int Flammability { get; private set; } = 0;
+
         [DataField]
         public SpriteSpecifier? MetamorphicSprite { get; private set; } = null;
 

--- a/Content.Shared/Fluids/SharedPuddleSystem.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Fluids.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.StepTrigger.Components;
+using Content.Shared.Atmos;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 
@@ -35,6 +36,7 @@ public abstract partial class SharedPuddleSystem : EntitySystem
         SubscribeLocalEvent<RefillableSolutionComponent, CanDropDraggedEvent>(OnRefillableCanDropDragged);
         SubscribeLocalEvent<PuddleComponent, GetFootstepSoundEvent>(OnGetFootstepSound);
         SubscribeLocalEvent<PuddleComponent, ExaminedEvent>(HandlePuddleExamined);
+        SubscribeLocalEvent<PuddleComponent, TileFireEvent>(OnPuddleBurn);
 
         InitializeSpillable();
     }
@@ -110,6 +112,14 @@ public abstract partial class SharedPuddleSystem : EntitySystem
         }
     }
 
+    private void OnPuddleBurn(Entity<PuddleComponent> entity, ref TileFireEvent args)
+    {
+        // TODO how the FUCK do we do this
+        if (!_solutionContainerSystem.ResolveSolution(entity.Owner, entity.Comp.SolutionName, ref entity.Comp.Solution,
+                out var solution))
+            return;
+        _solutionContainerSystem.BurnFlammableReagents(entity.Comp.Solution.Value, 0.05f);
+    }
     #region Spill
     // These methods are in Shared to make it easier to interact with PuddleSystem in Shared code.
     // Note that they always fail when run on the client, not creating a puddle and returning false.

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -143,6 +143,8 @@
         maxVol: 250
   - type: Tool
     speedModifier: 1.3
+  - type: IgnitionSource
+    temperature: 1000
 
 - type: entity
   name: experimental welding tool

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -43,6 +43,7 @@
   physicalDesc: reagent-physical-desc-soapy
   flavor: bitter
   color: "#FA00AF"
+  flammability: 5
   tileReactions:
   - !type:FlammableTileReaction
     temperatureMultiplier: 5
@@ -157,6 +158,7 @@
   recognizable: true
   boilingPoint: -84.7 # Acetylene. Close enough.
   meltingPoint: -80.7
+  flammability: 2
   friction: 0.4
   tileReactions:
   - !type:FlammableTileReaction {}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

This PR is ready for review but it is in draft as there are many possible suggestions that could be taken to improve this system.

## About the PR
Adds reagent fires. If a lit object is placed over a flammable puddle, it may ignite!

For testing, this property is only on welding fuel (flammability of 2) and napalm (flammability of 5) right now, but this can be extended to other reagents easily before it's merged.

## Why / Balance
It makes no sense that a puddle of welding fuel would *not* burst into flames.

The fires are currently very powerful, with a welding fuel fire reaching 400C easily, and a napalm fire reaching 1000C on average.

## Technical details
On puddle update, the puddle system will calculate a flammability rating for itself and pass that to the atmos tile through the Atmospherics API.

The rest is hooked into the Atmospherics Hotspot system, such that if a hotspot exposure is attempted at a tile with a flammability rating greater than 0, it will set itself on fire.

SharedPuddleSystem now listens for TileFireEvents, and "burns off" flammable reagents when required.

## Media
https://streamable.com/c7sjt0

As seen here, reagents that are more flammable burn off more quickly.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
TileFireEvent was moved to shared to prevent mispredicts.

**Changelog**
:cl: UpAndLeaves
- add: Puddles are now flammable, flammable substances may cause "reagent fires" if ignited.
