### PR TITLE
Fix dock radar colours

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleDockControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleDockControl.xaml.cs
@@ -40,6 +40,8 @@ public sealed partial class ShuttleDockControl : BaseShuttleControl
     private readonly HashSet<DockingPortState> _drawnDocks = new();
     private readonly Dictionary<DockingPortState, Button> _dockButtons = new();
 
+    private readonly Color _fallbackHighlightedColor = Color.Magenta;
+
     /// <summary>
     /// Store buttons for every other dock
     /// </summary>
@@ -311,7 +313,7 @@ public sealed partial class ShuttleDockControl : BaseShuttleControl
             ScalePosition(Vector2.Transform(new Vector2(-0.5f, 0.5f), rotation)),
             ScalePosition(Vector2.Transform(new Vector2(0.5f, -0.5f), rotation)));
 
-        var dockColor = _viewedState?.HighlightedColor ?? Color.Magenta;
+        var dockColor = _viewedState?.HighlightedColor ?? _fallbackHighlightedColor;
         var connectionColor = Color.Pink;
 
         handle.DrawRect(ourDockConnection, connectionColor.WithAlpha(0.2f));

--- a/Content.Client/Shuttles/UI/ShuttleDockControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleDockControl.xaml.cs
@@ -213,11 +213,11 @@ public sealed partial class ShuttleDockControl : BaseShuttleControl
 
                 if (HighlightedDock == dock.Entity)
                 {
-                    otherDockColor = Color.ToSrgb(Color.Magenta);
+                    otherDockColor = Color.ToSrgb(dock.HighlightedColor);
                 }
                 else
                 {
-                    otherDockColor = Color.ToSrgb(Color.Purple);
+                    otherDockColor = Color.ToSrgb(dock.Color);
                 }
 
                 /*
@@ -311,7 +311,7 @@ public sealed partial class ShuttleDockControl : BaseShuttleControl
             ScalePosition(Vector2.Transform(new Vector2(-0.5f, 0.5f), rotation)),
             ScalePosition(Vector2.Transform(new Vector2(0.5f, -0.5f), rotation)));
 
-        var dockColor = Color.Magenta;
+        var dockColor = _viewedState?.HighlightedColor ?? Color.Magenta;
         var connectionColor = Color.Pink;
 
         handle.DrawRect(ourDockConnection, connectionColor.WithAlpha(0.2f));

--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -308,7 +308,7 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
             -dockRadius * UIScale,
             (Size.X + dockRadius) * UIScale,
             (Size.Y + dockRadius) * UIScale);
-        
+
         if (_docks.TryGetValue(nent, out var docks))
         {
             foreach (var state in docks)
@@ -321,7 +321,7 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
                     continue;
                 }
 
-                var color = Color.ToSrgb(Color.Magenta);
+                var color = Color.ToSrgb(state.HighlightedColor);
 
                 var verts = new[]
                 {

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -235,6 +235,8 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
                     _xformQuery.TryGetComponent(comp.DockedWith, out var otherDockXform) ?
                     GetNetEntity(otherDockXform.GridUid) :
                     null,
+                Color = comp.RadarColor,
+                HighlightedColor = comp.HighlightedRadarColor
             };
 
             gridDocks.Add(state);

--- a/Content.Shared/Shuttles/BUIStates/DockingPortState.cs
+++ b/Content.Shared/Shuttles/BUIStates/DockingPortState.cs
@@ -18,7 +18,13 @@ public sealed class DockingPortState
 
     public NetEntity? GridDockedWith;
 
-    // The colours used on radar screens: HighlightedColor is used for all docks in standard view, and the currently focused dock in dock view. Color is used otherwise.
+    /// <summary>
+    /// The default colour used to shade a dock on a radar screen
+    /// </summary>
     public Color Color;
+
+    /// <summary>
+    /// The colour used to shade a dock on a radar screen if it is highlighted (hovered over/selected on docking screen/shown in the main ship radar)
+    /// </summary>
     public Color HighlightedColor;
 }

--- a/Content.Shared/Shuttles/BUIStates/DockingPortState.cs
+++ b/Content.Shared/Shuttles/BUIStates/DockingPortState.cs
@@ -18,6 +18,7 @@ public sealed class DockingPortState
 
     public NetEntity? GridDockedWith;
 
+    // The colours used on radar screens: HighlightedColor is used for all docks in standard view, and the currently focused dock in dock view. Color is used otherwise.
     public Color Color;
     public Color HighlightedColor;
 }

--- a/Content.Shared/Shuttles/BUIStates/DockingPortState.cs
+++ b/Content.Shared/Shuttles/BUIStates/DockingPortState.cs
@@ -17,4 +17,7 @@ public sealed class DockingPortState
     public bool Connected => GridDockedWith != null;
 
     public NetEntity? GridDockedWith;
+
+    public Color Color;
+    public Color HighlightedColor;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
DockingComponent has two components (RadarColor and HighlightedRadarColor) that were unused in favour of hardcoded values for some reason???

## Why / Balance
Dehardcode good

## Technical details
dockState now gets Color and HighlightedColor variables from the component
then dockState is read wherever it's needed :3

## Media
Example of a cyan dock:

<img width="94" height="95" alt="image" src="https://github.com/user-attachments/assets/540ef8a5-d52c-484f-b011-ddf368825ae3" />
<img width="100" alt="image" src="https://github.com/user-attachments/assets/da395762-6371-498d-af32-20c3ee723f2e" />
<img width="100" alt="image" src="https://github.com/user-attachments/assets/bf7a37bf-bf04-4036-af97-d0e38f2bef3f" />

No such utilities dock exists, this is just an example of what it could be.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None :3

**Changelog**

