### PR TITLE
Add contraband parent to war declarator

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/war_declarator.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/war_declarator.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseItem
+  parent: [BaseItem, BaseSyndicateContraband ]
   id: NukeOpsDeclarationOfWar
   name: war declarator
   description: Use to send a declaration of hostilities to the target, delaying your shuttle departure while they prepare for your assault. Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals. Must be used at start of mission, or your benefactors will lose interest.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
the nukeop war declarator is now syndicate contraband

## Why / Balance
oversight I guess

## Technical details
.yml warrior strikes again

## Media
<img width="648" height="322" alt="image_2025-07-13_153915724" src="https://github.com/user-attachments/assets/13ea18b3-4a93-42a8-89ec-a73a27ac5559" />




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: The nukeop war declarator is now syndicate contraband.
