### PR TITLE
Add interaction test for retractable arm blade

### DIFF
--- a/Content.IntegrationTests/Tests/Actions/RetractableItemActionTest.cs
+++ b/Content.IntegrationTests/Tests/Actions/RetractableItemActionTest.cs
@@ -3,7 +3,6 @@ using Content.IntegrationTests.Tests.Interaction;
 using Content.Shared.Actions;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.RetractableItemAction;
-using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.Actions;
@@ -23,43 +22,35 @@ public sealed class RetractableItemActionTest : InteractionTest
         var handsSystem = Server.System<SharedHandsSystem>();
         var playerUid = SEntMan.GetEntity(Player);
 
-        // Make sure the player's hand starts empty
-        var heldItem = Hands.ActiveHandEntity;
-        Assert.That(heldItem, Is.Null, $"Player is holding an item ({SEntMan.ToPrettyString(heldItem)}) at start of test.");
-
-        // Inspect the action prototype to find the item it spawns
-        var armBladeActionProto = ProtoMan.Index(ArmBladeActionProtoId);
-        EntProtoId? spawnedProtoId = null;
         await Server.WaitAssertion(() =>
         {
+            // Make sure the player's hand starts empty
+            var heldItem = Hands.ActiveHandEntity;
+            Assert.That(heldItem, Is.Null, $"Player is holding an item ({SEntMan.ToPrettyString(heldItem)}) at start of test.");
+
+            // Inspect the action prototype to find the item it spawns
+            var armBladeActionProto = ProtoMan.Index(ArmBladeActionProtoId);
+
             // Find the component
             Assert.That(armBladeActionProto.TryGetComponent<RetractableItemActionComponent>(out var actionComp, SEntMan.ComponentFactory));
             // Get the item protoId from the component
-            spawnedProtoId = actionComp!.SpawnedPrototype;
-        });
-        Assert.That(spawnedProtoId, Is.Not.Null);
+            var spawnedProtoId = actionComp!.SpawnedPrototype;
 
-        // Add the action to the player
-        EntityUid? actionUid = null;
-        await Server.WaitAssertion(() =>
-        {
-            actionUid = actionsSystem.AddAction(playerUid, ArmBladeActionProtoId);
-        });
-        // Make sure the player has the action now
-        Assert.That(actionUid, Is.Not.Null, "Failed to add action to player.");
-        var actionEnt = actionsSystem.GetAction(actionUid);
+            // Add the action to the player
+            var actionUid = actionsSystem.AddAction(playerUid, ArmBladeActionProtoId);
+            // Make sure the player has the action now
+            Assert.That(actionUid, Is.Not.Null, "Failed to add action to player.");
+            var actionEnt = actionsSystem.GetAction(actionUid);
 
-        // Make sure the player's hand is still empty
-        heldItem = Hands.ActiveHandEntity;
-        Assert.That(heldItem, Is.Null, $"Player is holding an item ({SEntMan.ToPrettyString(heldItem)}) after adding action.");
+            // Make sure the player's hand is still empty
+            heldItem = Hands.ActiveHandEntity;
+            Assert.That(heldItem, Is.Null, $"Player is holding an item ({SEntMan.ToPrettyString(heldItem)}) after adding action.");
 
