### PR TITLE
Security can now see how long someone has been handcuffed for

### DIFF
--- a/Content.Client/Cuffs/CuffableSystem.cs
+++ b/Content.Client/Cuffs/CuffableSystem.cs
@@ -33,6 +33,7 @@ public sealed class CuffableSystem : SharedCuffableSystem
             return;
 
         component.CanStillInteract = cuffState.CanStillInteract;
+        component.CuffedTime = cuffState.CuffedTime;
         _actionBlocker.UpdateCanMove(uid);
 
         var ev = new CuffedStateChangeEvent();

--- a/Content.Server/Cuffs/CuffableSystem.cs
+++ b/Content.Server/Cuffs/CuffableSystem.cs
@@ -29,7 +29,8 @@ namespace Content.Server.Cuffs
                 component.CanStillInteract,
                 cuffs?.CuffedRSI,
                 $"{cuffs?.BodyIconState}-{component.CuffedHandCount}",
-                cuffs?.Color);
+                cuffs?.Color,
+                component.CuffedTime);
             // the iconstate is formatted as blah-2, blah-4, blah-6, etc.
             // the number corresponds to how many hands are cuffed.
         }

--- a/Content.Shared/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Shared/Cuffs/Components/CuffableComponent.cs
@@ -62,14 +62,16 @@ public sealed class CuffableComponentState : ComponentState
     public readonly string? RSI;
     public readonly string? IconState;
     public readonly Color? Color;
+    public readonly TimeSpan? CuffedTime;
 
-    public CuffableComponentState(int numHandsCuffed, bool canStillInteract, string? rsiPath, string? iconState, Color? color)
+    public CuffableComponentState(int numHandsCuffed, bool canStillInteract, string? rsiPath, string? iconState, Color? color, TimeSpan? cuffedTime)
     {
         NumHandsCuffed = numHandsCuffed;
         CanStillInteract = canStillInteract;
         RSI = rsiPath;
         IconState = iconState;
         Color = color;
+        CuffedTime = cuffedTime;
     }
 }
 

--- a/Content.Shared/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Shared/Cuffs/Components/CuffableComponent.cs
@@ -42,6 +42,12 @@ public sealed partial class CuffableComponent : Component
     [DataField("canStillInteract"), ViewVariables(VVAccess.ReadWrite)]
     public bool CanStillInteract = true;
 
+    /// <summary>
+    /// The time at which this entity was cuffed.
+    /// </summary>
+    [DataField]
+    public TimeSpan? CuffedTime;
+
     [DataField]
     public ProtoId<AlertPrototype> CuffedAlert = "Handcuffed";
 }

--- a/Content.Shared/Cuffs/Components/HandcuffComponent.cs
+++ b/Content.Shared/Cuffs/Components/HandcuffComponent.cs
@@ -61,6 +61,12 @@ public sealed partial class HandcuffComponent : Component
     public bool Used;
 
     /// <summary>
+    /// Whether examining someone with these handcuffs will show you how long they've been cuffed for (providing they have the right hud).
+    /// </summary>
+    [DataField]
+    public bool ShowCuffedTime;
+
+    /// <summary>
     ///     The path of the RSI file used for the player cuffed overlay.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Cuffs/Components/ShowCuffedTimeComponent.cs
+++ b/Content.Shared/Cuffs/Components/ShowCuffedTimeComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Cuffs.Components;
+
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ShowCuffedTimeComponent : Component;

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -56,7 +56,7 @@ namespace Content.Shared.Cuffs
         [Dependency] private readonly SharedTransformSystem _transform = default!;
         [Dependency] private readonly UseDelaySystem _delay = default!;
         [Dependency] private readonly SharedCombatModeSystem _combatMode = default!;
-        [Dependency] private readonly GameTiming _timing = default!;
+        [Dependency] private readonly IGameTiming _timing = default!;
 
         public override void Initialize()
         {

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -33,6 +33,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using PullableComponent = Content.Shared.Movement.Pulling.Components.PullableComponent;
 
@@ -55,6 +56,7 @@ namespace Content.Shared.Cuffs
         [Dependency] private readonly SharedTransformSystem _transform = default!;
         [Dependency] private readonly UseDelaySystem _delay = default!;
         [Dependency] private readonly SharedCombatModeSystem _combatMode = default!;
+        [Dependency] private readonly GameTiming _timing = default!;
 
         public override void Initialize()
         {
@@ -341,6 +343,7 @@ namespace Content.Shared.Cuffs
             if (!args.Cancelled && TryAddNewCuffs(target, user, uid, cuffable))
             {
                 component.Used = true;
+                cuffable.CuffedTime ??= _timing.CurTime; // only record the time of the first cuffing
                 _audio.PlayPredicted(component.EndCuffSound, uid, user);
 
                 var popupText = (user == target)
@@ -738,6 +741,7 @@ namespace Content.Shared.Cuffs
 
             if (cuffable.CuffedHandCount == 0)
             {
+                cuffable.CuffedTime = null; // now fully uncuffed so remove the cuff time
                 if (user != null)
                 {
                     if (shoved)

--- a/Content.Shared/Cuffs/ShowCuffedTimeSystem.cs
+++ b/Content.Shared/Cuffs/ShowCuffedTimeSystem.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Cuffs;
 public sealed class ShowCuffedTimeSystem: EntitySystem
 {
     [Dependency] private readonly SharedCuffableSystem _cuffable = default!;
-    [Dependency] private readonly GameTiming _timing = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {

--- a/Content.Shared/Cuffs/ShowCuffedTimeSystem.cs
+++ b/Content.Shared/Cuffs/ShowCuffedTimeSystem.cs
@@ -34,6 +34,30 @@ public sealed class ShowCuffedTimeSystem: EntitySystem
             return;
         }
 
+        // show the time since the first pair of handcuffs was applied if:
+        // the wearer has the right hud
+        // and atleast one of the handcuffs has the ShowCuffedTime field set to true
+        var ev = new CanSeeCuffedTimeEvent();
+        RaiseLocalEvent(args.Examiner, ref ev);
+        if (!ev.CanSeeCuffedTime)
+            return;
+
+        var showCuffedTime = false;
+        foreach (var cuff in _cuffable.GetAllCuffs(comp))
+        {
+            if (!TryComp<HandcuffComponent>(cuff, out var cuffs))
+            {
+                Log.Warning("An entity is cuffed with another entity which doesn't have the HandcuffComponent.");
+                continue;
+            }
+
+            if (cuffs.ShowCuffedTime)
+                showCuffedTime = true;
+        }
+
+        if (!showCuffedTime)
+            return;
+
         var duration = _timing.CurTime - comp.CuffedTime;
         var minutes = duration.Value.Minutes;
         var seconds = duration.Value.Seconds;

--- a/Content.Shared/Cuffs/ShowCuffedTimeSystem.cs
+++ b/Content.Shared/Cuffs/ShowCuffedTimeSystem.cs
@@ -1,0 +1,57 @@
+using Content.Shared.Cuffs.Components;
+using Content.Shared.Examine;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Inventory;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.Cuffs;
+
+public sealed class ShowCuffedTimeSystem: EntitySystem
+{
+    [Dependency] private readonly SharedCuffableSystem _cuffable = default!;
+    [Dependency] private readonly GameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        Subs.SubscribeWithRelay<ShowCuffedTimeComponent, CanSeeCuffedTimeEvent>(OnCanSeeCuffedTime);
+        SubscribeLocalEvent<CuffableComponent, ExaminedEvent>(OnExamine);
+    }
+
+    private void OnCanSeeCuffedTime(EntityUid uid, ShowCuffedTimeComponent comp, ref CanSeeCuffedTimeEvent args)
+    {
+        args.CanSeeCuffedTime = true;
+    }
+
+    private void OnExamine(EntityUid uid, CuffableComponent comp, ExaminedEvent args)
+    {
+        if (!_cuffable.IsCuffed((uid, comp)))
+            return;
+
+        if (comp.CuffedTime is null)
+        {
+            Log.Warning("An entity is cuffed but the CuffTime wasn't set.");
+            return;
+        }
+
+        var duration = _timing.CurTime - comp.CuffedTime;
+        var minutes = duration.Value.Minutes;
+        var seconds = duration.Value.Seconds;
+        var identity = Identity.Entity(uid, EntityManager);
+
+        if (minutes == 0)
+            args.PushMarkup(Loc.GetString("examine-cuffed-time-seconds", ("identity", identity), ("seconds", seconds)));
+        else
+            args.PushMarkup(Loc.GetString("examine-cuffed-time-minutes-and-seconds", ("identity", identity), ("minutes", minutes), ("seconds", seconds)));
+    }
+}
+
+/// <summary>
+/// Raised on an entity to see if it can see the time another entity has been cuffed for.
+/// </summary>
+/// <param name="CanSeeCuffedTime"></param>
+[ByRefEvent]
+public record struct CanSeeCuffedTimeEvent(bool CanSeeCuffedTime = false) : IInventoryRelayEvent
+{
+    public SlotFlags TargetSlots => SlotFlags.EYES;
+}

--- a/Content.Shared/Cuffs/ShowCuffedTimeSystem.cs
+++ b/Content.Shared/Cuffs/ShowCuffedTimeSystem.cs
@@ -63,6 +63,9 @@ public sealed class ShowCuffedTimeSystem: EntitySystem
         var seconds = duration.Value.Seconds;
         var identity = Identity.Entity(uid, EntityManager);
 
+        if (seconds == 0 && minutes == 0)
+            return;
+
         if (minutes == 0)
             args.PushMarkup(Loc.GetString("examine-cuffed-time-seconds", ("identity", identity), ("seconds", seconds)));
         else

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -5,6 +5,7 @@ using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Hypospray.Events;
 using Content.Shared.Climbing.Events;
 using Content.Shared.Contraband;
+using Content.Shared.Cuffs;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Events;
 using Content.Shared.Electrocution;
@@ -67,6 +68,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, ProjectileReflectAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, HitScanReflectAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, GetContrabandDetailsEvent>(RefRelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, CanSeeCuffedTimeEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, FlashAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, WieldAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, UnwieldAttemptEvent>(RefRelayInventoryEvent);

--- a/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
+++ b/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
@@ -18,5 +18,5 @@ handcuff-component-cuff-interrupt-self-message = You were interrupted while rest
 handcuff-component-cuff-interrupt-buckled-message = You can't buckle while restrained!
 handcuff-component-cuff-interrupt-unbuckled-message = You can't unbuckle while restrained!
 handcuff-component-cannot-drop-cuffs = You are unable to put the restraints on {$target}.
-examine-cuffed-time-seconds = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$seconds}[/color] seconds.
-examine-cuffed-time-seconds-and-minutes = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$minutes}[/color] minutes and [color=yellow]{$seconds}[/color] seconds.
+examine-cuffed-time-seconds = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$seconds} seconds[/color].
+examine-cuffed-time-minutes-and-seconds = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$minutes} minutes and {$seconds} seconds[/color].

--- a/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
+++ b/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
@@ -18,5 +18,5 @@ handcuff-component-cuff-interrupt-self-message = You were interrupted while rest
 handcuff-component-cuff-interrupt-buckled-message = You can't buckle while restrained!
 handcuff-component-cuff-interrupt-unbuckled-message = You can't unbuckle while restrained!
 handcuff-component-cannot-drop-cuffs = You are unable to put the restraints on {$target}.
-examine-cuffed-time-seconds = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$seconds} {MANY("second", $seconds)}}[/color].
+examine-cuffed-time-seconds = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$seconds} {MANY("second", $seconds)}[/color].
 examine-cuffed-time-minutes-and-seconds = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$minutes} {MANY("minute", $minutes)} and {$seconds} {MANY("second", $seconds)}[/color].

