### PR TITLE
Predict passive welding fuel consumption

### DIFF
--- a/Content.Server/Tools/ToolSystem.cs
+++ b/Content.Server/Tools/ToolSystem.cs
@@ -1,47 +1,5 @@
-using Content.Shared.Chemistry.Components.SolutionManager;
-using Content.Shared.FixedPoint;
-using Content.Shared.Tools.Components;
-
-using SharedToolSystem = Content.Shared.Tools.Systems.SharedToolSystem;
+using Content.Shared.Tools.Systems;
 
 namespace Content.Server.Tools;
 
-public sealed class ToolSystem : SharedToolSystem
-{
-    public override void Update(float frameTime)
-    {
-        base.Update(frameTime);
-
-        UpdateWelders(frameTime);
-    }
-
-    //todo move to shared once you can remove reagents from shared without it freaking out.
-    private void UpdateWelders(float frameTime)
-    {
-        var query = EntityQueryEnumerator<WelderComponent, SolutionContainerManagerComponent>();
-        while (query.MoveNext(out var uid, out var welder, out var solutionContainer))
-        {
-            if (!welder.Enabled)
-                continue;
-
-            welder.WelderTimer += frameTime;
-
-            if (welder.WelderTimer < welder.WelderUpdateTimer)
-                continue;
-
-            if (!SolutionContainerSystem.TryGetSolution((uid, solutionContainer), welder.FuelSolutionName, out var solutionComp, out var solution))
-                continue;
-
-            SolutionContainerSystem.RemoveReagent(solutionComp.Value, welder.FuelReagent, welder.FuelConsumption * welder.WelderTimer);
-
-            if (solution.GetTotalPrototypeQuantity(welder.FuelReagent) <= FixedPoint2.Zero)
-            {
-                ItemToggle.Toggle(uid, predicted: false);
-            }
-
-            Dirty(uid, welder);
-            welder.WelderTimer -= welder.WelderUpdateTimer;
-        }
-    }
-}
-
+public sealed class ToolSystem : SharedToolSystem;

--- a/Content.Shared/Tools/Components/WelderComponent.cs
+++ b/Content.Shared/Tools/Components/WelderComponent.cs
@@ -38,7 +38,7 @@ public sealed partial class WelderComponent : Component
     public TimeSpan WelderUpdateTimer = TimeSpan.FromSeconds(1);
 
     /// <summary>
-    /// Name of <see cref="FuelSolution"/>.
+    /// Name of the fuel solution.
     /// </summary>
     [DataField]
     public string FuelSolutionName = "Welder";

--- a/Content.Shared/Tools/Components/WelderComponent.cs
+++ b/Content.Shared/Tools/Components/WelderComponent.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
 using Content.Shared.Tools.Systems;
