### PR TITLE
Add integration test for equipping/unequipping clothing entities

### DIFF
--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.UnitTesting;
 using Content.Shared.Item.ItemToggle;
+using Content.Shared.Tag;
 using Robust.Client.State;
 
 namespace Content.IntegrationTests.Tests.Interaction;
@@ -100,6 +101,7 @@ public abstract partial class InteractionTest
     protected SharedInteractionSystem InteractSys = default!;
     protected Content.Server.Construction.ConstructionSystem SConstruction = default!;
     protected SharedDoAfterSystem DoAfterSys = default!;
+    protected TagSystem Tags = default!;
     protected ToolSystem ToolSys = default!;
     protected ItemToggleSystem ItemToggleSys = default!;
     protected InteractionTestSystem STestSystem = default!;
@@ -167,6 +169,7 @@ public abstract partial class InteractionTest
         ToolSys = SEntMan.System<ToolSystem>();
         ItemToggleSys = SEntMan.System<ItemToggleSystem>();
         DoAfterSys = SEntMan.System<SharedDoAfterSystem>();
+        Tags = SEntMan.System<TagSystem>();
         Transform = SEntMan.System<SharedTransformSystem>();
         MapSystem = SEntMan.System<SharedMapSystem>();
         SConstruction = SEntMan.System<Server.Construction.ConstructionSystem>();

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
@@ -22,7 +22,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.UnitTesting;
 using Content.Shared.Item.ItemToggle;
-using Content.Shared.Tag;
+using Content.Shared.Whitelist;
 using Robust.Client.State;
 
 namespace Content.IntegrationTests.Tests.Interaction;
@@ -101,7 +101,6 @@ public abstract partial class InteractionTest
     protected SharedInteractionSystem InteractSys = default!;
     protected Content.Server.Construction.ConstructionSystem SConstruction = default!;
     protected SharedDoAfterSystem DoAfterSys = default!;
-    protected TagSystem Tags = default!;
     protected ToolSystem ToolSys = default!;
     protected ItemToggleSystem ItemToggleSys = default!;
     protected InteractionTestSystem STestSystem = default!;
@@ -109,6 +108,7 @@ public abstract partial class InteractionTest
     protected SharedMapSystem MapSystem = default!;
     protected ISawmill SLogger = default!;
     protected SharedUserInterfaceSystem SUiSys = default!;
+    protected EntityWhitelistSystem Whitelist = default!;
 
     // CLIENT dependencies
     protected IEntityManager CEntMan = default!;
@@ -169,7 +169,6 @@ public abstract partial class InteractionTest
         ToolSys = SEntMan.System<ToolSystem>();
         ItemToggleSys = SEntMan.System<ItemToggleSystem>();
         DoAfterSys = SEntMan.System<SharedDoAfterSystem>();
-        Tags = SEntMan.System<TagSystem>();
         Transform = SEntMan.System<SharedTransformSystem>();
         MapSystem = SEntMan.System<SharedMapSystem>();
         SConstruction = SEntMan.System<Server.Construction.ConstructionSystem>();
@@ -177,6 +176,7 @@ public abstract partial class InteractionTest
         Stack = SEntMan.System<StackSystem>();
         SLogger = Server.ResolveDependency<ILogManager>().RootSawmill;
         SUiSys = Client.System<SharedUserInterfaceSystem>();
+        Whitelist = SEntMan.System<EntityWhitelistSystem>();
 
         // client dependencies
         CEntMan = Client.ResolveDependency<IEntityManager>();

--- a/Content.IntegrationTests/Tests/Inventory/ClothingEquipTest.cs
+++ b/Content.IntegrationTests/Tests/Inventory/ClothingEquipTest.cs
@@ -11,6 +11,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Prototypes;
 using Content.Shared.Storage.Components;
+using Content.Shared.Tag;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 
@@ -35,6 +36,11 @@ public sealed class ClothingEquipTest : InteractionTest
         typeof(RandomSpawnerComponent),
     ];
 
