### PR TITLE
fix clones not getting the thieving skill

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -33,6 +33,7 @@
   - MindShield
   - MimePowers
   - SpaceNinja
+  - Thieving
   # accents
   - Accentless
   - BackwardsAccent


### PR DESCRIPTION
## About the PR
It was converted into a trait in #38123 but not added to the trait whitelist.

## Why / Balance
bugfix

## Technical details
1 line of yaml

## Media
<img width="995" height="407" alt="grafik" src="https://github.com/user-attachments/assets/4cc7d8f7-0b24-407a-b3c4-bafd617d837c" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed clones not getting the thieving skill.
