### PR TITLE
Log an error when adding an admin log containing a null char

### DIFF
--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -304,7 +304,10 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
 
         // PostgreSQL does not support storing null chars in text values.
         if (message.Contains('\0'))
+        {
             _sawmill.Error($"Null character detected in admin log message '{message}'! LogType: {type}, LogImpact: {impact}");
+            message = message.Replace("\0", "");
+        }
 
         var log = new AdminLog
         {

--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -304,7 +304,7 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
 
         // PostgreSQL does not support storing null chars in text values.
         if (message.Contains('\0'))
-            _sawmill.Error($"Null character detected in admin log message '{message}'");
+            _sawmill.Error($"Null character detected in admin log message '{message}'! LogType: {type}, LogImpact: {impact}");
 
         var log = new AdminLog
         {

--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -302,6 +302,10 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
             return;
         }
 
+        // PostgreSQL does not support storing null chars in text values.
+        if (message.Contains('\0'))
+            _sawmill.Error($"Null character detected in admin log message '{message}'");
+
         var log = new AdminLog
         {
             Id = NextLogId,


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
An error is now logged if a system tries to add an admin log containing a null character.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We are getting a bunch of errors when saving admin logs to the database: https://github.com/space-wizards/space-station-14/issues/38744

PostgreSQL produces this error when told to write null characters into text fields, but the error message isn't helpful for tracking down the offending text. This error log will help figure out what's going on.

## Technical details
<!-- Summary of code changes for easier review. -->
`AdminLogManager.Add` now checks the `message` parameter to see if it contains a null char (`'\0'`) and logs an error if it does.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->