### PR TITLE
LEC convert lsobjectives, tweak locales and structure of addobjective/rmobjective commands.

### DIFF
--- a/Content.Server/Objectives/Commands/AddObjectiveCommand.cs
+++ b/Content.Server/Objectives/Commands/AddObjectiveCommand.cs
@@ -24,24 +24,23 @@ public sealed class AddObjectiveCommand : LocalizedEntityCommands
     {
         if (args.Length != 2)
         {
-            shell.WriteError(Loc.GetString(Loc.GetString("cmd-addobjective-invalid-args")));
+            shell.WriteError(Loc.GetString(Loc.GetString("shell-wrong-arguments-number")));
             return;
         }
 
         if (!_players.TryGetSessionByUsername(args[0], out var data))
         {
-            shell.WriteError(Loc.GetString("cmd-addobjective-player-not-found"));
+            shell.WriteError(Loc.GetString("shell-target-player-does-not-exist"));
             return;
         }
 
         if (!_mind.TryGetMind(data, out var mindId, out var mind))
         {
-            shell.WriteError(Loc.GetString("cmd-addobjective-mind-not-found"));
+            shell.WriteError(Loc.GetString("shell-target-entity-does-not-have-message", ("missing", "mind")));
             return;
         }
 
-        if (!_prototypes.TryIndex<EntityPrototype>(args[1], out var proto) ||
-            !proto.HasComponent<ObjectiveComponent>())
+        if (!_prototypes.TryIndex<EntityPrototype>(args[1], out var proto) || !proto.HasComponent<ObjectiveComponent>())
         {
             shell.WriteError(Loc.GetString("cmd-addobjective-objective-not-found", ("obj", args[1])));
             return;
@@ -68,6 +67,6 @@ public sealed class AddObjectiveCommand : LocalizedEntityCommands
 
         return CompletionResult.FromHintOptions(
             _objectives.Objectives(),
-            Loc.GetString(Loc.GetString("cmd-add-objective-obj-completion")));
+            Loc.GetString(Loc.GetString("cmd-addobjective-obj-completion")));
     }
 }

--- a/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
+++ b/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
@@ -7,69 +7,58 @@ using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.Player;
 
-namespace Content.Server.Objectives.Commands
+namespace Content.Server.Objectives.Commands;
+
+[AdminCommand(AdminFlags.Logs)]
+public sealed class ListObjectivesCommand : LocalizedCommands
 {
-    [AdminCommand(AdminFlags.Logs)]
-    public sealed class ListObjectivesCommand : LocalizedCommands
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly SharedMindSystem _mindSystem = default!;
+    [Dependency] private readonly SharedObjectivesSystem _objectiveSystem = default!;
+
+    public override string Command => "lsobjectives";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IEntityManager _entities = default!;
-        [Dependency] private readonly IPlayerManager _players = default!;
+        ICommonSession? player;
+        if (args.Length > 0)
+            _playerManager.TryGetSessionByUsername(args[0], out player);
+        else
+            player = shell.Player;
 
-        public override string Command => "lsobjectives";
-
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (player == null)
         {
-            ICommonSession? player;
-            if (args.Length > 0)
-                _players.TryGetSessionByUsername(args[0], out player);
+            shell.WriteError(Loc.GetString("shell-target-player-does-not-exist"));
+            return;
+        }
+
+        if (!_mindSystem.TryGetMind(player, out var mindId, out var mind))
+        {
+            shell.WriteError(Loc.GetString("shell-target-entity-does-not-have-message", ("missing", "mind")));
+            return;
+        }
+
+        var objectives = mind.Objectives.ToList();
+        shell.WriteLine(objectives.Count == 0
+            ? Loc.GetString("cmd-lsobjectives-no-objectives", ("player", player.UserId))
+            : Loc.GetString("cmd-lsobjectives-for-player", ("player", player.UserId)));
+
+        for (var i = 0; i < objectives.Count; i++)
+        {
+            var info = _objectiveSystem.GetInfo(objectives[i], mindId, mind);
+            if (info == null)
+                shell.WriteLine($"- [{i}] {objectives[i]} - INVALID");
+
             else
-                player = shell.Player;
-
-            if (player == null)
             {
-                shell.WriteError(LocalizationManager.GetString("shell-target-player-does-not-exist"));
-                return;
-            }
-
-            var minds = _entities.System<SharedMindSystem>();
-            if (!minds.TryGetMind(player, out var mindId, out var mind))
-            {
-                shell.WriteError(LocalizationManager.GetString("shell-target-entity-does-not-have-message", ("missing", "mind")));
-                return;
-            }
-
-            shell.WriteLine($"Objectives for player {player.UserId}:");
-            var objectives = mind.Objectives.ToList();
-            if (objectives.Count == 0)
-            {
-                shell.WriteLine("None.");
-            }
-
-            var objectivesSystem = _entities.System<SharedObjectivesSystem>();
-            for (var i = 0; i < objectives.Count; i++)
-            {
-                var info = objectivesSystem.GetInfo(objectives[i], mindId, mind);
-                if (info == null)
-                {
-                    shell.WriteLine($"- [{i}] {objectives[i]} - INVALID");
-                }
-                else
-                {
-
-                    var progress = (int) (info.Value.Progress * 100f);
-                    shell.WriteLine($"- [{i}] {objectives[i]} ({info.Value.Title}) ({progress}%)");
-                }
+                var progress = (int) (info.Value.Progress * 100f);
+                shell.WriteLine($"- [{i}] {objectives[i]} ({info.Value.Title}) ({progress}%)");
             }
         }
+    }
 
