### PR TITLE
fix: EyeOffset when eyes are closed

### DIFF
--- a/Content.Shared/Camera/GetEyeOffsetEvent.cs
+++ b/Content.Shared/Camera/GetEyeOffsetEvent.cs
@@ -20,7 +20,7 @@ namespace Content.Shared.Camera;
 public record struct GetEyeOffsetEvent(Vector2 Offset);
 
 /// <summary>
-///     Riased before the <see cref="GetEyeOffsetEvent"/> and <see cref="GetEyeOffsetRelayedEvent"/>, to check if any of the subscribed
+///     Raised before the <see cref="GetEyeOffsetEvent"/> and <see cref="GetEyeOffsetRelayedEvent"/>, to check if any of the subscribed
 ///     systems want to cancel offset changes.
 /// </summary>
 [ByRefEvent]

--- a/Content.Shared/Camera/GetEyeOffsetEvent.cs
+++ b/Content.Shared/Camera/GetEyeOffsetEvent.cs
@@ -20,11 +20,11 @@ namespace Content.Shared.Camera;
 public record struct GetEyeOffsetEvent(Vector2 Offset);
 
 /// <summary>
-///     Riased before the <see cref="GetEyeOffsetRelayedEvent"/>, to check if any of the subscribed
+///     Riased before the <see cref="GetEyeOffsetEvent"/> and <see cref="GetEyeOffsetRelayedEvent"/>, to check if any of the subscribed
 ///     systems want to cancel offset changes.
 /// </summary>
 [ByRefEvent]
-public sealed class GetEyeOffsetRelayedAttemptEvent : CancellableEntityEventArgs;
+public record struct GetEyeOffsetAttemptEvent(bool Cancelled);
 
 /// <summary>
 ///     Raised on any equipped and in-hand items that may modify the eye offset.

--- a/Content.Shared/Camera/GetEyeOffsetEvent.cs
+++ b/Content.Shared/Camera/GetEyeOffsetEvent.cs
@@ -20,6 +20,13 @@ namespace Content.Shared.Camera;
 public record struct GetEyeOffsetEvent(Vector2 Offset);
 
 /// <summary>
+///     Riased before the <see cref="GetEyeOffsetRelayedEvent"/>, to check if any of the subscribed
+///     systems want to cancel offset changes.
+/// </summary>
+[ByRefEvent]
+public sealed class GetEyeOffsetRelayedAttemptEvent : CancellableEntityEventArgs;
+
+/// <summary>
 ///     Raised on any equipped and in-hand items that may modify the eye offset.
 ///     Pockets and suitstorage are excluded.
 /// </summary>

--- a/Content.Shared/Camera/GetEyePvsScaleEvent.cs
+++ b/Content.Shared/Camera/GetEyePvsScaleEvent.cs
@@ -21,11 +21,11 @@ namespace Content.Shared.Camera;
 public record struct GetEyePvsScaleEvent(float Scale);
 
 /// <summary>
-///     Riased before the <see cref="GetEyePvsScaleRelayedEvent"/>, to check if any on the subscribed
+///     Riased before the <see cref="GetEyePvsScaleEvent"/> and <see cref="GetEyePvsScaleRelayedEvent"/>, to check if any on the subscribed
 ///     systems want to cancel PVS changes.
 /// </summary>
 [ByRefEvent]
-public sealed class GetEyePvsScaleRelayedAttemptEvent : CancellableEntityEventArgs;
+public record struct GetEyePvsScaleAttemptEvent(bool Cancelled);
 
 /// <summary>
 ///     Raised on any equipped and in-hand items that may modify the eye offset.

--- a/Content.Shared/Camera/GetEyePvsScaleEvent.cs
+++ b/Content.Shared/Camera/GetEyePvsScaleEvent.cs
@@ -21,6 +21,13 @@ namespace Content.Shared.Camera;
 public record struct GetEyePvsScaleEvent(float Scale);
 
 /// <summary>
+///     Riased before the <see cref="GetEyePvsScaleRelayedEvent"/>, to check if any on the subscribed
+///     systems want to cancel PVS changes.
+/// </summary>
+[ByRefEvent]
+public sealed class GetEyePvsScaleRelayedAttemptEvent : CancellableEntityEventArgs;
+
+/// <summary>
 ///     Raised on any equipped and in-hand items that may modify the eye offset.
 ///     Pockets and suitstorage are excluded.
 /// </summary>

--- a/Content.Shared/Camera/GetEyePvsScaleEvent.cs
+++ b/Content.Shared/Camera/GetEyePvsScaleEvent.cs
@@ -21,7 +21,7 @@ namespace Content.Shared.Camera;
 public record struct GetEyePvsScaleEvent(float Scale);
 
 /// <summary>
