### PR TITLE
adds "food" solution to organs that were missing them

### DIFF
--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -103,6 +103,11 @@
     solutions:
       stomach:
         maxVol: 30
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
   - type: Item
     size: Small
     heldPrefix: stomach

--- a/Resources/Prototypes/Body/Organs/Animal/ruminant.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/ruminant.yml
@@ -8,3 +8,8 @@
     solutions:
       stomach:
         maxVol: 80
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5

--- a/Resources/Prototypes/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/slimes.yml
@@ -24,6 +24,11 @@
       solutions:
         stomach:
           maxVol: 30.0
+        food:
+          maxVol: 5
+          reagents:
+          - ReagentId: GreyMatter
+            Quantity: 5
 
 - type: entity
   id: OrganSlimesLungs

--- a/Resources/Prototypes/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/slimes.yml
@@ -55,3 +55,8 @@
         Lung:
           maxVol: 100.0
           canReact: false
+        food:
+          maxVol: 5
+          reagents:
+          - ReagentId: UncookedAnimalProteins
+            Quantity: 5

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -127,6 +127,11 @@
       Lung:
         maxVol: 100
         canReact: False
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
 
 # Organs that turn into nymphs on removal
 - type: entity


### PR DESCRIPTION
## About the PR
this PR adds a "food" solution to a few organs that were missing them due to SolutionContainerManager overrides

## Why / Balance
there was a PR a while ago (#20225) that made a bunch of organs edible and this PR aims to bring the rest of the organs up to parity, but the "food" solution is required for this purpose

the lack of a "food" solution in certain organs seemed like an oversight rather than an intentional thing, as i didnt see any commits that removed the food solution - just new organ additions that lacked the food solution.

## Technical details
just some YML changes, copypasted from other organs

## Media

https://github.com/user-attachments/assets/5ce186dc-2eee-45da-82db-c00506868cd7

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
none

**Changelog**
:cl:
- fix: Ruminant stomach, mouse stomach, (vent) slime organs, and Diona lungs are now edible.