@@ -8,51 +7,68 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Tools.Components;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), Access(typeof(SharedToolSystem))]
+/// <summary>
+/// Handles fuel consumption for the tool and allows it to explode welding fuel tanks.
+/// </summary>
+/// <summary>
+/// TODO: De-hardcode welder bombing.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), AutoGenerateComponentPause]
+[Access(typeof(SharedToolSystem))]
 public sealed partial class WelderComponent : Component
 {
+    /// <summary>
+    /// Is the welder currently enabled?
+    /// </summary>
     [DataField, AutoNetworkedField]
     public bool Enabled;
 
-    [DataField]
-    public float WelderTimer;
+    /// <summary>
+    /// Timestamp for the next update loop update.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan NextUpdate;
 
     /// <summary>
-    ///     Name of <see cref="FuelSolution"/>.
+    /// Delay between updates.
+    /// </summary>
+    [DataField]
+    public TimeSpan WelderUpdateTimer = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Name of <see cref="FuelSolution"/>.
     /// </summary>
     [DataField]
     public string FuelSolutionName = "Welder";
 
     /// <summary>
-    ///     Reagent that will be used as fuel for welding.
+    /// Reagent that will be used as fuel for welding.
     /// </summary>
     [DataField]
     public ProtoId<ReagentPrototype> FuelReagent = "WeldingFuel";
 
     /// <summary>
-    ///     Fuel consumption per second while the welder is active.
+    /// Fuel consumption per second while the welder is active.
+    /// In u/s
     /// </summary>
     [DataField, AutoNetworkedField]
     public FixedPoint2 FuelConsumption = FixedPoint2.New(1.0f);
 
     /// <summary>
-    ///     A fuel amount to be consumed when the welder goes from being unlit to being lit.
+    /// A fuel amount to be consumed when the welder goes from being unlit to being lit.
     /// </summary>
     [DataField, AutoNetworkedField]
     public FixedPoint2 FuelLitCost = FixedPoint2.New(0.5f);
 
     /// <summary>
-    ///     Sound played when refilling the welder.
+    /// Sound played when refilling the welder.
     /// </summary>
     [DataField]
     public SoundSpecifier WelderRefill = new SoundPathSpecifier("/Audio/Effects/refill.ogg");
 
     /// <summary>
-    ///     Whether the item is safe to refill while lit without exploding the tank.
+    /// Whether the item is safe to refill while lit without exploding the tank.
     /// </summary>
     [DataField]
     public bool TankSafe;
-
-    [DataField]
-    public float WelderUpdateTimer = 1f;
 }

--- a/Content.Shared/Tools/Components/WelderComponent.cs
+++ b/Content.Shared/Tools/Components/WelderComponent.cs
@@ -4,6 +4,7 @@ using Content.Shared.Tools.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Tools.Components;
 
@@ -26,7 +27,8 @@ public sealed partial class WelderComponent : Component
     /// <summary>
     /// Timestamp for the next update loop update.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoNetworkedField, AutoPausedField]
     public TimeSpan NextUpdate;
 
     /// <summary>

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
@@ -204,7 +204,6 @@ public abstract partial class SharedToolSystem
         if (args.User != null && !_actionBlocker.CanComplexInteract(args.User.Value))
         {
             args.Cancelled = true;
-            return;
         }
     }
 
