### PR TITLE
Fix localization error when trying to change hair on someone with a hat

### DIFF
--- a/Content.Server/MagicMirror/MagicMirrorSystem.cs
+++ b/Content.Server/MagicMirror/MagicMirrorSystem.cs
@@ -137,13 +137,13 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         if (component.Target is not { } target)
             return;
 
-                // Check if the target getting their hair altered has any clothes that hides their hair
+        // Check if the target getting their hair altered has any clothes that hides their hair
         if (CheckHeadSlotOrClothes(message.Actor, component.Target.Value))
         {
             _popup.PopupEntity(
                 component.Target == message.Actor
                     ? Loc.GetString("magic-mirror-blocked-by-hat-self")
-                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target"),
+                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target", ("target", Identity.Entity(message.Actor, EntityManager))),
                 message.Actor,
                 message.Actor,
                 PopupType.Medium);
@@ -222,7 +222,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             _popup.PopupEntity(
                 component.Target == message.Actor
                     ? Loc.GetString("magic-mirror-blocked-by-hat-self")
-                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target"),
+                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target", ("target", Identity.Entity(message.Actor, EntityManager))),
                 message.Actor,
                 message.Actor,
                 PopupType.Medium);
@@ -301,7 +301,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             _popup.PopupEntity(
                 component.Target == message.Actor
                     ? Loc.GetString("magic-mirror-blocked-by-hat-self")
-                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target"),
+                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target", ("target", Identity.Entity(message.Actor, EntityManager))),
                 message.Actor,
                 message.Actor,
                 PopupType.Medium);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Trying to add or change someone else's hair (using barber scissors) while they are wearing a hat will now display the proper popup message instead of a raw localization string ID.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Spotted the error on Grafana:
```
en-US/magic-mirror-blocked-by-hat-self-target: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'arg')
```

## Technical details
<!-- Summary of code changes for easier review. -->
The `Loc.GetString` call wasn't passing the required `target` parameter, so Fluent couldn't properly process the message.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:
<img width="449" height="148" alt="Screenshot 2025-07-10 at 12 58 41 PM" src="https://github.com/user-attachments/assets/aa996db3-dfa6-4dda-87b3-cf22c741191f" />

After:
<img width="449" height="148" alt="Screenshot 2025-07-10 at 12 54 24 PM" src="https://github.com/user-attachments/assets/66599ee1-be9f-4bfe-a08d-3cee44ec6f67" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->