### PR TITLE
Allow multitool device saving on devices with wireless

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
@@ -361,14 +361,11 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (hasLinking && HasComp<DeviceListComponent>(target) || hasLinking == configurator.LinkModeActive)
             return;
 
-        if (hasLinking)
-        {
-            SetMode(configuratorUid, configurator, userUid, true);
-            return;
-        }
-
-        if (HasComp<DeviceNetworkComponent>(target))
+        var hasNetworking = HasComp<DeviceNetworkComponent>(target);
+        if (hasNetworking)
             SetMode(configuratorUid, configurator, userUid, false);
+        else if (hasLinking)
+            SetMode(configuratorUid, configurator, userUid, true);
     }
 
     #endregion


### PR DESCRIPTION
## About the PR
Previously, a device with sink/source would always switch the multitool to link mode rather than list mode. This PR changes that, so it will only switch if the currently selected mode doesn't exist.

## Why / Balance
To allow coding devices that work with both modes, for example, if we want a device that can be turned on / off with a lever, but also connected to some fancy magic science thing to do its job. While this is already possible technically, it just isn't configurable with the multitool in game. 

## Media

https://github.com/user-attachments/assets/726df5f9-e110-410e-b21f-d5145b378f1a


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines]
- [X] I have added media to this PR or it does not require an ingame showcase.
