### PR TITLE
RespiratorSystem Cleanup

### DIFF
--- a/Content.IntegrationTests/Tests/Body/LungTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LungTest.cs
@@ -48,30 +48,6 @@ namespace Content.IntegrationTests.Tests.Body
     damageRecovery:
       types:
         Asphyxiation: -1.5
-
-- type: entity
-  name: HumanRespiratorDummy
-  id: HumanRespiratorDummy
-  components:
-  - type: MobState
-    allowedStates:
-      - Alive
-  - type: Damageable
-  - type: ThermalRegulator
-    metabolismHeat: 5000
-    radiatedHeat: 400
-    implicitHeatRegulation: 5000
-    sweatHeatRegulation: 5000
-    shiveringHeatRegulation: 5000
-    normalBodyTemperature: 310.15
-    thermalRegulationTemperatureThreshold: 25
-  - type: Respirator
-    damage:
-      types:
-        Asphyxiation: 1.5
-    damageRecovery:
-      types:
-        Asphyxiation: -1.5
 ";
 
         [Test]
@@ -154,83 +130,6 @@ namespace Content.IntegrationTests.Tests.Body
         }
 
         [Test]
-        public async Task AirConsistencyTestNoBody()
-        {
-            // --- Setup
-            await using var pair = await PoolManager.GetServerClient();
-            var server = pair.Server;
-
-            await server.WaitIdleAsync();
-
-            var entityManager = server.ResolveDependency<IEntityManager>();
-            var mapLoader = entityManager.System<MapLoaderSystem>();
-            var mapSys = entityManager.System<SharedMapSystem>();
-
-            EntityUid? grid = null;
-            RespiratorComponent resp = default;
-            EntityUid human = default;
-            GridAtmosphereComponent relevantAtmos = default;
-            var startingMoles = 0.0f;
-
-            var testMapName = new ResPath("Maps/Test/Breathing/3by3-20oxy-80nit.yml");
-
-            await server.WaitPost(() =>
-            {
-                mapSys.CreateMap(out var mapId);
-                Assert.That(mapLoader.TryLoadGrid(mapId, testMapName, out var gridEnt));
-                grid = gridEnt!.Value.Owner;
-            });
-
-            Assert.That(grid, Is.Not.Null, $"Test blueprint {testMapName} not found.");
-
-            float GetMapMoles()
-            {
-                var totalMapMoles = 0.0f;
-                foreach (var tile in relevantAtmos.Tiles.Values)
-                {
-                    totalMapMoles += tile.Air?.TotalMoles ?? 0.0f;
-                }
-
-                return totalMapMoles;
-            }
-
-            await server.WaitAssertion(() =>
-            {
-                var center = new Vector2(0.5f, 0.5f);
-                var coordinates = new EntityCoordinates(grid.Value, center);
-                human = entityManager.SpawnEntity("HumanRespiratorDummy", coordinates);
-                relevantAtmos = entityManager.GetComponent<GridAtmosphereComponent>(grid.Value);
-                startingMoles = 100f; // Hardcoded because GetMapMoles returns 900 here for some reason.
-
-#pragma warning disable NUnit2045
-                Assert.That(entityManager.TryGetComponent(human, out resp), Is.True);
-#pragma warning restore NUnit2045
-            });
-
-            // --- End setup
-
-            var inhaleCycles = 100;
-            for (var i = 0; i < inhaleCycles; i++)
-            {
-                // Breathe in
-                await PoolManager.WaitUntil(server, () => resp.Status == RespiratorStatus.Exhaling);
-                Assert.That(
-                    GetMapMoles(), Is.LessThan(startingMoles),
-                    "Did not inhale in any gas"
-                );
-
-                // Breathe out
-                await PoolManager.WaitUntil(server, () => resp.Status == RespiratorStatus.Inhaling);
-                Assert.That(
-                    GetMapMoles(), Is.EqualTo(startingMoles).Within(0.0002),
-                    "Did not exhale as much gas as was inhaled"
-                );
-            }
-
-            await pair.CleanReturnAsync();
-        }
-
-        [Test]
         public async Task NoSuffocationTest()
         {
             await using var pair = await PoolManager.GetServerClient();
@@ -268,66 +167,6 @@ namespace Content.IntegrationTests.Tests.Body
 #pragma warning disable NUnit2045
                 Assert.That(mixture.TotalMoles, Is.GreaterThan(0));
                 Assert.That(entityManager.HasComponent<BodyComponent>(human), Is.True);
-                Assert.That(entityManager.TryGetComponent(human, out respirator), Is.True);
-                Assert.That(respirator.SuffocationCycles, Is.LessThanOrEqualTo(respirator.SuffocationCycleThreshold));
-#pragma warning restore NUnit2045
-            });
-
-            var increment = 10;
-
-            // 20 seconds
-            var total = 20 * cfg.GetCVar(CVars.NetTickrate);
-
-            for (var tick = 0; tick < total; tick += increment)
-            {
-                await server.WaitRunTicks(increment);
-                await server.WaitAssertion(() =>
-                {
-                    Assert.That(respirator.SuffocationCycles, Is.LessThanOrEqualTo(respirator.SuffocationCycleThreshold),
-                        $"Entity {entityManager.GetComponent<MetaDataComponent>(human).EntityName} is suffocating on tick {tick}");
-                });
-            }
-
-            await pair.CleanReturnAsync();
-        }
-
-        [Test]
-        public async Task NoSuffocationBodylessTest()
-        {
-            await using var pair = await PoolManager.GetServerClient();
-            var server = pair.Server;
-
-            var mapManager = server.ResolveDependency<IMapManager>();
-            var entityManager = server.ResolveDependency<IEntityManager>();
-            var cfg = server.ResolveDependency<IConfigurationManager>();
-            var mapLoader = entityManager.System<MapLoaderSystem>();
-            var mapSys = entityManager.System<SharedMapSystem>();
-
-            EntityUid? grid = null;
-            RespiratorComponent respirator = null;
-            EntityUid human = default;
-
-            var testMapName = new ResPath("Maps/Test/Breathing/3by3-20oxy-80nit.yml");
-
-            await server.WaitPost(() =>
-            {
-                mapSys.CreateMap(out var mapId);
-                Assert.That(mapLoader.TryLoadGrid(mapId, testMapName, out var gridEnt));
-                grid = gridEnt!.Value.Owner;
-            });
-
-            Assert.That(grid, Is.Not.Null, $"Test blueprint {testMapName} not found.");
-
-            await server.WaitAssertion(() =>
-            {
-                var center = new Vector2(0.5f, 0.5f);
-
-                var coordinates = new EntityCoordinates(grid.Value, center);
-                human = entityManager.SpawnEntity("HumanRespiratorDummy", coordinates);
-
-                var mixture = entityManager.System<AtmosphereSystem>().GetContainingMixture(human);
-#pragma warning disable NUnit2045
-                Assert.That(mixture.TotalMoles, Is.GreaterThan(0));
                 Assert.That(entityManager.TryGetComponent(human, out respirator), Is.True);
                 Assert.That(respirator.SuffocationCycles, Is.LessThanOrEqualTo(respirator.SuffocationCycleThreshold));
 #pragma warning restore NUnit2045

--- a/Content.IntegrationTests/Tests/Body/LungTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LungTest.cs
@@ -48,6 +48,30 @@ namespace Content.IntegrationTests.Tests.Body
     damageRecovery:
       types:
         Asphyxiation: -1.5
+
+- type: entity
+  name: HumanRespiratorDummy
+  id: HumanRespiratorDummy
+  components:
+  - type: MobState
+    allowedStates:
+      - Alive
+  - type: Damageable
+  - type: ThermalRegulator
+    metabolismHeat: 5000
+    radiatedHeat: 400
+    implicitHeatRegulation: 5000
+    sweatHeatRegulation: 5000
+    shiveringHeatRegulation: 5000
+    normalBodyTemperature: 310.15
+    thermalRegulationTemperatureThreshold: 25
+  - type: Respirator
+    damage:
+      types:
+        Asphyxiation: 1.5
+    damageRecovery:
+      types:
+        Asphyxiation: -1.5
 ";
 
         [Test]
@@ -130,6 +154,83 @@ namespace Content.IntegrationTests.Tests.Body
         }
 
         [Test]
+        public async Task AirConsistencyTestNoBody()
+        {
+            // --- Setup
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
+
+            await server.WaitIdleAsync();
+
+            var entityManager = server.ResolveDependency<IEntityManager>();
+            var mapLoader = entityManager.System<MapLoaderSystem>();
+            var mapSys = entityManager.System<SharedMapSystem>();
+
+            EntityUid? grid = null;
+            RespiratorComponent resp = default;
+            EntityUid human = default;
+            GridAtmosphereComponent relevantAtmos = default;
+            var startingMoles = 0.0f;
+
+            var testMapName = new ResPath("Maps/Test/Breathing/3by3-20oxy-80nit.yml");
+
+            await server.WaitPost(() =>
+            {
+                mapSys.CreateMap(out var mapId);
+                Assert.That(mapLoader.TryLoadGrid(mapId, testMapName, out var gridEnt));
+                grid = gridEnt!.Value.Owner;
+            });
+
+            Assert.That(grid, Is.Not.Null, $"Test blueprint {testMapName} not found.");
+
+            float GetMapMoles()
+            {
+                var totalMapMoles = 0.0f;
+                foreach (var tile in relevantAtmos.Tiles.Values)
+                {
+                    totalMapMoles += tile.Air?.TotalMoles ?? 0.0f;
+                }
+
+                return totalMapMoles;
+            }
+
+            await server.WaitAssertion(() =>
+            {
+                var center = new Vector2(0.5f, 0.5f);
+                var coordinates = new EntityCoordinates(grid.Value, center);
+                human = entityManager.SpawnEntity("HumanRespiratorDummy", coordinates);
+                relevantAtmos = entityManager.GetComponent<GridAtmosphereComponent>(grid.Value);
+                startingMoles = 100f; // Hardcoded because GetMapMoles returns 900 here for some reason.
+
+#pragma warning disable NUnit2045
+                Assert.That(entityManager.TryGetComponent(human, out resp), Is.True);
+#pragma warning restore NUnit2045
+            });
+
+            // --- End setup
+
+            var inhaleCycles = 100;
+            for (var i = 0; i < inhaleCycles; i++)
+            {
+                // Breathe in
+                await PoolManager.WaitUntil(server, () => resp.Status == RespiratorStatus.Exhaling);
+                Assert.That(
+                    GetMapMoles(), Is.LessThan(startingMoles),
+                    "Did not inhale in any gas"
+                );
+
+                // Breathe out
+                await PoolManager.WaitUntil(server, () => resp.Status == RespiratorStatus.Inhaling);
+                Assert.That(
+                    GetMapMoles(), Is.EqualTo(startingMoles).Within(0.0002),
+                    "Did not exhale as much gas as was inhaled"
+                );
+            }
+
+            await pair.CleanReturnAsync();
+        }
+
+        [Test]
         public async Task NoSuffocationTest()
         {
             await using var pair = await PoolManager.GetServerClient();
@@ -167,6 +268,66 @@ namespace Content.IntegrationTests.Tests.Body
 #pragma warning disable NUnit2045
                 Assert.That(mixture.TotalMoles, Is.GreaterThan(0));
                 Assert.That(entityManager.HasComponent<BodyComponent>(human), Is.True);
+                Assert.That(entityManager.TryGetComponent(human, out respirator), Is.True);
+                Assert.That(respirator.SuffocationCycles, Is.LessThanOrEqualTo(respirator.SuffocationCycleThreshold));
+#pragma warning restore NUnit2045
+            });
+
+            var increment = 10;
+
+            // 20 seconds
+            var total = 20 * cfg.GetCVar(CVars.NetTickrate);
+
+            for (var tick = 0; tick < total; tick += increment)
+            {
+                await server.WaitRunTicks(increment);
+                await server.WaitAssertion(() =>
+                {
+                    Assert.That(respirator.SuffocationCycles, Is.LessThanOrEqualTo(respirator.SuffocationCycleThreshold),
+                        $"Entity {entityManager.GetComponent<MetaDataComponent>(human).EntityName} is suffocating on tick {tick}");
+                });
+            }
+
+            await pair.CleanReturnAsync();
+        }
+
+        [Test]
+        public async Task NoSuffocationBodylessTest()
+        {
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
+
+            var mapManager = server.ResolveDependency<IMapManager>();
+            var entityManager = server.ResolveDependency<IEntityManager>();
+            var cfg = server.ResolveDependency<IConfigurationManager>();
+            var mapLoader = entityManager.System<MapLoaderSystem>();
+            var mapSys = entityManager.System<SharedMapSystem>();
+
+            EntityUid? grid = null;
+            RespiratorComponent respirator = null;
+            EntityUid human = default;
+
+            var testMapName = new ResPath("Maps/Test/Breathing/3by3-20oxy-80nit.yml");
+
+            await server.WaitPost(() =>
+            {
+                mapSys.CreateMap(out var mapId);
+                Assert.That(mapLoader.TryLoadGrid(mapId, testMapName, out var gridEnt));
+                grid = gridEnt!.Value.Owner;
+            });
+
+            Assert.That(grid, Is.Not.Null, $"Test blueprint {testMapName} not found.");
+
+            await server.WaitAssertion(() =>
+            {
+                var center = new Vector2(0.5f, 0.5f);
+
+                var coordinates = new EntityCoordinates(grid.Value, center);
+                human = entityManager.SpawnEntity("HumanRespiratorDummy", coordinates);
+
+                var mixture = entityManager.System<AtmosphereSystem>().GetContainingMixture(human);
+#pragma warning disable NUnit2045
+                Assert.That(mixture.TotalMoles, Is.GreaterThan(0));
                 Assert.That(entityManager.TryGetComponent(human, out respirator), Is.True);
                 Assert.That(respirator.SuffocationCycles, Is.LessThanOrEqualTo(respirator.SuffocationCycleThreshold));
 #pragma warning restore NUnit2045

--- a/Content.Server/Body/Components/RespiratorComponent.cs
+++ b/Content.Server/Body/Components/RespiratorComponent.cs
@@ -22,18 +22,6 @@ namespace Content.Server.Body.Components
         };
 
         /// <summary>
-        ///     The gas our entity breathes
-        /// </summary>
-        [DataField]
-        public Gas MetabolizedGas = Gas.Oxygen;
-
-        /// <summary>
-        ///     The gas our entity exhales
-        /// </summary>
-        [DataField]
-        public Gas ByproductGas = Gas.CarbonDioxide;
-
-        /// <summary>
         ///     Volume of our breath in liters
         /// </summary>
         [DataField]
@@ -44,12 +32,6 @@ namespace Content.Server.Body.Components
         /// </summary>
         [DataField]
         public float Ratio = 1.0f;
-
-        /// <summary>
-        ///     Saturation per mol of gas
-        /// </summary>
-        [DataField]
-        public float SaturationMultiplier = Atmospherics.BreathMolesToReagentMultiplier;
 
         /// <summary>
         ///     The next time that this body will inhale or exhale.
@@ -104,12 +86,6 @@ namespace Content.Server.Body.Components
         /// </summary>
         [DataField]
         public ProtoId<EmotePrototype> GaspEmote = "Gasp";
-
-        /// <summary>
-        /// The type of gas this respirator needs. Used only for the breathing alerts, not actual metabolism.
-        /// </summary>
-        [DataField]
-        public ProtoId<AlertPrototype> Alert = "LowOxygen";
 
         /// <summary>
         ///     How many cycles in a row has the mob been under-saturated?

--- a/Content.Server/Body/Components/RespiratorComponent.cs
+++ b/Content.Server/Body/Components/RespiratorComponent.cs
@@ -34,10 +34,22 @@ namespace Content.Server.Body.Components
         public Gas ByproductGas = Gas.CarbonDioxide;
 
         /// <summary>
+        ///     Volume of our breath in liters
+        /// </summary>
+        [DataField]
+        public float BreathVolume = Atmospherics.BreathVolume;
+
+        /// <summary>
         ///     How much of the gas we inhale is metabolized? Value range is (0, 1]
         /// </summary>
         [DataField]
         public float Ratio = 1.0f;
+
+        /// <summary>
+        ///     Saturation per mol of gas
+        /// </summary>
+        [DataField]
+        public float SaturationMultiplier = Atmospherics.BreathMolesToReagentMultiplier;
 
         /// <summary>
         ///     The next time that this body will inhale or exhale.

--- a/Content.Server/Body/Components/RespiratorComponent.cs
+++ b/Content.Server/Body/Components/RespiratorComponent.cs
@@ -1,4 +1,6 @@
 using Content.Server.Body.Systems;
+using Content.Shared.Alert;
+using Content.Shared.Atmos;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Damage;
 using Robust.Shared.Prototypes;
@@ -9,6 +11,34 @@ namespace Content.Server.Body.Components
     [RegisterComponent, Access(typeof(RespiratorSystem))]
     public sealed partial class RespiratorComponent : Component
     {
+        /// <summary>
+        ///     Gas container for this entity
+        /// </summary>
+        [DataField]
+        public GasMixture Air = new()
+        {
+            Volume = 6, // 6 liters, the average lung capacity for a human according to Google
+            Temperature = Atmospherics.NormalBodyTemperature
+        };
+
+        /// <summary>
+        ///     The gas our entity breathes
+        /// </summary>
+        [DataField]
+        public Gas MetabolizedGas = Gas.Oxygen;
+
+        /// <summary>
+        ///     The gas our entity exhales
+        /// </summary>
+        [DataField]
+        public Gas ByproductGas = Gas.Oxygen;
+
+        /// <summary>
+        ///     How much of the gas we inhale is metabolized? Value range is (0, 1]
+        /// </summary>
+        [DataField]
+        public float Ratio = 1.0f;
+
         /// <summary>
         ///     The next time that this body will inhale or exhale.
         /// </summary>
@@ -62,6 +92,12 @@ namespace Content.Server.Body.Components
         /// </summary>
         [DataField]
         public ProtoId<EmotePrototype> GaspEmote = "Gasp";
+
+        /// <summary>
+        /// The type of gas this respirator needs. Used only for the breathing alerts, not actual metabolism.
+        /// </summary>
+        [DataField]
+        public ProtoId<AlertPrototype> Alert = "LowOxygen";
 
         /// <summary>
         ///     How many cycles in a row has the mob been under-saturated?

--- a/Content.Server/Body/Components/RespiratorComponent.cs
+++ b/Content.Server/Body/Components/RespiratorComponent.cs
@@ -31,7 +31,7 @@ namespace Content.Server.Body.Components
         ///     The gas our entity exhales
         /// </summary>
         [DataField]
-        public Gas ByproductGas = Gas.Oxygen;
+        public Gas ByproductGas = Gas.CarbonDioxide;
 
         /// <summary>
         ///     How much of the gas we inhale is metabolized? Value range is (0, 1]

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Atmos.EntitySystems;
+using Content.Server.Body.Components;
 using Content.Server.Popups;
 using Content.Shared.Alert;
 using Content.Shared.Atmos;
@@ -9,6 +10,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Internals;
 using Content.Shared.Inventory;
 using Content.Shared.Roles;
+using NetCord.Rest;
 
 namespace Content.Server.Body.Systems;
 
@@ -27,6 +29,7 @@ public sealed class InternalsSystem : SharedInternalsSystem
         _internalsQuery = GetEntityQuery<InternalsComponent>();
 
         SubscribeLocalEvent<InternalsComponent, InhaleLocationEvent>(OnInhaleLocation);
+        SubscribeLocalEvent<InternalsComponent, InhaledGasEvent>(OnInhaledGas);
         SubscribeLocalEvent<InternalsComponent, StartingGearEquippedEvent>(OnStartingGear);
     }
 
@@ -58,9 +61,14 @@ public sealed class InternalsSystem : SharedInternalsSystem
         if (AreInternalsWorking(ent))
         {
             var gasTank = Comp<GasTankComponent>(ent.Comp.GasTankEntity!.Value);
-            args.Gas = _gasTank.RemoveAirVolume((ent.Comp.GasTankEntity.Value, gasTank), Atmospherics.BreathVolume);
+            args.Gas = _gasTank.RemoveAirVolume((ent.Comp.GasTankEntity.Value, gasTank), args.Respirator.Comp.BreathVolume);
             // TODO: Should listen to gas tank updates instead I guess?
             _alerts.ShowAlert(ent, ent.Comp.InternalsAlert, GetSeverity(ent));
         }
+    }
+
+    private void OnInhaledGas(Entity<InternalsComponent> ent, ref InhaledGasEvent args)
+    {
+
     }
 }

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -29,7 +29,6 @@ public sealed class InternalsSystem : SharedInternalsSystem
         _internalsQuery = GetEntityQuery<InternalsComponent>();
 
         SubscribeLocalEvent<InternalsComponent, InhaleLocationEvent>(OnInhaleLocation);
