### PR TITLE
Cleaned up most job lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -13,14 +13,11 @@
     children:
     - id: ClothingBeltUtilityFilled
     - id: SurvivalKnife
-    - id: HandheldGPSBasic
     - id: RadioHandheld
     - id: AppraisalTool
     - id: FireExtinguisher
     - id: Flare
-      prob: 0.3
-      rolls: !type:ConstantNumberSelector
-        value: 3
+      amount: 2
 
 - type: entity
   id: LockerSalvageSpecialistFilledHardsuit

--- a/Resources/Prototypes/Catalog/Fills/Lockers/dressers.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/dressers.yml
@@ -63,6 +63,7 @@
     contents:
       - id: ClothingHeadHatBeretHoS
       - id: ClothingHeadHatHoshat
+      - id: ClothingMaskNeckGaiter
       - id: ClothingUniformJumpskirtHoSAlt
       - id: ClothingUniformJumpsuitHoSAlt
       - id: ClothingUniformJumpskirtHosFormal

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -10,8 +10,6 @@
     - id: CargoShuttleConsoleCircuitboard
     - id: SalvageMagnetMachineCircuitboard
     - id: SalvageJobBoardComputerCircuitboard
-    - id: CigPackGreen
-      prob: 0.50
     - id: ClothingHeadsetAltCargo
     - id: DoorRemoteCargo
     - id: RubberStampApproved
@@ -38,7 +36,6 @@
     children:
     - id: CaptainIDCard
     - id: CigarGoldCase
-      prob: 0.25
     - id: ClothingBeltSheathFilled
     - id: ClothingHeadsetAltCommand
     - id: ClothingOuterArmorCaptainCarapace
@@ -47,8 +44,8 @@
     - id: MedalCase
     - id: NukeDisk
     - id: PinpointerNuclear
-    - id: PlushieNuke
-      prob: 0.1
+    - id: RubberStampApproved
+    - id: RubberStampDenied
     - id: RubberStampCaptain
     - id: SpaceCash1000
     - id: WeaponDisabler
@@ -124,12 +121,6 @@
     - id: BoxHeadset
     - id: BoxID
     - id: BoxPDA
-    - id: CigarGoldCase
-      prob: 0.25
-      # Fuck the HoP they don't deserve fucking cigars.
-      # Yes they do fuck you.
-    - id: ClothingBackpackIan
-      prob: 0.5
     - id: ClothingHeadsetCommand
     - id: ClothingNeckGoldmedal
     - id: DoorRemoteService
@@ -160,8 +151,6 @@
     children:
     - id: AccessConfigurator
     - id: BoxEncryptionKeyEngineering
-    - id: CigarCase
-      prob: 0.15
     - id: ClothingBeltChiefEngineerFilled
     - id: ClothingEyesGlassesMeson
     - id: ClothingHandsGlovesColorYellow
@@ -170,6 +159,8 @@
     - id: CargoRequestEngineeringComputerCircuitboard
     - id: RCD
     - id: RCDAmmo
+    - id: RubberStampApproved
+    - id: RubberStampDenied
     - id: RubberStampCE
     - id: MetalFoamGrenade
 
@@ -217,10 +208,8 @@
     children:
     - id: BoxEncryptionKeyMedical
     - id: ClothingBackpackDuffelSurgeryFilled
-    - id: ClothingCloakCmo
     - id: ClothingEyesHudMedical
     - id: ClothingHandsGlovesNitrile
-    - id: ClothingHeadHatBeretCmo
     - id: ClothingHeadsetAltMedical
     - id: ClothingMaskSterile
     - id: DoorRemoteMedical
@@ -229,6 +218,8 @@
     - id: MedicalTechFabCircuitboard
     - id: CargoRequestMedicalComputerCircuitboard
     - id: MedkitFilled
+    - id: RubberStampApproved
+    - id: RubberStampDenied
     - id: RubberStampCMO
     - id: MedTekCartridge
 
