### PR TITLE
Retractable items get removed by handcuffs

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -824,7 +824,7 @@ namespace Content.Shared.Cuffs
     /// Relayed to their held items.
     /// </summary>
     [Serializable, NetSerializable]
-    public sealed partial class TargetHandcuffedEvent : EntityEventArgs, IInventoryRelayEvent
+    public record struct TargetHandcuffedEvent : IInventoryRelayEvent
     {
         /// <summary>
         /// All slots to relay to

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Item;
@@ -472,6 +473,9 @@ namespace Content.Shared.Cuffs
             if (TryComp<HandsComponent>(target, out var hands) && hands.Count <= component.CuffedHandCount)
                 return false;
 
+            var ev = new TargetHandcuffedEvent();
+            RaiseLocalEvent(target, ev);
+
             // Success!
             _hands.TryDrop(user, handcuff);
 
@@ -807,15 +811,24 @@ namespace Content.Shared.Cuffs
         {
             return component.Container.ContainedEntities;
         }
+    }
 
-        [Serializable, NetSerializable]
-        private sealed partial class UnCuffDoAfterEvent : SimpleDoAfterEvent
-        {
-        }
+    [Serializable, NetSerializable]
+    public sealed partial class UnCuffDoAfterEvent : SimpleDoAfterEvent;
 
-        [Serializable, NetSerializable]
-        private sealed partial class AddCuffDoAfterEvent : SimpleDoAfterEvent
-        {
-        }
+    [Serializable, NetSerializable]
+    public sealed partial class AddCuffDoAfterEvent : SimpleDoAfterEvent;
+
+    /// <summary>
+    /// Raised on the target when they get handcuffed.
+    /// Relayed to their held items.
+    /// </summary>
+    [Serializable, NetSerializable]
+    public sealed partial class TargetHandcuffedEvent : EntityEventArgs, IInventoryRelayEvent
+    {
+        /// <summary>
+        /// All slots to relay to
+        /// </summary>
+        public SlotFlags TargetSlots { get; set; }
     }
 }

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -474,7 +474,7 @@ namespace Content.Shared.Cuffs
                 return false;
 
             var ev = new TargetHandcuffedEvent();
-            RaiseLocalEvent(target, ev);
+            RaiseLocalEvent(target, ref ev);
 
             // Success!
             _hands.TryDrop(user, handcuff);
@@ -823,7 +823,7 @@ namespace Content.Shared.Cuffs
     /// Raised on the target when they get handcuffed.
     /// Relayed to their held items.
     /// </summary>
-    [Serializable, NetSerializable]
+    [ByRefEvent]
     public record struct TargetHandcuffedEvent : IInventoryRelayEvent
     {
         /// <summary>

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Relay.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Relay.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Atmos;
 using Content.Shared.Camera;
+using Content.Shared.Cuffs;
 using Content.Shared.Hands.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Projectiles;
@@ -15,6 +16,7 @@ public abstract partial class SharedHandsSystem
         SubscribeLocalEvent<HandsComponent, GetEyeOffsetRelayedEvent>(RelayEvent);
         SubscribeLocalEvent<HandsComponent, GetEyePvsScaleRelayedEvent>(RelayEvent);
         SubscribeLocalEvent<HandsComponent, RefreshMovementSpeedModifiersEvent>(RelayEvent);
+        SubscribeLocalEvent<HandsComponent, TargetHandcuffedEvent>(RelayEvent);
 
         // By-ref events.
         SubscribeLocalEvent<HandsComponent, ExtinguishEvent>(RefRelayEvent);

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Relay.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Relay.cs
@@ -16,7 +16,6 @@ public abstract partial class SharedHandsSystem
         SubscribeLocalEvent<HandsComponent, GetEyeOffsetRelayedEvent>(RelayEvent);
         SubscribeLocalEvent<HandsComponent, GetEyePvsScaleRelayedEvent>(RelayEvent);
         SubscribeLocalEvent<HandsComponent, RefreshMovementSpeedModifiersEvent>(RelayEvent);
-        SubscribeLocalEvent<HandsComponent, TargetHandcuffedEvent>(RelayEvent);
 
         // By-ref events.
         SubscribeLocalEvent<HandsComponent, ExtinguishEvent>(RefRelayEvent);
@@ -24,6 +23,7 @@ public abstract partial class SharedHandsSystem
         SubscribeLocalEvent<HandsComponent, HitScanReflectAttemptEvent>(RefRelayEvent);
         SubscribeLocalEvent<HandsComponent, WieldAttemptEvent>(RefRelayEvent);
         SubscribeLocalEvent<HandsComponent, UnwieldAttemptEvent>(RefRelayEvent);
+        SubscribeLocalEvent<HandsComponent, TargetHandcuffedEvent>(RefRelayEvent);
     }
 
     private void RelayEvent<T>(Entity<HandsComponent> entity, ref T args) where T : EntityEventArgs

