### PR TITLE
Made all door remotes use the access of the user, instead of having their own access.

### DIFF
--- a/Resources/Maps/marathon.yml
+++ b/Resources/Maps/marathon.yml
@@ -62244,19 +62244,6 @@ entities:
     - type: Transform
       pos: 3.6301537,20.758205
       parent: 30
-- proto: DoorRemoteSecurity
-  entities:
-  - uid: 2429
-    components:
-    - type: Transform
-      pos: -23.516384,50.539074
-      parent: 30
-    - type: Access
-      tags:
-      - HeadOfSecurity
-      - Security
-      - Armory
-      - Brig
 - proto: DoubleEmergencyOxygenTankFilled
   entities:
   - uid: 792

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -13,7 +13,7 @@
     - id: CigPackGreen
       prob: 0.50
     - id: ClothingHeadsetAltCargo
-    - id: DoorRemoteCargo
+    - id: DoorRemoteQm
     - id: RubberStampApproved
     - id: RubberStampDenied
     - id: RubberStampQm
@@ -43,7 +43,7 @@
     - id: ClothingHeadsetAltCommand
     - id: ClothingOuterArmorCaptainCarapace
     - id: CommsComputerCircuitboard
-    - id: DoorRemoteCustom
+    - id: DoorRemoteCaptain
     - id: MedalCase
     - id: NukeDisk
     - id: PinpointerNuclear
@@ -132,7 +132,7 @@
       prob: 0.5
     - id: ClothingHeadsetCommand
     - id: ClothingNeckGoldmedal
-    - id: DoorRemoteService
+    - id: DoorRemoteHop
     - id: HoPIDCard
     - id: IDComputerCircuitboard
     - id: FundingAllocationComputerCircuitboard
@@ -166,7 +166,7 @@
     - id: ClothingEyesGlassesMeson
     - id: ClothingHandsGlovesColorYellow
     - id: ClothingHeadsetAltEngineering
-    - id: DoorRemoteEngineering
+    - id: DoorRemoteCe
     - id: CargoRequestEngineeringComputerCircuitboard
     - id: RCD
     - id: RCDAmmo
@@ -223,7 +223,7 @@
     - id: ClothingHeadHatBeretCmo
     - id: ClothingHeadsetAltMedical
     - id: ClothingMaskSterile
-    - id: DoorRemoteMedical
+    - id: DoorRemoteCmo
     - id: HandheldCrewMonitor
     - id: Hypospray
     - id: MedicalTechFabCircuitboard
@@ -277,7 +277,7 @@
     - id: CircuitImprinterMachineCircuitboard
     - id: ClothingBeltUtilityFilled
     - id: ClothingHeadsetAltScience
-    - id: DoorRemoteResearch
+    - id: DoorRemoteRd
     - id: HandTeleporter
     - id: ProtolatheMachineCircuitboard
     - id: ResearchComputerCircuitboard
@@ -335,7 +335,7 @@
     - id: ClothingMaskNeckGaiter
     - id: ClothingOuterCoatHoSTrench
     - id: ClothingShoesBootsJack
-    - id: DoorRemoteSecurity
+    - id: DoorRemoteHos
     - id: HoloprojectorSecurity
     - id: RubberStampHos
     - id: SecurityTechFabCircuitboard

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -15,7 +15,7 @@
       - id: ClothingOuterCoatWarden
       - id: ClothingOuterWinterWarden
       - id: RubberStampWarden
-      - id: DoorRemoteArmory
+      - id: DoorRemoteWarden
       - id: ClothingOuterHardsuitWarden
       - id: HoloprojectorSecurity
       - id: BookSpaceLaw
@@ -41,7 +41,7 @@
       - id: ClothingOuterCoatWarden
       - id: ClothingOuterWinterWarden
       - id: RubberStampWarden
