### PR TITLE
NPCs behaving better in nograv/space

### DIFF
--- a/Content.Server/NPC/Components/NPCSteeringComponent.cs
+++ b/Content.Server/NPC/Components/NPCSteeringComponent.cs
@@ -98,13 +98,11 @@ public sealed partial class NPCSteeringComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)] public float Range = 0.2f;
 
-    // Goobstation
     /// <summary>
     /// Whether to ignore pathing and just move directly to target.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)] public bool DirectMove = false;
 
-    // Goobstation
     /// <summary>
     /// Up to how fast can we be going before being considered in range, if not null.
     /// </summary>

--- a/Content.Server/NPC/Components/NPCSteeringComponent.cs
+++ b/Content.Server/NPC/Components/NPCSteeringComponent.cs
@@ -100,6 +100,12 @@ public sealed partial class NPCSteeringComponent : Component
 
     // Goobstation
     /// <summary>
+    /// Whether to ignore pathing and just move directly to target.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)] public bool DirectMove = false;
+
+    // Goobstation
+    /// <summary>
     /// Up to how fast can we be going before being considered in range, if not null.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)] public float? InRangeMaxSpeed = null;

--- a/Content.Server/NPC/Components/NPCSteeringComponent.cs
+++ b/Content.Server/NPC/Components/NPCSteeringComponent.cs
@@ -98,6 +98,12 @@ public sealed partial class NPCSteeringComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)] public float Range = 0.2f;
 
+    // Goobstation
+    /// <summary>
+    /// Up to how fast can we be going before being considered in range, if not null.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)] public float? InRangeMaxSpeed = null;
+
     /// <summary>
     /// How far does the last node in the path need to be before considering re-pathfinding.
     /// </summary>

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
@@ -67,7 +67,7 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
     /// Don't try to brake if null (upstream behavior).
     /// </summary>
     [DataField]
-    public float? BrakeMaxVelocity = 0.1f;
+    public float? BrakeMaxVelocity = 0.03f;
 
     private const string MovementCancelToken = "MovementCancelToken";
 

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
@@ -184,6 +184,9 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
         }
         else if (blackboard.TryGetValue<PathResultEvent>(PathfindKey, out var result, _entManager))
         {
+            // Goobstation
+            comp.DirectMove = false;
+
             if (blackboard.TryGetValue<EntityCoordinates>(NPCBlackboard.OwnerCoordinates, out var coordinates, _entManager))
             {
                 var mapCoords = _transform.ToMapCoordinates(coordinates);

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
@@ -185,18 +185,9 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
             return HTNOperatorStatus.Finished;
         }
 
-        // Goobstation
-        var inRangeStatus = HTNOperatorStatus.Continuing;
-        if (BrakeMaxVelocity == null ||
-            !_entManager.TryGetComponent<PhysicsComponent>(owner, out var physics) ||
-            physics.LinearVelocity.Length() < BrakeMaxVelocity.Value)
-        {
-            inRangeStatus = HTNOperatorStatus.Finished;
-        }
-
         return steering.Status switch
         {
-            SteeringStatus.InRange => inRangeStatus, // Goobstation
+            SteeringStatus.InRange => HTNOperatorStatus.Finished,
             SteeringStatus.NoPath => HTNOperatorStatus.Failed,
             SteeringStatus.Moving => HTNOperatorStatus.Continuing,
             _ => throw new ArgumentOutOfRangeException()

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
@@ -187,11 +187,12 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
 
         // Goobstation
         var inRangeStatus = HTNOperatorStatus.Continuing;
-        if (BrakeMaxVelocity == null
-            || !_entManager.TryGetComponent<PhysicsComponent>(owner, out var physics)
-            || physics.LinearVelocity.Length() < BrakeMaxVelocity.Value
-        )
+        if (BrakeMaxVelocity == null ||
+            !_entManager.TryGetComponent<PhysicsComponent>(owner, out var physics) ||
+            physics.LinearVelocity.Length() < BrakeMaxVelocity.Value)
+        {
             inRangeStatus = HTNOperatorStatus.Finished;
+        }
 
         return steering.Status switch
         {

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
@@ -67,7 +67,7 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
     /// Don't try to brake if null (upstream behavior).
     /// </summary>
     [DataField]
-    public float? BrakeMaxVelocity = null;
+    public float? BrakeMaxVelocity = 0.1f;
 
     private const string MovementCancelToken = "MovementCancelToken";
 

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
@@ -98,9 +98,10 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
             !_entManager.TryGetComponent<PhysicsComponent>(owner, out var body))
             return (false, null);
 
-        // check if we or target are offgrid
-        var offGrid = !_entManager.TryGetComponent<MapGridComponent>(xform.GridUid, out var ownerGrid) ||
-                      !_entManager.TryGetComponent<MapGridComponent>(_transform.GetGrid(targetCoordinates), out var targetGrid);
+        // check if we or target are offgrid or on different grids
+        var doDirectMove = !_entManager.TryGetComponent<MapGridComponent>(xform.GridUid, out var ownerGrid) ||
+                      !_entManager.TryGetComponent<MapGridComponent>(_transform.GetGrid(targetCoordinates), out var targetGrid) ||
+                      ownerGrid != targetGrid;
 
         var range = blackboard.GetValueOrDefault<float>(RangeKey, _entManager);
 
@@ -121,8 +122,7 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
             });
         }
 
