### PR TITLE
Add a safety net for making sure you don't breathe from the wrong tank

### DIFF
--- a/Content.Shared/AirTank/AirTankLooksLikeComponent.cs
+++ b/Content.Shared/AirTank/AirTankLooksLikeComponent.cs
@@ -1,19 +1,22 @@
-﻿namespace Content.Shared.AirTank;
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.AirTank;
 
 /// <summary>
 ///     Specifies what a certain tank APPEARS to contain. Is not actually what it contains.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class AirTankLooksLikeComponent : Component
 {
     /// <summary>
     ///     What this air tank would normally contain
     /// </summary>
-    /// <returns></returns>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public AirTankLooksLike Contains = AirTankLooksLike.NotAir;
 }
 
+[Serializable, NetSerializable]
 public enum AirTankLooksLike : byte
 {
     Invalid,

--- a/Content.Shared/AirTank/AirTankLooksLikeComponent.cs
+++ b/Content.Shared/AirTank/AirTankLooksLikeComponent.cs
@@ -1,0 +1,25 @@
+﻿namespace Content.Shared.AirTank;
+
+/// <summary>
+///     Specifies what a certain tank APPEARS to contain. Is not actually what it contains.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AirTankLooksLikeComponent : Component
+{
+    /// <summary>
+    ///     What this air tank would normally contain
+    /// </summary>
+    /// <returns></returns>
+    [DataField]
+    public AirTankLooksLike Contains = AirTankLooksLike.NotAir;
+}
+
+public enum AirTankLooksLike : byte
+{
+    Invalid,
+    NotAir,
+    RegularAir,
+    Oxygen,
+    Nitrogen,
+    Plasma,
+}

--- a/Content.Shared/AirTank/AirTankLooksLikeSystem.cs
+++ b/Content.Shared/AirTank/AirTankLooksLikeSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Popups;
+﻿using Content.Shared.Examine;
+using Content.Shared.Popups;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
 
@@ -11,8 +12,15 @@ public sealed class AirTankLooksLikeSystem : EntitySystem
     [Dependency] private readonly INetManager _netMan = default!;
 
     public readonly LocId PopupText = "air-tank-looks-like";
-
+    public readonly LocId DontText = "air-tank-looks-like-dont";
     public readonly LocId ConfirmText = "air-tank-looks-like-confirm";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AirTankLooksLikeComponent, ExaminedEvent>(OnExamine);
+    }
 
     public void CreateShouldntBreathePopup(EntityUid user, EntityUid tank)
     {
@@ -25,13 +33,27 @@ public sealed class AirTankLooksLikeSystem : EntitySystem
         _popupSystem.PopupPredicted(PopupTextLoc + "\n" + ConfirmTextLoc, null, user, user, PopupType.MediumCaution);
     }
 