-      - id: DoorRemoteArmory
+      - id: DoorRemoteWarden
       - id: HoloprojectorSecurity
       - id: BookSpaceLaw
       - id: ClothingBackpackElectropack

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -16,26 +16,9 @@
 
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
-  id: DoorRemoteCommand
-  name: command door remote
-  components:
-  - type: Sprite
-    layers:
-    - state: door_remotebase
-    - state: door_remotelightscolour
-      color: "#e6e600"
-    - state: door_remotescreencolour
-      color: "#9f9f00"
-  - type: Access
-    groups:
-    - Command
-  - type: DoorRemote
-
-- type: entity
-  parent: [DoorRemoteDefault, BaseCommandContraband]
   id: DoorRemoteCustom
   name: custom door remote
-  description: A gadget which can open and bolt doors remotely. This advanced variant does not have built-in access, instead inheriting the ID access of the user.
+  description: A gadget which can open and bolt doors that the user has access to, remotely.
   components:
   - type: Sprite
     layers:
@@ -50,8 +33,26 @@
 
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
-  id: DoorRemoteSecurity
-  name: security door remote
+  id: DoorRemoteCaptain
+  name: captain's door remote
+  description: A gadget which can open and bolt doors that the user has access to, remotely. This one was custom made for the captain.
+  components:
+  - type: Sprite
+    layers:
+    - state: door_remotebase
+    - state: door_remotelightscolour
+      color: "#e6e600"
+    - state: door_remotescreencolour
+      color: "#9f9f00"
+  - type: Access
+  - type: DoorRemote
+    includeUserAccess: true
+
+- type: entity
+  parent: [DoorRemoteDefault, BaseCommandContraband]
+  id: DoorRemoteHos
+  name: head of security's door remote
+  description: A gadget which can open and bolt doors that the user has access to, remotely. This one was custom made for the head of security.
   components:
   - type: Sprite
     layers:
@@ -61,13 +62,14 @@
     - state: door_remotescreencolour
       color: "#830000"
   - type: Access
-    groups:
-    - Security
+  - type: DoorRemote
+    includeUserAccess: true
 
 - type: entity
   parent: [DoorRemoteDefault, BaseSecurityCommandContraband]
-  id: DoorRemoteArmory
-  name: armory door remote
+  id: DoorRemoteWarden
+  name: warden's door remote
+  description: A gadget which can open and bolt doors that the user has access to, remotely. This used to be the head of security's spare.
   components:
   - type: Sprite
     layers:
@@ -77,13 +79,14 @@
     - state: door_remotescreencolour
       color: "#a80000"
   - type: Access
-    groups:
-    - Armory
+  - type: DoorRemote
+    includeUserAccess: true
 
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
-  id: DoorRemoteService
-  name: service door remote
+  id: DoorRemoteHop
+  name: head of personnel's door remote
+  description: A gadget which can open and bolt doors that the user has access to, remotely. This one was custom made for the head of personnel.
   components:
   - type: Sprite
     layers:
@@ -93,13 +96,14 @@
     - state: door_remotescreencolour
       color: "#3a7231"
   - type: Access
-    groups:
-    - Service
+  - type: DoorRemote
+    includeUserAccess: true
 
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
-  id: DoorRemoteResearch
-  name: research door remote
+  id: DoorRemoteRd
+  name: research director's door remote
+  description: A gadget which can open and bolt doors that the user has access to, remotely. This one was custom made for the research director.
   components:
   - type: Sprite
     layers:
@@ -109,13 +113,14 @@
     - state: door_remotescreencolour
       color: "#652368"
   - type: Access
-    groups:
-    - Research
+  - type: DoorRemote
+    includeUserAccess: true
 
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
-  id: DoorRemoteCargo
-  name: cargo door remote
+  id: DoorRemoteQm
+  name: quartermaster's door remote
+  description: A gadget which can open and bolt doors that the user has access to, remotely. This one was custom made for the quartermaster.
   components:
   - type: Sprite
     layers:
@@ -125,13 +130,14 @@
     - state: door_remotescreencolour
       color: "#5b4523"
   - type: Access
-    groups:
-    - Cargo
+  - type: DoorRemote
+    includeUserAccess: true
 
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
-  id: DoorRemoteMedical
-  name: medical door remote
+  id: DoorRemoteCmo
+  name: chief medical officer's door remote
+  description: A gadget which can open and bolt doors that the user has access to, remotely. This one was custom made for the chief medical officer.
   components:
   - type: Sprite
     layers:
