### PR TITLE
Added a ConfirmableAction component to ActionRevertPolymorph

### DIFF
--- a/Resources/Locale/en-US/actions/actions/polymorph.ftl
+++ b/Resources/Locale/en-US/actions/actions/polymorph.ftl
@@ -1,2 +1,1 @@
-gera-transformation-popup = This action will transform you. Use it again to confirm.
 revert-polymorph-action-popup = This action is irreversible. Use it again to confirm.

--- a/Resources/Locale/en-US/actions/actions/polymorph.ftl
+++ b/Resources/Locale/en-US/actions/actions/polymorph.ftl
@@ -1,1 +1,2 @@
 gera-transformation-popup = This action will transform you. Use it again to confirm.
+revert-polymorph-action-popup = This action is irreversible. Use it again to confirm.

--- a/Resources/Prototypes/Actions/polymorph.yml
+++ b/Resources/Prototypes/Actions/polymorph.yml
@@ -4,6 +4,8 @@
   name: Revert
   description: Revert back into your original form.
   components:
+  - type: ConfirmableAction
+    popup: revert-polymorph-action-popup
   - type: InstantAction
     event: !type:RevertPolymorphActionEvent
 


### PR DESCRIPTION
## About the PR
The action of reverting from a polymorph now has to be confirmed.

## Why / Balance
In the short amount of time that Corgium has been available, I've seen people revert accidentally multiple times. This should help prevent that.

## Technical details
Added a ConfirmableAction component to ActionRevertPolymorph.

## Media
![screenshot](https://github.com/user-attachments/assets/8038ae1c-bfab-4a0d-be87-9b873be4efc9)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The action of reverting from a polymorph now has to be confirmed. 
