### PR TITLE
fix: dirty SSD indicator comp on mapinit

### DIFF
--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -66,6 +66,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
             component.FallAsleepTime == TimeSpan.Zero)
         {
             component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
+            Dirty(uid, component);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Dirty the SSD indicator component on map init.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As far as I know, this only affects downstreams/potential future use.

## Technical details
<!-- Summary of code changes for easier review. -->
Map init isn't called on client (I still don't understand why to be honest) so this needs a dirty. Otherwise it's possible to get into a state where the SSD sleep status effect is constantly mispredicted to be added, causing constant error spam every frame on the client since (I don't really know why) this ends up immediately becoming a deleted entity, that the client side status effect system tries to use in its state handler.

To recreate this you can use a mob like
```yml
- type: entity
  parent: MobHuman
  name: Sleepy Bones
  description: And Lazy Head
  id: AlwaysDisagree
  components:
  - type: TooTiredToSleep
```

Then in some random server-side system just add
```c#
SubscribeLocalEvent<TooTiredToSleepComponent, ComponentStartup>(OnDaydreams);
```
in your `Initialize` and 
```c#
private void OnDaydreams(Entity<TooTiredToSleepComponent> ent, ref ComponentStartup args)
{
    TrySetStatusEffectDuration(ent, SleepingSystem.StatusEffectForcedSleeping);
}
```
as your method.



## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
