### PR TITLE
Localize, cleanup, and LEC round control commands.

### DIFF
--- a/Content.Server/GameTicking/Commands/DelayStartCommand.cs
+++ b/Content.Server/GameTicking/Commands/DelayStartCommand.cs
@@ -40,6 +40,6 @@ public sealed class DelayStartCommand : LocalizedEntityCommands
 
         var time = TimeSpan.FromSeconds(seconds);
         if (!_gameTicker.DelayStart(time))
-            shell.WriteLine("An unknown error has occurred.");
+            shell.WriteLine(Loc.GetString("cmd-delaystart-too-late"));
     }
 }

--- a/Content.Server/GameTicking/Commands/DelayStartCommand.cs
+++ b/Content.Server/GameTicking/Commands/DelayStartCommand.cs
@@ -2,50 +2,44 @@
 using Content.Shared.Administration;
 using Robust.Shared.Console;
 
-namespace Content.Server.GameTicking.Commands
+namespace Content.Server.GameTicking.Commands;
+
+[AdminCommand(AdminFlags.Round)]
+public sealed class DelayStartCommand : LocalizedEntityCommands
 {
-    [AdminCommand(AdminFlags.Round)]
-    sealed class DelayStartCommand : IConsoleCommand
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+
+    public override string Command => "delaystart";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IEntityManager _e = default!;
-
-        public string Command => "delaystart";
-        public string Description => "Delays the round start.";
-        public string Help => $"Usage: {Command} <seconds>\nPauses/Resumes the countdown if no argument is provided.";
-
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (_gameTicker.RunLevel != GameRunLevel.PreRoundLobby)
         {
-            var ticker = _e.System<GameTicker>();
-            if (ticker.RunLevel != GameRunLevel.PreRoundLobby)
-            {
-                shell.WriteLine("This can only be executed while the game is in the pre-round lobby.");
-                return;
-            }
-
-            if (args.Length == 0)
-            {
-                var paused = ticker.TogglePause();
-                shell.WriteLine(paused ? "Paused the countdown." : "Resumed the countdown.");
-                return;
-            }
-
-            if (args.Length != 1)
-            {
-                shell.WriteLine("Need zero or one arguments.");
-                return;
-            }
-
-            if (!uint.TryParse(args[0], out var seconds) || seconds == 0)
-            {
-                shell.WriteLine($"{args[0]} isn't a valid amount of seconds.");
-                return;
-            }
-
-            var time = TimeSpan.FromSeconds(seconds);
-            if (!ticker.DelayStart(time))
-            {
-                shell.WriteLine("An unknown error has occurred.");
-            }
+            shell.WriteLine(Loc.GetString("shell-can-only-run-from-pre-round-lobby"));
+            return;
         }
+
+        switch (args.Length)
+        {
+            case 0:
+                var paused = _gameTicker.TogglePause();
+                shell.WriteLine(Loc.GetString(paused ? "cmd-delaystart-paused" : "cmd-delaystart-unpaused"));
+                return;
+            case 1:
+                break;
+            default:
+                shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+                return;
+        }
+
+        if (!uint.TryParse(args[0], out var seconds) || seconds == 0)
+        {
+            shell.WriteLine(Loc.GetString("cmd-delaystart-invalid-seconds", ("value", args[0])));
+            return;
+        }
+
+        var time = TimeSpan.FromSeconds(seconds);
+        if (!_gameTicker.DelayStart(time))
+            shell.WriteLine("An unknown error has occurred.");
     }
 }

--- a/Content.Server/GameTicking/Commands/EndRoundCommand.cs
+++ b/Content.Server/GameTicking/Commands/EndRoundCommand.cs
@@ -2,28 +2,23 @@
 using Content.Shared.Administration;
 using Robust.Shared.Console;
 
