### PR TITLE
Tweaks to admin CSV exporting

### DIFF
--- a/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
@@ -22,7 +22,6 @@ public sealed class AdminLogsEui : BaseEui
 
     private const char CsvSeparator = ',';
     private const string CsvQuote = "\"";
-    private const string CsvDoubleQuote = "\"\"";
     private const string CsvHeader = "Date,ID,PlayerID,Severity,Type,Message";
 
     private ISawmill _sawmill;
@@ -105,8 +104,8 @@ public sealed class AdminLogsEui : BaseEui
 
         try
         {
-            await using var writer = new StreamWriter(file.Value.fileStream, bufferSize: 4096);
             // Buffer is set to 4KB for performance reasons. As the average export of 1000 logs is ~200KB
+            await using var writer = new StreamWriter(file.Value.fileStream, bufferSize: 4096);
             await writer.WriteLineAsync(CsvHeader);
             foreach (var child in LogsControl.LogsContainer.Children)
             {
@@ -137,7 +136,7 @@ public sealed class AdminLogsEui : BaseEui
                 await writer.WriteAsync(CsvSeparator);
                 // Message
                 await writer.WriteAsync(CsvQuote);
-                await writer.WriteAsync(log.Message.Replace(CsvQuote, CsvDoubleQuote));
+                await writer.WriteAsync(log.Message.Replace(CsvQuote, CsvQuote + CsvQuote));
                 await writer.WriteAsync(CsvQuote);
 
                 await writer.WriteLineAsync();

--- a/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
@@ -20,6 +20,10 @@ public sealed class AdminLogsEui : BaseEui
     [Dependency] private readonly IFileDialogManager _dialogManager = default!;
     [Dependency] private readonly ILogManager _log = default!;
 
+    private const char CsvSeparator = ',';
+    private const char CsvQuote = '"';
+    private const string CsvHeader = "Date,ID,PlayerID,Severity,Type,Message";
+
     private ISawmill _sawmill;
 
     private bool _currentlyExportingLogs = false;
@@ -100,7 +104,9 @@ public sealed class AdminLogsEui : BaseEui
 
         try
         {
-            await using var writer = new StreamWriter(file.Value.fileStream);
+            await using var writer = new StreamWriter(file.Value.fileStream, bufferSize: 4096);
+            // Buffer is set to 4KB for performance reasons. As the average export of 1000 logs is ~200KB
+            await writer.WriteLineAsync(CsvHeader);
             foreach (var child in LogsControl.LogsContainer.Children)
             {
                 if (child is not AdminLogLabel logLabel || !child.Visible)
@@ -108,28 +114,31 @@ public sealed class AdminLogsEui : BaseEui
 
                 var log = logLabel.Log;
 
+                // Date
                 // I swear to god if someone adds ,s or "s to the other fields...
                 await writer.WriteAsync(log.Date.ToString("s", System.Globalization.CultureInfo.InvariantCulture));
-                await writer.WriteAsync(',');
+                await writer.WriteAsync(CsvSeparator);
+                // ID
                 await writer.WriteAsync(log.Id.ToString());
-                await writer.WriteAsync(',');
-                await writer.WriteAsync(log.Impact.ToString());
-                await writer.WriteAsync(',');
-                // Message
-                await writer.WriteAsync('"');
-                await writer.WriteAsync(log.Message.Replace("\"", "\"\""));
-                await writer.WriteAsync('"');
-                // End of message
-                await writer.WriteAsync(',');
-
+                await writer.WriteAsync(CsvSeparator);
+                // PlayerID
                 var players = log.Players;
                 for (var i = 0; i < players.Length; i++)
                 {
                     await writer.WriteAsync(players[i] + (i == players.Length - 1 ? "" : " "));
                 }
-
-                await writer.WriteAsync(',');
+                await writer.WriteAsync(CsvSeparator);
+                // Severity
+                await writer.WriteAsync(log.Impact.ToString());
+                await writer.WriteAsync(CsvSeparator);
+                // Type
                 await writer.WriteAsync(log.Type.ToString());
+                await writer.WriteAsync(CsvSeparator);
+                // Message
+                await writer.WriteAsync(CsvQuote);
+                await writer.WriteAsync(log.Message.Replace("\"", "\"\""));
+                await writer.WriteAsync(CsvQuote);
+
                 await writer.WriteLineAsync();
             }
         }

--- a/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
@@ -21,7 +21,8 @@ public sealed class AdminLogsEui : BaseEui
     [Dependency] private readonly ILogManager _log = default!;
 
     private const char CsvSeparator = ',';
-    private const char CsvQuote = '"';
+    private const string CsvQuote = "\"";
+    private const string CsvDoubleQuote = "\"\"";
     private const string CsvHeader = "Date,ID,PlayerID,Severity,Type,Message";
 
     private ISawmill _sawmill;
@@ -136,7 +137,7 @@ public sealed class AdminLogsEui : BaseEui
                 await writer.WriteAsync(CsvSeparator);
                 // Message
                 await writer.WriteAsync(CsvQuote);
-                await writer.WriteAsync(log.Message.Replace("\"", "\"\""));
+                await writer.WriteAsync(log.Message.Replace(CsvQuote, CsvDoubleQuote));
                 await writer.WriteAsync(CsvQuote);
 
                 await writer.WriteLineAsync();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Increased the export log buffer to 4KB for write performance.
Reformatted on how CSVs are exported.
Added headers to CSV exports

## Why / Balance
More clarity in logs & code, as for why the logs are exported in a different way then when it first was introduced is to appear more align as it is done with SS14.admin. Also this formatting style makes overall more sense.

## Technical details
3 private consts have been added for formatting purposes, and some log writing has been turned upside down!

## Media
![image](https://github.com/user-attachments/assets/fed077f5-a6d3-41dc-a972-40eda1f625e1)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Formatting of CSV exports, but realistically none due to its age.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
ADMIN:
 - tweak: Changed the way CSVs are exported
