### PR TITLE
Fix puncturase cauterizing bleeding

### DIFF
--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -23,7 +23,7 @@ namespace Content.Shared.Damage
         [JsonPropertyName("types")]
         [DataField("types", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<FixedPoint2, DamageTypePrototype>))]
         [UsedImplicitly]
-        private Dictionary<string,FixedPoint2>? _damageTypeDictionary;
+        private Dictionary<string, FixedPoint2>? _damageTypeDictionary;
 
         [JsonPropertyName("groups")]
         [DataField("groups", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<FixedPoint2, DamageGroupPrototype>))]
@@ -152,7 +152,7 @@ namespace Content.Shared.Damage
                 if (modifierSet.Coefficients.TryGetValue(key, out var coefficient))
                     newValue *= coefficient; // coefficients can heal you, e.g. cauterizing bleeding
 
-                if(newValue != 0)
+                if (newValue != 0)
                     newDamage.DamageDict[key] = FixedPoint2.New(newValue);
             }
 
@@ -179,6 +179,38 @@ namespace Content.Shared.Damage
 
             if (!any)
                 newDamage = new DamageSpecifier(damageSpec);
+
+            return newDamage;
+        }
+
+        /// <summary>
+        /// Returns a new DamageSpecifier that only contains the entries with positive value.
+        /// </summary>
+        public static DamageSpecifier GetPositive(DamageSpecifier damageSpec)
+        {
+            DamageSpecifier newDamage = new();
+
+            foreach (var (key, value) in damageSpec.DamageDict)
+            {
+                if (value > 0)
+                    newDamage.DamageDict[key] = value;
+            }
+
+            return newDamage;
+        }
+
+        /// <summary>
+        /// Returns a new DamageSpecifier that only contains the entries with negative value.
+        /// </summary>
+        public static DamageSpecifier GetNegative(DamageSpecifier damageSpec)
+        {
+            DamageSpecifier newDamage = new();
+
+            foreach (var (key, value) in damageSpec.DamageDict)
+            {
+                if (value < 0)
+                    newDamage.DamageDict[key] = value;
+            }
 
             return newDamage;
         }

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -237,21 +237,24 @@
 
 # Represents which damage types should be modified
 # in relation to how they cause bleed rate.
+# Make sure to add any new damage type here.
 - type: damageModifierSet
   id: BloodlossHuman
   coefficients:
-    Blunt: 0.08
-    Slash: 0.25
-    Piercing: 0.2
-    Shock: 0.0
-    Cold: 0.0
-    Heat: -0.5 # heat damage cauterizes wounds, but will still hurt obviously.
-    Poison: 0.0
-    Radiation: 0.0
     Asphyxiation: 0.0
     Bloodloss: 0.0 # no double dipping
-    Cellular: 0.0
+    Blunt: 0.08
     Caustic: 0.0
+    Cellular: 0.0
+    Cold: 0.0
+    Heat: -0.5 # heat damage cauterizes wounds, but will still hurt obviously.
+    Holy: 0
+    Piercing: 0.2
+    Poison: 0.0
+    Radiation: 0.0
+    Shock: 0.0
+    Slash: 0.25
+    Structural: 0.0
 
 - type: damageModifierSet
   id: SlimePet # Very survivable slimes


### PR DESCRIPTION
## About the PR
Fixes #31137
Supercedes #31656 (the fix in that PR was not working correctly and also hardcoded to heat damage)

## Why / Balance
bugfix

## Technical details
The bug occured when something heals and deals damage at the same time.
For example puncturase has a damage of
-4 Pierce
+0.1 Blunt

After the coefficients for bleeding were applied this caused `totalFloat` to be negative, which resulted in the bloodloss being reduced.
The `DamageIncreased` check was insufficient because that only checks if any damage type was increased.
Now we only consider damage dealing for bloodloss changes, not damage healing.

I also added some missing damage types to the list of bleeding coefficients. If revenants had a bloodstream they would bleed from holy damage.

## Media

https://github.com/user-attachments/assets/50e7b0d1-0311-4e05-a335-210480b3b151

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed some reagents like puncturase healing bleeding when they shouldn't.
