### PR TITLE
fix: use QueueDel for DeleteEntity construction graph action

### DIFF
--- a/Content.Server/Construction/Completions/DeleteEntity.cs
+++ b/Content.Server/Construction/Completions/DeleteEntity.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Construction.Completions
             entityManager.EventBus.RaiseLocalEvent(uid, ev);
 
             if (!ev.Cancelled)
-                entityManager.DeleteEntity(uid);
+                entityManager.QueueDeleteEntity(uid);
         }
     }
 }

--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -265,7 +265,10 @@ namespace Content.Server.Construction
                 PerformActions(uid, userUid, node.Actions);
 
             // An action might have deleted the entity... Account for this.
-            if (!Exists(uid))
+            // In general non-queued deletion should not occur, as if it is
+            // triggered by a DamageTrigger via a melee attack, there's still
+            // more processing that needs to occur.
+            if (EntityManager.IsQueuedForDeletion(uid) || !Exists(uid))
                 return false;
 
             UpdatePathfinding(uid, construction);

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -171,7 +171,8 @@ namespace Content.Server.Construction
                 // Edge finished!
                 PerformActions(uid, user, edge.Completed);
 
-                if (construction.Deleted)
+                // Actions should be queueing deletion—see also ChangeNode.
+                if (EntityManager.IsQueuedForDeletion(uid) || construction.Deleted)
                     return HandleResult.True;
 
                 construction.TargetEdgeIndex = null;
@@ -468,7 +469,7 @@ namespace Content.Server.Construction
             foreach (var action in actions)
             {
                 // If an action deletes the entity, we stop performing the rest of actions.
-                if (!Exists(uid))
+                if (EntityManager.IsQueuedForDeletion(uid) || !Exists(uid))
                     break;
 
                 action.PerformAction(uid, userUid, EntityManager);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The DeleteEntity construction graph action was using an unqueued entity delete, meaning systems that modified damage but still need the entity for further processing would explode.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The specific bug I ran into is that destroying an unfinished machine frame via melee ends up attempting to grab the transform of the deleted machine frame, as the threshold behavior triggered a node change triggering the EntityDelete construction action. This then causes the rest of the melee handling code catches fire.

## Technical details
<!-- Summary of code changes for easier review. -->
Okay, so, the more I think about it the less sure I am this is the way to go about fixing this issue: this has surprisingly far reaching ramifications, though I _think_ it's mostly limited to anything that changes construction nodes and is used to checking for deletion rather than queued deletion.

I wanted to put out this version first since I think it does make more sense for the node action to queue deletion (this is what the Destroy node graph action, via DestructibleSystem, as well as DeleteEntitiesInContainer), but I'm not sure if it's worth the possible pain.

Arguably the real fix here is to just fix the machine frame construction graph to not have a delete action on its starting node, and if that's thought to be best I can just switch to that.

That being said, things seem to test fine™.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

- The DeleteEntity construction graph action now queues the entity deletion rather than deleting the entity immediately.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No user facing changes. Probably.
