### PR TITLE
Fixed Snacks Mispredicting on Clients

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/FoodSystem.cs
@@ -26,6 +26,7 @@ using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Nutrition.EntitySystems;
@@ -53,6 +54,7 @@ public sealed class FoodSystem : EntitySystem
     [Dependency] private readonly StomachSystem _stomach = default!;
     [Dependency] private readonly UtensilSystem _utensil = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly INetManager _net = default!;
 
     public const float MaxFeedDistance = 1.0f;
 
@@ -340,6 +342,10 @@ public sealed class FoodSystem : EntitySystem
         var dev = new DestructionEventArgs();
         RaiseLocalEvent(food, dev);
 
+        // don't predict deletes on client
+        if (_net.IsClient)
+            return;
+
         if (component.Trash.Count == 0)
         {
             QueueDel(food);
@@ -365,6 +371,7 @@ public sealed class FoodSystem : EntitySystem
                 _hands.TryPickupAnyHand(user, spawnedTrash);
             }
         }
+
     }
 
     private void AddEatVerb(Entity<FoodComponent> entity, ref GetVerbsEvent<AlternativeVerb> ev)

--- a/Content.Shared/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/FoodSystem.cs
@@ -371,7 +371,6 @@ public sealed class FoodSystem : EntitySystem
                 _hands.TryPickupAnyHand(user, spawnedTrash);
             }
         }
-
     }
 
     private void AddEatVerb(Entity<FoodComponent> entity, ref GetVerbsEvent<AlternativeVerb> ev)

--- a/Content.Shared/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/FoodSystem.cs
@@ -342,13 +342,9 @@ public sealed class FoodSystem : EntitySystem
         var dev = new DestructionEventArgs();
         RaiseLocalEvent(food, dev);
 
-        // don't predict deletes on client
-        if (_net.IsClient)
-            return;
-
         if (component.Trash.Count == 0)
         {
-            QueueDel(food);
+            PredictedQueueDel(food);
             return;
         }
 
@@ -359,7 +355,7 @@ public sealed class FoodSystem : EntitySystem
         var trashes = component.Trash;
         var tryPickup = _hands.IsHolding(user, food, out _);
 
-        Del(food);
+        PredictedDel(food);
         foreach (var trash in trashes)
         {
             var spawnedTrash = Spawn(trash, position);

--- a/Content.Shared/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/FoodSystem.cs
@@ -26,7 +26,6 @@ using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Network;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Nutrition.EntitySystems;
@@ -54,7 +53,6 @@ public sealed class FoodSystem : EntitySystem
     [Dependency] private readonly StomachSystem _stomach = default!;
     [Dependency] private readonly UtensilSystem _utensil = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
-    [Dependency] private readonly INetManager _net = default!;
 
     public const float MaxFeedDistance = 1.0f;
 
@@ -358,7 +356,7 @@ public sealed class FoodSystem : EntitySystem
         PredictedDel(food);
         foreach (var trash in trashes)
         {
-            var spawnedTrash = Spawn(trash, position);
+            var spawnedTrash = EntityManager.PredictedSpawn(trash, position);
 
             // If the user is holding the item
             if (tryPickup)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Snacks have been mispredicting on clients for the last couple weeks. 
This is a somewhat bandage solution which just checks if the shared code handling deletions is running on the client, and quits before it deletes entities.

### Reproduction Steps
- Spawn as any species that can eat a snack food.
- Spawn a snack food for them.
- Pick up the snack food.
- Eat it.
- Observe.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

It was just annoying me.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/b2043c55-7bb9-4a74-b8f2-7d924ec12f8f


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
