### PR TITLE
Tiny Tiny Cleanup of the EyeClosingSystem.

### DIFF
--- a/Content.Shared/Eye/Blinding/Systems/EyeClosingSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/EyeClosingSystem.cs
@@ -15,7 +15,6 @@ public sealed class EyeClosingSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
-    [Dependency] private readonly IEntityManager _entityManager = default!;
 
     public override void Initialize()
     {
@@ -120,7 +119,7 @@ public sealed class EyeClosingSystem : EntitySystem
         var ev = new GetBlurEvent(blindable.Comp.EyeDamage);
         RaiseLocalEvent(blindable.Owner, ev);
 
-        if (_entityManager.TryGetComponent<EyeClosingComponent>(blindable, out var eyelids) && !eyelids.NaturallyCreated)
+        if (EntityManager.TryGetComponent<EyeClosingComponent>(blindable, out var eyelids) && !eyelids.NaturallyCreated)
             return;
 
         if (ev.Blur < BlurryVisionComponent.MaxMagnitude || ev.Blur >= blindable.Comp.MaxDamage)
@@ -135,6 +134,4 @@ public sealed class EyeClosingSystem : EntitySystem
     }
 }
 
-public sealed partial class ToggleEyesActionEvent : InstantActionEvent
-{
-}
+public sealed partial class ToggleEyesActionEvent : InstantActionEvent;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Super stupid simple change. EyeClosingSystem is an EntitySystem and as such doesn't need to bring in the entity manager dependency. Also removed the unused body from the event at the bottom of the file.  Thats all she wrote. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->