### PR TITLE
Fix #38935: Remove empty EnsnaringComponent.cs file

### DIFF
--- a/Content.Server/Ensnaring/Components/EnsnaringComponent.cs
+++ b/Content.Server/Ensnaring/Components/EnsnaringComponent.cs
@@ -1,5 +1,0 @@
-﻿using System.Threading;
-using Content.Shared.Ensnaring.Components;
-
-
-


### PR DESCRIPTION
The file Content.Server/Ensnaring/Components/EnsnaringComponent.cs was empty and served no purpose. Removing it helps keep the codebase clean and free of unnecessary files.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR removes the file `Content.Server/Ensnaring/Components/EnsnaringComponent.cs`, which was empty and served no purpose. Keeping the codebase free of unnecessary or empty files helps maintain clarity and reduces confusion for future contributors.

## Why / Balance
Empty files can cause confusion for new contributors and clutter the codebase. Removing unused files is a standard practice to keep the repository clean and maintainable.  
Related issue: [#38935](https://github.com/space-wizards/space-station-14/issues/38935)

## Technical details
- Deleted the file `Content.Server/Ensnaring/Components/EnsnaringComponent.cs`
- Verified that the project builds and all tests pass after removal

## Media
Not applicable – this is a code cleanup with no ingame changes.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).

## Breaking changes
None.
