### PR TITLE
Remove excess `SingularityLevelChangedEvent` subscriptions

### DIFF
--- a/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
@@ -45,10 +45,7 @@ public abstract class SharedSingularitySystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<SingularityComponent, ComponentStartup>(OnSingularityStartup);
-        SubscribeLocalEvent<AppearanceComponent, SingularityLevelChangedEvent>(UpdateAppearance);
         SubscribeLocalEvent<RadiationSourceComponent, SingularityLevelChangedEvent>(UpdateRadiation);
-        SubscribeLocalEvent<PhysicsComponent, SingularityLevelChangedEvent>(UpdateBody);
-        SubscribeLocalEvent<EventHorizonComponent, SingularityLevelChangedEvent>(UpdateEventHorizon);
         SubscribeLocalEvent<SingularityDistortionComponent, SingularityLevelChangedEvent>(UpdateDistortion);
         SubscribeLocalEvent<SingularityDistortionComponent, EntGotInsertedIntoContainerMessage>(UpdateDistortion);
         SubscribeLocalEvent<SingularityDistortionComponent, EntGotRemovedFromContainerMessage>(UpdateDistortion);
@@ -121,8 +118,26 @@ public abstract class SharedSingularitySystem : EntitySystem
     /// <param name="singularity">The state of the singularity which's level has changed.</param>
     public void UpdateSingularityLevel(EntityUid uid, byte oldValue, SingularityComponent? singularity = null)
     {
-        if(!Resolve(uid, ref singularity))
+        if (!Resolve(uid, ref singularity))
             return;
+
+        if (TryComp<EventHorizonComponent>(uid, out var eventHorizon))
+        {
+            _horizons.SetRadius(uid, EventHorizonRadius(singularity), false, eventHorizon);
+            _horizons.SetCanBreachContainment(uid, CanBreachContainment(singularity), false, eventHorizon);
+            _horizons.UpdateEventHorizonFixture(uid, eventHorizon: eventHorizon);
+        }
+
+        if (TryComp<PhysicsComponent>(uid, out var body))
+        {
+            if (singularity.Level <= 1 && oldValue > 1) // Apparently keeps singularities from getting stuck in the corners of containment fields.
+                _physics.SetLinearVelocity(uid, Vector2.Zero, body: body); // No idea how stopping the singularities movement keeps it from getting stuck though.
+        }
+
+        if (TryComp<AppearanceComponent>(uid, out var appearance))
+        {
+            _visualizer.SetData(uid, SingularityAppearanceKeys.Singularity, singularity.Level, appearance);
+        }
 
         RaiseLocalEvent(uid, new SingularityLevelChangedEvent(singularity.Level, oldValue, singularity));
         if (singularity.Level <= 0)
@@ -274,21 +289,6 @@ public abstract class SharedSingularitySystem : EntitySystem
         UpdateSingularityLevel(uid, comp);
     }
 
-    // TODO: Figure out which systems should have control of which coupling.
-    /// <summary>
-    /// Syncs the radius of an event horizon associated with a singularity that just changed levels.
-    /// </summary>
-    /// <param name="uid">The entity that the event horizon and singularity are attached to.</param>
-    /// <param name="comp">The event horizon associated with the singularity.</param>
-    /// <param name="args">The event arguments.</param>
-    private void UpdateEventHorizon(EntityUid uid, EventHorizonComponent comp, SingularityLevelChangedEvent args)
-    {
-        var singulo = args.Singularity;
-        _horizons.SetRadius(uid, EventHorizonRadius(singulo), false, comp);
-        _horizons.SetCanBreachContainment(uid, CanBreachContainment(singulo), false, comp);
-        _horizons.UpdateEventHorizonFixture(uid, eventHorizon: comp);
-    }
-
     /// <summary>
     /// Updates the distortion shader associated with a singularity when the singuarity changes levels.
     /// </summary>
@@ -344,29 +344,6 @@ public abstract class SharedSingularitySystem : EntitySystem
         var factor = DistortionContainerScaling - 1;
         comp.FalloffPower = absFalloffPower > 1 ? comp.FalloffPower * MathF.Pow(absFalloffPower, factor) : comp.FalloffPower;
         comp.Intensity = absIntensity > 1 ? comp.Intensity * MathF.Pow(absIntensity, factor) : comp.Intensity;
