### PR TITLE
Fix SSD sleep misprediction

### DIFF
--- a/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
@@ -12,17 +12,18 @@ namespace Content.Shared.SSDIndicator;
 [AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class SSDIndicatorComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
     [AutoNetworkedField]
     public bool IsSSD = true;
 
-    [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
     public ProtoId<SsdIconPrototype> Icon = "SSDIcon";
 
     /// <summary>
     ///     When the entity should fall asleep
     /// </summary>
-    [DataField, AutoPausedField, Access(typeof(SSDIndicatorSystem))]
+    [DataField]
+    [AutoNetworkedField, AutoPausedField]
+    [Access(typeof(SSDIndicatorSystem))]
     public TimeSpan FallAsleepTime = TimeSpan.Zero;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Networked the FallAsleepTime field in SSDIndicatorComponent.
Made the IsSSD field ReadOnly cause it could sometimes mess with PVS when edited.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #38768

## Technical details
<!-- Summary of code changes for easier review. -->
Networked the FallAsleepTime field in SSDIndicatorComponent.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
