### PR TITLE
Fix pinpointer screen rotation solution 1

### DIFF
--- a/Content.Client/Pinpointer/PinpointerSystem.cs
+++ b/Content.Client/Pinpointer/PinpointerSystem.cs
@@ -10,6 +10,20 @@ public sealed class PinpointerSystem : SharedPinpointerSystem
     [Dependency] private readonly IEyeManager _eyeManager = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
 
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<PinpointerComponent, AppearanceChangeEvent>(OnAppearanceChange);
+    }
+
+    private void OnAppearanceChange(Entity<PinpointerComponent> ent, ref AppearanceChangeEvent args)
+    {
+        if (args.Sprite is null)
+            return;
+
+        UpdateArrow((ent, ent.Comp, args.Sprite), force: true);
+    }
+
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -22,32 +36,38 @@ public sealed class PinpointerSystem : SharedPinpointerSystem
         var query = EntityQueryEnumerator<PinpointerComponent, SpriteComponent>();
         while (query.MoveNext(out var uid, out var pinpointer, out var sprite))
         {
-            if (!pinpointer.HasTarget)
-                continue;
-            var eye = _eyeManager.CurrentEye;
-            var angle = pinpointer.ArrowAngle + eye.Rotation;
-
-            if (!_sprite.TryGetLayer((uid, sprite), PinpointerLayers.Screen, out var layer, true))
-                return;
-
-            const float halfPixel = 0.5f / EyeManager.PixelsPerMeter;
-
-            switch (pinpointer.DistanceToTarget)
-            {
-                case Distance.Close:
-                case Distance.Medium:
-                case Distance.Far:
-                    // The point that the screen should be rotated is in the middle of a pixel
-                    // We need to translate half a pixel, rotate, then translate back.
-                    var translation = new Vector2(halfPixel, -halfPixel);
-                    layer.LocalMatrix = Matrix3x2.CreateTranslation(translation) *
-                                        Matrix3x2.CreateRotation((float)angle.Theta) *
-                                        Matrix3x2.CreateTranslation(-translation);
-                    break;
-                default:
-                    _sprite.LayerSetRotation((uid, sprite), PinpointerLayers.Screen, Angle.Zero);
-                    break;
-            }
+            UpdateArrow((uid, pinpointer, sprite));
         }
+    }
+
+    private void UpdateArrow(Entity<PinpointerComponent, SpriteComponent> ent, bool force = false)
+    {
+        if (!ent.Comp1.HasTarget)
+            return;
+        var eye = _eyeManager.CurrentEye;
+        var angle = ent.Comp1.ArrowAngle + eye.Rotation;
+
+        if (angle == ent.Comp1.CurrentRenderedAngle && !force)
+            return;
+
+        if (!_sprite.TryGetLayer((ent, ent.Comp2), PinpointerLayers.Screen, out var layer, true))
+            return;
+
+        const float halfPixel = 0.5f / EyeManager.PixelsPerMeter;
+
+        Angle? newAngle = ent.Comp1.DistanceToTarget switch
+        {
+            Distance.Close or Distance.Medium or Distance.Far => angle,
+            _ => null,
+        };
+
+        // The point that the screen should be rotated is in the middle of a pixel
+        // We need to translate half a pixel, rotate, then translate back.
+        var translation = new Vector2(halfPixel, -halfPixel);
+        layer.LocalMatrix = Matrix3x2.CreateTranslation(translation) *
+                            Matrix3x2.CreateRotation((float)(newAngle?.Theta ?? 0.0f)) *
+                            Matrix3x2.CreateTranslation(-translation);
+
+        ent.Comp1.CurrentRenderedAngle = newAngle;
     }
 }

--- a/Content.Shared/Pinpointer/PinpointerComponent.cs
+++ b/Content.Shared/Pinpointer/PinpointerComponent.cs
@@ -62,6 +62,9 @@ public sealed partial class PinpointerComponent : Component
 
     [ViewVariables]
     public bool HasTarget => DistanceToTarget != Distance.Unknown;
+
+    [ViewVariables]
+    public Angle? CurrentRenderedAngle;
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
## About the PR

The rotation of the screen layer of the pinpointer is off by half a pixel. This fixes that.

Note: this PR is mutually exclusive with #38657, leaving it up to maints to choose the solution.

## Why / Balance

bug fix

## Technical details

Just need to use a transformation matrix to rotate the layer about a different point.

## Media

The screen layer needs to be rotated around the red dot, it's actually rotated around the intersection of the lines.

![image](https://github.com/user-attachments/assets/aec83af7-fd55-4b08-9ec1-f7ab09e27c9a)

### Before

![image](https://github.com/user-attachments/assets/22c2c3a6-0070-4c01-8133-8f6c7ea92c57) ![image](https://github.com/user-attachments/assets/dd4bae42-2437-4b53-a89c-0184bbd97c1a) ![image](https://github.com/user-attachments/assets/affaba67-536f-4f5a-a58c-bf5a65c6bf14) ![image](https://github.com/user-attachments/assets/f0deb36e-361b-4315-ae4c-0d8257399195)

### After

![image](https://github.com/user-attachments/assets/fda5f3f9-d3cc-4a24-8b69-a88f3ffb6f16) ![image](https://github.com/user-attachments/assets/a74e20c4-9f16-4e59-9d53-70415bc74990) ![image](https://github.com/user-attachments/assets/deec9f65-db2a-49ff-bfd4-c35da2a7b06e) ![image](https://github.com/user-attachments/assets/7c13c74e-bd00-4b6f-960f-401fa2ca6669)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

none

**Changelog**
:cl:
- fix: pinpointer will no longer trigger sufferers of OCD
