### PR TITLE
give construction ghost normal interaction range

### DIFF
--- a/Resources/Prototypes/Entities/Markers/construction_ghost.yml
+++ b/Resources/Prototypes/Entities/Markers/construction_ghost.yml
@@ -8,6 +8,17 @@
   - type: ConstructionGhost
   - type: Clickable
   - type: InteractionOutline
+  - type: Physics
+    bodyType: Static
+    canCollide: false
+  - type: Fixtures # Allows proper interaction instead of fixed radius.
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.00"
+        layer:
+        - None
   - type: GuideHelp
     guides:
     - Construction


### PR DESCRIPTION
## About the PR
This pr adds physics and fixtures to the construction ghost proto

## Why / Balance
See #37741
QoL

## Technical details
Ghost spawns only on client side, and physics predicted. Pr shouldn't cause any issues

## Media
Range before:
![ohno](https://github.com/user-attachments/assets/afe94dad-9b48-4316-b304-df3d8587e10a)
Range after:
![ohyeah](https://github.com/user-attachments/assets/32a7e6de-d1b6-4bb3-b360-8375d39dfe88)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.