### PR TITLE
Voltage enum to shared

### DIFF
--- a/Content.Server/Power/Components/BaseNetConnectorComponent.cs
+++ b/Content.Server/Power/Components/BaseNetConnectorComponent.cs
@@ -4,6 +4,7 @@ using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.NodeGroups;
 using Content.Shared.NodeContainer;
 using Content.Shared.NodeContainer.NodeGroups;
+using Content.Shared.Power;
 
 namespace Content.Server.Power.Components
 {
@@ -93,12 +94,5 @@ namespace Content.Server.Power.Components
             _voltage = newVoltage;
             TryFindAndSetNet();
         }
-    }
-
-    public enum Voltage
-    {
-        High = NodeGroupID.HVPower,
-        Medium = NodeGroupID.MVPower,
-        Apc = NodeGroupID.Apc,
     }
 }

--- a/Content.Server/Power/Generator/PowerSwitchableSystem.cs
+++ b/Content.Server/Power/Generator/PowerSwitchableSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Power.Nodes;
 using Content.Shared.NodeContainer;
+using Content.Shared.Power;
 using Content.Shared.Power.Generator;
 using Content.Shared.Timing;
 using Content.Shared.Verbs;

--- a/Content.Shared/Power/SharedPower.cs
+++ b/Content.Shared/Power/SharedPower.cs
@@ -1,3 +1,4 @@
+using Content.Shared.NodeContainer.NodeGroups;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Power
@@ -30,5 +31,13 @@ namespace Content.Shared.Power
         HighVoltage,
         MediumVoltage,
         Apc,
+    }
+
+    [Serializable, NetSerializable]
+    public enum Voltage
+    {
+        High = NodeGroupID.HVPower,
+        Medium = NodeGroupID.MVPower,
+        Apc = NodeGroupID.Apc,
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Voltage enum got moved from Content.Server.Power.Components to Content.Shared.Power

## Why / Balance
Shared code, also required for future PR

## Technical details
Just a simple move between files.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Content.Server.Power.Components.Voltage has been moved to Content.Shared.Power.Voltage

**Changelog**
