### PR TITLE
Tweaks nukeop elimination announcement to be less wordy.

### DIFF
--- a/Resources/Locale/en-US/nukeops/nuke-ops.ftl
+++ b/Resources/Locale/en-US/nukeops/nuke-ops.ftl
@@ -1,2 +1,2 @@
-nuke-ops-no-more-threat-announcement-shuttle-call = Based on our scans from our long-range sensors, the nuclear threat is now eliminated. We will call emergency shuttle that will arrive shortly. ETA: {$time} {$units}. You can recall the shuttle to extend the shift.
-nuke-ops-no-more-threat-announcement = Based on our scans from our long-range sensors, the nuclear threat is now eliminated. Shuttle is already called.
+nuke-ops-no-more-threat-announcement-shuttle-call = Long-range sensors indicate the nuclear threat has been eliminated. The emergency shuttle has been called. ETA: {$time} {$units}. You may recall the shuttle to extend the shift.
+nuke-ops-no-more-threat-announcement = Long-range sensors indicate the nuclear threat has been eliminated. The emergency shuttle is already en route.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Just changes NukeOps elimination announcement to be less wordy.

## Why / Balance
Change was proposed in #38739 to make announcement less wordy and fix grammar.

## Technical details
Simple change in text in Resources/Locale/en-US/nukeops/nuke-ops.ftl

## Requirements
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Made NukeOps elimination announcement less wordy.

