### PR TITLE
Make Review Requested label get applied to all opened PRs

### DIFF
--- a/.github/workflows/labeler-needsreview.yml
+++ b/.github/workflows/labeler-needsreview.yml
@@ -2,7 +2,7 @@
 
 on:
   pull_request_target:
-    types: [review_requested]
+    types: [review_requested, opened]
 
 jobs:
   add_label:


### PR DESCRIPTION
It previously only applied automatically to PRs that have reviews requested, which happens if the PR touches files owned by code owners. Now it applies to *all* opened PRs.
