### PR TITLE
Kitchen knives can now hit and embed into targets upon being thrown!

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -41,6 +41,16 @@
   - type: Sprite
     sprite: Objects/Weapons/Melee/kitchen_knife.rsi
     state: icon
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+    offset: -0.15,0.0
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    damage:
+        types:
+          Slash: 10
+  - type: ThrowingAngle
+    angle: 225
   - type: Item
     sprite: Objects/Weapons/Melee/kitchen_knife.rsi
   - type: GuideHelp


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I made kitchen knifes embed into targets upon being thrown, dealing their usual damage.
The chef has finally learnt how to throw them properly!

## Why / Balance
It's always felt weird that kitchen knives just slide around harmlessly when thrown, instead of functioning as you'd expect and stylishly embedding in whatever they're thrown at.

Minimal balance concerns, due to it only being a 10 slash weapon, this is mostly for RP effect and dealing with mice, very rarely will it actually be helpful in a fight.

## Technical details
Brought EmbedProjectile and the related code over from combat knives to the kitchen knife, aswell as ThrowingAngle 225.

## Media
https://github.com/user-attachments/assets/670d56a2-ab81-4cde-8f63-b0e36801c24c



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Let kitchen knives embed into targets on throw!, the chef has learnt some skills!
