### PR TITLE
Added functionality for gasses to be considered "Internal" and ignore insulation for heating/cooling

### DIFF
--- a/Content.Server/Medical/Components/CryoPodAirComponent.cs
+++ b/Content.Server/Medical/Components/CryoPodAirComponent.cs
@@ -11,5 +11,5 @@ public sealed partial class CryoPodAirComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("gasMixture")]
-    public GasMixture Air { get; set; } = new GasMixture(1000f);
+    public GasMixture Air { get; set; } = new GasMixture(1000f, true);
 }

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -157,9 +157,10 @@ public sealed class TemperatureSystem : EntitySystem
         var temperatureDelta = args.GasMixture.Temperature - temperature.CurrentTemperature;
         var airHeatCapacity = _atmosphere.GetHeatCapacity(args.GasMixture, false);
         var heatCapacity = GetHeatCapacity(uid, temperature);
+        var ignoreHeatResistance = args.GasMixture.IsInternal;
         var heat = temperatureDelta * (airHeatCapacity * heatCapacity /
                                        (airHeatCapacity + heatCapacity));
-        ChangeHeat(uid, heat * temperature.AtmosTemperatureTransferEfficiency, temperature: temperature);
+        ChangeHeat(uid, heat * temperature.AtmosTemperatureTransferEfficiency, ignoreHeatResistance, temperature: temperature);
     }
 
     public float GetHeatCapacity(EntityUid uid, TemperatureComponent? comp = null, PhysicsComponent? physics = null)

--- a/Content.Shared/Atmos/GasMixture.cs
+++ b/Content.Shared/Atmos/GasMixture.cs
@@ -31,6 +31,8 @@ namespace Content.Shared.Atmos
 
         [DataField("immutable")]
         public bool Immutable { get; private set; }
+        [DataField("isInternal")]
+        public bool IsInternal { get; private set; }
 
         [ViewVariables]
         public readonly float[] ReactionResults =
@@ -75,14 +77,15 @@ namespace Content.Shared.Atmos
         {
         }
 
-        public GasMixture(float volume = 0f)
+        public GasMixture(float volume = 0f, bool isInternal = false)
         {
             if (volume < 0)
                 volume = 0;
             Volume = volume;
+            IsInternal = isInternal;
         }
 
-        public GasMixture(float[] moles, float temp, float volume = Atmospherics.CellVolume)
+        public GasMixture(float[] moles, float temp, float volume = Atmospherics.CellVolume, bool isInternal = false)
         {
             if (moles.Length != Atmospherics.AdjustedNumberOfGases)
                 throw new InvalidOperationException($"Invalid mole array length");
@@ -94,6 +97,7 @@ namespace Content.Shared.Atmos
             _temperature = temp;
             Moles = moles;
             Volume = volume;
+            IsInternal = isInternal;
         }
 
         public GasMixture(GasMixture toClone)
@@ -105,6 +109,12 @@ namespace Content.Shared.Atmos
         public void MarkImmutable()
         {
             Immutable = true;
+        }
+        // PR reviewer(s): This is definitley not needed right now, but might be required by future uses of IsInternal? Remove it if you don't think so.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void MarkInternal()
+        {
+            IsInternal = true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Content.Shared/Atmos/GasMixture.cs
+++ b/Content.Shared/Atmos/GasMixture.cs
@@ -32,7 +32,7 @@ namespace Content.Shared.Atmos
         [DataField("immutable")]
         public bool Immutable { get; private set; }
         [DataField("isInternal")]
-        public bool IsInternal { get; private set; }
+        public bool IsInternal { get; set; }
 
         [ViewVariables]
         public readonly float[] ReactionResults =
@@ -110,13 +110,7 @@ namespace Content.Shared.Atmos
         {
             Immutable = true;
         }
-        // PR reviewer(s): This is definitley not needed right now, but might be required by future uses of IsInternal? Remove it if you don't think so.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void MarkInternal()
-        {
-            IsInternal = true;
-        }
-
+        
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float GetMoles(int gasId)
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added an `IsInternal` bool to `GasMixture`, allowing any gas to be designated as "inside" someone. Currently only matters for temperature.
Added `ignoreHeatResistance` to this new `IsInternal` bool.
Added `IsInternal` to Cryotube's gas, allowing a Cryotube to cool off people wearing insulative clothing

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Adding `IsInternal` to `GasMixture` and giving it `ignoreHeatResistance` is intended to enable my yet-to-start-on lung simulation breathing system, and allowing said system to warm/cool any potential lung-havers. You can see my ideaguys-shizo-post on that later part here. When I have the time to start developing it properly, I will be making regular feedback requests as I figure it out. https://discord.com/channels/310555209753690112/311537926376783886/1383933196680564926

The reason for the Cryopod change is to make cryo more user friendly. It makes sense that cryo would ignore insulation when cooling people, as they are breathing the super cold gas, not just suspended in it. This change makes it so people in hardsuits/jackets don't need to be stripped before being placed into cryotubes, which is always bulky to do and impossible for borgs to do.

## Technical details
<!-- Summary of code changes for easier review. -->
Incredibly minor changes.
Added a new `DataField` to `GasMixture` and an `AggressiveInlining` `MarkInternal` void (Not needed but there for consistency, as `Immutable` has an equivalent)
Made `IsInternal` = `ignoreHeatResistance` for `OnAtmosExposedUpdate`'s `ChangeHeat` function.
Made `CryoPodAirComponent` have `IsInternal`

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/97144a86-9ffd-4478-83b0-2b8b51c863b9
First section of video is with my change, second section is without it. Demonstrates it working

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
I do not think anything here qualifies. `IsInternal` is by default false unless specified in the `GasMixture`, so shouldn't have any impact outside of specified changes.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Cryopods will now ignore insulating clothing when cooling down patients.
