### PR TITLE
wall closets no longer able to grab mobs

### DIFF
--- a/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
@@ -114,6 +114,12 @@ public abstract partial class SharedEntityStorageComponent : Component
     public EntityWhitelist? Whitelist;
 
     /// <summary>
+    ///     Blacklist for what entities are not allowed to be inserted into this container.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Blacklist;
+
+    /// <summary>
     /// The contents of the storage
     /// </summary>
     [ViewVariables]

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -350,9 +350,12 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (containerAttemptEvent.Cancelled)
             return false;
 
-        // Consult the whitelist. The whitelist ignores the default assumption about how entity storage works.
-        if (component.Whitelist != null)
-            return _whitelistSystem.IsValid(component.Whitelist, toInsert);
+        // Checks blacklist and whitelist.
+        if (_whitelistSystem.IsWhitelistFail(component.Whitelist, toInsert) ||
+            _whitelistSystem.IsBlacklistPass(component.Blacklist, toInsert))
+        {
+            return false;
+        }
 
         // The inserted entity must be a mob or an item.
         return HasComp<BodyComponent>(toInsert) || HasComp<ItemComponent>(toInsert);

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -164,6 +164,9 @@
       path: /Audio/Items/deconstruct.ogg
     openSound:
       path: /Audio/Items/deconstruct.ogg
+    blacklist:
+      components:
+      - Body
   - type: ContainerContainer
     containers:
       entity_storage: !type:Container


### PR DESCRIPTION
resolves #14409 
## About the PR
Wall closet no longer touches things with body component

## Why / Balance
Actually, this can be a pretty cool feature. But in 90 percent of situations, you can't just close locker without pixelhunting until you don't stop close yourself. Its sucks.

## Technical details
Added blacklist to the SharedEntityStorageComponent

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: now you can't insert mobs in wall lockers and wall closets