-///     Riased before the <see cref="GetEyePvsScaleEvent"/> and <see cref="GetEyePvsScaleRelayedEvent"/>, to check if any on the subscribed
+///     Raised before the <see cref="GetEyePvsScaleEvent"/> and <see cref="GetEyePvsScaleRelayedEvent"/>, to check if any on the subscribed
 ///     systems want to cancel PVS changes.
 /// </summary>
 [ByRefEvent]

--- a/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
@@ -16,8 +16,8 @@ public sealed class BlindableSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<BlindableComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<BlindableComponent, EyeDamageChangedEvent>(OnDamageChanged);
-        SubscribeLocalEvent<BlindableComponent, GetEyePvsScaleRelayedAttemptEvent>(OnGetEyePvsScaleRelayedAttemptEvent);
-        SubscribeLocalEvent<BlindableComponent, GetEyeOffsetRelayedAttemptEvent>(OnGetEyeOffsetRelayedAttemptEvent);
+        SubscribeLocalEvent<BlindableComponent, GetEyePvsScaleAttemptEvent>(OnGetEyePvsScaleAttemptEvent);
+        SubscribeLocalEvent<BlindableComponent, GetEyeOffsetAttemptEvent>(OnGetEyeOffsetAttemptEvent);
     }
 
     private void OnRejuvenate(Entity<BlindableComponent> ent, ref RejuvenateEvent args)
@@ -31,16 +31,16 @@ public sealed class BlindableSystem : EntitySystem
         _eyelids.UpdateEyesClosable((ent.Owner, ent.Comp));
     }
 
-    private void OnGetEyePvsScaleRelayedAttemptEvent(Entity<BlindableComponent> ent, ref GetEyePvsScaleRelayedAttemptEvent args)
+    private void OnGetEyePvsScaleAttemptEvent(Entity<BlindableComponent> ent, ref GetEyePvsScaleAttemptEvent args)
     {
         if (ent.Comp.IsBlind)
-            args.Cancel();
+            args.Cancelled = true;
     }
 
-    private void OnGetEyeOffsetRelayedAttemptEvent(Entity<BlindableComponent> ent, ref GetEyeOffsetRelayedAttemptEvent args)
+    private void OnGetEyeOffsetAttemptEvent(Entity<BlindableComponent> ent, ref GetEyeOffsetAttemptEvent args)
     {
         if (ent.Comp.IsBlind)
-            args.Cancel();
+            args.Cancelled = true;
     }
 
     [PublicAPI]

--- a/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Camera;
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Rejuvenate;
@@ -15,6 +16,8 @@ public sealed class BlindableSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<BlindableComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<BlindableComponent, EyeDamageChangedEvent>(OnDamageChanged);
+        SubscribeLocalEvent<BlindableComponent, GetEyePvsScaleRelayedAttemptEvent>(OnGetEyePvsScaleRelayedAttemptEvent);
+        SubscribeLocalEvent<BlindableComponent, GetEyeOffsetRelayedAttemptEvent>(OnGetEyeOffsetRelayedAttemptEvent);
     }
 
     private void OnRejuvenate(Entity<BlindableComponent> ent, ref RejuvenateEvent args)
@@ -26,6 +29,18 @@ public sealed class BlindableSystem : EntitySystem
     {
         _blurriness.UpdateBlurMagnitude((ent.Owner, ent.Comp));
         _eyelids.UpdateEyesClosable((ent.Owner, ent.Comp));
+    }
+
+    private void OnGetEyePvsScaleRelayedAttemptEvent(Entity<BlindableComponent> ent, ref GetEyePvsScaleRelayedAttemptEvent args)
+    {
+        if (ent.Comp.IsBlind)
+            args.Cancel();
+    }
+
+    private void OnGetEyeOffsetRelayedAttemptEvent(Entity<BlindableComponent> ent, ref GetEyeOffsetRelayedAttemptEvent args)
+    {
+        if (ent.Comp.IsBlind)
+            args.Cancel();
     }
 
     [PublicAPI]

--- a/Content.Shared/Movement/Components/ContentEyeComponent.cs
+++ b/Content.Shared/Movement/Components/ContentEyeComponent.cs
@@ -21,10 +21,4 @@ public sealed partial class ContentEyeComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("maxZoom"), AutoNetworkedField]
     public Vector2 MaxZoom = Vector2.One;
-
-    /// <summary>
-    /// Should eye offset be modified by relayed event.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public bool UseRelayedOffsets = true;
 }

--- a/Content.Shared/Movement/Components/ContentEyeComponent.cs
+++ b/Content.Shared/Movement/Components/ContentEyeComponent.cs
@@ -21,4 +21,10 @@ public sealed partial class ContentEyeComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("maxZoom"), AutoNetworkedField]
     public Vector2 MaxZoom = Vector2.One;
