### PR TITLE
Add advertised reagents to puddles

### DIFF
--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -23,10 +23,8 @@
       puddle:
         maxVol: 1000
         reagents:
-        - ReagentId: Nutriment
-          Quantity: 5
-        - ReagentId: Water
-          Quantity: 5
+        - ReagentId: Vomit
+          Quantity: 10
 
 - type: entity
   id: PuddleEgg
@@ -51,10 +49,8 @@
       puddle:
         maxVol: 1000
         reagents:
-        - ReagentId: Nutriment
-          Quantity: 5
-        - ReagentId: Water
-          Quantity: 5
+        - ReagentId: JuiceTomato
+          Quantity: 10
 
 - type: entity
   parent: PuddleTemporary
@@ -118,10 +114,8 @@
       puddle:
         maxVol: 1000
         reagents:
-        - ReagentId: Nutriment
-          Quantity: 15
-        - ReagentId: Water
-          Quantity: 15
+        - ReagentId: JuiceWatermelon
+          Quantity: 30
 
 - type: entity
   id: PuddleFlour


### PR DESCRIPTION
## About the PR
Fills puddles with the proper reagents

## Why / Balance
- Currently only filled with water that evaporates immediately. 
- Prevents lawsuit for false advertisement. 

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
n/a
