### PR TITLE
Validate `ShaderPrototype` IDs

### DIFF
--- a/Content.Benchmarks/SpawnEquipDeleteBenchmark.cs
+++ b/Content.Benchmarks/SpawnEquipDeleteBenchmark.cs
@@ -8,6 +8,7 @@ using Robust.Shared;
 using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
 
 namespace Content.Benchmarks;
 
@@ -18,9 +19,11 @@ namespace Content.Benchmarks;
 [Virtual, MemoryDiagnoser]
 public class SpawnEquipDeleteBenchmark
 {
+    private static readonly EntProtoId Mob = "MobHuman";
+    private static readonly ProtoId<StartingGearPrototype> CaptainStartingGear = "CaptainGear";
+
     private TestPair _pair = default!;
     private StationSpawningSystem _spawnSys = default!;
-    private const string Mob = "MobHuman";
     private StartingGearPrototype _gear = default!;
     private EntityUid _entity;
     private EntityCoordinates _coords;
@@ -39,7 +42,7 @@ public class SpawnEquipDeleteBenchmark
         var mapData = await _pair.CreateTestMap();
         _coords = mapData.GridCoords;
         _spawnSys = server.System<StationSpawningSystem>();
-        _gear = server.ProtoMan.Index<StartingGearPrototype>("CaptainGear");
+        _gear = server.ProtoMan.Index(CaptainStartingGear);
     }
 
     [GlobalCleanup]

