### PR TITLE
Describe reagent colours with words

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -915,7 +915,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
 
             args.PushMarkup(Loc.GetString(entity.Comp.LocPhysicalQuality,
                                         ("color", colorHex),
-                                        ("colorName", ColorNaming.Describe(solution.GetColor(PrototypeManager), _localization)),
+                                        ("colorName", ColorNaming.Describe(solution.GetColor(ProtoMan), _localization)),
                                         ("desc", primary.LocalizedPhysicalDescription),
                                         ("chemCount", solution.Contents.Count)));
 

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Localizations;
 using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
+using Robust.Shared.ColorNaming;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Network;
@@ -74,6 +75,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
     [Dependency] protected SharedAppearanceSystem AppearanceSystem = default!;
     [Dependency] protected SharedContainerSystem ContainerSystem = default!;
     [Dependency] protected SharedHandsSystem Hands = default!;
+    [Dependency] private ILocalizationManager _localization = default!;
 
     [Dependency] protected EntityQuery<ContainedSolutionComponent> ContainedQuery = default!;
     [Dependency] protected EntityQuery<SolutionComponent> SolutionQuery = default!;
@@ -913,6 +915,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
 
             args.PushMarkup(Loc.GetString(entity.Comp.LocPhysicalQuality,
                                         ("color", colorHex),
+                                        ("colorName", ColorNaming.Describe(solution.GetColor(PrototypeManager), _localization)),
                                         ("desc", primary.LocalizedPhysicalDescription),
                                         ("chemCount", solution.Contents.Count)));
 

--- a/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
+++ b/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
@@ -1,4 +1,4 @@
-shared-solution-container-component-on-examine-main-text = It contains {INDEFINITE($desc)} [color={$color}]{$desc}[/color] { $chemCount ->
+shared-solution-container-component-on-examine-main-text = It contains {INDEFINITE($desc)} [color={$color}]{$colorName} {$desc}[/color] { $chemCount ->
     [1] chemical.
    *[other] mixture of chemicals.
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reagents now display a textual description of their colour when inspected.

## Why / Balance
This is an accessibility feature that names colours that colourblind people may have trouble distinguishing. It is not toggleable as off-by-default features are seldom discoverable by users, and unlike other colorblindness accessibility tools, is not disruptive to non-colorblind uesrs when enabled.

## Technical details
- use https://github.com/space-wizards/RobustToolbox/pull/6067 to name the colours

## Media
![grafik](https://github.com/user-attachments/assets/d7506b66-610f-4597-a314-53c7192a50cf)
![grafik](https://github.com/user-attachments/assets/574cb46e-fcd2-461e-869f-acb6a52e67c9)
![grafik](https://github.com/user-attachments/assets/2c618e2f-14df-41e2-af5d-11247348ab01)
![grafik](https://github.com/user-attachments/assets/c9c2cce8-a84e-4d4f-9f72-8abd3238316b)
![grafik](https://github.com/user-attachments/assets/e12284cd-0a79-4715-a1c2-c0b9219da479)
![grafik](https://github.com/user-attachments/assets/033004e2-f709-4937-a81c-1393d4deea9c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Reagents now display a textual description of their colour when inspected, for colourblind people
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