-        SubscribeLocalEvent<InternalsComponent, InhaledGasEvent>(OnInhaledGas);
         SubscribeLocalEvent<InternalsComponent, StartingGearEquippedEvent>(OnStartingGear);
     }
 
@@ -65,10 +64,5 @@ public sealed class InternalsSystem : SharedInternalsSystem
             // TODO: Should listen to gas tank updates instead I guess?
             _alerts.ShowAlert(ent, ent.Comp.InternalsAlert, GetSeverity(ent));
         }
-    }
-
-    private void OnInhaledGas(Entity<InternalsComponent> ent, ref InhaledGasEvent args)
-    {
-
     }
 }

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -10,7 +10,6 @@ using Content.Shared.DoAfter;
 using Content.Shared.Internals;
 using Content.Shared.Inventory;
 using Content.Shared.Roles;
-using NetCord.Rest;
 
 namespace Content.Server.Body.Systems;
 

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -61,7 +61,7 @@ public sealed class InternalsSystem : SharedInternalsSystem
         if (AreInternalsWorking(ent))
         {
             var gasTank = Comp<GasTankComponent>(ent.Comp.GasTankEntity!.Value);
-            args.Gas = _gasTank.RemoveAirVolume((ent.Comp.GasTankEntity.Value, gasTank), args.Respirator.Comp.BreathVolume);
+            args.Gas = _gasTank.RemoveAirVolume((ent.Comp.GasTankEntity.Value, gasTank), args.Respirator.BreathVolume);
             // TODO: Should listen to gas tank updates instead I guess?
             _alerts.ShowAlert(ent, ent.Comp.InternalsAlert, GetSeverity(ent));
         }

