### PR TITLE
Fixed ghosts entities lingering after taking ghost roles

### DIFF
--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -256,14 +256,7 @@ public sealed class MindSystem : SharedMindSystem
 
         if (entity != null)
         {
-            component!.Mind = mindId;
             mind.OwnedEntity = entity;
-            mind.OriginalOwnedEntity ??= GetNetEntity(mind.OwnedEntity);
-            Entity<MindComponent> mindEnt = (mindId, mind);
-            Entity<MindContainerComponent> containerEnt = (entity.Value, component);
-            RaiseLocalEvent(entity.Value, new MindAddedMessage(mindEnt, containerEnt));
-            RaiseLocalEvent(mindId, new MindGotAddedEvent(mindEnt, containerEnt));
-            Dirty(entity.Value, component);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ghost entities no longer linger when observing, after taking a ghost role. Most likely a temporary fix until somebody figures out something better.

## Why / Balance
Mainly a QoL issue, should make observing better. Also requested in issue #38292 

## Technical details
7 lines of code deleted within an if statement within the TransferTo method. Removal did not affect the game, server, or client in any way adverse.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
🆑 
fix: Fixed ghosts lingering after taking ghost roles.
