### PR TITLE
wallmount debug overlay

### DIFF
--- a/Content.Client/Commands/ShowWallmountsCommand.cs
+++ b/Content.Client/Commands/ShowWallmountsCommand.cs
@@ -1,0 +1,24 @@
+using Content.Client.Wall;
+using Robust.Client.Graphics;
+using Robust.Shared.Console;
+
+namespace Content.Client.Commands;
+
+/// <summary>
+/// Shows the area in which entities with <see cref="Content.Shared.Wall.WallMountComponent" /> can be interacted from.
+/// </summary>
+public sealed class ShowWallmountsCommand : LocalizedCommands
+{
+    [Dependency] private readonly IOverlayManager _overlay = default!;
+
+    public override string Command => "showwallmounts";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var existing = _overlay.RemoveOverlay<WallmountDebugOverlay>();
+        if (!existing)
+            _overlay.AddOverlay(new WallmountDebugOverlay());
+
+        shell.WriteLine(Loc.GetString($"cmd-showwallmounts-status", ("status", !existing)));
+    }
+}

--- a/Content.Client/Wall/WallmountDebugOverlay.cs
+++ b/Content.Client/Wall/WallmountDebugOverlay.cs
@@ -1,0 +1,60 @@
+using Content.Shared.Interaction;
+using Content.Shared.Wall;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using System.Numerics;
+
+namespace Content.Client.Wall;
+
+/// <summary>
+/// Shows the area in which entities with <see cref="WallMountComponent" /> can be interacted from.
+/// </summary>
+public sealed class WallmountDebugOverlay : Overlay
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+    private readonly SharedTransformSystem _transform;
+    private readonly EntityLookupSystem _lookup;
+    private HashSet<Entity<WallMountComponent>> _intersecting = new();
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    public WallmountDebugOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+
+        _transform = _entManager.System<SharedTransformSystem>();
+        _lookup = _entManager.System<EntityLookupSystem>();
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var handle = args.WorldHandle;
+
+        _intersecting.Clear();
+        _lookup.GetEntitiesIntersecting(args.MapId, args.WorldBounds, _intersecting);
+        foreach (var ent in _intersecting)
+        {
+            var (worldPos, worldRot) = _transform.GetWorldPositionRotation(ent.Owner);
+            DrawArc(args.WorldHandle, worldPos, SharedInteractionSystem.InteractionRange, worldRot + ent.Comp.Direction, ent.Comp.Arc);
+        }
+    }
+
+    private void DrawArc(DrawingHandleWorld handle, Vector2 position, float radius, Angle rot, Angle arc)
+    {
+        // 16 segments for a full circle, but 2 at least
+        var segments = Math.Max((int)(arc.Theta / Math.Tau * 16), 2);
+        var step = arc.Theta / (segments - 1);
+        var verts = new Vector2[segments + 1];
+
+        verts[0] = position;
+        for (var i = 0; i < segments; i++)
+        {
+            var angle = (float)(-arc.Theta / 2 + i * step - rot.Theta + Math.PI);
+            var pos = new Vector2(MathF.Sin(angle), MathF.Cos(angle));
+
+            verts[i + 1] = position + pos * radius;
+        }
+
+        handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, verts, Color.Green.WithAlpha(0.5f));
+    }
+}

--- a/Resources/Locale/en-US/commands/show-wallmounts-command.ftl
+++ b/Resources/Locale/en-US/commands/show-wallmounts-command.ftl
@@ -1,0 +1,3 @@
+﻿cmd-showwallmounts-desc = Toggles showing wallmount interaction areas
+cmd-showwallmounts-help = Usage: showwallmounts
+cmd-showwallmounts-status = Set wallmount debug overlay to {$status}.


### PR DESCRIPTION
## About the PR
Adds an overlay to visualize the interaction area for wallmounts.

## Why / Balance
Makes it easier to debug them and helps mappers to plan room layouts.

## Technical details
Very simple overlay. Draws the interaction arc directly from reading the datafields from the `WallmountComponent` and constructing a partial circle from triangles.

## Media
![1](https://github.com/user-attachments/assets/7ec17579-771e-450f-bf3a-16fb7dbbfd12)
![2](https://github.com/user-attachments/assets/f5db23b4-8106-4d90-abc4-5dc6aeb03358)
The `Arc` datafield was modified via VV in the second image.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
not player facing