-        await Server.WaitAssertion(() =>
-        {
             // Activate the arm blade
             actionsSystem.PerformAction(ToServer(Player), actionEnt!.Value);
 
             // Make sure the player is now holding the expected item
-            var heldItem = Hands.ActiveHandEntity;
+            heldItem = Hands.ActiveHandEntity;
             Assert.That(heldItem, Is.Not.Null, $"Expected player to be holding {spawnedProtoId} but was holding nothing.");
             AssertPrototype(spawnedProtoId, SEntMan.GetNetEntity(heldItem));
 

--- a/Content.IntegrationTests/Tests/Actions/RetractableItemActionTest.cs
+++ b/Content.IntegrationTests/Tests/Actions/RetractableItemActionTest.cs
@@ -24,7 +24,7 @@ public sealed class RetractableItemActionTest : InteractionTest
         var playerUid = SEntMan.GetEntity(Player);
 
         // Make sure the player's hand starts empty
-        var heldItem = HandSys.GetActiveItem((ToServer(Player), Hands));
+        var heldItem = Hands.ActiveHandEntity;
         Assert.That(heldItem, Is.Null, $"Player is holding an item ({SEntMan.ToPrettyString(heldItem)}) at start of test.");
 
         // Inspect the action prototype to find the item it spawns
@@ -50,7 +50,7 @@ public sealed class RetractableItemActionTest : InteractionTest
         var actionEnt = actionsSystem.GetAction(actionUid);
 
         // Make sure the player's hand is still empty
-        heldItem = HandSys.GetActiveItem((ToServer(Player), Hands));
+        heldItem = Hands.ActiveHandEntity;
         Assert.That(heldItem, Is.Null, $"Player is holding an item ({SEntMan.ToPrettyString(heldItem)}) after adding action.");
 
         await Server.WaitAssertion(() =>
@@ -59,7 +59,7 @@ public sealed class RetractableItemActionTest : InteractionTest
             actionsSystem.PerformAction(ToServer(Player), actionEnt!.Value);
 
             // Make sure the player is now holding the expected item
-            var heldItem = HandSys.GetActiveItem((ToServer(Player), Hands));
+            var heldItem = Hands.ActiveHandEntity;
             Assert.That(heldItem, Is.Not.Null, $"Expected player to be holding {spawnedProtoId} but was holding nothing.");
             AssertPrototype(spawnedProtoId, SEntMan.GetNetEntity(heldItem));
 
@@ -67,7 +67,7 @@ public sealed class RetractableItemActionTest : InteractionTest
             actionsSystem.PerformAction(ToServer(Player), actionEnt.Value);
 
             // Make sure the player's hand is empty again
-            heldItem = HandSys.GetActiveItem((ToServer(Player), Hands));
+            heldItem = Hands.ActiveHandEntity;
             Assert.That(heldItem, Is.Null, $"Player is still holding an item ({SEntMan.ToPrettyString(heldItem)}) after second use.");
         });
     }