-namespace Content.Server.GameTicking.Commands
+namespace Content.Server.GameTicking.Commands;
+
+[AdminCommand(AdminFlags.Round)]
+public sealed class EndRoundCommand : LocalizedEntityCommands
 {
-    [AdminCommand(AdminFlags.Round)]
-    sealed class EndRoundCommand : IConsoleCommand
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+
+    public override string Command => "endround";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IEntityManager _e = default!;
-
-        public string Command => "endround";
-        public string Description => "Ends the round and moves the server to PostRound.";
-        public string Help => String.Empty;
-
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (_gameTicker.RunLevel != GameRunLevel.InRound)
         {
-            var ticker = _e.System<GameTicker>();
-
-            if (ticker.RunLevel != GameRunLevel.InRound)
-            {
-                shell.WriteLine("This can only be executed while the game is in a round.");
-                return;
-            }
-
-            ticker.EndRound();
+            shell.WriteLine(Loc.GetString("shell-can-only-run-while-round-is-active"));
+            return;
         }
+
+        _gameTicker.EndRound();
     }
 }

--- a/Content.Server/GameTicking/Commands/RestartRoundCommand.cs
+++ b/Content.Server/GameTicking/Commands/RestartRoundCommand.cs
@@ -3,43 +3,37 @@ using Content.Server.RoundEnd;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
 
-namespace Content.Server.GameTicking.Commands
+namespace Content.Server.GameTicking.Commands;
+
+[AdminCommand(AdminFlags.Round)]
+public sealed class RestartRoundCommand : LocalizedEntityCommands
 {
-    [AdminCommand(AdminFlags.Round)]
-    public sealed class RestartRoundCommand : IConsoleCommand
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
+
+    public override string Command => "restartround";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IEntityManager _e = default!;
-
-        public string Command => "restartround";
-        public string Description => "Ends the current round and starts the countdown for the next lobby.";
-        public string Help => string.Empty;
-
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (_gameTicker.RunLevel != GameRunLevel.InRound)
         {
-            var ticker = _e.System<GameTicker>();
-
-            if (ticker.RunLevel != GameRunLevel.InRound)
-            {
-                shell.WriteLine("This can only be executed while the game is in a round - try restartroundnow");
-                return;
-            }
-
-            _e.System<RoundEndSystem>().EndRound();
+            shell.WriteLine(Loc.GetString("shell-can-only-run-while-round-is-active"));
+            return;
         }
+
+        _roundEndSystem.EndRound();
     }
+}
 
-    [AdminCommand(AdminFlags.Round)]
-    public sealed class RestartRoundNowCommand : IConsoleCommand
+[AdminCommand(AdminFlags.Round)]
+public sealed class RestartRoundNowCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+
+    public override string Command => "restartroundnow";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IEntityManager _e = default!;
-
-        public string Command => "restartroundnow";
-        public string Description => "Moves the server from PostRound to a new PreRoundLobby.";
-        public string Help => String.Empty;
-
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
-        {
-            _e.System<GameTicker>().RestartRound();
-        }
+        _gameTicker.RestartRound();
     }
 }

--- a/Content.Server/GameTicking/Commands/StartRoundCommand.cs
+++ b/Content.Server/GameTicking/Commands/StartRoundCommand.cs
@@ -2,28 +2,23 @@
 using Content.Shared.Administration;
 using Robust.Shared.Console;
 
-namespace Content.Server.GameTicking.Commands
+namespace Content.Server.GameTicking.Commands;
+
+[AdminCommand(AdminFlags.Round)]
+public sealed class StartRoundCommand : LocalizedEntityCommands
 {
-    [AdminCommand(AdminFlags.Round)]
-    sealed class StartRoundCommand : IConsoleCommand
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+
+    public override string Command => "startround";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IEntityManager _e = default!;
-
-        public string Command => "startround";
-        public string Description => "Ends PreRoundLobby state and starts the round.";
-        public string Help => String.Empty;
-
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (_gameTicker.RunLevel != GameRunLevel.PreRoundLobby)
         {
-            var ticker = _e.System<GameTicker>();
-
-            if (ticker.RunLevel != GameRunLevel.PreRoundLobby)
-            {
-                shell.WriteLine("This can only be executed while the game is in the pre-round lobby.");
-                return;
-            }
-
-            ticker.StartRound();
+            shell.WriteLine(Loc.GetString("shell-can-only-run-from-pre-round-lobby"));
+            return;
         }
+
+        _gameTicker.StartRound();
     }
 }

