### PR TITLE
Cleanup SharedRoleCodewordSystem

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -136,8 +136,8 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         // Send codewords to only the traitor client
         var color = TraitorCodewordColor; // Fall back to a dark red Syndicate color if a prototype is not found
 
-        RoleCodewordComponent codewordComp = EnsureComp<RoleCodewordComponent>(mindId);
-        _roleCodewordSystem.SetRoleCodewords(codewordComp, "traitor", factionCodewords.ToList(), color);
+        var codewordComp = EnsureComp<RoleCodewordComponent>(mindId);
+        _roleCodewordSystem.SetRoleCodewords((mindId, codewordComp), "traitor", factionCodewords.ToList(), color);
 
         // Change the faction
         Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - Change faction");

--- a/Content.Shared/Roles/RoleCodeword/RoleCodewordComponent.cs
+++ b/Content.Shared/Roles/RoleCodeword/RoleCodewordComponent.cs
@@ -1,5 +1,4 @@
 using Robust.Shared.GameStates;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Roles.RoleCodeword;
@@ -16,8 +15,6 @@ public sealed partial class RoleCodewordComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public Dictionary<string, CodewordsData> RoleCodewords = new();
-
-    public override bool SessionSpecific => true;
 }
 
 [DataDefinition, Serializable, NetSerializable]

--- a/Content.Shared/Roles/RoleCodeword/SharedRoleCodewordSystem.cs
+++ b/Content.Shared/Roles/RoleCodeword/SharedRoleCodewordSystem.cs
@@ -1,49 +1,11 @@
-using Content.Shared.Mind;
-using Robust.Shared.GameStates;
-using Robust.Shared.Player;
-
 namespace Content.Shared.Roles.RoleCodeword;
 
 public abstract class SharedRoleCodewordSystem : EntitySystem
 {
-    [Dependency] private readonly SharedMindSystem _mindSystem = default!;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<RoleCodewordComponent, ComponentGetStateAttemptEvent>(OnCodewordCompGetStateAttempt);
-    }
-
-    /// <summary>
-    /// Determines if a codeword component should be sent to the client.
-    /// </summary>
-    private void OnCodewordCompGetStateAttempt(EntityUid uid, RoleCodewordComponent comp, ref ComponentGetStateAttemptEvent args)
-    {
-        args.Cancelled = !CanGetState(args.Player, comp);
-    }
-
-    /// <summary>
-    /// The criteria that determine whether a codeword component should be sent to a client.
-    /// Sends the component if its owner is the player mind.
-    /// </summary>
-    /// <param name="player"> The Player the component will be sent to.</param>
-    /// <param name="comp"> The component being checked against</param>
-    /// <returns></returns>
-    private bool CanGetState(ICommonSession? player, RoleCodewordComponent comp)
-    {
-        if (!_mindSystem.TryGetMind(player, out EntityUid mindId, out var _))
-            return false;
-
-        if (!TryComp(mindId, out RoleCodewordComponent? playerComp) && comp != playerComp)
-            return false;
-
-        return true;
-    }
-
-    public void SetRoleCodewords(RoleCodewordComponent comp, string key, List<string> codewords, Color color)
+    public void SetRoleCodewords(Entity<RoleCodewordComponent> ent, string key, List<string> codewords, Color color)
     {
         var data = new CodewordsData(color, codewords);
-        comp.RoleCodewords[key] = data;
+        ent.Comp.RoleCodewords[key] = data;
+        Dirty(ent, ent.Comp);
     }
 }


### PR DESCRIPTION
## About the PR
Remove some code that did not do anything.

## Why / Balance
cleanup

## Technical details
The component was made session specific to prevent cheat clients from seeing other player's codewords.
However, this was redundant.
`RoleCodewordComponent` is stored on the player's mind. Mind entities are stored in nullspace and the player it belongs to has a PVS override, so it gets networked to only them, which means other clients cannot see that component in the first place.

I also added a missing `Dirty` call for the `SetRoleCodewords` method. It was only working because it was called in the same tick where the component is added.

## Media
Proof that everything still works and other clients cannot see the component.

https://github.com/user-attachments/assets/76ec887e-94fb-45e3-8de4-6b6ad548ea45

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`SetRoleCodewords` in the `SharedRoleCodewordSystem` now requires an `Entity<RoleCodewordComponent>`

**Changelog**
none