### PR TITLE
Power cell examine is now predicted

### DIFF
--- a/Content.Server/PowerCell/PowerCellSystem.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.cs
@@ -34,6 +34,7 @@ public sealed partial class PowerCellSystem : SharedPowerCellSystem
 
         SubscribeLocalEvent<PowerCellComponent, ChargeChangedEvent>(OnChargeChanged);
         SubscribeLocalEvent<PowerCellComponent, EmpAttemptEvent>(OnCellEmpAttempt);
+        SubscribeLocalEvent<PowerCellComponent, MapInitEvent>(OnCellMapInit);
 
         SubscribeLocalEvent<PowerCellDrawComponent, ChargeChangedEvent>(OnDrawChargeChanged);
         SubscribeLocalEvent<PowerCellDrawComponent, PowerCellChangedEvent>(OnDrawCellChanged);
@@ -43,6 +44,16 @@ public sealed partial class PowerCellSystem : SharedPowerCellSystem
 
         SubscribeLocalEvent<PowerCellSlotComponent, GetChargeEvent>(OnGetCharge);
         SubscribeLocalEvent<PowerCellSlotComponent, ChangeChargeEvent>(OnChangeCharge);
+    }
+
+    private void OnCellMapInit(EntityUid uid, PowerCellComponent comp, MapInitEvent args)
+    {
+        if (!TryComp<BatteryComponent>(uid, out var battery))
+            return;
+
+        var percentage = battery.CurrentCharge / battery.MaxCharge * 100;
+        comp.PercentCharge = percentage;
+        Dirty(uid, comp);
     }
 
     private void OnSlotMicrowaved(EntityUid uid, PowerCellSlotComponent component, BeingMicrowavedEvent args)

--- a/Content.Shared/PowerCell/Components/PowerCellComponent.cs
+++ b/Content.Shared/PowerCell/Components/PowerCellComponent.cs
@@ -9,9 +9,16 @@ namespace Content.Shared.PowerCell;
 /// </summary>
 [NetworkedComponent]
 [RegisterComponent]
+[AutoGenerateComponentState]
 public sealed partial class PowerCellComponent : Component
 {
     public const int PowerCellVisualsLevels = 2;
+
+    /// <summary>
+    /// The percentage charge of this power cell.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float PercentCharge;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/PowerCell/SharedPowerCellSystem.cs
+++ b/Content.Shared/PowerCell/SharedPowerCellSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Examine;
 using Content.Shared.PowerCell.Components;
 using Content.Shared.Rejuvenate;
 using Robust.Shared.Containers;
@@ -18,6 +19,9 @@ public abstract class SharedPowerCellSystem : EntitySystem
 
         SubscribeLocalEvent<PowerCellDrawComponent, MapInitEvent>(OnMapInit);
 
+        SubscribeLocalEvent<PowerCellComponent, ExaminedEvent>(OnCellExamine);
+
+        SubscribeLocalEvent<PowerCellSlotComponent, ExaminedEvent>(OnCellSlotExamine);
         SubscribeLocalEvent<PowerCellSlotComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<PowerCellSlotComponent, EntInsertedIntoContainerMessage>(OnCellInserted);
         SubscribeLocalEvent<PowerCellSlotComponent, EntRemovedFromContainerMessage>(OnCellRemoved);
@@ -50,6 +54,22 @@ public abstract class SharedPowerCellSystem : EntitySystem
         {
             args.Cancel();
         }
+    }
+
+    private void OnCellExamine(EntityUid uid, PowerCellComponent comp, ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("power-cell-component-examine-details", ("currentCharge", $"{comp.PercentCharge:F0}")));
+    }
+
+    private void OnCellSlotExamine(EntityUid uid, PowerCellSlotComponent comp, ExaminedEvent args)
+    {
+        if (!_itemSlots.TryGetSlot(uid, comp.CellSlotId, out var cellSlot) || cellSlot.Item is null)
+        {
+            args.PushMarkup(Loc.GetString("power-cell-component-examine-details-no-battery"));
+            return;
+        }
+
+        RaiseLocalEvent(cellSlot.Item.Value, args);
     }
 
     private void OnCellInserted(EntityUid uid, PowerCellSlotComponent component, EntInsertedIntoContainerMessage args)

--- a/Resources/Locale/en-US/power-cell/components/power-cell-component.ftl
+++ b/Resources/Locale/en-US/power-cell/components/power-cell-component.ftl
@@ -1,4 +1,4 @@
-power-cell-component-examine-details = The charge indicator reads [color=#5E7C16]{$currentCharge}[/color] %.
+power-cell-component-examine-details = The charge indicator reads [color=#5E7C16]{$currentCharge}[/color]%.
 power-cell-component-examine-details-no-battery = There is no power cell inserted.
 power-cell-no-battery = No power cell found
 power-cell-insufficient = Insufficient power

--- a/Resources/Locale/en-US/power-cell/components/power-cell-component.ftl
+++ b/Resources/Locale/en-US/power-cell/components/power-cell-component.ftl
@@ -1,4 +1,4 @@
-power-cell-component-examine-details = The charge indicator reads [color=#5E7C16]{$currentCharge}[/color]%.
+power-cell-component-examine-details = The charge indicator reads [color=#5E7C16]{$currentCharge}[/color] %.
 power-cell-component-examine-details-no-battery = There is no power cell inserted.
 power-cell-no-battery = No power cell found
 power-cell-insufficient = Insufficient power


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Examining a power cell or an entity with a power cell inside will now instantly show you the percentage charge instead of waiting for the server.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
PowerCellComponent now has PercentageCharge field that is set server side.
The examine messages are moved to shared and they work off this field.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

It's the same as before it just happens instantly now.
![Screenshot from 2025-06-13 19-30-37](https://github.com/user-attachments/assets/b9129ff6-30aa-4c83-9b12-bdd51fc23a37)
![Screenshot from 2025-06-13 19-30-56](https://github.com/user-attachments/assets/cbf39584-1705-441b-89f9-92ce91230850)
![Screenshot from 2025-06-13 19-31-10](https://github.com/user-attachments/assets/6f82212b-0e0c-4b9b-8a97-d54ffb16aca2)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No changelog 
