### PR TITLE
Crusher/Glaive now shoots with left click and wideswings with right click.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -137,7 +137,6 @@
   - type: Gun
     soundGunshot: /Audio/Weapons/plasma_cutter.ogg
     fireRate: 1
-    useKey: false
   - type: RechargeBasicEntityAmmo
     rechargeCooldown: 0.5
     rechargeSound:
@@ -155,6 +154,8 @@
         Slash: 4
     soundHit:
       collection: MetalThud
+  - type: AltFireMelee
+    attackType: Heavy
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -215,8 +216,6 @@
     slots:
     - Back
     - suitStorage
-  - type: UseDelay
-    delay: 1.9
   - type: BasicEntityAmmoProvider
     proto: BulletChargeGlaive
     capacity: 1


### PR DESCRIPTION
## About the PR
Changes Crushers and Crusher Glaives. They now fire their leech projectile with left click (Use) when wielded, and wideswing with right click (Use secondary). 

## Why / Balance
Crushers and Crusher Glaives currently fire their leech projectile with right click, which is achieved by altering the usekey for the Gun component. This makes the weapons very clunky to use, as players either have to attempt to pixel hunt with the left click attack or (if they even know it is an option) attempt to hold down right click after firing a projectile to wideswing and hopefully hit their target in time. This is not ideal for a variety of reasons, and makes the Crusher/Glaive feel poorly designed and counterintuitive, which means people are naturally less likely to use and experiment with them.

By using the AltFireMelee component instead, we can remove all the confusion of the current system and improve these two weapons. While wielded, you left click to fire your marker, and right click to wideswing. This makes the Crusher/Glaive easier to understand and use and makes it viable in way more situations. 

Balance shouldn't be a major concern with this change. Following the big salvage weapon rebalance (#38131) Crushers and Glaives have had their potential for PVP abuse drastically scaled back, so this should hopefully make them a strong option for Melee Salvage gameplay (which was always their intended purpose).

## Technical details
Uses the AltFireMelee component to make the Crusher/Glaive only melee with alt input (right click). attackType Heavy is used to make the right click attack a wideswing. As the gun component of the crushers is locked to being wielded, left-clicking with the weapon while it's unwielded does nothing, but left clicking with an unweilded crusher was never a very good idea so nothing of value is lost there.

The crusher glaive also had an unnecessary UseDelay tacked onto it which did not work and only served to make it seem like the weapon's projectile was on a longer cooldown than it was. This has been removed to make the weapon less confusing to use and has no actual mechanical change.

## Media

https://github.com/user-attachments/assets/f7dce906-0ab8-4192-bf8b-0351e6d2219d

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Crushers and Crusher Glaives now fire their projectile with left click and wideswing with right click when wielded. 
