### PR TITLE
Revamps space dust damage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -75,7 +75,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 10
+        damage: 15
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -70,13 +70,12 @@
         - BulletImpassable
   - type: Explosive # 90 dmg at epicenter
     totalIntensity: 20
-    intensitySlope: 3
-    maxIntensity: 6
+    maxIntensity: 5
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 10
+        damage: 5
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -75,7 +75,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 5
+        damage: 10
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -68,14 +68,15 @@
         mask:
         - Impassable
         - BulletImpassable
-  - type: Explosive
-    totalIntensity: 25
-    maxIntensity: 5
+  - type: Explosive # 90 dmg at epicenter
+    totalIntensity: 20
+    intensitySlope: 3
+    maxIntensity: 6
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 10
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -70,6 +70,7 @@
         - BulletImpassable
   - type: Explosive
     totalIntensity: 25
+    maxIntensity: 5
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Prevents some instances of space dust from doing 100+ damage on hit
  - Capped at 90 damage total after reducing both meteor collision and explosion damage

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Space dust could do 100 blunt damage and an additional 80 or so explosive damage on top, leading to instances of players being crit or killed instantly on collision. While space dust is dangerous IRL (https://en.wikipedia.org/wiki/Space_debris#Hazards), it's a considerable source of frustration and should be nerfed. Space dust will now maim but not outright crit you, giving time to get back onto station before dying.

May affect structural damage but explosions seems buggy anyway (https://github.com/space-wizards/space-station-14/issues/38962), so it's hard to say what the intended behaviour is.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![dotnet_1tEfFWXLfO](https://github.com/user-attachments/assets/3b545f73-a44a-41cd-b0f9-5a8b8e90f530)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Space dust should no longer deal 100+ damage on collision.