### PR TITLE
Paracusia + MassHallucination minor refactor

### DIFF
--- a/Content.Client/Traits/ParacusiaSystem.cs
+++ b/Content.Client/Traits/ParacusiaSystem.cs
@@ -1,25 +1,28 @@
 using System.Numerics;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Traits.Assorted;
-using Robust.Shared.Random;
 using Robust.Client.Player;
-using Robust.Shared.Player;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player;
+using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
 namespace Content.Client.Traits;
 
 public sealed class ParacusiaSystem : SharedParacusiaSystem
 {
-    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlock = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<ParacusiaComponent, ComponentStartup>(OnComponentStartup);
+
+        SubscribeLocalEvent<ParacusiaComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<ParacusiaComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<ParacusiaComponent, LocalPlayerDetachedEvent>(OnPlayerDetach);
     }
 
@@ -30,46 +33,64 @@ public sealed class ParacusiaSystem : SharedParacusiaSystem
         if (!_timing.IsFirstTimePredicted)
             return;
 
-        if (_player.LocalEntity is not EntityUid localPlayer)
+        if (_player.LocalEntity is not { } localPlayer
+            || IsPaused(localPlayer))
             return;
 
         PlayParacusiaSounds(localPlayer);
     }
 
-    private void OnComponentStartup(EntityUid uid, ParacusiaComponent component, ComponentStartup args)
+
+    private void OnMapInit(Entity<ParacusiaComponent> ent, ref MapInitEvent args)
     {
-        component.NextIncidentTime = _timing.CurTime + TimeSpan.FromSeconds(_random.NextFloat(component.MinTimeBetweenIncidents, component.MaxTimeBetweenIncidents));
+        ent.Comp.NextIncidentTime = _timing.CurTime;
+        SetNewIncidentTime(ent);
     }
 
-    private void OnPlayerDetach(EntityUid uid, ParacusiaComponent component, LocalPlayerDetachedEvent args)
+    private void OnPlayerAttached(Entity<ParacusiaComponent> ent, ref LocalPlayerAttachedEvent args)
     {
-        component.Stream = _audio.Stop(component.Stream);
+        ent.Comp.NextIncidentTime = _timing.CurTime;
+        SetNewIncidentTime(ent);
     }
 
-    private void PlayParacusiaSounds(EntityUid uid)
+    private void OnPlayerDetach(Entity<ParacusiaComponent> ent, ref LocalPlayerDetachedEvent args)
     {
-        if (!TryComp<ParacusiaComponent>(uid, out var paracusia))
+        ent.Comp.Stream = _audio.Stop(ent.Comp.Stream);
+    }
+
+    private void PlayParacusiaSounds(Entity<ParacusiaComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
             return;
 
-        if (_timing.CurTime <= paracusia.NextIncidentTime)
+        if (_timing.CurTime <= ent.Comp.NextIncidentTime)
             return;
 
-        // Set the new time.
-        var timeInterval = _random.NextFloat(paracusia.MinTimeBetweenIncidents, paracusia.MaxTimeBetweenIncidents);
-        paracusia.NextIncidentTime += TimeSpan.FromSeconds(timeInterval);
+        SetNewIncidentTime((ent, ent.Comp));
+
+        // Would we actually have heard this?
+        if (!_actionBlock.CanConsciouslyPerformAction(ent))
+            return;
 
         // Offset position where the sound is played
-        var randomOffset =
-            new Vector2
-            (
-                _random.NextFloat(-paracusia.MaxSoundDistance, paracusia.MaxSoundDistance),
-                _random.NextFloat(-paracusia.MaxSoundDistance, paracusia.MaxSoundDistance)
-            );
+        var randomOffset = new Vector2(
+            _random.NextFloat(-ent.Comp.MaxSoundDistance, ent.Comp.MaxSoundDistance),
+            _random.NextFloat(-ent.Comp.MaxSoundDistance, ent.Comp.MaxSoundDistance)
+        );
 
-        var newCoords = Transform(uid).Coordinates.Offset(randomOffset);
+        var newCoords = Transform(ent).Coordinates.Offset(randomOffset);
 
         // Play the sound
-        paracusia.Stream = _audio.PlayStatic(paracusia.Sounds, uid, newCoords)?.Entity;
+        ent.Comp.Stream = _audio.PlayStatic(ent.Comp.Sounds, ent, newCoords)?.Entity;
     }
 
+    /// <summary>
+    /// Set a randomly generated time for the next incident to occur. Note this assumes that the component's
+    /// <see cref="ParacusiaComponent.NextIncidentTime" /> is close to the current time.
+    /// </summary>
+    private void SetNewIncidentTime(Entity<ParacusiaComponent> ent)
+    {
+        ent.Comp.NextIncidentTime +=
+            TimeSpan.FromSeconds(_random.NextFloat(ent.Comp.MinTimeBetweenIncidents, ent.Comp.MaxTimeBetweenIncidents));
+    }
 }

