### PR TITLE
Content fixes for engine PR

### DIFF
--- a/Content.Shared/Sound/Components/BaseEmitSoundComponent.cs
+++ b/Content.Shared/Sound/Components/BaseEmitSoundComponent.cs
@@ -1,6 +1,4 @@
 using Robust.Shared.Audio;
-using Robust.Shared.GameStates;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared.Sound.Components;
 
@@ -13,25 +11,13 @@ public abstract partial class BaseEmitSoundComponent : Component
     /// <summary>
     /// The <see cref="SoundSpecifier"/> to play.
     /// </summary>
-    [DataField(required: true)]
+    [DataField(required: true), AutoNetworkedField]
     public SoundSpecifier? Sound;
 
     /// <summary>
     /// Play the sound at the position instead of parented to the source entity.
     /// Useful if the entity is deleted after.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool Positional;
-}
-
-/// <summary>
-/// Represents the state of <see cref="BaseEmitSoundComponent"/>.
-/// </summary>
-/// <remarks>This is obviously very cursed, but since the BaseEmitSoundComponent is abstract, we cannot network it.
-/// AutoGenerateComponentState attribute won't work here, and since everything revolves around inheritance for some fucking reason,
-/// there's no better way of doing this.</remarks>
-[Serializable, NetSerializable]
-public struct EmitSoundComponentState(SoundSpecifier? sound) : IComponentState
-{
-    public SoundSpecifier? Sound { get; } = sound;
 }

