### PR TITLE
Scarves for Sec (Sec Loadout Options)

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -154,9 +154,10 @@ loadout-group-warden-jumpsuit = Warden jumpsuit
 loadout-group-warden-outerclothing = Warden outer clothing
 
 loadout-group-security-head = Security head
+loadout-group-security-neck = Security neck
 loadout-group-security-jumpsuit = Security jumpsuit
 loadout-group-security-backpack = Security backpack
-loadout-group-security-belt = Security Belt
+loadout-group-security-belt = Security belt
 loadout-group-security-outerclothing = Security outer clothing
 loadout-group-security-shoes = Security shoes
 loadout-group-security-id = Security ID

--- a/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
@@ -15,6 +15,11 @@
   equipment:
     neck: ClothingNeckTieDet
 
+- type: loadout
+  id: RedTie
+  equipment:
+    neck: ClothingNeckTieRed
+
 # Jumpsuit
 - type: loadout
   id: DetectiveJumpsuit

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -44,6 +44,12 @@
   equipment:
     head: ClothingHeadHatSecurityTrooper
 
+# Neck
+- type: loadout
+  id: RedScarf
+  equipment:
+    neck: ClothingNeckScarfStripedRed
+
 # Jumpsuit
 - type: loadout
   id: SecurityJumpsuit

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1014,6 +1014,13 @@
   - TrooperHat
 
 - type: loadoutGroup
+  id: SecurityNeck
+  name: loadout-group-security-neck
+  minLimit: 0
+  loadouts:
+  - RedScarf
+
+- type: loadoutGroup
   id: SecurityJumpsuit
   name: loadout-group-security-jumpsuit
   loadouts:
@@ -1076,6 +1083,8 @@
   minLimit: 0
   loadouts:
   - DetectiveTie
+  - RedTie
+  - RedScarf
 
 - type: loadoutGroup
   id: DetectiveJumpsuit

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -357,6 +357,7 @@
   id: JobWarden
   groups:
   - WardenHead
+  - SecurityNeck
   - WardenJumpsuit
   - SecurityBackpack
   - SecurityBelt
@@ -371,6 +372,7 @@
   id: JobSecurityOfficer
   groups:
   - SecurityHead
+  - SecurityNeck
   - SecurityJumpsuit
   - SecurityBackpack
   - SecurityOuterClothing


### PR DESCRIPTION
## About the PR
Adds the option to pick the red scarf for Sec roles in the Loadouts menu. Det also gets a cool red tie.

## Why / Balance
Drip or drown baby. 😎 Why should all of Sec have to fight over 3 red scarves from the SecDrobe? Det and HoS already have neck loadout options so I don't see the point in not expanding that to Ward and SecOff. (Cadets are dripless, as NT intended.)

## Technical details
Modified the loadout files for Sec. If there's intrest in doing this for other departments I can make additional PRs.

## Media
<img width="721" alt="sec" src="https://github.com/user-attachments/assets/8a330db4-49b3-48b3-ba38-fb1cc0571cba" />
<img width="740" alt="det" src="https://github.com/user-attachments/assets/0a5d81c2-eb37-4e5d-b5d7-6070cb4a9b27" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
NA

**Changelog**
:cl:
- add: Sec loadouts include the red scarf! (Not dripless Cadets though.)