@@ -141,13 +147,14 @@
     - state: door_remotescreencolour
       color: "#325f7a"
   - type: Access
-    groups:
-    - Medical
+  - type: DoorRemote
+    includeUserAccess: true
 
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]
-  id: DoorRemoteEngineering
-  name: engineering door remote
+  id: DoorRemoteCe
+  name: chief engineer's door remote
+  description: A gadget which can open and bolt doors that the user has access to, remotely. This one was custom made for the chief engineer.
   components:
   - type: Sprite
     layers:
@@ -157,8 +164,8 @@
     - state: door_remotescreencolour
       color: "#bc5b00"
   - type: Access
-    groups:
-    - Engineering
+  - type: DoorRemote
+    includeUserAccess: true
 
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]

--- a/Resources/ServerInfo/Guidebook/Command.xml
+++ b/Resources/ServerInfo/Guidebook/Command.xml
@@ -35,7 +35,7 @@ To deal with your new soul-crushing tasks, every head is given special items to 
 
 Your [color=#a4885c]remote[/color] is very simple but profoundly underestimated. A small but mighty force, your remote can open and close [color=#a4885c]airlocks[/color], spin the [color=#a4885c]bolts[/color] to lock them, or toggle [color=#a4885c]emergency access[/color]. It can do this from a distance.
   <Box>
-    <GuideEntityEmbed Entity="DoorRemoteCommand"/>
+    <GuideEntityEmbed Entity="DoorRemoteCaptain"/>
   </Box>
 The remote influences where people move around. Heads can lock personnel out of dangerous areas or let people in to grab something really quickly.
 

--- a/Resources/ServerInfo/Guidebook/Engineering/Airlocks.xml
+++ b/Resources/ServerInfo/Guidebook/Engineering/Airlocks.xml
@@ -1,4 +1,4 @@
-﻿<Document>
+<Document>
   # Airlocks
   Airlocks are used to control access to different areas of the station.
 
@@ -40,12 +40,12 @@
   </Box>
 
   <Box>
-    <GuideEntityEmbed Entity="DoorRemoteEngineering" Caption=""/>
-    <GuideEntityEmbed Entity="DoorRemoteCommand" Caption=""/>
-    <GuideEntityEmbed Entity="DoorRemoteMedical" Caption=""/>
-    <GuideEntityEmbed Entity="DoorRemoteService" Caption=""/>
-    <GuideEntityEmbed Entity="DoorRemoteSecurity" Caption=""/>
-    <GuideEntityEmbed Entity="DoorRemoteResearch" Caption=""/>
+    <GuideEntityEmbed Entity="DoorRemoteCe" Caption=""/>
+    <GuideEntityEmbed Entity="DoorRemoteCaptain" Caption=""/>
+    <GuideEntityEmbed Entity="DoorRemoteCmo" Caption=""/>
+    <GuideEntityEmbed Entity="DoorRemoteHop" Caption=""/>
+    <GuideEntityEmbed Entity="DoorRemoteHos" Caption=""/>
+    <GuideEntityEmbed Entity="DoorRemoteRd" Caption=""/>
   </Box>
   <Box>
     [color=#999999][italic]Precious door remotes. With unlimited power...[italic][/color]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds to #35536 

Removes all door remotes with their own access (except super and xenoborg because I didn't want to mess with that), and replaces them with door remotes that get the access of only the user.

Also renames them to [head]'s door remote

## Why / Balance
It doesn't make sense for heads to not be able to bolt or emergency access doors that they can access. (Big discussion in #35536)

## Technical details
I have _**NO IDEA**_ why there was a security door remote mapped in marathon, but there was, and I didn't want any errors or anything, so I just removed it.

Other than that is just YAML

## Media
![Content Client_ZLAdwMqtQ1](https://github.com/user-attachments/assets/4de52cf4-2f1a-4148-86b9-686a41bd4d40)
![Content Client_QDtHr01nJz](https://github.com/user-attachments/assets/0dbc28fa-0ed4-4725-86f7-990641556493)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
I hope not

**Changelog**
:cl:

- tweak: Door remotes now use the access of the owner, instead of having their own accesses.
- tweak: Door remotes are now named after their owner, not department.