### PR TITLE
NPC spiders sometimes spin webs 🕷️🕸️

### DIFF
--- a/Content.Server/Spider/SpiderSystem.cs
+++ b/Content.Server/Spider/SpiderSystem.cs
@@ -30,14 +30,14 @@ public sealed class SpiderSystem : SharedSpiderSystem
         var query = EntityQueryEnumerator<SpiderComponent>();
         while (query.MoveNext(out var uid, out var spider))
         {
-            if (HasComp<ActorComponent>(uid)
-                || !spider.SpawnsWebsAsNonPlayer
-                ||_timing.CurTime < spider.NextWebSpawn)
+            if (_timing.CurTime < spider.NextWebSpawn)
                 continue;
 
             spider.NextWebSpawn += TimeSpan.FromSeconds(spider.WebSpawnCooldownSeconds);
 
-            if (_mobState.IsDead(uid))
+            if (HasComp<ActorComponent>(uid)
+                || _mobState.IsDead(uid)
+                || !spider.SpawnsWebsAsNonPlayer)
                 continue;
 
             OnSpawnNet(uid, spider, new SpiderWebActionEvent());

--- a/Content.Shared/Spider/SharedSpiderSystem.cs
+++ b/Content.Shared/Spider/SharedSpiderSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Actions;
 using Robust.Shared.Network;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Spider;
 
@@ -9,6 +10,7 @@ public abstract class SharedSpiderSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _action = default!;
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -21,6 +23,7 @@ public abstract class SharedSpiderSystem : EntitySystem
     private void OnInit(EntityUid uid, SpiderComponent component, MapInitEvent args)
     {
         _action.AddAction(uid, ref component.Action, component.WebAction, uid);
+        component.NextWebSpawn = _timing.CurTime;
     }
 
     private void OnWebStartup(EntityUid uid, SpiderWebObjectComponent component, ComponentStartup args)

--- a/Content.Shared/Spider/SpiderComponent.cs
+++ b/Content.Shared/Spider/SpiderComponent.cs
@@ -18,6 +18,24 @@ public sealed partial class SpiderComponent : Component
     public string WebAction = "ActionSpiderWeb";
 
     [DataField] public EntityUid? Action;
+
+    /// <summary>
+    /// Whether the spider will spawn webs when not controlled by a player.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool SpawnsWebsAsNonPlayer = true;
+
+    /// <summary>
+    /// The cooldown in seconds between web spawns when not controlled by a player.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float WebSpawnCooldownSeconds = 120f;
+
+    /// <summary>
+    /// The next time the spider can spawn a web when not controlled by a player.
+    /// </summary>
+    [DataField, ViewVariables]
+    public TimeSpan NextWebSpawn = TimeSpan.Zero;
 }
 
 public sealed partial class SpiderWebActionEvent : InstantActionEvent { }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -672,7 +672,7 @@
         Piercing: 8
         Poison: 8
   - type: Spider
-    SpawnsWebsAsNonPlayer: false
+    spawnsWebsAsNonPlayer: false
   - type: Grammar
     attributes:
       proper: true

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -671,6 +671,8 @@
       types:
         Piercing: 8
         Poison: 8
+  - type: Spider
+    SpawnsWebsAsNonPlayer: false
   - type: Grammar
     attributes:
       proper: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
NPC spiders now spin webs sometimes!

Shiva is exempt in order not to web security constantly.
Salvage wreck space spiders are exempt.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Pretty cool innovation and good balancing for the spider when there are no ghosts to take over. This buffs spiders, but the buff is only powerful when nobody is dead yet!
- Gives a nice _spin_ to the spider, making it more fleshed out when controlled by game AI. When approached, it will sometimes have already spun some thick webs around it, and for the clown spider, some slippery webs.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/aabd55ef-6cef-48e6-ba90-3d886cf6a860)


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: NPC spiders now spin webs sometimes!
