### PR TITLE
Added playtime-related features to lobby to combat addiction

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -176,19 +176,22 @@ namespace Content.Client.Lobby
 
         private void UpdateLobbyUi()
         {
+            var minutesToday = _playtimeTracking.PlaytimeMinutesToday;
+
             if (_gameTicker.IsGameStarted)
             {
                 Lobby!.ReadyButton.Text = Loc.GetString("lobby-state-ready-button-join-state");
                 Lobby!.ReadyButton.ToggleMode = false;
                 Lobby!.ReadyButton.Pressed = false;
                 Lobby!.ObserveButton.Disabled = false;
+                Lobby!.ReadyButton.Disabled = false;
             }
             else
             {
                 Lobby!.StartTime.Text = string.Empty;
                 Lobby!.ReadyButton.Text = Loc.GetString(Lobby!.ReadyButton.Pressed ? "lobby-state-player-status-ready": "lobby-state-player-status-not-ready");
                 Lobby!.ReadyButton.ToggleMode = true;
-                Lobby!.ReadyButton.Disabled = false;
+                Lobby!.ReadyButton.Disabled = (minutesToday >= 180);
                 Lobby!.ReadyButton.Pressed = _gameTicker.AreWeReady;
                 Lobby!.ObserveButton.Disabled = true;
             }
@@ -198,7 +201,6 @@ namespace Content.Client.Lobby
                 Lobby!.ServerInfo.SetInfoBlob(_gameTicker.ServerInfoBlob);
             }
 
-            var minutesToday = _playtimeTracking.PlaytimeMinutesToday;
             if (minutesToday > 60)
             {
                 Lobby!.PlaytimeComment.Visible = true;

--- a/Resources/Locale/en-US/lobby/lobby-state.ftl
+++ b/Resources/Locale/en-US/lobby/lobby-state.ftl
@@ -26,6 +26,6 @@ lobby-state-playtime-comment-normal =
     [1]hour
     *[other]hours
     } ingame today. Remember to take breaks!
-lobby-state-playtime-comment-concerning = You've played for {$hours} hours today. Please take a break.
+lobby-state-playtime-comment-concerning = You've played for {$hours} hours today. Please take a break. Playable roles have been limited.
 lobby-state-playtime-comment-grasstouchless = {$hours} hours. Consider logging off to attend to your needs.
 lobby-state-playtime-comment-selfdestructive = {$hours} hours. Really?


### PR DESCRIPTION
## About the PR
  - 'Ready' button is disabled if threshold (180 minutes) is met. Players can only late-join.
  - Late-join roles are limited if threshold (180 minutes) is met.

## Why / Balance
Heavy handedly discourage long play session

## Technical details
Added client side role changes

## Media
https://github.com/user-attachments/assets/a95ee8e3-499e-424b-aafe-ad806fa9b10c

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
<!--
:cl:
- remove: Removed fun!
- tweak: Players with 3hrs+ playtime can only late join with limited roles!
-->
