### PR TITLE
Cleanup duplicate dependency in `AddActionCommand`

### DIFF
--- a/Content.Server/Actions/Commands/AddActionCommand.cs
+++ b/Content.Server/Actions/Commands/AddActionCommand.cs
@@ -12,7 +12,6 @@ namespace Content.Server.Actions.Commands;
 [AdminCommand(AdminFlags.Debug)]
 public sealed class AddActionCommand : LocalizedEntityCommands
 {
-    [Dependency] private readonly IPrototypeManager _prototypes = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
@@ -38,7 +37,7 @@ public sealed class AddActionCommand : LocalizedEntityCommands
             return;
         }
 
-        if (!_prototypes.TryIndex<EntityPrototype>(args[1], out var proto) ||
+        if (!_prototypeManager.TryIndex<EntityPrototype>(args[1], out var proto) ||
             !proto.HasComponent<ActionComponent>())
         {
             shell.WriteError(Loc.GetString("cmd-addaction-action-not-found", ("action", args[1])));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
There were two `IPrototypeManager` dependencies in `AddActionCommand`. Now there's just one.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

@ScarKy0 you so silly.

## Technical details
<!-- Summary of code changes for easier review. -->
Deleted one of the dependency fields and changed the code using it to use the other.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->