### PR TITLE
[BUGFIX] Stops scurrets from suffocating in crates

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -462,7 +462,7 @@
   name: hydrated scurret
   description: Wait, what?
   id: CrateFunScurret
-  parent: CratePlastic
+  parent: CrateLivestock
   components:
   - type: StorageFill
     contents:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Scurrets now spawn in livestock crates instead of the plastic crates.

## Why / Balance
Scurrets would die if nobody took the ghostrole.

## Technical details
Parent change

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="721" height="542" alt="image_2025-07-12_180144816" src="https://github.com/user-attachments/assets/11753d39-ecb7-4a43-b86c-93b64321ac00" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Toast_Enjoyer, huaqas
- fix: The Purchaseable Scurret now comes in a livestock crate instead of a plastic one. Wawa!
