### PR TITLE
Allow GenPop access perms on the AccessConfigurator

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -48,6 +48,8 @@
       - Security
       - Service
       - Theatre
+      - GenpopEnter
+      - GenpopLeave
       privilegedIdSlot:
         name: id-card-console-privileged-id
         ejectSound: /Audio/Machines/id_swipe.ogg


### PR DESCRIPTION
## About the PR
This PR allows you to use the access configurator to set Genpop Enter and Genpop Leave permissions on doors and turnstiles.

## Why / Balance
The reason behind this PR is to address grieving of the Turnstiles that exist for GenPop. As a antagonist can easily deconstruct the turnstiles on some maps. (notable Exo and Bagel) This hands some power back to Security where as with the help of HoP or CE's access configurators they can restore their now ruined GenPop to their former glory!

## Technical details
Just YAML!

## Media

https://github.com/user-attachments/assets/7e4ce7c2-b125-4a28-b4e1-8a133ab032a3


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**

:cl:
- tweak: The access configurator can now set GenPop enter and leave accesses on doors and turnstiles.