### PR TITLE
Add setscale, showrot, showvel, and showangvel engine command permissions

### DIFF
--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -9,6 +9,7 @@
   - vvwrite
   - vvinvoke
   - scale
+  - setscale
   - spin
 
 - Flags: DEBUG
@@ -40,6 +41,9 @@
   - hwid
   - showaudio
   - showpos
+  - showrot
+  - showvel
+  - showangvel
   - showray
   - showchunkbb
   - showgridnodes
@@ -60,7 +64,7 @@
   - watch
   - sendgarbage
   - setinputcontext
-  - showvelocities
+  - showplayervelocity
   - tilelookup
   - net_entityreport
   - scene


### PR DESCRIPTION
## About the PR
Requires https://github.com/space-wizards/RobustToolbox/pull/6096
Adds the new `setscale` command allowing you to set an entity's sprite scale for everyone on the server (instead of just your local client). This works similar to the existing `scale` command, but works in both dimensions and does not change the fixture.

I also enabled the `showrot`, `showvel` and `showangvel` commands for debugging permissions.
I originally forgot doing that when I added them in https://github.com/space-wizards/RobustToolbox/pull/5693
Those three are simple debugging overlays showing you entity rotation, velocity and angular velocity, similar to the existing `showpos` command which has the same permissions.
I also fixed the name of the `showplayervelocity` command which I had renamed in the PR above.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
ADMIN:
:cl:
- add: Added the "setscale" command to scale an entity's sprite in both dimensions.
- tweak: Enabled the "showrot", "showvel", and "showangvel" commands for debug permissions.

