### PR TITLE
Added nukeops tag to debug uplink

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -123,3 +123,6 @@
   - type: Store
     balance:
       Telecrystal: 99999
+  - type: Tag
+    tags:
+    - NukeOpsUplink


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The debug uplink can now buy the nukeops gear

## Why / Balance
Doesent make sense why you can buy nukeops stuff

## Technical details
Added a tag

## Media
<img width="494" height="335" alt="image_2025-07-14_180844359" src="https://github.com/user-attachments/assets/f0960e1c-0dc7-4274-930a-4987a68b711a" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
Not player facing
