### PR TITLE
Switch HSV to the default colorspace for character customization

### DIFF
--- a/Content.Client/Humanoid/EyeColorPicker.cs
+++ b/Content.Client/Humanoid/EyeColorPicker.cs
@@ -28,6 +28,13 @@ public sealed class EyeColorPicker : Control
 
         vBox.AddChild(_colorSelectors = new ColorSelectorSliders());
         _colorSelectors.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
+        // this is most certainly not the right way to do this but this was the only way I could get it to find the dropbox reliably.
+        if (_colorSelectors.GetChild(0) is BoxContainer rootBox &&
+            rootBox.GetChild(0) is BoxContainer headerBox &&
+            headerBox.GetChild(0) is OptionButton typeSelector)
+        {
+            typeSelector.Select((int) ColorSelectorSliders.ColorSelectorType.Hsv);
+        }
 
         _colorSelectors.OnColorChanged += ColorValueChanged;
     }

--- a/Content.Client/Humanoid/EyeColorPicker.cs
+++ b/Content.Client/Humanoid/EyeColorPicker.cs
@@ -27,7 +27,7 @@ public sealed class EyeColorPicker : Control
         AddChild(vBox);
 
         vBox.AddChild(_colorSelectors = new ColorSelectorSliders());
-        _colorSelectors.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv;
+        _colorSelectors.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
 
         _colorSelectors.OnColorChanged += ColorValueChanged;
     }

--- a/Content.Client/Humanoid/EyeColorPicker.cs
+++ b/Content.Client/Humanoid/EyeColorPicker.cs
@@ -28,13 +28,6 @@ public sealed class EyeColorPicker : Control
 
         vBox.AddChild(_colorSelectors = new ColorSelectorSliders());
         _colorSelectors.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
-        // this is most certainly not the right way to do this but this was the only way I could get it to find the dropbox reliably.
-        if (_colorSelectors.GetChild(0) is BoxContainer rootBox &&
-            rootBox.GetChild(0) is BoxContainer headerBox &&
-            headerBox.GetChild(0) is OptionButton typeSelector)
-        {
-            typeSelector.Select((int) ColorSelectorSliders.ColorSelectorType.Hsv);
-        }
 
         _colorSelectors.OnColorChanged += ColorValueChanged;
     }

--- a/Content.Client/Humanoid/EyeColorPicker.cs
+++ b/Content.Client/Humanoid/EyeColorPicker.cs
@@ -27,6 +27,7 @@ public sealed class EyeColorPicker : Control
         AddChild(vBox);
 
         vBox.AddChild(_colorSelectors = new ColorSelectorSliders());
+        _colorSelectors.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv;
 
         _colorSelectors.OnColorChanged += ColorValueChanged;
     }

--- a/Content.Client/Humanoid/MarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/MarkingPicker.xaml.cs
@@ -418,6 +418,13 @@ public sealed partial class MarkingPicker : Control
             ColorSelectorSliders colorSelector = new ColorSelectorSliders();
             colorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
             colorSliders.Add(colorSelector);
+            // this is most certainly not the right way to do this but this was the only way I could get it to find the dropbox reliably.
+            if (colorSelector.GetChild(0) is BoxContainer rootBox &&
+                rootBox.GetChild(0) is BoxContainer headerBox &&
+                headerBox.GetChild(0) is OptionButton typeSelector)
+            {
+                typeSelector.Select((int) ColorSelectorSliders.ColorSelectorType.Hsv);
+            }
 
             colorContainer.AddChild(new Label { Text = $"{stateNames[i]} color:" });
             colorContainer.AddChild(colorSelector);

--- a/Content.Client/Humanoid/MarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/MarkingPicker.xaml.cs
@@ -416,6 +416,7 @@ public sealed partial class MarkingPicker : Control
             CMarkingColors.AddChild(colorContainer);
 
             ColorSelectorSliders colorSelector = new ColorSelectorSliders();
+            colorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv;
             colorSliders.Add(colorSelector);
 
             colorContainer.AddChild(new Label { Text = $"{stateNames[i]} color:" });

--- a/Content.Client/Humanoid/MarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/MarkingPicker.xaml.cs
@@ -416,7 +416,7 @@ public sealed partial class MarkingPicker : Control
             CMarkingColors.AddChild(colorContainer);
 
             ColorSelectorSliders colorSelector = new ColorSelectorSliders();
-            colorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv;
+            colorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
             colorSliders.Add(colorSelector);
 
             colorContainer.AddChild(new Label { Text = $"{stateNames[i]} color:" });

--- a/Content.Client/Humanoid/MarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/MarkingPicker.xaml.cs
@@ -418,13 +418,6 @@ public sealed partial class MarkingPicker : Control
             ColorSelectorSliders colorSelector = new ColorSelectorSliders();
             colorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
             colorSliders.Add(colorSelector);
-            // this is most certainly not the right way to do this but this was the only way I could get it to find the dropbox reliably.
-            if (colorSelector.GetChild(0) is BoxContainer rootBox &&
-                rootBox.GetChild(0) is BoxContainer headerBox &&
-                headerBox.GetChild(0) is OptionButton typeSelector)
-            {
-                typeSelector.Select((int) ColorSelectorSliders.ColorSelectorType.Hsv);
-            }
 
             colorContainer.AddChild(new Label { Text = $"{stateNames[i]} color:" });
             colorContainer.AddChild(colorSelector);

--- a/Content.Client/Humanoid/SingleMarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/SingleMarkingPicker.xaml.cs
@@ -241,6 +241,13 @@ public sealed partial class SingleMarkingPicker : BoxContainer
             };
 
             ColorSelectorContainer.AddChild(selector);
+            // this is most certainly not the right way to do this but this was the only way I could get it to find the dropbox.
+            if (selector.GetChild(0) is BoxContainer rootBox &&
+                rootBox.GetChild(0) is BoxContainer headerBox &&
+                headerBox.GetChild(0) is OptionButton typeSelector)
+            {
+                typeSelector.Select((int) ColorSelectorSliders.ColorSelectorType.Hsv);
+            }
         }
     }
 

--- a/Content.Client/Humanoid/SingleMarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/SingleMarkingPicker.xaml.cs
@@ -241,13 +241,6 @@ public sealed partial class SingleMarkingPicker : BoxContainer
             };
 
             ColorSelectorContainer.AddChild(selector);
-            // this is most certainly not the right way to do this but this was the only way I could get it to find the dropbox.
-            if (selector.GetChild(0) is BoxContainer rootBox &&
-                rootBox.GetChild(0) is BoxContainer headerBox &&
-                headerBox.GetChild(0) is OptionButton typeSelector)
-            {
-                typeSelector.Select((int) ColorSelectorSliders.ColorSelectorType.Hsv);
-            }
         }
     }
 

--- a/Content.Client/Humanoid/SingleMarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/SingleMarkingPicker.xaml.cs
@@ -15,7 +15,7 @@ public sealed partial class SingleMarkingPicker : BoxContainer
     [Dependency] private readonly IEntityManager _entityManager = default!;
 
     private readonly SpriteSystem _sprite;
-    
+
     /// <summary>
     ///     What happens if a marking is selected.
     ///     It will send the 'slot' (marking index)
@@ -231,6 +231,7 @@ public sealed partial class SingleMarkingPicker : BoxContainer
                 HorizontalExpand = true
             };
             selector.Color = marking.MarkingColors[i];
+            selector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // forces color selector to HSV
 
             var colorIndex = i;
             selector.OnColorChanged += color =>

--- a/Content.Client/Humanoid/SingleMarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/SingleMarkingPicker.xaml.cs
@@ -231,7 +231,7 @@ public sealed partial class SingleMarkingPicker : BoxContainer
                 HorizontalExpand = true
             };
             selector.Color = marking.MarkingColors[i];