--- a/Content.Server/Body/Systems/LungSystem.cs
+++ b/Content.Server/Body/Systems/LungSystem.cs
@@ -63,6 +63,9 @@ public sealed class LungSystem : EntitySystem
         _solutionContainerSystem.UpdateChemicals(lung.Solution.Value);
     }
 
+    /* This should really be moved to somewhere in the atmos system and modernized,
+     so that other systems, like CondenserSystem, can use it.
+     */
     private void GasToReagent(GasMixture gas, Solution solution)
     {
         foreach (var gasId in Enum.GetValues<Gas>())

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -125,7 +125,7 @@ public sealed class RespiratorSystem : EntitySystem
         // Inhale gas
         var ev = new InhaleLocationEvent
         {
-            Respirator = (entity, entity.Comp),
+            Respirator = entity.Comp,
         };
         RaiseLocalEvent(entity, ref ev);
 
@@ -499,7 +499,7 @@ public sealed class RespiratorSystem : EntitySystem
 }
 
 [ByRefEvent]
-public record struct InhaleLocationEvent(GasMixture? Gas, Entity<RespiratorComponent> Respirator);
+public record struct InhaleLocationEvent(GasMixture? Gas, RespiratorComponent Respirator);
 
 [ByRefEvent]
 public record struct ExhaleLocationEvent(GasMixture? Gas);

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -217,10 +217,11 @@ public sealed class RespiratorSystem : EntitySystem
             return false;
 
         // If we don't have a body we can't be poisoned by gas, yet...
