### PR TITLE
Fix spawnpoints being ignored if arrivals is disabled; fix cryosleep spawn preference always being ignored

### DIFF
--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -23,6 +23,7 @@ using Content.Shared.GameTicking;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Components;
 using Content.Shared.Parallax.Biomes;
+using Content.Shared.Preferences;
 using Content.Shared.Salvage;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Tiles;
@@ -93,7 +94,8 @@ public sealed class ArrivalsSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<PlayerSpawningEvent>(HandlePlayerSpawning, before: new []{ typeof(SpawnPointSystem)}, after: new [] { typeof(ContainerSpawnPointSystem)});
+        // Order is arrivals → container spawn (cryosleep) → spawn points (includes fallback)
+        SubscribeLocalEvent<PlayerSpawningEvent>(HandlePlayerSpawning, before: [typeof(SpawnPointSystem)]);
 
         SubscribeLocalEvent<StationArrivalsComponent, StationPostInitEvent>(OnStationPostInit);
 
@@ -333,16 +335,23 @@ public sealed class ArrivalsSystem : EntitySystem
 
     public void HandlePlayerSpawning(PlayerSpawningEvent ev)
     {
+        // Someone already set a spawn result
         if (ev.SpawnResult != null)
             return;
 
-        // We use arrivals as the default spawn so don't check for job prio.
+        // Arrivals is checked as long as the spawn preference isn't explicitly set to cryosleep
+        if (ev.HumanoidCharacterProfile?.SpawnPriority == SpawnPriorityPreference.Cryosleep)
+            return;
 
         // Only works on latejoin even if enabled.
         if (!Enabled || _ticker.RunLevel != GameRunLevel.InRound)
             return;
 
         if (!HasComp<StationArrivalsComponent>(ev.Station))
+            return;
+
+        // If you aren't allowed in arrivals, begone.
+        if (!_protoManager.TryIndex(ev.Job, out var jobProto) || !jobProto.CanSpawnInArrivals)
             return;
 
         TryGetArrivals(out var arrivals);

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -112,6 +112,12 @@ namespace Content.Shared.Roles
         public ProtoId<StartingGearPrototype>? StartingGear { get; private set; }
 
         /// <summary>
+        /// Used to disallow certain jobs from being able to spawn in arrivals, such as AI.
+        /// </summary>
+        [DataField]
+        public bool CanSpawnInArrivals = true;
+
+        /// <summary>
         /// Use this to spawn in as a non-humanoid (borg, test subject, etc.)
         /// Starting gear will be ignored.
         /// If you want to just add special attributes to a humanoid, use AddComponentSpecial instead.

--- a/Resources/Maps/Test/empty.yml
+++ b/Resources/Maps/Test/empty.yml
@@ -55,5 +55,6 @@ entities:
     components:
     - type: Transform
       anchored: False
+      pos: -0.5,-0.5
       parent: 3
 ...

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -12,6 +12,7 @@
   canBeAntag: false
   icon: JobIconStationAi
   supervisors: job-supervisors-rd
+  canSpawnInArrivals: false
   jobEntity: StationAiBrain
   jobPreviewEntity: PlayerStationAiPreview
   applyTraits: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This reorders spawning logic slightly and tweaks a few of its checks to properly handle arrivals being disabled.

The behavior is now like this:

<table><thead>
  <tr>
    <th rowspan="2">Priority</th>
    <th colspan="2">Arrivals enabled</th>
    <th colspan="2">Arrivals disabled</th>
  </tr>
  <tr>
    <th>Round start</th>
    <th>Late join</th>
    <th>Round start</th>
    <th>Late join</th>
  </tr></thead>
<tbody>
  <tr>
    <td>None</td>
    <td>Spawn point</td>
    <td>Arrivals</td>
    <td>Spawn point</td>
    <td>Cryosleep</td>
  </tr>
  <tr>
    <td>Arrivals</td>
    <td>Spawn point</td>
    <td>Arrivals</td>
    <td>Spawn point</td>
    <td>Cryosleep</td>
  </tr>
  <tr>
    <td>Cryosleep</td>
    <td>Spawn point</td>
    <td>Cryosleep</td>
    <td>Spawn point</td>
    <td>Cryosleep</td>
  </tr>
</tbody>
</table>

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #38418, fixes #31753.

## Technical details
<!-- Summary of code changes for easier review. -->
I've tested this as thoroughly as I can but this whole system super duper badly needs integration tests, especially if GameTicker is ever going to be refactored.

I've tried every combination listed in the table above, all with nukeops going, and didn't run into any issues.

I also introduced a CanSpawnInArrivals prototype flag which is exclusively false on AI. The previous setup had arrivals logic run after container spawner logic, with container spawners attempting to spawn anything with a set JobEntity regardless of job preference. (This is why AI always spawned correctly.) Borgs, on the other hand, could latejoin  and fail to spawn in any cryotubes, before then being handled by arrivals. I chose to keep this behavior, so this required a new flag. (This makes more sense than having the flag be implied by JobEntity being set anyway.)

Cryosleep as a spawn preference was just being totally ignored, and the logic change at the top of container spawner system fixes that.

This also slightly changes the final fallback logic of picking a random spawn point if nothing else worked—it was clearly meant to be implemented as a random pick between all spawn points it could find, but it was actually stopping after it found a single spawn point. I also added a check that the spawn point is actually part of the target station, just in caseies™.

Anyway; this area of code is absurdly fragile, please merge this cautiously!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Cryosleep as a spawn preference is now respected.