### PR TITLE
storage and inventory toolshed commands

### DIFF
--- a/Content.Server/Inventory/InventoryCommand.cs
+++ b/Content.Server/Inventory/InventoryCommand.cs
@@ -1,0 +1,205 @@
+﻿using System.Linq;
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Inventory;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server.Inventory;
+
+[ToolshedCommand, AdminCommand(AdminFlags.Debug)]
+public sealed class InventoryCommand : ToolshedCommand
+{
+    private InventorySystem? _inventorySystem;
+
+    [CommandImplementation("getflags")]
+    public IEnumerable<EntityUid> InventoryGetFlags([PipedArgument] EntityUid ent, SlotFlags slotFlag)
+    {
+        _inventorySystem ??= GetSys<InventorySystem>();
+
+        if (!EntityManager.TryGetComponent<InventoryComponent>(ent, out var inventory))
+            return [];
+
+        List<EntityUid> items = new();
+
+        foreach (var slot in inventory.Slots)
+        {
+            if (!slot.SlotFlags.HasFlag(slotFlag))
+                continue;
+            if (_inventorySystem.TryGetSlotEntity(ent, slot.Name, out var item, inventory))
+                items.Add(item.Value);
+        }
+
+        return items;
+    }
+
+    [CommandImplementation("getflags")]
+    public IEnumerable<EntityUid> InventoryGetFlags([PipedArgument] IEnumerable<EntityUid> ents, SlotFlags slotFlag)
+    {
+        var items = Enumerable.Empty<EntityUid>();
+        foreach (var ent in ents)
+        {
+            items = items.Concat(InventoryGetFlags(ent, slotFlag));
+        }
+
+        return items;
+    }
+
+    [CommandImplementation("getnamed")]
+    public IEnumerable<EntityUid> InventoryGetNamed([PipedArgument] EntityUid ent, string slotName)
+    {
+        _inventorySystem ??= GetSys<InventorySystem>();
+
+        if (!EntityManager.TryGetComponent<InventoryComponent>(ent, out var inventory))
+            return [];
+
+        List<EntityUid> items = new();
+
+        foreach (var slot in inventory.Slots)
+        {
+            if (slot.Name != slotName)
+                continue;
+            if (_inventorySystem.TryGetSlotEntity(ent, slot.Name, out var item, inventory))
+                items.Add(item.Value);
+        }
+
+        return items;
+    }
+
+    [CommandImplementation("getnamed")]
+    public IEnumerable<EntityUid> InventoryGetNamed([PipedArgument] IEnumerable<EntityUid> ents, string slotName)
+    {
+        var items = Enumerable.Empty<EntityUid>();
+        foreach (var ent in ents)
+        {
+            items = items.Concat(InventoryGetNamed(ent, slotName));
+        }
+
+        return items;
+    }
+
+
+    [CommandImplementation("forceput")]
+    public EntityUid? InventoryForcePut([PipedArgument] EntityUid targetEnt, EntityUid itemEnt, SlotFlags slotFlag)
+    {
+        return InventoryPutBase(targetEnt,
+            itemEnt,
+            slotFlag,
+            PutType.ForcePut) is not null
+            ? targetEnt
+            : null;
+    }
+
+    [CommandImplementation("forceput")]
+    public EntityUid? InventoryForcePut([PipedArgument] IEnumerable<EntityUid> ents,
+        EntityUid itemEnt,
+        SlotFlags slotFlag) => InventoryPutEnumerableBase(ents, itemEnt, slotFlag, InventoryForcePut);
+
+    [CommandImplementation("put")]
+    public EntityUid? InventoryPut([PipedArgument] EntityUid targetEnt, EntityUid itemEnt, SlotFlags slotFlag)
+    {
+        return InventoryPutBase(targetEnt,
+            itemEnt,
+            slotFlag,
+            PutType.Put) is not null
+            ? targetEnt
+            : null;
+    }
+
+    [CommandImplementation("put")]
+    public EntityUid? InventoryPut([PipedArgument] IEnumerable<EntityUid> ents,
+        EntityUid itemEnt,
+        SlotFlags slotFlag) => InventoryPutEnumerableBase(ents, itemEnt, slotFlag, InventoryPut);
+
+
+    [CommandImplementation("tryput")]
+    public EntityUid? InventoryTryPut([PipedArgument] EntityUid targetEnt, EntityUid itemEnt, SlotFlags slotFlag)
+    {
+        return InventoryPutBase(targetEnt,
+            itemEnt,
+            slotFlag,
+            PutType.TryPut) is not null
+            ? targetEnt
+            : null;
+    }
+
+    [CommandImplementation("tryput")]
+    public EntityUid? InventoryTryPut([PipedArgument] IEnumerable<EntityUid> ents,
+        EntityUid itemEnt,
+        SlotFlags slotFlag) => InventoryPutEnumerableBase(ents, itemEnt, slotFlag, InventoryTryPut);
+
+
+    [CommandImplementation("ensure")]
+    public EntityUid? InventoryEnsure([PipedArgument] EntityUid targetEnt, EntityUid itemEnt, SlotFlags slotFlag)
+    {
+        return InventoryPutBase(targetEnt,
+            itemEnt,
+            slotFlag,
+            PutType.Ensure);
+    }
+
+    [CommandImplementation("ensure")]
+    public EntityUid? InventoryEnsure([PipedArgument] IEnumerable<EntityUid> ents,
+        EntityUid itemEnt,
+        SlotFlags slotFlag) => InventoryPutEnumerableBase(ents, itemEnt, slotFlag, InventoryEnsure);
+
+
+    private EntityUid? InventoryPutBase(EntityUid targetEnt,
+        EntityUid itemToInsert,
+        SlotFlags slotFlag,
+        PutType putType)
+    {
+        _inventorySystem ??= GetSys<InventorySystem>();
+
+        if (!EntityManager.TryGetComponent<InventoryComponent>(targetEnt, out var inventory))
+            return null;
+
+
+        foreach (var slot in inventory.Slots)
+        {
+            if (!slot.SlotFlags.HasFlag(slotFlag))
+                continue;
+
+
+            if (_inventorySystem.TryGetSlotEntity(targetEnt, slot.Name, out var originalItem, inventory))
+            {
+                if (putType == PutType.ForcePut)
+                    EntityManager.DeleteEntity(originalItem);
+                if (putType == PutType.Put)
+                {
+                    if (!_inventorySystem.TryUnequip(targetEnt, slot.Name, force: true, inventory: inventory))
+                        return null;
+                }
+            }
+
+            if (_inventorySystem.TryEquip(targetEnt, itemToInsert, slot.Name, force: true, inventory: inventory))
+                return itemToInsert;
+            else
+                return putType == PutType.Ensure ? originalItem : null;
+        }
+
+        return null;
+    }
+
+    private EntityUid? InventoryPutEnumerableBase(IEnumerable<EntityUid> targetEnts,
+        EntityUid itemToInsert,
+        SlotFlags slotFlags,
+        Func<EntityUid, EntityUid, SlotFlags, EntityUid?> targetFunc)
+    {
+        foreach (var entity in targetEnts)
+        {
+            var result = targetFunc(entity, itemToInsert, slotFlags);
+            if (result != null)
+                return result;
+        }
+
+        return null;
+    }
+
+    private enum PutType
+    {
+        ForcePut, // Put item in slot, delete old item
+        Put, // Put item in slot, put old item on floor
+        TryPut, // Put item in slot, fail if there is already an item
+        Ensure // Try put item in slot. If there is one, return the item already there
+    }
+}

