### PR TITLE
end round in 20 seconds after nuke explosion

### DIFF
--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -348,7 +348,14 @@ public sealed partial class CCVars
     ///     Defaults to 2 minutes.
     /// </summary>
     public static readonly CVarDef<float> RoundRestartTime =
-        CVarDef.Create("game.round_restart_time", 120f, CVar.SERVERONLY);
+    CVarDef.Create("game.round_restart_time", 120f, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     The time in seconds that the server should wait before restarting the round.
+    ///     Defaults to 2 minutes.
+    /// </summary>
+    public static readonly CVarDef<float> NukeRoundRestartTime =
+    CVarDef.Create("game.nuke_round_restart_time", 20f, CVar.SERVERONLY);
 
     /// <summary>
     ///     The prototype to use for secret weights.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
if a nuke explodes in nuke gamemode or with loneops, the time to the end round (to the lobby) will be 20 seconds

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
nobody wants to float 2 mins in space

## Technical details
<!-- Summary of code changes for easier review. -->
add a new ccvar and use it on calling EndRound from NukeOpsRuleSystem

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://youtu.be/Yc8bakG4Jlw

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
no

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The round will end in 20 secods after nuke explosion in a nuke round.