### PR TITLE
feat: add a component for rejuvenateable status effects

### DIFF
--- a/Content.Shared/StatusEffectNew/Components/CurableStatusEffectComponent.cs
+++ b/Content.Shared/StatusEffectNew/Components/CurableStatusEffectComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared.Rejuvenate;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.StatusEffectNew.Components;
+
+/// <summary>
+/// Marker component for a status effect that should be removed on rejuvenation.
+/// </summary>
+/// <seealso cref="RejuvenateEvent"/>
+/// <remarks> Pen name is RejuvenateableStatusEffectComponent </remarks>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CurableStatusEffectComponent : Component;

--- a/Content.Shared/StatusEffectNew/CurableStatusEffectSystem.cs
+++ b/Content.Shared/StatusEffectNew/CurableStatusEffectSystem.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Rejuvenate;
+using Content.Shared.StatusEffectNew.Components;
+
+namespace Content.Shared.StatusEffectNew;
+
+/// <summary>
+/// Handles killing status effects that have a <see cref="CurableStatusEffectComponent" />.
+/// </summary>
+public sealed class CurableStatusEffectSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CurableStatusEffectComponent, StatusEffectRelayedEvent<RejuvenateEvent>>(OnRejuvenate);
+    }
+
+    private void OnRejuvenate(Entity<CurableStatusEffectComponent> ent,
+        ref StatusEffectRelayedEvent<RejuvenateEvent> args)
+    {
+        PredictedQueueDel(ent.Owner);
+    }
+}

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Rejuvenate;
 using Content.Shared.StatusEffectNew.Components;
 using Robust.Shared.Player;
 
@@ -9,6 +10,7 @@ public sealed partial class StatusEffectsSystem
     {
         SubscribeLocalEvent<StatusEffectContainerComponent, LocalPlayerAttachedEvent>(RelayStatusEffectEvent);
         SubscribeLocalEvent<StatusEffectContainerComponent, LocalPlayerDetachedEvent>(RelayStatusEffectEvent);
+        SubscribeLocalEvent<StatusEffectContainerComponent, RejuvenateEvent>(RelayStatusEffectEvent);
     }
 
     private void RefRelayStatusEffectEvent<T>(EntityUid uid, StatusEffectContainerComponent component, ref T args) where T : struct

--- a/Resources/Prototypes/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/misc.yml
@@ -19,9 +19,17 @@
       components:
       - MobState
 
-# The creature sleeps so heavily that nothing can wake him up. Not even its own death.
+# Things that should be removed by rejuvenation should parent to this
 - type: entity
   parent: MobStatusEffectBase
+  id: MobStatusEffectDebuff
+  abstract: true
+  components:
+  - type: CurableStatusEffect
+
+# The creature sleeps so heavily that nothing can wake him up. Not even its own death.
+- type: entity
+  parent: MobStatusEffectDebuff
   id: StatusEffectForcedSleeping
   name: forced sleep
   components:
@@ -29,7 +37,7 @@
 
 # This creature is asleep because it's disconnected from the game.
 - type: entity
-  parent: MobStatusEffectBase
+  parent: MobStatusEffectBase # Not even rejuvenate can cure SSD...
   id: StatusEffectSSDSleeping
   name: forced sleep
   components:
@@ -37,7 +45,7 @@
 
 # Blurs your vision and makes you randomly fall asleep
 - type: entity
-  parent: MobStatusEffectBase
+  parent: MobStatusEffectDebuff
   id: StatusEffectDrowsiness
   name: drowsiness
   components:
@@ -45,7 +53,7 @@
 
 # Adds drugs overlay
 - type: entity
-  parent: MobStatusEffectBase
+  parent: MobStatusEffectDebuff
   id: StatusEffectSeeingRainbow
   name: hallucinations
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This makes rejuvenate work for new status effects. Everything except the forced sleep due to SSD status effect is now removed when their attached entity is removed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I don't want to see the funny rainbows anymore.

## Technical details
<!-- Summary of code changes for easier review. -->
Pretty simple. Maybe we'll want to change the parenting layout later but that's easy enough.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
ADMIN:
- add: Rejuvenate will now remove drowsiness, forced sleep, and the seeing rainbows status effect.