### PR TITLE
Make CuffableComponent and CuffableSystem not Crash (Hopefully)

### DIFF
--- a/Content.Client/Inventory/StrippableBoundUserInterface.cs
+++ b/Content.Client/Inventory/StrippableBoundUserInterface.cs
@@ -190,7 +190,7 @@ namespace Content.Client.Inventory
             if (EntMan.TryGetComponent<VirtualItemComponent>(heldEntity, out var virt))
             {
                 button.Blocked = true;
-                if (EntMan.TryGetComponent<CuffableComponent>(Owner, out var cuff) && _cuffable.GetAllCuffs(cuff).Contains(virt.BlockingEntity))
+                if (_cuffable.TryGetAllCuffs(Owner, out var cuffs) && cuffs.Contains(virt.BlockingEntity))
                     button.BlockedRect.MouseFilter = MouseFilterMode.Ignore;
             }
 

--- a/Content.Server/Cuffs/CuffableSystem.cs
+++ b/Content.Server/Cuffs/CuffableSystem.cs
@@ -15,7 +15,7 @@ namespace Content.Server.Cuffs
             SubscribeLocalEvent<CuffableComponent, ComponentGetState>(OnCuffableGetState);
         }
 
-        private void OnCuffableGetState(EntityUid uid, CuffableComponent component, ref ComponentGetState args)
+        private void OnCuffableGetState(Entity<CuffableComponent> entity, ref ComponentGetState args)
         {
             // there are 2 approaches i can think of to handle the handcuff overlay on players
             // 1 - make the current RSI the handcuff type that's currently active. all handcuffs on the player will appear the same.
@@ -23,12 +23,12 @@ namespace Content.Server.Cuffs
             // approach #2 would be more difficult/time consuming to do and the payoff doesn't make it worth it.
             // right now we're doing approach #1.
             HandcuffComponent? cuffs = null;
-            if (component.CuffedHandCount > 0)
-                TryComp(component.LastAddedCuffs, out cuffs);
-            args.State = new CuffableComponentState(component.CuffedHandCount,
-                component.CanStillInteract,
+            if (TryGetLastCuff((entity, entity.Comp), out var cuff))
+                TryComp(cuff, out cuffs);
+            args.State = new CuffableComponentState(entity.Comp.CuffedHandCount,
+                entity.Comp.CanStillInteract,
                 cuffs?.CuffedRSI,
-                $"{cuffs?.BodyIconState}-{component.CuffedHandCount}",
+                $"{cuffs?.BodyIconState}-{entity.Comp.CuffedHandCount}",
                 cuffs?.Color);
             // the iconstate is formatted as blah-2, blah-4, blah-6, etc.
             // the number corresponds to how many hands are cuffed.

--- a/Content.Server/Implants/SubdermalImplantSystem.cs
+++ b/Content.Server/Implants/SubdermalImplantSystem.cs
@@ -88,10 +88,17 @@ public sealed class SubdermalImplantSystem : SharedSubdermalImplantSystem
 
     private void OnFreedomImplant(EntityUid uid, SubdermalImplantComponent component, UseFreedomImplantEvent args)
     {
-        if (!TryComp<CuffableComponent>(component.ImplantedEntity, out var cuffs) || cuffs.Container.ContainedEntities.Count < 1)
+        // How did we even get here?
+        if (component.ImplantedEntity == null)
+        {
+            Log.Error($"Freedom Implant {ToPrettyString(uid)} is attempting to remove cuffs but it's not implanted into an entity.");
+            return;
+        }
+
+        if (!_cuffable.TryGetLastCuff(component.ImplantedEntity.Value, out var cuff))
             return;
 
-        _cuffable.Uncuff(component.ImplantedEntity.Value, cuffs.LastAddedCuffs, cuffs.LastAddedCuffs);
+        _cuffable.Uncuff(component.ImplantedEntity.Value, cuff, cuff.Value);
         args.Handled = true;
     }
 

--- a/Content.Shared/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Shared/Cuffs/Components/CuffableComponent.cs
@@ -25,12 +25,6 @@ public sealed partial class CuffableComponent : Component
     public int CuffedHandCount => Container.ContainedEntities.Count * 2;
 
     /// <summary>
-    /// The last pair of cuffs that was added to this entity.
-    /// </summary>
-    [ViewVariables]
-    public EntityUid LastAddedCuffs => Container.ContainedEntities[^1];
-
-    /// <summary>
     ///     Container of various handcuffs currently applied to the entity.
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)]

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Components;
@@ -255,7 +256,7 @@ namespace Content.Shared.Cuffs
         {
             if (args.Handled)
                 return;
-            TryUncuff(ent, ent, cuffable: ent.Comp);
+            TryUncuff((ent, ent.Comp), ent);
             args.Handled = true;
         }
 
