### PR TITLE
Add visibility shader to welding masks

### DIFF
--- a/Content.Client/Overlays/RectangleOverlay.cs
+++ b/Content.Client/Overlays/RectangleOverlay.cs
@@ -1,0 +1,61 @@
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Enums;
+
+namespace Content.Client.Overlays;
+
+public sealed partial class RectangleOverlay : Overlay
+{
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    public readonly List<(ShaderInstance, RectangleShaderValues)> RectangleShaders = new();
+
+    public RectangleOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var playerEntity = _playerManager.LocalSession?.AttachedEntity;
+
+        if (playerEntity == null)
+            return;
+
+        if (!_entityManager.TryGetComponent<EyeComponent>(playerEntity, out var eye))
+            return;
+
+        foreach (var (shader, values) in RectangleShaders)
+        {
+
+            var handle = args.WorldHandle;
+            shader.SetParameter("zoom", eye.Zoom.X);
+            shader.SetParameter("color", values.RectColor);
+            shader.SetParameter("outerRectangleWidth", values.OuterRectangleWidth);
+            shader.SetParameter("outerRectangleHeight", values.OuterRectangleHeight);
+            shader.SetParameter("innerRectangleThickness", values.InnerRectangleThickness);
+            shader.SetParameter("alphaOuter", values.OuterAlpha);
+            shader.SetParameter("alphaInner", values.InnerAlpha);
+            handle.UseShader(shader);
+            handle.DrawRect(args.WorldBounds, Color.White);
+            handle.UseShader(null);
+        }
+    }
+}
+
+public struct RectangleShaderValues
+{
+    public Vector3 RectColor = new Vector3(0, 0, 0);
+    public float OuterRectangleWidth = 1;
+    public float OuterRectangleHeight = 1;
+    public float InnerRectangleThickness = 0.05f;
+    public float OuterAlpha = 1.0f;
+    public float InnerAlpha = 0.0f;
+
+    public RectangleShaderValues()
+    {
+    }
+}

--- a/Content.Client/Overlays/RectangleOverlay.cs
+++ b/Content.Client/Overlays/RectangleOverlay.cs
@@ -4,6 +4,9 @@ using Robust.Shared.Enums;
 
 namespace Content.Client.Overlays;
 
