### PR TITLE
Fixed error thrown when hard suit helmet is worn during round restart

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -216,6 +216,9 @@ public sealed class ToggleableClothingSystem : EntitySystem
         if (toggleComp.LifeStage > ComponentLifeStage.Running)
             return;
 
+        if(Deleted(toggleComp.Owner) == false)
+            return;
+
         // As unequipped gets called in the middle of container removal, we cannot call a container-insert without causing issues.
         // So we delay it and process it during a system update:
         if (toggleComp.ClothingUid != null && toggleComp.Container != null)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a check for the hardsuit helmet removal to avoid errors being thrown if owner container (hardsuit) is already deleted.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #38917 
## Technical details
<!-- Summary of code changes for easier review. -->
Changed ToggleableClothingSystem.OnAttachedUnequip function to check if the Owner container has already been deleted. This function will now skip the step of moving helmet if Owner container is deleted.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before Restart:
<img width="1281" height="556" alt="before_restart" src="https://github.com/user-attachments/assets/4e1d7057-851b-4419-a7a0-66bf5c55158f" />
After Restart:
<img width="2089" height="855" alt="after_restart" src="https://github.com/user-attachments/assets/8c67c2ef-259c-4d69-bc7b-1688af4202ff" />
Server Log:
<img width="943" height="519" alt="server_restart_log" src="https://github.com/user-attachments/assets/fb1e330f-b1cc-465f-bd35-efafe5d02a9c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
