### PR TITLE
Stunnable New Status and Cleanup

### DIFF
--- a/Content.Server/Medical/VomitSystem.cs
+++ b/Content.Server/Medical/VomitSystem.cs
@@ -60,7 +60,7 @@ namespace Content.Server.Medical
             var solutionSize = (MathF.Abs(thirstAdded) + MathF.Abs(hungerAdded)) / 6;
             // Apply a bit of slowdown
             if (TryComp<StatusEffectsComponent>(uid, out var status))
-                _stun.TrySlowdown(uid, TimeSpan.FromSeconds(solutionSize), true, 0.5f, 0.5f, status);
+                _stun.TrySlowdown(uid, TimeSpan.FromSeconds(solutionSize), true, 0.5f, 0.5f);
 
             // TODO: Need decals
             var solution = new Solution();

--- a/Content.Server/Stunnable/Systems/StunOnCollideSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunOnCollideSystem.cs
@@ -25,13 +25,13 @@ namespace Content.Server.Stunnable
 
             if (EntityManager.TryGetComponent<StatusEffectsComponent>(target, out var status))
             {
-                _stunSystem.TryStun(target, TimeSpan.FromSeconds(component.StunAmount), true, status);
+                _stunSystem.TryStun(target, TimeSpan.FromSeconds(component.StunAmount), true);
 
                 _stunSystem.TryKnockdown(target, TimeSpan.FromSeconds(component.KnockdownAmount), true,
                     status);
 
                 _stunSystem.TrySlowdown(target, TimeSpan.FromSeconds(component.SlowdownAmount), true,
-                    component.WalkSpeedMultiplier, component.RunSpeedMultiplier, status);
+                    component.WalkSpeedMultiplier, component.RunSpeedMultiplier);
             }
         }
         private void HandleCollide(EntityUid uid, StunOnCollideComponent component, ref StartCollideEvent args)

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
@@ -427,6 +427,6 @@ public abstract partial class SharedStaminaSystem : EntitySystem
                 closest = thres.Key;
         }
 
-        _stunSystem.UpdateStunModifiers(ent, ent.Comp.StunModifierThresholds[closest]);
+        _stunSystem.UpdateStaminaModifiers(ent, ent.Comp.StunModifierThresholds[closest]);
     }
 }

--- a/Content.Shared/StatusEffectNew/StatusEffectNewSystem.API.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectNewSystem.API.cs
@@ -18,15 +18,19 @@ public abstract partial class SharedStatusEffectsSystem
     /// If True, the effect duration time will be reset and reapplied. If False, the effect duration time will be overlaid with the existing one.
     /// In the other case, the effect will either be added for the specified time or its time will be extended for the specified time.
     /// </param>
+    /// <param name="statusEffect">The status effect we have just created</param>
     public bool TryAddStatusEffect(
         EntityUid target,
         EntProtoId effectProto,
+        out EntityUid? statusEffect,
         TimeSpan? duration = null,
         bool resetCooldown = false
     )
     {
+        statusEffect = null;
         if (TryGetStatusEffect(target, effectProto, out var existedEffect))
         {
+            statusEffect = existedEffect;
             //We don't need to add the effect if it already exists
             if (duration is null)
                 return true;
@@ -46,6 +50,7 @@ public abstract partial class SharedStatusEffectsSystem
 
         //And only if all checks passed we spawn the effect
         var effect = PredictedSpawnAttachedTo(effectProto, Transform(target).Coordinates);
+        statusEffect = effect;
         _transform.SetParent(effect, target);
         if (!_effectQuery.TryComp(effect, out var effectComp))
             return false;
@@ -62,6 +67,19 @@ public abstract partial class SharedStatusEffectsSystem
         RaiseLocalEvent(effect, ref ev);
 
         return true;
+    }
+
+    /// <summary>
+    /// An overload of <see cref="TryAddStatusEffect(EntityUid,EntProtoId,out EntityUid?,TimeSpan?,bool)"/>
+    /// </summary>
+    public bool TryAddStatusEffect(
+        EntityUid target,
+        EntProtoId effectProto,
+        TimeSpan? duration = null,
+        bool resetCooldown = false
+    )
+    {
+        return TryAddStatusEffect(target, effectProto, out _, duration, resetCooldown);
     }
 
     /// <summary>

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -281,8 +281,7 @@ public abstract class SharedStunSystem : EntitySystem
             return false;
 
         // If it's not modifying anything then we don't need it
-        if (slowEffects.Count <= 0)
-            return false;
+        var modified = false;
 
         entity.Comp.WalkSpeedModifier = 1f;
         entity.Comp.SprintSpeedModifier = 1f;
@@ -292,13 +291,14 @@ public abstract class SharedStunSystem : EntitySystem
             if (effect == ignore)
                 continue;
 
+            modified = true;
             entity.Comp.WalkSpeedModifier *= effect.Comp1.WalkSpeedModifier;
             entity.Comp.SprintSpeedModifier *= effect.Comp1.SprintSpeedModifier;
         }
 
         _movementSpeedModifier.RefreshMovementSpeedModifiers(entity);
 