@@ -282,6 +273,8 @@
     - id: ProtolatheMachineCircuitboard
     - id: ResearchComputerCircuitboard
     - id: CargoRequestScienceComputerCircuitboard
+    - id: RubberStampApproved
+    - id: RubberStampDenied
     - id: RubberStampRd
 
 # Hardsuit table, used for suit storage as well
@@ -327,8 +320,6 @@
     - id: WeaponEnergyShotgun
     - id: BookSpaceLaw
     - id: BoxEncryptionKeySecurity
-    - id: CigarGoldCase
-      prob: 0.50
     - id: ClothingBeltSecurityFilled
     - id: ClothingEyesGlassesSecurity
     - id: ClothingHeadsetAltSecurity
@@ -337,6 +328,8 @@
     - id: ClothingShoesBootsJack
     - id: DoorRemoteSecurity
     - id: HoloprojectorSecurity
+    - id: RubberStampApproved
+    - id: RubberStampDenied
     - id: RubberStampHos
     - id: SecurityTechFabCircuitboard
     - id: CargoRequestSecurityComputerCircuitboard

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -323,7 +323,6 @@
     - id: ClothingBeltSecurityFilled
     - id: ClothingEyesGlassesSecurity
     - id: ClothingHeadsetAltSecurity
-    - id: ClothingMaskNeckGaiter
     - id: ClothingOuterCoatHoSTrench
     - id: ClothingShoesBootsJack
     - id: DoorRemoteSecurity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -76,6 +76,7 @@
     - id: BoxBottle
     - id: BoxVial
     - id: PlasmaChemistryVial
+    - id: ChemBag
     - id: ClothingHandsGlovesLatex
     - id: ClothingMaskSterile
     - id: HandLabeler

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -69,6 +69,12 @@
   id: LockerFillChemistry
   table: !type:AllSelector
     children:
+    - id: BoxSyringe
+    - id: BoxBeaker
+      amount: 2
+    - id: BoxPillCanister
+    - id: BoxBottle
+    - id: BoxVial
     - id: PlasmaChemistryVial
     - id: ClothingHandsGlovesLatex
     - id: ClothingMaskSterile

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -40,29 +40,8 @@
   id: LockerFillMedicalDoctor
   table: !type:AllSelector
     children:
-    - id: HandheldHealthAnalyzer
-      prob: 0.6
-    - id: ClothingHeadMirror
-      prob: 0.1
     - id: ClothingHandsGlovesLatex
-    - id: ClothingHeadsetMedical
     - id: ClothingEyesHudMedical
-    - !type:GroupSelector
-      children:
-      - id: ClothingHeadHatSurgcapGreen
-        weight: 0.1
-      - id: ClothingHeadHatSurgcapPurple
-        weight: 0.05
-      - id: ClothingHeadHatSurgcapBlue
-        weight: 0.90
-    - !type:GroupSelector
-      children:
-      - id: UniformScrubsColorBlue
-        weight: 0.5
-      - id: UniformScrubsColorGreen
-        weight: 0.1
-      - id: UniformScrubsColorPurple
-        weight: 0.05
     - id: ClothingMaskSterile
 
 - type: entity
@@ -90,20 +69,10 @@
   id: LockerFillChemistry
   table: !type:AllSelector
     children:
-    - id: BoxSyringe
-    - id: BoxBeaker
-    - id: BoxBeaker
-      prob: 0.3
-    - id: BoxPillCanister
-    - id: BoxBottle
-    - id: BoxVial
     - id: PlasmaChemistryVial
-    - id: ChemBag
     - id: ClothingHandsGlovesLatex
-    - id: ClothingHeadsetMedical
     - id: ClothingMaskSterile
     - id: HandLabeler
-      prob: 0.5
 
 - type: entity
   parent: LockerChemistry
