### PR TITLE
Rework metal foam grenades, again

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
@@ -5,6 +5,7 @@ using Content.Server.NodeContainer.NodeGroups;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Atmos.Reactions;
+using JetBrains.Annotations;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Utility;
 
@@ -215,6 +216,24 @@ public partial class AtmosphereSystem
         // If nothing handled the event, it'll default to true.
         // Oh well, this is a space game after all, deal with it!
         return true;
+    }
+
+    /// <summary>
+    /// Determines if a grid tile is true space (not lattice).
+    /// </summary>
+    /// <param name="grid">The grid whose tile coordinates are checked.</param>
+    /// <param name="tile">The tile to check.</param>
+    /// <returns>A bool whether a tile is true space or not. Returns false if the grid is null.</returns>
+    public bool IsTileNoGrid(Entity<GridAtmosphereComponent?>? grid,
+        Vector2i tile)
+    {
+        if (grid is { } gridEnt && _atmosQuery.Resolve(gridEnt, ref gridEnt.Comp, false)
+                                && gridEnt.Comp.Tiles.TryGetValue(tile, out var tileAtmos))
+        {
+            return tileAtmos.NoGridTile;
+        }
+
+        return false;
     }
 
     public bool IsTileMixtureProbablySafe(Entity<GridAtmosphereComponent?>? grid, Entity<MapAtmosphereComponent?> map, Vector2i tile)

--- a/Content.Server/Spawners/Components/GridEdgeSpawnComponent.cs
+++ b/Content.Server/Spawners/Components/GridEdgeSpawnComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Spawners.Components;
+
+[RegisterComponent]
+public sealed partial class GridEdgeSpawnComponent : Component
+{
+    /// <summary>
+    /// Entity prototype to spawn.
+    /// </summary>
+    [DataField(required: true)]
+    public EntProtoId Prototype = string.Empty;
+
+    /// <summary>
+    /// Whether to delete the spawner upon spawning the entity.
+    /// </summary>
+    [DataField]
+    public bool DeleteSpawner = true;
+}

--- a/Content.Server/Spawners/Components/GridEdgeSpawnComponent.cs
+++ b/Content.Server/Spawners/Components/GridEdgeSpawnComponent.cs
@@ -2,6 +2,10 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Spawners.Components;
 
+/// <summary>
+/// Spawns entities if the tile they're about to spawn on borders a pure space tile
+/// (not a scaffold or lattice tile).
+/// </summary>
 [RegisterComponent]
 public sealed partial class GridEdgeSpawnComponent : Component
 {

--- a/Content.Server/Spawners/EntitySystems/GridEdgeSpawnSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/GridEdgeSpawnSystem.cs
@@ -1,0 +1,74 @@
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.Spawners.Components;
+using Content.Shared.Atmos;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Spawners.EntitySystems;
+
+/// <summary>
+/// Spawns the prototype if the immediate tile in any cardinal direction is considered space.
+/// </summary>
+public sealed class GridEdgeSpawnSystem : EntitySystem
+{
+    [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GridEdgeSpawnComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(Entity<GridEdgeSpawnComponent> ent, ref MapInitEvent args)
+    {
+        TrySpawn(ent);
+    }
+
+    /// <summary>
+    /// Checks all cardinal directions for a space tile and spawns the entity if it is present.
+    /// </summary>
+    /// <returns>A true or false depending on if an entity was spawned.</returns>
+    public bool TrySpawn(Entity<GridEdgeSpawnComponent> ent)
+    {
+        var xform = Transform(ent);
+
+        if (!_transform.TryGetGridTilePosition((ent.Owner, xform), out var indices))
+            return false;
+
+        for (var i = 0; i < Atmospherics.Directions; i++)
+        {
+            var direction = (AtmosDirection)(1 << i);
+            var offsetTile = indices.Offset(direction);
+
+            if (_atmosphere.IsTileNoGrid(xform.GridUid, offsetTile))
+            {
+                Spawn(ent.Comp.Prototype, xform.Coordinates);
+
+                if (ent.Comp.DeleteSpawner)
+                {
+                    QueueDel(ent);
+                }
+
+                return true;
+            }
+        }
+
+        if (ent.Comp.DeleteSpawner)
+        {
+            QueueDel(ent);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Sets the prototype on this spawner to the one given.
+    /// </summary>
+    /// <param name="entity">The spawner entity targeted.</param>
+    /// <param name="prototype">The prototype to set.</param>
+    public void SetPrototype(Entity<GridEdgeSpawnComponent> entity, EntProtoId prototype)
+    {
+        entity.Comp.Prototype = prototype;
+    }
+}

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -152,7 +152,23 @@
   categories: [ HideSpawnMenu ]
   parent: MetalFoam
   components:
+  - type: ReplaceFloorOnSpawn
+    replaceableTiles:
+    - Plating
+    - Lattice
+    - TrainLattice
+    replacementTiles:
+    - FloorMetalFoam
   - type: SpawnOnDespawn
+    prototype: FoamedAluminiumMetalSpawner
+
+- type: entity
+  id: FoamedAluminiumMetalSpawner
+  name: aluminium metal foam
+  categories: [ HideSpawnMenu ]
+  parent: MetalFoam
+  components:
+  - type: GridEdgeSpawn # Technically double redundant logic, but here in case replacementTiles doesn't fill a space gap.
     prototype: FoamedAluminiumMetal
 
 - type: entity


### PR DESCRIPTION
## About the PR
Reworks metal foam grenades, making them more useful while preventing engineering trolling.

Foam will now no longer spawn foam walls unless the tile that the foam is about to be on borders pure space (not scaffolding or lattice).

Foam will now place down tile as it expands. I can remove this behavior if unnecessary.

## Why / Balance
Currently people are trolling evac shuttles and spaces by triggering the foam grenade. This causes airtight foam to disperse throughout the shuttle, removing the air that's on these tiles. When the subsequent foam is removed, shuttle air now rushes into the created void, thinning out the rest of the air and causing gasping.

Metal foam grenades have also struggled to repair significant voids, as they only repair scaffold and create a new tile one tile beyond that.

## Technical details
A new helper method in the Atmospherics API has been made to check whether a given tile indices is pure space (not a vacuum). If it is, `GridEdgeSpawnSystem` will greenlight the spawning of the desired prototype and self-dispose if requested to.

Note that, because metal foam now places a tile beneath itself before it spreads, enabling spreading, `GridEdgeSpawnSystem` commonly has to do no work. There are some instances where it does need to spawn a wall, however this is rare. If this is work that we should not be doing, I can gladly pull it out.

## Media

https://github.com/user-attachments/assets/e260a189-2b4c-49d9-afcb-d1f7e69bbd1f


Aftermath of a syndiebomb
<img width="1364" height="977" alt="image" src="https://github.com/user-attachments/assets/f54457f6-85ae-41f0-b721-ecacc6978374" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Metal foam grenades will now spread through pure space, filling voids in station hull much easier instead of moving around the void.
- tweak: Metal foam grenades will no longer spawn a metal foam wall unless it sees a pure space tile in any cardinal direction. This prevents trollgineers from voiding all of the air inside of an enclosed space that didn't need filling (like the evac shuttle).

