### PR TITLE
Nerfed the hypopen.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -655,7 +655,7 @@
   - type: SolutionContainerManager
     solutions:
       hypospray:
-        maxVol: 10
+        maxVol: 15
   - type: RefillableSolution
     solution: hypospray
   - type: ExaminableSolution
@@ -663,6 +663,7 @@
     heldOnly: true # Allow examination only when held in hand.
   - type: Hypospray
     onlyAffectsMobs: false
+    transferAmount: 2.5
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice # A new shitcurity meta


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the hypopen to have the same properties as the syndicate hypospray from #38711 (2.5u injected per click, internal storage of 15u) without removing the stealth-item aspect of the item. I personally think #38711 is better but this serves as an alternate option if people want to keep the stealth aspect. I still firmly believe traitors should not have access to a hypospray on par with the CMO's in practical use.

This is an alternate PR to #38711 and only one should be merged.

## Why / Balance
Same reasons as #38711. This one keeps the idea of the hypopen as a stealth item.

## Technical details
Added the transferAmount field to the Hypospray component of the hypopen prototype, setting it to 2.5.
Increased the maxVol of the hypopen prototype's SolutionContainerManager component to 15.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/b6da424f-ee31-44dd-b87f-b96e11507de7



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The hypopen now only injects 2.5u of a reagent per click. It now holds 15u in chemicals total.