@@ -120,18 +89,10 @@
   table: !type:AllSelector
     children:
     - id: ClothingOuterHardsuitVoidParamed
-    - id: ClothingOuterCoatParamedicWB
-    - id: ClothingHeadHatParamedicsoft
-    - id: ClothingOuterWinterPara
-    - id: ClothingUniformJumpsuitParamedic
-    - id: ClothingUniformJumpskirtParamedic
     - id: ClothingEyesHudMedical
     - id: ClothingHandsGlovesLatex
-    - id: ClothingHeadsetMedical
     - id: ClothingMaskSterile
     - id: HandheldGPSBasic
-    - id: MedkitFilled
-      prob: 0.3
 
 - type: entity
   parent: LockerParamedic

--- a/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
@@ -13,10 +13,6 @@
   table: !type:AllSelector
     children:
     - id: ClothingHandsGlovesLatex
-    - id: ClothingHeadsetScience
-    - id: ClothingMaskSterile
-    - id: ClothingOuterCoatRnd
+    - id: ClothingMaskGas
     - id: AnomalyScanner
     - id: NodeScanner
-    - id: NetworkConfigurator
-      prob: 0.5

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -67,8 +67,6 @@
       - id: ClothingHeadsetSecurity
       - id: ClothingHandsGlovesColorBlack
       - id: ClothingShoesBootsJack
-      - id: WeaponMeleeNeedle
-        prob: 0.1
       - id: HoloprojectorSecurity
       - id: BookSpaceLaw
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -120,11 +120,6 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingEyesGlassesNoir
-      - id: ClothingHeadHatDetGadget
-      - id: ClothingNeckTieDet
-      - id: ClothingOuterVestDetective
-      - id: ClothingOuterCoatDetectiveLoadout
       - id: FlippoEngravedLighter
       - id: FlashlightSeclite
       - id: ForensicScanner

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -40,6 +40,8 @@
       - id: ClothingShoesBootsJack
       - id: ClothingOuterCoatWarden
       - id: ClothingOuterWinterWarden
+      - id: RubberStampApproved
+      - id: RubberStampDenied
       - id: RubberStampWarden
       - id: DoorRemoteArmory
       - id: HoloprojectorSecurity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -64,10 +64,8 @@
       - id: ClothingBeltSecurityFilled
       - id: Flash
       - id: ClothingEyesGlassesSecurity
-      - id: ClothingHeadsetSecurity
       - id: ClothingHandsGlovesColorBlack
       - id: ClothingShoesBootsJack
-      - id: HoloprojectorSecurity
       - id: BookSpaceLaw
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -58,15 +58,11 @@
   - type: StorageFill
     contents:
       - id: FlashlightSeclite
-        prob: 0.8
       - id: WeaponDisabler
-      - id: ClothingUniformJumpsuitSecGrey
-        prob: 0.3
       - id: ClothingHeadHelmetBasic
       - id: ClothingOuterArmorBasic
       - id: ClothingBeltSecurityFilled
       - id: Flash
-        prob: 0.5
       - id: ClothingEyesGlassesSecurity
       - id: ClothingHeadsetSecurity
       - id: ClothingHandsGlovesColorBlack
@@ -74,9 +70,7 @@
       - id: WeaponMeleeNeedle
         prob: 0.1
       - id: HoloprojectorSecurity
-        prob: 0.6
       - id: BookSpaceLaw
-        prob: 0.5
 
 - type: entity
   id: LockerBrigmedicFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -7,16 +7,9 @@
     contents:
       - id: ClothingOuterArmorBasicSlim
       - id: WeaponShotgunDoubleBarreledRubber
-      - id: DrinkShaker
       - id: ClothingEyesHudBeer
       - id: HandLabeler
         amount: 1
-      - id: DrinkBottleBeer
-        prob: 0.5
-      - id: DrinkBottleBeer
-        prob: 0.5
-      - id: DrinkBottleBeer
-        prob: 0.5
       - id: BoxBeanbag
         amount: 2
       - id: RagItem
@@ -98,18 +91,12 @@
   - type: StorageFill
     contents:
       - id: ClothingHandsGlovesLeather
-      - id: ClothingOuterApronBotanist
-      - id: ClothingHeadBandBotany
       - id: ChemistryBottleRobustHarvest
-        prob: 0.3
       - id: ClothingBeltPlant
       - id: PlantBag ##Some maps don't have nutrivend
       - id: BoxMouthSwab
       - id: Dropper
       - id: HandLabeler
-      - id: ClothingUniformOveralls
-      - id: ClothingHeadHatTrucker
-        prob: 0.1
 
 - type: entity
   id: LockerBotanistLoot

--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
@@ -93,9 +93,6 @@
        - id: ClothingOuterCoatRnd
        - id: ClothingUniformJumpskirtScientist
        - id: ClothingEyesGlasses
-         prob: 0.5
-       - id: CrowbarRed #The jojoke - hit video game Half-Life
-         prob: 0.1
 
 
  - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
@@ -128,9 +128,7 @@
        - id: ClothingOuterCoatLab
        - id: ClothingUniformJumpskirtMedicalDoctor
        - id: ClothingHandsGlovesLatex
-         prob: 0.4
        - id: ClothingEyesGlasses
-         prob: 0.3
 
  - type: entity
    id: WardrobeChapelFilled

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemdrobe.yml
@@ -8,8 +8,7 @@
     ClothingBackpackChemistry: 2
     ClothingBackpackSatchelChemistry: 2
     ClothingBackpackDuffelChemistry: 2
-    ChemBag: 2
-    HandLabeler: 3
+    ChemBag: 4
     ClothingBeltMedical: 2
     ClothingHandsGlovesLatex: 2
     ClothingHeadsetMedical: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemdrobe.yml
@@ -8,7 +8,7 @@
     ClothingBackpackChemistry: 2
     ClothingBackpackSatchelChemistry: 2
     ClothingBackpackDuffelChemistry: 2
-    ChemBag: 4
+    ChemBag: 2
     ClothingBeltMedical: 2
     ClothingHandsGlovesLatex: 2
     ClothingHeadsetMedical: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -1,13 +1,6 @@
 - type: vendingMachineInventory
   id: ChemVendInventory
   startingInventory:
-    HandLabeler: 3
-    Syringe: 5
-    BoxPillCanister: 2
-    BoxVial: 2
-    BoxBottle: 2
-    Beaker: 5
-    LargeBeaker: 5
     Jug: 4
     JugAluminium: 2
     JugCarbon: 4
@@ -38,13 +31,6 @@
 - type: vendingMachineInventory
   id: ChemVendInventorySyndicate
   startingInventory:
-    HandLabeler: 3
-    Syringe: 5
-    BoxPillCanister: 2
-    BoxVial: 2
-    BoxBottle: 2
-    Beaker: 5
-    LargeBeaker: 5
     Jug: 4
     JugAluminium: 2
     JugCarbon: 4

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -40,9 +40,9 @@
   startingInventory:
     HandLabeler: 3
     Syringe: 5
-    BoxPillCanister: 3
-    BoxVial: 3
-    BoxBottle: 3
+    BoxPillCanister: 2
+    BoxVial: 2
+    BoxBottle: 2
     Beaker: 5
     LargeBeaker: 5
     Jug: 4

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -3,9 +3,9 @@
   startingInventory:
     HandLabeler: 3
     Syringe: 5
-    BoxPillCanister: 3
-    BoxVial: 3
-    BoxBottle: 3
+    BoxPillCanister: 2
+    BoxVial: 2
+    BoxBottle: 2
     Beaker: 5
     LargeBeaker: 5
     Jug: 4

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -1,6 +1,13 @@
 - type: vendingMachineInventory
   id: ChemVendInventory
   startingInventory:
