### PR TITLE
Fix SharedActionSystem spamming errors

### DIFF
--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -108,7 +108,7 @@ public abstract class SharedActionsSystem : EntitySystem
     /// </summary>
     public Entity<ActionComponent>? GetAction(Entity<ActionComponent?>? action, bool logError = true)
     {
-        if (action is not {} ent || TerminatingOrDeleted(ent))
+        if (action is not {} ent || Deleted(ent))
             return null;
 
         if (!_actionQuery.Resolve(ent, ref ent.Comp, logError))


### PR DESCRIPTION
## About the PR
This should fix https://github.com/space-wizards/space-station-14/issues/38293 but I only did limited testing so far.
So before merging it this should be thoroughly tested to make sure this does not introduce other problems.

## Why / Balance
server crashes bad

## Technical details
Deleted entities granting actions were not properly removed from the ActionsComponent.
To reproduce, spawn a flashlight, pick it up, and delete it while it is in your hand.
Then every time your actions change, for example when (un)equipping your PDA the server will try to network the action entity and fails.

This was caused because GetAction returns null when the entity granting the action is terminating.
However we still need to get it at this point as part of `RemoveProvidedActions`
![grafik](https://github.com/user-attachments/assets/51e9f57a-883d-49db-9a1f-789ac9570d34)

which in turn should be called when the flashlight is removed from your hand when deleting it
![grafik](https://github.com/user-attachments/assets/339a6525-12fd-442d-b5e2-f5b939b4edaa)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed actions sometimes not disappearing and causing server errors.
