### PR TITLE
Discord webhook automatic retry on rate limit

### DIFF
--- a/Content.Server/Discord/DiscordWebhook.cs
+++ b/Content.Server/Discord/DiscordWebhook.cs
@@ -1,13 +1,9 @@
-using Linguini.Syntax.Ast;
-using Microsoft.EntityFrameworkCore.Storage;
-using System;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using static Content.Shared.Administration.Notes.AdminMessageEuiState;
 
 namespace Content.Server.Discord;
 


### PR DESCRIPTION

## About the PR
Implemented a automatic retry for Discord web hook calls upon getting rate limited by the API. 

## Why / Balance
requested in issue #38287  

## Technical details
Implemented RetryAfterTimeout function in Content.Server.Discord.DiscordWebhook. This function checks the response to see if it was rate limited. If it was it recursively retires the call for an amount determined by the _retryDepth variable after waiting for the amount of time specified by the discord API. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