-            selector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // forces color selector to HSV
+            selector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
 
             var colorIndex = i;
             selector.OnColorChanged += color =>

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -240,6 +240,7 @@ namespace Content.Client.Lobby.UI
             };
 
             RgbSkinColorContainer.AddChild(_rgbSkinColorSelector = new ColorSelectorSliders());
+            _rgbSkinColorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv;
             _rgbSkinColorSelector.OnColorChanged += _ =>
             {
                 OnSkinColorOnValueChanged();

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -240,7 +240,7 @@ namespace Content.Client.Lobby.UI
             };
 
             RgbSkinColorContainer.AddChild(_rgbSkinColorSelector = new ColorSelectorSliders());
-            _rgbSkinColorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv;
+            _rgbSkinColorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
             _rgbSkinColorSelector.OnColorChanged += _ =>
             {
                 OnSkinColorOnValueChanged();

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -241,14 +241,6 @@ namespace Content.Client.Lobby.UI
 
             RgbSkinColorContainer.AddChild(_rgbSkinColorSelector = new ColorSelectorSliders());
             _rgbSkinColorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
-            // this is most certainly not the right way to do this but this was the only way I could get it to find the dropbox reliably.
-            if (_rgbSkinColorSelector.GetChild(0) is BoxContainer rootBox &&
-                rootBox.GetChild(0) is BoxContainer headerBox &&
-                headerBox.GetChild(0) is OptionButton typeSelector)
-            {
-                typeSelector.Select((int) ColorSelectorSliders.ColorSelectorType.Hsv);
-            }
-
             _rgbSkinColorSelector.OnColorChanged += _ =>
             {
                 OnSkinColorOnValueChanged();

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -241,6 +241,14 @@ namespace Content.Client.Lobby.UI
 
             RgbSkinColorContainer.AddChild(_rgbSkinColorSelector = new ColorSelectorSliders());
             _rgbSkinColorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
+            // this is most certainly not the right way to do this but this was the only way I could get it to find the dropbox reliably.
+            if (_rgbSkinColorSelector.GetChild(0) is BoxContainer rootBox &&
+                rootBox.GetChild(0) is BoxContainer headerBox &&
+                headerBox.GetChild(0) is OptionButton typeSelector)
+            {
+                typeSelector.Select((int) ColorSelectorSliders.ColorSelectorType.Hsv);
+            }
+
             _rgbSkinColorSelector.OnColorChanged += _ =>
             {
                 OnSkinColorOnValueChanged();


### PR DESCRIPTION
## About the PR
Changes the color pickers in character customization to use HSV by default instead of RGB. This does **NOT** remove RGB, just makes HSV default.

## Why / Balance
Currently, character customization uses RGB (Red, Green, Blue) as the default color selection colorspace. However, HSV (Hue, Saturation, Value) is more intuitive and user friendly for color picking in character customization. Its preferred in artistic workflows which makes sense especially for character customization. Having HSV be the default encourages and makes it easier for players to pick more visually appealing colors and overall make it feel more harmonious.

RGB colorspace still remains for whoever wants it for some _ungodly_ reason. This only changes the default.

## Technical details
Adds `colorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv;` after each initialization of color selectors in relevant code.

## Media
![image](https://github.com/user-attachments/assets/c3de35a1-a24f-453e-b923-c1ba4387dea0)
![image](https://github.com/user-attachments/assets/cc6d09fd-d3cd-4860-8a44-3f535027037b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- Should not break anything that does not touch the color selector initialization code in `EyeColorPicker.cs`, `MarkingPicker.xaml.cs`, `SingleMarkingPicker.xaml.cs`, and `HumanoidProfileEditor.xaml.cs`

**Changelog**
:cl: TrixxedHeart
- tweak: Made HSV the default color selector for character customization.
