### PR TITLE
Changed Deckard Contraband to Sec Only

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -52,7 +52,7 @@
 
 - type: entity
   name: Deckard
-  parent: [BaseWeaponRevolver, BaseSecurityCommandContraband]
+  parent: [BaseWeaponRevolver, BaseSecurityContraband]
   id: WeaponRevolverDeckard
   description: A beautifully machined, custom-built revolver. Used when there is no time for the Voight-Kampff test. Loads 5 rounds of .45 magnum.
   components:


### PR DESCRIPTION
## About the PR
Changed the Deckard to be Security contraband only.

## Why / Balance
So HoP, RD, or any other command can't pack a big iron without justification anymore. Too often I see either HoP or RD raid the vault and conveniently pocket the Deckard just because they can.

## Technical details
Simple 1 liner.

## Media
<img width="485" height="182" alt="Deckard" src="https://github.com/user-attachments/assets/625d563e-acd3-49d2-a874-438d39ec9028" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
Nah

**Changelog**
:cl:
- tweak: Deckard is now Sec contraband only