### PR TITLE
make biogenerator not accept low-nutrient plants

### DIFF
--- a/Content.Server/Materials/ProduceMaterialExtractorSystem.cs
+++ b/Content.Server/Materials/ProduceMaterialExtractorSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Materials.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Popups;
 using Robust.Server.Audio;
 
 namespace Content.Server.Materials;
@@ -13,6 +14,7 @@ public sealed class ProduceMaterialExtractorSystem : EntitySystem
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly MaterialStorageSystem _materialStorage = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -39,6 +41,13 @@ public sealed class ProduceMaterialExtractorSystem : EntitySystem
         var matAmount = solution.Value.Comp.Solution.Contents
             .Where(r => ent.Comp.ExtractionReagents.Contains(r.Reagent.Prototype))
             .Sum(r => r.Quantity.Float());
+
+        if (matAmount <= 0.1)
+        {
+            _popup.PopupEntity(Loc.GetString("material-extractor-comp-wrongreagent", ("used", args.Used)), args.User, args.User);
+            return;
+        }
+
         _materialStorage.TryChangeMaterialAmount(ent, ent.Comp.ExtractedMaterial, (int) matAmount);
 
         _audio.PlayPvs(ent.Comp.ExtractSound, ent);

--- a/Resources/Locale/en-US/materials/material-extractor.ftl
+++ b/Resources/Locale/en-US/materials/material-extractor.ftl
@@ -1,0 +1,1 @@
+material-extractor-comp-wrongreagent = {CAPITALIZE(THE($used))} has no required reagents for extraction.


### PR DESCRIPTION
## About the PR
Now plant can't be deleted by biogenerator if it has extremely low nutrient amount.

## Why / Balance
related to #31955. Issue itself feels not real issue, but this shows how players can be confused with current biogen system.

## Technical details
system not predicted, so no clientpopup(((

## Media
image here popup from the ftl file over biogenerator. I forgot to take a screenshot.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.