### PR TITLE
Cleanup AddPolymorphActionCommand and LEC conversion.

### DIFF
--- a/Content.Server/Administration/Commands/AddPolymorphActionCommand.cs
+++ b/Content.Server/Administration/Commands/AddPolymorphActionCommand.cs
@@ -6,17 +6,13 @@ using Robust.Shared.Console;
 namespace Content.Server.Administration.Commands;
 
 [AdminCommand(AdminFlags.Fun)]
-public sealed class AddPolymorphActionCommand : IConsoleCommand
+public sealed class AddPolymorphActionCommand : LocalizedEntityCommands
 {
-    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly PolymorphSystem _polySystem = default!;
 
-    public string Command => "addpolymorphaction";
+    public override string Command => "addpolymorphaction";
 
-    public string Description => Loc.GetString("add-polymorph-action-command-description");
-
-    public string Help => Loc.GetString("add-polymorph-action-command-help-text");
-
-    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         if (args.Length != 2)
         {
@@ -24,15 +20,13 @@ public sealed class AddPolymorphActionCommand : IConsoleCommand
             return;
         }
 
-        if (!NetEntity.TryParse(args[0], out var entityUidNet) || !_entityManager.TryGetEntity(entityUidNet, out var entityUid))
+        if (!NetEntity.TryParse(args[0], out var entityUidNet) || !EntityManager.TryGetEntity(entityUidNet, out var entityUid))
         {
-            shell.WriteError(Loc.GetString("shell-entity-uid-must-be-number"));
+            shell.WriteError(Loc.GetString("shell-could-not-find-entity-with-uid", ("uid", args[0])));
             return;
         }
 
-        var polySystem = _entityManager.EntitySysManager.GetEntitySystem<PolymorphSystem>();
-
-        var polymorphable = _entityManager.EnsureComponent<PolymorphableComponent>(entityUid.Value);
-        polySystem.CreatePolymorphAction(args[1], (entityUid.Value, polymorphable));
+        var polymorphable = EntityManager.EnsureComponent<PolymorphableComponent>(entityUid.Value);
+        _polySystem.CreatePolymorphAction(args[1], (entityUid.Value, polymorphable));
     }
 }

--- a/Resources/Locale/en-US/administration/commands/polymorph-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/polymorph-command.ftl
@@ -1,8 +1,0 @@
-﻿polymorph-command-description = For when you need someone to stop being a person. Takes an entity and a polymorph prototype.
-polymorph-command-help-text = polymorph <id> <polymorph prototype>
-
-add-polymorph-action-command-description = Takes an entity and gives them a voluntary polymorph.
-add-polymorph-action-command-help-text = addpolymorphaction <id> <polymorph prototype>
-
-
-polymorph-not-valid-prototype-error = Polymorph prototype is not valid.

--- a/Resources/Locale/en-US/commands/addpolymorphaction-command.ftl
+++ b/Resources/Locale/en-US/commands/addpolymorphaction-command.ftl
@@ -1,0 +1,2 @@
+﻿cmd-addpolymorphaction-desc = Takes an entity and gives them a voluntary polymorph.
+cmd-addpolymorphaction-help = Usage: addpolymorphaction <id> <polymorph prototype>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Technical details
Converts AddPolymorphActionCommand to LocalizedEntityCommands since it is using an entity system.
Move locale strings for command to addpolymorphaction-command.ftl in /locale/en-us/commands/
Remove unused locale strings for PolymorphCommand. I checked and the toolshed variant is using the desc from toolshed-commands.ftl
Changed one of the locale strings in the addpolymorphaction command to be a touch more specific.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->