### PR TITLE
fix: erase expedition disks when their map is deleted

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.Expeditions.cs
+++ b/Content.Server/Salvage/SalvageSystem.Expeditions.cs
@@ -6,6 +6,7 @@ using Content.Shared.CCVar;
 using Content.Shared.Examine;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Salvage.Expeditions;
+using Content.Shared.Shuttles.Components;
 using Robust.Shared.Audio;
 using Robust.Shared.CPUJob.JobQueues;
 using Robust.Shared.CPUJob.JobQueues.Queues;
@@ -75,6 +76,14 @@ public sealed partial class SalvageSystem
     private void OnExpeditionShutdown(EntityUid uid, SalvageExpeditionComponent component, ComponentShutdown args)
     {
         component.Stream = _audio.Stop(component.Stream);
+
+        // First wipe any disks referencing us
+        var disks = EntityQueryEnumerator<ShuttleDestinationCoordinatesComponent>();
+        while (disks.MoveNext(out var disk)
+               && disk.Destination == uid)
+        {
+            disk.Destination = null;
+        }
 
         foreach (var (job, cancelToken) in _salvageJobs.ToArray())
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Coordinate disks were causing PVS errors since they kept a reference to their destination map. Steps to reproduce:
1. Do expedition.
2. Run /fullstatereset or have someone connect.
3. Server cries.

This fixes it by just clearing any disks that referenced the map when an expedition map is deleted.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
Doesn't handle maps that get deleted but had references made to them via /ftldisk...

<details>
<summary>Stack trace</summary>

```
[ERRO] resolve: Can't resolve "Robust.Shared.GameObjects.MetaDataComponent" on entity 10342!
   at System.Environment.get_StackTrace()
   at Robust.Shared.GameObjects.EntityManager.GetNetEntity(EntityUid uid, MetaDataComponent metadata) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Network.cs:line 186
   at Robust.Shared.GameObjects.EntityManager.GetNetEntitySet(HashSet`1 entities) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Network.cs:line 512
   at Content.Shared.Actions.SharedActionsSystem.OnGetState(Entity`1 ent, ComponentGetState& args) in /Users/perry/git/space-station-14/Content.Shared/Actions/SharedActionsSystem.cs:line 103
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass57_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 324
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass67_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 460
   at Robust.Shared.GameObjects.EntityEventBus.DispatchComponent[TEvent](EntityUid euid, IComponent component, CompIdx baseType, Unit& args) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 678
   at Robust.Shared.GameObjects.EntityManager.GetComponentState(IEventBus eventBus, IComponent component, ICommonSession session, GameTick fromTick) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 1705
   at Robust.Server.GameStates.PvsSystem.GetEntityState(ICommonSession player, EntityUid entityUid, GameTick fromTick, MetaDataComponent meta) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.GetStates.cs:line 52
   at Robust.Server.GameStates.PvsSystem.AddPvsChunk(PvsChunk chunk, Single distance, PvsSession session) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.ToSendSet.cs:line 62
   at Robust.Server.GameStates.PvsSystem.AddPvsChunks(PvsSession pvsSession) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.ToSendSet.cs:line 22
   at Robust.Server.GameStates.PvsSystem.GetEntityStates(PvsSession session) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.cs:line 311
   at Robust.Server.GameStates.PvsSystem.ComputeSessionState(PvsSession session) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.Session.cs:line 44
   at Robust.Server.GameStates.PvsSystem.SerializeSessionState(PvsSession data) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.Serialize.cs:line 59
   at Robust.Server.GameStates.PvsSystem.SerializeState(Int32 i) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.Serialize.cs:line 41
   at System.Threading.Tasks.Parallel.<>c__DisplayClass19_0`2.<ForWorker>b__1(RangeWorker& currentWorker, Int64 timeout, Boolean& replicationDelegateYieldedBeforeCompletion)
   at System.Threading.Tasks.TaskReplicator.Replica.Execute()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
   at System.Threading.Tasks.ThreadPoolTaskScheduler.TryExecuteTaskInline(Task task, Boolean taskWasPreviouslyQueued)
   at System.Threading.Tasks.Task.InternalRunSynchronously(TaskScheduler scheduler, Boolean waitForCompletion)
   at System.Threading.Tasks.TaskReplicator.Run[TState](ReplicatableUserAction`1 action, ParallelOptions options, Boolean stopOnFirstFailure)
   at System.Threading.Tasks.Parallel.ForWorker[TLocal,TInt](TInt fromInclusive, TInt toExclusive, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Func`4 bodyWithLocal, Func`1 localInit, Action`1 localFinally)
   at System.Threading.Tasks.Parallel.For(Int32 fromInclusive, Int32 toExclusive, ParallelOptions parallelOptions, Action`1 body)
   at Robust.Server.GameStates.PvsSystem.SerializeStates() in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.Serialize.cs:line 27
   at Robust.Server.GameStates.PvsSystem.SendGameStates(ICommonSession[] players) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.cs:line 198
   at Robust.Server.GameStates.ServerGameStateManager.SendGameStateUpdate() in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/GameStates/ServerGameStateManager.cs:line 68
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 741
   at Robust.Server.BaseServer.<SetupMainLoop>b__67_1(Object sender, FrameEventArgs args) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 545
   at Robust.Shared.Timing.GameLoop.Run() in /Users/perry/git/space-station-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 235
   at Robust.Server.BaseServer.MainLoop() in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 572
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 42
   at Robust.Server.ContentStart.Start(String[] args) in /Users/perry/git/space-station-14/RobustToolbox/Robust.Server/ContentStart.cs:line 10
   at Content.Server.Program.Main(String[] args) in /Users/perry/git/space-station-14/Content.Server/Program.cs:line 9
```

</details>

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Disk gets destination cleared after expedition:
![image](https://github.com/user-attachments/assets/8acc8b5c-5886-4c76-aac3-9130db52765f)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
