### PR TITLE
Validate `CloningSettingsPrototype`s

### DIFF
--- a/Content.IntegrationTests/Tests/Cloning/CloningSettingsPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Cloning/CloningSettingsPrototypeTest.cs
@@ -1,0 +1,39 @@
+using Content.Shared.Cloning;
+
+namespace Content.IntegrationTests.Tests.Cloning;
+
+public sealed class CloningSettingsPrototypeTest
+{
+    /// <summary>
+    /// Checks that the components named in every <see cref="CloningSettingsPrototype"/> are valid components known to the server.
+    /// This is used instead of <see cref="ComponentNameSerializer"/> because we only care if the server are registered with the server,
+    /// and instead of a <see cref="ComponentRegistry"/> because we only need component names.
+    /// </summary>
+    [Test]
+    public async Task ValidatePrototypes()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var protoMan = server.ProtoMan;
+        var compFactory = server.EntMan.ComponentFactory;
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                var protos = protoMan.EnumeratePrototypes<CloningSettingsPrototype>();
+                foreach (var proto in protos)
+                {
+                    foreach (var compName in proto.Components)
+                    {
+                        Assert.That(compFactory.TryGetRegistration(compName, out _),
+                            $"Failed to find a component named {compName} for {nameof(CloningSettingsPrototype)} \"{proto.ID}\""
+                        );
+                    }
+                }
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a test that verifies that all components named by `CloningSettingsPrototype`s are actual components available to the server.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/38687.

## Technical details
<!-- Summary of code changes for easier review. -->
Pretty simple prototype-examining test. It finds all `CloningSettingPrototype`s and iterates through their `Components` fields, checking with `IComponentFactory` to verify each is registered with the server.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->