### PR TITLE
Aghost no longer marks your entity as SSD

### DIFF
--- a/Content.Client/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Client/SSDIndicator/SSDIndicatorSystem.cs
@@ -13,7 +13,7 @@ namespace Content.Client.SSDIndicator;
 /// <summary>
 ///     Handles displaying SSD indicator as status icon
 /// </summary>
-public sealed class SSDIndicatorSystem : EntitySystem
+public sealed class SSDIndicatorSystem : SharedSSDIndicatorSystem
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -132,6 +132,8 @@ public sealed class MindSystem : SharedMindSystem
         var comp = EnsureComp<VisitingMindComponent>(entity);
         comp.MindId = mindId;
 
+        Dirty(mindId, mind);
+
         // Do this AFTER the entity changes above as this will fire off a player-detached event
         // which will run ghosting twice.
         if (_players.TryGetSessionById(mind.UserId, out var session))

--- a/Content.Server/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Server/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,0 +1,86 @@
+using Content.Shared.CCVar;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
+using Content.Shared.SSDIndicator;
+using Content.Shared.StatusEffectNew;
+using Robust.Shared.Configuration;
+using Robust.Shared.Enums;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+/// <summary>
+///     Handles displaying SSD indicator as status icon
+/// </summary>
+public sealed class SSDIndicatorSystem : SharedSSDIndicatorSystem
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+
+    private bool _icSsdSleep;
+    private float _icSsdSleepTime;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<SSDIndicatorComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<SSDIndicatorComponent, PlayerDetachedEvent>(OnPlayerDetached);
+
+        SubscribeLocalEvent<VisitingMindComponent, PlayerDetachedEvent>(OnVisitingDetached);
+
+        _cfg.OnValueChanged(CCVars.ICSSDSleep, obj => _icSsdSleep = obj, true);
+        _cfg.OnValueChanged(CCVars.ICSSDSleepTime, obj => _icSsdSleepTime = obj, true);
+    }
+
+    private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args)
+    {
+        component.IsSSD = false;
+
+        // Removes force sleep and resets the time to zero
+        if (_icSsdSleep)
+        {
+            component.FallAsleepTime = TimeSpan.Zero;
+            _statusEffects.TryRemoveStatusEffect(uid, StatusEffectSSDSleeping);
+        }
+
+        Dirty(uid, component);
+    }
+
+    private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args)
+    {
+        // If the mind is only visiting another entity, don't mark it as SSD.
+        var disconnecting = args.Player.State.Status == SessionStatus.Disconnected;
+        _mind.TryGetMind(uid, out _, out var mind);
+
+        component.IsSSD = mind == null || disconnecting || !mind.IsVisitingEntity;
+
+        // Sets the time when the entity should fall asleep
+        if (_icSsdSleep)
+        {
+            component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
+        }
+
+        Dirty(uid, component);
+    }
+
+    private void OnVisitingDetached(EntityUid uid, VisitingMindComponent component, PlayerDetachedEvent args)
+    {
+        if (!_mind.TryGetMind(uid, out _, out var mind) || mind.OwnedEntity == null)
+            return;
+
+        if (!TryComp<SSDIndicatorComponent>(mind.OwnedEntity.Value, out var ssd))
+            return;
+
+        var disconnecting = args.Player.State.Status == SessionStatus.Disconnected;
+
+        ssd.IsSSD = disconnecting || !mind.IsVisitingEntity;
+
+        // Sets the time when the entity should fall asleep
+        if (_icSsdSleep)
+        {
+            ssd.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
+        }
+
+        Dirty(mind.OwnedEntity.Value, ssd);
+    }
+}

--- a/Content.Server/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Server/SSDIndicator/SSDIndicatorSystem.cs
@@ -23,27 +23,12 @@ public sealed class SSDIndicatorSystem : SharedSSDIndicatorSystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<SSDIndicatorComponent, PlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<SSDIndicatorComponent, PlayerDetachedEvent>(OnPlayerDetached);
 
         SubscribeLocalEvent<VisitingMindComponent, PlayerDetachedEvent>(OnVisitingDetached);
 
         _cfg.OnValueChanged(CCVars.ICSSDSleep, obj => _icSsdSleep = obj, true);
         _cfg.OnValueChanged(CCVars.ICSSDSleepTime, obj => _icSsdSleepTime = obj, true);
