### PR TITLE
Made Kobolds have like health to their genetically barely similar cousin

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1551,11 +1551,6 @@
       path: /Audio/Animals/lizard_happy.ogg
     interactFailureSound:
       path: /Audio/Items/wirecutter.ogg
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      60: Critical
-      125: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed: 3.5
     baseSprintSpeed: 5
@@ -1651,11 +1646,6 @@
   parent: MobBaseKobold
   suffix: syndicate base
   components:
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      100: Critical
-      200: Dead
   - type: NpcFactionMember
     factions:
     - Syndicate


### PR DESCRIPTION
## About the PR
For those unaware the base Kobold has less health than monkeys, taking only 40 less damage to go into crit while monkeys took 100 damage to go into crit
Now for some reason syndicate kobolds have as much health as a monkey which is inconsistent and mildly annoyed me

## Why / Balance
This will hopefully make people more willing to get kobold reinforcements because it's kinda well known that normal kobolds only take 60 damage to go into crit... but it's not well known that syndicate kobolds actually have the normal 100 health threshold of the monkey.

## Technical details
All YAML

## Media
Unless you want me to shoot a kobold an prove it with a med analyzer not much point

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
## Breaking changes

**Changelog**
:cl:
- tweak: Non-Syndicate Kobolds now have as much health as their genetic counterpart
