### PR TITLE
Fix communications console thinking it can announce in the first 5 seconds after spawning it

### DIFF
--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -42,7 +42,7 @@ namespace Content.Server.Communications
         {
             // All events that refresh the BUI
             SubscribeLocalEvent<AlertLevelChangedEvent>(OnAlertLevelChanged);
-            SubscribeLocalEvent<CommunicationsConsoleComponent, ComponentInit>((uid, comp, _) => UpdateCommsConsoleInterface(uid, comp));
+            SubscribeLocalEvent<CommunicationsConsoleComponent, ComponentInit>(OnCommunicationsConsoleInit);
             SubscribeLocalEvent<RoundEndSystemChangedEvent>(_ => OnGenericBroadcastEvent());
             SubscribeLocalEvent<AlertLevelDelayFinishedEvent>(_ => OnGenericBroadcastEvent());
 
@@ -52,9 +52,6 @@ namespace Content.Server.Communications
             SubscribeLocalEvent<CommunicationsConsoleComponent, CommunicationsConsoleBroadcastMessage>(OnBroadcastMessage);
             SubscribeLocalEvent<CommunicationsConsoleComponent, CommunicationsConsoleCallEmergencyShuttleMessage>(OnCallShuttleMessage);
             SubscribeLocalEvent<CommunicationsConsoleComponent, CommunicationsConsoleRecallEmergencyShuttleMessage>(OnRecallShuttleMessage);
-
-            // On console init, set cooldown
-            SubscribeLocalEvent<CommunicationsConsoleComponent, MapInitEvent>(OnCommunicationsConsoleMapInit);
         }
 
         public override void Update(float frameTime)
@@ -82,9 +79,10 @@ namespace Content.Server.Communications
             base.Update(frameTime);
         }
 
-        public void OnCommunicationsConsoleMapInit(EntityUid uid, CommunicationsConsoleComponent comp, MapInitEvent args)
+        private void OnCommunicationsConsoleInit(EntityUid uid, CommunicationsConsoleComponent comp, ComponentInit args)
         {
             comp.AnnouncementCooldownRemaining = comp.InitialDelay;
+            UpdateCommsConsoleInterface(uid, comp);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
There is a 30s delay after spawning a comms console where it can't announce. Despite this, the announce button is enabled for the first 5 seconds after spawning the console. Pressing announce within the 5 seconds does nothing. I fix it so the announce button is correctly grey from the very beginning.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bug fix

## Technical details
<!-- Summary of code changes for easier review. -->
The bug happens because `CommunicationsConsoleSystem.OnCommunicationsConsoleMapInit` was run after `CommunicationsConsoleSystem.UpdateCommsConsoleInterface` is run for the first time so `CommunicationsConsoleComponent.AnnouncementCooldownRemaining` would be checked before actually being set to `CommunicationsConsoleComponent.InitialDelay`.

I changed `MapInitEvent` to `ComponentInit`. The announce delay timer still stays frozen until map init.
