### PR TITLE
Gave bartender zipties & handcuff legality

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
@@ -16,5 +16,6 @@
     ClothingOuterVest: 2
     ClothingBeltBandolier: 2
     ClothingEyesGlassesSunglasses: 2
+    Zipties: 2
   contrabandInventory:
     ToyFigurineBartender: 1

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -2,7 +2,7 @@
   name: handcuffs
   description: Used to detain criminals and other assholes.
   id: Handcuffs
-  parent: [BaseItem, BaseSecurityCommandContraband]
+  parent: [BaseItem, BaseSecurityCommandBartenderContraband]
   components:
   - type: Item
     size: Small

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -181,6 +181,15 @@
     allowedJobs: [ Bartender ]
 
 - type: entity
+  id: BaseSecurityCommandBartenderContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Security, Command ]
+    allowedJobs: [ Bartender ]
+
+- type: entity
   id: BaseSecurityBartenderZookeeperContraband
   parent: BaseRestrictedContraband
   abstract: true


### PR DESCRIPTION

## About the PR
I gave the bartender legal rights to hold zipties, aswell as other cuffs, and added two zipties to the bardrobe for them to use, I also made a new contraband level to suit this new situation, a hybrid security command & bartender legality.

## Why / Balance
This was done to give the bartender a legal way to restrain problem customers until security arrives, if they've caused enough of an issue to deserve being stunned by the bartenders beanbag rounds, without the bartender having to hold illegal zipties to do so.

It's felt odd to me that the bartender has access to a stunning firearm, yet had no (legal) way to deal with the threat/issue once they're actually stunned, short of critting them whilst they're down, or letting them stand up & continue, potentially causing even bigger issues for the bartender, so I gave them a potential solution without the legality concerns.

Balance wise, antagonists might feel a bit more of an allure to the role, but they get armour & firearms already, so they're already a solid pick for them, another - minor - concern is that some bartenders might get too excited & go validhunt an antagonist, but they can do that even before this PR, with only 15 lv wires for some cuffs of their own.

## Technical details
Added a new contraband level to base_contraband; "BaseSecurityCommandBartenderContraband"

Changed base handcuff contraband level to "BaseSecurityCommandBartenderContraband"

Added two zipties to the Bardrobe's inventory

## Media
![bartendercuffupdate](https://github.com/user-attachments/assets/75560621-e642-4894-9921-265925698314)
![bartendercuffsvender](https://github.com/user-attachments/assets/59bddf17-1ff1-4f1b-8bd3-e81ff0d70ef3)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Gave bartenders legal rights & access to cuffs, with two zipties now being available in their Bardrobe.
