### PR TITLE
holidayrefresh command (Christmas in July)

### DIFF
--- a/Content.Server/Holiday/HolidayRefreshCommand.cs
+++ b/Content.Server/Holiday/HolidayRefreshCommand.cs
@@ -1,0 +1,59 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Holiday;
+using Robust.Shared.Console;
+
+namespace Content.Server.Holiday;
+
+/// <summary>
+///     Admin command for setting the date for holidays.
+/// </summary>
+[AdminCommand(AdminFlags.Fun)]
+public sealed class HolidayRefreshCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly SharedHolidaySystem _holidaySys = default!;
+
+    public override string Command => "holidayrefresh";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        DateTime date;
+
+        switch (args.Length)
+        {
+            case 0:
+                // Set holidays to today.
+                _holidaySys.RefreshCurrentHolidays();
+                shell.WriteLine(Loc.GetString("shell-command-success"));
+                return;
+
+            case 2:
+                if (!int.TryParse(args[0], out var day2) ||
+                    !int.TryParse(args[1], out var month2))
+                {
+                    shell.WriteError(Loc.GetString("shell-argument-must-be-number"));
+                    return;
+                }
+                date = new DateTime(DateTime.Now.Year, month2, day2);
+                break;
+
+            case 3:
+                if (!int.TryParse(args[0], out var day3) ||
+                    !int.TryParse(args[1], out var month3) ||
+                    !int.TryParse(args[2], out var year3))
+                {
+                    shell.WriteError(Loc.GetString("shell-argument-must-be-number"));
+                    return;
+                }
+                date = new DateTime(year3, month3, day3);
+                break;
+
+            default:
+                shell.WriteError(Loc.GetString("shell-need-between-arguments",("lower", 2), ("upper", 3)));
+                return;
+        }
+
+        _holidaySys.RefreshCurrentHolidays(date);
+        shell.WriteLine(Loc.GetString("shell-command-success"));
+    }
+}

--- a/Resources/Locale/en-US/administration/commands/holiday-refresh-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/holiday-refresh-command.ftl
@@ -1,0 +1,2 @@
+cmd-holidayrefresh-desc = Sets the current holidays to a date, or to server time.
+cmd-holidayrefresh-help = Usage: holidayrefresh <day> <month> [year]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Requires #39154

This PR adds an admin command to set the date used for checking holidays.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
For fun! Allows admins to setup holiday events off season.

## Technical details
<!-- Summary of code changes for easier review. -->
`holidayrefresh <day> <month> [year]`
Accepts 0, 2, or 3 arguments. At 0 arguments, it sets the date to the clock time on server.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are ex -->

https://github.com/user-attachments/assets/80a4c5ad-1524-4152-8eec-2f43a5998ab7


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: aada
ADMIN
- add: holidayrefresh command has been added, which sets the current holiday to any date. Note that holidays are reset when lobby starts.
