### PR TITLE
Scurrets - fix PDAs not being re-attachable if removed

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
@@ -47,7 +47,6 @@
     stripTime: 6
     uiWindowPos: 2,1
     strippingWindowPos: 2,4
-    dependsOn: jumpsuit
     displayName: ID
   - name: suitstorage
     slotTexture: suit_storage


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Emotional Support Scurrets spawn with a PDA but their PDA slot was set to require a jumpsuit. This has been fixed. Don't worry about how they clip the PDAs to themselves.

## Why / Balance
Whatever sorcery that allows scurrets to wear PDAs should not be single-use.

# Changelog

Nah