### PR TITLE
Allow EmoteSoundsPrototype to have parents

### DIFF
--- a/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
@@ -35,7 +35,6 @@ public sealed partial class EmoteSoundsPrototype : IPrototype, IInheritingProtot
     ///     This will overwrite any params that may be set in sound specifiers.
     /// </summary>
     [DataField("params")]
-    [AlwaysPushInheritance]
     public AudioParams? GeneralParams;
 
     /// <summary>

--- a/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
@@ -28,7 +28,6 @@ public sealed partial class EmoteSoundsPrototype : IPrototype, IInheritingProtot
     ///     doesn't have specific sound for this emote id.
     /// </summary>
     [DataField("sound")]
-    [AlwaysPushInheritance]
     public SoundSpecifier? FallbackSound;
 
     /// <summary>

--- a/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Chat.Prototypes;
 ///     Sounds collection for each <see cref="EmotePrototype"/>.
 ///     Different entities may use different sounds collections.
 /// </summary>
-[Prototype, Serializable, NetSerializable]
+[Prototype]
 public sealed partial class EmoteSoundsPrototype : IPrototype, IInheritingPrototype
 {
     [IdDataField]

--- a/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
@@ -44,7 +44,7 @@ public sealed partial class EmoteSoundsPrototype : IPrototype, IInheritingProtot
     /// <summary>
     ///     Collection of emote prototypes and their sounds.
     /// </summary>
-    [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<SoundSpecifier, EmotePrototype>))]
+    [DataField]
     [AlwaysPushInheritance]
-    public Dictionary<string, SoundSpecifier> Sounds = new();
+    public Dictionary<ProtoId<EmotePrototype>, SoundSpecifier> Sounds = new();
 }

--- a/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
@@ -1,7 +1,5 @@
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
 
 namespace Content.Shared.Chat.Prototypes;

--- a/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
@@ -2,6 +2,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
 
 namespace Content.Shared.Chat.Prototypes;
 
@@ -9,17 +10,27 @@ namespace Content.Shared.Chat.Prototypes;
 ///     Sounds collection for each <see cref="EmotePrototype"/>.
 ///     Different entities may use different sounds collections.
 /// </summary>
-[Prototype]
-public sealed partial class EmoteSoundsPrototype : IPrototype
+[Prototype, Serializable, NetSerializable]
+public sealed partial class EmoteSoundsPrototype : IPrototype, IInheritingPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;
+
+    /// <inheritdoc/>
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<EmoteSoundsPrototype>))]
+    public string[]? Parents { get; private set; }
+
+    /// <inheritdoc/>
+    [AbstractDataField]
+    [NeverPushInheritance]
+    public bool Abstract { get; }
 
     /// <summary>
     ///     Optional fallback sound that will play if collection
     ///     doesn't have specific sound for this emote id.
     /// </summary>
     [DataField("sound")]
+    [AlwaysPushInheritance]
     public SoundSpecifier? FallbackSound;
 
     /// <summary>
@@ -27,11 +38,13 @@ public sealed partial class EmoteSoundsPrototype : IPrototype
     ///     This will overwrite any params that may be set in sound specifiers.
     /// </summary>
     [DataField("params")]
+    [AlwaysPushInheritance]
     public AudioParams? GeneralParams;
 
     /// <summary>
     ///     Collection of emote prototypes and their sounds.
     /// </summary>
-    [DataField("sounds", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<SoundSpecifier, EmotePrototype>))]
+    [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<SoundSpecifier, EmotePrototype>))]
+    [AlwaysPushInheritance]
     public Dictionary<string, SoundSpecifier> Sounds = new();
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Allows ``EmoteSoundsPrototype`` to have parents, also gives it an ``AbstractDataField``

Need this to eventually clean up emote sounds here, and for downstream forks.

## Technical details
Not needed

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none
