### PR TITLE
fix ItemSlotsSystem debug assert

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -395,7 +395,7 @@ namespace Content.Shared.Containers.ItemSlots
             if (!Resolve(user, ref hands, false))
                 return false;
 
-            if (!_handsSystem.TryGetActiveItem((uid, hands), out var held))
+            if (!_handsSystem.TryGetActiveItem((user, hands), out var held))
                 return false;
 
             if (!CanInsert(uid, held.Value, user, slot))


### PR DESCRIPTION
## About the PR
Another bugfix for https://github.com/space-wizards/space-station-14/pull/38438
To reproduce the assert on master spawn a `sabre sheath [Filled]`, put it on your belt and use smart equip twice.

## Why / Balance
bugfix

## Technical details
It was passing in the wrong uid, which did not belong to the `HandsComponent`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed smart equip not being able to insert items into item slots (for example for the sabre sheath).
