### PR TITLE
Properly dispose of stale pipedata chunks for the atmos monitor

### DIFF
--- a/Content.Client/Atmos/Consoles/AtmosMonitoringConsoleNavMapControl.cs
+++ b/Content.Client/Atmos/Consoles/AtmosMonitoringConsoleNavMapControl.cs
@@ -162,10 +162,10 @@ public sealed partial class AtmosMonitoringConsoleNavMapControl : NavMapControl
         {
             var list = new List<AtmosMonitoringConsoleLine>();
 
-            foreach (var ((netId, layer, hexColor), atmosPipeData) in chunk.AtmosPipeData)
+            foreach (var ((netId, layer, pipeColor), atmosPipeData) in chunk.AtmosPipeData)
             {
                 // Determine the correct coloration for the pipe
-                var color = Color.FromHex(hexColor) * _basePipeNetColor;
+                var color = pipeColor * _basePipeNetColor;
 
                 if (FocusNetId != null && FocusNetId != netId)
                     color *= _unfocusedPipeNetColor;

--- a/Content.Server/Atmos/Consoles/AtmosMonitoringConsoleSystem.cs
+++ b/Content.Server/Atmos/Consoles/AtmosMonitoringConsoleSystem.cs
@@ -432,7 +432,7 @@ public sealed class AtmosMonitoringConsoleSystem : SharedAtmosMonitoringConsoleS
                 continue;
 
             var netId = GetPipeNodeNetId(pipeNode);
-            var subnet = new AtmosMonitoringConsoleSubnet(netId, pipeNode.CurrentPipeLayer, pipeColor.Color.ToHex());
+            var subnet = new AtmosMonitoringConsoleSubnet(netId, pipeNode.CurrentPipeLayer, pipeColor.Color);
             var pipeDirection = pipeNode.CurrentPipeDirection;
 
             chunk.AtmosPipeData.TryGetValue(subnet, out var atmosPipeData);

--- a/Content.Server/Atmos/Consoles/AtmosMonitoringConsoleSystem.cs
+++ b/Content.Server/Atmos/Consoles/AtmosMonitoringConsoleSystem.cs
@@ -54,7 +54,7 @@ public sealed class AtmosMonitoringConsoleSystem : SharedAtmosMonitoringConsoleS
 
         // Grid events
         SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
-        SubscribeLocalEvent<MapGridComponent, PipeNodeGroupRemovedEvent>(OnPipeNodeGroupRemoved);
+        SubscribeLocalEvent<PipeNodeGroupRemovedEvent>(OnPipeNodeGroupRemoved);
     }
 
     #region Event handling
@@ -297,13 +297,13 @@ public sealed class AtmosMonitoringConsoleSystem : SharedAtmosMonitoringConsoleS
 
     #region Pipe net functions
 
-    private void OnPipeNodeGroupRemoved(Entity<MapGridComponent> ent, ref PipeNodeGroupRemovedEvent args)
+    private void OnPipeNodeGroupRemoved(ref PipeNodeGroupRemovedEvent args)
     {
         // When a pipe node group is removed, we need to iterate over all of
         // our pipe chunks and remove any entries with a matching net id.
         // (We only need to check the chunks for the affected grid, though.)
 
-        if (!_gridAtmosPipeChunks.TryGetValue(ent, out var chunkData))
+        if (!_gridAtmosPipeChunks.TryGetValue(args.Grid, out var chunkData))
             return;
 
         foreach (var chunk in chunkData.Values)

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
@@ -279,6 +279,14 @@ public partial class AtmosphereSystem
 
     public bool RemovePipeNet(Entity<GridAtmosphereComponent?> grid, PipeNet pipeNet)
     {
+        // Technically this event can be fired even on grids that don't
+        // actually have grid atmospheres.
+        if (pipeNet.Grid is not null)
+        {
+            var ev = new PipeNodeGroupRemovedEvent(pipeNet.NetId);
+            RaiseLocalEvent(pipeNet.Grid.Value, ref ev);
+        }
+
         return _atmosQuery.Resolve(grid, ref grid.Comp, false) && grid.Comp.PipeNets.Remove(pipeNet);
     }
 
@@ -329,3 +337,11 @@ public partial class AtmosphereSystem
     [ByRefEvent] private record struct IsHotspotActiveMethodEvent
         (EntityUid Grid, Vector2i Tile, bool Result = false, bool Handled = false);
 }
+
+
+/// <summary>
+/// Raised against a grid when a pipe node group it contains has been removed.
+/// </summary>
+/// <param name="NetId">The net id of the removed node group.</param>
+[ByRefEvent]
+public record struct PipeNodeGroupRemovedEvent(int NetId);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
@@ -283,8 +283,8 @@ public partial class AtmosphereSystem
         // actually have grid atmospheres.
         if (pipeNet.Grid is not null)
         {
-            var ev = new PipeNodeGroupRemovedEvent(pipeNet.NetId);
-            RaiseLocalEvent(pipeNet.Grid.Value, ref ev);
+            var ev = new PipeNodeGroupRemovedEvent(grid, pipeNet.NetId);
+            RaiseLocalEvent(ref ev);
         }
 
         return _atmosQuery.Resolve(grid, ref grid.Comp, false) && grid.Comp.PipeNets.Remove(pipeNet);
@@ -340,8 +340,9 @@ public partial class AtmosphereSystem
 
 
 /// <summary>
-/// Raised against a grid when a pipe node group it contains has been removed.
+/// Raised broadcasted when a pipe node group within a grid has been removed.
 /// </summary>
+/// <param name="Grid">The grid with the removed node group.</param>
 /// <param name="NetId">The net id of the removed node group.</param>
 [ByRefEvent]
-public record struct PipeNodeGroupRemovedEvent(int NetId);
+public record struct PipeNodeGroupRemovedEvent(EntityUid Grid, int NetId);

--- a/Content.Shared/Atmos/Consoles/Components/AtmosMonitoringConsoleComponent.cs
+++ b/Content.Shared/Atmos/Consoles/Components/AtmosMonitoringConsoleComponent.cs
@@ -234,9 +234,9 @@ public struct AtmosMonitoringConsoleEntry
 /// </summary>
 /// <param name="NetId">The associated network ID.</param>
 /// <param name="PipeLayer">The associated pipe layer.</param>
-/// <param name="HexCode">The color of the pipe.</param>
+/// <param name="Color">The color of the pipe.</param>
 [Serializable, NetSerializable]
-public record AtmosMonitoringConsoleSubnet(int NetId, AtmosPipeLayer PipeLayer, string HexCode);
+public record AtmosMonitoringConsoleSubnet(int NetId, AtmosPipeLayer PipeLayer, Color Color);
 
 public enum AtmosPipeChunkDataFacing : byte
 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This fixes a performance issue that was especially prevalent on long running rounds, or in rounds that feature complex pipenets that are built out by hand or have a lot of signal or manual valves.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Slow bad. Fast good.

## Technical details
<!-- Summary of code changes for easier review. -->
Whenever a gas pipe is placed or built, it triggers a node group update:
```
[DEBG] nodegroup: Updated node groups in 39.8682ms. 147 new groups, 1285 nodes processed.
```
For pipenets in particular, this updates the node group of the pipenet to include this new pipe as being reachable. This also fires off a NodeGroupsRebuilt event which the atmos monitoring console handles in order to update its display of the pipenet. Internally, the system has a nested data structure that looks like this:

```
2: (grid uid)
  (12, 10): (chunk origin)
    - origin: (12, 10)
      pipedata:
        (pipe layer, pipe color, nodegroup net ID): (bitmask of actual position + rotation)
        (Primary, #FFFFFFFF, 27): 0000000000000000000000100111011100000000101111010000000000101011
        (Primary, #FFFFFFFF, 53): 0000000000000000000000000000000000000000000000000000001000010000
  (12, 9):
    - origin: (12, 9)
      pipedata:
        (Primary, #FFFFFFFF, 27): 0000000000000000010100000000000011000000000000001001000000000000
        (Primary, #FFFFFFFF, 29): 0000000000000000000000000000000000100000000000000000000000000000
        (Primary, #FF0000FF, 29): 0000000000000000000000000000000000000001000000000000000000000000
        (Primary, #FF0000FF, 35): 0010110100000000000010100101000000000010101100110000000000000000
  ...
```
And this gets updated node group update to match what the new pipe layout should be. The issue though is though that this update is strictly additive. Let's look at what happens when we build out two connected pipes. We start out with:

```
5113:
  (1, 0):
    - origin: (1, 0)
      pipedata:
        (Primary, #FFFFFFFF, 148): 0000000000000000000000000000000000110000000000000000000000000000
```
Then we add a pipe:
```
5113:
  (1, 0):
    - origin: (1, 0)
      pipedata:
        (Primary, #FFFFFFFF, 148): 0000000000000000000000000000000000000000000000000000000000000000
        (Primary, #FFFFFFFF, 149): 0000000000000000000000000000000000110000000000000000000000000000
  (1, 1):
    - origin: (1, 1)
      pipedata:
        (Primary, #FFFFFFFF, 149): 0000000000000000000000000000000000000000000000110000000000000000
```

The added pipe gets its node container started up and this triggers a reflood of all of that pipes nodes. This triggers a node group update, which will end up remaking the nodegroup. A NodeGroupsRebuilt event gets fired, and the atmos monitoring console updates its dictionary with the new node group. As part of this, it zeroes out every bitmask and builds everything back up.

The issue is that the node group 148 is now dead, and it never gets removed from this dictionary! This is super sucks.

Anyway, this PR adds an event that the monitoring console listens to which says if a pipe node group was remade, meaning it can be removed from its internal dictionary.

I also switched AtmosMonitoringConsoleSubnet to store the color as an actual Color since its used as a key so we can get a faster hashing algorithm.

Honestly, there's probably a lot of other performance improvements that could be made, but this at least fixes the cumulatively worsening effect which can be a _huge_ pain for long running rounds. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- `AtmosMonitoringConsoleSubnet.HexColor` is now `AtmosMonitoringConsoleSubnet.Color`, and is a `Color` instead of a `string`.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
wawa.