@@ -214,7 +213,6 @@ public abstract partial class SharedToolSystem
         var curTime = _timing.CurTime;
         while (query.MoveNext(out var uid, out var welder, out var solutionContainer))
         {
-
             if (curTime < welder.NextUpdate)
                 continue;
 

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
@@ -17,13 +17,16 @@ public abstract partial class SharedToolSystem
 
     public void InitializeWelder()
     {
+        SubscribeLocalEvent<WelderComponent, MapInitEvent>(OnWelderInit);
         SubscribeLocalEvent<WelderComponent, ExaminedEvent>(OnWelderExamine);
         SubscribeLocalEvent<WelderComponent, AfterInteractEvent>(OnWelderAfterInteract);
 
-        SubscribeLocalEvent<WelderComponent, ToolUseAttemptEvent>((uid, comp, ev) => {
+        SubscribeLocalEvent<WelderComponent, ToolUseAttemptEvent>((uid, comp, ev) =>
+        {
             CanCancelWelderUse((uid, comp), ev.User, ev.Fuel, ev);
         });
-        SubscribeLocalEvent<WelderComponent, DoAfterAttemptEvent<ToolDoAfterEvent>>((uid, comp, ev) => {
+        SubscribeLocalEvent<WelderComponent, DoAfterAttemptEvent<ToolDoAfterEvent>>((uid, comp, ev) =>
+        {
             CanCancelWelderUse((uid, comp), ev.Event.User, ev.Event.Fuel, ev);
         });
         SubscribeLocalEvent<WelderComponent, ToolDoAfterEvent>(OnWelderDoAfter);
@@ -69,6 +72,12 @@ public abstract partial class SharedToolSystem
         }
 
         return (fuelSolution.GetTotalPrototypeQuantity(welder.FuelReagent), fuelSolution.MaxVolume);
+    }
+
+    private void OnWelderInit(Entity<WelderComponent> ent, ref MapInitEvent args)
+    {
+        ent.Comp.NextUpdate = _timing.CurTime + ent.Comp.WelderUpdateTimer;
+        Dirty(ent);
     }
 
     private void OnWelderExamine(Entity<WelderComponent> entity, ref ExaminedEvent args)
@@ -169,7 +178,8 @@ public abstract partial class SharedToolSystem
 
     private void OnActivateAttempt(Entity<WelderComponent> entity, ref ItemToggleActivateAttemptEvent args)
     {
-        if (args.User != null && !_actionBlocker.CanComplexInteract(args.User.Value)) {
+        if (args.User != null && !_actionBlocker.CanComplexInteract(args.User.Value))
+        {
             args.Cancelled = true;
             return;
         }
@@ -191,9 +201,36 @@ public abstract partial class SharedToolSystem
 
     private void OnDeactivateAttempt(Entity<WelderComponent> entity, ref ItemToggleDeactivateAttemptEvent args)
     {
-        if (args.User != null && !_actionBlocker.CanComplexInteract(args.User.Value)) {
+        if (args.User != null && !_actionBlocker.CanComplexInteract(args.User.Value))
+        {
             args.Cancelled = true;
             return;
+        }
+    }
+
+    private void UpdateWelders()
+    {
+        var query = EntityQueryEnumerator<WelderComponent, SolutionContainerManagerComponent>();
+        var curTime = _timing.CurTime;
+        while (query.MoveNext(out var uid, out var welder, out var solutionContainer))
+        {
+
+            if (curTime < welder.NextUpdate)
+                continue;
+
+            welder.NextUpdate += welder.WelderUpdateTimer;
+            Dirty(uid, welder);
+
+            if (!welder.Enabled)
+                continue;
+
+            if (!SolutionContainerSystem.TryGetSolution((uid, solutionContainer), welder.FuelSolutionName, out var solutionComp, out var solution))
+                continue;
+
+            SolutionContainerSystem.RemoveReagent(solutionComp.Value, welder.FuelReagent, welder.FuelConsumption * welder.WelderUpdateTimer.TotalSeconds);
+
+            if (solution.GetTotalPrototypeQuantity(welder.FuelReagent) <= FixedPoint2.Zero)
+                ItemToggle.Toggle(uid);
         }
     }
 }

--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -12,12 +12,14 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Tools.Systems;
 
 public abstract partial class SharedToolSystem : EntitySystem
 {
+    [Dependency] private   readonly IGameTiming _timing = default!;
     [Dependency] private   readonly IMapManager _mapManager = default!;
     [Dependency] private   readonly IPrototypeManager _protoMan = default!;
     [Dependency] protected readonly ISharedAdminLogManager AdminLogger = default!;
@@ -261,6 +263,13 @@ public abstract partial class SharedToolSystem : EntitySystem
         }
 
         return !beforeAttempt.Cancelled;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        UpdateWelders();
     }
 
     #region DoAfterEvents


### PR DESCRIPTION
## About the PR
Resolves https://github.com/space-wizards/space-station-14/issues/38863

## Why / Balance
prediction good
resolves the TODO in the code comment

## Technical details
Predicted solutions freaking out like mentioned in the code comment was fixed in https://github.com/space-wizards/space-station-14/pull/34838
We  move everything to shared and network the NextUpdate field.
We also make the update loop compare TimeSpans rather than accumulating frametime so that it does not need to get dirtied every tick. This has the nice side-effect that fuel consumption is now actually numerically accurate and consumes one unit at a time rather than something like 1.01, which caused weird numbers to be displayed.

This PR only changes the passive fuel consumption when lit, the normal tool interaction was already predicted.

## Media

https://github.com/user-attachments/assets/dd247bb4-1103-47de-81b4-e8bc81ce9493

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
nah