--- a/Content.Client/Traits/ParacusiaSystem.cs
+++ b/Content.Client/Traits/ParacusiaSystem.cs
@@ -90,7 +90,6 @@ public sealed class ParacusiaSystem : SharedParacusiaSystem
     /// </summary>
     private void SetNewIncidentTime(Entity<ParacusiaComponent> ent)
     {
-        ent.Comp.NextIncidentTime +=
-            TimeSpan.FromSeconds(_random.NextFloat(ent.Comp.MinTimeBetweenIncidents, ent.Comp.MaxTimeBetweenIncidents));
+        ent.Comp.NextIncidentTime += _random.Next(ent.Comp.MinTimeBetweenIncidents, ent.Comp.MaxTimeBetweenIncidents);
     }
 }

--- a/Content.Server/StationEvents/Components/MassHallucinationsRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/MassHallucinationsRuleComponent.cs
@@ -1,6 +1,5 @@
 using Content.Server.StationEvents.Events;
 using Robust.Shared.Audio;
-using Robust.Shared.Collections;
 
 namespace Content.Server.StationEvents.Components;
 
@@ -8,23 +7,23 @@ namespace Content.Server.StationEvents.Components;
 public sealed partial class MassHallucinationsRuleComponent : Component
 {
     /// <summary>
-    /// The maximum time between incidents in seconds
+    /// The maximum time between incidents.
     /// </summary>
-    [DataField("maxTimeBetweenIncidents", required: true), ViewVariables(VVAccess.ReadWrite)]
-    public float MaxTimeBetweenIncidents;
+    [DataField]
+    public TimeSpan MaxTimeBetweenIncidents = TimeSpan.FromSeconds(60);
 
     /// <summary>
-    /// The minimum time between incidents in seconds
+    /// The minimum time between incidents.
     /// </summary>
-    [DataField("minTimeBetweenIncidents", required: true), ViewVariables(VVAccess.ReadWrite)]
-    public float MinTimeBetweenIncidents;
+    [DataField]
+    public TimeSpan MinTimeBetweenIncidents = TimeSpan.FromSeconds(30);
 
-    [DataField("maxSoundDistance", required: true), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float MaxSoundDistance;
 
-    [DataField("sounds", required: true)]
-    public SoundSpecifier Sounds = default!;
+    [DataField(required: true)]
+    public SoundSpecifier Sounds;
 
-    [DataField, ViewVariables(VVAccess.ReadOnly)]
-    public List<EntityUid> AffectedEntities = new();
+    [ViewVariables(VVAccess.ReadOnly)]
+    public List<EntityUid> AffectedEntities = [];
 }

--- a/Content.Server/StationEvents/Events/MassHallucinationsRule.cs
+++ b/Content.Server/StationEvents/Events/MassHallucinationsRule.cs
@@ -1,4 +1,3 @@
-using Content.Server.GameTicking.Rules.Components;
 using Content.Server.StationEvents.Components;
 using Content.Server.Traits.Assorted;
 using Content.Shared.GameTicking.Components;
@@ -20,14 +19,14 @@ public sealed class MassHallucinationsRule : StationEventSystem<MassHallucinatio
         var query = EntityQueryEnumerator<MindContainerComponent, HumanoidAppearanceComponent>();
         while (query.MoveNext(out var ent, out _, out _))
         {
-            if (!EnsureComp<ParacusiaComponent>(ent, out var paracusia))
-            {
-                _paracusia.SetSounds(ent, component.Sounds, paracusia);
-                _paracusia.SetTime(ent, component.MinTimeBetweenIncidents, component.MaxTimeBetweenIncidents, paracusia);
-                _paracusia.SetDistance(ent, component.MaxSoundDistance);
+            // People who already have paracusia (usually via trait) strangely don't hear mass hallucinations :)
+            if (EnsureComp<ParacusiaComponent>(ent, out var paracusia))
+                continue;
+            _paracusia.SetSounds((ent, paracusia), component.Sounds);
+            _paracusia.SetTime((ent, paracusia), component.MinTimeBetweenIncidents, component.MaxTimeBetweenIncidents);
+            _paracusia.SetDistance((ent, paracusia), component.MaxSoundDistance);
 
-                component.AffectedEntities.Add(ent);
-            }
+            component.AffectedEntities.Add(ent);
         }
     }
 

