### PR TITLE
Prediction for use of utensil on incompatible food

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/UtensilSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/UtensilSystem.cs
@@ -44,7 +44,7 @@ public sealed class UtensilSystem : EntitySystem
         //Prevents food usage with a wrong utensil
         if ((food.Utensil & utensil.Comp.Types) == 0)
         {
-            _popupSystem.PopupEntity(Loc.GetString("food-system-wrong-utensil", ("food", target), ("utensil", utensil.Owner)), user, user);
+            _popupSystem.PopupClient(Loc.GetString("food-system-wrong-utensil", ("food", target), ("utensil", utensil.Owner)), user, user);
             return (false, true);
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Using a utensil on an incompatible food will no longer spam the associated error message due to lack of prediction.

## Why / Balance
Minor bugfix. Fixing  unintended, visual behavior.

## Technical details
Changing the `PopupEntity` in `UtensilSystem.cs` into `PopupClient`.

## Media
Before:

https://github.com/user-attachments/assets/8f08fa92-9e02-4b49-9c01-751b7bd3384a

After:

https://github.com/user-attachments/assets/18a20b43-8687-4f6c-b7dd-33d39aeec179

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Utensils don't spam a warning for incompatible foods.