### PR TITLE
Fixup Sericulture to be clonable

### DIFF
--- a/Content.Shared/Sericulture/SericultureComponent.cs
+++ b/Content.Shared/Sericulture/SericultureComponent.cs
@@ -34,7 +34,7 @@ public sealed partial class SericultureComponent : Component
     [DataField(required: true)]
     [ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
-    public EntProtoId Action;
+    public EntProtoId Action = "ActionSericulture";
 
     [AutoNetworkedField]
     [DataField("actionEntity")]

--- a/Content.Shared/Sericulture/SericultureComponent.cs
+++ b/Content.Shared/Sericulture/SericultureComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class SericultureComponent : Component
     /// <summary>
     /// The entity needed to actually preform sericulture. This will be granted (and removed) upon the entity's creation.
     /// </summary>
-    [DataField(required: true)]
+    [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
     public EntProtoId Action = "ActionSericulture";

--- a/Content.Shared/Sericulture/SericultureSystem.cs
+++ b/Content.Shared/Sericulture/SericultureSystem.cs
@@ -38,12 +38,16 @@ public abstract partial class SharedSericultureSystem : EntitySystem
 
     private void OnClone(Entity<SericultureComponent> ent, ref CloningEvent args)
     {
+        if(!args.Settings.EventComponents.Contains("Sericulture"))
+            return;
+
         var comp = EnsureComp<SericultureComponent>(args.CloneUid);
         comp.PopupText = ent.Comp.PopupText;
         comp.ProductionLength = ent.Comp.ProductionLength;
         comp.HungerCost = ent.Comp.HungerCost;
         comp.EntityProduced = ent.Comp.EntityProduced;
         comp.MinHungerThreshold = ent.Comp.MinHungerThreshold;
+        Dirty<SericultureComponent>((args.CloneUid, comp));
     }
 
     /// <summary>

--- a/Content.Shared/Sericulture/SericultureSystem.cs
+++ b/Content.Shared/Sericulture/SericultureSystem.cs
@@ -39,6 +39,7 @@ public abstract partial class SharedSericultureSystem : EntitySystem
     private void OnClone(Entity<SericultureComponent> ent, ref CloningEvent args)
     {
         var comp = EnsureComp<SericultureComponent>(args.CloneUid);
+        comp.PopupText = ent.Comp.PopupText;
         comp.ProductionLength = ent.Comp.ProductionLength;
         comp.HungerCost = ent.Comp.HungerCost;
         comp.EntityProduced = ent.Comp.EntityProduced;

--- a/Content.Shared/Sericulture/SericultureSystem.cs
+++ b/Content.Shared/Sericulture/SericultureSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Actions;
+using Content.Shared.Cloning.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.Nutrition.EntitySystems;
 using Robust.Shared.Serialization;
@@ -32,6 +33,16 @@ public abstract partial class SharedSericultureSystem : EntitySystem
         SubscribeLocalEvent<SericultureComponent, ComponentShutdown>(OnCompRemove);
         SubscribeLocalEvent<SericultureComponent, SericultureActionEvent>(OnSericultureStart);
         SubscribeLocalEvent<SericultureComponent, SericultureDoAfterEvent>(OnSericultureDoAfter);
+        SubscribeLocalEvent<SericultureComponent, CloningEvent>(OnClone);
+    }
+
+    private void OnClone(Entity<SericultureComponent> ent, ref CloningEvent args)
+    {
+        var comp = EnsureComp<SericultureComponent>(args.CloneUid);
+        comp.ProductionLength = ent.Comp.ProductionLength;
+        comp.HungerCost = ent.Comp.HungerCost;
+        comp.EntityProduced = ent.Comp.EntityProduced;
+        comp.MinHungerThreshold = ent.Comp.MinHungerThreshold;
     }
 
     /// <summary>

--- a/Content.Shared/Sericulture/SericultureSystem.cs
+++ b/Content.Shared/Sericulture/SericultureSystem.cs
@@ -38,7 +38,7 @@ public abstract partial class SharedSericultureSystem : EntitySystem
 
     private void OnClone(Entity<SericultureComponent> ent, ref CloningEvent args)
     {
-        if(!args.Settings.EventComponents.Contains("Sericulture"))
+        if(!args.Settings.EventComponents.Contains(Factory.GetRegistration(ent.Comp.GetType()).Name))
             return;
 
         var comp = EnsureComp<SericultureComponent>(args.CloneUid);
@@ -47,7 +47,7 @@ public abstract partial class SharedSericultureSystem : EntitySystem
         comp.HungerCost = ent.Comp.HungerCost;
         comp.EntityProduced = ent.Comp.EntityProduced;
         comp.MinHungerThreshold = ent.Comp.MinHungerThreshold;
-        Dirty<SericultureComponent>((args.CloneUid, comp));
+        Dirty(args.CloneUid, comp);
     }
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -13,7 +13,6 @@
   - type: Hunger
   - type: Thirst
   - type: Sericulture
-    action: ActionSericulture
     productionLength: 2
     entityProduced: MaterialWebSilk1
     hungerCost: 4 # Should total to 25 total silk on full hunger


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Required for #34002 for transforming into an arachnid, Add a default entProtoId and add a OnClone event to ensure that any changes done to the prototype are cloned correctly.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Does not affect gamebalance
## Technical details
<!-- Summary of code changes for easier review. -->
Added an EntProtoId default, Added a Subscription to Clone Event as Sericulture is an ActionComponent and thus cannot be Deepcopied via CopyComps (there is an issue with copycomps on components with referenced entityUid's being copied, Like Screaming and Wagging, thus requiring facilitation by component itself to be copied to a given target)
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
No media, no ingame effects yet
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

No CL No Fun
