### PR TITLE
Convert `AtmosphereSystem` sound path strings to `SoundSpecifier`s

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
@@ -14,12 +15,14 @@ namespace Content.Server.Atmos.EntitySystems
 {
     public sealed partial class AtmosphereSystem
     {
+        private static readonly ProtoId<SoundCollectionPrototype> DefaultSpaceWindSounds = "SpaceWind";
+
         private const int SpaceWindSoundCooldownCycles = 75;
 
         private int _spaceWindSoundCooldown = 0;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public SoundSpecifier? SpaceWindSound { get; private set; } = new SoundPathSpecifier("/Audio/Effects/space_wind.ogg", AudioParams.Default.WithVariation(0.125f));
+        public SoundSpecifier? SpaceWindSound { get; private set; } = new SoundCollectionSpecifier(DefaultSpaceWindSounds, AudioParams.Default.WithVariation(0.125f));
 
         private readonly HashSet<Entity<MovedByPressureComponent>> _activePressures = new(8);
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -19,7 +19,7 @@ namespace Content.Server.Atmos.EntitySystems
         private int _spaceWindSoundCooldown = 0;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public string? SpaceWindSound { get; private set; } = "/Audio/Effects/space_wind.ogg";
+        public SoundSpecifier? SpaceWindSound { get; private set; } = new SoundPathSpecifier("/Audio/Effects/space_wind.ogg", AudioParams.Default.WithVariation(0.125f));
 
         private readonly HashSet<Entity<MovedByPressureComponent>> _activePressures = new(8);
 
@@ -105,10 +105,10 @@ namespace Content.Server.Atmos.EntitySystems
             // Don't play the space wind sound on tiles that are on fire...
             if (tile.PressureDifference > 15 && !tile.Hotspot.Valid)
             {
-                if (_spaceWindSoundCooldown == 0 && !string.IsNullOrEmpty(SpaceWindSound))
+                if (_spaceWindSoundCooldown == 0 && SpaceWindSound != null)
                 {
                     var coordinates = _mapSystem.ToCenterCoordinates(tile.GridIndex, tile.GridIndices);
-                    _audio.PlayPvs(SpaceWindSound, coordinates, AudioParams.Default.WithVariation(0.125f).WithVolume(MathHelper.Clamp(tile.PressureDifference / 10, 10, 100)));
+                    _audio.PlayPvs(SpaceWindSound, coordinates, SpaceWindSound.Params.WithVolume(MathHelper.Clamp(tile.PressureDifference / 10, 10, 100)));
                 }
             }
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Hotspot.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Hotspot.cs
@@ -7,12 +7,15 @@ using Content.Shared.Database;
 using Robust.Shared.Audio;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Atmos.EntitySystems
 {
     public sealed partial class AtmosphereSystem
     {
+        private static readonly ProtoId<SoundCollectionPrototype> DefaultHotspotSounds = "AtmosHotspot";
+
         [Dependency] private readonly DecalSystem _decalSystem = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
 
@@ -21,7 +24,7 @@ namespace Content.Server.Atmos.EntitySystems
         private int _hotspotSoundCooldown = 0;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public SoundSpecifier? HotspotSound { get; private set; } = new SoundPathSpecifier("/Audio/Effects/fire.ogg");
+        public SoundSpecifier? HotspotSound { get; private set; } = new SoundCollectionSpecifier(DefaultHotspotSounds);
 
         private void ProcessHotspot(
             Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent> ent,

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Hotspot.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Hotspot.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Atmos.EntitySystems
         private int _hotspotSoundCooldown = 0;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public string? HotspotSound { get; private set; } = "/Audio/Effects/fire.ogg";
+        public SoundSpecifier? HotspotSound { get; private set; } = new SoundPathSpecifier("/Audio/Effects/fire.ogg");
 
         private void ProcessHotspot(
             Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent> ent,
@@ -105,14 +105,14 @@ namespace Content.Server.Atmos.EntitySystems
             if (tile.Hotspot.Temperature > tile.MaxFireTemperatureSustained)
                 tile.MaxFireTemperatureSustained = tile.Hotspot.Temperature;
 
-            if (_hotspotSoundCooldown++ == 0 && !string.IsNullOrEmpty(HotspotSound))
+            if (_hotspotSoundCooldown++ == 0 && HotspotSound != null)
             {
                 var coordinates = _mapSystem.ToCenterCoordinates(tile.GridIndex, tile.GridIndices);
 
                 // A few details on the audio parameters for fire.
                 // The greater the fire state, the lesser the pitch variation.
                 // The greater the fire state, the greater the volume.
-                _audio.PlayPvs(HotspotSound, coordinates, AudioParams.Default.WithVariation(0.15f/tile.Hotspot.State).WithVolume(-5f + 5f * tile.Hotspot.State));
+                _audio.PlayPvs(HotspotSound, coordinates, HotspotSound.Params.WithVariation(0.15f / tile.Hotspot.State).WithVolume(-5f + 5f * tile.Hotspot.State));
             }
 
             if (_hotspotSoundCooldown > HotspotSoundCooldownCycles)

--- a/Resources/Prototypes/SoundCollections/atmospherics.yml
+++ b/Resources/Prototypes/SoundCollections/atmospherics.yml
@@ -4,3 +4,13 @@
   - /Audio/Effects/squeak1.ogg
   - /Audio/Effects/squeak2.ogg
   - /Audio/Effects/squeak3.ogg
+
+- type: soundCollection
+  id: SpaceWind
+  files:
+  - /Audio/Effects/space_wind.ogg
+
+- type: soundCollection
+  id: AtmosHotspot
+  files:
+  - /Audio/Effects/fire.ogg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Converts 2 sound file path strings in `AtmosphereSystem` partials into `SoundSpecifier`s.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
> String literals for sounds are deprecated, use a SoundSpecifier or ResolvedSoundSpecifier as appropriate instead

Fixes 2 warnings for https://github.com/space-wizards/space-station-14/issues/33279.

## Technical details
<!-- Summary of code changes for easier review. -->
- Replaced the `string?` properties with `SoundSpecifier?`s.
- Created `SoundCollection` prototypes for space wind and hotspots.
- Added `static readonly ProtoId<SoundCollectionPrototype` fields to validate the default sound collection IDs.
- Modified the `PlayPvs` calls so they don't bulldoze all the `AudioParams` of the specifiers.
- For space wind, moved the `WithVariation` call into the `SoundCollectionSpecifier` constructor call so it doesn't bulldoze any changes to the specifier. The other `WithWhatever` calls use dynamic values so they had to stay.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->