### PR TITLE
SignalSwitchSystem: Check button is locked before toggling

### DIFF
--- a/Content.Server/DeviceLinking/Systems/SignalSwitchSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/SignalSwitchSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.DeviceLinking.Components;
 using Content.Server.DeviceNetwork;
 using Content.Shared.Interaction;
+using Content.Shared.Lock;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 
@@ -10,6 +11,7 @@ public sealed class SignalSwitchSystem : EntitySystem
 {
     [Dependency] private readonly DeviceLinkSystem _deviceLink = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly LockSystem _lock = default!;
 
     public override void Initialize()
     {
@@ -27,6 +29,9 @@ public sealed class SignalSwitchSystem : EntitySystem
     private void OnActivated(EntityUid uid, SignalSwitchComponent comp, ActivateInWorldEvent args)
     {
         if (args.Handled || !args.Complex)
+            return;
+
+        if (_lock.IsLocked(uid))
             return;
 
         comp.State = !comp.State;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Access restricted locked switches can currently be toggled without having the correct access when locked.  This fixes that by first checking if they're locked.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This fixes a bug.  A locked button should only be pressable when the lock is open - this effectively removes the point of having a lock in the first place if anyone can activate it.

## Technical details
<!-- Summary of code changes for easier review. -->

New dependency in SignalSwitchSystem, one call in the ActivateInWorld event handler.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:

There are two switches.  The left is a signal button, the right is a locked button behind some access.  The user, without access, uses both buttons.  Both trigger and turn on a linked light.  The right should not.

https://github.com/user-attachments/assets/286182d1-cd7b-4b4a-ba2a-ff9c3f326d9b

After:

The same setup is repeated.  The user, without access, uses both buttons.  The left triggers, the right does not.  The user picks up their PDA from the floor, opens the right button, and uses it.  It triggers.  They drop the PDA and use it, it triggers.  This shows the desired behaviour.

https://github.com/user-attachments/assets/2f577acf-9f20-4ea1-9248-a09a4e5a98f1

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
honestly, pretty negligible
:cl:
- fix: Locked buttons must now be unlocked to trigger.