### PR TITLE
Improve HandsComponent sprite offset and displacement management

### DIFF
--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Numerics;
 using Content.Client.DisplacementMap;
 using Content.Client.Examine;
 using Content.Client.Strip;
@@ -350,13 +351,27 @@ namespace Content.Client.Hands.Systems
 
                 _sprite.LayerSetData((uid, sprite), index, layerData);
 
+                var offset = hand.Location switch
+                {
+                    HandLocation.Left => handComp.LeftHandSpriteOffset,
+                    HandLocation.Right => handComp.RightHandSpriteOffset,
+                    _ => handComp.SpriteOffset,
+                };
+
+                // Fallback to the SpriteOffset.
+                if (offset == Vector2.Zero)
+                    offset = handComp.SpriteOffset;
+
+                if (sprite[index] is SpriteComponent.Layer layer)
+                    _sprite.LayerSetOffset(layer, layer.Offset + offset);
+
                 // Add displacement maps
                 var displacement = hand.Location switch
                 {
                     HandLocation.Left => handComp.LeftHandDisplacement,
                     HandLocation.Right => handComp.RightHandDisplacement,
-                    _ => handComp.HandDisplacement
-                };
+                    _ => handComp.HandDisplacement,
+                } ?? handComp.HandDisplacement;
 
                 if (displacement is not null && _displacement.TryAddDisplacement(displacement, (uid, sprite), index, key, out var displacementKey))
                     revealedLayers.Add(displacementKey);

--- a/Content.Shared/Hands/Components/HandsComponent.cs
+++ b/Content.Shared/Hands/Components/HandsComponent.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared.DisplacementMap;
 using Content.Shared.Hands.EntitySystems;
 using Robust.Shared.Containers;
@@ -101,6 +102,30 @@ public sealed partial class HandsComponent : Component
     /// </summary>
     [DataField]
     public bool CanBeStripped = true;
+
+    /// <summary>
+    ///     The offset applied to the hand sprites.
+    ///     Used to shunt held items around on something with hands without using displacement maps, which clip when moving sprites as a whole.
+    ///     Note that for cleaner pixels, try and stick to multiples of 0.03125 (1/32). E.g. moving two pixels left is -0.0625,0.
+    /// </summary>
+    [DataField]
+    public Vector2 SpriteOffset = Vector2.Zero;
+
+    /// <summary>
+    ///     The offset applied to the left hand sprites. Overrides <see cref="SpriteOffset"/> if not zero.
+    ///     Used to shunt held items around on something with hands without using displacement maps, which clip when moving sprites as a whole.
+    ///     Note that for cleaner pixels, try and stick to multiples of 0.03125 (1/32). E.g. moving two pixels left is -0.0625,0.
+    /// </summary>
+    [DataField]
+    public Vector2 LeftHandSpriteOffset = Vector2.Zero;
+
+    /// <summary>
+    ///     The offset applied to the right hand sprites. Overrides <see cref="SpriteOffset"/> if not zero.
+    ///     Used to shunt held items around on something with hands without using displacement maps, which clip when moving sprites as a whole.
+    ///     Note that for cleaner pixels, try and stick to multiples of 0.03125 (1/32). E.g. moving two pixels left is -0.0625,0.
+    /// </summary>
+    [DataField]
+    public Vector2 RightHandSpriteOffset = Vector2.Zero;
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
HandsComponent didn't have equivalent behaviour to inventory slots when it came to controlling where sprites end up. This means that entities with unusually-placed hands, like monkeys and scurrets, have issues when some kind maintainer or contributor comes in and attempts to fix their inhand locations.

This PR fixes two things:

1. HandsComponent can now specify sprite offsets for left, right and any hand.
2. Displacement maps on hands correctly fall back to the fallback displacement map.

## Why / Balance
I couldn't make the wawa look good and displacement maps have issues when abused to move entire sprites around.

## Technical details
Largely trivial changes.

## Media
This is just technical under-the-hood changes to unlock future content fixes.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
Nah