### PR TITLE
Partially Revert Breaking New Status Effect Changes

### DIFF
--- a/Content.Client/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Client/StatusEffectNew/StatusEffectsSystem.cs
@@ -1,0 +1,6 @@
+﻿using Content.Shared.StatusEffectNew;
+
+namespace Content.Client.StatusEffectNew;
+
+/// <inheritdoc/>
+public sealed class StatusEffectsSystem : SharedStatusEffectsSystem;

--- a/Content.Server/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Server/StatusEffectNew/StatusEffectsSystem.cs
@@ -1,0 +1,6 @@
+﻿using Content.Shared.StatusEffectNew;
+
+namespace Content.Server.StatusEffectNew;
+
+/// <inheritdoc/>
+public sealed class StatusEffectsSystem : SharedStatusEffectsSystem;

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.API.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.API.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.StatusEffectNew;
 
-public sealed partial class StatusEffectsSystem
+public abstract partial class StatusEffectsSystem
 {
     /// <summary>
     /// Increments duration of status effect by <see cref="duration"/>.

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Player;
 
 namespace Content.Shared.StatusEffectNew;
 
-public sealed partial class StatusEffectsSystem
+public abstract partial class StatusEffectsSystem
 {
     private void InitializeRelay()
     {

--- a/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.StatusEffectNew;
 /// This system controls status effects, their lifetime, and provides an API for adding them to entities,
 /// removing them from entities, or getting information about current effects on entities.
 /// </summary>
-public sealed partial class StatusEffectsSystem : EntitySystem
+public abstract partial class SharedStatusEffectsSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Undid the removal of server client specific systems for the new status effects system as introduced by: #38915

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Accent status effects, which are used by: - Electrocution, - Drunkenness, - Bloodloss, - Cryptobolin, only work server side as the events raised to get accents are server side only. 

We need server side specific code if we want to move old status to new status.

## Technical details
<!-- Summary of code changes for easier review. -->
- Renamed StatusEffectsSystem to SharedStatusEffectsSystem
- Made SharedStatusEffectsSystem abstract
- Added Server and Client side StatusEffectSystem(s) which are currently empty. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

StatusEffectsSystem is now SharedStatusEffectsSystem.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No cl no fun