### PR TITLE
Convert `FlashSystem` timer to an update loop

### DIFF
--- a/Content.Shared/Flash/Components/FlashComponent.cs
+++ b/Content.Shared/Flash/Components/FlashComponent.cs
@@ -40,6 +40,18 @@ namespace Content.Shared.Flash.Components
 
         public bool Flashing;
 
+        /// <summary>
+        /// How long the visual of the flashing bulb lasts after activation.
+        /// </summary>
+        [DataField]
+        public TimeSpan FlashingDuration = TimeSpan.FromMilliseconds(400);
+
+        /// <summary>
+        /// The time at which the flashing bulb visual will end.
+        /// </summary>
+        [DataField]
+        public TimeSpan FlashingEndTime;
+
         [DataField]
         public float Probability = 1f;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Replaces the use of `SpawnTimer` for the flashing bulb effect in `FlashSystem` with an update loop.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
`SpawnTimer` is bad and deprecated.

https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Standard update loop stuff. Also de-hardcodes the duration of the flashing effect.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->