### PR TITLE
Fix Respirator Asserts

### DIFF
--- a/Content.Server/Body/Components/RespiratorComponent.cs
+++ b/Content.Server/Body/Components/RespiratorComponent.cs
@@ -11,16 +11,6 @@ namespace Content.Server.Body.Components
     public sealed partial class RespiratorComponent : Component
     {
         /// <summary>
-        ///     Gas container for this entity
-        /// </summary>
-        [DataField]
-        public GasMixture Air = new()
-        {
-            Volume = 6, // 6 liters, the average lung capacity for a human according to Google
-            Temperature = Atmospherics.NormalBodyTemperature
-        };
-
-        /// <summary>
         ///     Volume of our breath in liters
         /// </summary>
         [DataField]

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -48,7 +48,7 @@ public sealed class InternalsSystem : SharedInternalsSystem
             return;
 
         // Could the entity metabolise the air in the linked gas tank?
-        if (!_respirator.CanMetabolizeGas(uid, tank.Value.Comp.Air))
+        if (!_respirator.CanMetabolizeInhaledAir(uid, tank.Value.Comp.Air))
             return;
 
         ToggleInternals(uid, uid, force: false, component, ToggleMode.On);

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -210,7 +210,6 @@ public sealed class RespiratorSystem : EntitySystem
         if (organs.Count == 0)
             return false;
 
-        gas = new GasMixture(gas);
         var lungRatio = 1.0f / organs.Count;
         gas.Multiply(MathF.Min(lungRatio * gas.Volume / ent.Comp.BreathVolume, lungRatio));
         var solution = _lungSystem.GasToReagent(gas);

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -187,6 +187,11 @@ public sealed class RespiratorSystem : EntitySystem
         return (ent.Comp.Saturation > ent.Comp.SuffocationThreshold);
     }
 
+    /// <summary>
+    /// Checks if it's safe for a given entity to breathe the air from the environment it is currently situated in.
+    /// </summary>
+    /// <param name="ent">The entity attempting to metabolize the gas.</param>
+    /// <returns>Returns true only if the air is not toxic, and it wouldn't suffocate.</returns>
     public bool CanMetabolizeInhaledAir(Entity<RespiratorComponent?> ent)
     {
         if (!Resolve(ent, ref ent.Comp))
@@ -206,12 +211,11 @@ public sealed class RespiratorSystem : EntitySystem
     }
 
     /// <summary>
-    /// Checks if a given entity can safely metabolize a given gas mixture. Returns false if it would start suffocating,
-    /// or if the air is toxic.
+    /// Checks if a given entity can safely metabolize a given gas mixture.
     /// </summary>
     /// <param name="ent">The entity attempting to metabolize the gas.</param>
     /// <param name="gas">The gas mixture we are trying to metabolize.</param>
-    /// <returns></returns>
+    /// <returns>Returns true only if the gas mixture is not toxic, and it wouldn't suffocate.</returns>
     public bool CanMetabolizeInhaledAir(Entity<RespiratorComponent?> ent, GasMixture gas)
     {
         if (!Resolve(ent, ref ent.Comp))

--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -1,11 +1,4 @@
 ﻿Entries:
-- author: Nox38
-  changes:
-  - message: Nuclear operative agent is renamed to nuclear operative corpsman.
-    type: Tweak
-  id: 8236
-  time: '2025-04-18T19:56:57.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/34627
 - author: Ilya246
   changes:
   - message: The actions hotbar now has up to 10 more hotkeys accessible through the
@@ -3887,3 +3880,12 @@
   id: 8748
   time: '2025-07-07T19:19:28.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/36862
+- author: slarticodefast, EmoGarbage404
+  changes:
+  - message: 'Added a new science gadget: The H.A.R.M.P.A.C.K., a backpack that gives
+      you two extra hands when worn. Unlocked with a T2 arsenal research and printable
+      at the protolathe and secfab.'
+    type: Fix
+  id: 8749
+  time: '2025-07-07T21:43:33.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/38824


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fix respirators without body component from throwing errors when they try to breathe and can't find their lungs in their non-existent body component.

This does not stop Meat Kudzu from suffocating.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Errors bad, and the getting and setting of alerts should be de-bodied as well and not tied to BodyComponent. 

## Technical details
<!-- Summary of code changes for easier review. -->
Made it so suffocation progression and suffocation ending raises events same as inhalation and exhalation so that BodyComponent can pick it up and alter the alert instead of hardcoding the alert to BodySystem.

Renamed TryMetabolizeInhaledAir back to CanMetabolizeInhaledAir 

Remove an unused Air mixture in the RespiratorComponent 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/a1a4a8e1-f0d5-4142-a191-b9e43f3a478e

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

TryMetabolizeInhaledAir has been renamed back to CanMetabolizeInhaledAir

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
