### PR TITLE
fix polymorph errors

### DIFF
--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -146,7 +146,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
     public void CloneAppearance(EntityUid source, EntityUid target, HumanoidAppearanceComponent? sourceHumanoid = null,
         HumanoidAppearanceComponent? targetHumanoid = null)
     {
-        if (!Resolve(source, ref sourceHumanoid) || !Resolve(target, ref targetHumanoid))
+        if (!Resolve(source, ref sourceHumanoid, false) || !Resolve(target, ref targetHumanoid, false))
             return;
 
         targetHumanoid.Species = sourceHumanoid.Species;

--- a/Resources/Prototypes/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/Polymorphs/polymorph.yml
@@ -178,7 +178,6 @@
     entity: MobLizard
     forced: true
     transferName: true
-    transferHumanoidAppearance: true
     inventory: None
     revertOnDeath: true
     revertOnCrit: true
@@ -190,7 +189,6 @@
     entity: MobLuminousPerson
     forced: true
     transferName: true
-    transferHumanoidAppearance: true
     inventory: None
     revertOnDeath: true
     revertOnCrit: true


### PR DESCRIPTION
## About the PR
Caught this error on grafana:
```
Can't resolve "Content.Shared.Humanoid.HumanoidAppearanceComponent" on entity The Bark of Endurance (803) (845135/n845135, MobLuminousPerson)!
   at System.Environment.get_StackTrace()
   at Content.Shared.Humanoid.SharedHumanoidAppearanceSystem.CloneAppearance(EntityUid source, EntityUid target, HumanoidAppearanceComponent sourceHumanoid, HumanoidAppearanceComponent targetHumanoid) in /home/runner/work/space-station-14/space-station-14/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs:line 149
   at Content.Server.Polymorph.Systems.PolymorphSystem.PolymorphEntity(EntityUid uid, PolymorphConfiguration configuration) in /home/runner/work/space-station-14/space-station-14/Content.Server/Polymorph/Systems/PolymorphSystem.cs:line 265
   at Content.Server.Polymorph.Systems.PolymorphSystem.PolymorphEntity(EntityUid uid, ProtoId`1 protoId) in /home/runner/work/space-station-14/space-station-14/Content.Server/Polymorph/Systems/PolymorphSystem.cs:line 175
   at Content.Server.Xenoarchaeology.Artifact.XAE.XAEPolymorphSystem.OnActivated(Entity`1 ent, XenoArtifactNodeActivatedEvent& args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPolymorphSystem.cs:line 35
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass67_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 460
   at Robust.Shared.GameObjects.EntityEventBus.EntDispatch(EntityUid euid, Type eventType, Unit& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 633
   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 218
   at Content.Shared.Xenoarchaeology.Artifact.SharedXenoArtifactSystem.TryActivateXenoArtifact(Entity`1 artifact, Nullable`1 user, Nullable`1 target, EntityCoordinates coordinates, Boolean consumeDurability) in /home/runner/work/space-station-14/space-station-14/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAE.cs:line 74
   at Content.Shared.Xenoarchaeology.Artifact.SharedXenoArtifactSystem.OnActivateInWorld(Entity`1 ent, ActivateInWorldEvent& args) in /home/runner/work/space-station-14/space-station-14/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAE.cs:line 41
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass57_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 324
   at Robust.Shared.GameObjects.EntityEventBus.DispatchOrderedEvents(Unit& eventArgs, ValueList`1& found) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs:line 50
   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 200
   at Content.Shared.Interaction.SharedInteractionSystem.InteractionActivate(EntityUid user, EntityUid used, Boolean checkCanInteract, Boolean checkUseDelay, Boolean checkAccess, Nullable`1 complexInteractions, Boolean checkDeletion) in /home/runner/work/space-station-14/space-station-14/Content.Shared/Interaction/SharedInteractionSystem.cs:line 1163
   at Content.Shared.Interaction.SharedInteractionSystem.HandleActivateItemInWorld(ICommonSession session, EntityCoordinates coords, EntityUid uid) in /home/runner/work/space-station-14/space-station-14/Content.Shared/Interaction/SharedInteractionSystem.cs:line 1122
   at Robust.Shared.Input.Binding.PointerInputCmdHandler.HandleCmdMessage(IEntityManager entManager, ICommonSession session, IFullInputCmdMessage message) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Input/Binding/InputCmdHandler.cs:line 114
   at Robust.Server.GameObjects.InputSystem.InputMessageHandler(InputCmdMessage message, EntitySessionEventArgs eventArgs) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/EntitySystems/InputSystem.cs:line 41
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass4_0`1.<SubscribeEvent>b__0(Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs:line 173
   at Robust.Server.GameObjects.ServerEntityManager.DispatchEntityNetworkMessage(MsgEntity message) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 230
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 166
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 705
   at Robust.Shared.Timing.GameLoop.Run() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 235
   at Robust.Server.BaseServer.MainLoop() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 572
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 42
   at Robust.Server.Program.Main(String[] args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 25
 Sawmill=system.humanoid_appearance
```

## Why / Balance
errors bad

## Technical details
The polymorph prototypes for luminous person and lizards had `transferHumanoidAppearance` set to true, but the target entity is not a humanoid, so this fails and causes a resolve error. I set both of them to false so this is skipped.
I also set logging for these resolves to false so that `CloneAppearance` just does nothing if one of the two entities is not eligible.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
no cl no fun