### PR TITLE
Lets monkeys & kobolds shove/disarm!

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1325,6 +1325,7 @@
   abstract: true
   components:
   - type: CombatMode
+    canDisarm: true
   - type: Inventory
     templateId: monkey
     speciesId: monkey


### PR DESCRIPTION
## About the PR
I let monkeys & kobolds shove/disarm, with combat mode RMB whilst unarmed.

## Why / Balance
Oftentimes, a natural monkey/kobold ghost role has to escape and/or fight the chef for survival, and usually they won't have _any_ tools or weapons at their disposal, this PR lets them shove for a chance at survival; disarming the chef & providing the monkey/kobold with hope.

## Technical details
I just added "canDisarm: true" to "MobBaseAncestor"


## Media

https://github.com/user-attachments/assets/5426ff9e-4580-418f-a509-640f9a285617



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Monkeys & Kobolds can now shove/disarm like regular species!