### PR TITLE
fix RCD ghosts not disappearing

### DIFF
--- a/Content.Client/RCD/RCDConstructionGhostSystem.cs
+++ b/Content.Client/RCD/RCDConstructionGhostSystem.cs
@@ -38,8 +38,7 @@ public sealed class RCDConstructionGhostSystem : EntitySystem
         if (_playerManager.LocalSession?.AttachedEntity is not { } player)
             return;
 
-        if (!_hands.TryGetActiveItem(player, out var heldEntity))
-            return;
+        var heldEntity = _hands.GetActiveItem(player);
 
         if (!TryComp<RCDComponent>(heldEntity, out var rcd))
         {


### PR DESCRIPTION
## About the PR
Reported on discord by chobble
![grafik](https://github.com/user-attachments/assets/929f56d5-ec88-438e-b1a7-a8eb8d50cabc)
Introduced in https://github.com/space-wizards/space-station-14/pull/38438

## Why / Balance
bugfix

## Technical details
It was returning early in the update loop instead of cleaning up the ghost.
Now `heldEntity` gets assigned to `null` if there is no item, so that the TryComp returns false.

the change made in the refactor for comparison
![grafik](https://github.com/user-attachments/assets/de242303-16a2-427e-85e9-aebb66ecaaa7)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**

:cl:
- fix: Fixed RCD ghosts not disappearing when dropping the RCD.
