### PR TITLE
fix: don't default to uncharged sprite state for cells

### DIFF
--- a/Content.Client/PowerCell/PowerCellSystem.cs
+++ b/Content.Client/PowerCell/PowerCellSystem.cs
@@ -48,8 +48,9 @@ public sealed class PowerCellSystem : SharedPowerCellSystem
         if (!_sprite.LayerExists((uid, args.Sprite), PowerCellVisualLayers.Unshaded))
             return;
 
+        // If no appearance data is set, rely on whatever existing sprite state is set being correct.
         if (!_appearance.TryGetData<byte>(uid, PowerCellVisuals.ChargeLevel, out var level, args.Component))
-            level = 0;
+            return;
 
         var positiveCharge = level > 0;
         _sprite.LayerSetVisible((uid, args.Sprite), PowerCellVisualLayers.Unshaded, positiveCharge);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Power cells when spawned would always appear uncharged. Introduced by some goober in c3385f2599462b5a964ed9b4c2312be7ce2d93d4 who didn't test their work properly.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
I originally tried fixing this by just updating the appearance once on ComponentStartup, but this runs into the issue of the spawn menu icons then still showing the batteries as uncharged which I think hurts legibility a fair bit. This just means we have to rely on the starting sprite state of the batteries to be correct, which is currently the case.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/3ddc4d4f-2d0f-46e4-b934-0c19ee5803ea)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
