### PR TITLE
make scurret crate the same price as big lotto (10,000 spesos)

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -224,7 +224,7 @@
     sprite: Structures/Wallmounts/posters.rsi
     state: poster55_legit
   product: CrateFunScurret
-  cost: 25000 # You will surely not regret buying this
+  cost: 10000 # You will surely not regret buying this
   category: cargoproduct-category-name-fun
   group: market
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
ʕ●.●ʔ <( wawa

made scurret crates 10,000 spesos instead of 25,000

## Why / Balance
I feel like having scurret crates be essentially the equivalent of 2.5 big lottos is a bit nuts. Personally I think it could end up in causing cargo to neglect more legitimate duties in the pursuits of getting scurrets, which could cause other parts of the station to suffer.

Having it be the same price as the big lotto would at the very least make it a choice for cargo between a big lotto or a scurret, which I think is much more reasonable.

## Technical details
changed cargo_fun.yml scurrets from 25000 to 10000

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
changes scurret price

**Changelog**
:cl:
- tweak: Adjusted Scurret Crate from 25,000 to 10,000 spesos.
