### PR TITLE
fixes items with complex shapes failing to insert sometimes

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1296,7 +1296,8 @@ public abstract class SharedStorageSystem : EntitySystem
         Angle startAngle;
         if (storageEnt.Comp.DefaultStorageOrientation == null)
         {
-            startAngle = Angle.FromDegrees(-itemEnt.Comp.StoredRotation);
+            //if our start angle isn't a right angle we'll fail to insert if we're a complex shape, so we use zero instead
+            startAngle = (itemEnt.Comp.StoredRotation % 90 == 0) ? Angle.FromDegrees(-itemEnt.Comp.StoredRotation) : Angle.Zero;
         }
         else
         {

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1296,8 +1296,7 @@ public abstract class SharedStorageSystem : EntitySystem
         Angle startAngle;
         if (storageEnt.Comp.DefaultStorageOrientation == null)
         {
-            //if our start angle isn't a right angle we'll fail to insert if we're a complex shape, so we use zero instead
-            startAngle = (itemEnt.Comp.StoredRotation % 90 == 0) ? Angle.FromDegrees(-itemEnt.Comp.StoredRotation) : Angle.Zero;
+            startAngle = Angle.Zero;
         }
         else
         {


### PR DESCRIPTION
## About the PR
fixes bug where items with complex shapes would fail to insert if the item's StoredRotation wasn't a right angle, see #38856 

## Why / Balance
bugs are bad

## Technical details
startAngle for non-fast item insertion checking no longer defaults to the item component's `StoredRotation`

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none (hopefully)

**Changelog**
:cl:
- fix: Fixed certain items (like pickaxes) failing to insert into containers that have enough space to store them, sometimes.
