### PR TITLE
Allowed security to use the syndicate encryption key.

### DIFF
--- a/Resources/Locale/en-US/contraband/contraband-severity.ftl
+++ b/Resources/Locale/en-US/contraband/contraband-severity.ftl
@@ -14,3 +14,5 @@ contraband-examinable-verb-message = Check legality of this item.
 
 contraband-department-plural = {$department}
 contraband-job-plural = {MAKEPLURAL($job)}
+
+contraband-examine-text-SyndicateSecurity = [color=crimson]This item is highly illegal Syndicate contraband![/color] It is restricted to [color=red]Security[/color], and may be considered contraband.

--- a/Resources/Locale/en-US/contraband/contraband-severity.ftl
+++ b/Resources/Locale/en-US/contraband/contraband-severity.ftl
@@ -15,4 +15,4 @@ contraband-examinable-verb-message = Check legality of this item.
 contraband-department-plural = {$department}
 contraband-job-plural = {MAKEPLURAL($job)}
 
-contraband-examine-text-SyndicateSecurity = [color=crimson]This item is highly illegal Syndicate contraband![/color] It is restricted to [color=red]Security[/color], and may be considered contraband.
+contraband-examine-text-SyndicateSecurity = [color=crimson]This item is highly illegal Syndicate contraband![/color]  [color=yellow]However, Centcomm has authorized the use of this item by Security in order to more effectively root out Syndicate agents.[/color]

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -224,7 +224,7 @@
     - EncryptionService
 
 - type: entity
-  parent: [ EncryptionKey, BaseSyndicateContraband ]
+  parent: [ EncryptionKey, BaseSyndicateSecurityContraband ]
   id: EncryptionKeySyndie
   name: blood-red encryption key
   description: An encryption key used by... wait... Who is the owner of this chip?

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -48,6 +48,14 @@
     allowedDepartments: [  ]
     allowedJobs: [  ]
 
+# For contraband made by the syndicate, but allows the security department to use it.
+- type: entity
+  id: BaseSyndicateSecurityContraband
+  abstract: true
+  components:
+  - type: Contraband
+    severity: SyndicateSecurity
+
 # one department restricted contraband
 - type: entity
   id: BaseCentcommContraband

--- a/Resources/Prototypes/contraband_severities.yml
+++ b/Resources/Prototypes/contraband_severities.yml
@@ -26,6 +26,11 @@
   id: Syndicate
   examineText: contraband-examine-text-Syndicate
 
+# This is items that can be used by the syndicate and security legally.
+- type: contrabandSeverity
+  id: SyndicateSecurity
+  examineText: contraband-examine-text-SyndicateSecurity
+
 # This is magical contraband and not permitted to be used IC.
 - type: contrabandSeverity
   id: Magical


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a new contraband type, it is for items made _by_ the syndicate but can be used by the security department.

## Why / Balance
This was discussed internally by the admins, and I made the PR for them.

## Technical details
.yml stuff

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image_2025-07-09_115504926](https://github.com/user-attachments/assets/87ffa6cd-1bde-4cb7-bbba-1cffedf8a2bb)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:

- tweak: Security can now use the syndicate encryption key with permission from the Head of Security or captain to root out syndicate agents.