### PR TITLE
Adds BallisticAmmoSelfRefillerComponent

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.AutoFire.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.AutoFire.cs
@@ -6,10 +6,8 @@ namespace Content.Server.Weapons.Ranged.Systems;
 
 public sealed partial class GunSystem
 {
-    public override void Update(float frameTime)
+    private void UpdateAutoFire()
     {
-        base.Update(frameTime);
-
         /*
          * On server because client doesn't want to predict other's guns.
          */

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -1,11 +1,22 @@
+using Content.Server.Emp;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Map;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Weapons.Ranged.Systems;
 
 public sealed partial class GunSystem
 {
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    protected override void InitializeBallistic()
+    {
+        base.InitializeBallistic();
+
+        SubscribeLocalEvent<BallisticAmmoSelfRefillerComponent, EmpPulseEvent>(OnRefillerEmpPulsed);
+    }
+
     protected override void Cycle(EntityUid uid, BallisticAmmoProviderComponent component, MapCoordinates coordinates)
     {
         EntityUid? ent = null;
@@ -33,5 +44,37 @@ public sealed partial class GunSystem
 
         var cycledEvent = new GunCycledEvent();
         RaiseLocalEvent(uid, ref cycledEvent);
+    }
+
+    private void OnRefillerEmpPulsed(Entity<BallisticAmmoSelfRefillerComponent> entity, ref EmpPulseEvent args)
+    {
+        PauseSelfRefill(entity, args.Duration);
+    }
+
+    private void UpdateBallistic()
+    {
+        // Handle `BallisticAmmoSelfRefillerComponent` refills.
+        var query = EntityQueryEnumerator<BallisticAmmoSelfRefillerComponent, BallisticAmmoProviderComponent>();
+        while (query.MoveNext(out var uid, out var refiller, out var ammo))
+        {
+            var entity = new Entity<BallisticAmmoProviderComponent>(uid, ammo);
+            if (!refiller.AutoRefill ||
+                IsFull(entity) ||
+                _timing.CurTime < refiller.NextAutoRefill)
+                continue;
+
+            var ammoEntity = Spawn(refiller.AmmoProto);
+            var insertSucceeded = TryBallisticInsert(entity, ammoEntity, null, suppressInsertionSound: true);
+            if (!insertSucceeded)
+            {
+                QueueDel(ammoEntity);
+                Log.Error(
+                    $"Failed to insert ammo {ammoEntity} into non-full {entity}. Is the {nameof(BallisticAmmoSelfRefillerComponent)}'s {nameof(BallisticAmmoSelfRefillerComponent.AmmoProto)} incorrect for the {nameof(BallisticAmmoProviderComponent)}'s {nameof(BallisticAmmoProviderComponent.Whitelist)}?");
+                continue;
+            }
+
+            refiller.NextAutoRefill = _timing.CurTime + refiller.AutoRefillRate;
+            Dirty(uid, refiller);
+        }
     }
 }

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -449,4 +449,10 @@ public sealed partial class GunSystem : SharedGunSystem
     }
 
     #endregion
+
+    public override void Update(float frameTime)
+    {
+        UpdateBallistic();
+        UpdateAutoFire();
+    }
 }

