### PR TITLE
All pens embed

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -35,7 +35,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Piercing: 0.1
+        Piercing: 1
   - type: Fixtures
     fixtures:
       fix1:
@@ -50,16 +50,6 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
-
-- type: entity
-  parent: Pen
-  id: PenEmbeddable
-  abstract: true
-  components:
-  - type: DamageOtherOnHit
-    damage:
-      types:
-        Piercing: 3
 
 #TODO: I want the luxury pen to write a cool font like Merriweather in the future.
 
@@ -76,7 +66,7 @@
 
 - type: entity
   id: BaseAdvancedPen
-  parent: PenEmbeddable
+  parent: Pen
   abstract: true
   components:
   - type: Tag
@@ -124,7 +114,7 @@
 
 - type: entity
   name: captain's fountain pen
-  parent: PenEmbeddable
+  parent: Pen
   id: PenCap
   description: A luxurious fountain pen for the captain of the station.
   components:
@@ -133,7 +123,7 @@
 
 - type: entity
   name: hop's fountain pen
-  parent: PenEmbeddable
+  parent: Pen
   id: PenHop
   description: A luxurious fountain pen for the hop of the station.
   components:
@@ -142,7 +132,7 @@
 
 - type: entity
   name: wizard's magical pen
-  parent: [ PenEmbeddable, BaseMagicalContraband ]
+  parent: [ Pen, BaseMagicalContraband ]
   id: PenWiz
   description: A luxurious fountain pen. Seems to have a magical crystal eraser.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -51,11 +51,21 @@
         restitution: 0.3
         friction: 0.2
 
+- type: entity
+  parent: Pen
+  id: BasePenFancy
+  abstract: true
+  components:
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Piercing: 3 #nothing shows luxury like inflicting injury
+
 #TODO: I want the luxury pen to write a cool font like Merriweather in the future.
 
 - type: entity
   name: luxury pen
-  parent: Pen
+  parent: BasePenFancy
   id: LuxuryPen
   description: A fancy and expensive pen that you only deserve to own if you're qualified to handle vast amounts of paperwork.
   components:
@@ -66,7 +76,7 @@
 
 - type: entity
   id: BaseAdvancedPen
-  parent: Pen
+  parent: BasePenFancy
   abstract: true
   components:
   - type: Tag
@@ -114,7 +124,7 @@
 
 - type: entity
   name: captain's fountain pen
-  parent: Pen
+  parent: BasePenFancy
   id: PenCap
   description: A luxurious fountain pen for the captain of the station.
   components:
@@ -123,7 +133,7 @@
 
 - type: entity
   name: hop's fountain pen
-  parent: Pen
+  parent: BasePenFancy
   id: PenHop
   description: A luxurious fountain pen for the hop of the station.
   components:
@@ -132,7 +142,7 @@
 
 - type: entity
   name: wizard's magical pen
-  parent: [ Pen, BaseMagicalContraband ]
+  parent: [ BasePenFancy, BaseMagicalContraband ]
   id: PenWiz
   description: A luxurious fountain pen. Seems to have a magical crystal eraser.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -26,12 +26,6 @@
         maxDistance: 2
   - type: UseDelay
     delay: 1.5
-
-- type: entity
-  parent: Pen
-  id: PenEmbeddable
-  abstract: true
-  components:
   - type: EmbeddableProjectile
     offset: 0.3,0.0
     removalTime: 0.0
@@ -41,7 +35,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Piercing: 3
+        Piercing: 0.1
   - type: Fixtures
     fixtures:
       fix1:
@@ -56,6 +50,16 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
+
+- type: entity
+  parent: Pen
+  id: PenEmbeddable
+  abstract: true
+  components:
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Piercing: 3
 
 #TODO: I want the luxury pen to write a cool font like Merriweather in the future.
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: pen
   suffix: Exploding
-  parent: PenEmbeddable
+  parent: Pen
   description: A dark ink pen.
   id: PenExploding
   components:


### PR DESCRIPTION
Pen bombs embed into people
Regular pens don't

## About the PR
Now regular pens embed like their bomb counterparts. Basic Thrown pens now do 1 damage.

## Why / Balance
Notably harder to tell apart pens and pen bombs.

## Technical details
Moves thrown damage to the base "Pen" entity.
Removes PenEmbeddable Abstract entity, because it is somewhat redundant if regular pens can already embed.
Fancy Pens still do 3 damage.

## Media
<img width="211" height="234" alt="image" src="https://github.com/user-attachments/assets/f7ff14fa-f18f-43b6-aee3-2e4c93f1789b" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
The PenEmbeddable entity prototype has been removed, since all pens now embed. Any entities that used this as a parent should instead use Pen or BasePenFancy

**Changelog**
:cl:
- tweak: All pens now embed when thrown.
