### PR TITLE
Add a toolshed command "subtlemessage"

### DIFF
--- a/Resources/Locale/en-US/commands/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/commands/toolshed-commands.ftl
@@ -48,6 +48,8 @@ command-description-stationevent-lsprobtheoretical =
     Given a BasicStationEventScheduler prototype, player count, and round time, lists the probability of different station events occuring based on the specified number of players and round time.
 command-description-stationevent-prob =
     Given a BasicStationEventScheduler prototype and an event prototype, returns the probability of a single station event occuring out of the entire pool with current conditions.
+command-description-subtlemessage =
+    Sends a subtle message to all the input entities.
 command-description-admins-active =
     Returns a list of active admins.
 command-description-admins-all =


### PR DESCRIPTION
## About the PR

Add toolshed command `subtlemessage` to send a subtle message to all players or filtered players. This works in the same way as the subtle message admin verb.

## Why / Balance

A friend requested this feature to me and I think admins in the past have talked about it as well.

When running certain admemes or events, especially with complex roleplay, this can be used to remind players of certain things or convey feelings to players.

## Technical details

Really simple toolshed command that just hooks into the `PrayerSystem` function

## Media

https://github.com/user-attachments/assets/0608f465-4470-4b5c-980f-db0a460f6a8d

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

none

**Changelog**

:cl:
- add: Admin toolshed command to send subtle messages to players

