### PR TITLE
Predict GlueSystem

### DIFF
--- a/Content.Shared/Glue/GlueComponent.cs
+++ b/Content.Shared/Glue/GlueComponent.cs
@@ -7,36 +7,36 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Shared.Glue;
 
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(SharedGlueSystem))]
+[Access(typeof(GlueSystem))]
 public sealed partial class GlueComponent : Component
 {
     /// <summary>
     /// Noise made when glue applied.
     /// </summary>
-    [DataField("squeeze")]
+    [DataField]
     public SoundSpecifier Squeeze = new SoundPathSpecifier("/Audio/Items/squeezebottle.ogg");
 
     /// <summary>
     /// Solution on the entity that contains the glue.
     /// </summary>
-    [DataField("solution")]
+    [DataField]
     public string Solution = "drink";
 
     /// <summary>
     /// Reagent that will be used as glue.
     /// </summary>
-    [DataField("reagent", customTypeSerializer: typeof(PrototypeIdSerializer<ReagentPrototype>))]
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<ReagentPrototype>))]
     public string Reagent = "SpaceGlue";
 
     /// <summary>
     /// Reagent consumption per use.
     /// </summary>
-    [DataField("consumptionUnit"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public FixedPoint2 ConsumptionUnit = FixedPoint2.New(5);
 
     /// <summary>
     /// Duration per unit
     /// </summary>
-    [DataField("durationPerUnit"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public TimeSpan DurationPerUnit = TimeSpan.FromSeconds(6);
 }

--- a/Content.Shared/Glue/GluedComponent.cs
+++ b/Content.Shared/Glue/GluedComponent.cs
@@ -2,14 +2,15 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Glue;
 
-[RegisterComponent]
-[Access(typeof(SharedGlueSystem))]
+[RegisterComponent, AutoGenerateComponentPause]
+[Access(typeof(GlueSystem))]
 public sealed partial class GluedComponent : Component
 {
 
-    [DataField("until", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoPausedField]
     public TimeSpan Until;
 
-    [DataField("duration", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan Duration;
 }

--- a/Content.Shared/Glue/SharedGlueSystem.cs
+++ b/Content.Shared/Glue/SharedGlueSystem.cs
@@ -1,5 +1,0 @@
-namespace Content.Shared.Glue;
-
-public abstract class SharedGlueSystem : EntitySystem
-{
-}

--- a/Content.Shared/Interaction/Components/UnremoveableComponent.cs
+++ b/Content.Shared/Interaction/Components/UnremoveableComponent.cs
@@ -1,17 +1,14 @@
-using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Interaction.Components
+namespace Content.Shared.Interaction.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class UnremoveableComponent : Component
 {
-    [RegisterComponent]
-    [NetworkedComponent]
-    public sealed partial class UnremoveableComponent : Component
-    {
-        /// <summary>
-        /// If this is true then unremovable items that are removed from inventory are deleted (typically from corpse gibbing).
-        /// Items within unremovable containers are not deleted when removed.
-        /// </summary>
-        [DataField("deleteOnDrop")]
-        public bool DeleteOnDrop = true;
-    }
+    /// <summary>
+    /// If this is true then unremovable items that are removed from inventory are deleted (typically from corpse gibbing).
+    /// Items within unremovable containers are not deleted when removed.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool DeleteOnDrop = true;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Predicts the GlueSystem and networks components accordingly.

Resolves #38858 

## Why / Balance
A little bit of prediction, all of the time.

## Technical details
Moves the meat of GlueSystem.cs from server to SharedGlueSystem in shared.
Deletes content.server\glue\ and renames SharedGlueSystem.cs to GlueSystem.cs
Performs the changes suggested in the issue above.
Alphabetized the depends because it makes me happy.
Changed audio and popup usages to predicted varients.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

GlueSystem in all its glory has been moved to shared and its server-side files deleted. Any uses of GlueSystem will need updated to point to Content.Shared.Glue