-        // if we're not offgrid, pathfind normally
-        if (!offGrid)
+        if (!doDirectMove)
         {
             var path = await _pathfind.GetPath(
                 blackboard.GetValue<EntityUid>(NPCBlackboard.Owner),

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -134,8 +134,13 @@ public sealed partial class NPCSteeringSystem
         }
 
         // Goobstation
+        var careAboutSpeed = steering.InRangeMaxSpeed != null;
         var finalInRange = ourCoordinates.TryDistance(EntityManager, destinationCoordinates, out var targetDistance) && inLos && targetDistance <= steering.Range;
+                           // ideally this would be careAboutSpeed but schizo C#
         var velocityHigh = steering.InRangeMaxSpeed != null && body.LinearVelocity.LengthSquared() > steering.InRangeMaxSpeed.Value * steering.InRangeMaxSpeed.Value;
+        // if we're in range and we care about velocity, stop trying to move if we early return
+        if (finalInRange && careAboutSpeed)
+            moveMultiplier = 0f;
 
         // We've arrived, nothing else matters.
         // Goobstation - also check if our velocity is higher than desired
@@ -375,6 +380,7 @@ public sealed partial class NPCSteeringSystem
         switch (moveType)
         {
             case MovementType.MovingToTarget:
+                moveMultiplier = 1f;
                 ApplySeek(interest, offsetRot.RotateVec(direction.Normalized()), 1f);
                 break;
             case MovementType.Braking:

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -133,7 +133,10 @@ public sealed partial class NPCSteeringSystem
         // We've arrived, nothing else matters.
         if (xform.Coordinates.TryDistance(EntityManager, destinationCoordinates, out var targetDistance) &&
             inLos &&
-            targetDistance <= steering.Range)
+            targetDistance <= steering.Range &&
+            // Goobstation
+            (steering.InRangeMaxSpeed == null ||
+                body.LinearVelocity.LengthSquared() < steering.InRangeMaxSpeed.Value * steering.InRangeMaxSpeed.Value))
         {
             steering.Status = SteeringStatus.InRange;
             ResetStuck(steering, ourCoordinates);

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -360,7 +360,7 @@ public sealed partial class NPCSteeringSystem
             {
                 // attempt to prevent jitter on arrival from overbraking in yes-grav
                 const float easeInFactor = 1.5f; // scary magic number
-                var cvel = body.LinearVelocity * 1f; // copy
+                var cvel = body.LinearVelocity;
                 _mover.Friction(0f, frameTime, friction, ref cvel);
                 var postFrictionVel = cvel.Length();
                 var frameAccel = acceleration * frameTime * moveSpeed;

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -93,8 +93,8 @@ public sealed partial class NPCSteeringSystem
         TransformComponent xform,
         Angle offsetRot,
         float moveSpeed,
-        float acceleration,
-        float friction,
+        float acceleration, // Goobstation
+        float friction, // Goobstation
         Span<float> interest,
         float frameTime,
         ref bool forceSteer,
@@ -329,9 +329,8 @@ public sealed partial class NPCSteeringSystem
 
         // If we don't have a path yet then do nothing; this is to avoid stutter-stepping if it turns out there's no path
         // available but we assume there was.
-        if (steering is { Pathfind: true, CurrentPath.Count: 0 }
-            && !arrivedFinal // Goobstation
-        )
+        if (steering is { Pathfind: true, CurrentPath.Count: 0 } && !arrivedFinal)
+                                                                 // Goobstation
             return true;
 
         if (moveSpeed == 0f || direction == Vector2.Zero)
@@ -357,10 +356,11 @@ public sealed partial class NPCSteeringSystem
             // <Goobstation modified>
             var sameDirectionWeight = weight * 0.1f;
             norm = offsetRot.RotateVec(body.LinearVelocity.Normalized()); // fix TODO: upstream this
-            if (arrivedFinal) {
+            if (arrivedFinal)
+            {
                 // attempt to prevent jitter on arrival from overbraking in yes-grav
                 const float easeInFactor = 1.5f; // scary magic number
-                var cvel = body.LinearVelocity * 1f;
+                var cvel = body.LinearVelocity * 1f; // copy
                 _mover.Friction(0f, frameTime, friction, ref cvel);
                 var postFrictionVel = cvel.Length();
                 var frameAccel = acceleration * frameTime * moveSpeed;

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -384,14 +384,16 @@ public sealed partial class NPCSteeringSystem
                     _mover.Friction(0f, frameTime, friction, ref cvel);
                     // slow down our braking if we would overbrake in this frame
                     moveMultiplier = MapValue(cvel.Length(), 0f, frameAccel);
-                    ApplySeek(interest, -offsetRot.RotateVec(body.LinearVelocity.Normalized()), 1f);
+                                        // brake                                 // normalise
+                    ApplySeek(interest, -offsetRot.RotateVec(body.LinearVelocity / velLen), 1f);
                 }
                 break;
             case MovementType.BrakingTangential:
                 if (velLen > 0f)
                 {
                     moveMultiplier = MapValue(tgVel.Length(), 0f, frameAccel);
-                    ApplySeek(interest, -offsetRot.RotateVec(tgVel.Normalized()), tgVel.Length() / body.LinearVelocity.Length());
+                                        // brake
+                    ApplySeek(interest, -offsetRot.RotateVec(tgVel.Normalized()), tgVel.Length() / velLen);
                 }
                 break;
             case MovementType.Coasting:

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -387,9 +387,12 @@ public sealed partial class NPCSteeringSystem
             case MovementType.Braking:
                 if (velLen > 0f)
                 {
+                    // copy our velocity and apply friction to the copy
                     var cvel = body.LinearVelocity;
                     _mover.Friction(0f, frameTime, friction, ref cvel);
-                    // slow down our braking if we would overbrake in this frame
+                    // clamp our braking to what our post-friction velocity would be
+                    // otherwise we can overbrake in this frame and reverse movement direction
+                    // TODO: a way to tell calling code that we don't want to reverse movement direction to not have to do this
                     moveMultiplier = MapValue(cvel.Length(), 0f, frameAccel);
                                         // brake                                 // normalise
                     ApplySeek(interest, -offsetRot.RotateVec(body.LinearVelocity / velLen), 1f);

--- a/Resources/Prototypes/NPCs/Combat/melee.yml
+++ b/Resources/Prototypes/NPCs/Combat/melee.yml
@@ -110,6 +110,7 @@
             shutdownState: PlanFinished
             pathfindInPlanning: true
             removeKeyOnFinish: false
+            brakeMaxVelocity: null # Goobstation - no braking
             targetKey: TargetCoordinates
             pathfindKey: TargetPathfind
             rangeKey: MeleeRange
@@ -158,6 +159,7 @@
             shutdownState: PlanFinished
             pathfindInPlanning: true
             removeKeyOnFinish: false
+            brakeMaxVelocity: null # Goobstation - no braking
             targetKey: TargetCoordinates
             pathfindKey: TargetPathfind
             rangeKey: MeleeRange

--- a/Resources/Prototypes/NPCs/Combat/melee.yml
+++ b/Resources/Prototypes/NPCs/Combat/melee.yml
@@ -110,7 +110,7 @@
             shutdownState: PlanFinished
             pathfindInPlanning: true
             removeKeyOnFinish: false
-            brakeMaxVelocity: null # Goobstation - no braking
+            brakeMaxVelocity: null # don't try to brake
             targetKey: TargetCoordinates
             pathfindKey: TargetPathfind
             rangeKey: MeleeRange
@@ -159,7 +159,7 @@
             shutdownState: PlanFinished
             pathfindInPlanning: true
             removeKeyOnFinish: false
-            brakeMaxVelocity: null # Goobstation - no braking
+            brakeMaxVelocity: null # don't try to brake
             targetKey: TargetCoordinates
             pathfindKey: TargetPathfind
             rangeKey: MeleeRange

--- a/Resources/Prototypes/NPCs/idle.yml
+++ b/Resources/Prototypes/NPCs/idle.yml
@@ -24,6 +24,7 @@
         - !type:HTNPrimitiveTask
           operator: !type:MoveToOperator
             pathfindInPlanning: false
+            brakeMaxVelocity: 0.05 # Goobstation
 
         - !type:HTNPrimitiveTask
           operator: !type:RandomOperator

--- a/Resources/Prototypes/NPCs/idle.yml
+++ b/Resources/Prototypes/NPCs/idle.yml
@@ -24,7 +24,6 @@
         - !type:HTNPrimitiveTask
           operator: !type:MoveToOperator
             pathfindInPlanning: false
-            brakeMaxVelocity: 0.05 # Goobstation
 
         - !type:HTNPrimitiveTask
           operator: !type:RandomOperator


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
ports (my PRs, doesn't modify any goobcode so no licensing issues):
- https://github.com/Goob-Station/Goob-Station/pull/3181
- https://github.com/Goob-Station/Goob-Station/pull/3339
- https://github.com/Goob-Station/Goob-Station/pull/3359

does:
- NPCs will now brake tangentially if it thinks it's moving in a circle
- NPCs will now brake when approaching destination (idle NPCs shouldn't throw themselves off grid as badly anymore)
- if target or source of MoveToOperator is offgrid, now instead of doing nothing it will move to target with no pathfinding

has been merged on goob and works

## Why / Balance
needed
can't cheese space carp anymore

## Technical details
this really needs someone who actually knows HTN well to look at it
there's also the `// TODO: Move these to movercontroller` but this too should probably be done/supervised by someone who knows what MoverController is doing

## Media

https://github.com/user-attachments/assets/f7da84e4-25dc-446c-9271-727ef9e787df

i also tested a bunch more stuff in the goob third PR

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
may slightly interfere with mobs that don't want to brake on approach since default is to brake

**Changelog**
:cl:
- add: NPCs are now able to move in(to) open space. You can't cheese space carp anymore.
- fix: Fixed NPC jank when moving in 0-gravity.