### PR TITLE
Fix incorrect conditions on black pepper's forced cough

### DIFF
--- a/Content.Shared/EntityEffects/EffectConditions/InternalsCondition.cs
+++ b/Content.Shared/EntityEffects/EffectConditions/InternalsCondition.cs
@@ -19,7 +19,7 @@ public sealed partial class Internals : EntityEffectCondition
         if (!args.EntityManager.TryGetComponent(args.TargetEntity, out InternalsComponent? internalsComp))
             return !UsingInternals; // They have no internals to wear.
 
-        var internalsState = internalsComp.GasTankEntity == null;
+        var internalsState = internalsComp.GasTankEntity != null; // If gas tank is not null, they are wearing internals
         return UsingInternals == internalsState;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When splashed black pepper is meant to force you to cough if you are not wearing internals, but incorrectly was only working if you *were* wearing internals.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->
1 line change. Invert an incorrect comparison.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

no cl no glory