@@ -273,7 +274,7 @@ namespace Content.Shared.Cuffs
 
             Verb verb = new()
             {
-                Act = () => TryUncuff(uid, args.User, cuffable: component),
+                Act = () => TryUncuff((uid, component), args.User),
                 DoContactInteraction = true,
                 Text = Loc.GetString("uncuff-verb-get-data-text")
             };
@@ -582,36 +583,30 @@ namespace Content.Shared.Cuffs
         /// Attempt to uncuff a cuffed entity. Can be called by the cuffed entity, or another entity trying to help uncuff them.
         /// If the uncuffing succeeds, the cuffs will drop on the floor.
         /// </summary>
-        /// <param name="target"></param>
-        /// <param name="user">The cuffed entity</param>
+        /// <param name="target">The entity we're trying to remove cuffs from.</param>
+        /// <param name="user">The entity doing the cuffing.</param>
         /// <param name="cuffsToRemove">Optional param for the handcuff entity to remove from the cuffed entity. If null, uses the most recently added handcuff entity.</param>
-        /// <param name="cuffable"></param>
-        /// <param name="cuff"></param>
-        public void TryUncuff(EntityUid target, EntityUid user, EntityUid? cuffsToRemove = null, CuffableComponent? cuffable = null, HandcuffComponent? cuff = null)
+        public void TryUncuff(Entity<CuffableComponent?> target, EntityUid user, Entity<HandcuffComponent?>? cuffsToRemove = null)
         {
-            if (!Resolve(target, ref cuffable))
+            if (!Resolve(target, ref target.Comp))
                 return;
 
-            var isOwner = user == target;
+            var isOwner = user == target.Owner;
 
             if (cuffsToRemove == null)
-            {
-                if (cuffable.Container.ContainedEntities.Count == 0)
-                {
-                    return;
-                }
-
-                cuffsToRemove = cuffable.LastAddedCuffs;
-            }
+                cuffsToRemove = GetLastCuffOrNull(target);
             else
             {
-                if (!cuffable.Container.ContainedEntities.Contains(cuffsToRemove.Value))
-                {
+                if (!target.Comp.Container.ContainedEntities.Contains(cuffsToRemove.Value))
                     Log.Warning("A user is trying to remove handcuffs that aren't in the owner's container. This should never happen!");
-                }
             }
 
-            if (!Resolve(cuffsToRemove.Value, ref cuff))
+            if (cuffsToRemove == null)
+                return;
+
+            var cuff = cuffsToRemove.Value;
+
+            if (!Resolve(cuff, ref cuff.Comp))
                 return;
 
             var attempt = new UncuffAttemptEvent(user, target);
@@ -622,14 +617,14 @@ namespace Content.Shared.Cuffs
                 return;
             }
 
-            if (!isOwner && !_interaction.InRangeUnobstructed(user, target))
+            if (!isOwner && !_interaction.InRangeUnobstructed(user, target.Owner))
             {
                 _popup.PopupClient(Loc.GetString("cuffable-component-cannot-remove-cuffs-too-far-message"), user, user);
                 return;
             }
 
 
-            var ev = new ModifyUncuffDurationEvent(user, target, isOwner ? cuff.BreakoutTime : cuff.UncuffTime);
+            var ev = new ModifyUncuffDurationEvent(user, target, isOwner ? cuff.Comp.BreakoutTime : cuff.Comp.UncuffTime);
             RaiseLocalEvent(user, ref ev);
             var uncuffTime = ev.Duration;
 
@@ -659,7 +654,7 @@ namespace Content.Shared.Cuffs
 
             _adminLog.Add(LogType.Action, LogImpact.High, $"{ToPrettyString(user):player} is trying to uncuff {ToPrettyString(target):subject}");
 
-            var popupText = user == target
+            var popupText = user == target.Owner
                 ? "cuffable-component-start-uncuffing-self-observer"
                 : "cuffable-component-start-uncuffing-observer";
             _popup.PopupEntity(
@@ -671,7 +666,7 @@ namespace Content.Shared.Cuffs
                     .RemoveWhere(e => e.AttachedEntity == target || e.AttachedEntity == user),
                 true);
 
-            if (target == user)
+            if (isOwner)
             {
                 _popup.PopupClient(Loc.GetString("cuffable-component-start-uncuffing-self"), user, user);
             }
@@ -687,7 +682,7 @@ namespace Content.Shared.Cuffs
                     target);
             }
 
-            _audio.PlayPredicted(isOwner ? cuff.StartBreakoutSound : cuff.StartUncuffSound, target, user);
+            _audio.PlayPredicted(isOwner ? cuff.Comp.StartBreakoutSound : cuff.Comp.StartUncuffSound, target, user);
         }
 
         public void Uncuff(EntityUid target, EntityUid? user, EntityUid cuffsToRemove, CuffableComponent? cuffable = null, HandcuffComponent? cuff = null)
