### PR TITLE
Fix AI radial on objects without access

### DIFF
--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Airlock.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Airlock.cs
@@ -1,12 +1,14 @@
+using Content.Shared.Access.Systems;
 using Content.Shared.Doors.Components;
 using Robust.Shared.Serialization;
 using Content.Shared.Electrocution;
 
 namespace Content.Shared.Silicons.StationAi;
 
+// Handles airlock radial
 public abstract partial class SharedStationAiSystem
 {
-    // Handles airlock radial
+    [Dependency] private readonly AccessReaderSystem _access = default!;
 
     private void InitializeAirlock()
     {
@@ -20,7 +22,7 @@ public abstract partial class SharedStationAiSystem
     /// </summary>
     private void OnAirlockBolt(EntityUid ent, DoorBoltComponent component, StationAiBoltEvent args)
     {
-        if (component.BoltWireCut)
+        if (component.BoltWireCut || !_access.IsAllowed(args.User, ent))
         {
             ShowDeviceNotRespondingPopup(args.User);
             return;
@@ -38,7 +40,7 @@ public abstract partial class SharedStationAiSystem
     /// </summary>
     private void OnAirlockEmergencyAccess(EntityUid ent, AirlockComponent component, StationAiEmergencyAccessEvent args)
     {
-        if (!PowerReceiver.IsPowered(ent))
+        if (!PowerReceiver.IsPowered(ent) || !_access.IsAllowed(args.User, ent))
         {
             ShowDeviceNotRespondingPopup(args.User);
             return;
@@ -52,10 +54,7 @@ public abstract partial class SharedStationAiSystem
     /// </summary>
     private void OnElectrified(EntityUid ent, ElectrifiedComponent component, StationAiElectrifiedEvent args)
     {
-        if (
-            component.IsWireCut
-            || !PowerReceiver.IsPowered(ent)
-        )
+        if (component.IsWireCut || !PowerReceiver.IsPowered(ent) || !_access.IsAllowed(args.User, ent))
         {
             ShowDeviceNotRespondingPopup(args.User);
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
AI can no longer change bolt/EA/electrify states on doors it has no access to.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->
Simple IsAllowed check.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Station AI can no longer control bolts, emergency access and electrify status on doors it has no access to.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