-        if (!TryComp<BodyComponent>(ent, out var body))
-            return TryMetabolizeGas(ent);
+        var success = !TryComp<BodyComponent>(ent, out var body) ? TryMetabolizeGas(ent) : TryMetabolizeGas((ent, ent.Comp, body));
 
-        return TryMetabolizeGas((ent, ent.Comp, body));
+        // Don't keep that gas in our lungs lest it poisons a poor nuclear operative.
+        Exhale(ent);
+        return success;
     }
 
     /// <summary>

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -68,8 +68,8 @@ public sealed class RespiratorSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        var query = EntityQueryEnumerator<RespiratorComponent>();
-        while (query.MoveNext(out var uid, out var respirator))
+        var query = EntityQueryEnumerator<RespiratorComponent, BodyComponent>();
+        while (query.MoveNext(out var uid, out var respirator, out var body))
         {
             if (_gameTiming.CurTime < respirator.NextUpdate)
                 continue;

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -123,7 +123,10 @@ public sealed class RespiratorSystem : EntitySystem
             return false;
 
         // Inhale gas
-        var ev = new InhaleLocationEvent();
+        var ev = new InhaleLocationEvent
+        {
+            Respirator = (entity, entity.Comp),
+        };
         RaiseLocalEvent(entity, ref ev);
 
         ev.Gas ??= _atmosSys.GetContainingMixture(entity.Owner, excite: true);
@@ -133,7 +136,7 @@ public sealed class RespiratorSystem : EntitySystem
             return false;
         }
 
