### PR TITLE
Adds capfruit seeds to exotic seeds crate & removes them from gatfruit seed mutation.

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -290,7 +290,7 @@ uplink-carp-dehydrated-desc = Looks like a plush toy carp, but just add water an
 
 # Job Specific
 uplink-gatfruit-seeds-name = Packet Of Gatfruit Seeds
-uplink-gatfruit-seeds-desc = And who says guns don't grow on trees?
+uplink-gatfruit-seeds-desc = And who says guns don't grow on trees? Mutates into armor-piercing fake capfruit.
 
 uplink-rigged-boxing-gloves-name = Rigged Boxing Gloves
 uplink-rigged-boxing-gloves-desc = Float like a butterfly, sting like a bee.

--- a/Resources/Prototypes/Catalog/Fills/Crates/botany.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/botany.yml
@@ -20,6 +20,8 @@
         amount: 2
       - id: BungoSeeds
         amount: 2
+      - id: RealCapfruitSeeds
+        amount: 2
 
 - type: entity
   id: CrateHydroponicsSeedsMedicinal

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -728,7 +728,7 @@
   parent: SeedBase
   id: RealCapfruitSeeds
   name: packet of capfruit seeds
-  description: "Is it real, or is it fake?"
+  description: "These seeds grow into thin-rinded capguns. Earplugs not included."
   components:
     - type: Seed
       seedId: realCapfruit

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -1420,10 +1420,9 @@
     - FoodGatfruit
   mutationPrototypes:
     - fakeCapfruit
-    - realCapfruit
   lifespan: 65
-  maturation: 25
-  production: 25
+  maturation: 12
+  production: 12
   yield: 1
   potency: 10
   growthStages: 2
@@ -1448,8 +1447,8 @@
   productPrototypes:
     - FoodFakeCapfruit
   lifespan: 65
-  maturation: 25
-  production: 25
+  maturation: 12
+  production: 12
   yield: 1
   potency: 10
   growthStages: 2
@@ -1474,8 +1473,8 @@
   productPrototypes:
     - FoodRealCapfruit
   lifespan: 65
-  maturation: 25
-  production: 25
+  maturation: 12
+  production: 12
   yield: 1
   potency: 10
   growthStages: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Two capfruit seeds are added to the exotic seeds crate, and the potential for gatfruit to mutate into real capfruit is removed. The description of capfruit seed packets and the uplink entry for gatfruit seeds are updated to be more informative. Growth time for real + fake capfruit and gatfruit is reduced by about half.

## Why / Balance
Adds more flavor to the exotic seeds crate while also buffing gatfruit seeds, a somewhat underused job item (less often bought than the cane sword/combat bakery kit in the numbers I saw). The stealth status of fake capfruit seeds was always dubious, and adding them to the exotic seeds crate makes them more of a real stealth item especially in the face of upcoming changes to metashield rules. Halving the growth times for the plants doesn't change anything for the evil seeds as swabbing with a faster-growing plant like cocoa is always ideal due to the massive harvest difference + no caustic damage from eating sulfur. No economy changes since capguns + bullets together sell for 30 spesos.

## Technical details
All yaml edits. Production + Maturation gives the first-harvest time of a plant, with Production dictating followup harvests.

## Media
<img width="374" height="221" alt="image" src="https://github.com/user-attachments/assets/976f4ec3-828a-4aa2-86f7-376fe6f4c6a2" />
<img width="385" height="115" alt="image" src="https://github.com/user-attachments/assets/8e4c643e-378c-4a68-8071-a61f72eee95b" />
<img width="376" height="415" alt="image" src="https://github.com/user-attachments/assets/768e8077-53e9-4772-80cd-34ce7cf151be" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
:cl:
- add: Two capfruit seeds now come with the exotic seeds crate.
- tweak: Gatfruit can now only mutate into fake capfruit.
- tweak: Gatfruit and both capfruit variants now grow about twice as fast. 
- tweak: Gatfruit/Capfruit uplink/item descriptions are more informative.
