### PR TITLE
Remove species metabolizer types part 1: lungs

### DIFF
--- a/Resources/Locale/en-US/metabolism/metabolizer-types.ftl
+++ b/Resources/Locale/en-US/metabolism/metabolizer-types.ftl
@@ -9,3 +9,12 @@ metabolizer-type-plant = Plant
 metabolizer-type-dwarf = Dwarf
 metabolizer-type-moth = Moth
 metabolizer-type-arachnid = Arachnid
+
+metabolizer-type-oxygen-breather = Oxygen-breathing
+metabolizer-type-nitrogen-breather = Nitrogen-breathing
+metabolizer-type-oxygen-allergic = Oxygen-allergic
+metabolizer-type-carbon-dioxide-breather = Carbon Dioxide-breathing
+metabolizer-type-carbon-dioxide-immune = Carbon Dioxide-resistant
+metabolizer-type-ammonia-healer = Ammonia-receptive
+metabolizer-type-ammonia-resistant = Ammonia-resistant
+metabolizer-type-nitrous-oxide-immune = Nitrous Oxide-resistant

--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -46,7 +46,7 @@
     removeEmpty: true
     solutionOnBody: false
     solution: "Lung"
-    metabolizerTypes: [ Animal ]
+    metabolizerTypes: [ OxygenBreather ]
     groups:
     - id: Gas
       rateModifier: 100.0

--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -67,7 +67,7 @@
     removeEmpty: true
     solutionOnBody: false
     solution: "Lung"
-    metabolizerTypes: [ Human ]
+    metabolizerTypes: [ OxygenBreather ]
     groups:
     - id: Gas
       rateModifier: 100.0

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -108,12 +108,12 @@
   - type: Item
     size: Small
     heldPrefix: lungs
-  - type: Lung 
+  - type: Lung
   - type: Metabolizer
     removeEmpty: true
     solutionOnBody: false
     solution: "Lung"
-    metabolizerTypes: [ Plant ]
+    metabolizerTypes: [ OxygenBreather, CarbonDioxideBreather, CarbonDioxideImmune ]
     groups:
     - id: Gas
       rateModifier: 100.0
@@ -137,7 +137,7 @@
   description: "The source of incredible, unending intelligence. Honk."
   components:
   - type: Brain
-  - type: Nymph # This will make the organs turn into a nymph when they're removed. 
+  - type: Nymph # This will make the organs turn into a nymph when they're removed.
     entityPrototype: OrganDionaNymphBrain
     transferMind: true
 
@@ -176,11 +176,11 @@
 
 - type: entity
   id: OrganDionaNymphStomach
-  parent: MobDionaNymphAccent 
+  parent: MobDionaNymphAccent
   categories: [ HideSpawnMenu ]
   name: diona nymph
   suffix: Stomach
-  description: Contains the stomach of a formerly fully-formed Diona. It doesn't taste any better for it. 
+  description: Contains the stomach of a formerly fully-formed Diona. It doesn't taste any better for it.
   components:
   - type: IsDeadIC
   - type: Body
@@ -192,7 +192,7 @@
   categories: [ HideSpawnMenu ]
   name: diona nymph
   suffix: Lungs
-  description: Contains the lungs of a formerly fully-formed Diona. Breathtaking. 
+  description: Contains the lungs of a formerly fully-formed Diona. Breathtaking.
   components:
   - type: IsDeadIC
   - type: Body

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -74,7 +74,7 @@
   - type: Item
     size: Small
     heldPrefix: brain
-  
+
 - type: entity
   id: OrganHumanEyes
   parent: BaseHumanOrgan
@@ -136,7 +136,7 @@
     removeEmpty: true
     solutionOnBody: false
     solution: "Lung"
-    metabolizerTypes: [ Human ]
+    metabolizerTypes: [ OxygenBreather ]
     groups:
     - id: Gas
       rateModifier: 100.0

--- a/Resources/Prototypes/Body/Organs/rat.yml
+++ b/Resources/Prototypes/Body/Organs/rat.yml
@@ -4,7 +4,7 @@
   suffix: "rat"
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Rat ]
+    metabolizerTypes: [ OxygenBreather, AmmoniaHealer, AmmoniaResistant ]
 
 - type: entity
   id: OrganRatStomach

--- a/Resources/Prototypes/Body/Organs/slime.yml
+++ b/Resources/Prototypes/Body/Organs/slime.yml
@@ -37,7 +37,7 @@
       size: Small
       heldPrefix: brain
 
-      
+
 - type: entity
   id: OrganSlimeLungs
   parent: BaseHumanOrgan
@@ -55,7 +55,7 @@
     removeEmpty: true
     solutionOnBody: false
     solution: "Lung"
