### PR TITLE
Lawyers now spawn round-start with sunglasses, and their headset has been made distinct.

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
@@ -12,7 +12,6 @@
     ClothingUniformJumpsuitLawyerGood: 1
     ClothingUniformJumpskirtLawyerGood: 1
     ClothingShoesBootsLaceup: 2
-    ClothingHeadsetService: 2
     ClothingNeckLawyerbadge: 2
     BriefcaseBrown: 2
     BookSpaceLaw: 3

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -242,6 +242,23 @@
     sprite: Clothing/Ears/Headsets/security.rsi
 
 - type: entity
+  parent: [ClothingHeadset, BaseSecurityLawyerContraband]
+  id: ClothingHeadsetLawyer
+  name: lawyer's headset
+  description: A headset used by dreadful lawyers.
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeySecurity
+      - EncryptionKeyService
+      - EncryptionKeyCommon
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/security.rsi
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/security.rsi
+
+- type: entity
   parent: [ClothingHeadset, BaseSecurityContraband]
   id: ClothingHeadsetBrigmedic
   name: brigmedic headset

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -18,9 +18,10 @@
 - type: startingGear
   id: LawyerGear
   equipment:
+    eyes: ClothingEyesGlassesSunglasses
     shoes: ClothingShoesBootsLaceup
     id: LawyerPDA
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetLawyer
   inhand:
     - BriefcaseBrownFilled
   storage:

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -282,7 +282,7 @@
     outerClothing: ClothingOuterArmorBasicSlim
     pocket1: WeaponPistolMk58
     pocket2: MagazinePistol
-  inhand: 
+  inhand:
   - FlashlightSeclite
 
 - type: startingGear
@@ -859,7 +859,7 @@
     eyes: ClothingEyesHudMedical
     pocket1: RegenerativeMesh
     pocket2: PillCanisterBicaridine
-  inhand: 
+  inhand:
   - ScalpelAdvanced
   - MedicatedSuture
 
@@ -1120,7 +1120,8 @@
     neck: ClothingNeckLawyerbadge
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetLawyer
+    eyes: ClothingEyesGlassesSunglasses
     pocket1: RubberStampLawyer
     pocket2: LuxuryPen
   inhand:
@@ -1135,7 +1136,8 @@
     neck: ClothingNeckLawyerbadge
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetLawyer
+    eyes: ClothingEyesGlassesSunglasses
     pocket1: RubberStampLawyer
     pocket2: SmokingPipeFilledTobacco
   inhand:
@@ -1151,7 +1153,8 @@
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
     belt: ClothingBeltStorageWaistbag
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetLawyer
+    eyes: ClothingEyesGlassesSunglasses
     pocket1: RubberStampLawyer
     pocket2: SmokingPipeFilledTobacco
   inhand:
@@ -1168,7 +1171,8 @@
     mask: CigarGold
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetLawyer
+    eyes: ClothingEyesGlassesSunglasses
     outerClothing: ClothingOuterCoatExpensive
     pocket1: RubberStampLawyer
     pocket2: LuxuryPen
@@ -1185,7 +1189,8 @@
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
     belt: ClothingBeltStorageWaistbag
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetLawyer
+    eyes: ClothingEyesGlassesSunglasses
     pocket1: RubberStampLawyer
     pocket2: LuxuryPen
   inhand:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Lawyers & visiting lawyers now spawn with sunglasses pre-equipped.
- Made lawyer headsets distinct from security headsets, and they now come with service keys pre-slotted into them.
- Removed the now unneeded service headsets from the lawdrobe.

## Why / Balance
For the sunglasses; This allows lawyers to reliably have sunglasses in their shifts, so that they can walk into security without being blinded by the auto-flasher, without having to rely on it being mapped, it not being taken by another lawyer, or having to beg the busy warden for a pair.

For the lawyer headset change; This saves them the clunky & odd hassle of having to pull a service key out of a headset in the lawdrobe, instead now they simply spawn with one pre-slotted, Alongside this, the service headsets have been removed from the lawdrobe as they are now unneeded.

## Technical details
changed 'Jobs/Civilian/lawyer.yml' inventory to include 'eyes: ClothingEyesGlassesSunglasses'

added '- EncryptionKeyService' to the brand new 'ClothingHeadsetLawyer'

removed 'ClothingHeadsetService: 2' from 'VendingMachines/Inventories/lawdrobe.yml'

## Media
![lawyerPR](https://github.com/user-attachments/assets/2bceec15-71a7-4ac0-8e1a-c3521177fd0a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- add: Lawyer headsets are now distinct & include a service key. 
- tweak: Lawyers now spawn with sunglasses equipped.
- removal: Lawdrobes no longer have service headsets in their inventories.