### PR TITLE
Fix jukebox PVS state errors

### DIFF
--- a/Content.IntegrationTests/Tests/Jukebox/JukeboxPvsTest.cs
+++ b/Content.IntegrationTests/Tests/Jukebox/JukeboxPvsTest.cs
@@ -1,0 +1,76 @@
+using Content.Server.Audio.Jukebox;
+using Content.Shared.Audio.Jukebox;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Jukebox;
+
+public sealed class JukeboxPvsTest
+{
+    private static readonly EntProtoId JukeboxProtoId = "Jukebox";
+
+    private const string TrackId = "JukeboxTest";
+
+    [TestPrototypes]
+    private const string Prototypes = $@"
+- type: jukebox
+  id: {TrackId}
+  name: Test
+  path:
+    path: /Audio/Effects/beep1.ogg
+";
+
+    /// <summary>
+    /// Tests that a jukebox has a valid PVS state after a track finishes playing.
+    /// </summary>
+    [Test]
+    public async Task TrackEndTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var protoMan = server.ProtoMan;
+        var jukeboxSys = server.System<JukeboxSystem>();
+
+        var mapData = await pair.CreateTestMap();
+
+        EntityUid jukebox = default;
+        await server.WaitAssertion(() =>
+        {
+            // Spawn a jukebox
+            jukebox = entMan.SpawnEntity(JukeboxProtoId, mapData.MapCoords);
+
+            // Get the prototype for our test track
+            var track = protoMan.Index<JukeboxPrototype>(TrackId);
+
+            // Select the test track
+            jukeboxSys.SetSelectedTrack(jukebox, track);
+            // Start playing
+            jukeboxSys.TryPlay(jukebox);
+
+            // Make sure it's playing
+            Assert.That(jukeboxSys.IsPlaying(jukebox));
+        });
+
+        // Wait a moment for the music to end
+        await pair.RunSeconds(5);
+
+        await server.WaitAssertion(() =>
+        {
+            // Make sure the music has stopped
+            Assert.That(jukeboxSys.IsPlaying(jukebox), Is.False);
+        });
+
+        // Add a fake player session
+        var dummySession = await server.AddDummySession();
+
+        // Force a PVS update for the fake player
+        await server.WaitAssertion(() =>
+        {
+            Assert.DoesNotThrow(() => server.PvsTick([dummySession]));
+        });
+
+        await server.WaitRunTicks(5);
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Audio/Jukebox/JukeboxSystem.cs
+++ b/Content.Server/Audio/Jukebox/JukeboxSystem.cs
@@ -27,6 +27,8 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
         SubscribeLocalEvent<JukeboxComponent, ComponentShutdown>(OnComponentShutdown);
 
         SubscribeLocalEvent<JukeboxComponent, PowerChangedEvent>(OnPowerChanged);
+
+        SubscribeLocalEvent<JukeboxAudioComponent, EntityTerminatingEvent>(OnAudioTerminating);
     }
 
     private void OnComponentInit(Entity<JukeboxComponent> ent, ref ComponentInit args)
@@ -107,6 +109,16 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
         _appearanceSystem.SetData(uid, JukeboxVisuals.VisualState, state);
     }
 
+    private void OnAudioTerminating(Entity<JukeboxAudioComponent> ent, ref EntityTerminatingEvent args)
+    {
+        if (!TryComp<JukeboxComponent>(ent.Comp.Jukebox, out var jukebox))
+            return;
+
+        // Clear the jukebox's reference to the audio stream entity
+        jukebox.AudioStream = null;
+        Dirty(ent.Comp.Jukebox, jukebox);
+    }
+
     private void TryUpdateVisualState(Entity<JukeboxComponent?> ent)
     {
         if (!Resolve(ent, ref ent.Comp))
@@ -165,6 +177,11 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
             }
 
             ent.Comp.AudioStream = Audio.PlayPvs(jukeboxProto.Path, ent, AudioParams.Default.WithMaxDistance(10f))?.Entity;
+            if (ent.Comp.AudioStream is { } audioEnt)
+            {
+                var jukeboxAudioComp = EnsureComp<JukeboxAudioComponent>(audioEnt);
+                jukeboxAudioComp.Jukebox = ent;
+            }
             Dirty(ent);
         }
         return true;

--- a/Content.Shared/Audio/Jukebox/JukeboxAudioComponent.cs
+++ b/Content.Shared/Audio/Jukebox/JukeboxAudioComponent.cs
@@ -1,0 +1,15 @@
+namespace Content.Shared.Audio.Jukebox;
+
+/// <summary>
+/// Automatically attached to audio stream entities spawned by jukeboxes.
+/// Used to notify the jukebox when the audio entity is deleted.
+/// </summary>
+[RegisterComponent]
+public sealed partial class JukeboxAudioComponent : Component
+{
+    /// <summary>
+    /// The jukebox entity that owns this audio entity.
+    /// </summary>
+    [DataField]
+    public EntityUid Jukebox;
+}

--- a/Content.Shared/Audio/Jukebox/SharedJukeboxSystem.cs
+++ b/Content.Shared/Audio/Jukebox/SharedJukeboxSystem.cs
@@ -5,4 +5,12 @@ namespace Content.Shared.Audio.Jukebox;
 public abstract class SharedJukeboxSystem : EntitySystem
 {
     [Dependency] protected readonly SharedAudioSystem Audio = default!;
+
+    public bool IsPlaying(Entity<JukeboxComponent?> entity)
+    {
+        if (!Resolve(entity, ref entity.Comp))
+            return false;
+
+        return entity.Comp.AudioStream is { } audio && Audio.IsPlaying(audio);
+    }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Jukeboxes no longer wind up with an invalid component state after a track finishes playing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
According to the error logs on Grafana, we are getting pretty frequent errors due to the PVS system trying to generate and send the component state for `JukeboxComponent` to clients. These states are often invalid, because the component winds up with a reference to a deleted entity whenever a track finishes playing.

## Technical details
<!-- Summary of code changes for easier review. -->
A breakdown, by commit:
- https://github.com/space-wizards/space-station-14/commit/4c4929851cb360138f4c177acf5e0b716859588b: **Give `JukeboxSystem` a public API**. This was needed so the integration test could interact with it. The changes are pretty straightforward - the code that actually did stuff was moved into new public methods and the event handlers were changed to call those methods. A little code cleanup was done along the way, modernizing method signatures to use `Entity<T>`, etc.
- https://github.com/space-wizards/space-station-14/commit/958b11e8d275ea576d9f9aae8490f1ec0c0bd7fb: **Add an integration test that reproduces the PVS bug**. Now that we can tell jukeboxes to do stuff from code, we add a test that spawns a jukebox, selects a track (a short sound effect file), plays it, then forces a PVS update for a dummy client session. This reproduces the bug this PR is trying to fix.
- https://github.com/space-wizards/space-station-14/commit/0448bded65edc4926501f0d6a5817a70514f080c: **Fix the bug**. Now that we can reliably reproduce the bug, here's a proposed fix: Whenever `JukeboxSystem` spawns an audio entity to play music, a new `JukeboxAudioComponent` is added to the spawned entity and given a reference to the jukebox entity. When an entity with a `JukeboxAudioComponent` is terminating, it uses that reference to set the jukebox's `AudioStream` field to `null`. This removes the reference to a deleted object that was causing the PVS error.

I can think of a few alternative ways of fixing this bug: `AudioComponent` could be given a way to prevent automatic deletion when it finishes playing. `JukeboxComponent.AudioStream` could be converted to a `WeakEntityReference` (once that is available). If a different approach is preferred, I can change this PR to do that instead.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->