### PR TITLE
Remove prototype caching from `TransformableContainerComponent`

### DIFF
--- a/Content.Server/Chemistry/Components/TransformableContainerComponent.cs
+++ b/Content.Server/Chemistry/Components/TransformableContainerComponent.cs
@@ -1,6 +1,6 @@
-using Content.Server.Animals.Systems;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Chemistry.Components;
 
@@ -19,19 +19,19 @@ public sealed partial class TransformableContainerComponent : Component
     /// It will revert to this when emptied.
     ///     /// It defaults to the description of the parent entity unless overwritten.
     /// </summary>
-    [DataField("initialDescription")]
+    [DataField]
     public string? InitialDescription;
+
     /// <summary>
     /// This stores whatever primary reagent is currently in the container.
     /// It is used to help determine if a transformation is needed on solution update.
     /// </summary>
-    [DataField("currentReagent")]
-    public ReagentPrototype? CurrentReagent;
+    [DataField]
+    public ProtoId<ReagentPrototype>? CurrentReagent;
 
     /// <summary>
     /// This returns whether this container in a transformed or initial state.
     /// </summary>
-    ///
-    [DataField("transformed")]
+    [DataField]
     public bool Transformed;
 }

--- a/Content.Server/Chemistry/EntitySystems/TransformableContainerSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/TransformableContainerSystem.cs
@@ -45,8 +45,8 @@ public sealed class TransformableContainerSystem : EntitySystem
         //the biggest reagent in the solution decides the appearance
         var reagentId = solution.GetPrimaryReagentId();
 
-        //If biggest reagent didn't changed - don't change anything at all
-        if (entity.Comp.CurrentReagent != null && entity.Comp.CurrentReagent.ID == reagentId?.Prototype)
+        //If biggest reagent didn't change - don't change anything at all
+        if (entity.Comp.CurrentReagent != null && entity.Comp.CurrentReagent == reagentId?.Prototype)
         {
             return;
         }
@@ -66,7 +66,7 @@ public sealed class TransformableContainerSystem : EntitySystem
 
     private void OnRefreshNameModifiers(Entity<TransformableContainerComponent> entity, ref RefreshNameModifiersEvent args)
     {
-        if (entity.Comp.CurrentReagent is { } currentReagent)
+        if (_prototypeManager.TryIndex(entity.Comp.CurrentReagent, out var currentReagent))
         {
             args.AddModifier("transformable-container-component-glass", priority: -1, ("reagent", currentReagent.LocalizedName));
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`TransformableContainerComponent` no longer caches a `ReagentPrototype`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Caching prototypes is bad.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed `TransformableContainerComponent.CurrentReagent` from a `ReagentPrototype?` to a `ProtoId<ReagentPrototype>?` and made a few changes to `TransformableContainerSystem` to support the change.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`TransformableContainerComponent.CurrentReagent` is now a `ProtoId<ReagentPrototype>?` instead of a `ReagentPrototype?`. If you need to access fields from the prototype, simply index the `ProtoId` with prototype manager.