### PR TITLE
Fix styles color for group button in loadout menu

### DIFF
--- a/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
@@ -184,9 +184,7 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
             .OfType<LoadoutContainer>()
             .Any(c => c.Select.Pressed);
 
-        toggle.Modulate = anyActive
-            ? Color.Green
-            : Color.White;
+        toggle.Pressed = anyActive;
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
fix https://github.com/space-wizards/space-station-14/issues/38457#issuecomment-2989659399
changes the color of the group button according to the style
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
no balance
## Technical details
<!-- Summary of code changes for easier review. -->
changing 2 lines and setting toggle.Pressed if there is at least one item in the group

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
old
![image](https://github.com/user-attachments/assets/182e108f-9b35-43a5-8eea-091734944973)

new
![image](https://github.com/user-attachments/assets/b03be75c-366a-4c73-a584-bb723fbf5713)
![image](https://github.com/user-attachments/assets/2e5b75c6-def7-44db-b41f-729f01f46f57)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
no cl, no fun
