### PR TITLE
Paradox Clone Disastrous Dual-Body Collision

### DIFF
--- a/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
@@ -87,6 +87,8 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
         var gibComp = EnsureComp<GibOnRoundEndComponent>(clone.Value);
         gibComp.SpawnProto = ent.Comp.GibProto;
         gibComp.PreventGibbingObjectives = new() { "ParadoxCloneKillObjective" }; // don't gib them if they killed the original.
+        gibComp.ToGib.Add(ent.Comp.OriginalBody.Value);
+        gibComp.ToGib.Add(clone.Value);
 
         // turn their suit sensors off so they don't immediately get noticed
         _sensor.SetAllSensors(clone.Value, SuitSensorMode.SensorOff);

--- a/Content.Server/Gibbing/Systems/GibOnRoundEndSystem.cs
+++ b/Content.Server/Gibbing/Systems/GibOnRoundEndSystem.cs
@@ -46,10 +46,16 @@ public sealed class GibOnRoundEndSystem : EntitySystem
             if (!gib)
                 continue;
 
-            if (gibComp.SpawnProto != null)
-                SpawnAtPosition(gibComp.SpawnProto, Transform(uid).Coordinates);
+            foreach (var ent in gibComp.ToGib)
+            {
+                if (TerminatingOrDeleted(ent))
+                    continue;
 
-            _body.GibBody(uid, splatModifier: 5f);
+                if (gibComp.SpawnProto != null)
+                    SpawnAtPosition(gibComp.SpawnProto, Transform(ent).Coordinates);
+
+                _body.GibBody(ent, splatModifier: 5f);
+            }
         }
     }
 }

--- a/Content.Shared/Gibbing/Components/GibOnRoundEndComponent.cs
+++ b/Content.Shared/Gibbing/Components/GibOnRoundEndComponent.cs
@@ -19,4 +19,10 @@ public sealed partial class GibOnRoundEndComponent : Component
     /// </summary>
     [DataField]
     public EntProtoId? SpawnProto;
+
+    /// <summary>
+    /// A list of entities that will be gibbed on round-end
+    /// </summary>
+    [DataField]
+    public List<EntityUid> ToGib = new();
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes paradox clones so that when the round ends, if both players are left alive, both are gibbed instead of just the clone.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As the antag is currently balanced, paradox clones are at a massive disadvantage from every angle. On top of the expected subterfuge and murder shenanigans they have to perform, they're in the one-sided position of being under threat of multiversal evaporation if they don't complete their objective.

This means, while the paradox clone needs to hunt down their counterpart if they want to survive til the end of the round, the counterpart has no mirroring incentive. This creates an extremely exploitable situation, where essentially whichever player that acts aggressively is immediately outed as the clone, as the original has little reason to act aggressively towards the fake.

By changing the antagonist to place both the clone _and original_ in danger if both survive, this creates a more interesting scenario. The original player can no longer simply permit the existence of their clone, be it free or in jail, and must opt to dispatch of them, either by their own hand or through security. This creates an overall more proactive experience, as now both players are required to engage with each other and make a conclusive statement on which one is real and which one is fake and to be executed. This additionally lessens the burden on the clone to execute the other, as now the original player has an incentive to kill the clone if they wish to survive the round.

## Technical details
<!-- Summary of code changes for easier review. -->
Changes GibOnRoundEnd to take in a list of ents rather than just using the local one.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`GibOnRoundEnd` now takes in a list of entities to gib when the round ends.

**Changelog**
:cl:
- tweak: When the round ends with both a paradox clone and their counterpart left alive, both now die rather than only the clone.