### PR TITLE
Allow backwards travel through disposal routers

### DIFF
--- a/Content.Client/Disposal/Tube/DisposalRouterBoundUserInterface.cs
+++ b/Content.Client/Disposal/Tube/DisposalRouterBoundUserInterface.cs
@@ -23,14 +23,19 @@ namespace Content.Client.Disposal.Tube
 
             _window = this.CreateWindow<DisposalRouterWindow>();
 
-            _window.Confirm.OnPressed += _ => ButtonPressed(UiAction.Ok, _window.TagInput.Text);
-            _window.TagInput.OnTextEntered += args => ButtonPressed(UiAction.Ok, args.Text);
+            _window.Confirm.OnPressed += _ =>
+                ButtonPressed(UiAction.Ok, _window.TagInput.Text, _window.BackwardsAllowed.Pressed);
+            _window.TagInput.OnTextEntered +=
+                args => ButtonPressed(UiAction.Ok, args.Text, _window.BackwardsAllowed.Pressed);
+            _window.BackwardsAllowed.OnPressed +=
+                args => ButtonPressed(UiAction.Ok, _window.TagInput.Text, args.Button.Pressed, false);
         }
 
-        private void ButtonPressed(UiAction action, string tag)
+        private void ButtonPressed(UiAction action, string tag, bool backwardsAllowed, bool close = true)
         {
-            SendMessage(new UiActionMessage(action, tag));
-            Close();
+            SendMessage(new UiActionMessage(action, tag, backwardsAllowed));
+            if (close)
+                Close();
         }
 
         protected override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Client/Disposal/Tube/DisposalRouterWindow.xaml
+++ b/Content.Client/Disposal/Tube/DisposalRouterWindow.xaml
@@ -2,19 +2,20 @@
             Title="{Loc 'disposal-router-window-title'}"
             MinSize="500 110"
             SetSize="500 110">
-    <BoxContainer Orientation="Vertical">
-        <Label Text="{Loc 'disposal-router-window-tags-label'}" />
-        <Control MinSize="0 10" />
-        <BoxContainer Orientation="Horizontal">
+    <BoxContainer Orientation="Vertical" SeparationOverride="5">
+        <BoxContainer Orientation="Horizontal" SeparationOverride="5">
+            <Label Text="{Loc 'disposal-router-window-tags-label'}" />
             <LineEdit Name="TagInput"
                       Access="Public"
                       HorizontalExpand="True"
                       MinSize="320 0"
                       ToolTip="{Loc 'disposal-router-window-tag-input-tooltip'}" />
-            <Control MinSize="10 0" />
             <Button Name="Confirm"
                     Access="Public"
                     Text="{Loc 'disposal-router-window-tag-input-confirm-button'}" />
         </BoxContainer>
+        <CheckBox Name="BackwardsAllowed"
+                  Text="{Loc 'disposal-junction-backwards-travel-checkbox'}"
+                  Access="Public" />
     </BoxContainer>
 </DefaultWindow>

--- a/Content.Client/Disposal/Tube/DisposalRouterWindow.xaml.cs
+++ b/Content.Client/Disposal/Tube/DisposalRouterWindow.xaml.cs
@@ -23,6 +23,7 @@ namespace Content.Client.Disposal.Tube
         public void UpdateState(DisposalRouterUserInterfaceState state)
         {
             TagInput.Text = state.Tags;
+            BackwardsAllowed.Pressed = state.BackwardsAllowed;
         }
     }
 }

--- a/Content.Server/Disposal/Tube/DisposalJunctionComponent.cs
+++ b/Content.Server/Disposal/Tube/DisposalJunctionComponent.cs
@@ -6,7 +6,19 @@ namespace Content.Server.Disposal.Tube;
 public partial class DisposalJunctionComponent : Component
 {
     /// <summary>
-    ///     The angles to connect to.
+    /// The angles to connect to.
     /// </summary>
-    [DataField("degrees")] public List<Angle> Degrees = new();
+    [DataField]
+    public List<Angle> Degrees = [];
+
+    /// <summary>
+    /// If true, items entering from the outlet will try to continue straight, falling back
+    /// to the behavior described below if that's not possible.
+    ///
+    /// There are different behaviors if false for routers versus junctions for backwards
+    /// compatability reasons. If false, routers will treat items that enter from its outlet
+    /// as if it was the inlet, while junctions will choose any random non-outlet direction.
+    /// </summary>
+    [DataField]
+    public bool BackwardsAllowed;
 }

