### PR TITLE
Fix vocalization emotes

### DIFF
--- a/Content.Shared/Speech/Components/VocalComponent.cs
+++ b/Content.Shared/Speech/Components/VocalComponent.cs
@@ -19,9 +19,9 @@ public sealed partial class VocalComponent : Component
     ///     Emote sounds prototype id for each sex (not gender).
     ///     Entities without <see cref="HumanoidComponent"/> considered to be <see cref="Sex.Unsexed"/>.
     /// </summary>
-    [DataField("sounds", customTypeSerializer: typeof(PrototypeIdValueDictionarySerializer<Sex, EmoteSoundsPrototype>))]
+    [DataField]
     [AutoNetworkedField]
-    public Dictionary<Sex, string>? Sounds;
+    public Dictionary<Sex, ProtoId<EmoteSoundsPrototype>>? Sounds;
 
     [DataField("screamId", customTypeSerializer: typeof(PrototypeIdSerializer<EmotePrototype>))]
     [AutoNetworkedField]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Vocalization emotes (screams, beeps, etc.) work again.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/38626.

## Technical details
<!-- Summary of code changes for easier review. -->
`VocalComponent.Sounds` was using plain strings to store the protoIds of the `EmoteSoundsPrototype`s. This meant that the call to `PrototypeManager.HasIndex(protoId)` was unable to infer the type of prototype and used the `EntProtoId` overload to try to retrieve an `EntityPrototype`.

Our serialization support has improved since `VocalComponent` was created, and we can use ProtoIds inside dictionaries now. This PR replaces the plain strings in `VocalComponent.Sounds` with `ProtoId<EmoteSoundsPrototype>`s, which makes `PrototypeManager.HasIndex(protoId)` look for the right type of prototype.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->