-        public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
-        {
-            if (args.Length == 1)
-            {
-                return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), LocalizationManager.GetString("shell-argument-username-hint"));
-            }
-
-            return CompletionResult.Empty;
-        }
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        return args.Length == 1 ? CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), Loc.GetString("shell-argument-username-hint")) : CompletionResult.Empty;
     }
 }

--- a/Content.Server/Objectives/Commands/RemoveObjectiveCommand.cs
+++ b/Content.Server/Objectives/Commands/RemoveObjectiveCommand.cs
@@ -5,55 +5,54 @@ using Content.Shared.Objectives.Systems;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 
-namespace Content.Server.Objectives.Commands
+namespace Content.Server.Objectives.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class RemoveObjectiveCommand : LocalizedEntityCommands
 {
-    [AdminCommand(AdminFlags.Admin)]
-    public sealed class RemoveObjectiveCommand : LocalizedEntityCommands
+    [Dependency] private readonly IPlayerManager _players = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
+
+    public override string Command => "rmobjective";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IPlayerManager _players = default!;
-        [Dependency] private readonly SharedMindSystem _mind = default!;
-        [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
-
-        public override string Command => "rmobjective";
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (args.Length != 2)
         {
-            if (args.Length != 2)
-            {
-                shell.WriteError(Loc.GetString(Loc.GetString("cmd-rmobjective-invalid-args")));
-                return;
-            }
-
-            if (!_players.TryGetSessionByUsername(args[0], out var session))
-            {
-                shell.WriteError(Loc.GetString("cmd-rmojective-player-not-found"));
-                return;
-            }
-
-            if (!_mind.TryGetMind(session, out var mindId, out var mind))
-            {
-                shell.WriteError(Loc.GetString("cmd-rmojective-mind-not-found"));
-                return;
-            }
-
-            if (int.TryParse(args[1], out var i))
-            {
-                shell.WriteLine(Loc.GetString(_mind.TryRemoveObjective(mindId, mind, i)
-                    ? "cmd-rmobjective-success"
-                    : "cmd-rmobjective-failed"));
-            }
-            else
-            {
-                shell.WriteError(Loc.GetString("cmd-rmobjective-invalid-index", ("index", args[1])));
-            }
+            shell.WriteError(Loc.GetString(Loc.GetString("shell-wrong-objectives-number")));
+            return;
         }
 
-        public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        if (!_players.TryGetSessionByUsername(args[0], out var session))
         {
-            if (args.Length == 1)
-            {
+            shell.WriteError(Loc.GetString("shell-target-player-does-not-exist"));
+            return;
+        }
+
+        if (!_mind.TryGetMind(session, out var mindId, out var mind))
+        {
+            shell.WriteError(Loc.GetString("shell-target-entity-does-not-have-message", ("missing", "mind")));
+            return;
+        }
+
+        if (int.TryParse(args[1], out var i))
+        {
+            shell.WriteLine(Loc.GetString(_mind.TryRemoveObjective(mindId, mind, i)
+                ? "cmd-rmobjective-success"
+                : "cmd-rmobjective-failed"));
+        }
+        else
+            shell.WriteError(Loc.GetString("cmd-rmobjective-invalid-index", ("index", args[1])));
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        switch (args.Length)
+        {
+            case 1:
                 return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), LocalizationManager.GetString("shell-argument-username-hint"));
-            }
-            if (args.Length == 2)
+            case 2:
             {
                 if (!_players.TryGetSessionByUsername(args[0], out var session))
                     return CompletionResult.Empty;
@@ -74,8 +73,8 @@ namespace Content.Server.Objectives.Commands
 
                 return CompletionResult.FromOptions(options);
             }
-
-            return CompletionResult.Empty;
+            default:
+                return CompletionResult.Empty;
         }
     }
 }

