### PR TITLE
Ripping gloves

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -95,7 +95,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
         if (component.StripDelay == null)
             return;
 
-        var (time, stealth) = _strippable.GetStripTimeModifiers(user, wearer, item, component.StripDelay.Value);
+        var (time, stealth, _) = _strippable.GetStripTimeModifiers(user, wearer, item, component.StripDelay.Value);
 
         var args = new DoAfterArgs(EntityManager, user, time, new ToggleClothingDoAfterEvent(), item, wearer, item)
         {

--- a/Content.Shared/Strip/Components/StrippableComponent.cs
+++ b/Content.Shared/Strip/Components/StrippableComponent.cs
@@ -32,14 +32,15 @@ namespace Content.Shared.Strip.Components
     public sealed class StrippingEnsnareButtonPressed : BoundUserInterfaceMessage;
 
     [ByRefEvent]
-    public abstract class BaseBeforeStripEvent(TimeSpan initialTime, bool stealth = false) : EntityEventArgs, IInventoryRelayEvent
+    public abstract class BaseBeforeStripEvent(TimeSpan initialTime, bool stealth = false, bool popup = true) : EntityEventArgs, IInventoryRelayEvent
     {
         public readonly TimeSpan InitialTime = initialTime;
         public float Multiplier = 1f;
         public TimeSpan Additive = TimeSpan.Zero;
         public bool Stealth = stealth;
+        public bool Popup = popup;
 
-        public TimeSpan Time => TimeSpan.FromSeconds(MathF.Max(InitialTime.Seconds * Multiplier + Additive.Seconds, 0f));
+        public TimeSpan Time => TimeSpan.FromSeconds(MathF.Max(InitialTime.Seconds * Multiplier + (float)Additive.TotalSeconds, 0f));
 
         public SlotFlags TargetSlots { get; } = SlotFlags.GLOVES;
     }
@@ -80,12 +81,14 @@ namespace Content.Shared.Strip.Components
         public readonly bool InsertOrRemove;
         public readonly bool InventoryOrHand;
         public readonly string SlotOrHandName;
+        public readonly bool ShowPopup;
 
-        public StrippableDoAfterEvent(bool insertOrRemove, bool inventoryOrHand, string slotOrHandName)
+        public StrippableDoAfterEvent(bool insertOrRemove, bool inventoryOrHand, string slotOrHandName, bool showPopup = true)
         {
             InsertOrRemove = insertOrRemove;
             InventoryOrHand = inventoryOrHand;
             SlotOrHandName = slotOrHandName;
+            ShowPopup = showPopup;
         }
 
         public override DoAfterEvent Clone() => this;

--- a/Content.Shared/Strip/Components/ThievingComponent.cs
+++ b/Content.Shared/Strip/Components/ThievingComponent.cs
@@ -21,7 +21,13 @@ public sealed partial class ThievingComponent : Component
     /// Should it notify the user if they're stripping a pocket?
     /// </summary>
     [DataField, AutoNetworkedField]
-    public bool Stealthy;
+    public Stealthiness Stealthiness = Stealthiness.Visible;
+
+    /// <summary>
+    /// Whether the thieving is enabled.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Enabled = true;
 
     /// <summary>
     /// Variable pointing at the Alert modal
@@ -38,7 +44,18 @@ public sealed partial class ThievingComponent : Component
 }
 
 /// <summary>
+/// NotStealthy is regular slealing.
+/// Stealthy is fully slealthy stealing.
+/// Ripping is stealthy, but gives a popup after the stealing.
+/// </summary>
+public enum Stealthiness : byte
+{
+    Visible = 0,
+    Stealthy = 1,
+    Ripping = 2,
+}
+
+/// <summary>
 /// Event raised to toggle the thieving component.
 /// </summary>
 public sealed partial class ToggleThievingEvent : BaseAlertEvent;
-

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -338,6 +338,9 @@ uplink-clothing-no-slips-shoes-desc = Chameleon shoes that protect you from slip
 uplink-clothing-chameleon-thieving-gloves-name = Chameleon Thieving Gloves
 uplink-clothing-chameleon-thieving-gloves-desc = Discreetly steal from pockets and improve your thieving technique with these fancy new gloves. They can change appearance to match any pair of gloves!
 
+uplink-ripping-gloves-name = Chameleon Ripping Gloves
+uplink-ripping-gloves-desc = Boldly rip items out or forcefully put them into people's hands with these brand new gloves. They can change appearance to match any pair of gloves!
+
 uplink-clothing-outer-vest-web-name = Web Vest
 uplink-clothing-outer-vest-web-desc = A synthetic armor vest. This one has added webbing and ballistic plates.
 

