### PR TITLE
Fix some debugging permissions

### DIFF
--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -40,6 +40,9 @@
   - hwid
   - showaudio
   - showpos
+  - showvel
+  - showrot
+  - showangvel
   - showray
   - showchunkbb
   - showgridnodes
@@ -60,7 +63,7 @@
   - watch
   - sendgarbage
   - setinputcontext
-  - showvelocities
+  - showplayervelocity
   - tilelookup
   - net_entityreport
   - scene


### PR DESCRIPTION
## About the PR
I enabled the `showrot`, `showvel` and `showangvel` commands for debugging permissions.
I originally forgot doing that when I added them in https://github.com/space-wizards/RobustToolbox/pull/5693
Those three are simple debugging overlays showing you entity rotation, velocity and angular velocity, similar to the existing `showpos` command which has the same permissions.
I also fixed the name of the `showplayervelocity` command which I had renamed in same PR.

## Why / Balance
they are useful debugging overlays

## Technical details
edit the yaml file

## Media
showrot
<img width="694" height="475" alt="grafik" src="https://github.com/user-attachments/assets/aec2f805-047a-4112-b7fc-6ad37eba5879" />

showvel
<img width="307" height="275" alt="grafik" src="https://github.com/user-attachments/assets/e75994fa-abec-4115-8c3d-a664efe877fe" />

showangvel
<img width="210" height="169" alt="grafik" src="https://github.com/user-attachments/assets/26abd267-d079-42ed-912b-c27d05912872" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
ADMIN:
:cl:
- tweak: Enabled the "showrot", "showvel" and "showangvel" commands for debug permissions.
- tweak: Fixed the "showplayervelocity" command permissions.