--- a/Content.Shared/Weapons/Ranged/Components/BallisticAmmoSelfRefillerComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BallisticAmmoSelfRefillerComponent.cs
@@ -1,0 +1,50 @@
+﻿using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Weapons.Ranged.Components;
+
+/// <summary>
+/// This component, analogous to <c>BatterySelfRechargerComponent</c>, will attempt insert ballistic ammunition into
+/// its owner's <see cref="BallisticAmmoProviderComponent"/>.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause, Access(typeof(SharedGunSystem))]
+public sealed partial class BallisticAmmoSelfRefillerComponent : Component
+{
+    /// <summary>
+    /// Whether or not the refilling behavior is active.
+    /// </summary>
+    [DataField, ViewVariables, AutoNetworkedField]
+    public bool AutoRefill = true;
+
+    /// <summary>
+    /// How often a new piece of ammunition is inserted into the owner's <see cref="BallisticAmmoProviderComponent"/>.
+    /// </summary>
+    [DataField, ViewVariables, AutoNetworkedField]
+    public TimeSpan AutoRefillRate;
+
+    /// <summary>
+    /// If true, causes the refilling behavior to be delayed by at least <see cref="AutoRefillPauseDuration"/> after
+    /// the owner is fired.
+    /// </summary>
+    [DataField, ViewVariables, AutoNetworkedField]
+    public bool FiringPausesAutoRefill = false;
+
+    /// <summary>
+    /// How long to pause for if <see cref="FiringPausesAutoRefill"/> is true.
+    /// </summary>
+    [DataField, ViewVariables, AutoNetworkedField]
+    public TimeSpan AutoRefillPauseDuration = TimeSpan.Zero;
+
+    /// <summary>
+    /// What entity to spawn and attempt to insert into the owner.
+    /// </summary>
+    [DataField(required: true), ViewVariables, AutoNetworkedField]
+    public EntProtoId AmmoProto;
+
+    /// <summary>
+    /// When the next auto refill should occur. This is just implementation state.
+    /// </summary>
+    [ViewVariables, AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextAutoRefill = TimeSpan.Zero;
+}

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -8,6 +8,7 @@ using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Weapons.Ranged.Systems;
 
@@ -15,8 +16,9 @@ public abstract partial class SharedGunSystem
 {
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
-
+    [MustCallBase]
     protected virtual void InitializeBallistic()
     {
         SubscribeLocalEvent<BallisticAmmoProviderComponent, ComponentInit>(OnBallisticInit);
@@ -46,19 +48,8 @@ public abstract partial class SharedGunSystem
         if (args.Handled)
             return;
 
-        if (_whitelistSystem.IsWhitelistFailOrNull(component.Whitelist, args.Used))
-            return;
-
-        if (GetBallisticShots(component) >= component.Capacity)
-            return;
-
-        component.Entities.Add(args.Used);
-        Containers.Insert(args.Used, component.Container);
-        // Not predicted so
-        Audio.PlayPredicted(component.SoundInsert, uid, args.User);
-        args.Handled = true;
-        UpdateBallisticAppearance(uid, component);
-        DirtyField(uid, component, nameof(BallisticAmmoProviderComponent.Entities));
+        if (TryBallisticInsert((uid, component), args.Used, args.User))
+            args.Handled = true;
     }
 
     private void OnBallisticAfterInteract(EntityUid uid, BallisticAmmoProviderComponent component, AfterInteractEvent args)
@@ -251,6 +242,11 @@ public abstract partial class SharedGunSystem
                 component.Entities.RemoveAt(component.Entities.Count - 1);
                 DirtyField(uid, component, nameof(BallisticAmmoProviderComponent.Entities));
                 Containers.Remove(entity, component.Container);
+
+                if (TryComp<BallisticAmmoSelfRefillerComponent>(uid, out var refiller))
+                {
+                    PauseSelfRefill((uid, refiller));
+                }
             }
             else if (component.UnspawnedCount > 0)
             {
@@ -268,6 +264,72 @@ public abstract partial class SharedGunSystem
     {
         args.Count = GetBallisticShots(component);
         args.Capacity = component.Capacity;
+    }
+
+    /// <summary>
+    /// Causes <paramref name="entity"/> to pause its refilling for either at least <paramref name="overridePauseDuration"/>
+    /// (if not null) or the entity's <see cref="BallisticAmmoSelfRefillerComponent.AutoRefillPauseDuration"/>. If the
+    /// entity's next refill would occur after the pause duration, this function has no effect.
+    /// </summary>
+    public void PauseSelfRefill(
+        Entity<BallisticAmmoSelfRefillerComponent> entity,
+        TimeSpan? overridePauseDuration = null
+    )
+    {
+        if (overridePauseDuration == null && !entity.Comp.FiringPausesAutoRefill)
+            return;
+
+        var nextRefillByPause = _timing.CurTime + (overridePauseDuration ?? entity.Comp.AutoRefillPauseDuration);
+        if (nextRefillByPause > entity.Comp.NextAutoRefill)
+        {
+            entity.Comp.NextAutoRefill = nextRefillByPause;
+            Dirty(entity);
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the given <paramref name="entity"/>'s ballistic ammunition is full, false otherwise.
+    /// </summary>
+    public bool IsFull(Entity<BallisticAmmoProviderComponent> entity)
+    {
+        return GetBallisticShots(entity.Comp) >= entity.Comp.Capacity;
+    }
+
+    /// <summary>
+    /// Returns whether or not <paramref name="inserted"/> can be inserted into <paramref name="entity"/>, based on
+    /// available space and whitelists.
+    /// </summary>
+    public bool CanInsertBallistic(Entity<BallisticAmmoProviderComponent> entity, EntityUid inserted)
+    {
+        return !_whitelistSystem.IsWhitelistFailOrNull(entity.Comp.Whitelist, inserted) &&
+               !IsFull(entity);
+    }
+
+    /// <summary>
+    /// Attempts to insert <paramref name="inserted"/> into <paramref name="entity"/> as ammunition. Returns true on
+    /// success, false otherwise.
+    /// </summary>
+    public bool TryBallisticInsert(
+        Entity<BallisticAmmoProviderComponent> entity,
+        EntityUid inserted,
+        EntityUid? user,
+        bool suppressInsertionSound = false
+    )
+    {
+        if (!CanInsertBallistic(entity, inserted))
+            return false;
+
+        entity.Comp.Entities.Add(inserted);
+        Containers.Insert(inserted, entity.Comp.Container);
+        if (!suppressInsertionSound)
+        {
+            Audio.PlayPredicted(entity.Comp.SoundInsert, entity, user);
+        }
+
+        UpdateBallisticAppearance(entity, entity.Comp);
+        DirtyField(entity.AsNullable(), nameof(BallisticAmmoProviderComponent.Entities));
+
+        return true;
     }
 
     public void UpdateBallisticAppearance(EntityUid uid, BallisticAmmoProviderComponent component)

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -117,13 +117,14 @@
     - type: ContainerContainer
       containers:
         ballistic-ammo: !type:Container
-    - type: ProjectileBatteryAmmoProvider
+    - type: BallisticAmmoProvider
+      whitelist:
+        tags:
+        - CartridgeLightRifle
+      capacity: 100
       proto: CartridgeLightRifle
-      fireCost: 100
-    - type: Battery
-      maxCharge: 10000
-      startingCharge: 10000
-    - type: BatterySelfRecharger
-      autoRecharge: true
-      autoRechargeRate: 25
+      cycleable: false # No synthesizing ammo for your syndicate masters.
+    - type: BallisticAmmoSelfRefiller
+      autoRefillRate: 4s
+      ammoProto: CartridgeLightRifle
     - type: AmmoCounter

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -127,15 +127,16 @@
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container
-  - type: ProjectileBatteryAmmoProvider
-    proto: BulletPistol
-    fireCost: 100
-  - type: Battery
-    maxCharge: 1000
-    startingCharge: 1000
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 25
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+      - CartridgePistol
+    capacity: 10
+    proto: CartridgePistol
+    cycleable: false # No synthesizing ammo for your syndicate masters.
+  - type: BallisticAmmoSelfRefiller
+    autoRefillRate: 4s
+    ammoProto: CartridgePistol
   - type: AmmoCounter
 
 - type: entity


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Adds BallisticAmmoSelfRefillerComponent, a component analogous to `BatterySelfRechargerComponent`, but which refills `BallisticAmmoProviderComponent`s instead of `BatteryComponent`s.
This PR also swaps Syndicate L6 and Viper modules to use this new component instead of batteries.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Personally, I found it weird that a battery just makes ammo; but the real reason is I need this to make a borg module which can refill a foam force rifle with foam darts in a way that can also be manually reloaded.

There is one balance change in that presently an EMP will delete charge (ie shots) and pause recharge on the battery-guns; while this change does only the latter with EMPs not affecting ammunition already in the gun at all.

## Technical details
<!-- Summary of code changes for easier review. -->

### Automagic Ballistic Ammo Refilling
- Add `BallisticAmmoSelfRefillerComponent`
- Handle `EmpPulseEvent` to pause refilling behavior for EMP's duration

### Supporting Changes
- Change `Content.Server.Weapons.Ranged.Systems.Update` override in `GunSystem.AutoFire.cs` to `UpdateAutoFire`
- Add `Content.Server.Weapons.Ranged.Systems.Update` to `GunSystem.cs` so that it can call `UpdateAutoFire` and `UpdateBallistic`
- Add public methods to GunSystem for use by refilling implementation
  - PauseSelfRefill
  - IsFullBallistic (same as #38420)
  - CanInsertBallistic (same as #38420)
  - TryBallisticInsert (same as #38420)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/84956d00-d7e1-48ec-8d48-0fef4fdb35e6

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

No breakages, I think it's all additive.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
IMO no changelog since it's more of cosmetic than functional of a change.