### PR TITLE
allow more configuration of a gas miner's output

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasMinerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasMinerSystem.cs
@@ -46,11 +46,8 @@ public sealed class GasMinerSystem : SharedGasMinerSystem
         // The rates of moles mined/released are declared in mol/s, so to get the amount of gas we hope to mine, we have to multiply the rate by
         // how long we have been waiting to spawn it and further cap the number depending on other factors.
 
-        // This is how many mols we can mine right now.
-        var molesMinedPerSecond = minerComponent.MiningRate * args.dt;
-
         // Time to mine some gas. However, only mine as much as we can, and not too much that will exceed the internal storage.
-        minerComponent.StoredAmount = Math.Min(minerComponent.MaxStoredAmount, minerComponent.StoredAmount + molesMinedPerSecond);
+        minerComponent.StoredAmount = Math.Min(minerComponent.MaxStoredAmount, minerComponent.StoredAmount + minerComponent.MiningRate * args.dt);
 
         // Although we can mine gas in space, it's bad for the environment to release it into space. Atleast like this.
         if (_atmosphereSystem.IsTileSpace(transform.GridUid, transform.MapUid, minerTilePosition))

--- a/Content.Shared/Atmos/Components/GasMinerComponent.cs
+++ b/Content.Shared/Atmos/Components/GasMinerComponent.cs
@@ -45,7 +45,7 @@ public sealed partial class GasMinerComponent : Component
 
     /// <summary>
     ///     The number of moles released from the miner's internal storage, per second, when the miner is working,
-    ///         and if it has enough mols of gas stored to do so.
+    ///         if it has enough mols of gas stored to do so.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("releaseAmount")]
     public float ReleaseRate = Atmospherics.MolesCellStandard * 20f;

--- a/Content.Shared/Atmos/Components/GasMinerComponent.cs
+++ b/Content.Shared/Atmos/Components/GasMinerComponent.cs
@@ -54,7 +54,7 @@ public sealed partial class GasMinerComponent : Component
     ///      The maximum number of moles that can be stored within the miner's internal storage at once.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField]
-    public float MaxStoredAmount = 2500;
+    public float MaxStoredAmount = 2500f;
 
     /// <summary>
     ///      The number of moles that are currently stored within the miner's internal storage, to be released later at the rate of <see cref="ReleaseAmount">.

--- a/Content.Shared/Atmos/Components/GasMinerComponent.cs
+++ b/Content.Shared/Atmos/Components/GasMinerComponent.cs
@@ -55,7 +55,7 @@ public sealed partial class GasMinerComponent : Component
     /// </summary>
     /// <remarks>
     ///     This should not be infinite. Instead, <see cref="ReleaseRate"/> and <see cref="MiningRate"/>
-    ///         should be set to the same value, in order to effectively bypass internal gas storage.
+    ///         should both be of a lower or equal value compared to this.
     /// </remarks
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public float MaxStoredAmount = 1200f;

--- a/Content.Shared/Atmos/Components/GasMinerComponent.cs
+++ b/Content.Shared/Atmos/Components/GasMinerComponent.cs
@@ -51,19 +51,23 @@ public sealed partial class GasMinerComponent : Component
     public float ReleaseRate = Atmospherics.MolesCellStandard * 20f;
 
     /// <summary>
-    ///      The maximum number of moles that can be stored within the miner's internal storage at once.
+    ///     The maximum number of moles that can be stored within the miner's internal storage at once.
     /// </summary>
+    /// <remarks>
+    ///     This should not be infinite. Instead, <see cref="ReleaseRate"/> and <see cref="MiningRate"/>
+    ///         should be set to the same value, in order to effectively bypass internal gas storage.
+    /// </remarks
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public float MaxStoredAmount = 2500f;
 
     /// <summary>
-    ///      The number of moles that are currently stored within the miner's internal storage, to be released later at the rate of <see cref="ReleaseAmount">.
+    ///     The number of moles that are currently stored within the miner's internal storage, to be released later at the rate of <see cref="ReleaseRate">.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
     public float StoredAmount = 0f;
 
     /// <summary>
-    ///      The <see cref="StoredAmount"/>, the last time which it was replicated. This is used so that continuous very small changes in <see cref="StoredAmount"/> being
+    ///     The <see cref="StoredAmount"/>, the last time which it was replicated. This is used so that continuous very small changes in <see cref="StoredAmount"/> being
     ///         intentionally not replicated, will not adversly affect anyone who examines this.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Atmos/Components/GasMinerComponent.cs
+++ b/Content.Shared/Atmos/Components/GasMinerComponent.cs
@@ -58,7 +58,7 @@ public sealed partial class GasMinerComponent : Component
     ///         should be set to the same value, in order to effectively bypass internal gas storage.
     /// </remarks
     [ViewVariables(VVAccess.ReadWrite), DataField]