--- a/Resources/Locale/en-US/strip/strippable-component.ftl
+++ b/Resources/Locale/en-US/strip/strippable-component.ftl
@@ -10,6 +10,8 @@ strippable-component-alert-owner = {CAPITALIZE(THE($user))} is removing your {$i
 strippable-component-alert-owner-hidden = You feel someone fumbling in your {$slot}!
 strippable-component-alert-owner-insert = {CAPITALIZE(THE($user))} is putting {INDEFINITE($item)} {$item} on you!
 strippable-component-alert-owner-insert-hand = {CAPITALIZE(THE($user))} is putting {INDEFINITE($item)} {$item} in your hand!
+strippable-component-alert-force-unequip = {CAPITALIZE(THE($user))} has stripped you of {$item}!
+strippable-component-alert-force-equip = {CAPITALIZE(THE($user))} has given you {$item}!
 
 # generic warning for when a user interacts with your equipped items.
 strippable-component-alert-owner-interact = {CAPITALIZE(THE($user))} is fumbling around with your {$item}!

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1782,6 +1782,19 @@
   categories:
     - UplinkWearables
 
+- type: listing
+  id: UplinkClothingHandsChameleonRipping
+  name: uplink-ripping-gloves-name
+  description: uplink-ripping-gloves-desc
+  productEntity: ClothingHandsChameleonRipping
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 2
+  cost:
+    Telecrystal: 3
+  categories:
+  - UplinkWearables
+
  # Pointless
 
 - type: listing

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -232,7 +232,7 @@
   - type: FingerprintMask
   - type: Thieving
     stripTimeReduction: 1
-    stealthy: true
+    stealthiness: Stealthy
   - type: ToggleClothing
     action: ActionToggleNinjaGloves
     disableOnUnequip: true
@@ -360,19 +360,6 @@
     damageProtection:
       flatReductions:
         Heat: 0 # no protection
-
-- type: entity
-  # Intentionally named after regular gloves, they're meant to be sneaky.
-  # This means they can also be butchered if you need to look un-sus before a very thorough search...
-  parent: ClothingHandsGlovesColorBlack
-  id: ThievingGloves
-  suffix: Thieving
-  components:
-  - type: Tag
-    tags: [] # ignore "WhitelistChameleon" tag
-  - type: Thieving
-    stripTimeReduction: 1.5
-    stealthy: true
 
 - type: entity
   parent: ClothingHandsGlovesColorWhite

--- a/Resources/Prototypes/Entities/Clothing/Hands/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/specific.yml
@@ -24,9 +24,18 @@
 
 - type: entity
   parent: ClothingHandsChameleon
-  id: ClothingHandsChameleonThief
+  id: ClothingHandsChameleonThieving
   suffix: Chameleon, Thieving
   components:
   - type: Thieving
     stripTimeReduction: 2
-    stealthy: true
+    stealthiness: Stealthy
+
+- type: entity
+  parent: ClothingHandsChameleon
+  id: ClothingHandsChameleonRipping
+  suffix: Chameleon, Ripping
+  components:
+  - type: Thieving
+    stripTimeReduction: 2
+    stealthiness: Ripping

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -90,7 +90,7 @@
   - type: StationLimitedNetwork
   - type: Thieving
     stripTimeReduction: 9999
-    stealthy: true
+    stealthiness: Stealthy
   - type: Stripping
   - type: SolutionScanner
   - type: IgnoreUIRange

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -29,7 +29,7 @@
       - type: Pacified
       - type: Thieving
         stripTimeReduction: 2
-        stealthy: true
+        stealthiness: Stealthy
       mindRoles:
       - MindRoleThief
       briefing:

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -681,3 +681,7 @@ BarSignEmprahAlignTile: BarSignEmprah
 BarSignSpacebucksAlignTile: BarSignSpacebucks
 BarSignMaltroachAlignTile: BarSignMaltroach
 BarSignWhiskeyEchoesAlignTile: BarSignWhiskeyEchoes
+
+# 2025-06-19
+ClothingHandsChameleonThief: ClothingHandsChameleonRipping
+ThievingGloves: ClothingHandsChameleonRipping


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Taking an item (or forcefully giving one) from a person now gives them a popup not only when starting the doafter, but also when it's done. This does not apply to stealthy stealing, that thief and space ninja have.
Added in-between of normal (visible) and fully stealthy stealing - ripping. It will hide the initial popup and doafter bar, but will still show popup at the end.
Added chameleon ripping gloves to uplink.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/pull/38123#issuecomment-2952717387
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/34d3fc5d-92e0-48f5-9713-fbff2d2e0c95

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Successfully stripping someone of an item, or giving an item, will now also give a popup.
- add: Syndicate agents can now purchase chameleon ripping gloves. They hide the stealing process, but the target would still know that you ripped an item from them.