### PR TITLE
Allows cats to drag objects with their tail

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2992,6 +2992,8 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: cat
   - type: Physics
+  - type: Puller
+    needsHands: false
   - type: Fixtures
     fixtures:
       fix1:
@@ -3108,7 +3110,7 @@
     factions:
     - Syndicate
   - type: Access
-    tags: 
+    tags:
     - NuclearOperative
     - SyndicateAgent
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -224,6 +224,8 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: bingus
   - type: Physics
+  - type: Puller
+    needsHands: false
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
### Related Issues
No related open issues
## Overview
Allows cats (and Bingus, Bingus is basically a cat to drag objects using their tail, increasing versatility for those players interested in playing as our favorite feline friends.
## Reasoning
Cats don’t have much to do right now! Adding the ability to drag things seems like a mostly harmless change to increase their interact ability. Though not a part of this PR, imagine a world where Exception not only kills a mouse, but also drags it to the nearest player! So cute.  
The only negative I can see here is some balance concerns around the Syndicat. Giving them additional dragging ability is, in fact, a buff. That said, cats are very light and anything worth dragging for advantage is quite heavy making for a very slow delivery.
## Implementation Details
Dragging is permitted via the `PullingSystem` and more specifically the `PullerComponent` allows an entity to, well, pull. Modifying the `NeedsHands` parameter of that component to be false allows the kitty to do so even without hands.
### Technical  Changes
 – Added `PullerComponent` to `MobCat` in [Animals.yml](https://github.com/Zetaplx/space-station-14/blob/master/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml) with `needsHands`: **false**
 – Added `PullerComponent` to `MobBingus` in [Pets.yml](https://github.com/Zetaplx/space-station-14/blob/master/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml) with `needsHands`: **false**
### Test Cases
 – ✅ Station pet cats are capable of dragging objects.  
 – ✅ Purchased cats are capable of dragging objects.  
 – ✅ Syndicats are capable of dragging objects.  
 – ✅ Bingus is capable of dragging objects.  
## Media
https://github.com/user-attachments/assets/54985b62-3649-4201-9cb5-23a103e255d2

https://github.com/user-attachments/assets/ce1df486-87f0-4365-8ca9-b30506202cfa

## Requirements
 – ✅ I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).  
 – ✅ I have added media to this PR or it does not require an ingame showcase.  
## Change Log
:cl: Zetaplx
- tweak: Cats (and Bingus) can now drag objects with their tail.