### PR TITLE
Commands for adding and removing actions

### DIFF
--- a/Content.Server/Actions/Commands/AddActionCommand.cs
+++ b/Content.Server/Actions/Commands/AddActionCommand.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using Content.Server.Administration;
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.Administration;
+using Content.Shared.Prototypes;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Actions.Commands;
+
+[AdminCommand(AdminFlags.Fun)]
+public sealed class AddActionCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public override string Command => "addaction";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 2)
+        {
+            shell.WriteError(Loc.GetString(Loc.GetString("cmd-addaction-invalid-args")));
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[0], out var targetUidNet) || !EntityManager.TryGetEntity(targetUidNet, out var targetEntity))
+        {
+            shell.WriteLine(Loc.GetString("shell-entity-uid-must-be-number"));
+            return;
+        }
+
+        if (!EntityManager.HasComponent<ActionsComponent>(targetEntity))
+        {
+            shell.WriteError(Loc.GetString("cmd-addaction-actions-not-found"));
+            return;
+        }
+
+        if (!_prototypes.TryIndex<EntityPrototype>(args[1], out var proto) ||
+            !proto.HasComponent<ActionComponent>())
+        {
+            shell.WriteError(Loc.GetString("cmd-addaction-action-not-found", ("action", args[1])));
+            return;
+        }
+
+        if (_actions.AddAction(targetEntity.Value, args[1]) == null)
+        {
+            shell.WriteError(Loc.GetString("cmd-addaction-adding-failed"));
+        }
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.Components<ActionsComponent>(args[0]),
+                Loc.GetString("cmd-addaction-player-completion"));
+        }
+
+        if (args.Length != 2)
+            return CompletionResult.Empty;
+
+        var actionPrototypes = _prototypeManager.EnumeratePrototypes<EntityPrototype>()
+            .Where(p => p.HasComponent<ActionComponent>())
+            .Select(p => p.ID)
+            .Order();
+
+        return CompletionResult.FromHintOptions(
+            actionPrototypes,
+            Loc.GetString("cmd-addaction-action-completion"));
+    }
+}

--- a/Content.Server/Actions/Commands/RemoveActionCommand.cs
+++ b/Content.Server/Actions/Commands/RemoveActionCommand.cs
@@ -1,0 +1,84 @@
+﻿using Content.Server.Administration;
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server.Actions.Commands;
+
+[AdminCommand(AdminFlags.Fun)]
+public sealed class RmActionCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+
+    public override string Command => "rmaction";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 2)
+        {
+            shell.WriteError(Loc.GetString(Loc.GetString("cmd-rmaction-invalid-args")));
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[0], out var targetUidNet) || !EntityManager.TryGetEntity(targetUidNet, out var targetEntity))
+        {
+            shell.WriteLine(Loc.GetString("shell-could-not-find-entity-with-uid", ("uid", args[0])));
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[1], out var targetActionUidNet) || !EntityManager.TryGetEntity(targetActionUidNet, out var targetActionEntity))
+        {
+            shell.WriteLine(Loc.GetString("shell-could-not-find-entity-with-uid", ("uid", args[1])));
+            return;
+        }
+
+        if (!EntityManager.HasComponent<ActionsComponent>(targetEntity))
+        {
+            shell.WriteError(Loc.GetString("cmd-rmaction-actions-not-found"));
+            return;
+        }
+
+        if (_actions.GetAction(targetActionEntity) is not { } ent)
+        {
+            shell.WriteError(Loc.GetString("cmd-rmaction-not-an-action"));
+            return;
+        }
+
+        _actions.SetTemporary(ent.Owner, true);
+
+        _actions.RemoveAction(ent.Owner);
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.Components<ActionsComponent>(args[0]),
+                Loc.GetString("cmd-rmaction-player-completion"));
+        }
+
+        if (args.Length == 2)
+        {
+            if (!NetEntity.TryParse(args[0], out var targetUidNet) || !EntityManager.TryGetEntity(targetUidNet, out var targetEntity))
+                return CompletionResult.Empty;
+
+            if (!EntityManager.HasComponent<ActionsComponent>(targetEntity))
+                return CompletionResult.Empty;
+
+            var actions = _actions.GetActions(targetEntity.Value);
+
+            var options = new List<CompletionOption>();
+            foreach (var action in actions)
+            {
+                var hint = Loc.GetString("cmd-rmaction-action-info", ("action", action));
+                options.Add(new CompletionOption(action.Owner.ToString(), hint));
+            }
+
+            return CompletionResult.FromHintOptions(options, Loc.GetString("cmd-rmaction-action-completion"));
+        }
+
+        return CompletionResult.Empty;
+    }
+}

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -1019,4 +1019,17 @@ public abstract class SharedActionsSystem : EntitySystem
         // TODO: Check for charge recovery timer
         return action.Cooldown.HasValue && action.Cooldown.Value.End > curTime;
     }
+
+    /// <summary>
+    /// Marks the action as temporary.
+    /// Temporary actions get deleted upon being removed from an entity.
+    /// </summary>
+    public void SetTemporary(Entity<ActionComponent?> ent, bool temporary)
+    {
+        if (!Resolve(ent.Owner, ref ent.Comp, false))
+            return;
+
+        ent.Comp.Temporary = temporary;
+        Dirty(ent);
+    }
 }

--- a/Resources/Locale/en-US/actions/commands/addaction.ftl
+++ b/Resources/Locale/en-US/actions/commands/addaction.ftl
@@ -1,0 +1,11 @@
+# addaction
+cmd-addaction-desc = Adds an action to the target entity. The action will not work if the target requires an additional component on their entity (such as Dragon's Devour).
+cmd-addaction-help = addaction <EntityUid> <ActionPrototype>
+
+cmd-addaction-invalid-args = Expected exactly 2 arguments.
+cmd-addaction-actions-not-found = Target entity cannot use actions.
+cmd-addaction-action-not-found = Can't find matching action prototype {$action}.
+cmd-addaction-adding-failed = Failed to add the action.
+
+cmd-addaction-player-completion = <EntityUid>
+cmd-addaction-action-completion = <ActionProto>

--- a/Resources/Locale/en-US/actions/commands/rmaction.ftl
+++ b/Resources/Locale/en-US/actions/commands/rmaction.ftl
@@ -1,0 +1,12 @@
+# rmaction
+cmd-rmaction-desc = Removes an action from an entity.
+cmd-rmaction-help = rmaction <EntityUid> <ActionUid>
+
+cmd-rmaction-invalid-args = Expected exactly 2 arguments.
+cmd-rmaction-actions-not-found = Target entity cannot use actions.
+cmd-rmaction-not-an-action = Target entity is not an action.
+
+cmd-rmaction-player-completion = <EntityUid>
+cmd-rmaction-action-completion = <ActionUid>
+
+cmd-rmaction-action-info = {$action}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added commands for adding and removing actions from entities.
### NOTE: Addaction will not work correctly if an action requires the entity to have an additional component on them. (Such as Dragon's Devour)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Ease of testing. This sorta thing very much lacked when working on the armblade.

## Technical details
<!-- Summary of code changes for easier review. -->
Not much to say. Done it similiarly to how addobjective/rmobjective works.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/3a4266f1-acd6-47c0-bdb8-22deb1fed0c3

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
ADMIN:
- add: addaction/rmaction commands. NOTE: Addaction will not work correctly if the action requires the entity to have a component (such as Dragon's Devour).
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
