### PR TITLE
Allow pAIs to emote like a borg

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -93,6 +93,12 @@
       components:
         - SecretStash
         - WrappedParcel
+  - type: Vocal
+    sounds:
+      Unsexed: UnisexSilicon
+  - type: Tag
+    tags:
+    - SiliconEmotes
 
 - type: entity
   parent: [ PersonalAI, BaseSyndicateContraband]
@@ -129,6 +135,9 @@
           On: { state: syndicate-pai-on-overlay }
   - type: StaticPrice
     price: 500
+  - type: Vocal
+    sounds:
+      Unsexed: UnisexSiliconSyndicate
 
 - type: entity
   parent: PersonalAI


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Add cyborg emotes to pAI

## Why / Balance
Cyborg emotes like `*beeps` just make sense for a pAI.

## Technical details
Add VocalComponent and SiliconEmotes tag, as taken from the base cyborg chassis to the pAI.

## Media
n/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: pAIs can emote like borgs now
