### PR TITLE
Add subscription event for ion storms (minor refactor)

### DIFF
--- a/Content.Server/Silicons/Laws/StartIonStormedSystem.cs
+++ b/Content.Server/Silicons/Laws/StartIonStormedSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.StationEvents.Events;
 using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
@@ -9,7 +10,6 @@ namespace Content.Server.Silicons.Laws;
 /// </summary>
 public sealed class StartIonStormedSystem : EntitySystem
 {
-    [Dependency] private readonly IonStormSystem _ionStorm = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly SiliconLawSystem _siliconLaw = default!;
 
@@ -28,7 +28,8 @@ public sealed class StartIonStormedSystem : EntitySystem
 
         for (int currentIonStorm = 0; currentIonStorm < ent.Comp.IonStormAmount; currentIonStorm++)
         {
-            _ionStorm.IonStormTarget((ent.Owner, lawBound, target), false);
+            var ev = new IonStormEvent(false);
+            RaiseLocalEvent(ent, ref ev);
         }
 
         var laws = _siliconLaw.GetLaws(ent.Owner, lawBound);

--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -1,4 +1,3 @@
-using Content.Server.Silicons.Laws;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Silicons.Laws.Components;
@@ -8,8 +7,6 @@ namespace Content.Server.StationEvents.Events;
 
 public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
 {
-    [Dependency] private readonly IonStormSystem _ionStorm = default!;
-
     protected override void Started(EntityUid uid, IonStormRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
         base.Started(uid, comp, gameRule, args);
@@ -17,14 +14,20 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
         if (!TryGetRandomStation(out var chosenStation))
             return;
 
-        var query = EntityQueryEnumerator<SiliconLawBoundComponent, TransformComponent, IonStormTargetComponent>();
-        while (query.MoveNext(out var ent, out var lawBound, out var xform, out var target))
+        var query = EntityQueryEnumerator<TransformComponent, IonStormTargetComponent>();
+        while (query.MoveNext(out var ent, out var xform, out _))
         {
             // only affect law holders on the station
             if (CompOrNull<StationMemberComponent>(xform.GridUid)?.Station != chosenStation)
                 continue;
-
-            _ionStorm.IonStormTarget((ent, lawBound, target));
+            var ev = new IonStormEvent();
+            RaiseLocalEvent(ent, ref ev);
         }
     }
 }
+
+/// <summary>
+/// Event raised on an entity with <see cref="IonStormTargetComponent"/> when an ion storm occurs on the attached station.
+/// </summary>
+[ByRefEvent]
+public record struct IonStormEvent(bool Adminlog = true);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Previously ion storms were handled with an `EntityQueryEnumerator<SiliconLawBoundComponent, TransformComponent, IonStormTargetComponent>` which called the relevant method in `IonStormSystem` to give borgs a corrupted law. This is a minor refactor to swap that method over to an event-based subscription.

## Why / Balance
Mostly just futureproofing in case anyone wants ion storms to affect non-silicon entities- for example, computers, artifacts, whatever else.

## Technical details
- Creates a new ByRef event, `IonStormEvent`, that is raised on entities with `IonStormTargetComponent` attached to a station that experiences an ion storm.
- Modifies methods in 'IonStormSystem' and 'StartIonStormedSystem' to use events.
- Cleaned up some loose `using`s.

## Requirements
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Ion storms now function by using `IonStormEvent` subscriptions rather than calling specific methods.

**Changelog**
no cl, not player-facing. yippee!