--- a/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
+++ b/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
@@ -18,5 +18,5 @@ handcuff-component-cuff-interrupt-self-message = You were interrupted while rest
 handcuff-component-cuff-interrupt-buckled-message = You can't buckle while restrained!
 handcuff-component-cuff-interrupt-unbuckled-message = You can't unbuckle while restrained!
 handcuff-component-cannot-drop-cuffs = You are unable to put the restraints on {$target}.
-examine-cuffed-time-seconds = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$seconds} seconds[/color].
-examine-cuffed-time-minutes-and-seconds = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$minutes} minutes and {$seconds} seconds[/color].
+examine-cuffed-time-seconds = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$seconds} {MANY("second", $seconds)}}[/color].
+examine-cuffed-time-minutes-and-seconds = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$minutes} {MANY("minute", $minutes)} and {$seconds} {MANY("second", $seconds)}[/color].

--- a/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
+++ b/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
@@ -18,3 +18,5 @@ handcuff-component-cuff-interrupt-self-message = You were interrupted while rest
 handcuff-component-cuff-interrupt-buckled-message = You can't buckle while restrained!
 handcuff-component-cuff-interrupt-unbuckled-message = You can't unbuckle while restrained!
 handcuff-component-cannot-drop-cuffs = You are unable to put the restraints on {$target}.