--- a/Resources/Locale/en-US/commands/delaystart-command.ftl
+++ b/Resources/Locale/en-US/commands/delaystart-command.ftl
@@ -4,3 +4,4 @@ cmd-delaystart-help = Usage: delaystart [seconds]
 cmd-delaystart-invalid-seconds = {$value} isn't a valid amount of seconds.
 cmd-delaystart-paused = Paused the countdown.
 cmd-delaystart-unpaused = Resumed the countdown.
+cmd-delaystart-too-late = Round start could not be delayed in time!

--- a/Resources/Locale/en-US/commands/delaystart-command.ftl
+++ b/Resources/Locale/en-US/commands/delaystart-command.ftl
@@ -1,0 +1,6 @@
+﻿cmd-delaystart-desc = Delays the round start.
+cmd-delaystart-help = Usage: delaystart [seconds]
+                      If no arguments are passed, the round will be paused or resumed accordingly.
+cmd-delaystart-invalid-seconds = {$value} isn't a valid amount of seconds.
+cmd-delaystart-paused = Paused the countdown.
+cmd-delaystart-unpaused = Resumed the countdown.

--- a/Resources/Locale/en-US/commands/endround-command.ftl
+++ b/Resources/Locale/en-US/commands/endround-command.ftl
@@ -1,0 +1,2 @@
+﻿cmd-endround-desc = Ends the round and moves the server to PostRound.
+cmd-endround-help = Usage: endround

--- a/Resources/Locale/en-US/commands/restartround-command.ftl
+++ b/Resources/Locale/en-US/commands/restartround-command.ftl
@@ -1,0 +1,5 @@
+﻿cmd-restartround-desc = Ends the current round and starts the countdown for the next lobby.
+cmd-restartround-help = Usage: restartround
+
+cmd-restartroundnow-desc = Moves the server from PostRound to a new PreRoundLobby.
+cmd-restartroundnow-help = Usage: restartroundnow

--- a/Resources/Locale/en-US/commands/startround-command.ftl
+++ b/Resources/Locale/en-US/commands/startround-command.ftl
@@ -1,0 +1,2 @@
+﻿cmd-startround-desc = Ends PreRoundLobby state and starts the round.
+cmd-startround-help = Usage: startround

--- a/Resources/Locale/en-US/shell.ftl
+++ b/Resources/Locale/en-US/shell.ftl
@@ -5,6 +5,8 @@
 shell-command-success = Command successful
 shell-invalid-command = Invalid command.
 shell-invalid-command-specific = Invalid {$commandName} command.
+shell-can-only-run-from-pre-round-lobby = You can only run this command while the game is in the pre-round lobby.
+shell-can-only-run-while-round-is-active = You can only run this command while the game is in a round.
 shell-cannot-run-command-from-server = You cannot run this command from the server.
 shell-only-players-can-run-this-command = Only players can run this command.
 shell-must-be-attached-to-entity = You must be attached to an entity to run this command.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR performs localization and LEC conversion to the following commands:
restartroundnow
restartround
endround
startround
delaystart

Minor cleanup is performed a long the way and namespace scopes are changed to file based.

## Technical details
Converts all listed commands to LocalizedEntityCommands and changes them to using dependencies instead using the entity manager to hook systems.
Converts strings to localized versions using generics where possible.
Created a new shell generic for commands that can only be ran in the pre-round lobby.
Created a new shell generic for commands that can only be ran while the game is in session. (wording may be changed in the near future.
Did I miss anything..... I don't think.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->