### PR TITLE
Fixed dirt tiles having identical names

### DIFF
--- a/Resources/Locale/en-US/tiles/tiles.ftl
+++ b/Resources/Locale/en-US/tiles/tiles.ftl
@@ -119,6 +119,7 @@ tiles-wood2 = wood pattern floor
 tiles-desert-floor = desert floor
 tiles-low-desert-floor = low desert floor
 tiles-grass-planet-floor = grass planet floor
+tiles-dirt-planet-floor = dirt planet floor
 tiles-basalt-floor = basalt floor
 tiles-snow-floor = snow floor
 tiles-wood3 = wood broken floor

--- a/Resources/Prototypes/Tiles/planet.yml
+++ b/Resources/Prototypes/Tiles/planet.yml
@@ -1,6 +1,7 @@
 - type: tile
   id: FloorPlanetDirt
   name: tiles-dirt-floor
+  prefix: planet
   sprite: /Textures/Tiles/Planet/dirt.rsi/dirt.png
   variants: 4
   placementVariants:
@@ -58,6 +59,7 @@
 - type: tile
   id: FloorPlanetGrass
   name: tiles-grass-planet-floor
+  prefix: planet
   sprite: /Textures/Tiles/Planet/Grass/grass.png
   variants: 4
   placementVariants:

--- a/Resources/Prototypes/Tiles/planet.yml
+++ b/Resources/Prototypes/Tiles/planet.yml
@@ -1,7 +1,6 @@
 - type: tile
   id: FloorPlanetDirt
-  name: tiles-dirt-floor
-  prefix: planet
+  name: tiles-dirt-planet-floor
   sprite: /Textures/Tiles/Planet/dirt.rsi/dirt.png
   variants: 4
   placementVariants:
@@ -59,7 +58,6 @@
 - type: tile
   id: FloorPlanetGrass
   name: tiles-grass-planet-floor
-  prefix: planet
   sprite: /Textures/Tiles/Planet/Grass/grass.png
   variants: 4
   placementVariants:


### PR DESCRIPTION
## About the PR
The dirt tiles intended for station use and for planet use have the same name, so I fixed it.

## Why / Balance
![2025-06-22_02-00](https://github.com/user-attachments/assets/2b2457b2-f558-4854-89d5-c86f4fee4834)
This _is_ significant since the planet dirt is indestructible and the other isn't.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->