### PR TITLE
Fixed vapes unintentionally dealing all burn damage types

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -74,8 +74,8 @@
   components:
   - type: Vape
     damage:
-      groups:
-        Burn: 2
+      types:
+        Heat: 2
   - type: SolutionContainerManager
     solutions:
       smokable:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I made vapes not deal caustic, cold, and shock damage when used, alongside the intended heat.

## Why / Balance
An obvious oversight; vapes shouldn't be dealing three damage types (1.5 damage) that you can't naturally regen _every_ time you use a vape.

## Technical details
changed "groups: burn: 2" to "type: heat: 2"

## Media
![vapefix](https://github.com/user-attachments/assets/00e581cf-8ca9-4d00-a489-ce344c632d91)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes


**Changelog**
:cl:
- fix: Fixed vapes dealing unintended damage types to you when used.
