### PR TITLE
Mostly fix reaction sound effect stacking :(

### DIFF
--- a/Content.Shared/Chemistry/Reaction/ChemicalReactionSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/ChemicalReactionSystem.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+using System.Linq;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
@@ -6,9 +8,8 @@ using Content.Shared.EntityEffects;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
-using System.Collections.Frozen;
-using System.Linq;
 
 
 namespace Content.Shared.Chemistry.Reaction
@@ -25,9 +26,10 @@ namespace Content.Shared.Chemistry.Reaction
         /// </summary>
         private const int MaxReactionIterations = 20;
 
+        [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-        [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+        [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
 
         /// <summary>
@@ -225,7 +227,11 @@ namespace Content.Shared.Chemistry.Reaction
                 effect.Effect(args);
             }
 
-            _audio.PlayPvs(reaction.Sound, soln);
+            // Someday, some brave soul will thread through an optional actor
+            // argument in from every call of OnReaction up, all just to pass
+            // it to PlayPredicted. I am not that brave soul.
+            if (_timing.IsFirstTimePredicted)
+                _audio.PlayPvs(reaction.Sound, soln);
         }
 
         /// <summary>

--- a/Content.Shared/Chemistry/Reaction/ChemicalReactionSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/ChemicalReactionSystem.cs
@@ -241,7 +241,6 @@ namespace Content.Shared.Chemistry.Reaction
         /// </summary>
         private bool ProcessReactions(Entity<SolutionComponent> soln, SortedSet<ReactionPrototype> reactions, ReactionMixerComponent? mixerComponent)
         {
-            HashSet<ReactionPrototype> toRemove = new();
             List<string>? products = null;
 
             // attempt to perform any applicable reaction
@@ -249,7 +248,6 @@ namespace Content.Shared.Chemistry.Reaction
             {
                 if (!CanReact(soln, reaction, mixerComponent, out var unitReactions))
                 {
-                    toRemove.Add(reaction);
                     continue;
                 }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
:(

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #38870 :(

## Technical details
<!-- Summary of code changes for easier review. -->
Bit aside, this actually isn't a real fix and you still hear the sound twice (instead of like... ten times) if you're the initiator of the reaction. The _real_ solution would be to update like. Every single solution method to have an optional actor argument for whomever is triggering the input that would be predicted. (And that doesn't even handle updates from things like predicted update loops, which would need to go through PlayLocal instead... so that's arguably another flag/overload to add.)

Also I noticed a hashset wasn't being read from and looks like that came from [`0c4002bb`](https://github.com/space-wizards/space-station-14/commit/0c4002bbd3f354fe678638cd7bf838483988d9bc#diff-2b256ea0ad4991cf0adc85b3ab45ee5877243bc67500b3bcdaf8b5a99727690eL253-L256).

I also didn't test it but this probably improves but doesn't fix the coming into PVS range of a bunch of solutions and hearing the reaction sound a bajillion times.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