-    metabolizerTypes: [ Slime ]
+    metabolizerTypes: [ NitrogenBreather, NitrousOxideImmune ]
     groups:
     - id: Gas
       rateModifier: 100.0

--- a/Resources/Prototypes/Body/Organs/vox.yml
+++ b/Resources/Prototypes/Body/Organs/vox.yml
@@ -7,7 +7,7 @@
   - type: Sprite
     sprite: Mobs/Species/Vox/organs.rsi
   - type: Metabolizer
-    metabolizerTypes: [ Vox ]
+    metabolizerTypes: [ NitrogenBreather, OxygenAllergic, CarbonDioxideImmune, AmmoniaResistant ]
   - type: Lung
     alert: LowNitrogen
   - type: Item

--- a/Resources/Prototypes/Chemistry/metabolizer_types.yml
+++ b/Resources/Prototypes/Chemistry/metabolizer_types.yml
@@ -44,3 +44,37 @@
 - type: metabolizerType
   id: Arachnid
   name: metabolizer-type-arachnid
+
+# New Metabolizers for lungs, hopefully all content above can eventually be replaced with tags
+
+- type: metabolizerType
+  id: OxygenBreather
+  name: metabolizer-type-oxygen-breather
+
+- type: metabolizerType
+  id: NitrogenBreather
+  name: metabolizer-type-nitrogen-breather
+
+- type: metabolizerType
+  id: OxygenAllergic
+  name: metabolizer-type-oxygen-allergic
+
+- type: metabolizerType
+  id: CarbonDioxideBreather
+  name: metabolizer-type-carbon-dioxide-breather
+
+- type: metabolizerType
+  id: CarbonDioxideImmune
+  name: metabolizer-type-carbon-dioxide-immune
+
+- type: metabolizerType
+  id: AmmoniaHealer
+  name: metabolizer-type-ammonia-healer
+
+- type: metabolizerType
+  id: AmmoniaResistant
+  name: metabolizer-type-ammonia-resistant
+
+- type: metabolizerType
+  id: NitrousOxideImmune
+  name: metabolizer-type-nitrous-oxide-immune

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -222,7 +222,7 @@
       - !type:HealthChange
         conditions:
         - !type:OrganType
-          type: Rat
+          type: AmmoniaHealer
           shouldHave: false
         - !type:ReagentThreshold
           reagent: Ammonia
@@ -235,10 +235,7 @@
         probability: 0.12
         conditions:
         - !type:OrganType
-          type: Rat
-          shouldHave: false
-        - !type:OrganType
-          type: Vox
+          type: AmmoniaResistant
           shouldHave: false
         - !type:ReagentThreshold
           reagent: Ammonia
@@ -255,7 +252,7 @@
       - !type:HealthChange
         conditions:
         - !type:OrganType
-          type: Rat
+          type: AmmoniaHealer
         - !type:ReagentThreshold
           reagent: Ammonia
           min: 1
@@ -267,10 +264,12 @@
             Burn: -5
           types:
             Bloodloss: -5
-      - !type:Oxygenate # ammonia displaces nitrogen in vox blood
+      - !type:Oxygenate # ammonia displaces nitrogen in vox blood, should it also happen in slimes?
         conditions:
         - !type:OrganType
-          type: Vox
+          type: OxygenAllergic
+        - !type:OrganType
+          type: NitrogenBreather
         factor: -4
 
 

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -13,24 +13,12 @@
       - !type:Oxygenate
         conditions:
         - !type:OrganType
-          type: Human
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Animal
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Rat
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Plant
+          type: OxygenBreather
       # Convert Oxygen into CO2.
       - !type:ModifyLungGas
         conditions:
         - !type:OrganType
-          type: Vox
+          type: OxygenAllergic
           shouldHave: false
         ratios:
           CarbonDioxide: 1.0
@@ -38,7 +26,7 @@
       - !type:HealthChange
         conditions:
         - !type:OrganType
-          type: Vox
+          type: OxygenAllergic
         scaleByQuantity: true
         ignoreResistances: true
         damage:
@@ -51,7 +39,7 @@
           - !type:ReagentThreshold
             min: 0.5
           - !type:OrganType
-            type: Vox
+            type: OxygenAllergic
         clear: true
         time: 5
     Gas:
@@ -59,24 +47,12 @@
       - !type:Oxygenate
         conditions:
         - !type:OrganType
-          type: Human
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Animal
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Rat
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Plant
+          type: OxygenBreather
       # Convert Oxygen into CO2.
       - !type:ModifyLungGas
         conditions:
         - !type:OrganType
-          type: Vox
+          type: OxygenAllergic # Should this just be limited to OxygenBreather instead of Not Vox?
           shouldHave: false
         ratios:
           CarbonDioxide: 1.0
