### PR TITLE
Chameleon Controller Implants can be deimplanted

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -46,6 +46,7 @@
       - MindShieldImplant
       - FakeMindShieldImplant
       - RadioImplant
+      - ChameleonControllerImplant
       deimplantFailureDamage:
         types:
           Cellular: 50


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Chameleon Controller Implants can now be deimplanted.

## Why / Balance
They couldn't be deimplanted before. If this was intended behavior, then this PR may be dismissed.

## Technical details
Addition of `ChameleonControllerImplant` to the deimplant whitelist.

## Media
No.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
:cl:
- fix: Chameleon Controller Implants can be deimplanted.
