### PR TITLE
Convert `ProjectileComponent` to use `WeakEntityReference`

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/FlyBySoundSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/FlyBySoundSystem.cs
@@ -30,7 +30,7 @@ public sealed class FlyBySoundSystem : SharedFlyBySoundSystem
         if (attachedEnt == null ||
             args.OtherEntity != attachedEnt ||
             TryComp<ProjectileComponent>(uid, out var projectile) &&
-            projectile.Shooter == attachedEnt)
+            Resolve(ref projectile.Shooter) == attachedEnt)
         {
             return;
         }

--- a/Content.IntegrationTests/Tests/Weapons/Guns/GunNetworkingTest.cs
+++ b/Content.IntegrationTests/Tests/Weapons/Guns/GunNetworkingTest.cs
@@ -1,0 +1,46 @@
+using System.Numerics;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Server.Player;
+
+namespace Content.IntegrationTests.Tests.Weapons.Guns;
+
+public sealed class GunNetworkingTest
+{
+    [Test]
+    public async Task DeleteShooterTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.EntMan;
+        var gunSys = server.System<SharedGunSystem>();
+
+        var mapData = await pair.CreateTestMap();
+
+        await server.WaitPost(() =>
+        {
+            // Spawn gun and bullet
+            var gun = entMan.SpawnEntity(null, mapData.MapCoords);
+            var bullet = entMan.SpawnEntity(null, mapData.MapCoords);
+
+            // Shoot the bullet from the gun
+            gunSys.ShootProjectile(bullet, Vector2.E, Vector2.Zero, gun);
+
+            // Delete the gun
+            entMan.DeleteEntity(gun);
+        });
+
+        // Connect a fake player to the server
+        var dummySession = await server.AddDummySession();
+
+        // Force a PVS update for the fake player
+        await server.WaitAssertion(() =>
+        {
+            Assert.DoesNotThrow(() => server.PvsTick([dummySession]));
+        });
+
+        await server.WaitRunTicks(5);
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -44,7 +44,8 @@ public sealed class ProjectileSystem : SharedProjectileSystem
             return;
         }
 
-        var ev = new ProjectileHitEvent(component.Damage * _damageableSystem.UniversalProjectileDamageModifier, target, component.Shooter);
+        var shooter = Resolve(ref component.Shooter);
+        var ev = new ProjectileHitEvent(component.Damage * _damageableSystem.UniversalProjectileDamageModifier, target, shooter);
         RaiseLocalEvent(uid, ref ev);
 
         var otherName = ToPrettyString(target);
@@ -54,10 +55,10 @@ public sealed class ProjectileSystem : SharedProjectileSystem
             damageRequired -= damageableComponent.TotalDamage;
             damageRequired = FixedPoint2.Max(damageRequired, FixedPoint2.Zero);
         }
-        var modifiedDamage = _damageableSystem.TryChangeDamage(target, ev.Damage, component.IgnoreResistances, damageable: damageableComponent, origin: component.Shooter);
+        var modifiedDamage = _damageableSystem.TryChangeDamage(target, ev.Damage, component.IgnoreResistances, damageable: damageableComponent, origin: shooter);
         var deleted = Deleted(target);
 
-        if (modifiedDamage is not null && Exists(component.Shooter))
+        if (modifiedDamage is not null && Exists(shooter))
         {
             if (modifiedDamage.AnyPositive() && !deleted)
             {
@@ -66,7 +67,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
 
             _adminLogger.Add(LogType.BulletHit,
                 LogImpact.Medium,
-                $"Projectile {ToPrettyString(uid):projectile} shot by {ToPrettyString(component.Shooter!.Value):user} hit {otherName:target} and dealt {modifiedDamage.GetTotal():damage} damage");
+                $"Projectile {ToPrettyString(uid):projectile} shot by {ToPrettyString(shooter.Value):user} hit {otherName:target} and dealt {modifiedDamage.GetTotal():damage} damage");
         }
 
         // If penetration is to be considered, we need to do some checks to see if the projectile should stop.

