### PR TITLE
Remove spears from scurret crates

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -472,7 +472,6 @@
     - id: DrinkTequilaBottleFull # ...that explains it.
     - id: DrinkShotGlass
       amount: 2
-    - id: Spear # self defence
     - id: ClothingHeadHatHardhatYellow
     - id: ClothingNeckMantleQM
     - id: ClothingHeadsetCargo


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Firstly, this is my first PR so please tell me if I did this incorrectly. This PR removes the spear thats included in scurret crates for "self defense".

## Why / Balance
Scurrets often use their spear to validhunt and self antag, removing it would stop them from doing this but they would still be safe because everyone on the whole station shows up to beat you if you attack a scurret. Also, a emotional support animal doesn't need a contraband weapon

## Technical details
Unneeded

## Media
Unneeded

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Scurrets no longer have a spear in their crate.


