### PR TITLE
Buff parrot learn rates and radio chatter

### DIFF
--- a/Content.Server/Animals/Components/ParrotMemoryComponent.cs
+++ b/Content.Server/Animals/Components/ParrotMemoryComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class ParrotMemoryComponent : Component
     /// The % chance an entity with this component learns a phrase when learning is off cooldown
     /// </summary>
     [DataField]
-    public float LearnChance = 0.4f;
+    public float LearnChance = 0.6f;
 
     /// <summary>
     /// Time after which another attempt can be made at learning a phrase

--- a/Content.Server/Vocalization/Components/RadioVocalizerComponent.cs
+++ b/Content.Server/Vocalization/Components/RadioVocalizerComponent.cs
@@ -10,5 +10,5 @@ public sealed partial class RadioVocalizerComponent : Component
     /// chance the vocalizing entity speaks on the radio.
     /// </summary>
     [DataField]
-    public float RadioAttemptChance = 0.3f;
+    public float RadioAttemptChance = 0.6f;
 }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -866,9 +866,11 @@
   description: An expert in quantum cracker theory
   components:
   - type: ParrotMemory
-    learnChance: 0.5 # polly is smarter
+    learnChance: 0.8 # polly is smarter
   - type: Vocalizer
     maxVocalizeInterval: 240 # polly is chattier
+  - type: RadioVocalizer
+    radioAttemptChance: 0.8 # polly wants to share with the world
   - type: Grammar
     attributes:
       proper: true

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -866,7 +866,7 @@
   description: An expert in quantum cracker theory
   components:
   - type: ParrotMemory
-    learnChance: 0.8 # polly is smarter
+    learnChance: 0.6 # polly is smarter
   - type: Vocalizer
     maxVocalizeInterval: 240 # polly is chattier
   - type: RadioVocalizer

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -865,8 +865,6 @@
   id: MobPollyParrot
   description: An expert in quantum cracker theory
   components:
-  - type: ParrotMemory
-    learnChance: 0.6 # polly is smarter
   - type: Vocalizer
     maxVocalizeInterval: 240 # polly is chattier
   - type: RadioVocalizer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Buffed normal parrots, and further increase Polly's radio chance to 80%.

learn chance 40% -> 60%
Radio attempt chance 30% -> 60%
Polly radio attempt chance  default -> 80%


## Why / Balance
Judging from a few rounds, default Parrots learned too little to have a varied set of things to say during the round and used the radio they had equipped too infrequently.

One round I ordered a parrot crate with 3 of them and put them next to an intercom, which was closer to the rate of parrotry I had in mind, but still lacked variety.

Polly should share most of his wisdom on the radio, only sharing in secret every now and then, so I raised it to 80%. Polly's talk rate seemed fine.

## Technical details
Just some default changes

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