--- a/Content.Server/Traits/Assorted/ParacusiaSystem.cs
+++ b/Content.Server/Traits/Assorted/ParacusiaSystem.cs
@@ -5,34 +5,31 @@ namespace Content.Server.Traits.Assorted;
 
 public sealed class ParacusiaSystem : SharedParacusiaSystem
 {
-    public void SetSounds(EntityUid uid, SoundSpecifier sounds, ParacusiaComponent? component = null)
+    public void SetSounds(Entity<ParacusiaComponent?> ent, SoundSpecifier sounds)
     {
-        if (!Resolve(uid, ref component))
-        {
+        if (!Resolve(ent, ref ent.Comp))
             return;
-        }
-        component.Sounds = sounds;
-        Dirty(uid, component);
+
+        ent.Comp.Sounds = sounds;
+        Dirty(ent);
     }
 
-    public void SetTime(EntityUid uid, float minTime, float maxTime, ParacusiaComponent? component = null)
+    public void SetTime(Entity<ParacusiaComponent?> ent, TimeSpan minTime, TimeSpan maxTime)
     {
-        if (!Resolve(uid, ref component))
-        {
+        if (!Resolve(ent, ref ent.Comp))
             return;
-        }
-        component.MinTimeBetweenIncidents = minTime;
-        component.MaxTimeBetweenIncidents = maxTime;
-        Dirty(uid, component);
+
+        ent.Comp.MinTimeBetweenIncidents = minTime;
+        ent.Comp.MaxTimeBetweenIncidents = maxTime;
+        Dirty(ent);
     }
 
-    public void SetDistance(EntityUid uid, float maxSoundDistance, ParacusiaComponent? component = null)
+    public void SetDistance(Entity<ParacusiaComponent?> ent, float maxSoundDistance)
     {
-        if (!Resolve(uid, ref component))
-        {
+        if (!Resolve(ent, ref ent.Comp))
             return;
-        }
-        component.MaxSoundDistance = maxSoundDistance;
-        Dirty(uid, component);
+
+        ent.Comp.MaxSoundDistance = maxSoundDistance;
+        Dirty(ent);
     }
 }

--- a/Content.Shared/Traits/Assorted/ParacusiaComponent.cs
+++ b/Content.Shared/Traits/Assorted/ParacusiaComponent.cs
@@ -21,18 +21,18 @@ public sealed partial class ParacusiaComponent : Component
     public float MaxSoundDistance;
 
     /// <summary>
-    /// The maximum time between incidents in seconds
+    /// The maximum time between incidents.
     /// </summary>
     [DataField]
     [AutoNetworkedField]
-    public float MaxTimeBetweenIncidents = 60f;
+    public TimeSpan MaxTimeBetweenIncidents = TimeSpan.FromSeconds(60);
 
     /// <summary>
-    /// The minimum time between incidents in seconds
+    /// The minimum time between incidents.
     /// </summary>
     [DataField]
     [AutoNetworkedField]
-    public float MinTimeBetweenIncidents = 30f;
+    public TimeSpan MinTimeBetweenIncidents = TimeSpan.FromSeconds(30);
 
     [AutoPausedField]
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
@@ -41,9 +41,9 @@ public sealed partial class ParacusiaComponent : Component
     /// <summary>
     /// The sounds to choose from
     /// </summary>
-    [DataField]
+    [DataField(required: true)]
     [AutoNetworkedField]
-    public SoundSpecifier Sounds = default!;
+    public SoundSpecifier Sounds;
 
     public EntityUid? Stream;
 }

--- a/Content.Shared/Traits/Assorted/ParacusiaComponent.cs
+++ b/Content.Shared/Traits/Assorted/ParacusiaComponent.cs
@@ -9,39 +9,41 @@ namespace Content.Shared.Traits.Assorted;
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 [AutoGenerateComponentState]
+[AutoGenerateComponentPause]
 [Access(typeof(SharedParacusiaSystem))]
 public sealed partial class ParacusiaComponent : Component
 {
     /// <summary>
+    /// How far away at most can the sound be?
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public float MaxSoundDistance;
+
+    /// <summary>
     /// The maximum time between incidents in seconds
     /// </summary>
-    [DataField("maxTimeBetweenIncidents", required: true), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     [AutoNetworkedField]
     public float MaxTimeBetweenIncidents = 60f;
 
     /// <summary>
     /// The minimum time between incidents in seconds
     /// </summary>
-    [DataField("minTimeBetweenIncidents", required: true), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     [AutoNetworkedField]
     public float MinTimeBetweenIncidents = 30f;
 
-    /// <summary>
-    /// How far away at most can the sound be?
-    /// </summary>
-    [DataField("maxSoundDistance", required: true), ViewVariables(VVAccess.ReadWrite)]
-    [AutoNetworkedField]
-    public float MaxSoundDistance;
+    [AutoPausedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan NextIncidentTime;
 
     /// <summary>
     /// The sounds to choose from
     /// </summary>
-    [DataField("sounds", required: true)]
+    [DataField]
     [AutoNetworkedField]
     public SoundSpecifier Sounds = default!;
-
-    [DataField("timeBetweenIncidents", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan NextIncidentTime;
 
     public EntityUid? Stream;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This refactors the paracusia trait to be a bit more in-line with our current standards, especially with regard to TimeSpan updating, fixing a few bugs in the process. Most notably, paracusia incidents would build up while your player was detached from the character, making reattaching VERY loud.

Also cleans up the component definition to use auto paused fields, removes some unneeded field names, and unmarks fields as required that didn't need to be.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Headphone ops.

## Technical details
<!-- Summary of code changes for easier review. -->
If this should've been two PRs I'm sorry :(

Also dang, positive diff for a "cleanup" PR...

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- Server-side methods in ParacusiaSystem have been moved to use the Entity<T> pattern.
- Several fields in ParacusiaComponent and MassHallucinationsRuleComponent have been moved to be TimeSpans instead of float seconds.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no