--- a/Content.IntegrationTests/Tests/Actions/RetractableItemActionTest.cs
+++ b/Content.IntegrationTests/Tests/Actions/RetractableItemActionTest.cs
@@ -1,0 +1,74 @@
+#nullable enable
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Shared.Actions;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.RetractableItemAction;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Actions;
+
+public sealed class RetractableItemActionTest : InteractionTest
+{
+    private static readonly EntProtoId ArmBladeActionProtoId = "ActionRetractableItemArmBlade";
+
+    /// <summary>
+    /// Gives the player the arm blade action, then activates it and makes sure they are given the blade.
+    /// Afterwards, uses the action again to retract the blade and makes sure their hand is empty.
+    /// </summary>
+    [Test]
+    public async Task ArmBladeActivateDeactivateTest()
+    {
+        var actionsSystem = Server.System<SharedActionsSystem>();
+        var handsSystem = Server.System<SharedHandsSystem>();
+        var playerUid = SEntMan.GetEntity(Player);
+
+        // Make sure the player's hand starts empty
+        var heldItem = Hands.ActiveHandEntity;
+        Assert.That(heldItem, Is.Null, $"Player is holding an item ({SEntMan.ToPrettyString(heldItem)}) at start of test.");
+
+        // Inspect the action prototype to find the item it spawns
+        var armBladeActionProto = ProtoMan.Index(ArmBladeActionProtoId);
+        EntProtoId? spawnedProtoId = null;
+        await Server.WaitAssertion(() =>
+        {
+            // Find the component
+            Assert.That(armBladeActionProto.TryGetComponent<RetractableItemActionComponent>(out var actionComp, SEntMan.ComponentFactory));
+            // Get the item protoId from the component
+            spawnedProtoId = actionComp!.SpawnedPrototype;
+        });
+        Assert.That(spawnedProtoId, Is.Not.Null);
+
+        // Add the action to the player
+        EntityUid? actionUid = null;
+        await Server.WaitAssertion(() =>
+        {
+            actionUid = actionsSystem.AddAction(playerUid, ArmBladeActionProtoId);
+        });
+        // Make sure the player has the action now
+        Assert.That(actionUid, Is.Not.Null, "Failed to add action to player.");
+        var actionEnt = actionsSystem.GetAction(actionUid);
+
+        // Make sure the player's hand is still empty
+        heldItem = Hands.ActiveHandEntity;
+        Assert.That(heldItem, Is.Null, $"Player is holding an item ({SEntMan.ToPrettyString(heldItem)}) after adding action.");
+
+        await Server.WaitAssertion(() =>
+        {
+            // Activate the arm blade
+            actionsSystem.PerformAction(ToServer(Player), actionEnt!.Value);
+
+            // Make sure the player is now holding the expected item
+            var heldItem = Hands.ActiveHandEntity;
+            Assert.That(heldItem, Is.Not.Null, $"Expected player to be holding {spawnedProtoId} but was holding nothing.");
+            AssertPrototype(spawnedProtoId, SEntMan.GetNetEntity(heldItem));
+
+            // Use the action again to retract the arm blade
+            actionsSystem.PerformAction(ToServer(Player), actionEnt.Value);
+
+            // Make sure the player's hand is empty again
+            heldItem = Hands.ActiveHandEntity;
+            Assert.That(heldItem, Is.Null, $"Player is still holding an item ({SEntMan.ToPrettyString(heldItem)}) after second use.");
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/Actions/RetractableItemActionTest.cs
+++ b/Content.IntegrationTests/Tests/Actions/RetractableItemActionTest.cs
@@ -24,7 +24,7 @@ public sealed class RetractableItemActionTest : InteractionTest
         var playerUid = SEntMan.GetEntity(Player);
 
         // Make sure the player's hand starts empty
-        var heldItem = Hands.ActiveHandEntity;
+        var heldItem = HandSys.GetActiveItem((ToServer(Player), Hands));
         Assert.That(heldItem, Is.Null, $"Player is holding an item ({SEntMan.ToPrettyString(heldItem)}) at start of test.");
 
         // Inspect the action prototype to find the item it spawns
@@ -50,7 +50,7 @@ public sealed class RetractableItemActionTest : InteractionTest
         var actionEnt = actionsSystem.GetAction(actionUid);
 
         // Make sure the player's hand is still empty
-        heldItem = Hands.ActiveHandEntity;
+        heldItem = HandSys.GetActiveItem((ToServer(Player), Hands));
         Assert.That(heldItem, Is.Null, $"Player is holding an item ({SEntMan.ToPrettyString(heldItem)}) after adding action.");
 
         await Server.WaitAssertion(() =>
@@ -59,7 +59,7 @@ public sealed class RetractableItemActionTest : InteractionTest
             actionsSystem.PerformAction(ToServer(Player), actionEnt!.Value);
 
             // Make sure the player is now holding the expected item
-            var heldItem = Hands.ActiveHandEntity;
+            var heldItem = HandSys.GetActiveItem((ToServer(Player), Hands));
             Assert.That(heldItem, Is.Not.Null, $"Expected player to be holding {spawnedProtoId} but was holding nothing.");
             AssertPrototype(spawnedProtoId, SEntMan.GetNetEntity(heldItem));
 
@@ -67,7 +67,7 @@ public sealed class RetractableItemActionTest : InteractionTest
             actionsSystem.PerformAction(ToServer(Player), actionEnt.Value);
 
             // Make sure the player's hand is empty again
-            heldItem = Hands.ActiveHandEntity;
+            heldItem = HandSys.GetActiveItem((ToServer(Player), Hands));
             Assert.That(heldItem, Is.Null, $"Player is still holding an item ({SEntMan.ToPrettyString(heldItem)}) after second use.");
         });
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds an interaction test that makes sure that `RetractableItemActionSystem` is working correctly.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/pull/38438#discussion_r2157022917 identified an issue with the `HandsSystem` refactor that would've been caught if we had more test coverage. Having this test in place will make sure that we can't break it in the future.

Additionally, running this test against the `HandsSystem` refactor showed that the supposed fix for the issue was insufficient. This test can also be used to help find the source of the problem.

## Technical details
<!-- Summary of code changes for easier review. -->
- Make sure the player starts with an empty hand.
- Give the arm blade action to the player.
- Make sure the player still has an empty hand.
- Activate the arm blade action.
- Make sure the player is now "holding" the arm blade.
- Activate the arm blade action again.
- Make sure the player's hand is empty again.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->