### PR TITLE
Add piercing modkit

### DIFF
--- a/Content.Shared/Weapons/Ranged/Upgrades/Components/GunUpgradePenetrationComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/Components/GunUpgradePenetrationComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Weapons.Ranged.Upgrades.Components;
+
+/// <summary>
+/// A <see cref="GunUpgradeComponent"/> for adding piercing to a gun.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(GunUpgradeSystem))]
+public sealed partial class GunUpgradePenetrationComponent : Component
+{
+    /// <summary>
+    /// The penetration threshold
+    /// </summary>
+    [DataField]
+    public float Threshold = 0;
+}

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -38,6 +38,7 @@ public sealed class GunUpgradeSystem : EntitySystem
         SubscribeLocalEvent<GunUpgradeFireRateComponent, GunRefreshModifiersEvent>(OnFireRateRefresh);
         SubscribeLocalEvent<GunUpgradeSpeedComponent, GunRefreshModifiersEvent>(OnSpeedRefresh);
         SubscribeLocalEvent<GunUpgradeDamageComponent, GunShotEvent>(OnDamageGunShot);
+        SubscribeLocalEvent<GunUpgradePenetrationComponent, GunShotEvent>(OnPierceGunShot);
     }
 
     private void RelayEvent<T>(Entity<UpgradeableGunComponent> ent, ref T args) where T : notnull
@@ -108,6 +109,15 @@ public sealed class GunUpgradeSystem : EntitySystem
         {
             if (TryComp<ProjectileComponent>(ammo, out var proj))
                 proj.Damage += ent.Comp.Damage;
+        }
+    }
+
+    private void OnPierceGunShot(Entity<GunUpgradePenetrationComponent> ent, ref GunShotEvent args)
+    {
+        foreach (var (ammo, _) in args.Ammo)
+        {
+            if (TryComp<ProjectileComponent>(ammo, out var proj))
+                proj.PenetrationThreshold = ent.Comp.Threshold;
         }
     }
 

--- a/Resources/Locale/en-US/weapons/ranged/upgrades.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/upgrades.ftl
@@ -3,5 +3,6 @@ upgradeable-gun-popup-upgrade-limit = Max upgrades reached!
 gun-upgrade-popup-insert = Inserted {THE($upgrade)} into {THE($gun)}!
 
 gun-upgrade-examine-text-damage = This has upgraded [color=#ec9b2d][bold]damage.[/bold][/color]
+gun-upgrade-examine-text-piercing = This has been upgraded to have [color=#e6e6e6][bold]piercing[/bold][/color]
 gun-upgrade-examine-text-range = This has upgraded [color=#2decec][bold]range.[/bold][/color]
 gun-upgrade-examine-text-reload = This has upgraded [color=#bbf134][bold]fire rate.[/bold][/color]

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -271,6 +271,7 @@
       - id: PKAUpgradeDamage
       - id: PKAUpgradeRange
       - id: PKAUpgradeFireRate
+      - id: PKAUpgradePierce
 
 
 - type: entityTable

--- a/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
@@ -78,3 +78,23 @@
     examineText: gun-upgrade-examine-text-reload
   - type: GunUpgradeFireRate
     coefficient: 1.5
+
+- type: entity
+  id: PKAUpgradePierce
+  parent: BasePKAUpgrade
+  name: PKA modkit (piercing)
+  components:
+  - type: Sprite
+    layers:
+    - state: base
+    - state: overlay-1
+      color: "#e6e6e6"
+    - state: overlay-2
+      color: "#b4b4b4"
+    - state: overlay-3
+      color: "#c8c8c8"
+  - type: GunUpgrade
+    tags: [ GunUpgradePenetration ]
+    examineText: gun-upgrade-examine-text-piercing
+  - type: GunUpgradePenetration
+    threshold: 300 #pierces 2 rocks (hits 3)

--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -57,6 +57,7 @@
   - PKAUpgradeDamage
   - PKAUpgradeRange
   - PKAUpgradeFireRate
+  - PKAUpgradePierce
   - WeaponTetherGun
   - WeaponGauntletGorilla
 

--- a/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
@@ -60,3 +60,4 @@
   - PKAUpgradeDamage
   - PKAUpgradeRange
   - PKAUpgradeFireRate
+  - PKAUpgradePierce

--- a/Resources/Prototypes/Recipes/Lathes/salvage.yml
+++ b/Resources/Prototypes/Recipes/Lathes/salvage.yml
@@ -102,3 +102,13 @@
     Gold: 500
     Silver: 500
 
+- type: latheRecipe
+  id: PKAUpgradePierce
+  result: PKAUpgradePierce
+  categories:
+  - Weapons
+  completetime: 5
+  materials:
+    Steel: 1500
+    Gold: 500
+    Silver: 500

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -168,6 +168,7 @@
   - PKAUpgradeDamage
   - PKAUpgradeRange
   - PKAUpgradeFireRate
+  - PKAUpgradePierce
 
 - type: technology
   id: BasicShuttleArmament

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -670,6 +670,9 @@
   id: GunUpgradeDamage
 
 - type: Tag
+  id: GunUpgradePiercing
+
+- type: Tag
   id: GunUpgradeRange
 
 - type: Tag

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -670,7 +670,7 @@
   id: GunUpgradeDamage
 
 - type: Tag
-  id: GunUpgradePiercing
+  id: GunUpgradePenetration
 
 - type: Tag
   id: GunUpgradeRange


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the piercing modkit for salvagers to use (recipe and method of aquirement is identical to all other modkits)
This modkit allows the PKA to hit multiple rocks per shot (currently 3) and makes it slightly more effective at breaking through structures. 
It also, at the downside of sacrificing another modkit, allows the pka to have a slightly better matchup against hivelords.

## Why / Balance
The usage of this modkit allows salvagers for a third method of excavation, using their PKA to mine just like in ss13.
As far as breaking structures goes, due to how penetration works (projectile won't pierce if the damage wont break the structure) this modkit isn't extremely overpowered in that regard.
By sacrificing dps or range (you lose out on another modkit) you get a decent non melee option against hivelords while making other megafauna tougher to deal with.
Also mining like this is satisfying and a fun alternative to using pickaxes or drills.

## Technical details
Adds a PKA modkit (piercing) adjacent to the other 3 that uses PenetrationThreshold (just like the hristov) to make it pierce through stuff, the asteroid rocks have 150 health so with the threshold being 300 it will destroy 3 rocks.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Youtube link:
https://youtu.be/Sa8AOK-WYfM

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- ## Breaking changes
List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: HahayesSiH
- add: a new modkit for the PKA has been added, the piercing modkit, it allows for a new method of excavation while providing an option against weak crowded enemies.
