### PR TITLE
Lobby Audio from static to CVar

### DIFF
--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -3,13 +3,13 @@ using Content.Server.GameTicking;
 using Content.Server.GameTicking.Events;
 using Content.Shared.Audio;
 using Content.Shared.Audio.Events;
+using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
 using Robust.Server.Audio;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Configuration;
-using Content.Shared.CCVar;
 
 namespace Content.Server.Audio;
 
@@ -27,10 +27,12 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
     {
         base.Initialize();
 
-        //Onvalue chage changes the music collection and reshuffles the playlist to update the lobby music
-        _cfg.OnValueChanged(
+        //changes the music collection and reshuffles the playlist to update the lobby music
+        Subs.CVar(
+            _cfg,
             CCVars.LobbyMusicCollection,
-            x => {
+            x =>
+            {
                 _lobbyMusicCollection = _prototypeManager.Index<SoundCollectionPrototype>(x);
                 _lobbyPlaylist = ShuffleLobbyPlaylist();
             },

--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -30,6 +30,8 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
         _lobbyMusicCollection = _prototypeManager.Index<SoundCollectionPrototype>(_cfg.GetCVar(CCVars.LobbyMusicCollection));
         _lobbyPlaylist = ShuffleLobbyPlaylist();
 
+        _cfg.OnValueChanged(CCVars.LobbyMusicCollection, x => _lobbyMusicCollection = _prototypeManager.Index<SoundCollectionPrototype>(x), true);
+
         SubscribeLocalEvent<RoundEndMessageEvent>(OnRoundEnd);
         SubscribeLocalEvent<PlayerJoinedLobbyEvent>(OnPlayerJoinedLobby);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundCleanup);

--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -7,9 +7,10 @@ using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
 using Robust.Server.Audio;
 using Robust.Shared.Audio;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using Robust.Shared.Configuration;
+
 
 namespace Content.Server.Audio;
 
@@ -33,7 +34,19 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
             CCVars.LobbyMusicCollection,
             x =>
             {
-                _lobbyMusicCollection = _prototypeManager.Index<SoundCollectionPrototype>(x);
+
+                try
+                {
+                    _lobbyMusicCollection = _prototypeManager.Index<SoundCollectionPrototype>(x);
+                }
+                catch
+                {
+                    Log.Error("No matching sound collection found. Defaulting to LobbyMusic collection");
+                    //This realy should default to the default set inside of the Cvar to avoid a potential loop
+                    //  if the default is ever changed.
+                    _cfg.SetCVar("ambience.lobby_music_collection", "LobbyMusic", true);
+                }
+                
                 _lobbyPlaylist = ShuffleLobbyPlaylist();
             },
             true);

--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -27,8 +27,6 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
     {
         base.Initialize();
 
-        _lobbyPlaylist = ShuffleLobbyPlaylist();
-
         //Onvalue chage changes the music collection and reshuffles the playlist to update the lobby music
         _cfg.OnValueChanged(
             CCVars.LobbyMusicCollection,

--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -8,17 +8,17 @@ using Robust.Server.Audio;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Configuration;
+using Content.Shared.CCVar;
 
 namespace Content.Server.Audio;
 
 public sealed class ContentAudioSystem : SharedContentAudioSystem
 {
-    [ValidatePrototypeId<SoundCollectionPrototype>]
-    private const string LobbyMusicCollection = "LobbyMusic";
-
     [Dependency] private readonly AudioSystem _serverAudio = default!;
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     private SoundCollectionPrototype _lobbyMusicCollection = default!;
     private string[]? _lobbyPlaylist;
@@ -27,7 +27,7 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
     {
         base.Initialize();
 
-        _lobbyMusicCollection = _prototypeManager.Index<SoundCollectionPrototype>(LobbyMusicCollection);
+        _lobbyMusicCollection = _prototypeManager.Index<SoundCollectionPrototype>(_cfg.GetCVar(CCVars.LobbyMusicCollection));
         _lobbyPlaylist = ShuffleLobbyPlaylist();
 
         SubscribeLocalEvent<RoundEndMessageEvent>(OnRoundEnd);

--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -30,7 +30,14 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
         _lobbyMusicCollection = _prototypeManager.Index<SoundCollectionPrototype>(_cfg.GetCVar(CCVars.LobbyMusicCollection));
         _lobbyPlaylist = ShuffleLobbyPlaylist();
 
-        _cfg.OnValueChanged(CCVars.LobbyMusicCollection, x => _lobbyMusicCollection = _prototypeManager.Index<SoundCollectionPrototype>(x), true);
+        //Onvalue chage changes the music collection and reshuffles the playlist to update the lobby music
+        _cfg.OnValueChanged(
+            CCVars.LobbyMusicCollection,
+            x => {
+                _lobbyMusicCollection = _prototypeManager.Index<SoundCollectionPrototype>(x);
+                _lobbyPlaylist = ShuffleLobbyPlaylist();
+            },
+            true);
 
         SubscribeLocalEvent<RoundEndMessageEvent>(OnRoundEnd);
         SubscribeLocalEvent<PlayerJoinedLobbyEvent>(OnPlayerJoinedLobby);

--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -27,7 +27,6 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
     {
         base.Initialize();
 
-        _lobbyMusicCollection = _prototypeManager.Index<SoundCollectionPrototype>(_cfg.GetCVar(CCVars.LobbyMusicCollection));
         _lobbyPlaylist = ShuffleLobbyPlaylist();
 
         //Onvalue chage changes the music collection and reshuffles the playlist to update the lobby music

--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -34,19 +34,17 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
             CCVars.LobbyMusicCollection,
             x =>
             {
+                //Checks to see if the sound collection exists. If it does change it if not set a empty prototype
+                // as the new _lobbyMusicCollection meaning it wont play anything in the lobby.
+                if(_prototypeManager.TryIndex<SoundCollectionPrototype>(x, out var outputSoundCollection))
+                {
+                    _lobbyMusicCollection = outputSoundCollection;
+                }
+                else
+                {
+                    _lobbyMusicCollection = new SoundCollectionPrototype();
+                }
 
-                try
-                {
-                    _lobbyMusicCollection = _prototypeManager.Index<SoundCollectionPrototype>(x);
-                }
-                catch
-                {
-                    Log.Error("No matching sound collection found. Defaulting to LobbyMusic collection");
-                    //This realy should default to the default set inside of the Cvar to avoid a potential loop
-                    //  if the default is ever changed.
-                    _cfg.SetCVar("ambience.lobby_music_collection", "LobbyMusic", true);
-                }
-                
                 _lobbyPlaylist = ShuffleLobbyPlaylist();
             },
             true);

--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -21,7 +21,7 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
 
-    private SoundCollectionPrototype _lobbyMusicCollection = default!;
+    private SoundCollectionPrototype? _lobbyMusicCollection = default!;
     private string[]? _lobbyPlaylist;
 
     public override void Initialize()
@@ -34,7 +34,7 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
             CCVars.LobbyMusicCollection,
             x =>
             {
-                //Checks to see if the sound collection exists. If it does change it if not set a empty prototype
+                //Checks to see if the sound collection exists. If it does change it if not defaults to null
                 // as the new _lobbyMusicCollection meaning it wont play anything in the lobby.
                 if(_prototypeManager.TryIndex<SoundCollectionPrototype>(x, out var outputSoundCollection))
                 {
@@ -42,7 +42,8 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
                 }
                 else
                 {
-                    _lobbyMusicCollection = new SoundCollectionPrototype();
+                    Log.Error("Attempted to change Lobby Music Sound collection. No matching collection was found. Defaulting to null");
+                    _lobbyMusicCollection = null;
                 }
 
                 _lobbyPlaylist = ShuffleLobbyPlaylist();
@@ -95,11 +96,16 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
 
     private string[] ShuffleLobbyPlaylist()
     {
+        if (_lobbyMusicCollection == null)
+        {
+            return [];
+        }
+
         var playlist = _lobbyMusicCollection.PickFiles
                                             .Select(x => x.ToString())
                                             .ToArray();
-         _robustRandom.Shuffle(playlist);
+        _robustRandom.Shuffle(playlist);
 
-         return playlist;
+        return playlist;
     }
 }

--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -42,7 +42,7 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
                 }
                 else
                 {
-                    Log.Error("Attempted to change Lobby Music Sound collection. No matching collection was found. Defaulting to null");
+                    Log.Error($"Invalid Lobby Music sound collection specified: {x}");
                     _lobbyMusicCollection = null;
                 }
 

--- a/Content.Shared/CCVar/CCVars.Audio.cs
+++ b/Content.Shared/CCVar/CCVars.Audio.cs
@@ -63,7 +63,10 @@ public sealed partial class CCVars
     /// <summary>
     ///     Lobby music collection string
     /// </summary>
+    /// <remarks>
+    ///     This is only updatable when not in the lobby
+    /// </remarks>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<string> LobbyMusicCollection =
-        CVarDef.Create("ambience.lobby_music_collection", "LobbyMusic", CVar.ARCHIVE | CVar.SERVER);
+        CVarDef.Create("ambience.lobby_music_collection", "LobbyMusic", CVar.REPLICATED | CVar.SERVER);
 }

--- a/Content.Shared/CCVar/CCVars.Audio.cs
+++ b/Content.Shared/CCVar/CCVars.Audio.cs
@@ -64,7 +64,7 @@ public sealed partial class CCVars
     ///     Lobby music collection string
     /// </summary>
     /// <remarks>
-    ///     This is only updatable when not in the lobby
+    ///     If you change the default setting you need to change the default in Content.Server/Audio/ContentAudioSystem.cs
     /// </remarks>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<string> LobbyMusicCollection =

--- a/Content.Shared/CCVar/CCVars.Audio.cs
+++ b/Content.Shared/CCVar/CCVars.Audio.cs
@@ -63,6 +63,7 @@ public sealed partial class CCVars
     /// <summary>
     ///     Lobby music collection string
     /// </summary>
+    [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<string> LobbyMusicCollection =
         CVarDef.Create("ambience.lobby_music_collection", "LobbyMusic", CVar.ARCHIVE | CVar.SERVER);
 }

--- a/Content.Shared/CCVar/CCVars.Audio.cs
+++ b/Content.Shared/CCVar/CCVars.Audio.cs
@@ -1,4 +1,6 @@
-﻿using Robust.Shared.Configuration;
+using Content.Shared.Administration;
+using Content.Shared.CCVar.CVarAccess;
+using Robust.Shared.Configuration;
 
 namespace Content.Shared.CCVar;
 
@@ -58,4 +60,9 @@ public sealed partial class CCVars
         public static readonly CVarDef<float> InterfaceVolume =
             CVarDef.Create("audio.interface_volume", 0.50f, CVar.ARCHIVE | CVar.CLIENTONLY);
 
+    /// <summary>
+    ///     Lobby music collection string
+    /// </summary>
+    public static readonly CVarDef<string> LobbyMusicCollection =
+        CVarDef.Create("ambience.lobby_music_collection", "LobbyMusic", CVar.ARCHIVE | CVar.SERVER);
 }

--- a/Content.Shared/CCVar/CCVars.Audio.cs
+++ b/Content.Shared/CCVar/CCVars.Audio.cs
@@ -63,9 +63,6 @@ public sealed partial class CCVars
     /// <summary>
     ///     Lobby music collection string
     /// </summary>
-    /// <remarks>
-    ///     If you change the default setting you need to change the default in Content.Server/Audio/ContentAudioSystem.cs
-    /// </remarks>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<string> LobbyMusicCollection =
         CVarDef.Create("ambience.lobby_music_collection", "LobbyMusic", CVar.REPLICATED | CVar.SERVER);

--- a/Content.Shared/CCVar/CCVars.Audio.cs
+++ b/Content.Shared/CCVar/CCVars.Audio.cs
@@ -65,5 +65,5 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<string> LobbyMusicCollection =
-        CVarDef.Create("ambience.lobby_music_collection", "LobbyMusic", CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("audio.lobby_music_collection", "LobbyMusic", CVar.REPLICATED | CVar.SERVER);
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed Lobby Music Sound Collection from static string to Cvar editable by admin cli
## Why / Balance
Requested in issue #38355 
## Technical details
Added the LobbyMusicCollection Cvar in CCVars.Audio and refactored the code in the ContentAusioSystem to use the Cvar. Also added code to update the music collection and reshuffle the lobby music from the admin cli.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

