### PR TITLE
Fix stacks only recycling one instead of the stack amount

### DIFF
--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -19,13 +19,13 @@ using Content.Shared.Materials;
 using Content.Shared.Mind;
 using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Power;
+using Content.Shared.Stacks;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using System.Linq;
 using Content.Shared.Humanoid;
-using Content.Shared.Stacks;
 
 namespace Content.Server.Materials;
 
@@ -184,11 +184,7 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
 
         var xform = Transform(uid);
 
-        var modifer = 1.0f;
-        if (TryComp<StackComponent>(item, out var stack))
-            modifer = stack.Count;
-
-        SpawnMaterialsFromComposition(uid, item, completion * component.Efficiency, modifer, xform: xform);
+        SpawnMaterialsFromComposition(uid, item, completion * component.Efficiency, xform: xform);
 
         if (CanGib(uid, item, component))
         {
@@ -209,7 +205,6 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
     private void SpawnMaterialsFromComposition(EntityUid reclaimer,
         EntityUid item,
         float efficiency,
-        float modifer,
         MaterialStorageComponent? storage = null,
         TransformComponent? xform = null,
         PhysicalCompositionComponent? composition = null)
@@ -220,9 +215,12 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
         if (!Resolve(item, ref composition, false))
             return;
 
+        // If more of these checks are needed, use an event instead
+        var modifier = CompOrNull<StackComponent>(item)?.Count ?? 1.0f;
+
         foreach (var (material, amount) in composition.MaterialComposition)
         {
-            var outputAmount = (int) (amount * efficiency * modifer);
+            var outputAmount = (int) (amount * efficiency * modifier);
             _materialStorage.TryChangeMaterialAmount(reclaimer, material, outputAmount, storage);
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Resolves #25516 

## Technical details
<!-- Summary of code changes for easier review. -->

Not sure if I should use an event or just do a check like this - an event seems a little overkill but if someone can think of another example of where this might be needed I'll update it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Recycler now properly recycles item stacks.