--- a/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
+++ b/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
@@ -20,7 +20,7 @@ public sealed class RequireProjectileTargetSystem : EntitySystem
     private void PreventCollide(Entity<RequireProjectileTargetComponent> ent, ref PreventCollideEvent args)
     {
         if (args.Cancelled)
-          return;
+            return;
 
         if (!ent.Comp.Active)
             return;
@@ -30,7 +30,7 @@ public sealed class RequireProjectileTargetSystem : EntitySystem
             CompOrNull<TargetedProjectileComponent>(other)?.Target != ent)
         {
             // Prevents shooting out of while inside of crates
-            var shooter = projectile.Shooter;
+            var shooter = Resolve(ref projectile.Shooter);
             if (!shooter.HasValue)
                 return;
 
@@ -40,7 +40,7 @@ public sealed class RequireProjectileTargetSystem : EntitySystem
                 return;
 
             if (!_container.IsEntityOrParentInContainer(shooter.Value))
-               args.Cancelled = true;
+                args.Cancelled = true;
         }
     }
 

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -25,13 +25,13 @@ public sealed partial class ProjectileComponent : Component
     ///     User that shot this projectile.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public EntityUid? Shooter;
+    public WeakEntityReference? Shooter;
 
     /// <summary>
     ///     Weapon used to shoot.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public EntityUid? Weapon;
+    public WeakEntityReference? Weapon;
 
     /// <summary>
     ///     The projectile spawns inside the shooter most of the time, this prevents entities from shooting themselves.

--- a/Content.Shared/Projectiles/ProjectileEmbedEvent.cs
+++ b/Content.Shared/Projectiles/ProjectileEmbedEvent.cs
@@ -4,4 +4,4 @@ namespace Content.Shared.Projectiles;
 /// Raised directed on an entity when it embeds into something.
 /// </summary>
 [ByRefEvent]
-public readonly record struct ProjectileEmbedEvent(EntityUid? Shooter, EntityUid Weapon, EntityUid Embedded);
+public readonly record struct ProjectileEmbedEvent(EntityUid? Shooter, EntityUid? Weapon, EntityUid Embedded);

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -96,7 +96,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         // Raise a specific event for projectiles.
         if (TryComp(embeddable, out ProjectileComponent? projectile))
         {
-            var ev = new ProjectileEmbedEvent(projectile.Shooter!.Value, projectile.Weapon!.Value, args.Target);
+            var ev = new ProjectileEmbedEvent(Resolve(ref projectile.Shooter), Resolve(ref projectile.Weapon), args.Target);
             RaiseLocalEvent(embeddable, ref ev);
         }
     }
@@ -200,7 +200,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
 
     private void PreventCollision(EntityUid uid, ProjectileComponent component, ref PreventCollideEvent args)
     {
-        if (component.IgnoreShooter && (args.OtherEntity == component.Shooter || args.OtherEntity == component.Weapon))
+        if (component.IgnoreShooter && (args.OtherEntity == Resolve(ref component.Shooter) || args.OtherEntity == Resolve(ref component.Weapon)))
         {
             args.Cancelled = true;
         }
@@ -208,10 +208,10 @@ public abstract partial class SharedProjectileSystem : EntitySystem
 
     public void SetShooter(EntityUid id, ProjectileComponent component, EntityUid shooterId)
     {
-        if (component.Shooter == shooterId)
+        if (Resolve(ref component.Shooter) == shooterId)
             return;
 
-        component.Shooter = shooterId;
+        component.Shooter = new WeakEntityReference(GetNetEntity(shooterId));
         Dirty(id, component);
     }
 

--- a/Content.Shared/Weapons/Marker/SharedDamageMarkerSystem.cs
+++ b/Content.Shared/Weapons/Marker/SharedDamageMarkerSystem.cs
@@ -62,7 +62,8 @@ public abstract class SharedDamageMarkerSystem : EntitySystem
             component.Amount <= 0 ||
             _whitelistSystem.IsWhitelistFail(component.Whitelist, args.OtherEntity) ||
             !TryComp<ProjectileComponent>(uid, out var projectile) ||
-            projectile.Weapon == null)
+            projectile.Weapon == null ||
+            Resolve(ref projectile.Weapon) is not { } weapon)
         {
             return;
         }