--- a/Content.Shared/Sound/Components/EmitSoundOnActivateComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnActivateComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Sound.Components;
 /// <summary>
 /// Simple sound emitter that emits sound on ActivateInWorld
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class EmitSoundOnActivateComponent : BaseEmitSoundComponent
 {
     /// <summary>

--- a/Content.Shared/Sound/Components/EmitSoundOnCollideComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnCollideComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Sound.Components;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause, AutoGenerateComponentState]
 public sealed partial class EmitSoundOnCollideComponent : BaseEmitSoundComponent
 {
     public static readonly TimeSpan CollideCooldown = TimeSpan.FromSeconds(0.2);

--- a/Content.Shared/Sound/Components/EmitSoundOnDropComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnDropComponent.cs
@@ -5,5 +5,5 @@ namespace Content.Shared.Sound.Components;
 /// <summary>
 /// Simple sound emitter that emits sound on entity drop
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class EmitSoundOnDropComponent : BaseEmitSoundComponent;

--- a/Content.Shared/Sound/Components/EmitSoundOnInteractUsingComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnInteractUsingComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Sound.Components;
 /// <summary>
 /// Whenever this item is used upon by an entity, with a tag or component within a whitelist, in the hand of a user, play a sound
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class EmitSoundOnInteractUsingComponent : BaseEmitSoundComponent
 {
     /// <summary>

--- a/Content.Shared/Sound/Components/EmitSoundOnLandComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnLandComponent.cs
@@ -5,5 +5,5 @@ namespace Content.Shared.Sound.Components;
 /// <summary>
 /// Simple sound emitter that emits sound on LandEvent
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class EmitSoundOnLandComponent : BaseEmitSoundComponent;

--- a/Content.Shared/Sound/Components/EmitSoundOnPickupComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnPickupComponent.cs
@@ -5,5 +5,5 @@ namespace Content.Shared.Sound.Components;
 /// <summary>
 /// Simple sound emitter that emits sound on entity pickup
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class EmitSoundOnPickupComponent : BaseEmitSoundComponent;

--- a/Content.Shared/Sound/Components/EmitSoundOnSpawnComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnSpawnComponent.cs
@@ -5,5 +5,5 @@ namespace Content.Shared.Sound.Components;
 /// <summary>
 ///     Simple sound emitter that emits sound on entity spawn.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class EmitSoundOnSpawnComponent : BaseEmitSoundComponent;

--- a/Content.Shared/Sound/Components/EmitSoundOnThrowComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnThrowComponent.cs
@@ -5,5 +5,5 @@ namespace Content.Shared.Sound.Components;
 /// <summary>
 /// Simple sound emitter that emits sound on ThrowEvent
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class EmitSoundOnThrowComponent : BaseEmitSoundComponent;

--- a/Content.Shared/Sound/Components/EmitSoundOnUIOpenComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnUIOpenComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Sound.Components;
 /// <summary>
 /// Simple sound emitter that emits sound on AfterActivatableUIOpenEvent
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class EmitSoundOnUIOpenComponent : BaseEmitSoundComponent
 {
     /// <summary>

--- a/Content.Shared/Sound/Components/EmitSoundOnUseComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnUseComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Sound.Components;
 /// <summary>
 /// Simple sound emitter that emits sound on UseInHand
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class EmitSoundOnUseComponent : BaseEmitSoundComponent
 {
     /// <summary>

--- a/Content.Shared/Sound/SharedEmitSoundSystem.cs
+++ b/Content.Shared/Sound/SharedEmitSoundSystem.cs
@@ -55,47 +55,6 @@ public abstract class SharedEmitSoundSystem : EntitySystem
         SubscribeLocalEvent<EmitSoundOnCollideComponent, StartCollideEvent>(OnEmitSoundOnCollide);
 
         SubscribeLocalEvent<SoundWhileAliveComponent, MobStateChangedEvent>(OnMobState);
-
-        // We need to handle state manually here
-        // BaseEmitSoundComponent isn't registered so we have to subscribe to each one
-        // TODO: Make it use autonetworking instead of relying on inheritance
-        SubscribeEmitComponent<EmitSoundOnActivateComponent>();
-        SubscribeEmitComponent<EmitSoundOnCollideComponent>();
-        SubscribeEmitComponent<EmitSoundOnDropComponent>();
-        SubscribeEmitComponent<EmitSoundOnInteractUsingComponent>();
-        SubscribeEmitComponent<EmitSoundOnLandComponent>();
-        SubscribeEmitComponent<EmitSoundOnPickupComponent>();
-        SubscribeEmitComponent<EmitSoundOnSpawnComponent>();
-        SubscribeEmitComponent<EmitSoundOnThrowComponent>();
-        SubscribeEmitComponent<EmitSoundOnUIOpenComponent>();
-        SubscribeEmitComponent<EmitSoundOnUseComponent>();
-
-        // Helper method so it's a little less ugly
-        void SubscribeEmitComponent<T>() where T : BaseEmitSoundComponent
-        {
-            SubscribeLocalEvent<T, ComponentGetState>(GetBaseEmitState);
-            SubscribeLocalEvent<T, ComponentHandleState>(HandleBaseEmitState);
-        }
-    }
-
-    private static void GetBaseEmitState<T>(Entity<T> ent, ref ComponentGetState args) where T : BaseEmitSoundComponent
-    {
-        args.State = new EmitSoundComponentState(ent.Comp.Sound);
-    }
-
-    private static void HandleBaseEmitState<T>(Entity<T> ent, ref ComponentHandleState args) where T : BaseEmitSoundComponent
-    {
-        if (args.Current is not EmitSoundComponentState state)
-            return;
-
-        ent.Comp.Sound = state.Sound switch
-        {
-            SoundPathSpecifier pathSpec => new SoundPathSpecifier(pathSpec.Path, pathSpec.Params),
-            SoundCollectionSpecifier collectionSpec => collectionSpec.Collection != null
-                ? new SoundCollectionSpecifier(collectionSpec.Collection, collectionSpec.Params)
-                : null,
-            _ => null,
-        };
     }
 
     private void HandleEmitSoundOnUIOpen(EntityUid uid, EmitSoundOnUIOpenComponent component, AfterActivatableUIOpenEvent args)

--- a/Content.Shared/Weapons/Misc/ForceGunComponent.cs
+++ b/Content.Shared/Weapons/Misc/ForceGunComponent.cs
@@ -9,19 +9,13 @@ public sealed partial class ForceGunComponent : BaseForceGunComponent
     /// <summary>
     /// Maximum distance to throw entities.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("throwDistance"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public float ThrowDistance = 15f;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("throwForce"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public float ThrowForce = 30f;
 
-    /// <summary>
-    /// The entity currently tethered.
-    /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("tethered"), AutoNetworkedField]
-    public override EntityUid? Tethered { get; set; }
-
-    [ViewVariables(VVAccess.ReadWrite), DataField("soundLaunch")]
+    [DataField("soundLaunch")]
     public SoundSpecifier? LaunchSound = new SoundPathSpecifier("/Audio/Weapons/soup.ogg")
     {
         Params = AudioParams.Default.WithVolume(5f),

--- a/Content.Shared/Weapons/Misc/TetherGunComponent.cs
+++ b/Content.Shared/Weapons/Misc/TetherGunComponent.cs
@@ -5,18 +5,6 @@ namespace Content.Shared.Weapons.Misc;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 public sealed partial class TetherGunComponent : BaseForceGunComponent
 {
-    [ViewVariables(VVAccess.ReadWrite), DataField("maxDistance"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public float MaxDistance = 10f;
-
-    /// <summary>
-    /// The entity the tethered target has a joint to.
-    /// </summary>
-    [DataField("tetherEntity"), AutoNetworkedField]
-    public override EntityUid? TetherEntity { get; set; }
-
-    /// <summary>
-    /// The entity currently tethered.
-    /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("tethered"), AutoNetworkedField]
-    public override EntityUid? Tethered { get; set; }
 }


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/6090

Fixes AutoNetworkedField not working with inherited datafields.
Reverts https://github.com/space-wizards/space-station-14/pull/35030 and removes the boilerplate code.
Removes some duplicate datafields from `ForceGunComponent` and `TetherGunComponent` that were already inherited.