### PR TITLE
add the diona typing indicator to the FloraTree entity

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -229,6 +229,8 @@
         tree04: ""
         tree05: ""
         tree06: ""
+  - type: TypingIndicator
+    proto: diona
 
 - type: entity
   parent: BaseTreeSnow


### PR DESCRIPTION
## About the PR
I updated the typing indicator for the FloraTree entity so that diona maintain their special typing indicator when polymorphed into a tree using robust harvest.

## Why / Balance
To have a consistent typing indicator when playing as a diona.

## Media
Old:
https://github.com/user-attachments/assets/207264eb-29db-4736-a2a8-481c64d994a7

New:
https://github.com/user-attachments/assets/0ee4b303-75a4-4fce-aaa4-a3041713e983

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
