### PR TITLE
fix: spellbooks can have charges ≠ 3

### DIFF
--- a/Content.Shared/Charges/Components/LimitedChargesComponent.cs
+++ b/Content.Shared/Charges/Components/LimitedChargesComponent.cs
@@ -16,7 +16,7 @@ public sealed partial class LimitedChargesComponent : Component
     /// <summary>
     ///     The max charges this action has.
     /// </summary>
-    [DataField, AutoNetworkedField, Access(Other = AccessPermissions.Read)]
+    [DataField, AutoNetworkedField]
     public int MaxCharges = 3;
 
     /// <summary>

--- a/Content.Shared/Charges/Systems/SharedChargesSystem.cs
+++ b/Content.Shared/Charges/Systems/SharedChargesSystem.cs
@@ -219,6 +219,7 @@ public abstract class SharedChargesSystem : EntitySystem
     {
         if (!Resolve(action, ref action.Comp))
             return;
+
         // You can't have negative max charges (even zero is a bit goofy but eh)
         var adjusted = Math.Max(0, value);
         if (action.Comp.MaxCharges == adjusted)

--- a/Content.Shared/Charges/Systems/SharedChargesSystem.cs
+++ b/Content.Shared/Charges/Systems/SharedChargesSystem.cs
@@ -177,13 +177,20 @@ public abstract class SharedChargesSystem : EntitySystem
     }
 
     /// <summary>
-    /// Set the number of charges an action has, adding <see cref="LimitedChargesComponent"/> if needed.
+    /// Set the number of charges an action has.
     /// </summary>
     /// <param name="action">The action in question</param>
-    /// <param name="value">The number of charges. Clamped to [0, MaxCharges].</param>
+    /// <param name="value">
+    /// The number of charges. Clamped to [0, MaxCharges].
+    /// </param>
+    /// <remarks>
+    /// This method doesn't implicitly add <see cref="LimitedChargesComponent"/>
+    /// unlike some other methods in this system.
+    /// </remarks>
     public void SetCharges(Entity<LimitedChargesComponent?> action, int value)
     {
-        action.Comp ??= EnsureComp<LimitedChargesComponent>(action.Owner);
+        if (!Resolve(action, ref action.Comp))
+            return;
 
         var adjusted = Math.Clamp(value, 0, action.Comp.MaxCharges);
 
@@ -198,16 +205,20 @@ public abstract class SharedChargesSystem : EntitySystem
     }
 
     /// <summary>
-    /// Sets the maximum charges of a given action, adding <see cref="LimitedChargesComponent"/> if it doesn't have it.
+    /// Sets the maximum charges of a given action.
     /// </summary>
     /// <param name="action">The action being modified.</param>
     /// <param name="value">The new maximum charges of the action. Clamped to zero.</param>
     /// <remarks>
-    /// Does not change the current charge count, or adjust the accumulator for auto-recharge.
+    /// Does not change the current charge count, or adjust the
+    /// accumulator for auto-recharge. It also doesn't implicitly add
+    /// <see cref="LimitedChargesComponent"/> unlike some other methods
+    /// in this system.
     /// </remarks>
     public void SetMaxCharges(Entity<LimitedChargesComponent?> action, int value)
     {
-        action.Comp ??= EnsureComp<LimitedChargesComponent>(action.Owner);
+        if (!Resolve(action, ref action.Comp))
+            return;
         // You can't have negative max charges (even zero is a bit goofy but eh)
         var adjusted = Math.Max(0, value);
         if (action.Comp.MaxCharges == adjusted)

--- a/Content.Shared/Magic/SpellbookSystem.cs
+++ b/Content.Shared/Magic/SpellbookSystem.cs
@@ -37,7 +37,7 @@ public sealed class SpellbookSystem : EntitySystem
             // Null means infinite charges.
             if (charges is { } count)
             {
-                var chargeComp = EnsureComp<LimitedChargesComponent>(spell);
+                EnsureComp<LimitedChargesComponent>(spell, out var chargeComp);
                 _sharedCharges.SetMaxCharges((spell, chargeComp), count);
                 _sharedCharges.SetCharges((spell, chargeComp), count);
             }

--- a/Content.Shared/Magic/SpellbookSystem.cs
+++ b/Content.Shared/Magic/SpellbookSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
+using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction.Events;
@@ -36,8 +37,9 @@ public sealed class SpellbookSystem : EntitySystem
             // Null means infinite charges.
             if (charges is { } count)
             {
-                _sharedCharges.SetMaxCharges(spell, count);
-                _sharedCharges.SetCharges(spell, count);
+                var chargeComp = EnsureComp<LimitedChargesComponent>(spell);
+                _sharedCharges.SetMaxCharges((spell, chargeComp), count);
+                _sharedCharges.SetCharges((spell, chargeComp), count);
             }
 
             ent.Comp.Spells.Add(spell);
@@ -80,11 +82,12 @@ public sealed class SpellbookSystem : EntitySystem
             {
                 EntityUid? actionId = null;
                 if (!_actions.AddAction(args.Args.User, ref actionId, id)
-                    || charges is not { } count) // Null means infinite charges
+                    || charges is not { } count // Null means infinite charges
+                    || !TryComp<LimitedChargesComponent>(actionId, out var chargeComp))
                     continue;
 
-                _sharedCharges.SetMaxCharges(actionId.Value, count);
-                _sharedCharges.SetCharges(actionId.Value, count);
+                _sharedCharges.SetMaxCharges((actionId.Value, chargeComp), count);
+                _sharedCharges.SetCharges((actionId.Value, chargeComp), count);
             }
         }
 

--- a/Content.Shared/Magic/SpellbookSystem.cs
+++ b/Content.Shared/Magic/SpellbookSystem.cs
@@ -1,5 +1,5 @@
 using Content.Shared.Actions;
-﻿using Content.Shared.Actions.Components;
+using Content.Shared.Actions.Components;
 using Content.Shared.Charges.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction.Events;
@@ -35,7 +35,8 @@ public sealed class SpellbookSystem : EntitySystem
 
             // Null means infinite charges.
             if (charges is { } count)
-                _sharedCharges.SetCharges(spell.Value, count);
+                _sharedCharges.SetCharges(spell.Value, count, true);
+
             ent.Comp.Spells.Add(spell.Value);
         }
     }
@@ -77,7 +78,7 @@ public sealed class SpellbookSystem : EntitySystem
                 EntityUid? actionId = null;
                 if (_actions.AddAction(args.Args.User, ref actionId, id)
                     && charges is { } count) // Null means infinite charges
-                    _sharedCharges.SetCharges(actionId.Value, count);
+                    _sharedCharges.SetCharges(actionId.Value, count, true);
             }
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Tweaks ChargesSystem to allow setting a new max charge value when setting charges, and then makes charge-based spellbooks use that flag.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #38764.

## Technical details
<!-- Summary of code changes for easier review. -->
Access flag is removed because on field you still need to specify your friends even if your class has friends set, so this was just stopping anything from modifying MaxCharges. Then it already had rwxrwxr-- since that's the default if the class has friends set, so it could just be removed. Arguably it could be Other = ReadWrite buuuuut it's fine and that wouldn't make this PR any neater so.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- `SharedChargeSystem.SetCharges` will no longer implicitly add `LimitedChargesComponent` to its target, and will log an error if that occurs.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
