### PR TITLE
Conveyor friction change

### DIFF
--- a/Content.Shared/Physics/Controllers/SharedConveyorController.cs
+++ b/Content.Shared/Physics/Controllers/SharedConveyorController.cs
@@ -59,7 +59,10 @@ public abstract class SharedConveyorController : VirtualController
     private void OnConveyedFriction(Entity<ConveyedComponent> ent, ref TileFrictionEvent args)
     {
         // Conveyed entities don't get friction, they just get wishdir applied so will inherently slowdown anyway.
-        args.Modifier = 0f;
+        if (ent.Comp.Conveying) //check if the item is actually being conveyed, otherwise normal friction should apply
+        {
+            args.Modifier = 0f;
+        }
     }
 
     private void OnConveyedStartup(Entity<ConveyedComponent> ent, ref ComponentStartup args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This adds a check to the conveyor controller to only cancel friction while the item is being conveyed

based on https://github.com/ss14Starlight/space-station-14/pull/873

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I maintain Starlight, and we have been having massive issues with gamestate lag and overall TPS issues at the end of round recently. After about 2 weeks of theorizing and finding different things, fixing this issue has returned the gamestate graph to normal. Im porting this upstream so everyone can take advantage of it

## Technical details
<!-- Summary of code changes for easier review. -->
Heres data on performance before and after the fix.
Blue in the update system usage graph is gamestate updates, and the fix was applied at 06:00, and live after that round ended. as you can see through multiple rounds, there isn't the gamestate hill anymore, and the framebudget is met easily again.
![image](https://github.com/user-attachments/assets/77059888-da80-4fe1-8999-e57890875b34)

The main reason this was a issue is because, the items constantly spinning with no friction when thrown onto them means their physics is never slept. And this becomes a issue because all disposals lead directly onto conveyors, meaning you might have 200+ items by end of round just spinning and constantly awake. I'm not sure why this translates to a gamestate spike at end of round.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Happyrobot33
- fix: Fixed conveyors infinitely spinning items thrown onto them and causing TPS lag.