-    }
-
-    /// <summary>
-    /// Updates the state of the physics body associated with a singularity when the singualrity changes levels.
-    /// </summary>
-    /// <param name="uid">The entity that the physics body and singularity are attached to.</param>
-    /// <param name="comp">The physics body associated with the singularity.</param>
-    /// <param name="args">The event arguments.</param>
-    private void UpdateBody(EntityUid uid, PhysicsComponent comp, SingularityLevelChangedEvent args)
-    {
-        if (args.NewValue <= 1 && args.OldValue > 1) // Apparently keeps singularities from getting stuck in the corners of containment fields.
-            _physics.SetLinearVelocity(uid, Vector2.Zero, body: comp); // No idea how stopping the singularities movement keeps it from getting stuck though.
-    }
-
-    /// <summary>
-    /// Updates the appearance of a singularity when the singularities level changes.
-    /// </summary>
-    /// <param name="uid">The entity that the singularity is attached to.</param>
-    /// <param name="comp">The appearance associated with the singularity.</param>
-    /// <param name="args">The event arguments.</param>
-    private void UpdateAppearance(EntityUid uid, AppearanceComponent comp, SingularityLevelChangedEvent args)
-    {
-        _visualizer.SetData(uid, SingularityAppearanceKeys.Singularity, args.NewValue, comp);
     }
 
     /// <summary>

--- a/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
@@ -45,7 +45,6 @@ public abstract class SharedSingularitySystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<SingularityComponent, ComponentStartup>(OnSingularityStartup);
-        //SubscribeLocalEvent<RadiationSourceComponent, SingularityLevelChangedEvent>(UpdateRadiation);
         SubscribeLocalEvent<SingularityDistortionComponent, SingularityLevelChangedEvent>(UpdateDistortion);
         SubscribeLocalEvent<SingularityDistortionComponent, EntGotInsertedIntoContainerMessage>(UpdateDistortion);
         SubscribeLocalEvent<SingularityDistortionComponent, EntGotRemovedFromContainerMessage>(UpdateDistortion);

--- a/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
@@ -45,7 +45,7 @@ public abstract class SharedSingularitySystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<SingularityComponent, ComponentStartup>(OnSingularityStartup);
-        SubscribeLocalEvent<RadiationSourceComponent, SingularityLevelChangedEvent>(UpdateRadiation);
+        //SubscribeLocalEvent<RadiationSourceComponent, SingularityLevelChangedEvent>(UpdateRadiation);
         SubscribeLocalEvent<SingularityDistortionComponent, SingularityLevelChangedEvent>(UpdateDistortion);
         SubscribeLocalEvent<SingularityDistortionComponent, EntGotInsertedIntoContainerMessage>(UpdateDistortion);
         SubscribeLocalEvent<SingularityDistortionComponent, EntGotRemovedFromContainerMessage>(UpdateDistortion);
@@ -137,6 +137,11 @@ public abstract class SharedSingularitySystem : EntitySystem
         if (TryComp<AppearanceComponent>(uid, out var appearance))
         {
             _visualizer.SetData(uid, SingularityAppearanceKeys.Singularity, singularity.Level, appearance);
+        }
+
+        if (TryComp<RadiationSourceComponent>(uid, out var radiationSource))
+        {
+            UpdateRadiation(uid, singularity, radiationSource);
         }
 
         RaiseLocalEvent(uid, new SingularityLevelChangedEvent(singularity.Level, oldValue, singularity));
@@ -344,17 +349,6 @@ public abstract class SharedSingularitySystem : EntitySystem
         var factor = DistortionContainerScaling - 1;
         comp.FalloffPower = absFalloffPower > 1 ? comp.FalloffPower * MathF.Pow(absFalloffPower, factor) : comp.FalloffPower;
         comp.Intensity = absIntensity > 1 ? comp.Intensity * MathF.Pow(absIntensity, factor) : comp.Intensity;
-    }
-
-    /// <summary>
-    /// Updates the amount of radiation a singularity emits when the singularities level changes.
-    /// </summary>
-    /// <param name="uid">The entity that the singularity is attached to.</param>
-    /// <param name="comp">The radiation source associated with the singularity.</param>
-    /// <param name="args">The event arguments.</param>
-    private void UpdateRadiation(EntityUid uid, RadiationSourceComponent comp, SingularityLevelChangedEvent args)
-    {
-        UpdateRadiation(uid, args.Singularity, comp);
     }
 
 #endregion EventHandlers


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removes some overly-broad subscriptions to `SingularityLevelChangedEvent` in `SharedSingularitySystem`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This was causing every entity with an `AppearanceComponent`, `PhysicsComponent`, `EventHorizonComponent` or `RadiationSourceComponent` to subscribe to `SingularityLevelChangedEvent`.

Resolves https://github.com/space-wizards/space-station-14/issues/38476.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed the event subscriptions and moved their logic directly into the method that raises `SingularityLevelChangedEvent` (`UpdateSingularityLevel`).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Singulo still doing its thing after this change:
<img width="874" alt="Screenshot 2025-06-23 at 3 10 25 PM" src="https://github.com/user-attachments/assets/f3b91f31-d29c-4ffc-916c-47f793d637c8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->