### PR TITLE
Cleanup prototype instantiation in `DamageTest`

### DIFF
--- a/Content.Tests/Shared/DamageTest.cs
+++ b/Content.Tests/Shared/DamageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
-using System.Collections.Generic;
 using Content.Shared.FixedPoint;
 
 namespace Content.Tests.Shared
@@ -16,23 +15,6 @@ namespace Content.Tests.Shared
     [TestOf(typeof(DamageGroupPrototype))]
     public sealed class DamageTest : ContentUnitTest
     {
-
-        private static Dictionary<string, float> _resistanceCoefficientDict = new()
-        {
-            // "missing" blunt entry
-            { "Piercing", -2 },// Turn Piercing into Healing
-            { "Slash", 3 },
-            { "Radiation", 1.5f },
-        };
-
-        private static Dictionary<string, float> _resistanceReductionDict = new()
-        {
-            { "Blunt", - 5 },
-            // "missing" piercing entry
-            { "Slash", 8 },
-            { "Radiation", 0.5f },  // Fractional adjustment
-        };
-
         private IPrototypeManager _prototypeManager;
 
         private DamageSpecifier _damageSpec;
@@ -139,11 +121,7 @@ namespace Content.Tests.Shared
             DamageSpecifier damageSpec = 10 * new DamageSpecifier(_damageSpec);
 
             // Create a modifier set
-            DamageModifierSetPrototype modifierSet = new()
-            {
-                Coefficients = _resistanceCoefficientDict,
-                FlatReduction = _resistanceReductionDict
-            };
+            var modifierSet = _prototypeManager.Index<DamageModifierSetPrototype>("ModifierTestSet");
 
             //damage is initially   20 / 20 / 10 / 30
             //Each time we subtract -5 /  0 /  8 /  0.5
@@ -288,6 +266,17 @@ namespace Content.Tests.Shared
     Shock: 0
   flatReductions:
     Blunt: 5
+
+- type: damageModifierSet
+  id: ModifierTestSet
+  coefficients:
+    Piercing: -2
+    Slash: 3
+    Radiation: 1.5
+  flatReductions:
+    Blunt: -5
+    Slash: 8
+    Radiation: 0.5
 
 - type: damageContainer
   id: Biological


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a warning from manually instantiating a prototype in `DamageTest`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
Removed the manual instantiation code and added the equivalent prototype definition to the YAML already loaded by the test.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->