+/// <summary>
+/// Overlays a list of gradient rectangles, centered on the user's screen.
+/// </summary>
 public sealed partial class RectangleOverlay : Overlay
 {
     [Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -25,13 +28,14 @@ public sealed partial class RectangleOverlay : Overlay
         if (playerEntity == null)
             return;
 
+        // Zoom is required to ensure it stays consistent in-world
         if (!_entityManager.TryGetComponent<EyeComponent>(playerEntity, out var eye))
             return;
 
         foreach (var (shader, values) in RectangleShaders)
         {
-
             var handle = args.WorldHandle;
+
             shader.SetParameter("zoom", eye.Zoom.X);
             shader.SetParameter("color", values.RectColor);
             shader.SetParameter("outerRectangleWidth", values.OuterRectangleWidth);

--- a/Content.Client/Overlays/WeldingMaskOverlaySystem.cs
+++ b/Content.Client/Overlays/WeldingMaskOverlaySystem.cs
@@ -1,0 +1,52 @@
+using Content.Shared.Inventory.Events;
+using Content.Shared.Overlays;
+using Robust.Client.Graphics;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client.Overlays;
+
+public sealed partial class WeldingMaskOverlaySystem : EquipmentHudSystem<WeldingMaskOverlayComponent>
+{
+    [Dependency] private readonly IOverlayManager _overlayMan = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    private RectangleOverlay _overlay = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _overlay = new();
+    }
+
+    protected override void UpdateInternal(RefreshEquipmentHudEvent<WeldingMaskOverlayComponent> component)
+    {
+        base.UpdateInternal(component);
+
+        _overlay.RectangleShaders.Clear();
+
+        foreach (var comp in component.Components)
+        {
+            var values = new RectangleShaderValues();
+
+            values.OuterRectangleHeight = comp.OuterRectangleHeight;
+            values.OuterRectangleWidth = comp.OuterRectangleWidth;
+            values.InnerRectangleThickness = comp.InnerRectangleThickness;
+            values.OuterAlpha = comp.OuterAlpha;
+            values.InnerAlpha = comp.InnerAlpha;
+
+            _overlay.RectangleShaders.Add((_prototypeManager.Index<ShaderPrototype>("GradientRectangleMask").InstanceUnique(), values));
+        }
+
+        _overlayMan.AddOverlay(_overlay);
+    }
+
+    protected override void DeactivateInternal()
+    {
+        base.DeactivateInternal();
+
+        _overlay.RectangleShaders.Clear();
+
+        _overlayMan.RemoveOverlay(_overlay);
+    }
+}

--- a/Content.Client/Overlays/WeldingMaskOverlaySystem.cs
+++ b/Content.Client/Overlays/WeldingMaskOverlaySystem.cs
@@ -5,6 +5,10 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Client.Overlays;
 
+
+/// <summary>
+/// Adds a rectangular shader when wearing a welding mask or similar.
+/// </summary>
 public sealed partial class WeldingMaskOverlaySystem : EquipmentHudSystem<WeldingMaskOverlayComponent>
 {
     [Dependency] private readonly IOverlayManager _overlayMan = default!;

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -88,6 +88,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<ShowCriminalRecordIconsComponent>>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<BlackAndWhiteOverlayComponent>>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<NoirOverlayComponent>>(RefRelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<WeldingMaskOverlayComponent>>(RefRelayInventoryEvent);
 
         SubscribeLocalEvent<InventoryComponent, GetVerbsEvent<EquipmentVerb>>(OnGetEquipmentVerbs);
         SubscribeLocalEvent<InventoryComponent, GetVerbsEvent<InnateVerb>>(OnGetInnateVerbs);

--- a/Content.Shared/Overlays/WeldingMaskOverlayComponent.cs
+++ b/Content.Shared/Overlays/WeldingMaskOverlayComponent.cs
@@ -1,0 +1,55 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Overlays;
+
+/// <summary>
+/// Adds a rectangular shader when wearing an entity with this component.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class WeldingMaskOverlayComponent : Component
+{
+    /// <summary>
+    /// The width of the rectangle's bounds.
+    /// 1.0 is at the edge of the game view.
+    /// </summary>
+    [DataField]
+    public float OuterRectangleWidth = 0.35f;
+
+    /// <summary>
+    /// The height of the rectangle's bounds.
+    /// 1.0 is at the edge of the game view.
+    /// </summary>
+    [DataField]
+    public float OuterRectangleHeight = 0.3f;
+
+    /// <summary>
+    /// The thickness for the inner rectangle.
+    /// Scaled on the y-axis. 0.5 goes to the middle of the screen.
+    /// </summary>
+    [DataField]
+    public float InnerRectangleThickness = 0.04f;
+
+    /// <summary>
+    /// The alpha outside the rectangle.
+    /// </summary>
+    [DataField]
+    public float OuterAlpha = 1.0f;
+
+    /// <summary>
+    /// The alpha inside the rectangle.
+    /// </summary>
+    [DataField]
+    public float InnerAlpha = 0.5f;
+
+    /// <summary>
+    /// Color of the shader being applied.
+    /// </summary>
+    [DataField]
+    public Color Color = Color.Black;
+
+    /// <summary>
+    /// If false, the shader is not applied.
+    /// </summary>
+    [DataField]
+    public bool Active = true;
+}

--- a/Content.Shared/Overlays/WeldingMaskOverlayComponent.cs
+++ b/Content.Shared/Overlays/WeldingMaskOverlayComponent.cs
@@ -13,14 +13,14 @@ public sealed partial class WeldingMaskOverlayComponent : Component
     /// 1.0 is at the edge of the game view.
     /// </summary>
     [DataField]
-    public float OuterRectangleWidth = 0.35f;
+    public float OuterRectangleWidth = 0.45f;
 
     /// <summary>
     /// The height of the rectangle's bounds.
     /// 1.0 is at the edge of the game view.
     /// </summary>
     [DataField]
-    public float OuterRectangleHeight = 0.3f;
+    public float OuterRectangleHeight = 0.4f;
 
     /// <summary>
     /// The thickness for the inner rectangle.

--- a/Resources/Prototypes/Entities/Clothing/Head/welding.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/welding.yml
@@ -23,6 +23,7 @@
   - type: HideLayerClothing
     slots:
     - Snout
+  - type: WeldingMaskOverlay
 
 - type: entity
   parent: WeldingMaskBase

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -717,8 +717,8 @@
     tags:
     - WhitelistChameleon
   - type: WeldingMaskOverlay
-    outerRectangleWidth: 0.6
-    outerRectangleHeight: 0.55
+    outerRectangleWidth: 0.7
+    outerRectangleHeight: 0.6
     innerRectangleThickness: 0.04
     outerAlpha: 1.0
     innerAlpha: 0.2

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -716,6 +716,12 @@
   - type: Tag
     tags:
     - WhitelistChameleon
+  - type: WeldingMaskOverlay
+    outerRectangleWidth: 0.6
+    outerRectangleHeight: 0.55
+    innerRectangleThickness: 0.04
+    outerAlpha: 1.0
+    innerAlpha: 0.2
 
 # Entity tables
 - type: entityTable

--- a/Resources/Prototypes/Shaders/shaders.yml
+++ b/Resources/Prototypes/Shaders/shaders.yml
@@ -20,6 +20,11 @@
   path: "/Textures/Shaders/world_gradient_circle.swsl"
 
 - type: shader
+  id: GradientRectangleMask
+  kind: source
+  path: "/Textures/Shaders/gradient_rectangle_mask.swsl"
+
+- type: shader
   id: ColoredScreenBorder
   kind: source
   path: "/Textures/Shaders/colored_screen_border.swsl"

--- a/Resources/Textures/Shaders/gradient_rectangle_mask.swsl
+++ b/Resources/Textures/Shaders/gradient_rectangle_mask.swsl
@@ -1,0 +1,37 @@
+// Has an outer rectangle that defines the hard border to the outer alpha color. It's scaled based on a 0-zoom game view; 1.0/1.0 width/height is a rectangle at the edge of the game view when not zoomed.
+// The inner rectangle is defined via a thickness (scaled on the y-axis); 0.5 means the gradient will be fully to the middle.
+
+light_mode unshaded;
+
+uniform highp vec3 color;
+uniform highp float zoom;
+
+uniform highp float outerRectangleWidth;
+uniform highp float outerRectangleHeight;
+uniform highp float innerRectangleThickness;
+uniform highp float alphaInner;
+uniform highp float alphaOuter;
+
+void fragment() {
+	highp vec2 pixelCenter = vec2(1.0/SCREEN_PIXEL_SIZE.x, 1.0/SCREEN_PIXEL_SIZE.y) * 0.5;
+	highp float distance = length(FRAGCOORD.xy - pixelCenter);
+
+	highp float top = pixelCenter.y + outerRectangleHeight * 0.5 / zoom / SCREEN_PIXEL_SIZE.y;
+	highp float bottom = pixelCenter.y - outerRectangleHeight * 0.5 / zoom / SCREEN_PIXEL_SIZE.y;
+	highp float left = pixelCenter.x - outerRectangleWidth * 0.5 / zoom / SCREEN_PIXEL_SIZE.x;
+	highp float right = pixelCenter.x + outerRectangleWidth * 0.5 / zoom / SCREEN_PIXEL_SIZE.x;
+
+	if (FRAGCOORD.x < left || FRAGCOORD.x > right || FRAGCOORD.y > top || FRAGCOORD.y < bottom || innerRectangleThickness <= 0.0) {
+		COLOR = vec4(color.x, color.y, color.z, alphaOuter);
+	} else {
+	    highp float actualThickness = innerRectangleThickness / zoom / SCREEN_PIXEL_SIZE.y;
+        highp float ratio_left = 1 - (FRAGCOORD.x - left) / (actualThickness);
+        highp float ratio_bottom = 1 - (FRAGCOORD.y - bottom) / (actualThickness);
+        highp float ratio_right = (FRAGCOORD.x - (right - actualThickness)) / (actualThickness);
+        highp float ratio_top = (FRAGCOORD.y - (top - actualThickness)) / (actualThickness);
+
+        highp float alpha = alphaInner + ((alphaOuter - alphaInner) * clamp(max(max(max(ratio_right, ratio_top),ratio_left),ratio_bottom), 0.0, 1.0));
+
+        COLOR = vec4(color.x, color.y, color.z, alpha);
+	}
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds a visibility limiting shader to the welding mask and welding gas mask, limiting the view the player has access to. 

The welding mask has the most restrictive vision, limiting the view to 45% of the user's game view & 50% opacity. Welding gas masks, being a Science research item, have 70% view & 20% opacity. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Welding masks are ubiquitous in the game; not for their welding protection, but for the flash protection provided without any major downsides. It's one of the main reasons why flashes are seen as a fairly mediocre option and any player (antag or not) who wishes to have an easier time escaping Security utilizes them.

The values in this PR are meant to still make the masks fine to wear when doing construction work or moving around in a construction area.

Toggling down the welding gas mask currently does not disable the shader, since toggling it doesn't disable eye/flash protection.

## Technical details
<!-- Summary of code changes for easier review. -->

The main thing to keep note of is that the overlay, to allow for multiple layers of the shader (in case you wear multiple entities with the component) makes a new instance for each component. I *think* this is fine, as this method can be seen with something like the hologram shader, but I am not experienced enough in shaders to say for certain.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Default: 
![image](https://github.com/user-attachments/assets/4468e798-a6ef-4f30-b3ca-6418676955f9)

Welding mask:
![image](https://github.com/user-attachments/assets/57370763-2b6b-49a2-a590-7eea584a8404)

Welding gas mask:
![image](https://github.com/user-attachments/assets/cbb1fa8f-a8b7-4a75-818a-f5757d10e62a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Welding masks and welding gas masks now partially block vision when worn.
