### PR TITLE
fix water coolers

### DIFF
--- a/Content.Shared/Storage/EntitySystems/BinSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/BinSystem.cs
@@ -67,12 +67,18 @@ public sealed class BinSystem : EntitySystem
 
     private void OnEntInserted(Entity<BinComponent> ent, ref EntInsertedIntoContainerMessage args)
     {
+        if (args.Container.ID != ent.Comp.ContainerId)
+            return;
+
         ent.Comp.Items.Add(args.Entity);
     }
 
-    private void OnEntRemoved(EntityUid uid, BinComponent component, EntRemovedFromContainerMessage args)
+    private void OnEntRemoved(Entity<BinComponent> ent, ref EntRemovedFromContainerMessage args)
     {
-        component.Items.Remove(args.Entity);
+        if (args.Container.ID != ent.Comp.ContainerId)
+            return;
+
+        ent.Comp.Items.Remove(args.Entity);
     }
 
     private void OnInteractHand(EntityUid uid, BinComponent component, InteractHandEvent args)


### PR DESCRIPTION
## About the PR
You could not grab any water cups from them sometimes.

## Why / Balance
bugfix

## Technical details
It was adding all entities inserted into any container into the queue of entities that can be grabbed via interaction.
However the water reagent inside is a solution entity, which gets spawned on map init by SharedSolutionContainerSystem and then inserted into a container and thus got added to the queue as well. So you were trying to pick up the water entity in the tank with your hands which was failing. To fix it we check that the entities are inserted into the correct container.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed water cups not being able to be picked up from water coolers.
