### PR TITLE
Tweaks to ShowRulesCommand structure, localization, and autocomplete.

### DIFF
--- a/Content.Server/Info/ShowRulesCommand.cs
+++ b/Content.Server/Info/ShowRulesCommand.cs
@@ -10,55 +10,46 @@ using Robust.Shared.Network;
 namespace Content.Server.Info;
 
 [AdminCommand(AdminFlags.Admin)]
-public sealed class ShowRulesCommand : IConsoleCommand
+public sealed class ShowRulesCommand : LocalizedCommands
 {
-    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly IConfigurationManager _configuration = default!;
+    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
 
-    public string Command => "showrules";
-    public string Description => "Opens the rules popup for the specified player.";
-    public string Help => "showrules <username> [seconds]";
-    public async void Execute(IConsoleShell shell, string argStr, string[] args)
+    public override string Command => "showrules";
+
+    public override async void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        string target;
-        float seconds;
-
-        switch (args.Length)
+        if (args.Length is < 1 or > 2)
         {
-            case 1:
-            {
-                target = args[0];
-                seconds = _configuration.GetCVar(CCVars.RulesWaitTime);
-                break;
-            }
-            case 2:
-            {
-                if (!float.TryParse(args[1], out seconds))
-                {
-                    shell.WriteError($"{args[1]} is not a valid amount of seconds.\n{Help}");
-                    return;
-                }
-
-                target = args[0];
-                break;
-            }
-            default:
-            {
-                shell.WriteLine(Help);
-                return;
-            }
+            shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+            return;
         }
 
+        var seconds = _configuration.GetCVar(CCVars.RulesWaitTime);
 
-        if (!_player.TryGetSessionByUsername(target, out var player))
+        if (args.Length == 2 && !float.TryParse(args[1], out seconds))
         {
-            shell.WriteError("Unable to find a player with that name.");
-           return;
+            shell.WriteError(Loc.GetString("cmd-showrules-invalid-seconds", ("seconds", args[1])));
+            return;
+        }
+
+        if (!_player.TryGetSessionByUsername(args[0], out var player))
+        {
+            shell.WriteError(Loc.GetString("shell-target-player-does-not-exist"));
+            return;
         }
 
         var coreRules = _configuration.GetCVar(CCVars.RulesFile);
-        var message = new SendRulesInformationMessage { PopupTime = seconds, CoreRules = coreRules, ShouldShowRules = true};
+        var message = new SendRulesInformationMessage
+            { PopupTime = seconds, CoreRules = coreRules, ShouldShowRules = true };
         _net.ServerSendMessage(message, player.Channel);
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        return args.Length == 1
+            ? CompletionResult.FromOptions(CompletionHelper.SessionNames(players: _player))
+            : CompletionResult.Empty;
     }
 }

--- a/Resources/Locale/en-US/commands/showrules-command.ftl
+++ b/Resources/Locale/en-US/commands/showrules-command.ftl
@@ -1,0 +1,3 @@
+﻿cmd-showrules-desc = Opens the rules popup for the specified player.
+cmd-showrules-help = Usage: showrules <username> [seconds]
+cmd-showrules-invalid-seconds = {$seconds} is not a valid number of seconds!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Technical details
<!-- Summary of code changes for easier review. -->
Converts ShowRulesCommand to LocalizedCommand and localizes accordingly.
Modified some locale strings to be consistent with other commands.
Implemented SessionName autocomplete.
Performed minor cleanup.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl:
ADMIN:
- tweak: The showrules command now has autocomplete.