-    }
-
-    private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args)
-    {
-        component.IsSSD = false;
-
-        // Removes force sleep and resets the time to zero
-        if (_icSsdSleep)
-        {
-            component.FallAsleepTime = TimeSpan.Zero;
-            _statusEffects.TryRemoveStatusEffect(uid, StatusEffectSSDSleeping);
-        }
-
-        Dirty(uid, component);
     }
 
     private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args)

--- a/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class SSDIndicatorComponent : Component
     /// The time at which the entity will fall asleep, if <see cref="CCVars.ICSSDSleep"/> is true.
     /// </summary>
     [AutoNetworkedField, AutoPausedField]
-    [Access(typeof(SSDIndicatorSystem))]
+    [Access(typeof(SharedSSDIndicatorSystem))]
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan FallAsleepTime = TimeSpan.Zero;
 

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,7 +1,6 @@
 using Content.Shared.CCVar;
 using Content.Shared.StatusEffectNew;
 using Robust.Shared.Configuration;
-using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -10,7 +9,7 @@ namespace Content.Shared.SSDIndicator;
 /// <summary>
 ///     Handle changing player SSD indicator status
 /// </summary>
-public sealed class SSDIndicatorSystem : EntitySystem
+public abstract class SharedSSDIndicatorSystem : EntitySystem
 {
     public static readonly EntProtoId StatusEffectSSDSleeping = "StatusEffectSSDSleeping";
 
@@ -23,40 +22,12 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<SSDIndicatorComponent, PlayerAttachedEvent>(OnPlayerAttached);
-        SubscribeLocalEvent<SSDIndicatorComponent, PlayerDetachedEvent>(OnPlayerDetached);
         SubscribeLocalEvent<SSDIndicatorComponent, MapInitEvent>(OnMapInit);
 
         _cfg.OnValueChanged(CCVars.ICSSDSleep, obj => _icSsdSleep = obj, true);
         _cfg.OnValueChanged(CCVars.ICSSDSleepTime, obj => _icSsdSleepTime = obj, true);
     }
 
-    private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args)
-    {
-        component.IsSSD = false;
-
-        // Removes force sleep and resets the time to zero
-        if (_icSsdSleep)
-        {
-            component.FallAsleepTime = TimeSpan.Zero;
-            _statusEffects.TryRemoveStatusEffect(uid, StatusEffectSSDSleeping);
-        }
-
-        Dirty(uid, component);
-    }
-
-    private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args)
-    {
-        component.IsSSD = true;
-
-        // Sets the time when the entity should fall asleep
-        if (_icSsdSleep)
-        {
-            component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
-        }
-
-        Dirty(uid, component);
-    }
 
     // Prevents mapped mobs to go to sleep immediately
     private void OnMapInit(EntityUid uid, SSDIndicatorComponent component, MapInitEvent args)
@@ -66,6 +37,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
         component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
         component.NextUpdate = _timing.CurTime + component.UpdateInterval;
+
         Dirty(uid, component);
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Visiting a mind no longer marks your original entity as SSD

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A small admin QoL, it looks weird if youre doing an admeme and gotta aghost out to do whatever

Resolves #25623

## Technical details
<!-- Summary of code changes for easier review. -->
Moved handling of PlayerAttached and PlayerDetached from SSDIndicatorSystem to it's server version. This is due to minds and (soon) sessions not being accessible on client, causing mispredictions on non-local clients.
Also this was not predicted anyways, mainly because minds are all server, so you could never see a predicted SSDIndicator as you gotta wait for server to spawn you a ghost or put you in a new entity.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/9b39b3c6-7186-4c35-9004-35616935f656


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`SSDIndicatorSystem` renamed to `SharedSSDIndicatorSystem` and split into a Server and Client variant.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
ADMIN:
- tweak: Aghosting out of entities no longer marks them as SSD.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
