### PR TITLE
fixes parallax biomesystem dictionary usage

### DIFF
--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -337,7 +337,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
             if (biome.LifeStage < ComponentLifeStage.Running)
                 continue;
 
-            _activeChunks.Add(biome, _tilePool.Get());
+            _activeChunks[biome] = _tilePool.Get();
             _markerChunks.GetOrNew(biome);
         }
 

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -322,6 +322,16 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         }
     }
 
+    private void UpdateActiveChunks(BiomeComponent biome)
+    {
+        if (!_activeChunks.TryGetValue(biome, out _))
+        {
+            _activeChunks.Add(biome, _tilePool.Get());
+        }
+        else
+            _activeChunks[biome] = _tilePool.Get();
+    }
+
     private bool CanLoad(EntityUid uid)
     {
         return !_ghostQuery.HasComp(uid) || _tags.HasTag(uid, AllowBiomeLoadingTag);
@@ -337,7 +347,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
             if (biome.LifeStage < ComponentLifeStage.Running)
                 continue;
 
-            _activeChunks[biome] = _tilePool.Get();
+            UpdateActiveChunks(biome);
             _markerChunks.GetOrNew(biome);
         }
 

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -408,6 +408,9 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         {
             _tilePool.Return(tiles);
         }
+
+        _activeChunks.Clear();
+        _markerChunks.Clear();
     }
 
     private void AddChunksInRange(BiomeComponent biome, Vector2 worldPos)

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -322,16 +322,6 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         }
     }
 
-    private void UpdateActiveChunks(BiomeComponent biome)
-    {
-        if (!_activeChunks.TryGetValue(biome, out _))
-        {
-            _activeChunks.Add(biome, _tilePool.Get());
-        }
-        else
-            _activeChunks[biome] = _tilePool.Get();
-    }
-
     private bool CanLoad(EntityUid uid)
     {
         return !_ghostQuery.HasComp(uid) || _tags.HasTag(uid, AllowBiomeLoadingTag);
@@ -342,12 +332,15 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         base.Update(frameTime);
         var biomes = AllEntityQuery<BiomeComponent>();
 
+        _activeChunks.Clear();
+        _markerChunks.Clear();
+
         while (biomes.MoveNext(out var biome))
         {
             if (biome.LifeStage < ComponentLifeStage.Running)
                 continue;
 
-            UpdateActiveChunks(biome);
+            _activeChunks.Add(biome, _tilePool.Get());
             _markerChunks.GetOrNew(biome);
         }
 
@@ -415,9 +408,6 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         {
             _tilePool.Return(tiles);
         }
-
-        _activeChunks.Clear();
-        _markerChunks.Clear();
     }
 
     private void AddChunksInRange(BiomeComponent biome, Vector2 worldPos)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

removes endless serverside error spam from loading/existing in a biome sometimes

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Errors

## Technical details
<!-- Summary of code changes for easier review. -->

you can't use Add() to change an existing key within a dictionary, so it'd properly create the first key and then spam errors non-stop every tick trying to add a new key/value combo with a duplicate, existing key already present. 

we clear the dictionaries before trying to add new ones by moving up the clear function to be first thing.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

