### PR TITLE
Dehardcoded Air Alarm's UI window title

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
@@ -2,7 +2,7 @@
             xmlns:x="http://schemas.microsoft.com/winfx/2007/xaml"
             xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
             xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-            MinSize="500 500" Resizable="True" Title="Air Alarm">
+            MinSize="500 500" Resizable="True" Title="{Loc air-alarm-ui-title}">
     <BoxContainer Orientation="Vertical" Margin="5 5 5 5">
         <!-- Status (pressure, temperature, alarm state, device total, address, etc) -->
         <BoxContainer Orientation="Horizontal" Margin="0 0 0 2">

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -2,6 +2,8 @@
 
 ## Window
 
+air-alarm-ui-title = Air Alarm
+
 air-alarm-ui-access-denied = Insufficient access!
 
 air-alarm-ui-window-pressure-label = Pressure


### PR DESCRIPTION
## About the PR
I removed the hardcoded air alarm title and replaced it with a locale var called air-alarm-ui-title.

Closes https://github.com/space-wizards/space-station-14/issues/39051

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
Not needed, not player facing
