### PR TITLE
fix: fix non-access checking EntityTargetActions

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -334,7 +334,12 @@ namespace Content.Client.Actions
 
         private void OnEntityTargetAttempt(Entity<EntityTargetActionComponent> ent, ref ActionTargetAttemptEvent args)
         {
-            if (args.Handled || args.Input.EntityUid is not { Valid: true } entity)
+            if (args.Handled)
+                return;
+
+            args.Handled = true;
+
+            if (args.Input.EntityUid is not { Valid: true } entity)
                 return;
 
             // let world target component handle it
@@ -344,8 +349,6 @@ namespace Content.Client.Actions
                 DebugTools.Assert(HasComp<WorldTargetActionComponent>(ent), $"Action {ToPrettyString(ent)} requires WorldTargetActionComponent for entity-world targeting");
                 return;
             }
-
-            args.Handled = true;
 
             var action = args.Action;
             var user = args.User;

--- a/Content.Shared/Actions/Components/TargetActionComponent.cs
+++ b/Content.Shared/Actions/Components/TargetActionComponent.cs
@@ -1,6 +1,6 @@
-using Content.Shared.Actions;
-﻿using Content.Shared.Interaction;
-﻿using Robust.Shared.GameStates;
+using Content.Shared.Interaction;
+using Content.Shared.Physics;
+using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Actions.Components;
@@ -36,6 +36,12 @@ public sealed partial class TargetActionComponent : Component
     /// </remarks>
     [DataField]
     public bool CheckCanAccess = true;
+
+    /// <summary>
+    ///     The collision group to use to check for accessibility if <see cref="CheckCanAccess" /> is true.
+    /// </summary>
+    [DataField]
+    public CollisionGroup AccessMask = SharedInteractionSystem.InRangeUnobstructedMask;
 
     /// <summary>
     ///     The allowed range for a target to be. If zero or negative, the range check is skipped,

--- a/Content.Shared/Actions/Components/TargetActionComponent.cs
+++ b/Content.Shared/Actions/Components/TargetActionComponent.cs
@@ -37,6 +37,10 @@ public sealed partial class TargetActionComponent : Component
     [DataField]
     public bool CheckCanAccess = true;
 
+    /// <summary>
+    ///     The allowed range for a target to be. If zero or negative, the range check is skipped,
+    ///     unless <see cref="CheckCanAccess"/> is true.
+    /// </summary>
     [DataField]
     public float Range = SharedInteractionSystem.InteractionRange;
 

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -417,13 +417,18 @@ public abstract class SharedActionsSystem : EntitySystem
             return comp.CanTargetSelf;
 
         var targetAction = Comp<TargetActionComponent>(uid);
+
         // not using the ValidateBaseTarget logic since its raycast fails if the target is e.g. a wall
         if (targetAction.CheckCanAccess)
             return _interaction.InRangeAndAccessible(user, target, range: targetAction.Range);
 
-        // if not just checking pure range, let stored entities be targeted by actions
-        // if it's out of range it probably isn't stored anyway...
-        return _interaction.CanAccessViaStorage(user, target);
+        // Just check normal in range, allowing <= 0 range to mean infinite range.
+        if (targetAction.Range > 0
+            && !_transform.InRange(user, target, targetAction.Range))
+            return false;
+
+        // If checkCanAccess isn't set, we allow targeting things in containers
+        return _interaction.IsAccessible(user, target);
     }
 
     public bool ValidateWorldTarget(EntityUid user, EntityCoordinates target, Entity<WorldTargetActionComponent> ent)

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -420,7 +420,7 @@ public abstract class SharedActionsSystem : EntitySystem
 
         // not using the ValidateBaseTarget logic since its raycast fails if the target is e.g. a wall
         if (targetAction.CheckCanAccess)
-            return _interaction.InRangeAndAccessible(user, target, range: targetAction.Range);
+            return _interaction.InRangeAndAccessible(user, target, targetAction.Range, targetAction.AccessMask);
 
         // Just check normal in range, allowing <= 0 range to mean infinite range.
         if (targetAction.Range > 0

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -86,7 +86,11 @@ namespace Content.Shared.Interaction
         private EntityQuery<UseDelayComponent> _delayQuery;
         private EntityQuery<ActivatableUIComponent> _uiQuery;
 
-        private const CollisionGroup InRangeUnobstructedMask = CollisionGroup.Impassable | CollisionGroup.InteractImpassable;
+        /// <summary>
+        /// The collision mask used by default for
+        /// <see cref="InRangeUnobstructed(MapCoordinates,MapCoordinates,float,CollisionGroup,Ignored?,bool)" />
+        /// </summary>
+        public const CollisionGroup InRangeUnobstructedMask = CollisionGroup.Impassable | CollisionGroup.InteractImpassable;
 
         public const float InteractionRange = 1.5f;
         public const float InteractionRangeSquared = InteractionRange * InteractionRange;

--- a/Resources/Prototypes/Magic/teleport_spells.yml
+++ b/Resources/Prototypes/Magic/teleport_spells.yml
@@ -35,7 +35,8 @@
       sprite: Objects/Magic/Eldritch/eldritch_actions.rsi
       state: voidblink
   - type: TargetAction
-    checkCanAccess: false
+    accessMask:
+    - Opaque
     repeat: false
     range: 16
   - type: EntityTargetAction


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes any entity target actions that had checkCanAccess: false not working. Currently this just affects void applause.

Also fixes a warning about OnEntityTargetAttempt not marking the event as handled if the target was invalid.

Also also makes range that's less than or equal to 0 act as infinite range for entity target actions, but that doesn't affect anything. It's just parity with the behavior of world target actions.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #38631.

## Technical details
<!-- Summary of code changes for easier review. -->
Don't worry, devour still works.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Void applause should now function as expected again.