### PR TITLE
Cleanup warnings: CS0414

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -40,7 +40,6 @@ namespace Content.Server.Electrocution;
 public sealed class ElectrocutionSystem : SharedElectrocutionSystem
 {
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
-    [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;

--- a/Content.Server/Spider/SpiderSystem.cs
+++ b/Content.Server/Spider/SpiderSystem.cs
@@ -10,7 +10,6 @@ namespace Content.Server.Spider;
 public sealed class SpiderSystem : SharedSpiderSystem
 {
     [Dependency] private readonly PopupSystem _popup = default!;
-    [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly TurfSystem _turf = default!;
 
     /// <summary>

--- a/Content.Server/Worldgen/Systems/Debris/SimpleFloorPlanPopulatorSystem.cs
+++ b/Content.Server/Worldgen/Systems/Debris/SimpleFloorPlanPopulatorSystem.cs
@@ -12,7 +12,6 @@ namespace Content.Server.Worldgen.Systems.Debris;
 public sealed class SimpleFloorPlanPopulatorSystem : BaseWorldSystem
 {
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly ITileDefinitionManager _tileDefinition = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly TurfSystem _turf = default!;
 

--- a/Content.Shared/Actions/ActionUpgradeSystem.cs
+++ b/Content.Shared/Actions/ActionUpgradeSystem.cs
@@ -11,7 +11,6 @@ public sealed class ActionUpgradeSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
-    [Dependency] private readonly EntityManager _entityManager = default!;
 
     public override void Initialize()
     {


### PR DESCRIPTION
## About the PR
Remove 4x `CS0414` warnings

[CS0414](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0414): The private field 'field' is assigned but its value is never used.

## Why / Balance
[https://github.com/space-wizards/space-station-14/issues/33279](https://github.com/space-wizards/space-station-14/issues/33279)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

