### PR TITLE
Fix adjacent north/south cable terminals breaking east/west HV cable

### DIFF
--- a/Content.Server/Power/Nodes/CableNode.cs
+++ b/Content.Server/Power/Nodes/CableNode.cs
@@ -52,7 +52,6 @@ namespace Content.Server.Power.Nodes
                         {
                             // Target tile has a terminal towards us, block the direction.
                             terminalDirs |= 1 << (int) dir;
-                            break;
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes an issue with adjacent cable terminals breaking connections they shouldn't.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes (not) https://github.com/space-wizards/space-station-14/issues/36339#issuecomment-2781189884 (as far as I can tell - _only_ the comment, not the larger issue)

## Technical details
<!-- Summary of code changes for easier review. -->

C# one-liner.  Having a cable terminal across from you does not mean you have no more nodes to connect to.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

This setup is impossible to create without this PR - the bottom row of cables would be split in two between the SMESes.
![image](https://github.com/user-attachments/assets/62abf656-464e-46c7-9917-929f5adee4f9)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No CL, really only of use for mappers.