### PR TITLE
Fix PDAs placed on belt slot not identifying players properly

### DIFF
--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -629,7 +629,7 @@ public sealed class AccessReaderSystem : EntitySystem
         items = new(_handsSystem.EnumerateHeld(uid));
 
         // maybe its inside an inventory slot?
-        if (_inventorySystem.TryGetSlotEntity(uid, "id", out var idUid))
+        if (_inventorySystem.TryGetSlotEntity(uid, "id", out var idUid) || _inventorySystem.TryGetSlotEntity(uid, "belt", out idUid))
         {
             items.Add(idUid.Value);
         }

--- a/Content.Shared/Access/Systems/IdExaminableSystem.cs
+++ b/Content.Shared/Access/Systems/IdExaminableSystem.cs
@@ -48,7 +48,7 @@ public sealed class IdExaminableSystem : EntitySystem
 
     public string? GetInfo(EntityUid uid)
     {
-        if (_inventorySystem.TryGetSlotEntity(uid, "id", out var idUid))
+        if (_inventorySystem.TryGetSlotEntity(uid, "id", out var idUid) || _inventorySystem.TryGetSlotEntity(uid, "belt", out idUid))
         {
             // PDA
             if (EntityManager.TryGetComponent(idUid, out PdaComponent? pda) &&

--- a/Content.Shared/Access/Systems/SharedIdCardSystem.cs
+++ b/Content.Shared/Access/Systems/SharedIdCardSystem.cs
@@ -95,7 +95,8 @@ public abstract class SharedIdCardSystem : EntitySystem
             return true;
 
         // check inventory slot?
-        if (_inventorySystem.TryGetSlotEntity(uid, "id", out var idUid) && TryGetIdCard(idUid.Value, out idCard))
+        if ((_inventorySystem.TryGetSlotEntity(uid, "id", out var idUid) || _inventorySystem.TryGetSlotEntity(uid, "belt", out idUid))
+            && TryGetIdCard(idUid.Value, out idCard))
             return true;
 
         return false;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Players that place their PDA on their belt slot can now have the job icon of the contained ID, and can be properly identified while covering their face. 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I think if you're allowed to put a PDA on your belt slot it probably should work just like as if you had it in your ID slot. This also lets the "free spirits" who don't like jumpsuits and can't use the ID slot be considered crew by silicons and not have security harass them for appearing ID-less. 
## Technical details
<!-- Summary of code changes for easier review. -->
Adjusted some conditionals to also check the belt slot, first time doing any c# changes so I may have messed up some sort of coding convention/standard for this codebase. In the case of multiple equipped IDs, the one in the ID slot will take precedence.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
(before) PDA on belt but no identification
![image](https://github.com/user-attachments/assets/944cb663-32e0-44d2-bc5d-17e34ae25c56)
(after) Fixed
![image](https://github.com/user-attachments/assets/25bcec86-d4df-485a-acf3-014474787087)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Players wearing their PDA on their belt slot can now be properly identified