### PR TITLE
Fix Bagel Salvage's airlock not being an airlock

### DIFF
--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 07/10/2025 16:46:10
-  entityCount: 25502
+  time: 07/13/2025 00:19:59
+  entityCount: 25504
 maps:
 - 943
 grids:
@@ -11884,17 +11884,25 @@ entities:
       parent: 60
     - type: DeviceLinkSource
       linkedPorts:
-        12706:
+        15897:
         - - DoorStatus
-          - DoorBolt
+          - InputB
   - uid: 12706
     components:
     - type: Transform
       pos: 55.5,0.5
       parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
         8358:
+        - - DoorStatus
+          - DoorBolt
+        19007:
+        - - DoorStatus
+          - DoorBolt
+        19006:
         - - DoorStatus
           - DoorBolt
   - uid: 13183
@@ -113722,6 +113730,39 @@ entities:
         - 0
 - proto: LogicGateOr
   entities:
+  - uid: 15846
+    components:
+    - type: Transform
+      anchored: True
+      rot: -1.5707963267948966 rad
+      pos: 54.5,2.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        15897:
+        - - Output
+          - InputA
+    - type: Physics
+      canCollide: False
+      bodyType: Static
+  - uid: 15897
+    components:
+    - type: Transform
+      anchored: True
+      pos: 54.5,0.5
+      parent: 60
+    - type: DeviceLinkSource
+      linkedPorts:
+        12706:
+        - - Output
+          - DoorBolt
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: Physics
+      canCollide: False
+      bodyType: Static
   - uid: 25536
     components:
     - type: Transform
@@ -157181,11 +157222,25 @@ entities:
     - type: Transform
       pos: 53.5,3.5
       parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        15846:
+        - - DoorStatus
+          - InputA
   - uid: 19007
     components:
     - type: Transform
       pos: 54.5,3.5
       parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        15846:
+        - - DoorStatus
+          - InputB
   - uid: 19023
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added logic gates into the salvage airlock on Bagel, so that the airlock works as an airlock.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Spacing the cargo bay throughout the shift is probably a bad thing.
## Technical details
<!-- Summary of code changes for easier review. -->
Mapping
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
[Screencast_20250712_192131.webm](https://github.com/user-attachments/assets/4713e925-e706-4aa6-8fcf-671d61df8260)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: WarPigeon
MAPS:
- fix: The salvage airlock on Bagel should no longer space the cargo bay.

