### PR TITLE
Replace the hypopen with the Syndicate Hypospray.

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -171,6 +171,9 @@ uplink-binary-translator-key-desc = Lets you tap into the silicons' binary chann
 uplink-hypopen-name = Hypopen
 uplink-hypopen-desc = A chemical hypospray disguised as a pen, capable of instantly injecting up to 10u of reagents. Starts empty.
 
+uplink-hypospray-name = Syndicate Hypospray
+uplink-hypospray-desc = A chemical hypospray capable of instantly injecting 2.5u of reagents per use. Has an internal chemical storage of 15u and starts empty.
+
 uplink-voice-mask-name = Voice Mask
 uplink-voice-mask-desc = A gas mask that lets you adjust your voice to whoever you can think of. Also utilizes cutting-edge chameleon technology.
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -661,11 +661,11 @@
 #Chemicals
 
 - type: listing
-  id: UplinkHypopen
-  name: uplink-hypopen-name
-  description: uplink-hypopen-desc
-  icon: { sprite: /Textures/Objects/Misc/pens.rsi, state: pen }
-  productEntity: HypopenBox
+  id: UplinkHypospray
+  name: uplink-hypospray-name
+  description: uplink-hypospray-desc
+  icon: { sprite: /Textures/Objects/Specific/Medical/syndihypo.rsi, state: hypo }
+  productEntity: SyndiHypoTraitor
   discountCategory: rareDiscounts
   discountDownTo:
     Telecrystal: 4

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -73,6 +73,42 @@
     fillBaseName: hypo_fill
     solutionName: hypospray
 
+
+- type: entity
+  name: syndicate hypospray
+  parent: BaseItem
+  description: Using reverse engineered designs from NT, Cybersun made these hyposprays as a cheaper, less effective version of the ones they provided to Gorlex Marauders.
+  id: SyndiHypoTraitor
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Medical/syndihypo.rsi
+    layers:
+      - state: hypo
+        map: ["enum.SolutionContainerLayers.Base"]
+      - state: hypo_fill1
+        map: ["enum.SolutionContainerLayers.Fill"]
+        visible: false
+  - type: Item
+    sprite: Objects/Specific/Medical/syndihypo.rsi
+  - type: SolutionContainerManager
+    solutions:
+      hypospray:
+        maxVol: 15
+  - type: RefillableSolution
+    solution: hypospray
+  - type: ExaminableSolution
+    solution: hypospray
+  - type: Hypospray
+    onlyAffectsMobs: false
+    transferAmount: 2.5
+  - type: UseDelay
+    delay: 0.5
+  - type: Appearance
+  - type: SolutionContainerVisuals
+    maxFillLevels: 4
+    fillBaseName: hypo_fill
+    solutionName: hypospray
+
 - type: entity
   name: borghypo
   parent: BaseItem

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -86,7 +86,6 @@
       hypospray:
         maxVol: 15
   - type: Hypospray
-    onlyAffectsMobs: false
     transferAmount: 2.5
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -41,7 +41,7 @@
 
 - type: entity
   name: gorlex hypospray
-  parent: BaseItem
+  parent: [ BaseItem, BaseSyndicateContraband ]
   description: Using reverse engineered designs from NT, Cybersun produced these in limited quantities for Gorlex Marauder operatives.
   id: SyndiHypo
   components:
@@ -72,8 +72,6 @@
     maxFillLevels: 4
     fillBaseName: hypo_fill
     solutionName: hypospray
-  - type: Contraband
-    severity: Syndicate
 
 - type: entity
   name: syndicate hypospray

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -72,6 +72,8 @@
     maxFillLevels: 4
     fillBaseName: hypo_fill
     solutionName: hypospray
+  - type: Contraband
+    severity: Syndicate
 
 - type: entity
   name: syndicate hypospray

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -73,41 +73,19 @@
     fillBaseName: hypo_fill
     solutionName: hypospray
 
-
 - type: entity
   name: syndicate hypospray
-  parent: BaseItem
+  parent: SyndiHypo
   description: Using reverse engineered designs from NT, Cybersun made these hyposprays as a cheaper, less effective version of the ones they provided to Gorlex Marauders.
   id: SyndiHypoTraitor
   components:
-  - type: Sprite
-    sprite: Objects/Specific/Medical/syndihypo.rsi
-    layers:
-      - state: hypo
-        map: ["enum.SolutionContainerLayers.Base"]
-      - state: hypo_fill1
-        map: ["enum.SolutionContainerLayers.Fill"]
-        visible: false
-  - type: Item
-    sprite: Objects/Specific/Medical/syndihypo.rsi
   - type: SolutionContainerManager
     solutions:
       hypospray:
         maxVol: 15
-  - type: RefillableSolution
-    solution: hypospray
-  - type: ExaminableSolution
-    solution: hypospray
   - type: Hypospray
     onlyAffectsMobs: false
     transferAmount: 2.5
-  - type: UseDelay
-    delay: 0.5
-  - type: Appearance
-  - type: SolutionContainerVisuals
-    maxFillLevels: 4
-    fillBaseName: hypo_fill
-    solutionName: hypospray
 
 - type: entity
   name: borghypo


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The hypopen has been removed from the uplink. It has been replaced by the Syndicate Hypospray, which is not a stealth item, injects half as quickly as the old hypopen (2.5u a click), but has an increased chemical storage (up to 15u).

It also makes the Gorlex hypospray Syndicate contraband. The Syndicate hypospray parents off of it so this means the syndicate hypospray is also contraband.

## Why / Balance
The hypopen is absurdly overpowered, even if nocturine receives the 6 second sleep delay. It allows for instant administration of chemicals into other players absurdly quickly, which when used with nocturine, pax or lexorin creates an uncounterable situation. It is also a stealth item for some reason, meaning that even if the traitor walked up to you with it in their hand, you weren't able to react until there were already chems in your system. It also meant there was zero value in stealing the CMO's hypospray as you could get one that was functionally the same for all purposes a traitor needed from your uplink.

This new hypospray gives the victim adequate time to react to having chemicals forced into their system as it can only inject half as much of a chemical in a given timespan. It is also obviously a syndicate item, meaning that they may be able to react to the traitor before they can get their first injection off.

As for making the gorlex hypospray Syndicate contraband, I'm not sure why it wasn't in the first place.

This idea was suggested by 2DSiggy in the SS14 discord.
![image](https://github.com/user-attachments/assets/4bfdc286-58d0-45e5-896f-04b655c8f23b)


## Technical details
Removed the listing for the hypopen from uplink_catalog, replaced it with one for the syndicate hypospray
Added a new prototype for the syndicate hypospray (SyndiHypoTraitor). It currently uses the same sprite as the gorlex hypospray (syndihypo.rsi)


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
A video showing the new hypospray. First beaker contains nocturine, second contains lexorin. Note that for the lexorin injection, only 2 injections were made; the third injection was caused by a bug. Fixing that bug is out of the PR's scope and I'm also not sure what causes it.

https://github.com/user-attachments/assets/ab7ad739-b8e0-4b77-aab1-7e6db6ed1990

![image](https://github.com/user-attachments/assets/b8911df8-1c80-402e-9f78-4cc735299488)



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: SuperGDPWYL, 2DSiggy
- remove: The hypopen has been removed from the uplink.
- add: A new type of hypospray, the syndicate hypospray, has been added to the uplink. It injects 2.5u of a reagent per click but has an increased storage of 15u.
- tweak: The gorlex hypospray is now Syndicate contraband.