### PR TITLE
LOOC Modifications

### DIFF
--- a/Content.Client/Chat/UI/SpeechBubble.cs
+++ b/Content.Client/Chat/UI/SpeechBubble.cs
@@ -25,7 +25,6 @@ namespace Content.Client.Chat.UI
             Emote,
             Say,
             Whisper,
-            Looc
         }
 
         /// <summary>
@@ -76,9 +75,6 @@ namespace Content.Client.Chat.UI
 
                 case SpeechType.Whisper:
                     return new FancyTextSpeechBubble(message, senderEntity, "whisperBox");
-
-                case SpeechType.Looc:
-                    return new TextSpeechBubble(message, senderEntity, "emoteBox", Color.FromHex("#48d1cc"));
 
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -45,7 +45,6 @@ public sealed partial class MiscTab : Control
 
         Control.AddOptionCheckBox(CVars.DiscordEnabled, DiscordRich);
         Control.AddOptionCheckBox(CCVars.ShowOocPatronColor, ShowOocPatronColor);
-        Control.AddOptionCheckBox(CCVars.LoocAboveHeadShow, ShowLoocAboveHeadCheckBox);
         Control.AddOptionCheckBox(CCVars.HudHeldItemShow, ShowHeldItemCheckBox);
         Control.AddOptionCheckBox(CCVars.CombatModeIndicatorsPointShow, ShowCombatModeIndicatorsCheckBox);
         Control.AddOptionCheckBox(CCVars.OpaqueStorageWindow, OpaqueStorageWindowCheckBox);

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -890,11 +890,6 @@ public sealed partial class ChatUIController : UIController
             case ChatChannel.Emotes:
                 AddSpeechBubble(msg, SpeechBubble.SpeechType.Emote);
                 break;
-
-            case ChatChannel.LOOC:
-                if (_config.GetCVar(CCVars.LoocAboveHeadShow))
-                    AddSpeechBubble(msg, SpeechBubble.SpeechType.Looc);
-                break;
         }
     }
 

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -619,7 +619,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             return;
 
         var wrappedMessage = Loc.GetString("chat-manager-entity-looc-wrap-message",
-            ("entityName", name),
+            ("entityName", player.Name),
             ("message", FormattedMessage.EscapeText(message)));
 
         SendInVoiceRange(ChatChannel.LOOC, message, wrappedMessage, source, hideChat ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal, player.UserId);

--- a/Content.Shared/CCVar/CCVars.Hud.cs
+++ b/Content.Shared/CCVar/CCVars.Hud.cs
@@ -13,9 +13,6 @@ public sealed partial class CCVars
     public static readonly CVarDef<bool> CombatModeIndicatorsPointShow =
         CVarDef.Create("hud.combat_mode_indicators_point_show", true, CVar.ARCHIVE | CVar.CLIENTONLY);
 
-    public static readonly CVarDef<bool> LoocAboveHeadShow =
-        CVarDef.Create("hud.show_looc_above_head", true, CVar.ARCHIVE | CVar.CLIENTONLY);
-
     public static readonly CVarDef<float> HudHeldItemOffset =
         CVarDef.Create("hud.held_item_offset", 28f, CVar.ARCHIVE | CVar.CLIENTONLY);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes LOOC a proper out-of-character channel, making it no longer appear above player's heads or use their in-game names.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
LOOC is notoriously an IC malding channel to the point where it is painfully detrimental to any attempt to meaningfully RP in game. Rather than being used for actual light OOC chatting (i had some good dinner today, the weather has been nice, my gf just left me, etc.), it instead is almost exclusively used for either complaining about rule breaks, in-game changes, or other players.

This plainly is just frustrating as a player. Its existence basically just perpetuates toxicity which makes it extremely annoying to deal with.

This is due to the fact that it largely just resembles local chat. Rather than normal OOC chat, which uses your username and doesn't appear tied to a character, LOOC both uses your IC name (which doesn't make sense) but also appears above the player's head, further cementing it as an IC char--something it explicitly is not. This is to a point where i've heard people say that it actually refers to "light" OOC chat.

My goal is that by removing these more IC features, it'll push players to not use it for that type of discussion and ideally resolve things IC more.

## Technical details
<!-- Summary of code changes for easier review. -->
basically just straight removal and very minor changing in some of the chat stuff.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/0d95076a-4fe2-4161-8161-7eebd12cefd8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Removed `SpeechBubble.SpeechType.Looc` and `LoocAboveHeadShow` CVAR.

**Changelog**
:cl:
- tweak: LOOC chat now uses your username rather than your character name. Additionally, it no longer appears above a character's head when they speak.
