### PR TITLE
FTL Fixes

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -895,7 +895,7 @@ public sealed partial class ShuttleSystem
         var transform = new Transform(_transform.ToWorldPosition(xform.Coordinates), angle);
         var adjustedOffset = Robust.Shared.Physics.Transform.Mul(transform, offset);
 
-        coordinates = new EntityCoordinates(targetXform.MapUid.Value,  spawnPos + adjustedOffset);
+        coordinates = new EntityCoordinates(targetXform.MapUid.Value, spawnPos + adjustedOffset);
         return true;
     }
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -860,7 +860,7 @@ public sealed partial class ShuttleSystem
 
         // TODO: This should prefer the position's angle instead.
         // TODO: This is pretty crude for multiple landings.
-        if (nearbyGrids.Count > 1 || !HasComp<MapComponent>(targetXform.GridUid))
+        if (nearbyGrids.Count >= 1)
         {
             // Pick a random angle
             var offsetAngle = _random.NextAngle();
@@ -869,13 +869,9 @@ public sealed partial class ShuttleSystem
             var minRadius = MathF.Max(targetAABB.Width / 2f, targetAABB.Height / 2f);
             spawnPos = targetAABB.Center + offsetAngle.RotateVec(new Vector2(_random.NextFloat(minRadius + minOffset, minRadius + maxOffset), 0f));
         }
-        else if (shuttleBody != null)
-        {
-            (spawnPos, angle) = _transform.GetWorldPositionRotation(targetXform);
-        }
         else
         {
-            spawnPos = _transform.GetWorldPosition(targetXform);
+            spawnPos = _transform.ToWorldPosition(targetCoordinates);
         }
 
         var offset = Vector2.Zero;
@@ -896,10 +892,10 @@ public sealed partial class ShuttleSystem
         }
 
         // Rotate our localcenter around so we spawn exactly where we "think" we should (center of grid on the dot).
-        var transform = new Transform(spawnPos, angle);
-        spawnPos = Robust.Shared.Physics.Transform.Mul(transform, offset);
+        var transform = new Transform(_transform.ToWorldPosition(xform.Coordinates), angle);
+        var adjustedOffset = Robust.Shared.Physics.Transform.Mul(transform, offset);
 
-        coordinates = new EntityCoordinates(targetXform.MapUid.Value, spawnPos - offset);
+        coordinates = new EntityCoordinates(targetXform.MapUid.Value,  spawnPos + adjustedOffset);
         return true;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Various fixes to TryGetFTLProximity, which is used not just for ship FTL but also for grids spawning around the station.
Generally, this makes them spawn in a more consistent location and ideally intersect less with other grids.

I noticed in my testing that oftentimes grids spawned using this method would be wildly off-center from where I wanted. Through more testing, i noticed even more issues.

## Technical details
<!-- Summary of code changes for easier review. -->
Following changes:
- The conditions for applying the random offset have been reduced. Now, you simply need to have an overlapping grid in the base area. Previously, this was being called for every shuttle in space, which made the behavior _extremely inconsistent_.
- Removed redundant code for getting the spawn position and angle.
- Fixed the transform being centered at the wrong point. Previously, it was centered to the offset spawn position, when it needed to be set at the grid center in order to ensure that the actual center of the grid would end up where we wanted.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="735" height="800" alt="image" src="https://github.com/user-attachments/assets/de84b355-b274-475b-922f-3a8a93825cce" />

testing showing that 5 grids with random rotations spawn in the spots we want them to (in an exact plus sign) while being centered correctly.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun