### PR TITLE
Fix PowerCellDrawComponent draw rate

### DIFF
--- a/Content.Server/PowerCell/PowerCellSystem.Draw.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.Draw.cs
@@ -28,7 +28,7 @@ public sealed partial class PowerCellSystem
             if (!TryGetBatteryFromSlot(uid, out var batteryEnt, out var battery, slot))
                 continue;
 
-            if (_battery.TryUseCharge(batteryEnt.Value, comp.DrawRate, battery))
+            if (_battery.TryUseCharge(batteryEnt.Value, comp.DrawRate * (float)comp.Delay.TotalSeconds, battery))
                 continue;
 
             var ev = new PowerCellSlotEmptyEvent();

--- a/Content.Shared/PowerCell/PowerCellDrawComponent.cs
+++ b/Content.Shared/PowerCell/PowerCellDrawComponent.cs
@@ -44,9 +44,12 @@ public sealed partial class PowerCellDrawComponent : Component
     public float DrawRate = 1f;
 
     /// <summary>
-    /// How much power is used whenever the entity is "used".
+    /// How much power is used whenever the entity is "used" (in Joules).
     /// This is used to ensure the UI won't open again without a minimum use power.
     /// </summary>
+    /// <remarks>
+    /// This is not a rate how the datafield name implies, but a one-time cost.
+    /// </remarks>
     [DataField]
     public float UseRate;
 

--- a/Content.Shared/PowerCell/PowerCellDrawComponent.cs
+++ b/Content.Shared/PowerCell/PowerCellDrawComponent.cs
@@ -18,13 +18,13 @@ public sealed partial class PowerCellDrawComponent : Component
     /// <summary>
     /// Whether there is any charge available to draw.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("canDraw"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public bool CanDraw;
 
     /// <summary>
     /// Whether there is sufficient charge to use.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("canUse"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public bool CanUse;
 
     #endregion
@@ -37,17 +37,17 @@ public sealed partial class PowerCellDrawComponent : Component
     public bool Enabled = true;
 
     /// <summary>
-    /// How much the entity draws while the UI is open.
+    /// How much the entity draws while the UI is open (in Watts).
     /// Set to 0 if you just wish to check for power upon opening the UI.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("drawRate")]
+    [DataField]
     public float DrawRate = 1f;
 
     /// <summary>
     /// How much power is used whenever the entity is "used".
     /// This is used to ensure the UI won't open again without a minimum use power.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("useRate")]
+    [DataField]
     public float UseRate;
 
     /// <summary>


### PR DESCRIPTION
## About the PR
It wasn't multiplying with the update timespan, so the units were wrong.
The default was 1 second though, so this did not affect anything.
However, if someone would change the update rate it would result in a different draw rate.

## Why / Balance
bugfix

## Technical details
A power draw rate is measured in Watts.
1W = 1J/s
The power cell gets updated every `Delay` seconds, so we multiply the draw rate with that time to get the energy (in joule) to be removed from the power cell.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Forks may have to adjust the balance if they have set a Delay != 1 anywhere.

**Changelog**
no player facing bugs on upstream
