### PR TITLE
Switch Discord integration to use NetCord instead of Discord.Net

### DIFF
--- a/Content.Packaging/ServerPackaging.cs
+++ b/Content.Packaging/ServerPackaging.cs
@@ -47,7 +47,7 @@ public static class ServerPackaging
         // Python script had Npgsql. though we want Npgsql.dll as well soooo
         "Npgsql",
         "Microsoft",
-        "Discord",
+        "NetCord",
     };
 
     private static readonly List<string> ServerNotExtraAssemblies = new()

--- a/Content.Server/Content.Server.csproj
+++ b/Content.Server/Content.Server.csproj
@@ -14,8 +14,8 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net" />
     <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
+    <PackageReference Include="NetCord" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Content.Packaging\Content.Packaging.csproj" />

--- a/Content.Server/Discord/DiscordLink/DiscordChatLink.cs
+++ b/Content.Server/Discord/DiscordLink/DiscordChatLink.cs
@@ -1,8 +1,7 @@
-﻿using System.Threading.Tasks;
-using Content.Server.Chat.Managers;
+﻿using Content.Server.Chat.Managers;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
-using Discord.WebSocket;
+using NetCord.Gateway;
 using Robust.Shared.Asynchronous;
 using Robust.Shared.Configuration;
 
@@ -59,18 +58,18 @@ public sealed class DiscordChatLink : IPostInjectInit
         _adminChannelId = ulong.Parse(channelId);
     }
 
-    private void OnMessageReceived(SocketMessage message)
+    private void OnMessageReceived(Message message)
     {
         if (message.Author.IsBot)
             return;
 
         var contents = message.Content.ReplaceLineEndings(" ");
 
-        if (message.Channel.Id == _oocChannelId)
+        if (message.ChannelId == _oocChannelId)
         {
             _taskManager.RunOnMainThread(() => _chatManager.SendHookOOC(message.Author.Username, contents));
         }
-        else if (message.Channel.Id == _adminChannelId)
+        else if (message.ChannelId == _adminChannelId)
         {
             _taskManager.RunOnMainThread(() => _chatManager.SendHookAdmin(message.Author.Username, contents));
         }

--- a/Content.Server/Discord/DiscordLink/DiscordSawmillLogger.cs
+++ b/Content.Server/Discord/DiscordLink/DiscordSawmillLogger.cs
@@ -1,0 +1,34 @@
+﻿using NetCord.Logging;
+using NLogLevel = NetCord.Logging.LogLevel;
+using LogLevel = Robust.Shared.Log.LogLevel;
+
+namespace Content.Server.Discord.DiscordLink;
+
+public sealed class DiscordSawmillLogger(ISawmill sawmill) : IGatewayLogger, IRestLogger, IVoiceLogger
+{
+    private static LogLevel GetLogLevel(NLogLevel logLevel)
+    {
+        return logLevel switch
+        {
+            NLogLevel.Critical => LogLevel.Fatal,
+            NLogLevel.Error => LogLevel.Error,
+            NLogLevel.Warning => LogLevel.Warning,
+            _ => LogLevel.Debug,
+        };
+    }
+
+    void IGatewayLogger.Log<TState>(NetCord.Logging.LogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        sawmill.Log(GetLogLevel(logLevel), exception, formatter(state, exception));
+    }
+
+    void IRestLogger.Log<TState>(NetCord.Logging.LogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        sawmill.Log(GetLogLevel(logLevel), exception, formatter(state, exception));
+    }
+
+    void IVoiceLogger.Log<TState>(NetCord.Logging.LogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        sawmill.Log(GetLogLevel(logLevel), exception, formatter(state, exception));
+    }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
     <PackageVersion Remove="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageVersion Remove="Microsoft.EntityFrameworkCore.Design" />
     <PackageVersion Include="CsvHelper" Version="33.0.1" />
-    <PackageVersion Include="Discord.Net" Version="3.16.0" />
     <PackageVersion Include="ImGui.NET" Version="1.87.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="9.0.1" />
+    <PackageVersion Include="NetCord" Version="1.0.0-alpha.388" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
     <PackageVersion Include="OpenTK" Version="4.7.2" />
     <PackageVersion Include="Veldrid" Version="4.8.0" />


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
See title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Discord.Net has horrible inefficient code. See `PJB looks at a game server profile` thread for more information.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Discord.NET as a package has been removed in favor of NetCord. All code written to use Discord.NET needs to be rewritten to use NetCord.