### PR TITLE
Suppress prototype instantiation warning in `BodyPrototypeSerializer`

### DIFF
--- a/Content.Shared/Body/Prototypes/BodyPrototypeSerializer.cs
+++ b/Content.Shared/Body/Prototypes/BodyPrototypeSerializer.cs
@@ -173,6 +173,9 @@ public sealed class BodyPrototypeSerializer : ITypeReader<BodyPrototype, Mapping
             slots.Add(slotId, slot);
         }
 
+#pragma warning disable RA0039 // Do not instantiate prototypes directly
+        // TODO - Kill body code and make this not need a custom serializer
         return new BodyPrototype(id, name, root, slots);
+#pragma warning restore RA0039 // Do not instantiate prototypes directly
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Suppresses a warning from manually instantiating a prototype in some code that needs to be redone anyway.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
The entire purpose of this class is to consume a `MappingDataNode` and return a new `BodyPrototype`, which means that it has to make a new prototype instance. This code needs to be redone so it doesn't need a custom serializer to read the prototype, and body code in general needs to be rethought, so it's not really worth the effort to redo it now.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="551" alt="Screenshot 2025-06-28 at 4 18 12 PM" src="https://github.com/user-attachments/assets/57bc4cc1-95fe-452b-ae1e-8bfeaa6e25c9" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->