### PR TITLE
Improve lathe queue performance

### DIFF
--- a/Content.Client/Lathe/UI/LatheBoundUserInterface.cs
+++ b/Content.Client/Lathe/UI/LatheBoundUserInterface.cs
@@ -43,7 +43,7 @@ namespace Content.Client.Lathe.UI
                         _menu.Recipes = msg.Recipes;
                     _menu?.PopulateRecipes();
                     _menu?.UpdateCategories();
-                    _menu?.PopulateQueueList(msg.Queue.Value);
+                    _menu?.PopulateQueueList(msg.Queue);
                     _menu?.SetQueueInfo(msg.CurrentlyProducing);
                     break;
             }

--- a/Content.Client/Lathe/UI/LatheBoundUserInterface.cs
+++ b/Content.Client/Lathe/UI/LatheBoundUserInterface.cs
@@ -43,7 +43,7 @@ namespace Content.Client.Lathe.UI
                         _menu.Recipes = msg.Recipes;
                     _menu?.PopulateRecipes();
                     _menu?.UpdateCategories();
-                    _menu?.PopulateQueueList(msg.Queue);
+                    _menu?.PopulateQueueList(msg.Queue.Value);
                     _menu?.SetQueueInfo(msg.CurrentlyProducing);
                     break;
             }

--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -223,13 +223,14 @@ public sealed partial class LatheMenu : DefaultWindow
     /// Populates the build queue list with all queued items
     /// </summary>
     /// <param name="queue"></param>
