### PR TITLE
Fixes missing underwear FTLs

### DIFF
--- a/Resources/Locale/en-US/markings/undergarment.ftl
+++ b/Resources/Locale/en-US/markings/undergarment.ftl
@@ -1,21 +1,21 @@
-marking-UndergarmentTopTanktop-tanktop = Tanktop
-marking-UndergarmentTopBinder-binder = Binder
-marking-UndergarmentTopBra-classic = Classic Bra
-marking-UndergarmentTopSportsbra-sports = Sports Bra
+marking-UndergarmentTopTanktop = Tanktop
+marking-UndergarmentTopBinder = Binder
+marking-UndergarmentTopBra = Classic Bra
+marking-UndergarmentTopSportsbra = Sports Bra
 
-marking-UndergarmentBottomBoxers-boxers = Boxers
-marking-UndergarmentBottomBriefs-briefs = Briefs
-marking-UndergarmentBottomSatin-satin = Satin
+marking-UndergarmentBottomBoxers = Boxers
+marking-UndergarmentBottomBriefs = Briefs
+marking-UndergarmentBottomSatin = Satin
 
-marking-UndergarmentTopTanktopVox-tanktop_vox = Tanktop
-marking-UndergarmentTopBinderVox-binder_vox = Binder
-marking-UndergarmentTopBraVox-classic_vox = Classic Bra
-marking-UndergarmentTopSportsbraVox-sports_vox = Sports Bra
+marking-UndergarmentTopTanktopVox = Tanktop
+marking-UndergarmentTopBinderVox = Binder
+marking-UndergarmentTopBraVox = Classic Bra
+marking-UndergarmentTopSportsbraVox = Sports Bra
 
-marking-UndergarmentBottomBoxersVox-boxers_vox = Boxers
-marking-UndergarmentBottomBriefsVox-briefs_vox = Briefs
-marking-UndergarmentBottomSatinVox-satin_vox = Satin
+marking-UndergarmentBottomBoxersVox = Boxers
+marking-UndergarmentBottomBriefsVox = Briefs
+marking-UndergarmentBottomSatinVox = Satin
 
-marking-UndergarmentBottomBoxersReptilian-boxers_reptilian = Boxers
-marking-UndergarmentBottomBriefsReptilian-briefs_reptilian = Briefs
-marking-UndergarmentBottomSatinReptilian-satin_reptilian = Satin
+marking-UndergarmentBottomBoxersReptilian = Boxers
+marking-UndergarmentBottomBriefsReptilian = Briefs
+marking-UndergarmentBottomSatinReptilian = Satin


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes the trailing things added by #38304, which apparently fixes the fact they have missing FTL entries. I have no clue why they were added in the first place but this seems to fix things

(I am Minerva on the discord! Formerly Kirby)
## Media
(vox and human also work but I'm too lazy to take more screenshots)
![image](https://github.com/user-attachments/assets/41ba3652-8c01-4f3a-a6a7-96dea6789ead)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
