### PR TITLE
Fix error when a player's profile contains an outdated antag preference

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -590,7 +590,7 @@ namespace Content.Shared.Preferences
             }
 
             var antags = AntagPreferences
-                .Where(id => prototypeManager.TryIndex(id, out var antag) && antag.SetPreference)
+                .Where(id => prototypeManager.TryIndex(id, out var antag, logError: false) && antag.SetPreference)
                 .ToList();
 
             var traits = TraitPreferences


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The server no longer logs an error when validating the profile of a player who has preference data for an antag type that is no longer in the game.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This error shows up in Grafana somewhat frequently:
```
Attempted to resolve invalid ProtoId<AntagPrototype>: SuspicionTraitor
 Sawmill=proto
```

## Technical details
<!-- Summary of code changes for easier review. -->
This comes from calling `PrototypeManager.TryIndex` with an invalid `AntagPrototype` ID. In most cases, this should be logged as an error so the source can be fixed, but in this case the bad ID is coming from the player profile in the database and shouldn't be considered an error.

This just adds `logError: false` to the `TryIndex` call so an error isn't logged. The invalid preference is already correctly ignored by the validation code.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->