### PR TITLE
Vox can eat cloth and fiberous objects/foods inefficently

### DIFF
--- a/Resources/Prototypes/Body/Organs/vox.yml
+++ b/Resources/Prototypes/Body/Organs/vox.yml
@@ -21,12 +21,13 @@
   description: "A stomach that smells of ammonia."
   components:
   - type: Metabolizer #Skreeeee!
-    metabolizerTypes: [Vox]
+    metabolizerTypes: [ Vox ]
   - type: Stomach
 #Bird vs tags
     specialDigestible:
       tags:
       - Trash
+      - ClothMade
     isSpecialDigestibleExclusive: false
 
 - type: entity

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -41,6 +41,11 @@
         conditions:
         - !type:OrganType
           type: Moth
+      - !type:SatiateHunger
+        conditions:
+        - !type:OrganType
+          type: Vox
+        factor: 0.50 #Vox will get 0.50 hunger per unit of Fiber, moths appear to get 3.00 per unit.
 
 - type: reagent
   id: BuzzochloricBees


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
lets Vox eat everything Moths can, but at a much lower rate, gaining ~0.50 hunger per unit of fiber, compared to the Moth's getting ~3.00. Exact value uncertain.

## Why / Balance
Vox have strong enough stomachs to digest various forms of trash, such as wrappers, which would require a stomach stronger than the norm. If #37519 were to be merged, this would lend more credence to the strength of their stomach, being able to digest things like Popsicle sticks and broken plates, things which I have heard approval of from Discord. Vox can now digest fiber, but they are not specialized to do so and so they can only do so with a low hunger to unit ratio. This also gives more uses for cotton foods, so that they don't only have to be made for only Moths. Also provides more reason to design and implement new cotton foods by providing more individuals who could consume it, not just one species.

## Technical details
Addition of `ClothMade` to the allowed Vox stomach tags. Addition of a new `!type:SatiateHunger` condition for fiber for Vox stomachs, defining it to have a `factor` of 0.50, regulating how much satiation they get from consuming it.

## Media

https://github.com/user-attachments/assets/614155e2-1fc0-43a2-8545-10cac038c421

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
:cl:
- add: Vox can now eat Moth Foods, at a inefficient rate.
