### PR TITLE
Make vending machine restocks predicted (and its sound not spammable)

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -7,17 +7,12 @@ using Content.Server.Power.EntitySystems;
 using Content.Shared.Cargo;
 using Content.Shared.Damage;
 using Content.Shared.Destructible;
-using Content.Shared.DoAfter;
 using Content.Shared.Emp;
-using Content.Shared.IdentityManagement;
-using Content.Shared.Popups;
 using Content.Shared.Power;
 using Content.Shared.Throwing;
 using Content.Shared.UserInterface;
 using Content.Shared.VendingMachines;
 using Content.Shared.Wall;
-using Robust.Shared.Audio;
-using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -42,12 +37,8 @@ namespace Content.Server.VendingMachines
             SubscribeLocalEvent<VendingMachineComponent, DamageChangedEvent>(OnDamageChanged);
             SubscribeLocalEvent<VendingMachineComponent, PriceCalculationEvent>(OnVendingPrice);
             SubscribeLocalEvent<VendingMachineComponent, EmpPulseEvent>(OnEmpPulse);
-
             SubscribeLocalEvent<VendingMachineComponent, ActivatableUIOpenAttemptEvent>(OnActivatableUIOpenAttempt);
-
             SubscribeLocalEvent<VendingMachineComponent, VendingMachineSelfDispenseEvent>(OnSelfDispense);
-
-            SubscribeLocalEvent<VendingMachineComponent, RestockDoAfterEvent>(OnDoAfter);
 
             SubscribeLocalEvent<VendingMachineRestockComponent, PriceCalculationEvent>(OnPriceCalculation);
         }
@@ -129,30 +120,6 @@ namespace Content.Server.VendingMachines
 
             args.Handled = true;
             EjectRandom(uid, throwItem: true, forceEject: false, component);
-        }
-
-        private void OnDoAfter(EntityUid uid, VendingMachineComponent component, DoAfterEvent args)
-        {
-            if (args.Handled || args.Cancelled || args.Args.Used == null)
-                return;
-
-            if (!TryComp<VendingMachineRestockComponent>(args.Args.Used, out var restockComponent))
-            {
-                Log.Error($"{ToPrettyString(args.Args.User)} tried to restock {ToPrettyString(uid)} with {ToPrettyString(args.Args.Used.Value)} which did not have a VendingMachineRestockComponent.");
-                return;
-            }
-
-            TryRestockInventory(uid, component);
-
-            Popup.PopupEntity(Loc.GetString("vending-machine-restock-done-self", ("target", uid)), args.Args.User, args.Args.User, PopupType.Medium);
-            var othersFilter = Filter.PvsExcept(args.Args.User);
-            Popup.PopupEntity(Loc.GetString("vending-machine-restock-done-others", ("user", Identity.Entity(args.User, EntityManager)), ("target", uid)), args.Args.User, othersFilter, true, PopupType.Medium);
-
-            Audio.PlayPvs(restockComponent.SoundRestockDone, uid, AudioParams.Default.WithVolume(-2f).WithVariation(0.2f));
-
-            Del(args.Args.Used.Value);
-
-            args.Handled = true;
         }
 
         /// <summary>
@@ -263,17 +230,6 @@ namespace Content.Server.VendingMachines
                     comp.NextEmpEject += (5 * comp.EjectDelay);
                 }
             }
-        }
-
-        public void TryRestockInventory(EntityUid uid, VendingMachineComponent? vendComponent = null)
-        {
-            if (!Resolve(uid, ref vendComponent))
-                return;
-
-            RestockInventoryFromPrototype(uid, vendComponent);
-
-            Dirty(uid, vendComponent);
-            TryUpdateVisualState((uid, vendComponent));
         }
 
         private void OnPriceCalculation(EntityUid uid, VendingMachineRestockComponent component, ref PriceCalculationEvent args)

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
@@ -3,7 +3,6 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Wires;
-using Robust.Shared.Audio;
 
 namespace Content.Shared.VendingMachines;
 
@@ -46,6 +45,17 @@ public abstract partial class SharedVendingMachineSystem
         return true;
     }
 
