### PR TITLE
Fix mouse rotator error spam

### DIFF
--- a/Content.Client/MouseRotator/MouseRotatorSystem.cs
+++ b/Content.Client/MouseRotator/MouseRotatorSystem.cs
@@ -57,7 +57,8 @@ public sealed class MouseRotatorSystem : SharedMouseRotatorSystem
                 rotation += 2 * Math.PI;
             RaisePredictiveEvent(new RequestMouseRotatorRotationEvent
             {
-                Rotation = rotation
+                Rotation = rotation,
+                User = GetNetEntity(player)
             });
 
             return;
@@ -77,7 +78,8 @@ public sealed class MouseRotatorSystem : SharedMouseRotatorSystem
 
         RaisePredictiveEvent(new RequestMouseRotatorRotationEvent
         {
-            Rotation = angle
+            Rotation = angle,
+            User = GetNetEntity(player)
         });
     }
 }

--- a/Content.Shared/MouseRotator/MouseRotatorComponent.cs
+++ b/Content.Shared/MouseRotator/MouseRotatorComponent.cs
@@ -48,4 +48,5 @@ public sealed partial class MouseRotatorComponent : Component
 public sealed class RequestMouseRotatorRotationEvent : EntityEventArgs
 {
     public Angle Rotation;
+    public NetEntity? User;
 }

--- a/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
+++ b/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
@@ -47,6 +47,11 @@ public abstract class SharedMouseRotatorSystem : EntitySystem
 
     private void OnRequestRotation(RequestMouseRotatorRotationEvent msg, EntitySessionEventArgs args)
     {
+        // Ignore the request if the requested entity is not the user's attached entity.
+        // This can happen when a player switches controlled entities while rotating.
+        if (args.SenderSession.AttachedEntity != GetEntity(msg.User))
+            return;
+
         if (args.SenderSession.AttachedEntity is not { } ent
             || !TryComp<MouseRotatorComponent>(ent, out var rotator))
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed a bug that was causing fairly frequent server errors about missing mouse rotator components.
```
User [redacted] tried setting local rotation directly without a valid mouse rotator component attached!
 Sawmill=system.mouse_rotator
```

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/38399.

## Technical details
<!-- Summary of code changes for easier review. -->
The error is logged when the server receives a client's request to change rotation and is unable to find a `MouseRotatorComponent` on that client's controlled entity:
```cs
        if (args.SenderSession.AttachedEntity is not { } ent
            || !TryComp<MouseRotatorComponent>(ent, out var rotator))
        {
            Log.Error($"User {args.SenderSession.Name} ({args.SenderSession.UserId}) tried setting local rotation directly without a valid mouse rotator component attached!");
            return;
        }
```
The bug happens when a player is in combat mode and rotating and their controlled entity changes to something that doesn't have a `MouseRotatorComponent` - most commonly a ghost.

The client isn't aware of the entity change yet, so it continues sending rotation requests for the player's mob to the server. But the server is aware of the entity change, so when it looks up the player's controlled entity, it gets their ghost. The ghost doesn't have the required component, so the error is triggered.

To fix this, the rotation request event (`RequestMouseRotatorRotationEvent`) now includes the `NetEntity` of the player's controlled entity. When the server receives a rotation request, it checks that the entity requesting rotation is the player's controlled entity. If it isn't, the rotation request is ignored and no error is logged.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
