### PR TITLE
Fix AddHandCommand not working on aghosts

### DIFF
--- a/Content.Server/Body/Commands/AddHandCommand.cs
+++ b/Content.Server/Body/Commands/AddHandCommand.cs
@@ -1,12 +1,13 @@
 using System.Linq;
 using Content.Server.Administration;
 using Content.Server.Body.Systems;
+using Content.Server.Hands.Systems;
 using Content.Shared.Administration;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
+using Content.Shared.Hands.Components;
 using Robust.Shared.Console;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
 
 namespace Content.Server.Body.Commands
 {
@@ -15,9 +16,9 @@ namespace Content.Server.Body.Commands
     {
         [Dependency] private readonly IEntityManager _entManager = default!;
         [Dependency] private readonly IPrototypeManager _protoManager = default!;
-        [Dependency] private readonly IRobustRandom _random = default!;
 
         private static readonly EntProtoId DefaultHandPrototype = "LeftHandHuman";
+        private static int _handIdAccumulator;
 
         public string Command => "addhand";
         public string Description => "Adds a hand to your entity.";
@@ -114,9 +115,17 @@ namespace Content.Server.Body.Commands
 
             if (!_entManager.TryGetComponent(entity, out BodyComponent? body) || body.RootContainer.ContainedEntity == null)
             {
-                var text = $"You have no body{(_random.Prob(0.2f) ? " and you must scream." : ".")}";
+                var location = _entManager.GetComponentOrNull<BodyPartComponent>(hand)?.Symmetry switch
+                {
+                    BodyPartSymmetry.None => HandLocation.Middle,
+                    BodyPartSymmetry.Left => HandLocation.Left,
+                    BodyPartSymmetry.Right => HandLocation.Right,
+                    _ => HandLocation.Right
+                };
+                _entManager.DeleteEntity(hand);
 
-                shell.WriteLine(text);
+                // You have no body and you must scream.
+                _entManager.System<HandsSystem>().AddHand(entity, $"{hand}-cmd-{_handIdAccumulator++}", location);
                 return;
             }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes the AddHandCommand as using it as an entity without a body (aghost) did not work. This also lets it work for borgs i'm pretty sure.

PsychoMed bros are weeping because this is like barely decoupled but we go as we go

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
