### PR TITLE
Bladed flatcaps are minor contraband

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -146,7 +146,7 @@
     storedSprite: null
 
 - type: entity
-  parent: ClothingHeadHatGreyFlatcap
+  parent: [ClothingHeadHatGreyFlatcap, BaseMinorContraband]
   id: BladedFlatcapGrey
   name: grey flatcap
   description: Fashionable for both the working class and old man Jenkins. It has glass shards hidden in the brim.


### PR DESCRIPTION
## About the PR
Bladed flatcaps (flatcaps which were given a glass shard via the crafting menu) are now minor contraband, like shivs.

## Why / Balance
Bladed flatcaps could be hidden weapons, particularly with their thrown damage. I don't see why they shouldn't be contraband if shivs are. I don't imagine security would enjoy someone walking around with their hat ready to use to attack someone at a moment's notice, using this unexpected tool.

## Technical details
Addition of `BaseMinorContraband` to the parenting of `BladedFlatcapGrey`, which is also used for the brown bladed flatcap.

## Media

![image](https://github.com/user-attachments/assets/3b0964e2-c690-4ad2-bb89-ebe76f069b4b)

![image](https://github.com/user-attachments/assets/ea0bea5e-3631-4d2d-a421-59eb8e5d8ad4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl:
- tweak: Bladed flatcaps are now minor contraband.
