### PR TITLE
China lake rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/grenade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/grenade.yml
@@ -54,3 +54,20 @@
     count: 10
   - type: TimedDespawn
     lifetime: 0.25
+
+- type: entity
+  id: PelletClusterLessLethal
+  name: pellet (ball, less lethal)
+  categories: [ HideSpawnMenu ]
+  parent: BaseBullet
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
+    state: buckshot
+  - type: Projectile
+    deleteOnCollide: false
+    damage:
+      types:
+        Piercing: 5
+  - type: TimedDespawn
+    lifetime: 0.25

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -863,6 +863,7 @@
     totalIntensity: 150 # a ~2 tile radius
     intensitySlope: 5
     maxIntensity: 10
+    canCreateVacuum: false
 
 - type: entity
   id: BulletGrenadeFlash
@@ -896,9 +897,13 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    totalIntensity: 175 # about a ~6 tile radius
+    totalIntensity: 50
     intensitySlope: 1
-    maxIntensity: 10
+    maxIntensity: 5
+    canCreateVacuum: false
+  - type: ProjectileGrenade
+    fillPrototype: PelletClusterLessLethal
+    capacity: 30
 
 - type: entity
   parent: BaseBulletTrigger

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -901,6 +901,9 @@
     intensitySlope: 1
     maxIntensity: 5
     canCreateVacuum: false
+  - type: ContainerContainer
+    containers:
+      cluster-payload: !type:Container
   - type: ProjectileGrenade
     fillPrototype: PelletClusterLessLethal
     capacity: 30

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -883,7 +883,6 @@
     timeRemaining: 0.3
   - type: DeleteOnTrigger
 
-# This is supposed to spawn shrapnel and stuff so uhh... TODO?
 - type: entity
   id: BulletGrenadeFrag
   name: frag grenade


### PR DESCRIPTION
## About the PR
This PR rebalances the power of the China lake, by changing the effectiveness of its rounds and generally making things more fair.

The fragmentation grenades now properly generate fragmentation that spews out from the round on impact. The explosion damage has been lightened. This forms a gradient, where people caught in a direct hit are indeed punished, and people caught in the corners of a room still have damage dealt to them.

Blast grenades now no longer cause spacing.

## Why / Balance
A combination of factors has revealed major problems in the crew vs. Nukies space:
- Spacing as of right now is extremely powerful for Nukies and detrimental to crew gameplay and the crew's agency.
- Common nukie equipment, like the China Lake, causes spacing passively, or wholesale, just by use of their equipment.
- It is not ideal to nerf spacing - spacing should be a real threat that forces creative problem solving and should cause players to avoid areas and replan routes.
	- This does not hold up well when spacing is being caused wholesale by antagonists, like Nukies.
- It is not ideal to buff crew efforts in fixing spacing, as Nukies can almost always intervene with crew stopping the spread of spacing.

So the solution is to nerf Nukies reliance on spacing, and how much spacing they can cause.

Fragmentation is meant for clearing out rooms/dead ends that crew have gotten themselves into, as well as crew holding places like Medical or a bar FOB.
Blast is for the targeted breach of physical blocks or reinforcements that the crew have setup.

Overall, the changes have been made so that crew have a bit more agency in their actions - they still die at the end, yes, but commonly they are left standing for a bit longer and thus they have a feeling that they're able to do something before they die. And sometimes, that little something can turn a fight or get them somewhere safe.

Because fragmentation grenades now rely on, well, fragmentation, they can be blocked by bodies, objects in a room, etc. So if you fire into a room, it is likely that the people at the center of the room will take a lot of damage, but the people protected by those people might not be as hurt.

If blast grenades are wasted on crew, well, that's one less wall or firelock you can pop open.

## Technical details
Just some damage tweaks and grenade additions.

## Media
Fragmentation grenade vs. 6 secoffs in a room:

https://github.com/user-attachments/assets/6e43fd7c-db80-4e9c-a93c-7fb57e073dba


Shrapnel grenade in a similar aituation:


https://github.com/user-attachments/assets/6b1a6d31-b209-43ef-8cd4-d18c807cda8d


Post-rebalance fragmentation grenade vs. a quiet medbay:


https://github.com/user-attachments/assets/5fe45486-43eb-4dc2-9e0e-168aa1d7f4e2


Pre-rebalance:

https://github.com/user-attachments/assets/ad23d6d1-afe8-4401-8255-68069ab7a39d


No-spacing blast grenades:

https://github.com/user-attachments/assets/e67d10e7-5e9c-47bb-af31-fc1d7fe6e962


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
wawawawawawa

**Changelog**
:cl:
- tweak: China-lake fragmentation grenades now spew fragmentation in all directions upon impact. They now do reduced explosion damage.
- tweak: China-lake blast grenades no longer cause spacing.