--- a/Content.Server/Disposal/Tube/DisposalTubeSystem.cs
+++ b/Content.Server/Disposal/Tube/DisposalTubeSystem.cs
@@ -111,6 +111,8 @@ namespace Content.Server.Disposal.Tube
             //Check for correct message and ignore maleformed strings
             if (msg.Action == SharedDisposalRouterComponent.UiAction.Ok && SharedDisposalRouterComponent.TagRegex.IsMatch(msg.Tags))
             {
+                router.BackwardsAllowed = msg.BackwardsAllowed;
+
                 router.Tags.Clear();
                 foreach (var tag in msg.Tags.Split(',', StringSplitOptions.RemoveEmptyEntries))
                 {
@@ -197,7 +199,7 @@ namespace Content.Server.Disposal.Tube
             var headingTo = args.Holder.PreviousDirection;
             var comingFrom = args.Holder.PreviousDirectionFrom;
 
-            if (comingFrom == next && directions.Contains(headingTo))
+            if (component.BackwardsAllowed && comingFrom == next && directions.Contains(headingTo))
                 // We're backwards, but able to pass through without changing direction
                 args.Next = headingTo;
             else if (comingFrom == next || comingFrom == Direction.Invalid)
@@ -227,7 +229,9 @@ namespace Content.Server.Disposal.Tube
             var next = Transform(uid).LocalRotation.GetDir();
 
             // If we are going "backwards", try to keep moving straight
-            if (args.Holder.PreviousDirectionFrom == next && directions.Contains(args.Holder.PreviousDirection))
+            if (component.BackwardsAllowed
+                && args.Holder.PreviousDirectionFrom == next
+                && directions.Contains(args.Holder.PreviousDirection))
                 args.Next = args.Holder.PreviousDirection;
             else
                 args.Next = next;
@@ -306,7 +310,9 @@ namespace Content.Server.Disposal.Tube
         {
             if (router.Tags.Count <= 0)
             {
-                _uiSystem.SetUiState(uid, SharedDisposalRouterComponent.DisposalRouterUiKey.Key, new SharedDisposalRouterComponent.DisposalRouterUserInterfaceState(""));
+                _uiSystem.SetUiState(uid,
+                    SharedDisposalRouterComponent.DisposalRouterUiKey.Key,
+                    new SharedDisposalRouterComponent.DisposalRouterUserInterfaceState("", router.BackwardsAllowed));
                 return;
             }
 
@@ -320,7 +326,10 @@ namespace Content.Server.Disposal.Tube
 
             taglist.Remove(taglist.Length - 2, 2);
 
-            _uiSystem.SetUiState(uid, SharedDisposalRouterComponent.DisposalRouterUiKey.Key, new SharedDisposalRouterComponent.DisposalRouterUserInterfaceState(taglist.ToString()));
+            _uiSystem.SetUiState(uid,
+                SharedDisposalRouterComponent.DisposalRouterUiKey.Key,
+                new SharedDisposalRouterComponent.DisposalRouterUserInterfaceState(taglist.ToString(),
+                    router.BackwardsAllowed));
         }
 
         private void OnAnchorChange(EntityUid uid, DisposalTubeComponent component, ref AnchorStateChangedEvent args)

--- a/Content.Shared/Disposal/Mailing/SharedDisposalRouterComponent.cs
+++ b/Content.Shared/Disposal/Mailing/SharedDisposalRouterComponent.cs
@@ -11,10 +11,12 @@ namespace Content.Shared.Disposal.Components
         public sealed class DisposalRouterUserInterfaceState : BoundUserInterfaceState
         {
             public readonly string Tags;
+            public readonly bool BackwardsAllowed;
 
-            public DisposalRouterUserInterfaceState(string tags)
+            public DisposalRouterUserInterfaceState(string tags, bool backwardsAllowed = false)
             {
                 Tags = tags;
+                BackwardsAllowed = backwardsAllowed;
             }
         }
 
@@ -23,14 +25,16 @@ namespace Content.Shared.Disposal.Components
         {
             public readonly UiAction Action;
             public readonly string Tags = "";
+            public readonly bool BackwardsAllowed;
 
-            public UiActionMessage(UiAction action, string tags)
+            public UiActionMessage(UiAction action, string tags, bool backwardsAllowed = false)
             {
                 Action = action;
 
                 if (Action == UiAction.Ok)
                 {
                     Tags = tags.Substring(0, Math.Min(tags.Length, 150));
+                    BackwardsAllowed = backwardsAllowed;
                 }
             }
         }

--- a/Resources/Locale/en-US/disposal/tube/components/disposal-router-component.ftl
+++ b/Resources/Locale/en-US/disposal/tube/components/disposal-router-component.ftl
@@ -4,3 +4,4 @@ disposal-router-window-title = Disposal Router
 disposal-router-window-tags-label = Tags:
 disposal-router-window-tag-input-tooltip = A comma separated list of tags
 disposal-router-window-tag-input-confirm-button = Confirm
+disposal-junction-backwards-travel-checkbox = Allow backwards travel


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This adds a toggle to the UI for disposal routers that will  allow items to move "backwards" (opposite the sprite's arrow) through it, as opposed to making the item do a 180° if it doesn't match the filter. This effectively turns it into a Y-junction.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Currently it's very difficult to build large routed disposals network if they don't conform to a sort of circular shape. This makes it _much_ easier to make long router runs that don't double back on themselves.
- This is a UI toggle and not just a change to its behavior for map backwards compatibility (mapwards compatibility?). If this is needed, I would vastly prefer this just being the default behavior, and is what my first commit does.
- I'm open to changing this to be a new disposal pipe that is just a filtered Y junction.
- Disposal junctions have a similar issue, except it will roll 50/50 on which direction it throws your item if it's entering backwards. This adds the flag to junctions as well, but there's no UI to toggle it (yet, see technical details). 

## Technical details
<!-- Summary of code changes for easier review. -->
- Disposal code is currently really outdated, and for the sake of scope I'm not going to update it to newer standards in this PR. Notably, this includes the fact that the router UI is not predicted which makes using it feel just... not great.
- I plan on making a second PR that brings disposal code up to date, makes its UIs predicted, and so on without having to include any user-facing changes in it.
  - As part of this I'm hoping to merge routers and junctions, which would give junctions a UI with this toggle—assuming this stays as a toggle.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/996a4521-4e02-4c63-90cb-0bcedaa35025

If someone has a better label for the checkbox please say.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Disposal routers now have an option that allows items to travel backwards through them.