### PR TITLE
Observe command tweaks and bug fix.

### DIFF
--- a/Content.Server/GameTicking/Commands/ObserveCommand.cs
+++ b/Content.Server/GameTicking/Commands/ObserveCommand.cs
@@ -3,50 +3,37 @@ using Content.Shared.Administration;
 using Content.Shared.GameTicking;
 using Robust.Shared.Console;
 
-namespace Content.Server.GameTicking.Commands
+namespace Content.Server.GameTicking.Commands;
+
+[AnyCommand]
+public sealed class ObserveCommand : LocalizedEntityCommands
 {
-    [AnyCommand]
-    sealed class ObserveCommand : IConsoleCommand
+    [Dependency] private readonly IAdminManager _adminManager = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+
+    public override string Command => "observe";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IEntityManager _e = default!;
-        [Dependency] private readonly IAdminManager _adminManager = default!;
-
-        public string Command => "observe";
-        public string Description => "";
-        public string Help => "";
-
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (shell.Player is not { } player)
         {
-            if (shell.Player is not { } player)
-            {
-                shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
-                return;
-            }
-
-            var ticker = _e.System<GameTicker>();
-
-            if (ticker.RunLevel == GameRunLevel.PreRoundLobby)
-            {
-                shell.WriteError("Wait until the round starts.");
-                return;
-            }
-
-            var isAdminCommand = args.Length > 0 && args[0].ToLower() == "admin";
-
-            if (!isAdminCommand && _adminManager.IsAdmin(player))
-            {
-                _adminManager.DeAdmin(player);
-            }
-
-            if (ticker.PlayerGameStatuses.TryGetValue(player.UserId, out var status) &&
-                status != PlayerGameStatus.JoinedGame)
-            {
-                ticker.JoinAsObserver(player);
-            }
-            else
-            {
-                shell.WriteError($"{player.Name} is not in the lobby.   This incident will be reported.");
-            }
+            shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
+            return;
         }
+
+        if ((_gameTicker.PlayerGameStatuses.TryGetValue(player.UserId, out var status) &&
+             status != PlayerGameStatus.JoinedGame) ||
+            _gameTicker.RunLevel == GameRunLevel.PreRoundLobby)
+        {
+            shell.WriteError(Loc.GetString("shell-can-only-run-from-in-round-lobby"));
+            return;
+        }
+
+        var isAdminCommand = args.Length > 0 && args[0].ToLower() == "admin";
+
+        if (!isAdminCommand && _adminManager.IsAdmin(player))
+            _adminManager.DeAdmin(player);
+
+        _gameTicker.JoinAsObserver(player);
     }
 }

--- a/Resources/Locale/en-US/shell.ftl
+++ b/Resources/Locale/en-US/shell.ftl
@@ -5,6 +5,7 @@
 shell-command-success = Command successful
 shell-invalid-command = Invalid command.
 shell-invalid-command-specific = Invalid {$commandName} command.
+shell-can-only-run-from-in-round-lobby = You can only run this command while the game is in the pre-round lobby.
 shell-cannot-run-command-from-server = You cannot run this command from the server.
 shell-only-players-can-run-this-command = Only players can run this command.
 shell-must-be-attached-to-entity = You must be attached to an entity to run this command.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR tweaks the functionality of the observe command and fixes a minor bug.

## Technical details
Localized the command, converting it to LocalizedEntityCommands.
Fixed an issue where running the command while in game as an admin would cause it to deadmin you.
Removed certain wording promising an action that never takes place.
Performed any cleanup along the way.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
ADMIN:
- tweak: Observe command usage has changed. You must pass true as an argument to the command to retain admin.

## Note
I would like to have this command open the ObserveWarningWindow in the future as this makes more sense.
Currently its not really clear that you need to specify admin