### PR TITLE
allow combat mode toggling when unable to interact

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -221,7 +221,7 @@
     event: !type:ToggleClothingEvent
 
 - type: entity
-  parent: BaseAction
+  parent: BaseMentalAction
   id: ActionCombatModeToggle
   name: "[color=red]Combat Mode[/color]"
   description: Enter combat mode


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
allow combat mode toggling when cuffed or crit, or when unable to perform other normal actions. fix https://discord.com/channels/310555209753690112/1385281778486345870

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This prevents being stuck in combat mode while in crit, and while cuffed, so you don't stare awkwardly in one direction and can still examine things.