### PR TITLE
Add directionality to cable terminal port nodes

### DIFF
--- a/Content.Server/Power/Nodes/CableTerminalPortNode.cs
+++ b/Content.Server/Power/Nodes/CableTerminalPortNode.cs
@@ -21,9 +21,11 @@ namespace Content.Server.Power.Nodes
             var gridIndex = grid.TileIndicesFor(xform.Coordinates);
 
             var nodes = NodeHelpers.GetCardinalNeighborNodes(nodeQuery, grid, gridIndex, includeSameTile: false);
-            foreach (var (_, node) in nodes)
+            foreach (var (dir, node) in nodes)
             {
-                if (node is CableTerminalNode)
+                if (node is CableTerminalNode
+                    && dir != Direction.Invalid
+                    && xformQuery.GetComponent(node.Owner).LocalRotation.GetCardinalDir().GetOpposite() == dir)
                     yield return node;
             }
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Adds directionality to the cable terminal port node ReachableNodes check.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes https://github.com/space-wizards/space-station-14/issues/36339

Roomba looking down its whirring nose at me.  The _gall_.  The _cheek_.

## Technical details
<!-- Summary of code changes for easier review. -->

Replicates the terminal check in cable node in the CableTerminalPortNode.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Simple connection case.
![image](https://github.com/user-attachments/assets/628c3948-bfaf-4a19-b939-889425809343)

Case from the bug.  Note that each terminal port node only connects to one terminal.
![image](https://github.com/user-attachments/assets/ada4e888-8c29-4b07-94bd-c39083b946ff)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no