### PR TITLE
Adds Estoc DMR magazines to the syndicate ammo bundle

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -243,7 +243,7 @@ uplink-meds-bundle-name = Interdyne Medical Bundle
 uplink-meds-bundle-desc = An assortment of autoinjectors and premium medical equipment to cover for every possible situation. Contains an elite compact defibrillator that can be used as a weapon.
 
 uplink-ammo-bundle-name = Ammo Bundle
-uplink-ammo-bundle-desc = Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, and 2 ammo boxes for the L6 SAW.
+uplink-ammo-bundle-desc = Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, 3 magazines for the Estoc DMR, and 2 ammo boxes for the L6 SAW.
 
 uplink-sniper-bundle-name = Sniper Bundle
 uplink-sniper-bundle-desc = An inconspicuous briefcase that contains a Hristov, 10 spare bullets and a convenient disguise.

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -128,7 +128,7 @@
   parent: ClothingBackpackDuffelSyndicateAmmo
   id: ClothingBackpackDuffelSyndicateAmmoFilled
   name: ammo bundle
-  description: "Reloading! Contains 4 magazines for the C-20r, 5 drums for the Bulldog, and 2 ammo boxes for the L6 SAW."
+  description: "Reloading! Contains 4 magazines for the C-20r, 5 drums for the Bulldog, 3 magazines for the Estoc DMR, and 2 ammo boxes for the L6 SAW."
   components:
   - type: StorageFill
     contents:
@@ -136,6 +136,8 @@
         amount: 4
       - id: MagazineShotgun
         amount: 4
+      - id: MagazineRifle
+        amount: 3
       - id: MagazineShotgunSlug
         amount: 1
       - id: MagazineLightRifleBox


### PR DESCRIPTION

## About the PR
Adds rifle magazines for the Estoc DMR (#38122) to the syndicate ammo bundle.

## Why / Balance
As a primary weapon, the ammo should've been included in the ammo bundle initially, but this was an oversight on my part. If the ammo bundle price needs to be adjusted, I'll let maintainers decide if that's necessary and what that looks like!

## Technical details

## Media

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes


**Changelog**

no cl no fun