-    public void PopulateQueueList(Queue<LatheRecipePrototype> queue)
+    public void PopulateQueueList(Queue<ProtoId<LatheRecipePrototype>> queue)
     {
         QueueList.DisposeAllChildren();
 
         var idx = 1;
-        foreach (var recipe in queue)
+        foreach (var recipeProto in queue)
         {
+            var recipe = _prototypeManager.Index(recipeProto);
             var queuedRecipeBox = new BoxContainer();
             queuedRecipeBox.Orientation = BoxContainer.LayoutOrientation.Horizontal;
 

--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -223,7 +223,7 @@ public sealed partial class LatheMenu : DefaultWindow
     /// Populates the build queue list with all queued items
     /// </summary>
     /// <param name="queue"></param>
-    public void PopulateQueueList(Queue<ProtoId<LatheRecipePrototype>> queue)
+    public void PopulateQueueList(IReadOnlyCollection<ProtoId<LatheRecipePrototype>> queue)
     {
         QueueList.DisposeAllChildren();
 

--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -244,11 +244,13 @@ public sealed partial class LatheMenu : DefaultWindow
         }
     }
 
-    public void SetQueueInfo(LatheRecipePrototype? recipe)
+    public void SetQueueInfo(ProtoId<LatheRecipePrototype>? recipeProto)
     {
-        FabricatingContainer.Visible = recipe != null;
-        if (recipe == null)
+        FabricatingContainer.Visible = recipeProto != null;
+        if (recipeProto == null)
             return;
+
+        var recipe = _prototypeManager.Index(recipeProto.Value);
 
         FabricatingDisplayContainer.Children.Clear();
         FabricatingDisplayContainer.AddChild(GetRecipeDisplayControl(recipe));

--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -223,7 +223,7 @@ public sealed partial class LatheMenu : DefaultWindow
     /// Populates the build queue list with all queued items
     /// </summary>
     /// <param name="queue"></param>
-    public void PopulateQueueList(List<LatheRecipePrototype> queue)
+    public void PopulateQueueList(Queue<LatheRecipePrototype> queue)
     {
         QueueList.DisposeAllChildren();
 

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -195,7 +195,8 @@ namespace Content.Server.Lathe
             if (component.CurrentRecipe != null || component.Queue.Count <= 0 || !this.IsPowered(uid, EntityManager))
                 return false;
 
-            var recipe = component.Queue.Dequeue();
+            var recipeProto = component.Queue.Dequeue();
+            var recipe = _proto.Index(recipeProto);
 
             var time = _reagentSpeed.ApplySpeed(uid, recipe.CompleteTime) * component.TimeMultiplier;
 
@@ -268,7 +269,7 @@ namespace Content.Server.Lathe
             if (!Resolve(uid, ref component))
                 return;
 
-            var producing = component.CurrentRecipe ?? component.Queue.FirstOrDefault();
+            var producing = component.CurrentRecipe ?? (component.Queue.TryPeek(out var protoId) ? _proto.Index(protoId) : null);
 
             var state = new LatheUpdateState(GetAvailableRecipes(uid, component), component.Queue, producing);
             _uiSys.SetUiState(uid, LatheUiKey.Key, state);

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -274,7 +274,7 @@ namespace Content.Server.Lathe
             if (producing == null && component.Queue.TryPeek(out var next))
                 producing = next;
 
-            var state = new LatheUpdateState(GetAvailableRecipes(uid, component), new(component.Queue.ToArray()), producing);
+            var state = new LatheUpdateState(GetAvailableRecipes(uid, component), component.Queue.ToArray(), producing);
             _uiSys.SetUiState(uid, LatheUiKey.Key, state);
         }
 

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -226,13 +226,14 @@ namespace Content.Server.Lathe
 
             if (comp.CurrentRecipe != null)
             {
-                if (comp.CurrentRecipe.Result is { } resultProto)
+                var currentRecipe = _proto.Index(comp.CurrentRecipe.Value);
+                if (currentRecipe.Result is { } resultProto)
                 {
                     var result = Spawn(resultProto, Transform(uid).Coordinates);
                     _stack.TryMergeToContacts(result);
                 }
 
-                if (comp.CurrentRecipe.ResultReagents is { } resultReagents &&
+                if (currentRecipe.ResultReagents is { } resultReagents &&
                     comp.ReagentOutputSlotId is { } slotId)
                 {
                     var toAdd = new Solution(
@@ -269,7 +270,9 @@ namespace Content.Server.Lathe
             if (!Resolve(uid, ref component))
                 return;
 
-            var producing = component.CurrentRecipe ?? (component.Queue.TryPeek(out var protoId) ? _proto.Index(protoId) : null);
+            var producing = component.CurrentRecipe;
+            if (producing == null && component.Queue.TryPeek(out var next))
+                producing = next;
 
             var state = new LatheUpdateState(GetAvailableRecipes(uid, component), new(component.Queue.ToArray()), producing);
             _uiSys.SetUiState(uid, LatheUiKey.Key, state);

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -271,7 +271,7 @@ namespace Content.Server.Lathe
 
             var producing = component.CurrentRecipe ?? (component.Queue.TryPeek(out var protoId) ? _proto.Index(protoId) : null);
 
-            var state = new LatheUpdateState(GetAvailableRecipes(uid, component), component.Queue, producing);
+            var state = new LatheUpdateState(GetAvailableRecipes(uid, component), new(component.Queue.ToArray()), producing);
             _uiSys.SetUiState(uid, LatheUiKey.Key, state);
         }
 

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -183,7 +183,7 @@ namespace Content.Server.Lathe
 
                 _materialStorage.TryChangeMaterialAmount(uid, mat, adjustedAmount);
             }
-            component.Queue.Add(recipe);
+            component.Queue.Enqueue(recipe);
 
             return true;
         }
@@ -195,8 +195,7 @@ namespace Content.Server.Lathe
             if (component.CurrentRecipe != null || component.Queue.Count <= 0 || !this.IsPowered(uid, EntityManager))
                 return false;
 
-            var recipe = component.Queue.First();
-            component.Queue.RemoveAt(0);
+            var recipe = component.Queue.Dequeue();
 
             var time = _reagentSpeed.ApplySpeed(uid, recipe.CompleteTime) * component.TimeMultiplier;
 

--- a/Content.Shared/Lathe/LatheComponent.cs
+++ b/Content.Shared/Lathe/LatheComponent.cs
@@ -64,7 +64,7 @@ namespace Content.Shared.Lathe
         /// The recipe the lathe is currently producing
         /// </summary>
         [ViewVariables]
-        public LatheRecipePrototype? CurrentRecipe;
+        public ProtoId<LatheRecipePrototype>? CurrentRecipe;
 
         #region MachineUpgrading
         /// <summary>

--- a/Content.Shared/Lathe/LatheComponent.cs
+++ b/Content.Shared/Lathe/LatheComponent.cs
@@ -29,7 +29,7 @@ namespace Content.Shared.Lathe
         /// The lathe's construction queue
         /// </summary>
         [DataField]
-        public Queue<LatheRecipePrototype> Queue = new();
+        public Queue<ProtoId<LatheRecipePrototype>> Queue = new();
 
         /// <summary>
         /// The sound that plays when the lathe is producing an item, if any

--- a/Content.Shared/Lathe/LatheComponent.cs
+++ b/Content.Shared/Lathe/LatheComponent.cs
@@ -29,7 +29,7 @@ namespace Content.Shared.Lathe
         /// The lathe's construction queue
         /// </summary>
         [DataField]
-        public List<LatheRecipePrototype> Queue = new();
+        public Queue<LatheRecipePrototype> Queue = new();
 
         /// <summary>
         /// The sound that plays when the lathe is producing an item, if any

--- a/Content.Shared/Lathe/LatheMessages.cs
+++ b/Content.Shared/Lathe/LatheMessages.cs
@@ -10,11 +10,11 @@ public sealed class LatheUpdateState : BoundUserInterfaceState
 {
     public List<ProtoId<LatheRecipePrototype>> Recipes;
 
-    public NetListAsArray<ProtoId<LatheRecipePrototype>> Queue;
+    public ProtoId<LatheRecipePrototype>[] Queue;
 
     public ProtoId<LatheRecipePrototype>? CurrentlyProducing;
 
-    public LatheUpdateState(List<ProtoId<LatheRecipePrototype>> recipes, NetListAsArray<ProtoId<LatheRecipePrototype>> queue, ProtoId<LatheRecipePrototype>? currentlyProducing = null)
+    public LatheUpdateState(List<ProtoId<LatheRecipePrototype>> recipes, ProtoId<LatheRecipePrototype>[] queue, ProtoId<LatheRecipePrototype>? currentlyProducing = null)
     {
         Recipes = recipes;
         Queue = queue;

--- a/Content.Shared/Lathe/LatheMessages.cs
+++ b/Content.Shared/Lathe/LatheMessages.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Research.Prototypes;
+using NetSerializer;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
@@ -9,11 +10,11 @@ public sealed class LatheUpdateState : BoundUserInterfaceState
 {
     public List<ProtoId<LatheRecipePrototype>> Recipes;
 
-    public Queue<ProtoId<LatheRecipePrototype>> Queue;
+    public NetListAsArray<ProtoId<LatheRecipePrototype>> Queue;
 
     public LatheRecipePrototype? CurrentlyProducing;
 
-    public LatheUpdateState(List<ProtoId<LatheRecipePrototype>> recipes, Queue<ProtoId<LatheRecipePrototype>> queue, LatheRecipePrototype? currentlyProducing = null)
+    public LatheUpdateState(List<ProtoId<LatheRecipePrototype>> recipes, NetListAsArray<ProtoId<LatheRecipePrototype>> queue, LatheRecipePrototype? currentlyProducing = null)
     {
         Recipes = recipes;
         Queue = queue;

--- a/Content.Shared/Lathe/LatheMessages.cs
+++ b/Content.Shared/Lathe/LatheMessages.cs
@@ -9,11 +9,11 @@ public sealed class LatheUpdateState : BoundUserInterfaceState
 {
     public List<ProtoId<LatheRecipePrototype>> Recipes;
 
-    public Queue<LatheRecipePrototype> Queue;
+    public Queue<ProtoId<LatheRecipePrototype>> Queue;
 
     public LatheRecipePrototype? CurrentlyProducing;
 
-    public LatheUpdateState(List<ProtoId<LatheRecipePrototype>> recipes, Queue<LatheRecipePrototype> queue, LatheRecipePrototype? currentlyProducing = null)
+    public LatheUpdateState(List<ProtoId<LatheRecipePrototype>> recipes, Queue<ProtoId<LatheRecipePrototype>> queue, LatheRecipePrototype? currentlyProducing = null)
     {
         Recipes = recipes;
         Queue = queue;

--- a/Content.Shared/Lathe/LatheMessages.cs
+++ b/Content.Shared/Lathe/LatheMessages.cs
@@ -12,9 +12,9 @@ public sealed class LatheUpdateState : BoundUserInterfaceState
 
     public NetListAsArray<ProtoId<LatheRecipePrototype>> Queue;
 
-    public LatheRecipePrototype? CurrentlyProducing;
+    public ProtoId<LatheRecipePrototype>? CurrentlyProducing;
 
-    public LatheUpdateState(List<ProtoId<LatheRecipePrototype>> recipes, NetListAsArray<ProtoId<LatheRecipePrototype>> queue, LatheRecipePrototype? currentlyProducing = null)
+    public LatheUpdateState(List<ProtoId<LatheRecipePrototype>> recipes, NetListAsArray<ProtoId<LatheRecipePrototype>> queue, ProtoId<LatheRecipePrototype>? currentlyProducing = null)
     {
         Recipes = recipes;
         Queue = queue;

--- a/Content.Shared/Lathe/LatheMessages.cs
+++ b/Content.Shared/Lathe/LatheMessages.cs
@@ -9,11 +9,11 @@ public sealed class LatheUpdateState : BoundUserInterfaceState
 {
     public List<ProtoId<LatheRecipePrototype>> Recipes;
 
-    public List<LatheRecipePrototype> Queue;
+    public Queue<LatheRecipePrototype> Queue;
 
     public LatheRecipePrototype? CurrentlyProducing;
 
-    public LatheUpdateState(List<ProtoId<LatheRecipePrototype>> recipes, List<LatheRecipePrototype> queue, LatheRecipePrototype? currentlyProducing = null)
+    public LatheUpdateState(List<ProtoId<LatheRecipePrototype>> recipes, Queue<LatheRecipePrototype> queue, LatheRecipePrototype? currentlyProducing = null)
     {
         Recipes = recipes;
         Queue = queue;

--- a/Content.Shared/Research/Prototypes/LatheRecipePrototype.cs
+++ b/Content.Shared/Research/Prototypes/LatheRecipePrototype.cs
@@ -3,13 +3,12 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Lathe.Prototypes;
 using Content.Shared.Materials;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Research.Prototypes
 {
-    [NetSerializable, Serializable, Prototype]
+    [Prototype]
     public sealed partial class LatheRecipePrototype : IPrototype, IInheritingPrototype
     {
         [ViewVariables]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes lathe queue logic more efficient, especially with large queues.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves https://github.com/space-wizards/space-station-14/issues/38567.

## Technical details
<!-- Summary of code changes for easier review. -->
Two main changes:
- The queue now stores `ProtoId<LatheRecipePrototype>`s instead of `LatheRecipePrototype`s. This significantly reduces the size of the BUI state, reducing network use.
- The queue is now actually a Queue. It was a List before this change, despite being used as a queue. Notably, this meant that removing the first element from the front of the queue with `RemoveAt(0)` was quite inefficient when the queue was long: O(n), as each element needed to be shifted forward. Now that the queue is a proper Queue, this is a simple `Dequeue`, which is O(1).
 
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`LatheComponent.Queue` is now a `Queue<ProtoId<LatheRecipePrototype>>` instead of a `List<LatheRecipePrototype>`.