-        return true;
+        return modified;
     }
 
     /// <summary>

--- a/Content.Shared/Stunnable/SlowdownStatusEffectComponent.cs
+++ b/Content.Shared/Stunnable/SlowdownStatusEffectComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Stunnable;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(SharedStunSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class SlowdownStatusEffectComponent : Component
 {
     [ViewVariables, DataField("sprintSpeedModifier"), AutoNetworkedField]

--- a/Content.Shared/Stunnable/SlowdownStatusEffectComponent.cs
+++ b/Content.Shared/Stunnable/SlowdownStatusEffectComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Stunnable;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(SharedStunSystem))]
+public sealed partial class SlowdownStatusEffectComponent : Component
+{
+    [ViewVariables, DataField("sprintSpeedModifier"), AutoNetworkedField]
+    public float SprintSpeedModifier = 0.5f;
+
+    [ViewVariables, DataField("walkSpeedModifier"), AutoNetworkedField]
+    public float WalkSpeedModifier = 0.5f;
+}

--- a/Content.Shared/Stunnable/SlowedDownComponent.cs
+++ b/Content.Shared/Stunnable/SlowedDownComponent.cs
@@ -3,12 +3,22 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Stunnable;
 
+/// <summary>
+/// This is used to apply a movement speed modifier to an entity temporarily
+/// To be used only in conjunction with <see cref="SlowdownStatusEffectComponent"/>, on the status effect entity.
+/// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(SharedStunSystem))]
 public sealed partial class SlowedDownComponent : Component
 {
-    [ViewVariables, DataField("sprintSpeedModifier"), AutoNetworkedField]
+    /// <summary>
+    /// Multiplicative sprint modifier, with bounds of [0, 1)
+    /// </summary>
+    [DataField, AutoNetworkedField]
     public float SprintSpeedModifier = 0.5f;
 
-    [ViewVariables, DataField("walkSpeedModifier"), AutoNetworkedField]
+    /// <summary>
+    /// Multiplicative walk modifier, with bounds of [0, 1)
+    /// </summary>
+    [DataField, AutoNetworkedField]
     public float WalkSpeedModifier = 0.5f;
 }

--- a/Content.Shared/Stunnable/StunnedStatusEffectComponent.cs
+++ b/Content.Shared/Stunnable/StunnedStatusEffectComponent.cs
@@ -3,9 +3,9 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Stunnable;
 
 /// <summary>
-/// This is used to pause an entity temporarily preventing them from moving or acting.
+/// Stun as a status effect.
 /// </summary>
 [RegisterComponent, NetworkedComponent, Access(typeof(SharedStunSystem))]
-public sealed partial class StunnedComponent : Component
+public sealed partial class StunnedStatusEffectComponent : Component
 {
 }

--- a/Resources/Prototypes/Entities/StatusEffects/stunnable.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/stunnable.yml
@@ -1,0 +1,22 @@
+- type: entity
+  parent: MobStatusEffectBase
+  id: StatusEffectSlowdown
+  name: slowdown
+  components:
+  - type: SlowdownStatusEffect
+    
+- type: entity
+  parent: StatusEffectSlowdown
+  id: StatusEffectStamina
+  name: stamina
+  components:
+  - type: SlowdownStatusEffect
+
+- type: entity
+  parent: MobStatusEffectBase
+  id: StatusEffectStunned
+  name: stunned
+  components:
+  - type: StatusEffect
+    alert: Stun
+  - type: StunnedStatusEffect


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Helps with: #38575 

Project Zero warnings PR basically.

Cleaned up almost every warning in Stunnable and moved Stunnable things over to new status.

The only thing I didn't fix up was Knockdown because Knockdown and crawling is complicated and I have another monstrous PR that disconnects Knockdown from status altogether: #36881

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Warnings bad, new status good.

Knockdown is unchanged because Knockdown is special. 

## Technical details
<!-- Summary of code changes for easier review. -->
- Converted Statuses to New Status and added event listeners and a bunch of new methods to take advantage of the new system.
- Fixed a bug with Stamina Slowdown where it could delete other slowdown modifiers
- Cleaned up every other warning I saw that wasn't Knockdown related

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun