### PR TITLE
Add VV button to the solution editor

### DIFF
--- a/Content.Client/Administration/UI/ManageSolutions/EditSolutionsWindow.xaml
+++ b/Content.Client/Administration/UI/ManageSolutions/EditSolutionsWindow.xaml
@@ -8,6 +8,21 @@
             <OptionButton Name="SolutionOption" HorizontalExpand="True"/>
         </BoxContainer>
 
+        <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="0 4">
+            <Button Name="VVButton"
+                    Text="{Loc 'admin-solutions-window-vv-button'}"
+                    ToolTip="{Loc 'admin-solutions-window-vv-button-tooltip'}"
+                    Disabled="True"
+                    HorizontalExpand="True"
+                    StyleClasses="OpenRight"/>
+            <Button Name="SolutionButton"
+                    Text="{Loc 'admin-solutions-window-solution-button'}"
+                    ToolTip="{Loc 'admin-solutions-window-solution-button-tooltip'}"
+                    Disabled="True"
+                    HorizontalExpand="True"
+                    StyleClasses="OpenLeft"/>
+        </BoxContainer>
+
         <!-- The total volume / capacity of the solution -->
         <BoxContainer Name="VolumeBox" Orientation="Vertical" HorizontalExpand="True" Margin="0 4"/>
 

--- a/Content.Client/Administration/UI/ManageSolutions/EditSolutionsWindow.xaml.cs
+++ b/Content.Client/Administration/UI/ManageSolutions/EditSolutionsWindow.xaml.cs
@@ -1,3 +1,4 @@
+using Content.Client.Administration.Managers;
 using Content.Shared.Administration;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
@@ -20,6 +21,7 @@ namespace Content.Client.Administration.UI.ManageSolutions
         [Dependency] private readonly IClientConsoleHost _consoleHost = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IClientGameTiming _timing = default!;
+        [Dependency] private readonly IClientAdminManager _admin = default!;
 
         private NetEntity _target = NetEntity.Invalid;
         private string? _selectedSolution;
@@ -34,6 +36,11 @@ namespace Content.Client.Administration.UI.ManageSolutions
 
             SolutionOption.OnItemSelected += SolutionSelected;
             AddButton.OnPressed += OpenAddReagentWindow;
+            VVButton.OnPressed += OpenVVWindow;
+            SolutionButton.OnPressed += OpenSolutionWindow;
+
+            VVButton.Disabled = !_admin.CanViewVar();
+            SolutionButton.Disabled = !_admin.CanViewVar();
         }
 
         public override void Close()
@@ -269,6 +276,32 @@ namespace Content.Client.Administration.UI.ManageSolutions
 
             _addReagentWindow = new AddReagentWindow(_target, _selectedSolution);
             _addReagentWindow.OpenCentered();
+        }
+
+        /// <summary>
+        ///     Open the corresponding solution entity in a ViewVariables window.
+        /// </summary>
+        private void OpenVVWindow(BaseButton.ButtonEventArgs obj)
+        {
+            if (_solutions == null
+                || _selectedSolution == null
+                || !_solutions.TryGetValue(_selectedSolution, out var uid)
+                || !_entityManager.TryGetNetEntity(uid, out var netEntity))
+                return;
+            _consoleHost.ExecuteCommand($"vv {netEntity}");
+        }
+
+        /// <summary>
+        ///     Open the corresponding Solution instance in a ViewVariables window.
+        /// </summary>
+        private void OpenSolutionWindow(BaseButton.ButtonEventArgs obj)
+        {
+            if (_solutions == null
+                || _selectedSolution == null
+                || !_solutions.TryGetValue(_selectedSolution, out var uid)
+                || !_entityManager.TryGetNetEntity(uid, out var netEntity))
+                return;
+            _consoleHost.ExecuteCommand($"vv /entity/{netEntity}/Solution/Solution");
         }
 
         /// <summary>

--- a/Resources/Locale/en-US/administration/ui/manage-solutions/manage-solutions.ftl
+++ b/Resources/Locale/en-US/administration/ui/manage-solutions/manage-solutions.ftl
@@ -1,5 +1,9 @@
 admin-solutions-window-title = Solution Editor - {$targetName}
 admin-solutions-window-solution-label = Target solution:
+admin-solutions-window-solution-button = Solution
+admin-solutions-window-solution-button-tooltip = Opens the corresponding server-side Solution instance in ViewVariables. Useful for debugging prediction issues.
+admin-solutions-window-vv-button = VV
+admin-solutions-window-vv-button-tooltip = Opens the corresponding solution entity in ViewVariables.
 admin-solutions-window-add-new-button = Add new reagent
 admin-solutions-window-volume-label = Volume {$currentVolume}/{$maxVolume}u
 admin-solutions-window-capacity-label = Capacity (u):


### PR DESCRIPTION
## About the PR
Adds a button for opening the solution entity and the solution itself in VV.

## Why / Balance
I've been doing and reviewing some solution prediction PRs recently and checking if prediction works as intended is a pain.
The solution editor only shows the client side values, so you have to compare them with the values on the server to see if they are correct. To open this you have to first find the solution entity in the container manager, then open VV for that, then find the solution component and finally open the Solution instance itself. This has cost me hours of my life, so it's a button now.

## Technical details
Add two new buttons, disabled by default unless the user has VV permissions.
When clicked on they simply execute the `vv` console command with the correct path.

## Media

https://github.com/user-attachments/assets/ad089e3c-8401-4193-b8a7-20396f5c2111

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:ADMIN:
:cl:
- add: Added VV buttons to the solution editor.