+    private readonly List<ProtoId<TagPrototype>> _ignoredTags =
+    [
+        "PetOnly",
+    ];
+
     private readonly List<Type> _removedComponents =
     [
         // Material bag can pick up other clothing items.
@@ -51,6 +57,8 @@ public sealed class ClothingEquipTest : InteractionTest
                         && !x.HideSpawnMenu
                         && !x.Abstract
                         && !Pair.IsTestPrototype(x)
+                        && !(x.TryGetComponent<TagComponent>(out var tags, Factory)
+                             && Tags.HasAnyTag(tags, _ignoredTags))
                         && !_ignoredComponents.Any(ignore => x.HasComponent(ignore)));
 
         List<EntityUid> clothings = [];

--- a/Content.IntegrationTests/Tests/Inventory/ClothingEquipTest.cs
+++ b/Content.IntegrationTests/Tests/Inventory/ClothingEquipTest.cs
@@ -26,20 +26,32 @@ public sealed class ClothingEquipTest : InteractionTest
 {
     private const string HardsuitProto = "ClothingOuterHardsuitEVA";
     private const string JumpsuitProto = "ClothingUniformJumpsuitColorGrey";
+
+    private readonly List<Type> _ignoredComponents =
+    [
+        // Mobs are a massive pain in this test
+        // (Admeme mouse eating your cak, cancer mouse killing you... mice just dying...)
+        typeof(MobStateComponent),
+        typeof(RandomSpawnerComponent),
+    ];
+
+    private readonly List<Type> _removedComponents =
+    [
+        // Material bag can pick up other clothing items.
+        typeof(MagnetPickupComponent),
+    ];
+
     protected override string PlayerPrototype => "MobHuman";
 
     [Test]
-    public async Task EquipAllClothingTesting()
+    public async Task EquipAllClothingTest()
     {
         var clothingProtos = ProtoMan.EnumeratePrototypes<EntityPrototype>()
             .Where(x => x.HasComponent<ClothingComponent>()
                         && !x.HideSpawnMenu
                         && !x.Abstract
                         && !Pair.IsTestPrototype(x)
-                        && !x.HasComponent<RandomSpawnerComponent>()
-                        // Mobs are a massive pain in this test
-                        // (Admeme mouse eating your cak, cancer mouse killing you... mice just dying...)
-                        && !x.HasComponent<MobStateComponent>());
+                        && !_ignoredComponents.Any(ignore => x.HasComponent(ignore)));
 
         List<EntityUid> clothings = [];
         EntityUid jumpsuit = default!;
@@ -51,8 +63,7 @@ public sealed class ClothingEquipTest : InteractionTest
                 var ent = SEntMan.SpawnAtPosition(clothing.ID, ToServer(PlayerCoords));
                 clothings.Add(ent);
 
-                // Material bag can pick up other clothing items.
-                SEntMan.RemoveComponent<MagnetPickupComponent>(ent);
+                _removedComponents.ForEach(remove => SEntMan.RemoveComponent(ent, remove));
             }
 
             jumpsuit = SEntMan.SpawnAtPosition(JumpsuitProto, ToServer(PlayerCoords));

