### PR TITLE
Adjust uplink buy button to be under item icon

### DIFF
--- a/Content.Client/Store/Ui/StoreListingControl.xaml
+++ b/Content.Client/Store/Ui/StoreListingControl.xaml
@@ -1,24 +1,29 @@
 <Control xmlns="https://spacestation14.io">
-    <BoxContainer Margin="8,8,8,8" Orientation="Vertical">
+    <BoxContainer Margin="8,0,8,8" Orientation="Vertical">
         <BoxContainer Orientation="Horizontal">
             <Label Name="StoreItemName" HorizontalExpand="True" />
             <Label Name="DiscountSubText"
                    HorizontalAlignment="Right"/>
-            <Button
-                Name="StoreItemBuyButton"
-                MinWidth="64"
-                HorizontalAlignment="Right"
-                Access="Public" />
         </BoxContainer>
-        <PanelContainer StyleClasses="HighDivider" />
+        <PanelContainer StyleClasses="HighDivider" Margin="0,1,0,2"/>
         <BoxContainer HorizontalExpand="True" Orientation="Horizontal">
+            <BoxContainer Orientation="Vertical" VerticalAlignment="Center">
             <TextureRect
                 Name="StoreItemTexture"
                 Margin="0,0,4,0"
                 MinSize="48 48"
                 Stretch="KeepAspectCentered" />
-            <Control MinWidth="5"/>
-            <RichTextLabel Name="StoreItemDescription" />
+            <Button
+                Name="StoreItemBuyButton"
+                MinWidth="48"
+                MaxHeight="48"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Top"
+                Margin="0,4,0,0"
+                Access="Public" />
+            </BoxContainer>
+            <Control MinWidth="4"/>
+            <RichTextLabel Name="StoreItemDescription" VerticalAlignment="Top"/>
         </BoxContainer>
     </BoxContainer>
 </Control>

--- a/Content.Client/Store/Ui/StoreListingControl.xaml
+++ b/Content.Client/Store/Ui/StoreListingControl.xaml
@@ -2,8 +2,6 @@
     <BoxContainer Margin="8,0,8,8" Orientation="Vertical">
         <BoxContainer Orientation="Horizontal">
             <Label Name="StoreItemName" HorizontalExpand="True" />
-            <Label Name="DiscountSubText"
-                   HorizontalAlignment="Right"/>
         </BoxContainer>
         <PanelContainer StyleClasses="HighDivider" Margin="0,1,0,2"/>
         <BoxContainer HorizontalExpand="True" Orientation="Horizontal">
@@ -21,6 +19,8 @@
                 VerticalAlignment="Top"
                 Margin="0,4,0,0"
                 Access="Public" />
+            <Label Name="DiscountSubText"
+                   HorizontalAlignment="Center"/>
             </BoxContainer>
             <Control MinWidth="4"/>
             <RichTextLabel Name="StoreItemDescription" VerticalAlignment="Top"/>

--- a/Content.Client/Store/Ui/StoreListingControl.xaml
+++ b/Content.Client/Store/Ui/StoreListingControl.xaml
@@ -5,24 +5,23 @@
         </BoxContainer>
         <PanelContainer StyleClasses="HighDivider" Margin="0,1,0,2"/>
         <BoxContainer HorizontalExpand="True" Orientation="Horizontal">
-            <BoxContainer Orientation="Vertical" VerticalAlignment="Center">
-            <TextureRect
-                Name="StoreItemTexture"
-                Margin="0,0,4,0"
-                MinSize="48 48"
-                Stretch="KeepAspectCentered" />
-            <Button
-                Name="StoreItemBuyButton"
-                MinWidth="48"
-                MaxHeight="48"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Top"
-                Margin="0,4,0,0"
-                Access="Public" />
-            <Label Name="DiscountSubText"
-                   HorizontalAlignment="Center"/>
+            <BoxContainer Orientation="Vertical" VerticalAlignment="Center" Margin="0,0,4,0">
+                <TextureRect
+                    Name="StoreItemTexture"
+                    Margin="0,0,4,0"
+                    MinSize="48 48"
+                    Stretch="KeepAspectCentered" />
+                <Button
+                    Name="StoreItemBuyButton"
+                    MinWidth="48"
+                    MaxHeight="48"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Top"
+                    Margin="0,4,0,0"
+                    Access="Public" />
+                <Label Name="DiscountSubText"
+                       HorizontalAlignment="Center"/>
             </BoxContainer>
-            <Control MinWidth="4"/>
             <RichTextLabel Name="StoreItemDescription" VerticalAlignment="Top"/>
         </BoxContainer>
     </BoxContainer>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Moved the item purchase button appear below the item icon in uplinks.

## Why / Balance
The number of times I've bought the wrong item because I thought the button was for a different item is embarrassing so I'm fixing it so I may never suffer from embarrassment again.

## Technical details
Moved the buy button under the texturerect and placed them both into a vertical container

## Media
![image](https://github.com/user-attachments/assets/d0269826-ee23-4025-a9a7-bc59a65a1af0)
![image](https://github.com/user-attachments/assets/68a3d264-8c53-4546-bc51-7f5e28185c34)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Moved Syndicate Uplink TC purchase button beneath the respective item's icon.