-        var gas = ev.Gas.RemoveVolume(Atmospherics.BreathVolume);
+        var gas = ev.Gas.RemoveVolume(entity.Comp.BreathVolume);
 
         var inhaleEv = new InhaledGasEvent(gas);
         RaiseLocalEvent(entity, ref inhaleEv);
@@ -239,7 +242,7 @@ public sealed class RespiratorSystem : EntitySystem
 
         gas = new GasMixture(gas);
         var lungRatio = 1.0f / organs.Count;
-        gas.Multiply(MathF.Min(lungRatio * gas.Volume / Atmospherics.BreathVolume, lungRatio));
+        gas.Multiply(MathF.Min(lungRatio * gas.Volume / ent.Comp.BreathVolume, lungRatio));
         var solution = _lungSystem.GasToReagent(gas);
 
         float saturation = 0;
@@ -391,7 +394,7 @@ public sealed class RespiratorSystem : EntitySystem
     {
         var moles = gas[(int)entity.Comp.MetabolizedGas];
 
-        return Math.Max(0, moles * Atmospherics.BreathMolesToReagentMultiplier);
+        return Math.Max(0, moles * entity.Comp.SaturationMultiplier);
     }
 
     /// <summary>
@@ -496,7 +499,7 @@ public sealed class RespiratorSystem : EntitySystem
 }
 
 [ByRefEvent]
