### PR TITLE
Fixed mis-labeled component filter

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -124,9 +124,9 @@
     - 0,0,1,1
     whitelist:
       components:
-      - Artifact
+      - XenoArtifact
   - type: Item
-    sprite: Objects/Storage/artifact_container.rsi  
+    sprite: Objects/Storage/artifact_container.rsi
     size: Huge
   - type: MeleeWeapon
     damage:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Buxfix to allow handheld artifact containers to actually store handheld artifacts

## Why / Balance
This is pretty clearly a bug and unintended, given that handheld artifact containers currently cannot store *anything* due to that error in the filters.

## Technical details
Storage whitelist filtered for the Artifact component (which seems to be a material?) rather than the XenoArtifact component, which is what actually denotes an artifact.

## Media
Pre-fix:
![grafik](https://github.com/user-attachments/assets/6e6bb2eb-a432-4848-9495-277c1e3410f4)

Works now!
![grafik](https://github.com/user-attachments/assets/4ebfee06-fc66-4e27-8541-6c5692a3fc83)



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Handheld artifact containers can now properly store handheld artifacts.


Not sure if this should be a hotfix, but it does not seem overly urgent, as normal artifact containers can still also safely contain handheld artifacts.