--- a/Resources/Locale/en-US/objectives/commands/addobjectives.ftl
+++ b/Resources/Locale/en-US/objectives/commands/addobjectives.ftl
@@ -1,12 +1,9 @@
 # addobjectives
 cmd-addobjective-desc = Adds an objective to the player's mind.
-cmd-addobjective-help = addobjective <username> <objectiveID>
+cmd-addobjective-help = Usage: addobjective <username> <objectiveID>
 
-cmd-addobjective-invalid-args = Expected exactly 2 arguments.
-cmd-addobjective-player-not-found = Can't find the playerdata.
-cmd-addobjective-mind-not-found = Can't find the mind.
 cmd-addobjective-objective-not-found = Can't find matching objective prototype {$obj}
 cmd-addobjective-adding-failed = Failed to add the objective. Maybe requirements dont allow that objective to be added.
 
 cmd-addobjective-player-completion = <Player>
-cmd-add-objective-obj-completion = <Objective>
+cmd-addobjective-obj-completion = <Objective>

--- a/Resources/Locale/en-US/objectives/commands/lsobjectives.ftl
+++ b/Resources/Locale/en-US/objectives/commands/lsobjectives.ftl
@@ -1,3 +1,5 @@
 # lsobjectives
 cmd-lsobjectives-desc = Lists all objectives in a players mind.
 cmd-lsobjectives-help = Usage: lsobjectives <username>
+cmd-lsobjectives-for-player = Objectives for player {$player}:
+cmd-lsobjectives-no-objectives = Player {$player} has no objectives.

--- a/Resources/Locale/en-US/objectives/commands/rmobjective.ftl
+++ b/Resources/Locale/en-US/objectives/commands/rmobjective.ftl
@@ -2,9 +2,6 @@
 cmd-rmobjective-desc = Removes an objective from the player's mind.
 cmd-rmobjective-help = rmobjective <username> <index>
 
-cmd-rmobjective-invalid-args = Expected exactly 2 arguments.
-cmd-rmobjective-player-not-found = Can't find the playerdata.
-cmd-rmobjective-mind-not-found = Can't find the mind.
 cmd-rmobjective-success = Objective successfully removed!
 cmd-rmobjective-failed = Objective removing failed. Maybe the index is out of bounds? Check lsobjectives!
 cmd-rmobjective-invalid-index = Could not parse index { $index } as an integer.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Another PR in my work to standardize commands. The bulk of the work here was switching certain locale strings to shell generic alternatives. I had planned on creating a shell variant of the can't find mind message but this may work as well. 

## Technical details
<!-- Summary of code changes for easier review. -->
I believe I've explained this before but my desire with these prs is more than just cleanup. I want to bring consistency to structure and experience for each command. I haven't fully settled on how that'll look yet but each pr is one small step forward for it. The biggest changes I want to make are switching commands that use their own locale strings in places where generics would arguably be better or sufficient.  I've also been slowly moving ftl files to the /locale/en-us/commands/ directory and renaming or condensing files where needed to make everything consistent. This may be merge conflict bait though so if theres any issues with it, please do say so.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Multiple locale strings for the lsobjectives, rmobjective, and addobjective commands were removed and replaced with generic alternatives. If those generics have already been localized on your end, no changes are necessary.