--- a/Content.Client/Access/UI/GroupedAccessLevelChecklist.xaml.cs
+++ b/Content.Client/Access/UI/GroupedAccessLevelChecklist.xaml.cs
@@ -15,6 +15,8 @@ namespace Content.Client.Access.UI;
 [GenerateTypedNameReferences]
 public sealed partial class GroupedAccessLevelChecklist : BoxContainer
 {
+    private static readonly ProtoId<AccessGroupPrototype> GeneralAccessGroup = "General";
+
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
 
     private bool _isMonotone;
@@ -63,7 +65,7 @@ public sealed partial class GroupedAccessLevelChecklist : BoxContainer
 
         // Ensure that the 'general' access group is added to handle
         // misc. access levels that aren't associated with any group
-        if (_protoManager.TryIndex<AccessGroupPrototype>("General", out var generalAccessProto))
+        if (_protoManager.TryIndex(GeneralAccessGroup, out var generalAccessProto))
             _groupedAccessLevels.TryAdd(generalAccessProto, new());
 
         // Assign known access levels with their associated groups

--- a/Content.Client/Access/UI/GroupedAccessLevelChecklist.xaml.cs
+++ b/Content.Client/Access/UI/GroupedAccessLevelChecklist.xaml.cs
@@ -15,8 +15,6 @@ namespace Content.Client.Access.UI;
 [GenerateTypedNameReferences]
 public sealed partial class GroupedAccessLevelChecklist : BoxContainer
 {
-    private static readonly ProtoId<AccessGroupPrototype> GeneralAccessGroup = "General";
-
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
 
     private bool _isMonotone;
@@ -65,7 +63,7 @@ public sealed partial class GroupedAccessLevelChecklist : BoxContainer
 
         // Ensure that the 'general' access group is added to handle
         // misc. access levels that aren't associated with any group
-        if (_protoManager.TryIndex(GeneralAccessGroup, out var generalAccessProto))
+        if (_protoManager.TryIndex<AccessGroupPrototype>("General", out var generalAccessProto))
             _groupedAccessLevels.TryAdd(generalAccessProto, new());
 
         // Assign known access levels with their associated groups

--- a/Content.Client/Atmos/Overlays/GasTileOverlay.cs
+++ b/Content.Client/Atmos/Overlays/GasTileOverlay.cs
@@ -19,6 +19,8 @@ namespace Content.Client.Atmos.Overlays
 {
     public sealed class GasTileOverlay : Overlay
     {
+        private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+
         private readonly IEntityManager _entManager;
         private readonly IMapManager _mapManager;
         private readonly SharedMapSystem _mapSystem;
@@ -54,7 +56,7 @@ namespace Content.Client.Atmos.Overlays
             _mapManager = IoCManager.Resolve<IMapManager>();
             _mapSystem = entManager.System<SharedMapSystem>();
             _xformSys = xformSys;
-            _shader = protoMan.Index<ShaderPrototype>("unshaded").Instance();
+            _shader = protoMan.Index(UnshadedShader).Instance();
             ZIndex = GasOverlayZIndex;
 
             _gasCount = system.VisibleGasId.Length;

--- a/Content.Client/CombatMode/ColoredScreenBorderOverlay.cs
+++ b/Content.Client/CombatMode/ColoredScreenBorderOverlay.cs
@@ -8,6 +8,8 @@ namespace Content.Client.CombatMode
 {
     public sealed class ColoredScreenBorderOverlay : Overlay
     {
+        private static readonly ProtoId<ShaderPrototype> Shader = "ColoredScreenBorder";
+
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
         public override OverlaySpace Space => OverlaySpace.WorldSpace;
@@ -16,7 +18,7 @@ namespace Content.Client.CombatMode
         public ColoredScreenBorderOverlay()
         {
             IoCManager.InjectDependencies(this);
-            _shader = _prototypeManager.Index<ShaderPrototype>("ColoredScreenBorder").Instance();
+            _shader = _prototypeManager.Index(Shader).Instance();
         }
 
         protected override void Draw(in OverlayDrawArgs args)

--- a/Content.Client/Cooldown/CooldownGraphic.cs
+++ b/Content.Client/Cooldown/CooldownGraphic.cs
@@ -7,6 +7,8 @@ namespace Content.Client.Cooldown
 {
     public sealed class CooldownGraphic : Control
     {
+        private static readonly ProtoId<ShaderPrototype> Shader = "CooldownAnimation";
+
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IPrototypeManager _protoMan = default!;
 
@@ -15,7 +17,7 @@ namespace Content.Client.Cooldown
         public CooldownGraphic()
         {
             IoCManager.InjectDependencies(this);
-            _shader = _protoMan.Index<ShaderPrototype>("CooldownAnimation").InstanceUnique();
+            _shader = _protoMan.Index(Shader).InstanceUnique();
         }
 
         /// <summary>

--- a/Content.Client/Delivery/DeliveryVisualizerSystem.cs
+++ b/Content.Client/Delivery/DeliveryVisualizerSystem.cs
@@ -7,6 +7,8 @@ namespace Content.Client.Delivery;
 
 public sealed class DeliveryVisualizerSystem : VisualizerSystem<DeliveryComponent>
 {
+    private static readonly EntProtoId JobIconUnknown = "JobIconUnknown";
+
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
 
@@ -24,7 +26,7 @@ public sealed class DeliveryVisualizerSystem : VisualizerSystem<DeliveryComponen
 
         if (!_prototype.TryIndex<JobIconPrototype>(job, out var icon))
         {
-            SpriteSystem.LayerSetTexture((uid, args.Sprite), DeliveryVisualLayers.JobStamp, SpriteSystem.Frame0(_prototype.Index("JobIconUnknown")));
+            SpriteSystem.LayerSetTexture((uid, args.Sprite), DeliveryVisualLayers.JobStamp, SpriteSystem.Frame0(_prototype.Index(JobIconUnknown)));
             return;
         }
 

--- a/Content.Client/Delivery/DeliveryVisualizerSystem.cs
+++ b/Content.Client/Delivery/DeliveryVisualizerSystem.cs
@@ -7,8 +7,6 @@ namespace Content.Client.Delivery;
 
 public sealed class DeliveryVisualizerSystem : VisualizerSystem<DeliveryComponent>
 {
-    private static readonly EntProtoId JobIconUnknown = "JobIconUnknown";
-
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
 
@@ -26,7 +24,7 @@ public sealed class DeliveryVisualizerSystem : VisualizerSystem<DeliveryComponen
 
         if (!_prototype.TryIndex<JobIconPrototype>(job, out var icon))
         {
-            SpriteSystem.LayerSetTexture((uid, args.Sprite), DeliveryVisualLayers.JobStamp, SpriteSystem.Frame0(_prototype.Index(JobIconUnknown)));
+            SpriteSystem.LayerSetTexture((uid, args.Sprite), DeliveryVisualLayers.JobStamp, SpriteSystem.Frame0(_prototype.Index("JobIconUnknown")));
             return;
         }
 

--- a/Content.Client/DoAfter/DoAfterOverlay.cs
+++ b/Content.Client/DoAfter/DoAfterOverlay.cs
@@ -14,6 +14,8 @@ namespace Content.Client.DoAfter;
 
 public sealed class DoAfterOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+
     private readonly IEntityManager _entManager;
     private readonly IGameTiming _timing;
     private readonly IPlayerManager _player;
@@ -50,7 +52,7 @@ public sealed class DoAfterOverlay : Overlay
         var sprite = new SpriteSpecifier.Rsi(new("/Textures/Interface/Misc/progress_bar.rsi"), "icon");
         _barTexture = _entManager.EntitySysManager.GetEntitySystem<SpriteSystem>().Frame0(sprite);
 
-        _unshadedShader = protoManager.Index<ShaderPrototype>("unshaded").Instance();
+        _unshadedShader = protoManager.Index(UnshadedShader).Instance();
     }
 
     protected override void Draw(in OverlayDrawArgs args)

--- a/Content.Client/Drowsiness/DrowsinessOverlay.cs
+++ b/Content.Client/Drowsiness/DrowsinessOverlay.cs
@@ -10,6 +10,8 @@ namespace Content.Client.Drowsiness;
 
 public sealed class DrowsinessOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> Shader = "Drowsiness";
+
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -33,7 +35,7 @@ public sealed class DrowsinessOverlay : Overlay
 
         _statusEffects = _sysMan.GetEntitySystem<SharedStatusEffectsSystem>();
 
-        _drowsinessShader = _prototypeManager.Index<ShaderPrototype>("Drowsiness").InstanceUnique();
+        _drowsinessShader = _prototypeManager.Index(Shader).InstanceUnique();
     }
 
     protected override void FrameUpdate(FrameEventArgs args)

--- a/Content.Client/Drugs/RainbowOverlay.cs
+++ b/Content.Client/Drugs/RainbowOverlay.cs
@@ -12,6 +12,8 @@ namespace Content.Client.Drugs;
 
 public sealed class RainbowOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> Shader = "Rainbow";
+
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
@@ -41,7 +43,7 @@ public sealed class RainbowOverlay : Overlay
 
         _statusEffects = _sysMan.GetEntitySystem<SharedStatusEffectsSystem>();
 
-        _rainbowShader = _prototypeManager.Index<ShaderPrototype>("Rainbow").InstanceUnique();
+        _rainbowShader = _prototypeManager.Index(Shader).InstanceUnique();
         _config.OnValueChanged(CCVars.ReducedMotion, OnReducedMotionChanged, invokeImmediately: true);
     }
 

--- a/Content.Client/Drunk/DrunkOverlay.cs
+++ b/Content.Client/Drunk/DrunkOverlay.cs
@@ -10,6 +10,8 @@ namespace Content.Client.Drunk;
 
 public sealed class DrunkOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> Shader = "Drunk";
+
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -30,7 +32,7 @@ public sealed class DrunkOverlay : Overlay
     public DrunkOverlay()
     {
         IoCManager.InjectDependencies(this);
-        _drunkShader = _prototypeManager.Index<ShaderPrototype>("Drunk").InstanceUnique();
+        _drunkShader = _prototypeManager.Index(Shader).InstanceUnique();
     }
 
     protected override void FrameUpdate(FrameEventArgs args)

--- a/Content.Client/Explosion/ExplosionOverlay.cs
+++ b/Content.Client/Explosion/ExplosionOverlay.cs
@@ -13,6 +13,8 @@ namespace Content.Client.Explosion;
 [UsedImplicitly]
 public sealed class ExplosionOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly IEntityManager _entMan = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
@@ -26,7 +28,7 @@ public sealed class ExplosionOverlay : Overlay
     public ExplosionOverlay(SharedAppearanceSystem appearanceSystem)
     {
         IoCManager.InjectDependencies(this);
-        _shader = _proto.Index<ShaderPrototype>("unshaded").Instance();
+        _shader = _proto.Index(UnshadedShader).Instance();
         _transformSystem = _entMan.System<SharedTransformSystem>();
         _appearance = appearanceSystem;
     }

--- a/Content.Client/Eye/Blinding/BlindOverlay.cs
+++ b/Content.Client/Eye/Blinding/BlindOverlay.cs
@@ -12,6 +12,9 @@ namespace Content.Client.Eye.Blinding
 {
     public sealed class BlindOverlay : Overlay
     {
+        private static readonly ProtoId<ShaderPrototype> GreyscaleShader = "GreyscaleFullscreen";
+        private static readonly ProtoId<ShaderPrototype> CircleShader = "CircleMask";
+
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
@@ -27,8 +30,8 @@ namespace Content.Client.Eye.Blinding
         public BlindOverlay()
         {
             IoCManager.InjectDependencies(this);
-            _greyscaleShader = _prototypeManager.Index<ShaderPrototype>("GreyscaleFullscreen").InstanceUnique();
-            _circleMaskShader = _prototypeManager.Index<ShaderPrototype>("CircleMask").InstanceUnique();
+            _greyscaleShader = _prototypeManager.Index(GreyscaleShader).InstanceUnique();
+            _circleMaskShader = _prototypeManager.Index(CircleShader).InstanceUnique();
         }
         protected override bool BeforeDraw(in OverlayDrawArgs args)
         {

--- a/Content.Client/Eye/Blinding/BlurryVisionOverlay.cs
+++ b/Content.Client/Eye/Blinding/BlurryVisionOverlay.cs
@@ -10,6 +10,9 @@ namespace Content.Client.Eye.Blinding
 {
     public sealed class BlurryVisionOverlay : Overlay
     {
+        private static readonly ProtoId<ShaderPrototype> CataractsShader = "Cataracts";
+        private static readonly ProtoId<ShaderPrototype> CircleShader = "CircleMask";
+
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
@@ -33,8 +36,8 @@ namespace Content.Client.Eye.Blinding
         public BlurryVisionOverlay()
         {
             IoCManager.InjectDependencies(this);
-            _cataractsShader = _prototypeManager.Index<ShaderPrototype>("Cataracts").InstanceUnique();
-            _circleMaskShader = _prototypeManager.Index<ShaderPrototype>("CircleMask").InstanceUnique();
+            _cataractsShader = _prototypeManager.Index(CataractsShader).InstanceUnique();
+            _circleMaskShader = _prototypeManager.Index(CircleShader).InstanceUnique();
 
             _circleMaskShader.SetParameter("CircleMinDist", 0.0f);
             _circleMaskShader.SetParameter("CirclePow", NoMotion_Pow);

--- a/Content.Client/Flash/FlashOverlay.cs
+++ b/Content.Client/Flash/FlashOverlay.cs
@@ -11,6 +11,8 @@ namespace Content.Client.Flash
 {
     public sealed class FlashOverlay : Overlay
     {
+        private static readonly ProtoId<ShaderPrototype> FlashedEffectShader = "FlashedEffect";
+
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -27,7 +29,7 @@ namespace Content.Client.Flash
         public FlashOverlay()
         {
             IoCManager.InjectDependencies(this);
-            _shader = _prototypeManager.Index<ShaderPrototype>("FlashedEffect").InstanceUnique();
+            _shader = _prototypeManager.Index(FlashedEffectShader).InstanceUnique();
             _flash = _entityManager.System<SharedFlashSystem>();
             _statusSys = _entityManager.System<StatusEffectsSystem>();
         }

--- a/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
+++ b/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
@@ -7,16 +7,13 @@ namespace Content.Client.Interactable.Components
     [RegisterComponent]
     public sealed partial class InteractionOutlineComponent : Component
     {
+        private static readonly ProtoId<ShaderPrototype> ShaderInRange = "SelectionOutlineInrange";
+        private static readonly ProtoId<ShaderPrototype> ShaderOutOfRange = "SelectionOutline";
+
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IEntityManager _entMan = default!;
 
         private const float DefaultWidth = 1;
-
-        [ValidatePrototypeId<ShaderPrototype>]
-        private const string ShaderInRange = "SelectionOutlineInrange";
-
-        [ValidatePrototypeId<ShaderPrototype>]
-        private const string ShaderOutOfRange = "SelectionOutline";
 
         private bool _inRange;
         private ShaderInstance? _shader;
@@ -65,7 +62,7 @@ namespace Content.Client.Interactable.Components
         {
             var shaderName = inRange ? ShaderInRange : ShaderOutOfRange;
 
-            var instance = _prototypeManager.Index<ShaderPrototype>(shaderName).InstanceUnique();
+            var instance = _prototypeManager.Index(shaderName).InstanceUnique();
             instance.SetParameter("outline_width", DefaultWidth * renderScale);
             return instance;
         }

--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -29,6 +29,10 @@ namespace Content.Client.Interaction;
 /// </summary>
 public sealed class DragDropSystem : SharedDragDropSystem
 {
+    private static readonly ProtoId<ShaderPrototype> ShaderDropTargetInRange = "SelectionOutlineInrange";
+
+    private static readonly ProtoId<ShaderPrototype> ShaderDropTargetOutOfRange = "SelectionOutline";
+
     [Dependency] private readonly IStateManager _stateManager = default!;
     [Dependency] private readonly IInputManager _inputManager = default!;
     [Dependency] private readonly IEyeManager _eyeManager = default!;
@@ -53,12 +57,6 @@ public sealed class DragDropSystem : SharedDragDropSystem
     // amount of time since the mousedown, we will "replay" the original
     // mousedown event so it can be treated like a regular click
     private const float MaxMouseDownTimeForReplayingClick = 0.85f;
-
-    [ValidatePrototypeId<ShaderPrototype>]
-    private const string ShaderDropTargetInRange = "SelectionOutlineInrange";
-
-    [ValidatePrototypeId<ShaderPrototype>]
-    private const string ShaderDropTargetOutOfRange = "SelectionOutline";
 
     /// <summary>
     /// Current entity being dragged around.
@@ -113,8 +111,8 @@ public sealed class DragDropSystem : SharedDragDropSystem
 
         Subs.CVar(_cfgMan, CCVars.DragDropDeadZone, SetDeadZone, true);
 
-        _dropTargetInRangeShader = _prototypeManager.Index<ShaderPrototype>(ShaderDropTargetInRange).Instance();
-        _dropTargetOutOfRangeShader = _prototypeManager.Index<ShaderPrototype>(ShaderDropTargetOutOfRange).Instance();
+        _dropTargetInRangeShader = _prototypeManager.Index(ShaderDropTargetInRange).Instance();
+        _dropTargetOutOfRangeShader = _prototypeManager.Index(ShaderDropTargetOutOfRange).Instance();
         // needs to fire on mouseup and mousedown so we can detect a drag / drop
         CommandBinds.Builder
             .BindBefore(EngineKeyFunctions.Use, new PointerInputCmdHandler(OnUse, false, true), new[] { typeof(SharedInteractionSystem) })

--- a/Content.Client/Light/AmbientOcclusionOverlay.cs
+++ b/Content.Client/Light/AmbientOcclusionOverlay.cs
@@ -15,6 +15,10 @@ namespace Content.Client.Light;
 /// </summary>
 public sealed class AmbientOcclusionOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+    private static readonly ProtoId<ShaderPrototype> StencilMaskShader = "StencilMask";
+    private static readonly ProtoId<ShaderPrototype> StencilEqualDrawShader = "StencilEqualDraw";
+
     [Dependency] private readonly IClyde _clyde = default!;
     [Dependency] private readonly IConfigurationManager _cfgManager = default!;
     [Dependency] private readonly IEntityManager _entManager = default!;
@@ -87,7 +91,7 @@ public sealed class AmbientOcclusionOverlay : Overlay
         args.WorldHandle.RenderInRenderTarget(_aoTarget,
             () =>
             {
-                worldHandle.UseShader(_proto.Index<ShaderPrototype>("unshaded").Instance());
+                worldHandle.UseShader(_proto.Index(UnshadedShader).Instance());
                 var invMatrix = _aoTarget.GetWorldToLocalMatrix(viewport.Eye!, scale);
 
                 foreach (var entry in query.QueryAabb(mapId, worldBounds))
@@ -110,7 +114,7 @@ public sealed class AmbientOcclusionOverlay : Overlay
             () =>
             {
                 // Don't want lighting affecting it.
-                worldHandle.UseShader(_proto.Index<ShaderPrototype>("unshaded").Instance());
+                worldHandle.UseShader(_proto.Index(UnshadedShader).Instance());
 
                 foreach (var grid in _mapManager.FindGridsIntersecting(mapId, worldBounds))
                 {
@@ -131,11 +135,11 @@ public sealed class AmbientOcclusionOverlay : Overlay
             }, Color.Transparent);
 
         // Draw the stencil texture to depth buffer.
-        worldHandle.UseShader(_proto.Index<ShaderPrototype>("StencilMask").Instance());
+        worldHandle.UseShader(_proto.Index(StencilMaskShader).Instance());
         worldHandle.DrawTextureRect(_aoStencilTarget!.Texture, worldBounds);
 
         // Draw the Blurred AO texture finally.
-        worldHandle.UseShader(_proto.Index<ShaderPrototype>("StencilEqualDraw").Instance());
+        worldHandle.UseShader(_proto.Index(StencilEqualDrawShader).Instance());
         worldHandle.DrawTextureRect(_aoTarget!.Texture, worldBounds, color);
 
         args.WorldHandle.SetTransform(Matrix3x2.Identity);

--- a/Content.Client/Light/SunShadowOverlay.cs
+++ b/Content.Client/Light/SunShadowOverlay.cs
@@ -11,6 +11,8 @@ namespace Content.Client.Light;
 
 public sealed class SunShadowOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> MixShader = "Mix";
+
     public override OverlaySpace Space => OverlaySpace.BeforeLighting;
 
     [Dependency] private readonly IClyde _clyde = default!;
@@ -150,7 +152,7 @@ public sealed class SunShadowOverlay : Overlay
                         viewport.LightRenderTarget.GetWorldToLocalMatrix(eye, scale);
                     worldHandle.SetTransform(invMatrix);
 
-                    var maskShader = _protoManager.Index<ShaderPrototype>("Mix").Instance();
+                    var maskShader = _protoManager.Index(MixShader).Instance();
                     worldHandle.UseShader(maskShader);
 
                     worldHandle.DrawTextureRect(_target.Texture, worldBounds, Color.Black.WithAlpha(alpha));

--- a/Content.Client/Mapping/MappingOverlay.cs
+++ b/Content.Client/Mapping/MappingOverlay.cs
@@ -11,6 +11,8 @@ namespace Content.Client.Mapping;
 
 public sealed class MappingOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+
     [Dependency] private readonly IEntityManager _entities = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
@@ -35,7 +37,7 @@ public sealed class MappingOverlay : Overlay
         _sprite = _entities.System<SpriteSystem>();
 
         _state = state;
-        _shader = _prototypes.Index<ShaderPrototype>("unshaded").Instance();
+        _shader = _prototypes.Index(UnshadedShader).Instance();
     }
 
     protected override void Draw(in OverlayDrawArgs args)

--- a/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
+++ b/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
@@ -8,6 +8,8 @@ namespace Content.Client.Movement.Systems;
 
 public sealed class FloorOcclusionSystem : SharedFloorOcclusionSystem
 {
+    private static readonly ProtoId<ShaderPrototype> HorizontalCut = "HorizontalCut";
+
     [Dependency] private readonly IPrototypeManager _proto = default!;
 
     private EntityQuery<SpriteComponent> _spriteQuery;
@@ -48,7 +50,7 @@ public sealed class FloorOcclusionSystem : SharedFloorOcclusionSystem
         if (!_spriteQuery.Resolve(sprite.Owner, ref sprite.Comp, false))
             return;
 
-        var shader = _proto.Index<ShaderPrototype>("HorizontalCut").Instance();
+        var shader = _proto.Index(HorizontalCut).Instance();
 
         if (sprite.Comp.PostShader is not null && sprite.Comp.PostShader != shader)
             return;

--- a/Content.Client/Outline/TargetOutlineSystem.cs
+++ b/Content.Client/Outline/TargetOutlineSystem.cs
@@ -15,6 +15,9 @@ namespace Content.Client.Outline;
 /// </summary>
 public sealed class TargetOutlineSystem : EntitySystem
 {
+    private static readonly ProtoId<ShaderPrototype> ShaderTargetValid = "SelectionOutlineInrange";
+    private static readonly ProtoId<ShaderPrototype> ShaderTargetInvalid = "SelectionOutline";
+
     [Dependency] private readonly IEyeManager _eyeManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
@@ -70,12 +73,6 @@ public sealed class TargetOutlineSystem : EntitySystem
 
     private Vector2 LookupVector => new(LookupSize, LookupSize);
 
-    [ValidatePrototypeId<ShaderPrototype>]
-    private const string ShaderTargetValid = "SelectionOutlineInrange";
-
-    [ValidatePrototypeId<ShaderPrototype>]
-    private const string ShaderTargetInvalid = "SelectionOutline";
-
     private ShaderInstance? _shaderTargetValid;
     private ShaderInstance? _shaderTargetInvalid;
 
@@ -85,8 +82,8 @@ public sealed class TargetOutlineSystem : EntitySystem
     {
         base.Initialize();
 
-        _shaderTargetValid = _prototypeManager.Index<ShaderPrototype>(ShaderTargetValid).InstanceUnique();
-        _shaderTargetInvalid = _prototypeManager.Index<ShaderPrototype>(ShaderTargetInvalid).InstanceUnique();
+        _shaderTargetValid = _prototypeManager.Index(ShaderTargetValid).InstanceUnique();
+        _shaderTargetInvalid = _prototypeManager.Index(ShaderTargetInvalid).InstanceUnique();
     }
 
     public void Disable()

--- a/Content.Client/Overlays/BlackAndWhiteOverlay.cs
+++ b/Content.Client/Overlays/BlackAndWhiteOverlay.cs
@@ -6,6 +6,8 @@ namespace Content.Client.Overlays;
 
 public sealed partial class BlackAndWhiteOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> Shader = "GreyscaleFullscreen";
+
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
@@ -15,7 +17,7 @@ public sealed partial class BlackAndWhiteOverlay : Overlay
     public BlackAndWhiteOverlay()
     {
         IoCManager.InjectDependencies(this);
-        _greyscaleShader = _prototypeManager.Index<ShaderPrototype>("GreyscaleFullscreen").InstanceUnique();
+        _greyscaleShader = _prototypeManager.Index(Shader).InstanceUnique();
         ZIndex = 10; // draw this over the DamageOverlay, RainbowOverlay etc.
     }
 

--- a/Content.Client/Overlays/NoirOverlay.cs
+++ b/Content.Client/Overlays/NoirOverlay.cs
@@ -6,6 +6,8 @@ namespace Content.Client.Overlays;
 
 public sealed partial class NoirOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> Shader = "Noir";
+
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
@@ -15,7 +17,7 @@ public sealed partial class NoirOverlay : Overlay
     public NoirOverlay()
     {
         IoCManager.InjectDependencies(this);
-        _noirShader = _prototypeManager.Index<ShaderPrototype>("Noir").InstanceUnique();
+        _noirShader = _prototypeManager.Index(Shader).InstanceUnique();
         ZIndex = 9; // draw this over the DamageOverlay, RainbowOverlay etc, but before the black and white shader
     }
 

--- a/Content.Client/Overlays/StencilOverlay.RestrictedRange.cs
+++ b/Content.Client/Overlays/StencilOverlay.RestrictedRange.cs
@@ -45,13 +45,13 @@ public sealed partial class StencilOverlay
         }, Color.Transparent);
 
         worldHandle.SetTransform(Matrix3x2.Identity);
-        worldHandle.UseShader(_protoManager.Index<ShaderPrototype>("StencilMask").Instance());
+        worldHandle.UseShader(_protoManager.Index(StencilMask).Instance());
         worldHandle.DrawTextureRect(_blep!.Texture, worldBounds);
         var curTime = _timing.RealTime;
         var sprite = _sprite.GetFrame(new SpriteSpecifier.Texture(new ResPath("/Textures/Parallaxes/noise.png")), curTime);
 
         // Draw the rain
-        worldHandle.UseShader(_protoManager.Index<ShaderPrototype>("StencilDraw").Instance());
+        worldHandle.UseShader(_protoManager.Index(StencilDraw).Instance());
         _parallax.DrawParallax(worldHandle, worldAABB, sprite, curTime, position, new Vector2(0.5f, 0f));
     }
 }

--- a/Content.Client/Overlays/StencilOverlay.Weather.cs
+++ b/Content.Client/Overlays/StencilOverlay.Weather.cs
@@ -55,13 +55,13 @@ public sealed partial class StencilOverlay
         }, Color.Transparent);
 
         worldHandle.SetTransform(Matrix3x2.Identity);
-        worldHandle.UseShader(_protoManager.Index<ShaderPrototype>("StencilMask").Instance());
+        worldHandle.UseShader(_protoManager.Index(StencilMask).Instance());
         worldHandle.DrawTextureRect(_blep!.Texture, worldBounds);
         var curTime = _timing.RealTime;
         var sprite = _sprite.GetFrame(weatherProto.Sprite, curTime);
 
         // Draw the rain
-        worldHandle.UseShader(_protoManager.Index<ShaderPrototype>("StencilDraw").Instance());
+        worldHandle.UseShader(_protoManager.Index(StencilDraw).Instance());
         _parallax.DrawParallax(worldHandle, worldAABB, sprite, curTime, position, Vector2.Zero, modulate: (weatherProto.Color ?? Color.White).WithAlpha(alpha));
 
         worldHandle.SetTransform(Matrix3x2.Identity);

--- a/Content.Client/Overlays/StencilOverlay.cs
+++ b/Content.Client/Overlays/StencilOverlay.cs
@@ -17,6 +17,10 @@ namespace Content.Client.Overlays;
 /// </summary>
 public sealed partial class StencilOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> CircleShader = "WorldGradientCircle";
+    private static readonly ProtoId<ShaderPrototype> StencilMask = "StencilMask";
+    private static readonly ProtoId<ShaderPrototype> StencilDraw = "StencilDraw";
+
     [Dependency] private readonly IClyde _clyde = default!;
     [Dependency] private readonly IEntityManager _entManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -43,7 +47,7 @@ public sealed partial class StencilOverlay : Overlay
         _sprite = sprite;
         _weather = weather;
         IoCManager.InjectDependencies(this);
-        _shader = _protoManager.Index<ShaderPrototype>("WorldGradientCircle").InstanceUnique();
+        _shader = _protoManager.Index(CircleShader).InstanceUnique();
     }
 
     protected override void Draw(in OverlayDrawArgs args)

--- a/Content.Client/Paper/UI/StampLabel.xaml.cs
+++ b/Content.Client/Paper/UI/StampLabel.xaml.cs
@@ -10,6 +10,8 @@ namespace Content.Client.Paper.UI;
 [GenerateTypedNameReferences]
 public sealed partial class StampLabel : Label
 {
+    private static readonly ProtoId<ShaderPrototype> PaperStamp = "PaperStamp";
+
     /// A scale that's applied to the text to ensure it
     /// fits in the allowed space.
     private Vector2 _textScaling = Vector2.One;
@@ -26,7 +28,7 @@ public sealed partial class StampLabel : Label
         RobustXamlLoader.Load(this);
 
         var prototypes = IoCManager.Resolve<IPrototypeManager>();
-        _stampShader = prototypes.Index<ShaderPrototype>("PaperStamp").InstanceUnique();
+        _stampShader = prototypes.Index(PaperStamp).InstanceUnique();
     }
 
     protected override Vector2 MeasureOverride(Vector2 availableSize)

--- a/Content.Client/Paper/UI/StampWidget.xaml.cs
+++ b/Content.Client/Paper/UI/StampWidget.xaml.cs
@@ -12,6 +12,8 @@ namespace Content.Client.Paper.UI;
 [GenerateTypedNameReferences]
 public sealed partial class StampWidget : PanelContainer
 {
+    private static readonly ProtoId<ShaderPrototype> PaperStamp = "PaperStamp";
+
     private StyleBoxTexture _borderTexture;
     private ShaderInstance? _stampShader;
 
@@ -42,7 +44,7 @@ public sealed partial class StampWidget : PanelContainer
         PanelOverride = _borderTexture;
 
         var prototypes = IoCManager.Resolve<IPrototypeManager>();
-        _stampShader = prototypes.Index<ShaderPrototype>("PaperStamp").InstanceUnique();
+        _stampShader = prototypes.Index(PaperStamp).InstanceUnique();
     }
 
     protected override void Draw(DrawingHandleScreen handle)

--- a/Content.Client/ParticleAccelerator/UI/ParticleAcceleratorControlMenu.xaml.cs
+++ b/Content.Client/ParticleAccelerator/UI/ParticleAcceleratorControlMenu.xaml.cs
@@ -262,6 +262,7 @@ public sealed partial class ParticleAcceleratorControlMenu : FancyWindow
 
 public sealed class PASegmentControl : Control
 {
+    private static readonly ProtoId<ShaderPrototype> GreyscaleShaderId = "Greyscale";
     private readonly ShaderInstance _greyScaleShader;
     private readonly TextureRect _base;
     private readonly TextureRect _unlit;
@@ -272,7 +273,7 @@ public sealed class PASegmentControl : Control
 
     public PASegmentControl()
     {
-        _greyScaleShader = IoCManager.Resolve<IPrototypeManager>().Index<ShaderPrototype>("Greyscale").Instance();
+        _greyScaleShader = IoCManager.Resolve<IPrototypeManager>().Index(GreyscaleShaderId).Instance();
 
         AddChild(_base = new TextureRect());
         AddChild(_unlit = new TextureRect());

--- a/Content.Client/Popups/PopupOverlay.cs
+++ b/Content.Client/Popups/PopupOverlay.cs
@@ -16,6 +16,8 @@ namespace Content.Client.Popups;
 /// </summary>
 public sealed class PopupOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+
     private readonly IConfigurationManager _configManager;
     private readonly IEntityManager _entManager;
     private readonly IPlayerManager _playerMgr;
@@ -48,7 +50,7 @@ public sealed class PopupOverlay : Overlay
         _popup = popup;
         _controller = controller;
 
-        _shader = protoManager.Index<ShaderPrototype>("unshaded").Instance();
+        _shader = protoManager.Index(UnshadedShader).Instance();
     }
 
     protected override void Draw(in OverlayDrawArgs args)

--- a/Content.Client/Radiation/Overlays/RadiationPulseOverlay.cs
+++ b/Content.Client/Radiation/Overlays/RadiationPulseOverlay.cs
@@ -13,6 +13,8 @@ namespace Content.Client.Radiation.Overlays
 {
     public sealed class RadiationPulseOverlay : Overlay
     {
+        private static readonly ProtoId<ShaderPrototype> RadiationShader = "Radiation";
+
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IGameTiming _gameTiming = default!;
@@ -29,7 +31,7 @@ namespace Content.Client.Radiation.Overlays
         public RadiationPulseOverlay()
         {
             IoCManager.InjectDependencies(this);
-            _baseShader = _prototypeManager.Index<ShaderPrototype>("Radiation").Instance().Duplicate();
+            _baseShader = _prototypeManager.Index(RadiationShader).Instance().Duplicate();
         }
 
         protected override bool BeforeDraw(in OverlayDrawArgs args)

--- a/Content.Client/Shuttles/FtlArrivalOverlay.cs
+++ b/Content.Client/Shuttles/FtlArrivalOverlay.cs
@@ -14,6 +14,8 @@ namespace Content.Client.Shuttles;
 /// </summary>
 public sealed class FtlArrivalOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowEntities;
 
     private EntityLookupSystem _lookups;
@@ -36,7 +38,7 @@ public sealed class FtlArrivalOverlay : Overlay
         _maps = _entManager.System<SharedMapSystem>();
         _sprites = _entManager.System<SpriteSystem>();
 
-        _shader = _protos.Index<ShaderPrototype>("unshaded").Instance();
+        _shader = _protos.Index(UnshadedShader).Instance();
     }
 
     protected override bool BeforeDraw(in OverlayDrawArgs args)

--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -12,6 +12,10 @@ namespace Content.Client.Silicons.StationAi;
 
 public sealed class StationAiOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> CameraStaticShader = "CameraStatic";
+    private static readonly ProtoId<ShaderPrototype> StencilMaskShader = "StencilMask";
+    private static readonly ProtoId<ShaderPrototype> StencilDrawShader = "StencilDraw";
+
     [Dependency] private readonly IClyde _clyde = default!;
     [Dependency] private readonly IEntityManager _entManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -91,7 +95,7 @@ public sealed class StationAiOverlay : Overlay
             () =>
             {
                 worldHandle.SetTransform(invMatrix);
-                var shader = _proto.Index<ShaderPrototype>("CameraStatic").Instance();
+                var shader = _proto.Index(CameraStaticShader).Instance();
                 worldHandle.UseShader(shader);
                 worldHandle.DrawRect(worldBounds, Color.White);
             },
@@ -114,11 +118,11 @@ public sealed class StationAiOverlay : Overlay
         }
 
         // Use the lighting as a mask
-        worldHandle.UseShader(_proto.Index<ShaderPrototype>("StencilMask").Instance());
+        worldHandle.UseShader(_proto.Index(StencilMaskShader).Instance());
         worldHandle.DrawTextureRect(_stencilTexture!.Texture, worldBounds);
 
         // Draw the static
-        worldHandle.UseShader(_proto.Index<ShaderPrototype>("StencilDraw").Instance());
+        worldHandle.UseShader(_proto.Index(StencilDrawShader).Instance());
         worldHandle.DrawTextureRect(_staticTexture!.Texture, worldBounds);
 
         worldHandle.SetTransform(Matrix3x2.Identity);

--- a/Content.Client/Singularity/SingularityOverlay.cs
+++ b/Content.Client/Singularity/SingularityOverlay.cs
@@ -9,6 +9,8 @@ namespace Content.Client.Singularity
 {
     public sealed class SingularityOverlay : Overlay, IEntityEventSubscriber
     {
+        private static readonly ProtoId<ShaderPrototype> Shader = "Singularity";
+
         [Dependency] private readonly IEntityManager _entMan = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         private SharedTransformSystem? _xformSystem = null;
@@ -29,7 +31,7 @@ namespace Content.Client.Singularity
         public SingularityOverlay()
         {
             IoCManager.InjectDependencies(this);
-            _shader = _prototypeManager.Index<ShaderPrototype>("Singularity").Instance().Duplicate();
+            _shader = _prototypeManager.Index(Shader).Instance().Duplicate();
             _shader.SetParameter("maxDistance", MaxDistance * EyeManager.PixelsPerMeter);
             _entMan.EventBus.SubscribeEvent<PixelToMapEvent>(EventSource.Local, this, OnProjectFromScreenToMap);
             ZIndex = 101; // Should be drawn after the placement overlay so admins placing items near the singularity can tell where they're going.

--- a/Content.Client/StatusIcon/StatusIconOverlay.cs
+++ b/Content.Client/StatusIcon/StatusIconOverlay.cs
@@ -11,6 +11,8 @@ namespace Content.Client.StatusIcon;
 
 public sealed class StatusIconOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+
     [Dependency] private readonly IEntityManager _entity = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -29,7 +31,7 @@ public sealed class StatusIconOverlay : Overlay
         _sprite = _entity.System<SpriteSystem>();
         _transform = _entity.System<TransformSystem>();
         _statusIcon = _entity.System<StatusIconSystem>();
-        _unshadedShader = _prototype.Index<ShaderPrototype>("unshaded").Instance();
+        _unshadedShader = _prototype.Index(UnshadedShader).Instance();
     }
 
     protected override void Draw(in OverlayDrawArgs args)

--- a/Content.Client/Stealth/StealthSystem.cs
+++ b/Content.Client/Stealth/StealthSystem.cs
@@ -10,6 +10,8 @@ namespace Content.Client.Stealth;
 
 public sealed class StealthSystem : SharedStealthSystem
 {
+    private static readonly ProtoId<ShaderPrototype> Shader = "Stealth";
+
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
@@ -20,7 +22,7 @@ public sealed class StealthSystem : SharedStealthSystem
     {
         base.Initialize();
 
-        _shader = _protoMan.Index<ShaderPrototype>("Stealth").InstanceUnique();
+        _shader = _protoMan.Index(Shader).InstanceUnique();
 
         SubscribeLocalEvent<StealthComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<StealthComponent, ComponentStartup>(OnStartup);

--- a/Content.Client/SurveillanceCamera/UI/SurveillanceCameraMonitorWindow.xaml.cs
+++ b/Content.Client/SurveillanceCamera/UI/SurveillanceCameraMonitorWindow.xaml.cs
@@ -17,6 +17,8 @@ namespace Content.Client.SurveillanceCamera.UI;
 [GenerateTypedNameReferences]
 public sealed partial class SurveillanceCameraMonitorWindow : DefaultWindow
 {
+    private static readonly ProtoId<ShaderPrototype> CameraStaticShader = "CameraStatic";
+
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IResourceCache _resourceCache = default!;
 
@@ -53,7 +55,7 @@ public sealed partial class SurveillanceCameraMonitorWindow : DefaultWindow
 
         // This could be done better. I don't want to deal with stylesheets at the moment.
         var texture = _resourceCache.GetTexture("/Textures/Interface/Nano/square_black.png");
-        var shader = _prototypeManager.Index<ShaderPrototype>("CameraStatic").Instance().Duplicate();
+        var shader = _prototypeManager.Index(CameraStaticShader).Instance().Duplicate();
 
         CameraView.ViewportSize = new Vector2i(500, 500);
         CameraView.Eye = _defaultEye; // sure

--- a/Content.Client/UserInterface/Systems/DamageOverlays/Overlays/DamageOverlay.cs
+++ b/Content.Client/UserInterface/Systems/DamageOverlays/Overlays/DamageOverlay.cs
@@ -9,6 +9,8 @@ namespace Content.Client.UserInterface.Systems.DamageOverlays.Overlays;
 
 public sealed class DamageOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> CircleMaskShader = "GradientCircleMask";
+
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
@@ -49,9 +51,9 @@ public sealed class DamageOverlay : Overlay
     {
         // TODO: Replace
         IoCManager.InjectDependencies(this);
-        _oxygenShader = _prototypeManager.Index<ShaderPrototype>("GradientCircleMask").InstanceUnique();
-        _critShader = _prototypeManager.Index<ShaderPrototype>("GradientCircleMask").InstanceUnique();
-        _bruteShader = _prototypeManager.Index<ShaderPrototype>("GradientCircleMask").InstanceUnique();
+        _oxygenShader = _prototypeManager.Index(CircleMaskShader).InstanceUnique();
+        _critShader = _prototypeManager.Index(CircleMaskShader).InstanceUnique();
+        _bruteShader = _prototypeManager.Index(CircleMaskShader).InstanceUnique();
     }
 
     protected override void Draw(in OverlayDrawArgs args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Converts every(?) instance of a string literal being passed into `PrototypeManager.Index<ShaderPrototype>` to a `private static readonly ProtoId<ShaderPrototype>`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Magic strings are bad. The YAML linter now checks that these shader prototypes actually exist, which will help catch bugs if they are renamed or deleted.

## Technical details
<!-- Summary of code changes for easier review. -->
String literals were replaced with static fields.
Additionally, some instances of the `ValidatePrototypeId` attribute being used for this purpose were updated to use `ProtoId` instead.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->