-public record struct InhaleLocationEvent(GasMixture? Gas);
+public record struct InhaleLocationEvent(GasMixture? Gas, Entity<RespiratorComponent> Respirator);
 
 [ByRefEvent]
 public record struct ExhaleLocationEvent(GasMixture? Gas);

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -289,6 +289,8 @@ public sealed class RespiratorSystem : EntitySystem
             if (_solutionContainerSystem.ResolveSolution(organUid, lung.SolutionName, ref lung.Solution))
                 _solutionContainerSystem.RemoveAllSolution(lung.Solution.Value);
         }
+
+        _atmosSys.Merge(gas, outGas);
     }
 
     /// <summary>
@@ -480,14 +482,14 @@ public sealed class RespiratorSystem : EntitySystem
     private void OnGasInhaled(Entity<BodyComponent> entity, ref InhaledGasEvent args)
     {
         args.Handled = true;
-        
+
         args.Succeeded = TryInhaleGasToBody((entity, entity.Comp), args.Gas);
     }
 
     private void OnGasExhaled(Entity<BodyComponent> entity, ref ExhaledGasEvent args)
     {
         args.Handled = true;
-        
+
         RemoveGasFromBody(entity, args.Gas);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Eventified a decent amount of the RespiratorSystem so it can be used without a BodySystem.

Made the entityQuery only for Respirators.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Useful for downstream and necessary for decoupling BodySystem from RespiratorSystem.

Needed for downstream + general cleanup

## Technical details
<!-- Summary of code changes for easier review. -->

- Cleaned up some tests to not copypaste code
- Added two new events that raise the gas inhaled and gas exhaled that are handleable for downstream use and also for Body System to do its thing if it exists.
- Moved one const to be used in the component instead
- Breath volume is now able to be changed on a per respirator basis.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun, no breaking changes