+    public void OnExamine(Entity<AirTankLooksLikeComponent> uid, ref ExaminedEvent args)
+    {
+        if (!TryComp(args.Examiner, out AirTankShouldBreatheComponent? shouldBreathe))
+            return;
+
+        if (!CanBreathe(shouldBreathe, uid.Comp))
+            args.PushMarkup(Loc.GetString(DontText));
+    }
+
+    public bool CanBreathe(AirTankShouldBreatheComponent user, AirTankLooksLikeComponent tank)
+    {
+        return user.TankTypes.Contains(tank.Contains);
+    }
+
     public bool CheckShouldBreathe(EntityUid user, EntityUid tank)
     {
         if (!TryComp(user, out AirTankShouldBreatheComponent? shouldBreathe) ||
             !TryComp(tank, out AirTankLooksLikeComponent? looksLike))
             return true;
 
-        if (shouldBreathe.TankTypes.Contains(looksLike.Contains))
+        if (CanBreathe(shouldBreathe, looksLike))
         {
             shouldBreathe.LastAttempted = null;
             return true;

--- a/Content.Shared/AirTank/AirTankLooksLikeSystem.cs
+++ b/Content.Shared/AirTank/AirTankLooksLikeSystem.cs
@@ -10,21 +10,19 @@ public sealed class AirTankLooksLikeSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly INetManager _netMan = default!;
 
-    public readonly string PopupPrefix = "air-tank-looks-like-";
-    public readonly string ConfirmText = "air-tank-looks-like-confirm";
+    public readonly LocId PopupText = "air-tank-looks-like";
+
+    public readonly LocId ConfirmText = "air-tank-looks-like-confirm";
 
     public void CreateShouldntBreathePopup(EntityUid user, EntityUid tank)
     {
-        if (_netMan.IsServer)
-            return;
-
         if (!TryComp(tank, out AirTankLooksLikeComponent? airTankLooksLike))
             return;
 
-        string PopupTextLoc = _localization.GetString(PopupPrefix + airTankLooksLike.Contains.ToString().ToLower());
+        string PopupTextLoc = _localization.GetString(PopupText, ("state", airTankLooksLike.Contains));
         string ConfirmTextLoc = _localization.GetString(ConfirmText);
 
-        _popupSystem.PopupEntity(PopupTextLoc + "\n" + ConfirmTextLoc, user, PopupType.MediumCaution);
+        _popupSystem.PopupPredicted(PopupTextLoc + "\n" + ConfirmTextLoc, null, user, user, PopupType.MediumCaution);
     }
 
     public bool CheckShouldBreathe(EntityUid user, EntityUid tank)

--- a/Content.Shared/AirTank/AirTankLooksLikeSystem.cs
+++ b/Content.Shared/AirTank/AirTankLooksLikeSystem.cs
@@ -1,0 +1,51 @@
+﻿using Content.Shared.Popups;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.AirTank;
+
+public sealed class AirTankLooksLikeSystem : EntitySystem
+{
+    [Dependency] private readonly ILocalizationManager _localization = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly INetManager _netMan = default!;
+
+    public readonly string PopupPrefix = "air-tank-looks-like-";
+    public readonly string ConfirmText = "air-tank-looks-like-confirm";
+
+    public void CreateShouldntBreathePopup(EntityUid user, EntityUid tank)
+    {
+        if (_netMan.IsServer)
+            return;
+
+        if (!TryComp(tank, out AirTankLooksLikeComponent? airTankLooksLike))
+            return;
+
+        string PopupTextLoc = _localization.GetString(PopupPrefix + airTankLooksLike.Contains.ToString().ToLower());
+        string ConfirmTextLoc = _localization.GetString(ConfirmText);
+
+        _popupSystem.PopupEntity(PopupTextLoc + "\n" + ConfirmTextLoc, user, PopupType.MediumCaution);
+    }
+
+    public bool CheckShouldBreathe(EntityUid user, EntityUid tank)
+    {
+        if (!TryComp(user, out AirTankShouldBreatheComponent? shouldBreathe) ||
+            !TryComp(tank, out AirTankLooksLikeComponent? looksLike))
+            return true;
+
+        if (shouldBreathe.TankTypes.Contains(looksLike.Contains))
+        {
+            shouldBreathe.LastAttempted = null;
+            return true;
+        }
+
+        if (shouldBreathe.LastAttempted == tank)
+        {
+            return true;
+        }
+
+        shouldBreathe.LastAttempted = tank;
+
+        return false;
+    }
+}

--- a/Content.Shared/AirTank/AirTankShouldBreatheComponent.cs
+++ b/Content.Shared/AirTank/AirTankShouldBreatheComponent.cs
@@ -1,20 +1,22 @@
-﻿namespace Content.Shared.AirTank;
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.AirTank;
 
 /// <summary>
 ///     Specifies what kinds of air tanks someone should be breathing from.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class AirTankShouldBreatheComponent : Component
 {
     /// <summary>
     ///     What this species should be able to breathe.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public List<AirTankLooksLike> TankTypes = new();
 
     /// <summary>
     ///     The last tank we toggled.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public EntityUid? LastAttempted;
 }

--- a/Content.Shared/AirTank/AirTankShouldBreatheComponent.cs
+++ b/Content.Shared/AirTank/AirTankShouldBreatheComponent.cs
@@ -1,0 +1,20 @@
+﻿namespace Content.Shared.AirTank;
+
+/// <summary>
+///     Specifies what kinds of air tanks someone should be breathing from.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AirTankShouldBreatheComponent : Component
+{
+    /// <summary>
+    ///     What this species should be able to breathe.
+    /// </summary>
+    [DataField]
+    public List<AirTankLooksLike> TankTypes = new();
+
+    /// <summary>
+    ///     The last tank we toggled.
+    /// </summary>
+    [DataField]
+    public EntityUid? LastAttempted;
+}

--- a/Content.Shared/Atmos/EntitySystems/SharedGasTankSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedGasTankSystem.cs
@@ -118,7 +118,7 @@ public abstract class SharedGasTankSystem : EntitySystem
         return internalsComp != null && internalsComp.BreathTools.Count != 0 && !ent.Comp.IsValveOpen;
     }
 
-    public bool ConnectToInternals(Entity<GasTankComponent> ent, EntityUid? user = null, bool noSafety = false)
+    public bool ConnectToInternals(Entity<GasTankComponent> ent, EntityUid? user = null, bool safety = true)
     {
         var (owner, component) = ent;
         if (component.IsConnected || !CanConnectToInternals(ent))
@@ -128,7 +128,7 @@ public abstract class SharedGasTankSystem : EntitySystem
         if (internalsUid == null || internalsComp == null)
             return false;
 
-        if ((user is {} notNull) && !noSafety && !_airTankLooks.CheckShouldBreathe(notNull, ent))
+        if ((user is {} notNull) && safety && !_airTankLooks.CheckShouldBreathe(notNull, ent))
         {
             // it  3am
             _airTankLooks.CreateShouldntBreathePopup(notNull, ent);

--- a/Content.Shared/Body/Systems/SharedInternalsSystem.cs
+++ b/Content.Shared/Body/Systems/SharedInternalsSystem.cs
@@ -121,7 +121,7 @@ public abstract class SharedInternalsSystem : EntitySystem
         if (mode == ToggleMode.Off)
             return false;
 
-        return _gasTank.ConnectToInternals(tank.Value, user: user, noSafety: force);
+        return _gasTank.ConnectToInternals(tank.Value, user: user, safety: !force);
     }
 
     private bool StartToggleInternalsDoAfter(EntityUid user, Entity<InternalsComponent> targetEnt, ToggleMode mode)

--- a/Content.Shared/Body/Systems/SharedInternalsSystem.cs
+++ b/Content.Shared/Body/Systems/SharedInternalsSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.AirTank;
 using Content.Shared.Alert;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Atmos.EntitySystems;
@@ -105,7 +106,7 @@ public abstract class SharedInternalsSystem : EntitySystem
             return StartToggleInternalsDoAfter(user, (target, internals), mode);
         }
 
-        // Toggle off.
+         // Toggle off.
         if (TryComp(internals.GasTankEntity, out GasTankComponent? gas))
         {
             if (mode == ToggleMode.On)
@@ -120,7 +121,7 @@ public abstract class SharedInternalsSystem : EntitySystem
         if (mode == ToggleMode.Off)
             return false;
 
-        return _gasTank.ConnectToInternals(tank.Value, user: user);
+        return _gasTank.ConnectToInternals(tank.Value, user: user, noSafety: force);
     }
 
     private bool StartToggleInternalsDoAfter(EntityUid user, Entity<InternalsComponent> targetEnt, ToggleMode mode)

--- a/Resources/Locale/en-US/airtank/airtank.ftl
+++ b/Resources/Locale/en-US/airtank/airtank.ftl
@@ -3,6 +3,6 @@ air-tank-looks-like-oxygen = This tank looks like it has oxygen, which you don't
 air-tank-looks-like-nitrogen = This tank looks like it has nitrogen, which you don't breathe.
 air-tank-looks-like-regularair = This tank looks like it has regular air, which you don't breathe.
 air-tank-looks-like-plasma = This tank looks like it has highly toxic plasma gas.
-air-tank-looks-like-notair = This air tank looks like it doesn't actually have any air.
+air-tank-looks-like-notair = This air tank looks like it doesn't actually contain air.
 
-air-tank-looks-like-confirm = Are you sure you should breathe from this?
+air-tank-looks-like-confirm = Use it again to breathe from the tank anyway.

--- a/Resources/Locale/en-US/airtank/airtank.ftl
+++ b/Resources/Locale/en-US/airtank/airtank.ftl
@@ -1,12 +1,14 @@
 ﻿-air-tank-looks-like-states = { $state ->
-    [notair] This air tank looks like it doesn't actually contain air.
-    [regularair] This tank looks like it has regular air, which you don't breathe.
-    [oxygen] This tank looks like it has oxygen, which you don't breathe.
-    [nitrogen] This tank looks like it has nitrogen, which you don't breathe.
-    [plasma] This tank looks like it has highly toxic plasma gas.
+    [notair] This probably doesn't actually contain air.
+    [regularair] This probably has regular air, which you don't breathe.
+    [oxygen] This probably has oxygen, which you don't breathe.
+    [nitrogen] This probably has nitrogen, which you don't breathe.
+    [plasma] This looks toxic.
    *[invalid] This tank has broken the laws of reality.
 }
 
 air-tank-looks-like = {-air-tank-looks-like-states(state:$state)}
+air-tank-looks-like-examine = {-air-tank-looks-like-examine-states(state:$state)}
+air-tank-looks-like-dont = You shouldn't breathe from this.
 
 air-tank-looks-like-confirm = Use it again to breathe from the tank anyway.

--- a/Resources/Locale/en-US/airtank/airtank.ftl
+++ b/Resources/Locale/en-US/airtank/airtank.ftl
@@ -1,0 +1,8 @@
+﻿air-tank-looks-like-invalid = This tank has broken the laws of reality.
+air-tank-looks-like-oxygen = This tank looks like it has oxygen, which you don't breathe.
+air-tank-looks-like-nitrogen = This tank looks like it has nitrogen, which you don't breathe.
+air-tank-looks-like-regularair = This tank looks like it has regular air, which you don't breathe.
+air-tank-looks-like-plasma = This tank looks like it has highly toxic plasma gas.
+air-tank-looks-like-notair = This air tank looks like it doesn't actually have any air.
+
+air-tank-looks-like-confirm = Are you sure you should breathe from this?

--- a/Resources/Locale/en-US/airtank/airtank.ftl
+++ b/Resources/Locale/en-US/airtank/airtank.ftl
@@ -1,8 +1,12 @@
-﻿air-tank-looks-like-invalid = This tank has broken the laws of reality.
-air-tank-looks-like-oxygen = This tank looks like it has oxygen, which you don't breathe.
-air-tank-looks-like-nitrogen = This tank looks like it has nitrogen, which you don't breathe.
-air-tank-looks-like-regularair = This tank looks like it has regular air, which you don't breathe.
-air-tank-looks-like-plasma = This tank looks like it has highly toxic plasma gas.
-air-tank-looks-like-notair = This air tank looks like it doesn't actually contain air.
+﻿-air-tank-looks-like-states = { $state ->
+    [notair] This air tank looks like it doesn't actually contain air.
+    [regularair] This tank looks like it has regular air, which you don't breathe.
+    [oxygen] This tank looks like it has oxygen, which you don't breathe.
+    [nitrogen] This tank looks like it has nitrogen, which you don't breathe.
+    [plasma] This tank looks like it has highly toxic plasma gas.
+   *[invalid] This tank has broken the laws of reality.
+}
+
+air-tank-looks-like = {-air-tank-looks-like-states(state:$state)}
 
 air-tank-looks-like-confirm = Use it again to breathe from the tank anyway.

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -118,6 +118,10 @@
   - type: Inventory
     templateId: arachnid
     speciesId: arachnid
+  - type: AirTankShouldBreathe
+    tankTypes:
+    - Oxygen
+    - RegularAir
 
 
 - type: entity
@@ -128,7 +132,7 @@
   - type: HumanoidAppearance
     species: Arachnid
   - type: Inventory
-    speciesId: arachnid 
+    speciesId: arachnid
 
 
 #>88w88<

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -113,6 +113,10 @@
             sprite: Mobs/Species/Human/displacement.rsi
             state: jumpsuit-female
   - type: Rootable
+  - type: AirTankShouldBreathe
+    tankTypes:
+    - Oxygen
+    - RegularAir
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -63,6 +63,10 @@
           32:
             sprite: Mobs/Species/Human/displacement.rsi
             state: jumpsuit-female
+  - type: AirTankShouldBreathe
+    tankTypes:
+    - Oxygen
+    - RegularAir
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -27,6 +27,10 @@
           32:
             sprite: Mobs/Species/Human/displacement.rsi
             state: jumpsuit-female
+  - type: AirTankShouldBreathe
+    tankTypes:
+    - Oxygen
+    - RegularAir
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -171,6 +171,10 @@
           32:
             sprite: Mobs/Species/Moth/displacement.rsi
             state: shoes
+  - type: AirTankShouldBreathe
+    tankTypes:
+    - Oxygen
+    - RegularAir
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -77,6 +77,10 @@
           32:
             sprite: Mobs/Species/Human/displacement.rsi
             state: jumpsuit-female
+  - type: AirTankShouldBreathe
+    tankTypes:
+    - Oxygen
+    - RegularAir
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -116,6 +116,10 @@
           32:
             sprite: Mobs/Species/Human/displacement.rsi
             state: jumpsuit-female
+  - type: AirTankShouldBreathe
+    tankTypes:
+    - Nitrogen
+    - RegularAir
 
 - type: entity
   parent: MobHumanDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -163,6 +163,9 @@
         32:
           sprite: Mobs/Species/Vox/displacement.rsi
           state: hand_r
+  - type: AirTankShouldBreathe
+    tankTypes:
+    - Nitrogen
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -18,6 +18,8 @@
     slots:
     - Back
     - suitStorage
+  - type: AirTankLooksLike
+    contains: RegularAir
   - type: UseDelay
     delays:
       gasTank:
@@ -66,6 +68,8 @@
   name: oxygen tank
   description: A standard cylindrical gas tank for oxygen. It can hold 5 L of gas.
   components:
+  - type: AirTankLooksLike
+    contains: Oxygen
   - type: Sprite
     sprite: Objects/Tanks/oxygen.rsi
   - type: Item
@@ -79,6 +83,8 @@
   name: nitrogen tank
   description: A standard cylindrical gas tank for nitrogen. It can hold 5 L of gas.
   components:
+  - type: AirTankLooksLike
+    contains: Nitrogen
   - type: Sprite
     sprite: Objects/Tanks/red.rsi
   - type: Item
@@ -92,6 +98,8 @@
   name: emergency oxygen tank
   description: An easily portable tank for emergencies. Contains very little oxygen, rated for survival use only. It can hold 0.66 L of gas.
   components:
+  - type: AirTankLooksLike
+    contains: Oxygen
   - type: Sprite
     sprite: Objects/Tanks/emergency.rsi
   - type: Item
@@ -121,6 +129,8 @@
   name: emergency nitrogen tank
   description: An easily portable tank for emergencies. Contains very little nitrogen, rated for survival use only. It can hold 0.66 L of gas.
   components:
+  - type: AirTankLooksLike
+    contains: Nitrogen
   - type: Sprite
     sprite: Objects/Tanks/emergency_red.rsi
   - type: Item
@@ -151,6 +161,8 @@
   name: extended-capacity emergency nitrogen tank
   description: An emergency tank with extended capacity. Technically rated for prolonged use. It can hold 1.5 L of gas.
   components:
+  - type: AirTankLooksLike
+    contains: Nitrogen
   - type: Sprite
     sprite: Objects/Tanks/emergency_extended_red.rsi
   - type: Item
@@ -186,6 +198,8 @@
   name: double emergency nitrogen tank
   description: A high-grade dual-tank emergency life support container. It holds a decent amount of nitrogen for its small size. It can hold 2.5 L of gas.
   components:
+  - type: AirTankLooksLike
+    contains: Nitrogen
   - type: Sprite
     sprite: Objects/Tanks/emergency_double_red.rsi
   - type: Item
@@ -199,6 +213,8 @@
   name: funny emergency oxygen tank
   description: An easily portable tank for emergencies. Contains very little oxygen with an extra of funny gas, rated for survival use only. It can hold 0.66 L of gas.
   components:
+  - type: AirTankLooksLike
+    contains: NotAir
   - type: Sprite
     sprite: Objects/Tanks/emergency_clown.rsi
   - type: Item
@@ -221,6 +237,8 @@
   name: nitrous oxide tank
   description: Contains a mixture of air and nitrous oxide. Make sure you don't refill it with pure N2O. It can hold 5 L of gas.
   components:
+  - type: AirTankLooksLike
+    contains: NotAir
   - type: Sprite
     sprite: Objects/Tanks/anesthetic.rsi
   - type: Item
@@ -237,6 +255,8 @@
   name: plasma tank
   description: Contains dangerous plasma. Do not inhale. Extremely flammable. It can hold 5 L of gas.
   components:
+  - type: AirTankLooksLike
+    contains: Plasma
   - type: Sprite
     sprite: Objects/Tanks/plasma.rsi
   - type: Item


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Gas tanks will now warn you if you try to use an improper one

This is not based on what is actually in the tank, only what the tank looks like

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

New players may pick a non-oxygen breathing character and try to breathe from an oxygen tank, then get confused when it says they're not getting any air. This communicates the fact that not every role breathes oxygen. also i was bored

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/186cb66c-27c6-4909-981a-aebf37211d16

![image](https://github.com/user-attachments/assets/c9165e77-ebbb-4f99-986f-a8a2314931df)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: Tanks that might have gas you can't breathe will now warn you if you try to use them. Use them again to breathe from them anyway.