### PR TITLE
Remove redundant IoC Resolve in `EmptyOrWindowValidInTile`

### DIFF
--- a/Content.Shared/Construction/Conditions/EmptyOrWindowValidInTile.cs
+++ b/Content.Shared/Construction/Conditions/EmptyOrWindowValidInTile.cs
@@ -21,7 +21,7 @@ namespace Content.Shared.Construction.Conditions
 
             foreach (var entity in lookupSys.GetEntitiesIntersecting(location, LookupFlags.Approximate | LookupFlags.Static))
             {
-                if (IoCManager.Resolve<IEntityManager>().HasComponent<SharedCanBuildWindowOnTopComponent>(entity))
+                if (entManager.HasComponent<SharedCanBuildWindowOnTopComponent>(entity))
                     result = true;
             }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removes an unneeded `IoCManager.Resolve` call from the `EmptyOrWindowValidInTile` construction condition.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Micro-optimization, I guess? I stumbled across it and wanted to fix it.

## Technical details
<!-- Summary of code changes for easier review. -->
Line 16 already does an `IoCManager.Resolve` call to get the entity manager, so we just use use the result of that instead.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->