### PR TITLE
Fix StoreTests EventBus usage

### DIFF
--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -128,7 +128,7 @@ public sealed class StoreTests
 
 
                     var buyMsg = new StoreBuyListingMessage(discountedListingItem.ID){Actor = human};
-                    server.EntMan.EventBus.RaiseComponentEvent(pda, storeComponent, buyMsg);
+                    server.EntMan.EventBus.RaiseLocalEvent(pda, buyMsg);
 
                     var newBalance = storeComponent.Balance[UplinkSystem.TelecrystalCurrencyPrototype];
                     Assert.That(newBalance.Value, Is.EqualTo((originalBalance - plainDiscountedCost).Value), "Expected to have balance reduced by discounted cost");
@@ -141,7 +141,7 @@ public sealed class StoreTests
                     Assert.That(costAfterBuy.Value, Is.EqualTo(prototypeCost.Value), "Expected cost after discount refund to be equal to prototype cost.");
 
                     var refundMsg = new StoreRequestRefundMessage { Actor = human };
-                    server.EntMan.EventBus.RaiseComponentEvent(pda, storeComponent, refundMsg);
+                    server.EntMan.EventBus.RaiseLocalEvent(pda, refundMsg);
 
                     // get refreshed item after refund re-generated items
                     discountedListingItem = storeComponent.FullListingsCatalog.First(x => x.ID == itemId);


### PR DESCRIPTION
Fix split off from #37349 to avoid needing to sync the content/engine PRs.
