### PR TITLE
Fix microwave keeps cooking after power is cut

### DIFF
--- a/Content.Client/Kitchen/UI/MicrowaveBoundUserInterface.cs
+++ b/Content.Client/Kitchen/UI/MicrowaveBoundUserInterface.cs
@@ -70,10 +70,10 @@ namespace Content.Client.Kitchen.UI
                 return;
             }
 
-            _menu.IsBusy = cState.IsMicrowaveBusy;
-            _menu.CurrentCooktimeEnd = cState.CurrentCookTimeEnd;
+            _menu.IsBusy = cState.IsPowered ? cState.IsMicrowaveBusy : false;
+            _menu.CurrentCooktimeEnd = cState.IsPowered ? cState.CurrentCookTimeEnd : new TimeSpan();
 
-            _menu.ToggleBusyDisableOverlayPanel(cState.IsMicrowaveBusy || cState.ContainedSolids.Length == 0);
+            _menu.ToggleBusyDisableOverlayPanel(_menu.IsBusy || cState.ContainedSolids.Length == 0 || !cState.IsPowered);
             // TODO move this to a component state and ensure the net ids.
             RefreshContentsDisplay(EntMan.GetEntityArray(cState.ContainedSolids));
 
@@ -85,8 +85,8 @@ namespace Content.Client.Kitchen.UI
 
             _menu.CookTimeInfoLabel.Text = Loc.GetString("microwave-bound-user-interface-cook-time-label",
                                                          ("time", cookTime));
-            _menu.StartButton.Disabled = cState.IsMicrowaveBusy || cState.ContainedSolids.Length == 0;
-            _menu.EjectButton.Disabled = cState.IsMicrowaveBusy || cState.ContainedSolids.Length == 0;
+            _menu.StartButton.Disabled = cState.IsMicrowaveBusy || cState.ContainedSolids.Length == 0 || !cState.IsPowered;
+            _menu.EjectButton.Disabled = cState.IsMicrowaveBusy || cState.ContainedSolids.Length == 0 || !cState.IsPowered;
 
 
             //Set the correct button active button
@@ -101,7 +101,7 @@ namespace Content.Client.Kitchen.UI
             }
 
             //Set the "micowave light" ui color to indicate if the microwave is busy or not
-            if (cState.IsMicrowaveBusy && cState.ContainedSolids.Length > 0)
+            if (cState.IsMicrowaveBusy && cState.ContainedSolids.Length > 0 && cState.IsPowered)
             {
                 _menu.IngredientsPanel.PanelOverride = new StyleBoxFlat { BackgroundColor = Color.FromHex("#947300") };
             }

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -465,7 +465,8 @@ namespace Content.Server.Kitchen.EntitySystems
                 HasComp<ActiveMicrowaveComponent>(uid),
                 component.CurrentCookTimeButtonIndex,
                 component.CurrentCookTimerTime,
-                component.CurrentCookTimeEnd
+                component.CurrentCookTimeEnd,
+                _power.IsPowered(uid)
             ));
         }
 

--- a/Content.Shared/Kitchen/Components/SharedMicrowave.cs
+++ b/Content.Shared/Kitchen/Components/SharedMicrowave.cs
@@ -53,17 +53,18 @@ namespace Content.Shared.Kitchen.Components
         public bool IsMicrowaveBusy;
         public int ActiveButtonIndex;
         public uint CurrentCookTime;
-
         public TimeSpan CurrentCookTimeEnd;
+        public bool IsPowered;
 
         public MicrowaveUpdateUserInterfaceState(NetEntity[] containedSolids,
-            bool isMicrowaveBusy, int activeButtonIndex, uint currentCookTime, TimeSpan currentCookTimeEnd)
+            bool isMicrowaveBusy, int activeButtonIndex, uint currentCookTime, TimeSpan currentCookTimeEnd, bool isPowered)
         {
             ContainedSolids = containedSolids;
             IsMicrowaveBusy = isMicrowaveBusy;
             ActiveButtonIndex = activeButtonIndex;
             CurrentCookTime = currentCookTime;
             CurrentCookTimeEnd = currentCookTimeEnd;
+            IsPowered = isPowered;
         }
 
     }


### PR DESCRIPTION
## About the PR
I added a flag for whether or not the microwave is powered when updating the ui so that it will now reset/stop the timer and disable the buttons when power is cut from the microwave while it is running.

Closes https://github.com/space-wizards/space-station-14/issues/39078

## Why / Balance
Currently the microwave ui looks like it continues to run after power is cut.

## Technical details
I added a new flag IsPowered to MicrowaveUpdateUserInterfaceState so that when checking if the microwave is running, it will also check that power is still supplied to the microwave.

NOTE: The ToggleBusyDisableOverlayPanel method seems to disable all the buttons so with these changes, if power is cut, the food is still stuck inside the microwave as you cannot eject the food until power is back which makes sense since we cannot insert food unless the microwave is powered. Currently if you unanchor the microwave, it spits out all the items within it, but I wasn't sure if that's what we wanted to do if the power goes out since that may be very annoying for chefs early round having everything tossed from the microwave everytime the lights flicker.

## Media
Old:
![microwave_would_not_stop_when_power_was_cut](https://github.com/user-attachments/assets/eeca17d8-3edc-474e-a2dd-bec6255ed5e3)

New:
![microwave_now_stops_when_power_is_cut](https://github.com/user-attachments/assets/2276e86a-3738-42e8-86ba-5b39c49b0c2c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
Don't think this needs a change log as it is more of a minor bug fix.
