### PR TITLE
Don't add ImplicitRoof to grids with roof component

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -105,13 +105,11 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
 
         EnsureComp<ShuttleComponent>(ev.EntityUid);
 
+        // This and RoofComponent should be mutually exclusive, so ImplicitRoof should be removed if the grid has RoofComponent
         if (HasComp<RoofComponent>(ev.EntityUid))
-        {
             RemComp<ImplicitRoofComponent>(ev.EntityUid);
-            return;
-        }
-
-        EnsureComp<ImplicitRoofComponent>(ev.EntityUid);
+        else
+            EnsureComp<ImplicitRoofComponent>(ev.EntityUid);
     }
 
     private void OnShuttleStartup(EntityUid uid, ShuttleComponent component, ComponentStartup args)

--- a/Content.Shared/Light/Components/ImplicitRoofComponent.cs
+++ b/Content.Shared/Light/Components/ImplicitRoofComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Light.Components;
 
 /// <summary>
-/// Assumes the entire attached grid is rooved.
+/// Assumes the entire attached grid is rooved. This component will get removed if the grid has RoofComponent.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ImplicitRoofComponent : Component

--- a/Content.Shared/Light/Components/RoofComponent.cs
+++ b/Content.Shared/Light/Components/RoofComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Light.Components;
 
 /// <summary>
-/// Will draw shadows over tiles flagged as roof tiles on the attached grid.
+/// Will draw shadows over tiles flagged as roof tiles on the attached grid. ImplicitRoofComponent will get removed if the grid has this component.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class RoofComponent : Component


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes #38401

ImplicitRoof component will not be forced upon the grids that already have RoofComponent. ImplicitRoof will also be removed if it loads with a grid that has RoofComponent.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This could potentially cause issues for the planet/island stations (if there will ever be such stations) that do have roofs and MapLight components and for forks that already have such stations.

## Technical details
<!-- Summary of code changes for easier review. -->
ShuttleSystem now checks if the grid has RoofComponent. If it does, system removes the ImplicitRoof component, else it ensures that ImplicitRoof is present.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Testing demonstration (?)

https://github.com/user-attachments/assets/560514e8-59d9-4894-8259-9d27e3149453



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
I guess it's not needed since there are no player-facing changes
