### PR TITLE
Make VendingMachineInventoryEntry a data definition for post-init savegrid

### DIFF
--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -193,15 +193,18 @@ namespace Content.Shared.VendingMachines
         #endregion
     }
 
-    [Serializable, NetSerializable]
-    public sealed class VendingMachineInventoryEntry
+    [Serializable, NetSerializable, DataDefinition]
+    public sealed partial class VendingMachineInventoryEntry
     {
-        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public InventoryType Type;
-        [ViewVariables(VVAccess.ReadWrite)]
+
+        [DataField]
         public string ID;
-        [ViewVariables(VVAccess.ReadWrite)]
+
+        [DataField]
         public uint Amount;
+
         public VendingMachineInventoryEntry(InventoryType type, string id, uint amount)
         {
             Type = type;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title; makes VendingMachineInventoryEntry a data definition so it can be saved to disk.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Post-mapinit vending machines are currently unable to be saved with savegrid or savemap. While this is generally not something that's very well supported (all sorts of quirks will be noticeable, especially with appearance data it seems), it's good to be able to give something bare-bones for saving things made for example in game.

(Currently the only other large cause of failed savegrids is if the grid is a station member, but I don't have a good solution for that besides making it not part of the station. Removing all vending machines on the other hand is very annoying.)

## Technical details
<!-- Summary of code changes for easier review. -->
I'll be so real I don't understand data definition's internals at all. I'd appreciate some careful review on this. That being said, it tests fine.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
ADMIN:
- fix: savegrid and savemap will no longer fail to save unpaused grids with vending machines on them.