+    public void TryRestockInventory(EntityUid uid, VendingMachineComponent? vendComponent = null)
+    {
+        if (!Resolve(uid, ref vendComponent))
+            return;
+
+        RestockInventoryFromPrototype(uid, vendComponent);
+
+        Dirty(uid, vendComponent);
+        TryUpdateVisualState((uid, vendComponent));
+    }
+
     private void OnAfterInteract(EntityUid uid, VendingMachineRestockComponent component, AfterInteractEvent args)
     {
         if (args.Target is not { } target || !args.CanReach || args.Handled)
@@ -62,8 +72,13 @@ public abstract partial class SharedVendingMachineSystem
 
         args.Handled = true;
 
-        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, (float)component.RestockDelay.TotalSeconds, new RestockDoAfterEvent(), target,
-            target: target, used: uid)
+        var doAfterArgs = new DoAfterArgs(EntityManager,
+            args.User,
+            component.RestockDelay,
+            new RestockDoAfterEvent(),
+            target,
+            target: target,
+            used: uid)
         {
             BreakOnMove = true,
             BreakOnDamage = true,
@@ -74,13 +89,47 @@ public abstract partial class SharedVendingMachineSystem
             return;
 
         var selfMessage = Loc.GetString("vending-machine-restock-start-self", ("target", target));
-        var othersMessage = Loc.GetString("vending-machine-restock-start-others", ("user", Identity.Entity(args.User, EntityManager)), ("target", target));
-        Popup.PopupPredicted(selfMessage,
-            othersMessage,
-            uid,
-            args.User,
-            PopupType.Medium);
+        var othersMessage = Loc.GetString("vending-machine-restock-start-others",
+            ("user", Identity.Entity(args.User, EntityManager)),
+            ("target", target));
+        Popup.PopupPredicted(selfMessage, othersMessage, target, args.User, PopupType.Medium);
 
-        Audio.PlayPredicted(component.SoundRestockStart, uid, args.User);
+
+        if (!Timing.IsFirstTimePredicted)
+            return;
+
+        Audio.Stop(machineComponent.RestockStream);
+        machineComponent.RestockStream = Audio.PlayPredicted(component.SoundRestockStart, target, args.User)?.Entity;
+    }
+
+    private void OnRestockDoAfter(Entity<VendingMachineComponent> ent, ref RestockDoAfterEvent args)
+    {
+        if (args.Cancelled)
+        {
+            if (Timing.IsFirstTimePredicted)
+                ent.Comp.RestockStream = Audio.Stop(ent.Comp.RestockStream);
+            return;
+        }
+
+        if (args.Handled || args.Used == null)
+            return;
+
+        if (!TryComp<VendingMachineRestockComponent>(args.Used, out var restockComponent))
+        {
+            Log.Error($"{ToPrettyString(args.User)} tried to restock {ToPrettyString(ent)} with {ToPrettyString(args.Used.Value)} which did not have a VendingMachineRestockComponent.");
+            return;
+        }
+
+        TryRestockInventory(ent, ent.Comp);
+
+        var userMessage = Loc.GetString("vending-machine-restock-done-self", ("target", ent));
+        var othersMessage = Loc.GetString("vending-machine-restock-done-others",
+            ("user", Identity.Entity(args.User, EntityManager)),
+            ("target", ent));
+        Popup.PopupPredicted(userMessage, othersMessage, ent, args.User, PopupType.Medium);
+
+        Audio.PlayPredicted(restockComponent.SoundRestockDone, ent, args.User);
+
+        PredictedQueueDel(args.Used.Value);
     }
 }

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
@@ -41,6 +41,7 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
         SubscribeLocalEvent<VendingMachineComponent, ComponentGetState>(OnVendingGetState);
         SubscribeLocalEvent<VendingMachineComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<VendingMachineComponent, GotEmaggedEvent>(OnEmagged);
+        SubscribeLocalEvent<VendingMachineComponent, RestockDoAfterEvent>(OnRestockDoAfter);
 
         SubscribeLocalEvent<VendingMachineRestockComponent, AfterInteractEvent>(OnAfterInteract);
 

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -139,6 +139,11 @@ namespace Content.Shared.VendingMachines
         [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
         public TimeSpan NextEmpEject = TimeSpan.Zero;
 
+        /// <summary>
+        /// Audio entity used during restock in case the doafter gets canceled.
+        /// </summary>
+        public EntityUid? RestockStream;
+
         #region Client Visuals
         /// <summary>
         /// RSI state for when the vending machine is unpowered.

--- a/Content.Shared/VendingMachines/VendingMachineRestockComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineRestockComponent.cs
@@ -43,7 +43,8 @@ public sealed partial class VendingMachineRestockComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("soundRestockDone")]
-    public SoundSpecifier SoundRestockDone = new SoundPathSpecifier("/Audio/Machines/vending_restock_done.ogg");
+    public SoundSpecifier SoundRestockDone = new SoundPathSpecifier("/Audio/Machines/vending_restock_done.ogg",
+        AudioParams.Default.WithVolume(-2f).WithVariation(0.2f));
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/VendingMachines/VendingMachineRestockComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineRestockComponent.cs
@@ -12,23 +12,20 @@ public sealed partial class VendingMachineRestockComponent : Component
     /// <summary>
     /// The time (in seconds) that it takes to restock a machine.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("restockDelay")]
+    [DataField]
     public TimeSpan RestockDelay = TimeSpan.FromSeconds(5.0f);
 
     /// <summary>
     /// What sort of machine inventory does this restock?
     /// This is checked against the VendingMachineComponent's pack value.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("canRestock", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<VendingMachineInventoryPrototype>))]
-    public HashSet<string> CanRestock = new();
+    [DataField(customTypeSerializer: typeof(PrototypeIdHashSetSerializer<VendingMachineInventoryPrototype>))]
+    public HashSet<string> CanRestock = [];
 
     /// <summary>
     ///     Sound that plays when starting to restock a machine.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("soundRestockStart")]
+    [DataField]
     public SoundSpecifier SoundRestockStart = new SoundPathSpecifier("/Audio/Machines/vending_restock_start.ogg")
     {
         Params = new AudioParams
@@ -41,13 +38,10 @@ public sealed partial class VendingMachineRestockComponent : Component
     /// <summary>
     ///     Sound that plays when finished restocking a machine.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("soundRestockDone")]
+    [DataField]
     public SoundSpecifier SoundRestockDone = new SoundPathSpecifier("/Audio/Machines/vending_restock_done.ogg",
         AudioParams.Default.WithVolume(-2f).WithVariation(0.2f));
 }
 
 [Serializable, NetSerializable]
-public sealed partial class RestockDoAfterEvent : SimpleDoAfterEvent
-{
-}
+public sealed partial class RestockDoAfterEvent : SimpleDoAfterEvent;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Make restocking stuff predicted and also stop the restock sound if the restock doafter is canceled since it's mega spammable.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
Was basically already all predicted. 
- Switched two separate popup calls to the combined method.
- Added a stream for tracking the played audio for stopping it.
  Had to throw in some IsFirstTimePredicteds in there to deal with making sure the sound gets stopped properly on the initiator's client if they spamclick the restock.
- Standard field cleanup to the restock component.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
nah