@@ -70,7 +71,7 @@ public abstract class SharedDamageMarkerSystem : EntitySystem
         // Markers are exclusive, deal with it.
         var marker = EnsureComp<DamageMarkerComponent>(args.OtherEntity);
         marker.Damage = new DamageSpecifier(component.Damage);
-        marker.Marker = projectile.Weapon.Value;
+        marker.Marker = weapon;
         marker.EndTime = _timing.CurTime + component.Duration;
         component.Amount--;
         Dirty(args.OtherEntity, marker);

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -208,8 +208,11 @@ public abstract class SharedGrapplingGunSystem : EntitySystem
         if (!Timing.IsFirstTimePredicted)
             return;
 
+        if (args.Weapon is not { } weapon)
+            return;
+
         var jointComp = EnsureComp<JointComponent>(uid);
-        var joint = _joints.CreateDistanceJoint(uid, args.Weapon, anchorA: new Vector2(0f, 0.5f), id: GrapplingJoint);
+        var joint = _joints.CreateDistanceJoint(uid, weapon, anchorA: new Vector2(0f, 0.5f), id: GrapplingJoint);
         joint.MaxLength = joint.Length + 0.2f;
         joint.Stiffness = 1f;
         joint.MinLength = 0.35f;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -426,7 +426,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         Physics.SetLinearVelocity(uid, finalLinear, body: physics);
 
         var projectile = EnsureComp<ProjectileComponent>(uid);
-        projectile.Weapon = gunUid;
+        projectile.Weapon = new WeakEntityReference(GetNetEntity(gunUid) ?? NetEntity.Invalid);
         var shooter = user ?? gunUid;
         if (shooter != null)
             Projectiles.SetShooter(uid, projectile, shooter.Value);

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -129,8 +129,9 @@ public sealed class ReflectSystem : EntitySystem
         {
             _adminLogger.Add(LogType.BulletHit, LogImpact.Medium, $"{ToPrettyString(user)} reflected {ToPrettyString(projectile)} from {ToPrettyString(projectile.Comp.Weapon)} shot by {projectile.Comp.Shooter}");
 
-            projectile.Comp.Shooter = user;
-            projectile.Comp.Weapon = user;
+            var weakUser = new WeakEntityReference(GetNetEntity(user));
+            projectile.Comp.Shooter = weakUser;
+            projectile.Comp.Weapon = weakUser;
             Dirty(projectile, projectile.Comp);
         }
         else


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The `Shooter` and `Weapon` fields of `ProjectileComponent` (used to track the mob and gun that fired them) are now `WeakEntityReference`s instead of `EntityUid?`s.

Requires https://github.com/space-wizards/RobustToolbox/pull/5577

## Why / Balance / Technical details
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is intended as a test run and demo of `WeakEntityReference`. The intention is to find anything that might be lacking in the API and to show how it's useful for this type of situation. It's also meant to make sure that I'm using the API in the correct way!

This PR includes a [test](https://github.com/space-wizards/space-station-14/commit/4f350df8cc1d42b4b1f7775656c154fd6980af43) that demonstrates a bug currently in master - if a projectile is fired and the entity that fired it is deleted, the component state will become invalid and log errors whenever it is serialized. The test spawns entities to use as a gun and a bullet, then fires the bullet from the gun and deletes the gun. Forcing a PVS update makes the server attempt to serialize the bullet entity, which is now contains a reference to a deleted entity in its `Weapon` field. This causes an error and fails the test.

In some similar cases, this situation has been resolved by adding two-way tracking - for example, followers have a reference to the entity they are following, and followed entities keep track of everything currently following them, so that if either is deleted, they can inform the other to stop tracking. This works well enough for that case, but in this instance would require guns to manage references to every projectile they fire, which is clunky and a lot of overhead. `WeakEntityReference` makes this much easier to deal with, as it allows the projectile to store a reference to the gun while telling the serializer that it's fine if it has been deleted.

The rest of the PR converts the `Shooter` and `Weapon` fields to `WeakEntityReference`s and makes the needed changes to other systems to support this - either wrapping assignments to these fields in `WeakEntityReference`s or using `Resolve` to convert them into usable `EntityUid`s.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Remind me to fill this out when undrafting this.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Not player-facing.