### PR TITLE
Don't compile EF Core designer files on release builds

### DIFF
--- a/Content.Server.Database/Content.Server.Database.csproj
+++ b/Content.Server.Database/Content.Server.Database.csproj
@@ -9,6 +9,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Nullable>enable</Nullable>
     <NoWarn>RA0003</NoWarn>
+    <DefineConstants Condition="'$(FullRelease)' != 'True'">$(DefineConstants);EF_DESIGNER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Content.Server.Database/Migrations/Postgres/20200929113117_Init.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20200929113117_Init.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20200929113117_Init")]
     partial class Init
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -387,5 +388,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20201028210620_Admins.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20201028210620_Admins.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20201028210620_Admins")]
     partial class Admins
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -505,5 +506,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20201109092921_ExtraIndices.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20201109092921_ExtraIndices.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20201109092921_ExtraIndices")]
     partial class ExtraIndices
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -513,5 +514,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20201203093409_ClothingAndPronouns.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20201203093409_ClothingAndPronouns.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20201203093409_ClothingAndPronouns")]
     partial class ClothingAndPronouns
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -566,5 +567,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20210103151756_BackpackPreference.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20210103151756_BackpackPreference.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20210103151756_BackpackPreference")]
     partial class BackpackPreference
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -571,5 +572,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20210211211033_AdminOOCColor.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20210211211033_AdminOOCColor.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20210211211033_AdminOOCColor")]
     partial class AdminOOCColor
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -576,5 +577,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20210321230012_HWID.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20210321230012_HWID.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20210321230012_HWID")]
     partial class HWID
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -588,5 +589,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20210915093340_UniqueHighPriorityJob.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20210915093340_UniqueHighPriorityJob.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20210915093340_UniqueHighPriorityJob")]
     partial class UniqueHighPriorityJob
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -595,5 +596,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20211120202701_AdminLogs.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20211120202701_AdminLogs.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20211120202701_AdminLogs")]
     partial class AdminLogs
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -844,5 +845,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20211121123543_AdminLogsImpact.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20211121123543_AdminLogsImpact.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20211121123543_AdminLogsImpact")]
     partial class AdminLogsImpact
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -848,5 +849,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220103235647_whitelist.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220103235647_whitelist.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220103235647_whitelist")]
     partial class Whitelist
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -861,5 +862,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220108185749_add-species.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220108185749_add-species.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220108185749_add-species")]
     partial class AddSpecies
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -866,5 +867,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220127170845_UnifyMore.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220127170845_UnifyMore.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220127170845_UnifyMore")]
     partial class UnifyMore
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -866,5 +867,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220129005644_ServerBanHit.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220129005644_ServerBanHit.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220129005644_ServerBanHit")]
     partial class ServerBanHit
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -927,5 +928,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220214061058_RoleBans.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220214061058_RoleBans.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220214061058_RoleBans")]
     partial class RoleBans
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1037,5 +1038,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220308222742_Cleanup.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220308222742_Cleanup.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220308222742_Cleanup")]
     partial class Cleanup
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1031,5 +1032,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220310173734_SpeciesMarkings.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220310173734_SpeciesMarkings.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220310173734_SpeciesMarkings")]
     partial class SpeciesMarkings
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1036,5 +1037,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220313151800_ServerNameFts.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220313151800_ServerNameFts.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220313151800_ServerNameFts")]
     partial class ServerNameFts
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1078,5 +1079,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220324144654_AdminNotes.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220324144654_AdminNotes.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220324144654_AdminNotes")]
     partial class AdminNotes
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1207,5 +1208,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220325170225_PlayerReadRules.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220325170225_PlayerReadRules.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220325170225_PlayerReadRules")]
     partial class PlayerReadRules
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1082,5 +1083,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220326104916_UploadedResourcesLog.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220326104916_UploadedResourcesLog.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220326104916_UploadedResourcesLog")]
     partial class UploadedResourcesLog
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1111,5 +1112,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220503222955_FixIndices.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220503222955_FixIndices.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220503222955_FixIndices")]
     partial class FixIndices
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1248,5 +1249,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220505084828_MarkingsJsonb.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220505084828_MarkingsJsonb.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220505084828_MarkingsJsonb")]
     partial class MarkingsJsonb
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1252,5 +1253,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220509060724_FlavorText.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220509060724_FlavorText.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220509060724_FlavorText")]
     partial class FlavorText
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1257,5 +1258,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220724000132_PlayTime.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220724000132_PlayTime.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220724000132_PlayTime")]
     partial class PlayTime
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1288,5 +1289,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20220816163319_Traits.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220816163319_Traits.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20220816163319_Traits")]
     partial class Traits
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1329,5 +1330,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20230319110655_ProfileTraitIndexUnique.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20230319110655_ProfileTraitIndexUnique.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20230319110655_ProfileTraitIndexUnique")]
     partial class ProfileTraitIndexUnique
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1329,5 +1330,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20230319112124_ServerBanExemption.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20230319112124_ServerBanExemption.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20230319112124_ServerBanExemption")]
     partial class ServerBanExemption
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1352,5 +1353,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20230402214647_BanAutoDelete.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20230402214647_BanAutoDelete.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20230402214647_BanAutoDelete")]
     partial class BanAutoDelete
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1360,5 +1361,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20230503001749_AdminNotesImprovement.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20230503001749_AdminNotesImprovement.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20230503001749_AdminNotesImprovement")]
     partial class AdminNotesImprovement
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1766,5 +1767,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20230725193102_AdminNotesImprovementsForeignKeys.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20230725193102_AdminNotesImprovementsForeignKeys.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20230725193102_AdminNotesImprovementsForeignKeys")]
     partial class AdminNotesImprovementsForeignKeys
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1766,5 +1767,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20230727190902_AdminLogCompoundKey.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20230727190902_AdminLogCompoundKey.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20230727190902_AdminLogCompoundKey")]
     partial class AdminLogCompoundKey
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1763,5 +1764,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20231021071411_RoundStartDate.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20231021071411_RoundStartDate.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20231021071411_RoundStartDate")]
     partial class RoundStartDate
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1771,5 +1772,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20231024041204_DropAdminLogEntity.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20231024041204_DropAdminLogEntity.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20231024041204_DropAdminLogEntity")]
     partial class DropAdminLogEntity
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1731,5 +1732,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20231126234054_ConnectionLogServer.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20231126234054_ConnectionLogServer.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20231126234054_ConnectionLogServer")]
     partial class ConnectionLogServer
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1754,5 +1755,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20231226154937_AdminLogPk.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20231226154937_AdminLogPk.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20231226154937_AdminLogPk")]
     partial class AdminLogPk
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1752,5 +1753,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20240112194620_Blacklist.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20240112194620_Blacklist.Designer.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20240112194620_Blacklist")]
     partial class Blacklist
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1765,5 +1766,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20240201091301_SpawnPriorityPreference.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20240201091301_SpawnPriorityPreference.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20240201091301_SpawnPriorityPreference")]
     partial class SpawnPriorityPreference
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1757,5 +1758,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20240301130641_ClothingRemoval.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20240301130641_ClothingRemoval.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20240301130641_ClothingRemoval")]
     partial class ClothingRemoval
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1834,5 +1835,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20240318022005_AdminMessageDismiss.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20240318022005_AdminMessageDismiss.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20240318022005_AdminMessageDismiss")]
     partial class AdminMessageDismiss
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1764,5 +1765,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20240403072242_Loadouts.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20240403072242_Loadouts.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20240403072242_Loadouts")]
     partial class Loadouts
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1880,5 +1881,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20240409013837_FixRoundStartDateNullability.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20240409013837_FixRoundStartDateNullability.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20240409013837_FixRoundStartDateNullability")]
     partial class FixRoundStartDateNullability
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1762,5 +1763,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20240531011555_RoleWhitelist.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20240531011555_RoleWhitelist.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20240531011555_RoleWhitelist")]
     partial class RoleWhitelist
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1909,5 +1910,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20240606065731_RemoveLastReadRules.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20240606065731_RemoveLastReadRules.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20240606065731_RemoveLastReadRules")]
     partial class RemoveLastReadRules
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1905,5 +1906,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20240606121555_ban_notify_trigger.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20240606121555_ban_notify_trigger.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20240606121555_ban_notify_trigger")]
     partial class ban_notify_trigger
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1909,5 +1910,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20240606175154_ReturnLastReadRules.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20240606175154_ReturnLastReadRules.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20240606175154_ReturnLastReadRules")]
     partial class ReturnLastReadRules
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1909,5 +1910,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20240621120713_ConnectionLogTimeIndex.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20240621120713_ConnectionLogTimeIndex.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20240621120713_ConnectionLogTimeIndex")]
     partial class ConnectionLogTimeIndex
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1911,5 +1912,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20240623005121_BanTemplate.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20240623005121_BanTemplate.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20240623005121_BanTemplate")]
     partial class BanTemplate
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1956,5 +1957,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20241111170112_ModernHwid.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20241111170112_ModernHwid.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20241111170112_ModernHwid")]
     partial class ModernHwid
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -2068,5 +2069,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20241111193608_ConnectionTrust.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20241111193608_ConnectionTrust.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20241111193608_ConnectionTrust")]
     partial class ConnectionTrust
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -2072,5 +2073,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20241122174243_IPIntel.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20241122174243_IPIntel.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20241122174243_IPIntel")]
     partial class IPIntel
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -2100,5 +2101,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20241223235939_AdminStatus.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20241223235939_AdminStatus.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20241223235939_AdminStatus")]
     partial class AdminStatus
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -2080,5 +2081,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20250211131539_LoadoutNames.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20250211131539_LoadoutNames.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20250211131539_LoadoutNames")]
     partial class LoadoutNames
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -2113,5 +2114,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Postgres/20250314222016_ConstructionFavorites.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20250314222016_ConstructionFavorites.Designer.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Database.Migrations.Postgres
     [Migration("20250314222016_ConstructionFavorites")]
     partial class ConstructionFavorites
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -2116,5 +2117,6 @@ namespace Content.Server.Database.Migrations.Postgres
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20200929113112_Init.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20200929113112_Init.Designer.cs
@@ -12,6 +12,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20200929113112_Init")]
     partial class Init
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -357,5 +358,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20201028210616_Admins.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20201028210616_Admins.Designer.cs
@@ -12,6 +12,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20201028210616_Admins")]
     partial class Admins
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -472,5 +473,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20201109092917_ExtraIndices.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20201109092917_ExtraIndices.Designer.cs
@@ -12,6 +12,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20201109092917_ExtraIndices")]
     partial class ExtraIndices
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -480,5 +481,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20201203093351_ClothingAndPronouns.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20201203093351_ClothingAndPronouns.Designer.cs
@@ -12,6 +12,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20201203093351_ClothingAndPronouns")]
     partial class ClothingAndPronouns
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -533,5 +534,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20210103151752_BackpackPreference.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20210103151752_BackpackPreference.Designer.cs
@@ -12,6 +12,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20210103151752_BackpackPreference")]
     partial class BackpackPreference
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -538,5 +539,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20210211211028_AdminOOCColor.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20210211211028_AdminOOCColor.Designer.cs
@@ -12,6 +12,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20210211211028_AdminOOCColor")]
     partial class AdminOOCColor
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -543,5 +544,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20210321225959_HWID.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20210321225959_HWID.Designer.cs
@@ -12,6 +12,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20210321225959_HWID")]
     partial class HWID
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -555,5 +556,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20210915093336_UniqueHighPriorityJob.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20210915093336_UniqueHighPriorityJob.Designer.cs
@@ -12,6 +12,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20210915093336_UniqueHighPriorityJob")]
     partial class UniqueHighPriorityJob
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -562,5 +563,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20211120202654_AdminLogs.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20211120202654_AdminLogs.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20211120202654_AdminLogs")]
     partial class AdminLogs
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -790,5 +791,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20211121123536_AdminLogsImpact.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20211121123536_AdminLogsImpact.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20211121123536_AdminLogsImpact")]
     partial class AdminLogsImpact
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -794,5 +795,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220103235637_whitelist.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220103235637_whitelist.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220103235637_whitelist")]
     partial class Whitelist
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -807,5 +808,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220108185734_add-species.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220108185734_add-species.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220108185734_add-species")]
     partial class AddSpecies
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -812,5 +813,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220127165122_UnifyMore.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220127165122_UnifyMore.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220127165122_UnifyMore")]
     partial class UnifyMore
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -823,5 +824,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220129005638_ServerBanHit.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220129005638_ServerBanHit.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220129005638_ServerBanHit")]
     partial class ServerBanHit
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -882,5 +883,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220214060745_RoleBans.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220214060745_RoleBans.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220214060745_RoleBans")]
     partial class RoleBans
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -986,5 +987,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220308222736_Cleanup.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220308222736_Cleanup.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220308222736_Cleanup")]
     partial class Cleanup
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -980,5 +981,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220310173728_SpeciesMarkings.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220310173728_SpeciesMarkings.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220310173728_SpeciesMarkings")]
     partial class SpeciesMarkings
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -985,5 +986,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220313151753_ServerNameFts.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220313151753_ServerNameFts.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220313151753_ServerNameFts")]
     partial class ServerNameFts
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1022,5 +1023,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220324144649_AdminNotes.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220324144649_AdminNotes.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220324144649_AdminNotes")]
     partial class AdminNotes
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1149,5 +1150,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220325170220_PlayerReadRules.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220325170220_PlayerReadRules.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220325170220_PlayerReadRules")]
     partial class PlayerReadRules
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1026,5 +1027,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220326104908_UploadedResourcesLog.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220326104908_UploadedResourcesLog.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220326104908_UploadedResourcesLog")]
     partial class UploadedResourcesLog
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1053,5 +1054,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220503222949_FixIndices.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220503222949_FixIndices.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220503222949_FixIndices")]
     partial class FixIndices
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1186,5 +1187,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220505084819_MarkingsJsonb.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220505084819_MarkingsJsonb.Designer.cs
@@ -15,6 +15,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220505084819_MarkingsJsonb")]
     partial class MarkingsJsonb
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1191,5 +1192,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220509060717_FlavorText.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220509060717_FlavorText.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220509060717_FlavorText")]
     partial class FlavorText
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1195,5 +1196,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220724000127_PlayTime.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220724000127_PlayTime.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220724000127_PlayTime")]
     partial class PlayTime
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1224,5 +1225,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20220816163313_Traits.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220816163313_Traits.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20220816163313_Traits")]
     partial class Traits
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1263,5 +1264,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20230319110651_ProfileTraitIndexUnique.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20230319110651_ProfileTraitIndexUnique.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20230319110651_ProfileTraitIndexUnique")]
     partial class ProfileTraitIndexUnique
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1263,5 +1264,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20230319112120_ServerBanExemption.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20230319112120_ServerBanExemption.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20230319112120_ServerBanExemption")]
     partial class ServerBanExemption
     {
+#if EF_DESIGNER
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
@@ -1286,5 +1287,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20230402214642_BanAutoDelete.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20230402214642_BanAutoDelete.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20230402214642_BanAutoDelete")]
     partial class BanAutoDelete
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1292,5 +1293,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20230503001739_AdminNotesImprovement.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20230503001739_AdminNotesImprovement.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20230503001739_AdminNotesImprovement")]
     partial class AdminNotesImprovement
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1694,5 +1695,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20230725193058_AdminNotesImprovementsForeignKeys.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20230725193058_AdminNotesImprovementsForeignKeys.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20230725193058_AdminNotesImprovementsForeignKeys")]
     partial class AdminNotesImprovementsForeignKeys
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1694,5 +1695,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20230727190858_AdminLogCompoundKey.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20230727190858_AdminLogCompoundKey.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20230727190858_AdminLogCompoundKey")]
     partial class AdminLogCompoundKey
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1693,5 +1694,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20231021071407_RoundStartDate.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20231021071407_RoundStartDate.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20231021071407_RoundStartDate")]
     partial class RoundStartDate
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1701,5 +1702,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20231024041159_DropAdminLogEntity.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20231024041159_DropAdminLogEntity.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20231024041159_DropAdminLogEntity")]
     partial class DropAdminLogEntity
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1663,5 +1664,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20231126234049_ConnectionLogServer.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20231126234049_ConnectionLogServer.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20231126234049_ConnectionLogServer")]
     partial class ConnectionLogServer
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1686,5 +1687,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20231226154929_AdminLogPk.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20231226154929_AdminLogPk.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20231226154929_AdminLogPk")]
     partial class AdminLogPk
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1684,5 +1685,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20240112194612_Blacklist.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20240112194612_Blacklist.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20240112194612_Blacklist")]
     partial class Blacklist
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1697,5 +1698,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20240201091254_SpawnPriorityPreference.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20240201091254_SpawnPriorityPreference.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20240201091254_SpawnPriorityPreference")]
     partial class SpawnPriorityPreference
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1688,5 +1689,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20240301130602_ClothingRemoval.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20240301130602_ClothingRemoval.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20240301130602_ClothingRemoval")]
     partial class ClothingRemoval
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1761,5 +1762,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20240318021959_AdminMessageDismiss.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20240318021959_AdminMessageDismiss.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20240318021959_AdminMessageDismiss")]
     partial class AdminMessageDismiss
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1695,5 +1696,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20240403072258_Loadouts.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20240403072258_Loadouts.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20240403072258_Loadouts")]
     partial class Loadouts
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1805,5 +1806,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20240409013832_FixRoundStartDateNullability.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20240409013832_FixRoundStartDateNullability.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20240409013832_FixRoundStartDateNullability")]
     partial class FixRoundStartDateNullability
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1693,5 +1694,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20240409014937_FixRoundStartDateNullability2.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20240409014937_FixRoundStartDateNullability2.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20240409014937_FixRoundStartDateNullability2")]
     partial class FixRoundStartDateNullability2
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1693,5 +1694,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20240531011549_RoleWhitelist.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20240531011549_RoleWhitelist.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20240531011549_RoleWhitelist")]
     partial class RoleWhitelist
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1834,5 +1835,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20240606065717_RemoveLastReadRules.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20240606065717_RemoveLastReadRules.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20240606065717_RemoveLastReadRules")]
     partial class RemoveLastReadRules
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1830,5 +1831,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20240606175141_ReturnLastReadRules.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20240606175141_ReturnLastReadRules.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20240606175141_ReturnLastReadRules")]
     partial class ReturnLastReadRules
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1834,5 +1835,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20240621120705_ConnectionLogTimeIndex.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20240621120705_ConnectionLogTimeIndex.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20240621120705_ConnectionLogTimeIndex")]
     partial class ConnectionLogTimeIndex
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1836,5 +1837,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20240623005113_BanTemplate.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20240623005113_BanTemplate.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20240623005113_BanTemplate")]
     partial class BanTemplate
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1879,5 +1880,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20241111170107_ModernHwid.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20241111170107_ModernHwid.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20241111170107_ModernHwid")]
     partial class ModernHwid
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1991,5 +1992,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20241111193602_ConnectionTrust.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20241111193602_ConnectionTrust.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20241111193602_ConnectionTrust")]
     partial class ConnectionTrust
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -1995,5 +1996,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20241122174236_IPIntel.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20241122174236_IPIntel.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20241122174236_IPIntel")]
     partial class IPIntel
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -2024,5 +2025,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20241223235932_AdminStatus.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20241223235932_AdminStatus.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20241223235932_AdminStatus")]
     partial class AdminStatus
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -2003,5 +2004,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20250211131517_LoadoutNames.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20250211131517_LoadoutNames.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20250211131517_LoadoutNames")]
     partial class LoadoutNames
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -2037,5 +2038,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }

--- a/Content.Server.Database/Migrations/Sqlite/20250314222717_ConstructionFavorites.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20250314222717_ConstructionFavorites.Designer.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Database.Migrations.Sqlite
     [Migration("20250314222717_ConstructionFavorites")]
     partial class ConstructionFavorites
     {
+#if EF_DESIGNER
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -2040,5 +2041,6 @@ namespace Content.Server.Database.Migrations.Sqlite
                 });
 #pragma warning restore 612, 618
         }
+#endif
     }
 }


### PR DESCRIPTION
These take up like 1.6 MB of space on the final compiled DLL and that just seemed ridiculous to me. This probably doesn't matter that much though.

Doesn't change anything on non-full-release builds to avoid causing tooling issues, even though I doubt it actually matters.