--- a/Content.IntegrationTests/Tests/Inventory/ClothingEquipTest.cs
+++ b/Content.IntegrationTests/Tests/Inventory/ClothingEquipTest.cs
@@ -1,0 +1,176 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Server.Actions;
+using Content.Server.Inventory;
+using Content.Server.Spawners.Components;
+using Content.Shared.Actions.Components;
+using Content.Shared.Clothing.Components;
+using Content.Shared.Interaction.Components;
+using Content.Shared.Inventory;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Prototypes;
+using Content.Shared.Storage.Components;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Inventory;
+
+/// <summary>
+/// This test spawns in every item that has a ClothingComponent and then simulates:
+/// 1. Equipping it (and jumpsuit/hardsuit if needed)
+/// 2. Triggering any InstantActions it grants.
+/// 3. Unequipping it.
+/// </summary>
+public sealed class ClothingEquipTest : InteractionTest
+{
+    private const string HardsuitProto = "ClothingOuterHardsuitEVA";
+    private const string JumpsuitProto = "ClothingUniformJumpsuitColorGrey";
+    protected override string PlayerPrototype => "MobHuman";
+
+    [Test]
+    public async Task EquipAllClothingTesting()
+    {
+        var clothingProtos = ProtoMan.EnumeratePrototypes<EntityPrototype>()
+            .Where(x => x.HasComponent<ClothingComponent>()
+                        && !x.HideSpawnMenu
+                        && !x.Abstract
+                        && !Pair.IsTestPrototype(x)
+                        && !x.HasComponent<RandomSpawnerComponent>()
+                        // Mobs are a massive pain in this test
+                        // (Admeme mouse eating your cak, cancer mouse killing you... mice just dying...)
+                        && !x.HasComponent<MobStateComponent>());
+
+        List<EntityUid> clothings = [];
+        EntityUid jumpsuit = default!;
+        EntityUid hardsuit = default!;
+        await Server.WaitPost(() =>
+        {
+            foreach (var clothing in clothingProtos)
+            {
+                var ent = SEntMan.SpawnAtPosition(clothing.ID, ToServer(PlayerCoords));
+                clothings.Add(ent);
+
+                // Material bag can pick up other clothing items.
+                SEntMan.RemoveComponent<MagnetPickupComponent>(ent);
+            }
+
+            jumpsuit = SEntMan.SpawnAtPosition(JumpsuitProto, ToServer(PlayerCoords));
+            hardsuit = SEntMan.SpawnAtPosition(HardsuitProto, ToServer(PlayerCoords));
+        });
+
+        await AddAtmosphere();
+
+        var invSystem = Server.System<ServerInventorySystem>();
+        var invComp = SEntMan.GetComponent<InventoryComponent>(SPlayer);
+
+        var actionSys = Server.System<ActionsSystem>();
+        var baseActions = actionSys.GetActions(SPlayer).ToList();
+
+        foreach (var clothing in clothings)
+        {
+            Assert.That(SEntMan.TryGetComponent<ClothingComponent>(clothing, out var clothingComp),
+                $"{SEntMan.ToPrettyString(clothing)} doesn't have ClothingComponent");
+            foreach (var slot in invComp.Slots)
+            {
+                if ((slot.SlotFlags & clothingComp!.Slots) == 0x0)
+                    continue;
+
+                await Server.WaitAssertion(() =>
+                {
+                    if (slot.SlotFlags is SlotFlags.IDCARD or SlotFlags.POCKET)
+                        DoEquip(invSystem, jumpsuit, "jumpsuit");
+
+                    if (slot.SlotFlags == SlotFlags.SUITSTORAGE)
+                        DoEquip(invSystem, hardsuit, "outerClothing");
+
+                    DoEquip(invSystem, clothing, slot.Name, clothingComp);
+                });
+                await RunTicks(1);
+
+                var newActions = actionSys.GetActions(SPlayer)
+                    .Except(baseActions)
+                    // Don't bother with more complicated actions (they can take targets, etc.)
+                    .Where(action => SEntMan.HasComponent<InstantActionComponent>(action.Owner))
+                    .ToList();
+
+                await Server.WaitPost(() => RunActions(newActions, actionSys));
+                await RunTicks(1);
+
+                var unremovableComp = SEntMan.GetComponentOrNull<UnremoveableComponent>(clothing);
+                // Electropack or similar has to be force removed, since our unequip actor is always ourselves
+                var needsForce = SEntMan.HasComponent<SelfUnremovableClothingComponent>(clothing);
+
+                if (unremovableComp != null)
+                {
+                    needsForce = true;
+                    // We want to reuse this entity for other slots. (E.g., CluwnePDA)
+                    unremovableComp.DeleteOnDrop = false;
+                }
+
+                var isRemoved = false;
+                await Server.WaitPost(() =>
+                {
+                    // Try without forcing first
+                    isRemoved = DoUnequip(invSystem, clothing, slot.Name, false, clothingComp, false);
+
+                    // If we should've needed to force for this item, but got it off, that's no good.
+                    Assert.That(isRemoved && needsForce,
+                        Is.False,
+                        $"Unequipped {SEntMan.ToPrettyString(clothing)}, which should have been unremovable.");
+
+                    // Just in case some kind of toggle action put us into a state that this test doesn't expect.
+                    // Currently this doesn't seem to get hit.
+                    if (!isRemoved)
+                        RunActions(newActions, actionSys);
+                });
+                await RunTicks(1);
+
+                await Server.WaitAssertion(() =>
+                {
+                    if (!isRemoved)
+                        DoUnequip(invSystem, clothing, slot.Name, needsForce, clothingComp);
+
+                    if (slot.SlotFlags is SlotFlags.IDCARD or SlotFlags.POCKET)
+                        DoUnequip(invSystem, jumpsuit, "jumpsuit");
+
+                    if (slot.SlotFlags == SlotFlags.SUITSTORAGE)
+                        DoUnequip(invSystem, hardsuit, "outerClothing");
+                });
+                await RunTicks(1);
+            }
+        }
+    }
+
+    private void DoEquip(ServerInventorySystem invSystem,
+        EntityUid clothing,
+        string slot,
+        ClothingComponent clothingComp = null,
+        bool assert = true)
+    {
+        var equipped = invSystem.TryEquip(SPlayer, clothing, slot, clothing: clothingComp);
+        if (assert)
+            Assert.That(equipped, $"Failed to equip {SEntMan.ToPrettyString(clothing)} to {slot}");
+    }
+
+    private bool DoUnequip(ServerInventorySystem invSystem,
+        EntityUid clothing,
+        string slot,
+        bool force = false,
+        ClothingComponent clothingComp = null,
+        bool assert = true)
+    {
+        var equipped = invSystem.TryUnequip(SPlayer, SPlayer, slot, force: force, clothing: clothingComp);
+        if (assert)
+            Assert.That(equipped, $"Failed to unequip {SEntMan.ToPrettyString(clothing)} to {slot}");
+        return equipped;
+    }
+
+    private void RunActions(List<Entity<ActionComponent>> actions, ActionsSystem actionSys)
+    {
+        foreach (var action in actions)
+        {
+            actionSys.PerformAction(SPlayer, action);
+        }
+    }
+}