+
+    /// <summary>
+    /// Should eye offset be modified by relayed event.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool UseRelayedOffsets = true;
 }

--- a/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
@@ -153,7 +153,6 @@ public abstract class SharedContentEyeSystem : EntitySystem
         var ev = new GetEyeOffsetEvent();
         RaiseLocalEvent(eye, ref ev);
 
-
         var evRelayed = new GetEyeOffsetRelayedEvent();
         if (!TryComp<ContentEyeComponent>(eye.Owner, out var contentEye) || contentEye.UseRelayedOffsets)
             RaiseLocalEvent(eye, ref evRelayed);

--- a/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Camera;
 using Content.Shared.Ghost;
 using Content.Shared.Input;
 using Content.Shared.Movement.Components;
-using Content.Shared.Eye.Blinding.Systems;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;

--- a/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
@@ -142,15 +142,20 @@ public abstract class SharedContentEyeSystem : EntitySystem
 
     public void UpdateEyeOffset(Entity<EyeComponent> eye)
     {
+        var evAttempt = new GetEyeOffsetAttemptEvent();
+        RaiseLocalEvent(eye, ref evAttempt);
+
+        if (evAttempt.Cancelled)
+        {
+            _eye.SetOffset(eye, Vector2.Zero, eye);
+            return;
+        }
+
         var ev = new GetEyeOffsetEvent();
         RaiseLocalEvent(eye, ref ev);
 
-        var evRelayedAttempt = new GetEyeOffsetRelayedAttemptEvent();
-        RaiseLocalEvent(eye, ref evRelayedAttempt);
-
         var evRelayed = new GetEyeOffsetRelayedEvent();
-        if (!evRelayedAttempt.Cancelled)
-            RaiseLocalEvent(eye, ref evRelayed);
+        RaiseLocalEvent(eye, ref evRelayed);
 
         _eye.SetOffset(eye, ev.Offset + evRelayed.Offset, eye);
     }
@@ -160,15 +165,20 @@ public abstract class SharedContentEyeSystem : EntitySystem
         if (!Resolve(uid, ref contentEye) || !Resolve(uid, ref eye))
             return;
 
+        var evAttempt = new GetEyePvsScaleAttemptEvent();
+        RaiseLocalEvent(uid, ref evAttempt);
+
+        if (evAttempt.Cancelled)
+        {
+            _eye.SetPvsScale((uid, eye), 1);
+            return;
+        }
+
         var ev = new GetEyePvsScaleEvent();
         RaiseLocalEvent(uid, ref ev);
 
-        var evRelayedAttempt = new GetEyePvsScaleRelayedAttemptEvent();
-        RaiseLocalEvent(uid, ref evRelayedAttempt);
-
         var evRelayed = new GetEyePvsScaleRelayedEvent();
-        if (!evRelayedAttempt.Cancelled)
-            RaiseLocalEvent(uid, ref evRelayed);
+        RaiseLocalEvent(uid, ref evRelayed);
 
         _eye.SetPvsScale((uid, eye), 1 + ev.Scale + evRelayed.Scale);
     }

--- a/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Camera;
 using Content.Shared.Ghost;
 using Content.Shared.Input;
 using Content.Shared.Movement.Components;
+using Content.Shared.Eye.Blinding.Components;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
@@ -146,7 +147,8 @@ public abstract class SharedContentEyeSystem : EntitySystem
         RaiseLocalEvent(eye, ref ev);
 
         var evRelayed = new GetEyeOffsetRelayedEvent();
-        RaiseLocalEvent(eye, ref evRelayed);
+        if (!TryComp<EyeClosingComponent>(eye.Owner, out var eyeClosing) || !eyeClosing.EyesClosed)
+            RaiseLocalEvent(eye, ref evRelayed);
 
         _eye.SetOffset(eye, ev.Offset + evRelayed.Offset, eye);
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Binoculars, and other zoom allowing items no longer zoom when character has closed eyes, allowing to see through walls.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Characters with closed eyes were able to see through walls, using any items that offset the camera.

## Technical details
<!-- Summary of code changes for easier review. -->
two new cancelable events: `GetEyeOffsetRelayedAttemptEvent` and `GetEyePvsScaleRelayedAttemptEvent` - they run before `GetEyeOffsetRelayedEvent` and `GetEyePvsScaleRelayedEvent` for any subscribed system to cancell offset and PVS changes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- `GetEyeOffsetEvent`,  `GetEyeOffsetRelayedEvent` is no longer being raised if the `GetEyeOffsetAttemptEvent` gets cancelled.
- `GetEyePvsScaleEvent`, `GetEyePvsScaleRelayedEvent` is no longer being raised if the `GetEyePvcScaleAttemptEvent` gets cancelled.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Closed eyes and binoculars no longer allow you to see through walls.