+    HandLabeler: 3
+    Syringe: 5
+    BoxPillCanister: 3
+    BoxVial: 3
+    BoxBottle: 3
+    Beaker: 5
+    LargeBeaker: 5
     Jug: 4
     JugAluminium: 2
     JugCarbon: 4
@@ -31,6 +38,13 @@
 - type: vendingMachineInventory
   id: ChemVendInventorySyndicate
   startingInventory:
+    HandLabeler: 3
+    Syringe: 5
+    BoxPillCanister: 3
+    BoxVial: 3
+    BoxBottle: 3
+    Beaker: 5
+    LargeBeaker: 5
     Jug: 4
     JugAluminium: 2
     JugCarbon: 4

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
@@ -4,16 +4,18 @@
     ClothingUniformJumpsuitDetective: 2
     ClothingUniformJumpskirtDetective: 2
     ClothingShoesColorBrown: 2
-    ClothingOuterCoatDetectiveLoadout: 1
-    ClothingOuterCoatDetectiveLoadoutGrey: 1
+    ClothingOuterVestDetective: 2
+    ClothingOuterCoatDetectiveLoadout: 2
+    ClothingOuterCoatDetectiveLoadoutGrey: 2
     ClothingHeadHatFedoraBrown: 2
     ClothingUniformJumpsuitDetectiveGrey: 2
     ClothingUniformJumpskirtDetectiveGrey: 2
-    ClothingOuterVestDetective: 2
     ClothingNeckTieDet: 2
     ClothingHeadHatFedoraGrey: 2
     ClothingHandsGlovesColorBlack: 2
     ClothingHandsGlovesLatex: 2
     ClothingHeadsetSecurity: 2
+    ClothingHeadHatDetGadget: 1
+    ClothingEyesGlassesNoir: 1
   contrabandInventory:
     ToyFigurineDetective: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/hydrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/hydrobe.yml
@@ -4,12 +4,15 @@
     ClothingBackpackHydroponics: 2
     ClothingBackpackSatchelHydroponics: 2
     ClothingBackpackDuffelHydroponics: 2
-    ClothingOuterApronBotanist: 2
+    PlantBag: 3
+    ClothingOuterApronBotanist: 3
     ClothingUniformOveralls: 3
     ClothingUniformJumpsuitHydroponics: 3
     ClothingUniformJumpskirtHydroponics: 3
     ClothingNeckScarfStripedGreen: 3
     ClothingHeadBandBotany: 3
+    ClothingHeadHatTrucker: 3
+    ClothingHandsGlovesLeather: 3
     ClothingHeadsetService: 2
     ClothingOuterWinterHydro: 2
   contrabandInventory:

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -1,7 +1,7 @@
 - type: vendingMachineInventory
   id: NanoMedPlusInventory
   startingInventory:
-    HandheldHealthAnalyzer: 3
+    HandheldHealthAnalyzer: 6
     Brutepack: 5
     Ointment: 5
     Bloodpack: 5

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
@@ -6,20 +6,26 @@
     ClothingBackpackSatchelMedical: 4
     ClothingUniformJumpsuitMedicalDoctor: 4
     ClothingUniformJumpskirtMedicalDoctor: 4
+    ClothingUniformJumpsuitParamedic: 2
+    ClothingUniformJumpskirtParamedic: 2
     ClothingBeltMedical: 4
     ClothingHeadHatBeretMedic: 4
     ClothingHeadNurseHat: 4
+    ClothingHeadMirror: 2
+    ClothingHeadHatParamedicsoft: 2
     ClothingOuterCoatLab: 4
+    ClothingOuterCoatParamedicWB: 2
     ClothingShoesColorWhite: 4
     ClothingHandsGlovesLatex: 4
     ClothingHandsGlovesNitrile: 2
     ClothingHeadsetMedical: 4
     ClothingOuterWinterMed: 2
