### PR TITLE
Update content to remove redundant Robust math types

### DIFF
--- a/Content.Client/Cooldown/CooldownGraphic.cs
+++ b/Content.Client/Cooldown/CooldownGraphic.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Client.Graphics;
+﻿using System.Numerics;
+using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -36,7 +37,7 @@ namespace Content.Client.Cooldown
             if (Progress >= 0f)
             {
                 var hue = (5f / 18f) * lerp;
-                color = Color.FromHsv((hue, 0.75f, 0.75f, 0.50f));
+                color = Color.FromHsv(new Vector4(hue, 0.75f, 0.75f, 0.50f));
             }
             else
             {

--- a/Content.Client/Disposal/PressureBar.cs
+++ b/Content.Client/Disposal/PressureBar.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Disposal;
+﻿using System.Numerics;
+using Content.Shared.Disposal;
 using Content.Shared.Disposal.Unit;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;

--- a/Content.Client/Holopad/HolopadSystem.cs
+++ b/Content.Client/Holopad/HolopadSystem.cs
@@ -5,6 +5,7 @@ using Robust.Client.Graphics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using System.Linq;
+using System.Numerics;
 using DrawDepth = Content.Shared.DrawDepth.DrawDepth;
 
 namespace Content.Client.Holopad;

--- a/Content.Client/Light/RgbLightControllerSystem.cs
+++ b/Content.Client/Light/RgbLightControllerSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Numerics;
 using Content.Client.Items.Systems;
 using Content.Shared.Clothing;
 using Content.Shared.Hands;

--- a/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
@@ -3,6 +3,7 @@ using Robust.Client.UserInterface.XAML;
 using Robust.Client.GameObjects;
 using Robust.Shared.IoC;
 using System;
+using System.Numerics;
 using Content.Client.Stylesheets;
 using Content.Shared.APC;
 using Robust.Client.Graphics;

--- a/Content.Client/Power/PowerMonitoringWindow.xaml.Widgets.cs
+++ b/Content.Client/Power/PowerMonitoringWindow.xaml.Widgets.cs
@@ -6,7 +6,6 @@ using Robust.Shared.Utility;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
-using Vector4 = Robust.Shared.Maths.Vector4;
 
 namespace Content.Client.Power;
 

--- a/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
@@ -10,7 +10,6 @@ using Robust.Shared.Physics;
 using Robust.Shared.Threading;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
-using Vector2 = System.Numerics.Vector2;
 
 namespace Content.Client.Shuttles.UI;
 

--- a/Content.Client/UserInterface/Systems/DamageOverlays/Overlays/DamageOverlay.cs
+++ b/Content.Client/UserInterface/Systems/DamageOverlays/Overlays/DamageOverlay.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared.Mobs;
 using Robust.Client.Graphics;
 using Robust.Client.Player;

--- a/Content.Client/UserInterface/Systems/ProgressColorSystem.cs
+++ b/Content.Client/UserInterface/Systems/ProgressColorSystem.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
 
@@ -43,7 +44,7 @@ public sealed class ProgressColorSystem : EntitySystem
 
             // lerp
             var hue = 5f / 18f * progress;
-            return Color.FromHsv((hue, 1f, 0.75f, 1f));
+            return Color.FromHsv(new Vector4(hue, 1f, 0.75f, 1f));
         }
 
         return InterpolateColorGaussian(Plasma, progress);

--- a/Content.Client/UserInterface/Systems/Storage/Controls/StorageWindow.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/StorageWindow.cs
@@ -621,7 +621,7 @@ public sealed class StorageWindow : BaseWindow
                         {
                             marked.Add(cell);
                             cell.ModulateSelfOverride = spotFree
-                                ? Color.FromHsv((0.18f, 1 / spot, 0.5f / spot + 0.5f, 1f))
+                                ? Color.FromHsv(new Vector4(0.18f, 1 / spot, 0.5f / spot + 0.5f, 1f))
                                 : Color.FromHex("#2222CC");
                         }
                     }

--- a/Content.Shared/Humanoid/SkinColor.cs
+++ b/Content.Shared/Humanoid/SkinColor.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using System.Security.Cryptography;
 using Microsoft.VisualBasic.CompilerServices;
 


### PR DESCRIPTION
Vector3, Vector4, Matrix4, and Quaternion are now gone. This switches us over to System.Numerics where applicable.

Requires https://github.com/space-wizards/RobustToolbox/pull/6078

# Breaking Changes

`Vector3`, `Vector4`, `Matrix4`, and `Quaternion` have been removed from `Robust.Shared.Maths`. Use the types in `System.Numerics` instead.