--- a/Content.Shared/RetractableItemAction/RetractableItemActionSystem.cs
+++ b/Content.Shared/RetractableItemAction/RetractableItemActionSystem.cs
@@ -87,8 +87,6 @@ public sealed class RetractableItemActionSystem : EntitySystem
 
     private void OnItemHandcuffed(Entity<ActionRetractableItemComponent> ent, ref HeldRelayedEvent<TargetHandcuffedEvent> args)
     {
-        Log.Debug("Event received.");
-
         if (_actions.GetAction(ent.Comp.SummoningAction) is not { } action)
             return;
 

--- a/Content.Shared/RetractableItemAction/RetractableItemActionSystem.cs
+++ b/Content.Shared/RetractableItemAction/RetractableItemActionSystem.cs
@@ -1,6 +1,10 @@
 using Content.Shared.Actions;
+using Content.Shared.Cuffs;
+using Content.Shared.Hands;
+using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction.Components;
+using Content.Shared.Inventory;
 using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
@@ -26,6 +30,7 @@ public sealed class RetractableItemActionSystem : EntitySystem
         SubscribeLocalEvent<RetractableItemActionComponent, OnRetractableItemActionEvent>(OnRetractableItemAction);
 
         SubscribeLocalEvent<ActionRetractableItemComponent, ComponentShutdown>(OnActionSummonedShutdown);
+        Subs.SubscribeWithRelay<ActionRetractableItemComponent, HeldRelayedEvent<TargetHandcuffedEvent>>(OnItemHandcuffed);
     }
 
     private void OnActionInit(Entity<RetractableItemActionComponent> ent, ref MapInitEvent args)
@@ -58,16 +63,11 @@ public sealed class RetractableItemActionSystem : EntitySystem
 
         if (_hands.IsHolding(args.Performer, ent.Comp.ActionItemUid))
         {
-            RemComp<UnremoveableComponent>(ent.Comp.ActionItemUid.Value);
-            var container = _containers.GetContainer(ent, RetractableItemActionComponent.ContainerId);
-            _containers.Insert(ent.Comp.ActionItemUid.Value, container);
-            _audio.PlayPredicted(ent.Comp.RetractSounds, action.Comp.AttachedEntity.Value, action.Comp.AttachedEntity.Value);
+            RetractRetractableItem(args.Performer, ent.Comp.ActionItemUid.Value, ent.Owner);
         }
         else
         {
-            _hands.TryForcePickup(args.Performer, ent.Comp.ActionItemUid.Value, userHand, checkActionBlocker: false);
-            _audio.PlayPredicted(ent.Comp.SummonSounds, action.Comp.AttachedEntity.Value, action.Comp.AttachedEntity.Value);
-            EnsureComp<UnremoveableComponent>(ent.Comp.ActionItemUid.Value);
+            SummonRetractableItem(args.Performer, ent.Comp.ActionItemUid.Value, userHand, ent.Owner);
         }
 
         args.Handled = true;
@@ -83,6 +83,22 @@ public sealed class RetractableItemActionSystem : EntitySystem
 
         // If the item is somehow destroyed, re-add it to the action.
         PopulateActionItem(action.Owner);
+    }
+
+    private void OnItemHandcuffed(Entity<ActionRetractableItemComponent> ent, ref HeldRelayedEvent<TargetHandcuffedEvent> args)
+    {
+        Log.Debug("Event received.");
+
+        if (_actions.GetAction(ent.Comp.SummoningAction) is not { } action)
+            return;
+
+        if (action.Comp.AttachedEntity == null)
+            return;
+
+        if (_hands.GetActiveHand(action.Comp.AttachedEntity.Value) is not { } userHand)
+            return;
+
+        RetractRetractableItem(action.Comp.AttachedEntity.Value, ent, action.Owner);
     }
 
     private void PopulateActionItem(Entity<RetractableItemActionComponent?> ent)
@@ -101,5 +117,26 @@ public sealed class RetractableItemActionSystem : EntitySystem
         Dirty(summoned.Value, summonedComp);
 
         Dirty(ent);
+    }
+
+    private void RetractRetractableItem(EntityUid holder, EntityUid item, Entity<RetractableItemActionComponent?> action)
+    {
+        if (!Resolve(action, ref action.Comp, false))
+            return;
+
+        RemComp<UnremoveableComponent>(item);
+        var container = _containers.GetContainer(action, RetractableItemActionComponent.ContainerId);
+        _containers.Insert(item, container);
+        _audio.PlayPredicted(action.Comp.RetractSounds, holder, holder);
+    }
+
+    private void SummonRetractableItem(EntityUid holder, EntityUid item, Hand hand, Entity<RetractableItemActionComponent?> action)
+    {
+        if (!Resolve(action, ref action.Comp, false))
+            return;
+
+        _hands.TryForcePickup(holder, item, hand, checkActionBlocker: false);
+        _audio.PlayPredicted(action.Comp.SummonSounds, holder, holder);
+        EnsureComp<UnremoveableComponent>(item);
     }
 }

--- a/Content.Shared/RetractableItemAction/RetractableItemActionSystem.cs
+++ b/Content.Shared/RetractableItemAction/RetractableItemActionSystem.cs
@@ -30,7 +30,7 @@ public sealed class RetractableItemActionSystem : EntitySystem
         SubscribeLocalEvent<RetractableItemActionComponent, OnRetractableItemActionEvent>(OnRetractableItemAction);
 
         SubscribeLocalEvent<ActionRetractableItemComponent, ComponentShutdown>(OnActionSummonedShutdown);
-        Subs.SubscribeWithRelay<ActionRetractableItemComponent, HeldRelayedEvent<TargetHandcuffedEvent>>(OnItemHandcuffed);
+        Subs.SubscribeWithRelay<ActionRetractableItemComponent, HeldRelayedEvent<TargetHandcuffedEvent>>(OnItemHandcuffed, inventory: false);
     }
 
     private void OnActionInit(Entity<RetractableItemActionComponent> ent, ref MapInitEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made retractable items get retracted on getting handcuffed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A small bug and it looked weird. While the item was unable to be used, seeing the cuff on only one hand was extremely awkward.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new TargetHandcuffedEvent with a HeldRelay. It's sent on the target right before handcuffs are added to them.
RetractableItemSystem listens to that event and retracts the item upon receiving it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/ae991626-99df-45fd-af13-6cace1e804bf

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Not player facing... yet.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
