### PR TITLE
Fix the tail wagging action being blocked by cuffs.

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -369,6 +369,7 @@
     iconOn: { sprite: Mobs/Customization/reptilian_parts.rsi, state: tail_smooth_behind }
     itemIconStyle: NoItem
     useDelay: 1 # emote spam
+    checkCanInteract: false
 
 - type: entity
   parent: BaseAction


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
As the title says. Sets checkCanInteract to false for ActionToggleWagging.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Handcuffs no longer interfere with your daily tail wagging activities.