--- a/Content.IntegrationTests/Tests/Inventory/ClothingEquipTest.cs
+++ b/Content.IntegrationTests/Tests/Inventory/ClothingEquipTest.cs
@@ -25,8 +25,8 @@ namespace Content.IntegrationTests.Tests.Inventory;
 /// </summary>
 public sealed class ClothingEquipTest : InteractionTest
 {
-    private const string HardsuitProto = "ClothingOuterHardsuitEVA";
-    private const string JumpsuitProto = "ClothingUniformJumpsuitColorGrey";
+    private static readonly EntProtoId HardsuitProto = "ClothingOuterHardsuitEVA";
+    private static readonly EntProtoId JumpsuitProto = "ClothingUniformJumpsuitColorGrey";
 
     private readonly HashSet<Type> _ignoredComponents =
     [

--- a/Content.IntegrationTests/Tests/Inventory/DeleteInventoryTest.cs
+++ b/Content.IntegrationTests/Tests/Inventory/DeleteInventoryTest.cs
@@ -4,7 +4,7 @@ using Content.Shared.Inventory;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 
-namespace Content.IntegrationTests.Tests
+namespace Content.IntegrationTests.Tests.Inventory
 {
     [TestFixture]
     public sealed class DeleteInventoryTest

--- a/Content.IntegrationTests/Tests/Inventory/HumanInventoryUniformSlotsTest.cs
+++ b/Content.IntegrationTests/Tests/Inventory/HumanInventoryUniformSlotsTest.cs
@@ -1,7 +1,7 @@
 using Content.Shared.Inventory;
 using Robust.Shared.GameObjects;
 
-namespace Content.IntegrationTests.Tests
+namespace Content.IntegrationTests.Tests.Inventory
 {
     // Tests the behavior of InventoryComponent.
     // i.e. the interaction between uniforms and the pocket/ID slots.

--- a/Content.IntegrationTests/Tests/Inventory/InventoryHelpersTest.cs
+++ b/Content.IntegrationTests/Tests/Inventory/InventoryHelpersTest.cs
@@ -4,7 +4,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 
-namespace Content.IntegrationTests.Tests
+namespace Content.IntegrationTests.Tests.Inventory
 {
     [TestFixture]
     public sealed class InventoryHelpersTest


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR requires #38274, and will be marked as a draft until it's merged.

This introduces an integration test that, at the broad level:
1. Spawns in every item that has a ClothingComponent and then
2. Equips each one (plus jumpsuit/hardsuit if needed) into each slot it can fit in
3. Triggers any InstantActions it gains on each equip
4. Unequips it (and jumpsuit/hardsuit)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #38194. Would have caught part of #38274 (equip mask, toggle mask, unequip mask), as well as #38286.

## Technical details
<!-- Summary of code changes for easier review. -->

- This is my first time writing an integration test for SS14—any nitpicks are welcome. I'll do a self review on a few bits I have questions about.
- Running the test on a downstream passed without issue.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
