### PR TITLE
Reduces Surveillance Camera HP, Standardizes their wiring within departments, simplifies their deconstruction.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
@@ -49,7 +49,6 @@
     anchored: true
   - type: WiresPanel
   - type: Wires
-    alwaysRandomize: true
     layoutId: SurveillanceCamera
   - type: Damageable
     damageContainer: StructuralInorganic
@@ -85,7 +84,7 @@
             acts: [ "Destruction" ]
       - trigger:
           !type:DamageTrigger
-          damage: 100
+          damage: 14
         behaviors:
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
@@ -105,6 +104,8 @@
   name: camera
   suffix: Constructed
   components:
+    - type: Wires
+      layoutId: SurveillanceCameraConstructed
     - type: DeviceNetwork
       deviceNetId: Wired
       transmitFrequencyId: SurveillanceCamera
@@ -125,6 +126,8 @@
   name: camera
   suffix: Engineering
   components:
+  - type: Wires
+    layoutId: SurveillanceCameraEngineering
   - type: DeviceNetwork
     deviceNetId: Wired
     receiveFrequencyId: SurveillanceCameraEngineering
@@ -138,6 +141,8 @@
   name: camera
   suffix: Security
   components:
+  - type: Wires
+    layoutId: SurveillanceCameraSecurity
   - type: DeviceNetwork
     deviceNetId: Wired
     receiveFrequencyId: SurveillanceCameraSecurity
@@ -151,6 +156,8 @@
   name: camera
   suffix: Science
   components:
+  - type: Wires
+    layoutId: SurveillanceCameraScience
   - type: DeviceNetwork
     deviceNetId: Wired
     receiveFrequencyId: SurveillanceCameraScience
@@ -164,6 +171,8 @@
   name: camera
   suffix: Supply
   components:
+  - type: Wires
+    layoutId: SurveillanceCameraSupply
   - type: DeviceNetwork
     deviceNetId: Wired
     receiveFrequencyId: SurveillanceCameraSupply
@@ -177,6 +186,8 @@
   name: camera
   suffix: Command
   components:
+  - type: Wires
+    layoutId: SurveillanceCameraCommand
   - type: DeviceNetwork
     deviceNetId: Wired
     receiveFrequencyId: SurveillanceCameraCommand
@@ -190,6 +201,8 @@
   name: camera
   suffix: Service
   components:
+  - type: Wires
+    layoutId: SurveillanceCameraService
   - type: DeviceNetwork
     deviceNetId: Wired
     receiveFrequencyId: SurveillanceCameraService
@@ -203,6 +216,8 @@
   name: camera
   suffix: Medical
   components:
+  - type: Wires
+    layoutId: SurveillanceCameraMedical
   - type: DeviceNetwork
     deviceNetId: Wired
     receiveFrequencyId: SurveillanceCameraMedical
@@ -216,6 +231,8 @@
   name: camera
   suffix: General
   components:
+  - type: Wires
+    layoutId: SurveillanceCameraGeneral
   - type: DeviceNetwork
     deviceNetId: Wired
     receiveFrequencyId: SurveillanceCameraGeneral

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/cameras.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/cameras.yml
@@ -37,7 +37,7 @@
               doAfter: 2
 
     # once a camera is constructed, it will
-    # instead just require wire cutting + welding
+    # instead just require wire cutting + anchoring
     # to immediately deconstruct
     - node: camera
       entity: SurveillanceCameraConstructed
@@ -52,6 +52,6 @@
               amount: 2
             - !type:DeleteEntity {}
           steps:
-            - tool: Welding
-              doAfter: 2
+            - tool: Anchoring
+              doAfter: 1
 

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -122,7 +122,7 @@
 
 - type: wireLayout
   parent: SurveillanceCamera
-  id: SurveillanceCameraCargo
+  id: SurveillanceCameraSupply
 
 - type: wireLayout
   parent: SurveillanceCamera

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -113,6 +113,42 @@
   - !type:AiVisionWireAction
 
 - type: wireLayout
+  parent: SurveillanceCamera
+  id: SurveillanceCameraSecurity
+
+- type: wireLayout
+  parent: SurveillanceCamera
+  id: SurveillanceCameraService
+
+- type: wireLayout
+  parent: SurveillanceCamera
+  id: SurveillanceCameraCargo
+
+- type: wireLayout
+  parent: SurveillanceCamera
+  id: SurveillanceCameraEngineering
+
+- type: wireLayout
+  parent: SurveillanceCamera
+  id: SurveillanceCameraMedical
+
+- type: wireLayout
+  parent: SurveillanceCamera
+  id: SurveillanceCameraScience
+
+- type: wireLayout
+  parent: SurveillanceCamera
+  id: SurveillanceCameraCommand
+
+- type: wireLayout
+  parent: SurveillanceCamera
+  id: SurveillanceCameraGeneral
+
+- type: wireLayout
+  parent: SurveillanceCamera
+  id: SurveillanceCameraConstructed
+
+- type: wireLayout
   id: CryoPod
   dummyWires: 2
   wires:


### PR DESCRIPTION

## About the PR
This Mald PR is dedicated to the brave thieves who have lost their rounds in the line of duty
Camera HP reduced from 100 --> 14
Wiring is now the same for every camera of the same department
Deconstructing cameras now requires anchoring instead of welding and is 1s faster

## Why / Balance
Camera sabotage is often proposed as a method of circumventing the station AI's surveillance, but sabotage methods are unreasonably demanding. Each camera has randomized wires, requires welding to fully deconstruct, and is about as hard to break as a security officer. Cameras are also incredibly easy to construct, requiring 2 steel, 1 lv cable, and a screwdriver. This PR is intended as a camera nerf alternative to https://github.com/space-wizards/space-station-14/pull/38875 which doesn't leave AI players completely in the dark during power outages. 

HP total was chosen so that the baseball bat can one-hit break, other relevant breakpoints:
1 hit from energy sword, pickaxe, .50 pellet
2 hits from suspicious toolbox, .35 Auto round, .30 Rifle round
3 hits from toolbox, combat knife
5 hits from lit welding tool
7 hits from crowbar

## Technical details
Copied format from airlocks for everything wiring-related, one-liner HP reduction and construction graph.

## Media
<img width="924" height="410" alt="image" src="https://github.com/user-attachments/assets/9d710489-bc33-4995-8e5d-cec0ef1f3ac5" />

<img width="382" height="185" alt="image" src="https://github.com/user-attachments/assets/e64f8785-fb70-4796-8e40-b4d750772cdd" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- tweak: Surveillance camera HP reduced from 100 to 14.
- tweak: Surveillance cameras are now wired the same within departments.
- tweak: Surveillance cameras require wrenching instead of welding to fully disassemble.
