### PR TITLE
Translatable mapping entities

### DIFF
--- a/Content.Server/Localizations/Components/TranslatableEntityComponent.cs
+++ b/Content.Server/Localizations/Components/TranslatableEntityComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Server.Localizations.Components;
+
+/// <summary>
+///     Marks entity as translatable.
+///     Name and description of the translated entity will be changed to their LocIds on mapinit.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TranslatableEntityComponent : Component;

--- a/Content.Server/Localizations/TranslatableEntitySystem.cs
+++ b/Content.Server/Localizations/TranslatableEntitySystem.cs
@@ -1,0 +1,29 @@
+using Content.Server.Localizations.Components;
+
+namespace Content.Server.Localizations;
+
+/// <summary>
+///     Handles logic relating to <see cref="TranslatableEntityComponent" />
+/// </summary>
+public sealed class TranslatableEntitySystem : EntitySystem
+{
+    [Dependency] private readonly MetaDataSystem _metadata = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TranslatableEntityComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(Entity<TranslatableEntityComponent> ent, ref MapInitEvent args)
+    {
+        var meta = MetaData(ent);
+
+        var newName = Loc.GetString(meta.EntityName);
+        var newDesc = Loc.GetString(meta.EntityDescription);
+
+        _metadata.SetEntityName(ent, newName, meta);
+        _metadata.SetEntityDescription(ent, newDesc, meta);
+    }
+}


### PR DESCRIPTION
## About the PR
This pr adds a new component - `TranslatableEntityComponent`. Name and desc of the entity with that component will be changed to theirs `LocIds`

## Why / Balance
I pretty often play on non-english forks and every time when I see untranslated entity mapped by wizden mapper I became pretty sad (see jani remote and warden cell buttons on bagel). This pr adds plus-minus proper ability to translate exclusive entity names and descriptions by adding `TranslatableEntityComponent` and changing desc/name to the `LocId`

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
tbh I want to put this into mapping CL but it was created for other proposes