@@ -814,6 +809,58 @@ namespace Content.Shared.Cuffs
         public IReadOnlyList<EntityUid> GetAllCuffs(CuffableComponent component)
         {
             return component.Container.ContainedEntities;
+        }
+
+        /// <summary>
+        /// Tries to get a list of all the handcuffs stored in a entity's <see cref="CuffableComponent"/>.
+        /// </summary>
+        /// <param name="entity">The cuffable entity in question.</param>
+        /// <param name="cuffs">A list of cuffs if it exists.</param>
+        /// <returns>True if a list of cuffs with cuffs exists.</returns>
+        public bool TryGetAllCuffs(Entity<CuffableComponent?> entity, [NotNullWhen(true)] out IReadOnlyList<EntityUid>? cuffs)
+        {
+            cuffs = GetAllCuffsOrNull(entity);
+
+            return cuffs != null;
+        }
+
+        /// <summary>
+        /// Tries to get a list of all the handcuffs stored in a entity's <see cref="CuffableComponent"/>.
+        /// </summary>
+        /// <param name="entity">The cuffable entity in question.</param>
+        /// <returns>A list of cuffs if it exists, or null if there are no cuffs.</returns>
+        public IReadOnlyList<EntityUid>? GetAllCuffsOrNull(Entity<CuffableComponent?> entity)
+        {
+            if (!Resolve(entity, ref entity.Comp))
+                return null;
+
+            return entity.Comp.Container.ContainedEntities.Count == 0 ? null : entity.Comp.Container.ContainedEntities;
+        }
+
+        /// <summary>
+        /// Tries to get the most recently added pair of handcuffs added to an entity with <see cref="CuffableComponent"/>.
+        /// </summary>
+        /// <param name="entity">The cuffable entity in question.</param>
+        /// <param name="cuff">The most recently added cuff.</param>
+        /// <returns>Returns true if a cuff exists and false if one doesn't.</returns>
+        public bool TryGetLastCuff(Entity<CuffableComponent?> entity, [NotNullWhen(true)] out EntityUid? cuff)
+        {
+            cuff = GetLastCuffOrNull(entity);
+
+            return cuff != null;
+        }
+
+        /// <summary>
+        /// Tries to get the most recently added pair of handcuffs added to an entity with <see cref="CuffableComponent"/>.
+        /// </summary>
+        /// <param name="entity">The cuffable entity in question.</param>
+        /// <returns>The most recently added cuff or null if none exists.</returns>
+        public EntityUid? GetLastCuffOrNull(Entity<CuffableComponent?> entity)
+        {
+            if (!Resolve(entity, ref entity.Comp))
+                return null;
+
+            return entity.Comp.Container.ContainedEntities.Count == 0 ? null : entity.Comp.Container.ContainedEntities.Last();
         }
     }
 

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -806,11 +806,6 @@ namespace Content.Shared.Cuffs
 
         #endregion
 
-        public IReadOnlyList<EntityUid> GetAllCuffs(CuffableComponent component)
-        {
-            return component.Container.ContainedEntities;
-        }
-
         /// <summary>
         /// Tries to get a list of all the handcuffs stored in a entity's <see cref="CuffableComponent"/>.
         /// </summary>

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -128,10 +128,10 @@ public abstract class SharedStrippableSystem : EntitySystem
 
         // Is the target a handcuff?
         if (TryComp<VirtualItemComponent>(heldEntity, out var virtualItem) &&
-            TryComp<CuffableComponent>(target.Owner, out var cuffable) &&
-            _cuffableSystem.GetAllCuffs(cuffable).Contains(virtualItem.BlockingEntity))
+            _cuffableSystem.TryGetAllCuffs(target.Owner, out var cuffs) &&
+            cuffs.Contains(virtualItem.BlockingEntity))
         {
-            _cuffableSystem.TryUncuff(target.Owner, user, virtualItem.BlockingEntity, cuffable);
+            _cuffableSystem.TryUncuff(target.Owner, user, virtualItem.BlockingEntity);
             return;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made it so CuffableComponent and CuffableSystem are less prone to crashing the client and throwing errors by improving the API, and removing a really horrible ViewVariable. 

Partially resolves: #39108

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
#39108

I can't go further into debugging the other crashes if I can't even VV the component I'm debugging.

## Technical details
<!-- Summary of code changes for easier review. -->
Destroyed VV Last Added Cuffs
Destroyed GetAllCuffs

Added 4 new API methods that properly handle the very real possibility of a cuffable entity not having cuffs on so you don't 
have to copypaste the same checks all over the codebase. 

Cleaned up various systems to use these new API methods.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="500" height="164" alt="image" src="https://github.com/user-attachments/assets/9ff99d4c-e44f-4de9-a7ed-c68810fe5e3f" />

Proof of the component actually being able to open when not cuffed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

CuffableComponent.LastAddedCuff has been completely deleted, use TryGetLastCuff or GetLastCuffOrNull instead.

SharedCuffableSystem GetAllCuffs has been deleted, use TryGetAllCuffs or GetAllCuffsOrNull instead.

TryUncuff now uses Entity<T> typing for the cuffable entity and the cuffs.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
