### PR TITLE
Allows the cryotube beaker container to be inserted to by Dragging and Dropping(Needs Review)

### DIFF
--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -137,7 +137,11 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
 
     private void HandleDragDropOn(Entity<CryoPodComponent> entity, ref DragDropTargetEvent args)
     {
-        if (entity.Comp.BodyContainer.ContainedEntity != null)
+        if (_itemSlotsSystem.TryInsert(entity, entity.Comp.SolutionContainerName, args.Dragged, args.User) == false)
+            args.Handled = false;
+        else args.Handled = true;
+
+        if (entity.Comp.BodyContainer.ContainedEntity != null || args.Handled == true)
             return;
 
         var doAfterArgs = new DoAfterArgs(EntityManager, args.User, entity.Comp.EntryDelay, new CryoPodDragFinished(), entity, target: args.Dragged, used: entity)

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -137,9 +137,10 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
 
     private void HandleDragDropOn(Entity<CryoPodComponent> entity, ref DragDropTargetEvent args)
     {
-        if (_itemSlotsSystem.TryInsert(entity, entity.Comp.SolutionContainerName, args.Dragged, args.User) == false)
-            args.Handled = false;
-        else args.Handled = true;
+        if (_itemSlotsSystem.TryInsert(entity, entity.Comp.SolutionContainerName, args.Dragged, args.User) == true) {
+            args.Handled = true;
+            return;
+        }
 
         if (entity.Comp.BodyContainer.ContainedEntity != null || args.Handled == true)
             return;

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -72,7 +72,6 @@ namespace Content.Shared.Containers.ItemSlots
                     continue;
 
                 var item = Spawn(slot.StartingItem, Transform(uid).Coordinates);
-                    
                 if (slot.ContainerSlot != null)
                     _containers.Insert(item, slot.ContainerSlot);
             }

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -72,6 +72,7 @@ namespace Content.Shared.Containers.ItemSlots
                     continue;
 
                 var item = Spawn(slot.StartingItem, Transform(uid).Coordinates);
+
                 if (slot.ContainerSlot != null)
                     _containers.Insert(item, slot.ContainerSlot);
             }

--- a/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
+++ b/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Administration.Logs;
 using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.Components;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
@@ -12,7 +13,6 @@ using Content.Shared.Stunnable;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 using Robust.Shared.Serialization;
-using Content.Shared.Chemistry.Components;
 
 namespace Content.Shared.Medical.Cryogenics;
 

--- a/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
+++ b/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Stunnable;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 using Robust.Shared.Serialization;
+using Content.Shared.Chemistry.Components;
 
 namespace Content.Shared.Medical.Cryogenics;
 
@@ -38,8 +39,8 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
     {
         if (args.Handled)
             return;
+        args.CanDrop = true ? HasComp<BodyComponent>(args.Dragged) | HasComp<FitsInDispenserComponent>(args.Dragged) : true;
 
-        args.CanDrop = HasComp<BodyComponent>(args.Dragged);
         args.Handled = true;
     }
 

--- a/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
+++ b/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
@@ -39,7 +39,7 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
     {
         if (args.Handled)
             return;
-        args.CanDrop = true ? HasComp<BodyComponent>(args.Dragged) | HasComp<FitsInDispenserComponent>(args.Dragged) : true;
+        args.CanDrop = HasComp<BodyComponent>(args.Dragged) | HasComp<FitsInDispenserComponent>(args.Dragged);
 
         args.Handled = true;
     }


### PR DESCRIPTION
## About the PR
This is a very simple change that allows for items that can be inserted into the cryotube's Chemical Beaker slot by clicking on the cryotube itself while holding the item in your hand to also be insertable through dragging and dropping the item entity onto the cryotube

## Why / Balance
My main reason for doing this is to allow borgs to use cryotubes as intended, as they are otherwise unable to insert anything into a Chemical Beaker slot. This would make cryotubes more usable for any sillicon players, which would (hopefully) make cryotubes used more in general.

## Technical details
Only a couple lines of change were made. Reading the code will be faster than reading this explanation:
Added an or statement to the `CanDrop` argument in `OnCryoPodCanDropOn` in `SharedCryoPodSystems,` which makes `CanDrop` true whenever the dragged entity has the `BodyComponent` (default behavior) or the `FitsInDispenserComponent.` I also had to add using `Content.Shared.Chemistry.Components` to allow this check.

Second change is to `HandleDragDropOn` event in `CryoPodSystems,` also simple, it simply tries to insert the item into the Chemical Beaker slot using `TryInsert,` if it fails the argument Handled is set to false, if it succeeds the argument `Handled` is set to true. One more line is changed right after to cause the `HandleOnDragDropOn` to return if `Handled` has been set to true.

This is my first PR, and I am still new to C#, so I expect there to be at least something wrong with how I went about this. Please let me know so I can improve!

## Media

https://github.com/user-attachments/assets/dd6ec930-bd4a-4db4-bca5-738bfabd7954



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
None

**Changelog**
:cl:
- add: Added the ability for the Cryotube's beaker container to have beakers inserted through Dragging and Dropping.