### PR TITLE
Adds swabs and an Emag inventory to the biogenerator

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -578,6 +578,9 @@
     staticPacks:
     - BioGenIngredientsStatic
     - BioGenMaterialsStatic
+  - type: EmagLatheRecipes
+    emagStaticPacks:
+    - BioGenEmagStatic
 
 - type: entity
   parent: BaseLathe

--- a/Resources/Prototypes/Recipes/Lathes/Packs/biogen.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/biogen.yml
@@ -20,6 +20,7 @@
   - BioGenLeft4Zed
   - BioGenEZNutrient
   - BioGenRobustHarvest
+  - BioGenDiseaseSwab
 
 - type: latheRecipePack
   id: BioGenMaterialsStatic
@@ -28,3 +29,8 @@
   - BioGenMaterialCardboard1
   - BioGenPaper
   - BioGenPaperRolling1
+
+- type: latheRecipePack
+  id: BioGenEmagStatic
+  recipes:
+  - BioGenUnstableMutagen

--- a/Resources/Prototypes/Recipes/Lathes/biogen.yml
+++ b/Resources/Prototypes/Recipes/Lathes/biogen.yml
@@ -249,5 +249,24 @@
   materials:
     Biomass: 18
 
+- type: latheRecipe
+  id: BioGenDiseaseSwab
+  result: DiseaseSwab
+  categories:
+  - Materials
+  completetime: 3
+  materials:
+    Biomass: 15
 
-
+- type: latheRecipe
+  id: BioGenUnstableMutagen
+  resultReagents:
+    UnstableMutagen: 10
+  categories:
+  - Chemicals
+  icon:
+    sprite: Objects/Specific/Chemistry/bottle.rsi
+    state: bottle-1
+  completetime: 5
+  materials:
+    Biomass: 20


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added individual swabs to the biogenerator for 15 biomass each, and also added a new emag inventory with 10u of unstable mutagen for 20 biomass each.

## Why / Balance
Right now there is only 2 sources of swabs outside of the round start boxes in botany, medical supply crates, and the medical lathe. This should also make genpop botany more interesting, especially if someone manages to smuggle in an emag.

## Technical details
It's just yaml

## Media
<img width="719" height="543" alt="image" src="https://github.com/user-attachments/assets/714fd3b6-cc3b-4f11-9385-6c882d18aae8" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Added swabs and an emag inventory to the biogenerator

