### PR TITLE
AddBodyPartCommand localization.

### DIFF
--- a/Content.Server/Administration/Commands/AddBodyPartCommand.cs
+++ b/Content.Server/Administration/Commands/AddBodyPartCommand.cs
@@ -3,52 +3,41 @@ using Content.Shared.Administration;
 using Content.Shared.Body.Part;
 using Robust.Shared.Console;
 
-namespace Content.Server.Administration.Commands
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class AddBodyPartCommand : LocalizedEntityCommands
 {
-    [AdminCommand(AdminFlags.Admin)]
-    public sealed class AddBodyPartCommand : IConsoleCommand
+    [Dependency] private readonly BodySystem _bodySystem = default!;
+
+    public override string Command => "addbodypart";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IEntityManager _entManager = default!;
-
-        public string Command => "addbodypart";
-        public string Description => "Adds a given entity to a containing body.";
-        public string Help => "Usage: addbodypart <entity uid> <body uid> <part slot> <part type>";
-
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (args.Length != 4)
         {
-            if (args.Length != 3)
-            {
-                shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
-                return;
-            }
-
-            if (!NetEntity.TryParse(args[0], out var childNetId))
-            {
-                shell.WriteError(Loc.GetString("shell-entity-uid-must-be-number"));
-                return;
-            }
-
-            if (!NetEntity.TryParse(args[1], out var parentNetId))
-            {
-                shell.WriteError(Loc.GetString("shell-entity-uid-must-be-number"));
-                return;
-            }
-
-            var childId = _entManager.GetEntity(childNetId);
-            var parentId = _entManager.GetEntity(parentNetId);
-            var bodySystem = _entManager.System<BodySystem>();
-
-
-
-            if (Enum.TryParse<BodyPartType>(args[3], out var partType) &&
-                bodySystem.TryCreatePartSlotAndAttach(parentId, args[2], childId, partType))
-            {
-                shell.WriteLine($@"Added {childId} to {parentId}.");
-            }
-            else
-            {
-                shell.WriteError($@"Could not add {childId} to {parentId}.");
-            }
+            shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+            return;
         }
+
+        if (!NetEntity.TryParse(args[0], out var childNetId) || !EntityManager.TryGetEntity(childNetId, out var childId))
+        {
+            shell.WriteError(Loc.GetString("shell-invalid-entity-uid", ("uid", args[0])));
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[1], out var parentNetId) || !EntityManager.TryGetEntity(parentNetId, out var parentId))
+        {
+            shell.WriteError(Loc.GetString("shell-invalid-entity-uid", ("uid", args[1])));
+            return;
+        }
+
+        if (Enum.TryParse<BodyPartType>(args[3], out var partType) &&
+            _bodySystem.TryCreatePartSlotAndAttach(parentId.Value, args[2], childId.Value, partType))
+        {
+            shell.WriteLine($@"Added {childId} to {parentId}.");
+        }
+        else
+            shell.WriteError($@"Could not add {childId} to {parentId}.");
     }
 }

--- a/Resources/Locale/en-US/commands/add-body-part-command.ftl
+++ b/Resources/Locale/en-US/commands/add-body-part-command.ftl
@@ -1,0 +1,2 @@
+﻿cmd-addbodypart-desc = Adds a given entity to a containing body.
+cmd-addbodypart-help = Usage: addbodypart <entity uid> <body uid> <part slot> <part type>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
LEC convert addbodypartcommand. Also fixed the fact that the command was no exaggeration, literally unusable.

Adding to the list of things to look into, this command and the attachbodypartcommand are very *very* similar. This one doesn't give body part comps to TryCreatePartSlotAndAttach. 

Resolves #35582

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
ADMIN:
- fix: The addbodypart command no longer incorrectly errors out when you try to pass the required number of arguments.

