### PR TITLE
Cleanup warnings: CS0649

### DIFF
--- a/Content.Client/Parallax/Managers/GeneratedParallaxCache.cs
+++ b/Content.Client/Parallax/Managers/GeneratedParallaxCache.cs
@@ -195,7 +195,6 @@ public sealed class GeneratedParallaxCache : IPostInjectInit
         public required ResPath ConfigPath;
         public required Task<Texture> LoadTask;
         public required CancellationTokenSource CancellationSource;
-        public ValueList<CancellationTokenRegistration> CancelRegistrations;
 
         public int RefCount;
     }


### PR DESCRIPTION
## About the PR
Remove 1x `CS0649` warning

[CS0649](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0649): Field 'field' is never assigned to, and will always have its default value 'value'.

In fact, the `CancelRegistrations` field is not used anywhere and has no associated logic, so it is safe to delete it.

## Why / Balance
[https://github.com/space-wizards/space-station-14/issues/33279](https://github.com/space-wizards/space-station-14/issues/33279)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