-    public float MaxStoredAmount = 2500f;
+    public float MaxStoredAmount = 1200f;
 
     /// <summary>
     ///     The number of moles that are currently stored within the miner's internal storage, to be released later at the rate of <see cref="ReleaseRate">.

--- a/Content.Shared/Atmos/Components/GasMinerComponent.cs
+++ b/Content.Shared/Atmos/Components/GasMinerComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Atmos.Components;
 
 [NetworkedComponent]
-[AutoGenerateComponentState]
+[AutoGenerateComponentState(fieldDeltas: true)]
 [RegisterComponent]
 public sealed partial class GasMinerComponent : Component
 {
@@ -16,14 +16,14 @@ public sealed partial class GasMinerComponent : Component
     public GasMinerState MinerState = GasMinerState.Disabled;
 
     /// <summary>
-    ///      If the number of moles in the external environment exceeds this number, no gas will be mined.
+    ///      If the number of moles in the external environment exceeds this number, no gas will be released.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
     public float MaxExternalAmount = float.PositiveInfinity;
 
     /// <summary>
-    ///      If the pressure (in kPA) of the external environment exceeds this number, no gas will be mined.
+    ///      If the pressure (in kPA) of the external environment exceeds this number, no gas will be released.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
@@ -44,11 +44,36 @@ public sealed partial class GasMinerComponent : Component
     public float SpawnTemperature = Atmospherics.T20C;
 
     /// <summary>
-    ///     Number of moles created per second when the miner is working.
+    ///     The number of moles released from the miner's internal storage, per second, when the miner is working,
+    ///         and if it has enough mols of gas stored to do so.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("releaseAmount")]
+    public float ReleaseRate = Atmospherics.MolesCellStandard * 20f;
+
+    /// <summary>
+    ///      The maximum number of moles that can be stored within the miner's internal storage at once.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public float MaxStoredAmount = 2500;
+
+    /// <summary>
+    ///      The number of moles that are currently stored within the miner's internal storage, to be released later at the rate of <see cref="ReleaseAmount">.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    public float StoredAmount = 0f;
+
+    /// <summary>
+    ///      The <see cref="StoredAmount"/>, the last time which it was replicated. This is used so that continuous very small changes in <see cref="StoredAmount"/> being
+    ///         intentionally not replicated, will not adversly affect anyone who examines this.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField]
-    public float SpawnAmount = Atmospherics.MolesCellStandard * 20f;
+    public float LastReplicatedStoredAmount = 0f;
+
+    /// <summary>
+    ///     The number of moles that are mined, per second, into the miner's internal storage, not released.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("spawnAmount")]
+    public float MiningRate = Atmospherics.MolesCellStandard * 20f;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Atmos/EntitySystems/SharedGasMinerSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedGasMinerSystem.cs
@@ -23,8 +23,8 @@ public abstract class SharedGasMinerSystem : EntitySystem
             args.PushMarkup(Loc.GetString("gas-miner-mines-text",
                 ("gas", Loc.GetString(_sharedAtmosphereSystem.GetGas(component.SpawnGas).Name))));
 
-            // Display stats only about effective amount of gas mined, unless the miner both doesn't have a negligible amount of gas, and doesn't just immediately release the gas it mines.
-            if (component.MiningRate == component.ReleaseRate && component.StoredAmount >= Atmospherics.GasMinMoles)
+            // Display stats only about effective amount of gas mined, unless the miner is full, and it's mining and releasing rates are the same.
+            if (component.MiningRate == component.ReleaseRate && component.StoredAmount == component.MaxStoredAmount)
                 args.PushText(Loc.GetString("gas-miner-amount-no-storage-text",
                     ("moles", $"{component.ReleaseRate:0.#}")));
             else

--- a/Content.Shared/Atmos/EntitySystems/SharedGasMinerSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedGasMinerSystem.cs
@@ -23,8 +23,15 @@ public abstract class SharedGasMinerSystem : EntitySystem
             args.PushMarkup(Loc.GetString("gas-miner-mines-text",
                 ("gas", Loc.GetString(_sharedAtmosphereSystem.GetGas(component.SpawnGas).Name))));
 
-            args.PushText(Loc.GetString("gas-miner-amount-text",
-                ("moles", $"{component.SpawnAmount:0.#}")));
+            // Display stats only about effective amount of gas mined, unless the miner both doesn't have a negligible amount of gas, and doesn't just immediately release the gas it mines.
+            if (component.MiningRate == component.ReleaseRate && component.StoredAmount >= Atmospherics.GasMinMoles)
+                args.PushText(Loc.GetString("gas-miner-amount-no-storage-text",
+                    ("moles", $"{component.ReleaseRate:0.#}")));
+            else
+                args.PushText(Loc.GetString("gas-miner-amount-with-storage-text",
+                    ("molesMined", $"{component.MiningRate:0.#}"),
+                    ("molesReleased", $"{component.ReleaseRate:0.#}"),
+                    ("storedMoles", $"{component.StoredAmount:0.#}")));
 
             args.PushText(Loc.GetString("gas-miner-temperature-text",
                 ("tempK", $"{component.SpawnTemperature:0.#}"),

--- a/Resources/Locale/en-US/atmos/gas-miner-component.ftl
+++ b/Resources/Locale/en-US/atmos/gas-miner-component.ftl
@@ -1,7 +1,7 @@
 gas-miner-mines-text = It mines [color=lightgray]{$gas}[/color] when active.
 
 gas-miner-amount-no-storage-text = It mines and releases {$moles} moles of gas per second, when active.
-gas-miner-amount-with-storage-text = It mines {$molesMined}, and releases {$molesReleased}, out of the stored {$storedMoles} moles of gas, per second when active.
+gas-miner-amount-with-storage-text = It mines {$molesMined}, and releases {$molesReleased}, out of the stored {$storedMoles}, moles of gas per second active.
 gas-miner-temperature-text = Mined gas temp: {$tempK}K ({$tempC}°C).
 
 gas-miner-moles-cutoff-text = Surrounding moles cutoff: {$moles} moles.

--- a/Resources/Locale/en-US/atmos/gas-miner-component.ftl
+++ b/Resources/Locale/en-US/atmos/gas-miner-component.ftl
@@ -1,6 +1,7 @@
 gas-miner-mines-text = It mines [color=lightgray]{$gas}[/color] when active.
 
-gas-miner-amount-text = It mines {$moles} moles of gas a second when active.
+gas-miner-amount-no-storage-text = It mines and releases {$moles} moles of gas per second, when active.
+gas-miner-amount-with-storage-text = It mines {$molesMined}, and releases {$molesReleased}, out of the stored {$storedMoles} moles of gas, per second when active.
 gas-miner-temperature-text = Mined gas temp: {$tempK}K ({$tempC}°C).
 
 gas-miner-moles-cutoff-text = Surrounding moles cutoff: {$moles} moles.

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -32,6 +32,7 @@
     - type: GasMiner
       maxExternalPressure: 300
       spawnAmount: 400
+      releaseAmount: 400
     - type: GuideHelp
       guides:
       - GasMiningAndStorage


### PR DESCRIPTION
## About the PR
Gas miners now have an internal storage that can hold a certain maximum amount of gas. The default capacity is 1200 moles, as it only needs to be equal to or more than both the release rate and mining rate of the miner for gas to be released as soon as it is mined.

Now, when a gas miner mines gas, the gas will be deposited into an internal storage of the miner at a fixed rate until it is full. Gas miners will release gas (in the same manner as they did before, at their original fixed rate) into the environment when they are able to, i.e. usually when their pressure cutoff is subceeded. (or deceeded? whatever)

This is visible in the examine menu of the gas miner if the mining rate isn't equal to the release rate of gas, or if it is not completely full. Otherwise, it will display only one rate.

Miners are configured to have no actual observable change in output in-game as this PR is only to add this functionality.

## Why / Balance
As said, this doesn't actually have any in-game effect *right now*, but is intended to be used to alleviate any problems with gas miners being able to output absurd amounts of gas in a short time-span.

Specifically, I will probably use this feature to justify bringing back plasma gas miners while actually properly dealing with the issue of atmos getting way too much plasma than they actually need for their *real* duty (aka TEG). However that isn't the scope of this PR.

## Technical details
Some private methods were changed to reduce repetitive code and unnecessary nesting.

`GasMinerComponent.LastReplicatedStoredAmount` is only set every time `GasMinerComponent.StoredAmount` is dirtied, to be used to compare against the gas miner's new amount of stored gas and whether it is worth dirtying a gas miner for. 

A gas miner's stored amount won't be dirtied if the difference between the new and old amount is negligible, and that value exists so that continuous negligible changes in stored amount of gas won't result in a stored amount of gas that differs from the real value when examining the gas miner.

## Media
VV-ed plasma miner
<img height="220" alt="image" src="https://github.com/user-attachments/assets/66f81d19-9a7f-4895-b2ce-b21be81014db" />
Default gas miner
<img height="220" alt="image" src="https://github.com/user-attachments/assets/0b4e97c5-87ed-4104-9d0e-45adbcbee656" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`GasMinerComponent.SpawnAmount` has been changed to `GasMinerComponent.MiningRate`. The datafield stays the same, being `spawnAmount`. To preserve original behaviour of gas miners, `GasMinerComponent.ReleaseRate` *(datafield: `releaseAmount`)* should be set to the same value as `spawnAmount`.

`gas-miner-amount-text` has been split into `gas-miner-amount-no-storage-text` and `gas-miner-amount-with-storage-text`.
