### PR TITLE
allow atmos reactions to take entityuids as parameters

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -495,6 +495,13 @@ namespace Content.Server.Atmos.EntitySystems
             => React(mixture, holder, holderUid: null);
 
         /// <summary>
+        ///     Performs reactions for a given gas mixture on an optional holder
+        ///     with an optional entity.
+        /// </summary>
+        public ReactionResult React(GasMixture mixture, EntityUid? uid, IGasMixtureHolder? holder)
+            => React(mixture, holder, holderUid: uid);
+
+        /// <summary>
         ///     Performs reactions for a given gas mixture on an entity with a
         ///     component that inherits <see cref="IGasMixtureHolder"/> .
         /// </summary>

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -114,4 +114,20 @@ public partial class AtmosphereSystem
 
         _tile.PryTile(tileRef);
     }
+
+    /// <summary>
+    ///     Possibly gets the coordinates of an optionally given <see cref="EntityUid">,
+    ///     and then an optionally given <see cref="IGasMixtureHolder"/>.
+    /// </summary>
+    // Both args are nullable because this is exposed for use by reactions to get the position of the reaction.
+    public EntityCoordinates? GetMixtureHolderCoordinates(IGasMixtureHolder? holder, EntityUid? holderEntity)
+    {
+        if (holderEntity != null)
+            return Transform(holderEntity.Value).Coordinates;
+
+        if (holder is TileAtmosphere tileAtmosphere && _mapGridQuery.TryComp(tileAtmosphere.GridIndex, out var mapGridComponent))
+            return _mapSystem.GridTileToLocal(tileAtmosphere.GridIndex, mapGridComponent, tileAtmosphere.GridIndices);
+
+        return null;
+    }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using Content.Server.Atmos.Components;
 using Content.Server.Maps;
+using Content.Server.NodeContainer.Nodes;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Maps;
@@ -124,6 +125,9 @@ public partial class AtmosphereSystem
     {
         if (holderEntity != null)
             return Transform(holderEntity.Value).Coordinates;
+
+        if (holder is PipeNode pipeNode)
+            return Transform(pipeNode.Owner).Coordinates;
 
         if (holder is TileAtmosphere tileAtmosphere && _mapGridQuery.TryComp(tileAtmosphere.GridIndex, out var mapGridComponent))
             return _mapSystem.GridTileToLocal(tileAtmosphere.GridIndex, mapGridComponent, tileAtmosphere.GridIndices);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -12,6 +12,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
 using System.Linq;
@@ -43,6 +44,7 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
 
     private EntityQuery<GridAtmosphereComponent> _atmosQuery;
     private EntityQuery<MapAtmosphereComponent> _mapAtmosQuery;
+    private EntityQuery<MapGridComponent> _mapGridQuery;
     private EntityQuery<AirtightComponent> _airtightQuery;
     private EntityQuery<FirelockComponent> _firelockQuery;
     private HashSet<EntityUid> _entSet = new();
@@ -62,6 +64,7 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
         InitializeMap();
 
         _mapAtmosQuery = GetEntityQuery<MapAtmosphereComponent>();
+        _mapGridQuery = GetEntityQuery<MapGridComponent>();
         _atmosQuery = GetEntityQuery<GridAtmosphereComponent>();
         _airtightQuery = GetEntityQuery<AirtightComponent>();
         _firelockQuery = GetEntityQuery<FirelockComponent>();

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -93,9 +93,7 @@ namespace Content.Server.Atmos.EntitySystems
                 }
 
                 if (comp.Air != null)
-                {
-                    _atmosphereSystem.React(comp.Air, comp);
-                }
+                    _atmosphereSystem.React<GasTankComponent>((uid, comp));
 
                 CheckStatus(gasTank);
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
@@ -68,9 +68,10 @@ public sealed class GasCanisterSystem : SharedGasCanisterSystem
             new GasCanisterBoundUserInterfaceState(canister.Air.Pressure, portStatus, tankPressure));
     }
 
-    private void OnCanisterUpdated(EntityUid uid, GasCanisterComponent canister, ref AtmosDeviceUpdateEvent args)
+    private void OnCanisterUpdated(Entity<GasCanisterComponent> ent, ref AtmosDeviceUpdateEvent args)
     {
-        _atmos.React(canister.Air, canister);
+        var (uid, canister) = ent;
+        _atmos.React(ent);
 
         if (!TryComp<NodeContainerComponent>(uid, out var nodeContainer)
             || !TryComp<AppearanceComponent>(uid, out var appearance))

--- a/Content.Server/Atmos/Reactions/GasReactionPrototype.cs
+++ b/Content.Server/Atmos/Reactions/GasReactionPrototype.cs
@@ -55,7 +55,8 @@ namespace Content.Server.Atmos.Reactions
         /// <param name="holder">The container of this gas mixture</param>
         /// <param name="atmosphereSystem">The atmosphere system</param>
         /// <param name="heatScale">Scaling factor that should be applied to all heat input or outputs.</param>
-        public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
+        /// <param name="holderUid">The optional <see cref="EntityUid"/> that this reaction may be related with.</param>
+        public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale, EntityUid? holderUid = null)
         {
             var result = ReactionResult.NoReaction;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
see title
also includes 1 more addition, listed in details, and very minor optimisation

## Why / Balance
because why *cant* reactions have entities associated with them
(it's completely possible solely with `IGasMixtureHolder` and a few typechecks but that would rely on the obsolete `IComponent.Owner` and it's rather weird of an approach)

## Technical details
added entityuid as optional parameter for reactions

`AtmosphereSystem` also now has `React<T>(Entity<T>)` where T inherits IComponent and IGasMixtureHolder (because yes, there are components that inherit `IGasMixtureHolder`) and an analog for it. made some calls for `AtmosphereSystem.React` use this instead

because reactions only get `AtmosphereSystem` and not entitymanager or whatever, so they would have to resolve it via IoCManager which is silly, so: i added a utility method `AtmosphereSystem.GetMixtureHolderCoordinates` that may return a position of the entityuid or gasmixtureholder provided. you might view it as hardcoded but what else can you really do

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none