@@ -84,7 +60,7 @@
       - !type:HealthChange
         conditions:
         - !type:OrganType
-          type: Vox
+          type: OxygenAllergic
         scaleByQuantity: true
         ignoreResistances: true
         damage:
@@ -97,7 +73,7 @@
           - !type:ReagentThreshold
             min: 0.5
           - !type:OrganType
-            type: Vox
+            type: OxygenAllergic
         clear: true
         time: 5
 
@@ -201,14 +177,11 @@
       - !type:Oxygenate
         conditions:
         - !type:OrganType
-          type: Plant
+          type: CarbonDioxideBreather
       - !type:HealthChange
         conditions:
         - !type:OrganType
-          type: Plant
-          shouldHave: false
-        - !type:OrganType
-          type: Vox
+          type: CarbonDioxideImmune
           shouldHave: false
         scaleByQuantity: true
         ignoreResistances: true
@@ -219,7 +192,7 @@
       - !type:Oxygenate
         conditions:
         - !type:OrganType
-          type: Plant
+          type: CarbonDioxideBreather
           shouldHave: false
         factor: -4
     Gas:
@@ -227,14 +200,11 @@
       - !type:Oxygenate
         conditions:
         - !type:OrganType
-          type: Plant
+          type: CarbonDioxideBreather
       - !type:HealthChange
         conditions:
         - !type:OrganType
-          type: Plant
-          shouldHave: false
-        - !type:OrganType
-          type: Vox
+          type: CarbonDioxideImmune
           shouldHave: false
         # Don't want people to get toxin damage from the gas they just
         # exhaled, right?
@@ -249,7 +219,7 @@
       - !type:Oxygenate # carbon dioxide displaces oxygen from the bloodstream, causing asphyxiation
         conditions:
         - !type:OrganType
-          type: Plant
+          type: CarbonDioxideBreather
           shouldHave: false
         factor: -4
       # We need a metabolism effect on reagent removal
@@ -277,23 +247,24 @@
       - !type:Oxygenate
         conditions:
         - !type:OrganType
-          type: Vox
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Slime
+          type: NitrogenBreather
       # Converts Nitrogen into CO2
       - !type:ModifyLungGas
         conditions:
         - !type:OrganType
-          type: Vox
+          type: NitrogenBreather
+        - !type:OrganType
+          type: OxygenAllergic
         ratios:
           Ammonia: 1.0
           Nitrogen: -1.0
       - !type:ModifyLungGas
         conditions:
         - !type:OrganType
-          type: Slime
+          type: NitrogenBreather
+        - !type:OrganType
+          type: OxygenAllergic
+          shouldHave: false
         ratios:
           NitrousOxide: 1.0
           Nitrogen: -1.0
@@ -322,7 +293,7 @@
           reagent: NitrousOxide
           min: 0.2
         - !type:OrganType
-          type: Slime
+          type: NitrousOxideImmune
           shouldHave: false
         emote: Laugh
         showInChat: true
@@ -333,7 +304,7 @@
           reagent: NitrousOxide
           min: 0.2
         - !type:OrganType
-          type: Slime
+          type: NitrousOxideImmune
           shouldHave: false
         emote: Scream
         showInChat: true
@@ -344,7 +315,7 @@
           reagent: NitrousOxide
           min: 0.5
         - !type:OrganType
-          type: Slime
+          type: NitrousOxideImmune
           shouldHave: false
         type: Local
         visualType: Medium
@@ -356,7 +327,7 @@
           reagent: NitrousOxide
           min: 1
         - !type:OrganType
-          type: Slime
+          type: NitrousOxideImmune
           shouldHave: false
         walkSpeedModifier: 0.65
         sprintSpeedModifier: 0.65
@@ -366,7 +337,7 @@
           reagent: NitrousOxide
           min: 1.8
         - !type:OrganType
-          type: Slime
+          type: NitrousOxideImmune
           shouldHave: false
         effectProto: StatusEffectForcedSleeping
         time: 3
@@ -377,7 +348,7 @@
           reagent: NitrousOxide
           min: 3.5
         - !type:OrganType
-          type: Slime
+          type: NitrousOxideImmune
           shouldHave: false
         ignoreResistances: true
         damage:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Replace the Human, Rat, Animal tags etc with tags based on lung capabilities (OxygenBreather, NitrousOxideImmune etc), and update the reagent effects to match

read the code for the full list.

## Why / Balance
Having effects be tied to species is limiting if you want to make more species (because you have to manually add it to all the reagent effects).

See metabolizer-types.yml for all the new tags, no actual species balance was touched.

## Technical details
All yaml, only touched lungs for now (more in future PRs)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
No player-facing changes
