### PR TITLE
Add more transfer amounts to the Chemical Dispenser

### DIFF
--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
@@ -15,7 +15,7 @@
                 Columns="3"
                 HorizontalAlignment="Center"
                 Margin="5"
-                ButtonList="1,5,10,15,20,25,30,50,100"
+                ButtonList="1,2,3,4,5,10,15,20,25,30,50,100"
                 RadioGroup="True">
             </ui:ButtonGrid>
             <Control VerticalExpand="True" />

--- a/Content.Shared/Chemistry/SharedReagentDispenser.cs
+++ b/Content.Shared/Chemistry/SharedReagentDispenser.cs
@@ -34,6 +34,15 @@ namespace Content.Shared.Chemistry
                 case "1":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U1;
                     break;
+                case "2":
+                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U2;
+                    break;
+                case "3":
+                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U3;
+                    break;
+                case "4":
+                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U4;
+                    break;
                 case "5":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U5;
                     break;
@@ -98,6 +107,9 @@ namespace Content.Shared.Chemistry
     public enum ReagentDispenserDispenseAmount
     {
         U1 = 1,
+        U2 = 2,
+        U3 = 3,
+        U4 = 4,
         U5 = 5,
         U10 = 10,
         U15 = 15,


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added 3 more buttons to the Chemical Dispenser: 2, 3, 4.

I've found a way to implement my own suggestion [from the website](https://forum.spacestation14.com/t/more-batch-input-buttons/21970) :3

## Why / Balance
The Chemical Dispenser is an underused device that would be more convenient to use if it had more buttons.
Adding 9 of an ingredient currently involves pressing 5, 1, 1, 1, 1. With lag, you can't even click quickly.
In a Chemmaster, you can add 10, and subtract 1.
With this change, you'll click 5 and 4.

## Technical details
Added 3 buttons by extending existing code. Tested in IDE, working.

## Media
<img width="145" height="163" alt="image" src="https://github.com/user-attachments/assets/ceedd73b-79c9-46c2-a24b-247a1fed9472" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
tweak: The Chemical Dispenser now has three more transfer amount buttons.