--- a/Content.Server/Storage/StorageCommand.cs
+++ b/Content.Server/Storage/StorageCommand.cs
@@ -1,0 +1,57 @@
+﻿using System.Linq;
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Item;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
+using Robust.Shared.Containers;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server.Storage;
+
+[ToolshedCommand, AdminCommand(AdminFlags.Debug)]
+public sealed class StorageCommand : ToolshedCommand
+{
+    private SharedStorageSystem? _storage;
+    private SharedContainerSystem? _container;
+
+    [CommandImplementation("insert")]
+    public EntityUid? StorageInsert([PipedArgument] EntityUid entToInsert, EntityUid targetEnt)
+    {
+        _storage ??= GetSys<SharedStorageSystem>();
+
+        if (!EntityManager.TryGetComponent<StorageComponent>(targetEnt, out var storage))
+            return null;
+
+        return _storage.Insert(targetEnt, entToInsert, out EntityUid? stackedEntity, null, storage, false)
+            ? entToInsert
+            : null;
+    }
+
+    [CommandImplementation("insert")]
+    public IEnumerable<EntityUid> StorageInsert([PipedArgument] IEnumerable<EntityUid> entsToInsert,
+        EntityUid targetEnt) => entsToInsert.Where(x => StorageInsert(x, targetEnt) != null);
+
+    [CommandImplementation("fasttake")]
+    public EntityUid? StorageFastTake([PipedArgument] EntityUid storageEnt)
+    {
+        _storage ??= GetSys<SharedStorageSystem>();
+        _container ??= GetSys<SharedContainerSystem>();
+
+
+        if (!EntityManager.TryGetComponent<StorageComponent>(storageEnt, out var storage))
+            return null;
+
+        var removing = storage.Container.ContainedEntities[^1];
+        if (_container.RemoveEntity(storageEnt, removing))
+            return removing;
+
+        return null;
+    }
+
+    [CommandImplementation("fasttake")]
+    public IEnumerable<EntityUid> StorageFastTake([PipedArgument] IEnumerable<EntityUid> storageEnts) =>
+        storageEnts.Select(StorageFastTake).OfType<EntityUid>();
+
+
+}

