### PR TITLE
Added a handheld station map to the cyborg thruster module

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/station_map.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_map.yml
@@ -52,16 +52,3 @@
   id: HandheldStationMapUnpowered
   parent: BaseHandheldStationMap
   suffix: Handheld, Always Powered
-
-- type: entity
-  id: HandheldStationMapBorg
-  parent: BaseHandheldStationMap
-  suffix: Borg
-  components:
-  - type: ItemSlots
-    slots:
-      cell_slot:
-        name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMicroreactor
-        disableEject: true
-        swap: false

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -446,7 +446,7 @@
     items:
     - BorgFireExtinguisher
     - BorgHandheldGPSBasic
-    - HandheldStationMapBorg
+    - HandheldStationMapUnpowered
     - HandHeldMassScannerBorg
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: extinguisher-module }


### PR DESCRIPTION
## About the PR
I added a Handheld Station Map to the Thruster module for borgs, to allow them to navigate better with it

## Why / Balance
This allows borgs to navigate around the station exterior better, find breaches, & navigate the station if they are unfamiliar; it also fits the general theme of a cyborg to have mobile map interfacing if they wish it!, as-well as the theme of the thruster module being more of a navigation module, given it already has both a GPS & a handheld mass scanner inside it.

## Technical details
I made a handheld station map variant - HandHeldStationMapBorg - and added it to the thruster module item list

## Media
![engiborgmap](https://github.com/user-attachments/assets/8a030f68-b63f-4a37-bbb7-c91e23def5db)
![borgmap](https://github.com/user-attachments/assets/a0d8e7cf-ecf6-465a-a7fb-f827f6216c96)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added a handheld station map to the borg thruster module!