+    ClothingOuterWinterPara: 2
     ClothingOuterHospitalGown: 5
     UniformScrubsColorGreen: 4
     UniformScrubsColorBlue: 4
     UniformScrubsColorPurple: 4
-    ClothingHeadHatSurgcapGreen: 4 
+    ClothingHeadHatSurgcapGreen: 4
     ClothingHeadHatSurgcapBlue: 4
     ClothingHeadHatSurgcapPurple: 4
     ClothingShoesBootsWinterMed: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
@@ -7,7 +7,6 @@
     HydroponicsToolScythe: 4
     HydroponicsToolHatchet: 4
     Dropper: 4
-    PlantBag: 3
     PlantBGoneSpray: 20
     WeedSpray: 20
     PestSpray: 20

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/scidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/scidrobe.yml
@@ -7,13 +7,14 @@
     ClothingUniformJumpsuitScientist: 3
     ClothingUniformJumpskirtScientist: 3
     ClothingUniformJumpsuitScientistFormal: 3
+    ClothingOuterCoatLab: 3
     ClothingOuterCoatRnd: 3
     ClothingShoesColorWhite: 3
     ClothingNeckTieSci: 3
     ClothingHeadsetScience: 3
-    ClothingMaskGas: 3
+    ClothingMaskSterile: 3
     ClothingOuterWinterSci: 2
     ClothingNeckScarfStripedPurple: 3
     ClothingShoesBootsWinterSci: 2
   contrabandInventory:
-    ToyFigurineResearchDirector: 1  
+    ToyFigurineResearchDirector: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -22,7 +22,7 @@
     RadioHandheldSecurity: 5
   # security officers need to follow a diet regimen!
   contrabandInventory:
-    WeaponMeleeNeedle: 2
+    WeaponMeleeNeedle: 3
     FoodDonutHomer: 12
     FoodBoxDonut: 2
     #box evidence


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Most job lockers have been cleaned up. For the most part this entails removing purely-cosmetic clothing items (moving them to the department's wardrobe vendor if absent), and removing randomness.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
To my knowledge, maintainers' current stance on job lockers is that they should only contain job-essential equipment. To that end, having them filled with clothing or non-essential items causes them to be cluttered and makes that essential equipment harder to access.

I don't think these changes should have any significant impact on game balance, since removed items should be easily accessible from other places in the department (usually vending machines). One change I did make was to add APPROVED/DENIED stamps to all department heads' lockers (and the Warden's), which could potentially make thief stamp-collecting objectives easier to accomplish.

## Technical details
<!-- Summary of code changes for easier review. -->
LockerFillSalvageSpecialist:
- Now always spawns with two flares (instead of 0-3 at random)
- No longer spawns with a handheld GPS (redundant with AstroNav app, can be printed in autolathe anyway)

DresserHeadOfSecurityFilled:
- Now spawns with a neck gaiter

LockerFillQuartermaster:
- No longer spawns with cigarettes (if a QM character does not smoke this is useless, if a QM character smokes they will likely have cigarettes as a trinket anyway)

LockerFillCaptainNoLaser:
- Now always spawns with a premium cigar case (rest of the department heads had any randomly-spawning smokables removed, but captain now always has the premium cigar case so it isn't just gone entirely)
- Now spawns with approved/denied rubber stamps
- No longer spawns with a nukie plushie

LockerFillHeadOfPersonnel:
- No longer spawns with a premium cigar case (if a HoP character does not smoke this is useless, if a HoP character smokes they will likely have some kind of smokables as a trinket anyway)
- No longer spawns with an Ian backpack (currently a loadout playtime reward so having it also spawn randomly in the locker is odd)

LockerFillChiefEngineerNoHardsuit:
- Now spawns with approved/denied rubber stamps
- No longer spawns with a cigar case (if a CE character does not smoke this is useless, if a QM character smokes they will likely have a cigar case as a trinket anyway)

LockerFillChiefMedicalOfficerNoHardsuit:
- Now spawns with approved/denied rubber stamps
- No longer spawns with CMO's cloak or beret (these are already in the CMO's dresser)

LockerFillResearchDirectorNoHardsuit:
- Now spawns with approved/denied rubber stamps

LockerFillHeadOfSecurityNoHardsuit:
- Now spawns with approved/denied rubber stamps
- No longer spawns with a premium cigar case (if a HoS character does not smoke this is useless, if a HoS character smokes they will likely have some kind of smokables as a trinket anyway)
- No longer spawns with a neck gaiter (moved to HoS's dresser)

LockerFillMedicalDoctor:
- No longer spawns with a medical headset
- No longer spawns with a head mirror, surgical cap, or surgical scrubs
- No longer spawns with a health analyzer (medical PDA makes it obsolete, spares can be dispensed from MedTech and medical fab anyway)

LockerFillChemistry:
- Now always spawns with two beaker boxes
- Now always spawns with a hand labeler
- No longer spawns with a medical headset

LockerFillParamedic:
- No longer spawns with a medical headset
- No longer spawns with paramedic jumpsuits, coats, or hats (moved to MediDrobe)
- No longer has a chance to spawn with a medkit (medbays generally have a whole back room where medical supplies are kept, so one random medkit in a job locker is unnecessary)

FillLockerScientist:
- No longer spawns with a science headset
- No longer spawns with a science lab coat
- No longer spawns with a network configurator (science doesn't need it most of the time, and can print them anyway)
- Sterile mask replaced with a gas mask

LockerWardenFilled:
- Now spawns with approved/denied rubber stamps

LockerSecurityFilled:
- Now always spawns with a seclite, a flash, and a Space Law book
- No longer spawns with a security headset
- No longer has a chance to spawn with a grey security jumpsuit
- No longer has a chance to spawn with a holoprojector (the security belt already contains one) or an anti-inflatable armament (to reduce clutter)

LockerDetectiveFilled:
- No longer contains noir-tech glasses, gogo hat, detectives's tie, detective's vest, or detective's coat

LockerBoozeFilled:
- No longer contains a random quantity of empty beer bottles
- No longer contains a shaker (Booze-O-Mat can dispense them already)

LockerBotanistFilled:
- Now always spawns with a robust harvest bottle
- No longer spawns with apron, botany headband, overalls, or trucker hat

WardrobeScienceFilled:
- Now always spawns with glasses
- No longer spawns with a crowbar (Half-Life reference is funny, but I'm trying to reduce item clutter regardless)

WardrobeMedicalDoctorFilled:
- Now always spawns with glasses and latex gloves

ChemDrobeInventory:
- No longer contains hand labelers (chemists get one in their locker and if they really need a spare the MedFab can print one)

DetDrobeInventory:
- Now contains detective's vest (x2), gogo hat (x1), and noir glasses (x1)
- Increased number of detective coats and noir coats in inventory (1 each -> 2 each)

HyDrobeInventory:
- Now contains leather gloves (x3) and trucker hats (x3)
- Now contains one additional apron (2 -> 3)
- Now contains plant bags (x3)

NanoMedPlusInventory:
- Now contains more health analyzers (3 -> 6) (to compensate for removal from lockers)

MediDrobeInventory:
- Now contains head mirrors, paramedic jumpsuits, coats, and hats (2 of each type)

NutriMaxInventory:
- No longer contains plant bags (moved to HyDrobe)

SciDrobeInventory:
- Now contains regular lab coats (x3)
- Gas masks replaced with sterile masks

SecTechInventory:
- Increased number of anti-inflatable armaments in manager inventory (2 -> 3)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

N/A (purely YML changes)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Most job lockers have had their contents tweaked slightly to reduce randomness and clutter. Some items have been entirely moved to job vending machines.