--- a/Resources/Locale/en-US/commands/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/commands/toolshed-commands.ftl
@@ -96,3 +96,19 @@ command-description-xenoartifact-unlockAllNodes =
     Unlocks all nodes of artifact.
 command-description-jobboard-completeJob =
     Completes a given salvage job board job for the station.
+command-description-storage-fasttake =
+    Takes the most recently placed item from the piped storage entity.
+command-description-storage-insert =
+    Inserts the piped entity into the given storage entity.
+command-description-inventory-getflags =
+    Gets all entities in slots on the piped inventory entity matching a certain slot flag.
+command-description-inventory-getnamed =
+    Gets all entities in slots on the piped inventory entity matching a certain slot name.
+command-description-inventory-forceput =
+    Puts a given entity on the first piped entity that has a slot matching the given flag, deleting any item previously in that slot.
+command-description-inventory-put =
+    Puts a given entity on the first piped entity that has a slot matching the given flag, unequiping any item previously in that slot.
+command-description-inventory-tryput =
+    Puts a given entity on the first piped entity that has a slot matching the given flag, failing if any item is in currently in that slot.
+command-description-inventory-ensure =
+    Puts a given entity on the first piped entity that has a slot matching the given flag if none exists, passing through the UID of whatever is in the slot by the end.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds 8 commands:

- **storage:insert** Attempt to insert all piped entities into the given entity (that has StorageComponent), piping out all entities that were successfully inserted
- **storage:fasttake** Attempt to smart-take an item from the piped storage entity, piping it through on success
- **inventory:getflags** try get all entities from the piped inventory entity in slots that match the given SlotFlag
- **inventory:getnamed** try get all entities from the piped inventory entity in slots that match a certain slot name.
- **inventory:put** put an item in a flagged inventory slot on the piped entity, unequiping any previous item and returning the inventory entity on success (if multiple inventory entities are passed, the first entity that successfully equips the item will be piped through)
- **inventory:forceput** same as above, but if there is a previous item it is deleted instead
- **inventory:tryput** similar, but fails if there is already an item in the slot instead of unequiping/deleting it
- **inventory:ensure** same as tryput, except when it finds a slot instead of piping the inventory entity it will pipe whatever entity ends up in that slot (either the old item or the new one if no old one exists) (intended use case: "we just need SOMETHING in this slot to iterate on (eg a jumpsuit) I don't care what it is")
## Why / Balance
More admin commands good. Spawn:in was very limited (only prototypes, you had to find the container entity first etc etc).

Also in the words of @ScarKy0 , " i like admin abuse tools"

## Technical details
Mostly normal toolshed stuff, but the inventory put commands (forceput, tryput, put, ensure) are all variations on InventoryPutBase and InventoryPutEnumerableBase.

## Media
<img width="1176" height="485" alt="image" src="https://github.com/user-attachments/assets/30a4a2a5-00ae-4b89-8a1c-3e1935545a76" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None cuz it's new shit only

**Changelog**
:cl: UpAndLeaves
ADMIN:
- add: Added 8 new storage and inventory toolshed commands
