### PR TITLE
fix smart equip

### DIFF
--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -80,7 +80,7 @@ public sealed class SmartEquipSystem : EntitySystem
         }
 
         // early out if we have an item and cant drop it at all
-        if (hands.ActiveHandId != null && !_hands.CanDropHeld(uid, hands.ActiveHandId))
+        if (handItem != null && !_hands.CanDropHeld(uid, hands.ActiveHandId))
         {
             _popup.PopupClient(Loc.GetString("smart-equip-cant-drop"), uid, uid);
             return;


### PR DESCRIPTION
## About the PR
Broken in https://github.com/space-wizards/space-station-14/pull/38438

## Why / Balance
bugfix

## Technical details
Here the code change the refactor made
![grafik](https://github.com/user-attachments/assets/454f8cdc-6aef-41c8-bf1c-3a71278ff1f5)

We revert the last line because we already checked for an active hand above and want to check if we are holding an item.

## Media
![ss14](https://github.com/user-attachments/assets/07f6f742-0cc9-43b1-9b70-223fbf193123)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed smart equip not retrieving items.