+examine-cuffed-time-seconds = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$seconds}[/color] seconds.
+examine-cuffed-time-seconds-and-minutes = {CAPITALIZE(SUBJECT($identity))} {CONJUGATE-HAVE($identity)} been cuffed for [color=yellow]{$minutes}[/color] minutes and [color=yellow]{$seconds}[/color] seconds.

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -7,6 +7,7 @@
   - type: ShowMindShieldIcons
   - type: ShowCriminalRecordIcons
   - type: ShowContrabandDetails
+  - type: ShowCuffedTime
 
 - type: entity
   id: ShowMedicalIcons

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -10,6 +10,7 @@
   - type: Handcuff
     cuffedRSI: Objects/Misc/handcuffs.rsi
     bodyIconState: body-overlay
+    showCuffedTime: true
   - type: Sprite
     sprite: Objects/Misc/handcuffs.rsi
     state: handcuff
@@ -38,6 +39,7 @@
   components:
   - type: Handcuff
     breakoutTime: 3
+    showCuffedTime: false
     cuffedRSI: Objects/Misc/cablecuffs.rsi
     bodyIconState: body-overlay
     color: forestgreen
@@ -155,6 +157,7 @@
     cuffTime: 10
     uncuffTime: 10
     stunBonus: 4
+    showCuffedTime: true
   - type: Sprite
     sprite: Clothing/OuterClothing/Misc/straight_jacket.rsi
     state: icon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
If you are wearing secglasses or a sechud, you can examine a cuffed person to see how long they have been cuffed for.
Only works for handcuffs and zipties (stuff sec will use), not makeshift cuffs.

## Why / Balance
When sec arrests someone and gives them brig time they are meant to factor in how long someone has already been detained for.
But no one has ever bothered to check this ever and even if they do factor it in they go off vibes.
Being able to examine someone you have in custody and see exactly how long they have spent in custody will be a great QoL feature for sec!

## Technical details
* HandcuffComponent now has field for ShowCuffedTime, set to true on handcuffs and zipties.
* CuffableComponent now has a nullable field called CuffedTime which is set to the current time when the first pair of of cuffs are applied and set to null when the final pair of cuffs is removed.

> (the Cuffable system has legacy code from when arachnids had 4 arms so it has to deal with tons of edge cases which will never happen, like more than one pair of cuffs. I think Slarti or Emo said that if they give arachnids back their 4 arms then they will refactor it so one pair of cuffs will cuff any number of arms)

* there is ShowCuffedTimeComponent on secglasses and sec huds, if you have it on your entity or you are wearing something with it on your eyes then it lets you see the cuff time
* as long as you have the right hud and atleast one of the cuffs has ShowCuffedTime set to true then you will see the examine text which calculates cuffed time by comparing the CuffedTime field with the current time (has to factor for multiple handcuffs despite this not being possible and never gonna happen :pensive:)


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Screenshot from 2025-07-01 23-24-52](https://github.com/user-attachments/assets/86618e1f-e281-41da-8ac0-5c7297914597)
![Screenshot from 2025-07-01 22-50-58](https://github.com/user-attachments/assets/d0572e6b-c023-47ae-9557-7681e288e205)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Security can now see how long someone has been handcuffed for.
