### PR TITLE
Fix styles for group button in loadout menu

### DIFF
--- a/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
@@ -145,7 +145,7 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
                     subList.AddChild(proto);
                 }
 
-                UpdateToggleColor(toggle, subList);
+                UpdateSubGroupSelectedInfo(firstElement, toggle, subList);
             }
             else
             {
@@ -178,13 +178,19 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
         return toggle;
     }
 
-    private void UpdateToggleColor(Button toggle, BoxContainer subList)
+    private void UpdateSubGroupSelectedInfo(LoadoutContainer loadout, Button toggle, BoxContainer subList)
     {
-        var anyActive = subList.Children
+        var countSubSelected = subList.Children
             .OfType<LoadoutContainer>()
-            .Any(c => c.Select.Pressed);
+            .Count(c => c.Select.Pressed);
 
-        toggle.Pressed = anyActive;
+        var anySelected = countSubSelected > 0;
+
+        if (anySelected)
+        {
+            loadout.Text += " " + Loc.GetString("loadouts-count-items-in-group", ("count", countSubSelected));
+            toggle.Pressed = anySelected;
+        }
     }
 
     /// <summary>

--- a/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
@@ -144,8 +144,8 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
                 {
                     subList.AddChild(proto);
                 }
-
-                UpdateSubGroupSelectedInfo(firstElement, toggle, subList);
+                var itemName = firstElement.Text ?? "";
+                UpdateSubGroupSelectedInfo(firstElement, itemName, subList);
             }
             else
             {
@@ -164,12 +164,14 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
         };
 
         toggle.Text = subContainer.Visible ? OpenedGroupMark : ClosedGroupMark;
+        toggle.Pressed = subContainer.Visible;
 
         toggle.OnPressed += _ =>
         {
             var willOpen = !subContainer.Visible;
             subContainer.Visible = willOpen;
             toggle.Text = willOpen ? OpenedGroupMark : ClosedGroupMark;
+            toggle.Pressed = willOpen;
             _openedGroups[kvp.Key] = willOpen;
         };
 
@@ -178,18 +180,15 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
         return toggle;
     }
 
-    private void UpdateSubGroupSelectedInfo(LoadoutContainer loadout, Button toggle, BoxContainer subList)
+    private void UpdateSubGroupSelectedInfo(LoadoutContainer loadout, string itemName, BoxContainer subList)
     {
         var countSubSelected = subList.Children
             .OfType<LoadoutContainer>()
             .Count(c => c.Select.Pressed);
 
-        var anySelected = countSubSelected > 0;
-
-        if (anySelected)
+        if (countSubSelected > 0)
         {
-            loadout.Text += " " + Loc.GetString("loadouts-count-items-in-group", ("count", countSubSelected));
-            toggle.Pressed = anySelected;
+            loadout.Text = Loc.GetString("loadouts-count-items-in-group", ("item", itemName), ("count", countSubSelected));
         }
     }
 

--- a/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
@@ -184,9 +184,7 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
             .OfType<LoadoutContainer>()
             .Any(c => c.Select.Pressed);
 
-        toggle.Modulate = anyActive
-            ? Color.Green
-            : Color.White;
+        toggle.Pressed = anyActive;
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/preferences/loadouts.ftl
+++ b/Resources/Locale/en-US/preferences/loadouts.ftl
@@ -9,4 +9,9 @@ loadouts-min-limit = Min count: {$count}
 loadouts-max-limit = Max count: {$count}
 loadouts-points-limit = Points: {$count} / {$max}
 
+loadouts-count-items-in-group = and {$count} other {$count ->
+[1] item
+*[other] items
+}
+
 loadouts-points-restriction = Insufficient points

--- a/Resources/Locale/en-US/preferences/loadouts.ftl
+++ b/Resources/Locale/en-US/preferences/loadouts.ftl
@@ -9,7 +9,7 @@ loadouts-min-limit = Min count: {$count}
 loadouts-max-limit = Max count: {$count}
 loadouts-points-limit = Points: {$count} / {$max}
 
-loadouts-count-items-in-group = and {$count} other {$count ->
+loadouts-count-items-in-group = {$item} and {$count} other {$count ->
 [1] item
 *[other] items
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

fix #38457

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
improves the intuitiveness of the loadout menu

## Technical details
<!-- Summary of code changes for easier review. -->
Added output of the number of items that were selected in a subgroup, as suggested here https://github.com/space-wizards/space-station-14/issues/38457#issuecomment-2993754430

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/4492bd46-da43-45a2-9305-e8be0bc59733)
![image](https://github.com/user-attachments/assets/15985ee5-9dc9-46af-a586-3874222427f3)
![image](https://github.com/user-attachments/assets/39e91965-7457-4f43-8eaa-4a3468687e1b)
![image](https://github.com/user-attachments/assets/74126d05-7b52-4ea4-9ef6-ab69f6a6d09e)
![image](https://github.com/user-attachments/assets/516e86d3-55ca-44c0-943c-60ca11a21fa8)




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: qrwas
- tweak: Loadout item group UI improvements
