### PR TITLE
Cleanup CS0618 and CS0414 warnings

### DIFF
--- a/Content.Server/Dragon/Components/DragonRiftComponent.cs
+++ b/Content.Server/Dragon/Components/DragonRiftComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Dragon;
+using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
@@ -37,4 +38,11 @@ public sealed partial class DragonRiftComponent : SharedDragonRiftComponent
 
     [ViewVariables(VVAccess.ReadWrite), DataField("spawn", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string SpawnPrototype = "MobCarpDragon";
+
+    /// <summary>
+    /// Sound played when the dragon rift reaches its warning state.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly), DataField]
+    public ResolvedSoundSpecifier? NoticeSound { get; private set; }
+
 }

--- a/Content.Server/Dragon/DragonRiftSystem.cs
+++ b/Content.Server/Dragon/DragonRiftSystem.cs
@@ -6,12 +6,10 @@ using Content.Shared.Damage;
 using Content.Shared.Dragon;
 using Content.Shared.Examine;
 using Content.Shared.Sprite;
-using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization.Manager;
 using System.Numerics;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.GameStates;
 using Robust.Shared.Utility;
@@ -83,7 +81,7 @@ public sealed class DragonRiftSystem : EntitySystem
                 var msg = Loc.GetString("carp-rift-warning",
                     ("location", FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, xform)))));
                 _chat.DispatchGlobalAnnouncement(msg, playSound: false, colorOverride: Color.Red);
-                _audio.PlayGlobal(new ResolvedPathSpecifier("/Audio/Misc/notice1.ogg"), Filter.Broadcast(), true);
+                _audio.PlayGlobal(comp.NoticeSound, Filter.Broadcast(), true);
                 _navMap.SetBeaconEnabled(uid, true);
             }
 

--- a/Content.Server/Dragon/DragonRiftSystem.cs
+++ b/Content.Server/Dragon/DragonRiftSystem.cs
@@ -83,7 +83,7 @@ public sealed class DragonRiftSystem : EntitySystem
                 var msg = Loc.GetString("carp-rift-warning",
                     ("location", FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, xform)))));
                 _chat.DispatchGlobalAnnouncement(msg, playSound: false, colorOverride: Color.Red);
-                _audio.PlayGlobal("/Audio/Misc/notice1.ogg", Filter.Broadcast(), true);
+                _audio.PlayGlobal(new ResolvedPathSpecifier("/Audio/Misc/notice1.ogg"), Filter.Broadcast(), true);
                 _navMap.SetBeaconEnabled(uid, true);
             }
 

--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -15,8 +15,6 @@ using Content.Server.Info;
 using Content.Server.IoC;
 using Content.Server.Maps;
 using Content.Server.NodeContainer.NodeGroups;
-using Content.Server.Objectives;
-using Content.Server.Players;
 using Content.Server.Players.JobWhitelist;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Players.RateLimiting;
@@ -190,7 +188,8 @@ namespace Content.Server.Entry
             _dbManager?.Shutdown();
             IoCManager.Resolve<ServerApi>().Shutdown();
 
-            IoCManager.Resolve<DiscordLink>().Shutdown();
+            // Use GetAwaiter().GetResult() to synchronously wait for async shutdown and avoid CS4014 warning.
+            IoCManager.Resolve<DiscordLink>().Shutdown().GetAwaiter().GetResult();
             IoCManager.Resolve<DiscordChatLink>().Shutdown();
         }
 

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -578,7 +578,7 @@ public sealed class FaxSystem : EntitySystem
         _appearanceSystem.SetData(uid, FaxMachineVisuals.VisualState, FaxMachineVisualState.Printing);
 
         if (component.NotifyAdmins)
-            NotifyAdmins(faxName);
+            NotifyAdmins(faxName, component);
 
         component.PrintingQueue.Enqueue(printout);
     }
@@ -619,9 +619,9 @@ public sealed class FaxSystem : EntitySystem
         _adminLogger.Add(LogType.Action, LogImpact.Low, $"\"{component.FaxName}\" {ToPrettyString(uid):tool} printed {ToPrettyString(printed):subject}: {printout.Content}");
     }
 
-    private void NotifyAdmins(string faxName)
+    private void NotifyAdmins(string faxName, FaxMachineComponent component)
     {
         _chat.SendAdminAnnouncement(Loc.GetString("fax-machine-chat-notify", ("fax", faxName)));
-        _audioSystem.PlayGlobal(new ResolvedPathSpecifier("/Audio/Machines/high_tech_confirm.ogg"), Filter.Empty().AddPlayers(_adminManager.ActiveAdmins), false, AudioParams.Default.WithVolume(-8f));
+        _audioSystem.PlayGlobal(component.AdminNoticeSound, Filter.Empty().AddPlayers(_adminManager.ActiveAdmins), false, AudioParams.Default.WithVolume(-8f));
     }
 }

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -622,6 +622,6 @@ public sealed class FaxSystem : EntitySystem
     private void NotifyAdmins(string faxName)
     {
         _chat.SendAdminAnnouncement(Loc.GetString("fax-machine-chat-notify", ("fax", faxName)));
-        _audioSystem.PlayGlobal("/Audio/Machines/high_tech_confirm.ogg", Filter.Empty().AddPlayers(_adminManager.ActiveAdmins), false, AudioParams.Default.WithVolume(-8f));
+        _audioSystem.PlayGlobal(new ResolvedPathSpecifier("/Audio/Machines/high_tech_confirm.ogg"), Filter.Empty().AddPlayers(_adminManager.ActiveAdmins), false, AudioParams.Default.WithVolume(-8f));
     }
 }

--- a/Content.Server/Mapping/MappingManager.cs
+++ b/Content.Server/Mapping/MappingManager.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Mapping;
 
 public sealed class MappingManager : IPostInjectInit
 {
+#if !FULL_RELEASE
     [Dependency] private readonly IAdminManager _admin = default!;
     [Dependency] private readonly ILogManager _log = default!;
     [Dependency] private readonly IServerNetManager _net = default!;
@@ -23,6 +24,7 @@ public sealed class MappingManager : IPostInjectInit
 
     private ISawmill _sawmill = default!;
     private ZStdCompressionContext _zstd = default!;
+#endif
 
     public void PostInject()
     {

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerComponent.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Storage;
+using Robust.Shared.Audio;
 
 namespace Content.Server.Medical.BiomassReclaimer
 {
@@ -73,5 +74,11 @@ namespace Content.Server.Medical.BiomassReclaimer
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite), DataField]
         public bool SafetyEnabled = true;
+
+        /// <summary>
+        /// Sound to be played when biomass reclaimer is started.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadOnly), DataField]
+        public SoundSpecifier StartupSound { get; private set; }
     }
 }

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -130,7 +130,12 @@ namespace Content.Server.Medical.BiomassReclaimer
         private void OnInit(EntityUid uid, ActiveBiomassReclaimerComponent component, ComponentInit args)
         {
             _jitteringSystem.AddJitter(uid, -10, 100);
-            _sharedAudioSystem.PlayPvs(new ResolvedPathSpecifier("/Audio/Machines/reclaimer_startup.ogg"), uid);
+
+            if (EntityManager.TryGetComponent(uid, out BiomassReclaimerComponent? reclaimer))
+            {
+                _sharedAudioSystem.PlayPvs(reclaimer.StartupSound, uid);
+            }
+
             _ambientSoundSystem.SetAmbience(uid, true);
         }
 

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -27,6 +27,7 @@ using Content.Shared.Popups;
 using Content.Shared.Power;
 using Content.Shared.Throwing;
 using Robust.Server.Player;
+using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.Physics.Components;
@@ -129,7 +130,7 @@ namespace Content.Server.Medical.BiomassReclaimer
         private void OnInit(EntityUid uid, ActiveBiomassReclaimerComponent component, ComponentInit args)
         {
             _jitteringSystem.AddJitter(uid, -10, 100);
-            _sharedAudioSystem.PlayPvs("/Audio/Machines/reclaimer_startup.ogg", uid);
+            _sharedAudioSystem.PlayPvs(new ResolvedPathSpecifier("/Audio/Machines/reclaimer_startup.ogg"), uid);
             _ambientSoundSystem.SetAmbience(uid, true);
         }
 

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -50,7 +50,7 @@ public sealed class NukeSystem : EntitySystem
     ///     Used to calculate when the nuke song should start playing for maximum kino with the nuke sfx
     /// </summary>
     private float _nukeSongLength;
-    private ResolvedSoundSpecifier _selectedNukeSong = new ResolvedPathSpecifier(String.Empty);
+    private ResolvedSoundSpecifier? _selectedNukeSong;
 
     /// <summary>
     ///     Time to leave between the nuke song and the nuke alarm playing.
@@ -321,7 +321,8 @@ public sealed class NukeSystem : EntitySystem
         // should play
         if (nuke.RemainingTime <= _nukeSongLength + nuke.AlertSoundTime + NukeSongBuffer && !nuke.PlayedNukeSong && !ResolvedSoundSpecifier.IsNullOrEmpty(_selectedNukeSong))
         {
-            _sound.DispatchStationEventMusic(uid, _selectedNukeSong, StationEventMusicType.Nuke);
+            // Using '!' because null check just happened, but the compiler doesn't recognize it.
+            _sound.DispatchStationEventMusic(uid, _selectedNukeSong!, StationEventMusicType.Nuke);
             nuke.PlayedNukeSong = true;
         }
 

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -50,7 +50,7 @@ public sealed class NukeSystem : EntitySystem
     ///     Used to calculate when the nuke song should start playing for maximum kino with the nuke sfx
     /// </summary>
     private float _nukeSongLength;
-    private ResolvedSoundSpecifier _selectedNukeSong = String.Empty;
+    private ResolvedSoundSpecifier _selectedNukeSong = new ResolvedPathSpecifier(String.Empty);
 
     /// <summary>
     ///     Time to leave between the nuke song and the nuke alarm playing.

--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -1,5 +1,6 @@
 using Content.Server.ParticleAccelerator.Wires;
 using Content.Shared.Singularity.Components;
+using Robust.Shared.Audio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.ParticleAccelerator.Components;
@@ -125,6 +126,12 @@ public sealed partial class ParticleAcceleratorControlBoxComponent : Component
     /// </summary>
     [DataField]
     public TimeSpan CooldownDuration = TimeSpan.FromSeconds(10f);
+
+    /// <summary>
+    /// Sound to be played for admin alarm sound effect.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly), DataField]
+    public SoundSpecifier AdminAlertSound { get; private set; }
 
     /// <summary>
     /// Whether the PA can be turned on.

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
@@ -187,7 +187,7 @@ public sealed partial class ParticleAcceleratorSystem
                         ("machine", ToPrettyString(uid)),
                         ("powerState", GetPANumericalLevel(strength)),
                         ("coordinates", pos.Coordinates)));
-                    _audio.PlayGlobal(new ResolvedPathSpecifier("/Audio/Misc/adminlarm.ogg"),
+                    _audio.PlayGlobal(comp.AdminAlertSound,
                         Filter.Empty().AddPlayers(_adminManager.ActiveAdmins),
                         false,
                         AudioParams.Default.WithVolume(-8f));

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
@@ -187,7 +187,7 @@ public sealed partial class ParticleAcceleratorSystem
                         ("machine", ToPrettyString(uid)),
                         ("powerState", GetPANumericalLevel(strength)),
                         ("coordinates", pos.Coordinates)));
-                    _audio.PlayGlobal("/Audio/Misc/adminlarm.ogg",
+                    _audio.PlayGlobal(new ResolvedPathSpecifier("/Audio/Misc/adminlarm.ogg"),
                         Filter.Empty().AddPlayers(_adminManager.ActiveAdmins),
                         false,
                         AudioParams.Default.WithVolume(-8f));

--- a/Content.Server/Power/Nodes/CableNode.cs
+++ b/Content.Server/Power/Nodes/CableNode.cs
@@ -1,7 +1,5 @@
-using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.Nodes;
 using Content.Shared.NodeContainer;
-using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 
 namespace Content.Server.Power.Nodes

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -188,8 +188,7 @@ namespace Content.Server.RoundEnd
                 null,
                 Color.Gold);
 
-            _audio.PlayGlobal("/Audio/Announcements/shuttlecalled.ogg", Filter.Broadcast(), true);
-
+            _audio.PlayGlobal("/Audio/Announcements/shuttlerecalled.ogg", Filter.Broadcast(), true);
             LastCountdownStart = _gameTiming.CurTime;
             ExpectedCountdownEnd = _gameTiming.CurTime + countdownTime;
 

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared.DeviceNetwork.Components;
+using Robust.Shared.Audio;
 using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.RoundEnd
@@ -235,7 +236,7 @@ namespace Content.Server.RoundEnd
             _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("round-end-system-shuttle-recalled-announcement"),
                 Loc.GetString("round-end-system-shuttle-sender-announcement"), false, colorOverride: Color.Gold);
 
-            _audio.PlayGlobal("/Audio/Announcements/shuttlerecalled.ogg", Filter.Broadcast(), true);
+            _audio.PlayGlobal(new ResolvedPathSpecifier("/Audio/Announcements/shuttlerecalled.ogg"), Filter.Broadcast(), true);
 
             LastCountdownStart = null;
             ExpectedCountdownEnd = null;

--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -438,15 +438,6 @@ public sealed partial class SalvageSystem
             var box2 = Box2.CenteredAround(finalCoords.Position, bounds.Size);
             var box2Rot = new Box2Rotated(box2, angle, finalCoords.Position);
 
-            // This doesn't stop it from spawning on top of random things in space
-            // Might be better like this, ghosts could stop it before
-            if (_mapManager.FindGridsIntersecting(finalCoords.MapId, box2Rot).Any())
-            {
-                // Bump it further and further just in case.
-                fraction += 0.1f;
-                continue;
-            }
-
             coords = finalCoords;
             return true;
         }

--- a/Content.Server/Shuttles/Components/EmergencyShuttleConsoleComponent.cs
+++ b/Content.Server/Shuttles/Components/EmergencyShuttleConsoleComponent.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Audio;
+
 namespace Content.Server.Shuttles.Components;
 
 [RegisterComponent]
@@ -13,4 +15,10 @@ public sealed partial class EmergencyShuttleConsoleComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField("authorizationsRequired")]
     public int AuthorizationsRequired = 3;
+
+    /// <summary>
+    /// Sound to be played when Emergency is authorized
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly), DataField]
+    public SoundSpecifier EmergencyAuthorizeSound  { get;  private set; }
 }

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -306,7 +306,7 @@ public sealed partial class EmergencyShuttleSystem
                 playSound: false, colorOverride: DangerColor);
 
         if (!CheckForLaunch(component))
-            _audio.PlayGlobal(new ResolvedPathSpecifier("/Audio/Misc/notice1.ogg"), Filter.Broadcast(), recordReplay: true);
+            _audio.PlayGlobal(component.EmergencyAuthorizeSound, Filter.Broadcast(), recordReplay: true);
 
         UpdateAllEmergencyConsoles();
     }

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -12,6 +12,7 @@ using Content.Shared.Shuttles.BUIStates;
 using Content.Shared.Shuttles.Events;
 using Content.Shared.Shuttles.Systems;
 using Content.Shared.UserInterface;
+using Robust.Shared.Audio;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -305,7 +306,7 @@ public sealed partial class EmergencyShuttleSystem
                 playSound: false, colorOverride: DangerColor);
 
         if (!CheckForLaunch(component))
-            _audio.PlayGlobal("/Audio/Misc/notice1.ogg", Filter.Broadcast(), recordReplay: true);
+            _audio.PlayGlobal(new ResolvedPathSpecifier("/Audio/Misc/notice1.ogg"), Filter.Broadcast(), recordReplay: true);
 
         UpdateAllEmergencyConsoles();
     }
@@ -409,7 +410,7 @@ public sealed partial class EmergencyShuttleSystem
             playSound: false,
             colorOverride: DangerColor);
 
-        _audio.PlayGlobal("/Audio/Misc/notice1.ogg", Filter.Broadcast(), recordReplay: true);
+        _audio.PlayGlobal(new ResolvedPathSpecifier("/Audio/Misc/notice1.ogg"), Filter.Broadcast(), recordReplay: true);
     }
 
     public bool DelayEmergencyRoundEnd()

--- a/Content.Server/StationEvents/Events/ImmovableRodRule.cs
+++ b/Content.Server/StationEvents/Events/ImmovableRodRule.cs
@@ -1,12 +1,10 @@
 using System.Numerics;
-using Content.Server.GameTicking.Rules.Components;
 using Content.Server.ImmovableRod;
 using Content.Server.StationEvents.Components;
 using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Storage;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
 using TimedDespawnComponent = Robust.Shared.Spawners.TimedDespawnComponent;
 using System.Linq;
 

--- a/Content.Server/StationEvents/Events/ImmovableRodRule.cs
+++ b/Content.Server/StationEvents/Events/ImmovableRodRule.cs
@@ -35,7 +35,7 @@ public sealed class ImmovableRodRule : StationEventSystem<ImmovableRodRuleCompon
             var speed = RobustRandom.NextFloat(rod.MinSpeed, rod.MaxSpeed);
             var angle = RobustRandom.NextAngle();
             var direction = angle.ToVec();
-            var spawnCoords = targetCoords.ToMap(EntityManager, _transform).Offset(-direction * speed * despawn.Lifetime / 2);
+            var spawnCoords = _transform.ToMapCoordinates(targetCoords).Offset(-direction * speed * despawn.Lifetime / 2);
             var ent = Spawn(protoName, spawnCoords);
             _gun.ShootProjectile(ent, direction, Vector2.Zero, uid, speed: speed);
         }

--- a/Content.Shared/Fax/Components/FaxMachineComponent.cs
+++ b/Content.Shared/Fax/Components/FaxMachineComponent.cs
@@ -62,14 +62,20 @@ public sealed partial class FaxMachineComponent : Component
     /// <summary>
     /// Sound to play when fax printing new message
     /// </summary>
-    [DataField]
-    public SoundSpecifier PrintSound = new SoundPathSpecifier("/Audio/Machines/printer.ogg");
+    [ViewVariables(VVAccess.ReadOnly), DataField]
+    public SoundSpecifier PrintSound { get; private set; }
 
     /// <summary>
-    /// Sound to play when fax successfully send message
+    /// Sound to play when a fax successfully sends a message
     /// </summary>
-    [DataField]
-    public SoundSpecifier SendSound = new SoundPathSpecifier("/Audio/Machines/high_tech_confirm.ogg");
+    [ViewVariables(VVAccess.ReadOnly), DataField]
+    public SoundSpecifier SendSound { get; private set; }
+
+    /// <summary>
+    /// Sound to play when notifying admins of a fax.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly), DataField("notifyAdminSound")]
+    public SoundSpecifier AdminNoticeSound { get; private set; }
 
     /// <summary>
     /// Known faxes in network by address with fax names

--- a/Content.Shared/Movement/Systems/WormSystem.cs
+++ b/Content.Shared/Movement/Systems/WormSystem.cs
@@ -12,7 +12,6 @@ namespace Content.Shared.Movement.Systems;
 public sealed class WormSystem : EntitySystem
 {
     [Dependency] private readonly AlertsSystem _alerts = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
 
     public override void Initialize()

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -100,6 +100,7 @@
     access:
     - [ Command ]
   - type: EmergencyShuttleConsole
+    emergencyAuthorizeSound: /Audio/Misc/notice1.ogg
   - type: ActivatableUI
     key: enum.EmergencyConsoleUiKey.Key
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/biomass_reclaimer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/biomass_reclaimer.yml
@@ -11,6 +11,7 @@
     state: icon
     snapCardinals: true
   - type: BiomassReclaimer
+    startupSound: /Audio/Machines/reclaimer_startup.ogg
   - type: Climbable
     delay: 7
   - type: AmbientSound

--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -51,6 +51,10 @@
       blacklist:
         components:
           - CargoSlip
+    sounds:
+      notifyAdminSound: /Audio/Machines/high_tech_confirm.ogg
+      sendSound: /Audio/Machines/high_tech_confirm.ogg
+      printSound: /Audio/Machines/printer.ogg
   - type: GenericVisualizer
     visuals:
       enum.PowerDeviceVisuals.Powered:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
@@ -7,6 +7,7 @@
   - type: Sprite
     sprite: Structures/Power/Generation/PA/control_box.rsi
   - type: ParticleAcceleratorControlBox
+    adminAlertSound: /Audio/Misc/adminlarm.ogg
   - type: ApcPowerReceiver
     powerLoad: 250
   - type: ExtensionCableReceiver

--- a/Resources/Prototypes/Entities/Structures/Specific/dragon.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/dragon.yml
@@ -6,6 +6,8 @@
     mode: SnapgridCenter
   components:
   - type: DragonRift
+    sound:
+      noticeSound: /Audio/Misc/notice1.ogg
   - type: Transform
     anchored: true
   - type: Physics


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Various build warning fixes/removals. Reduces Content.Server warnings from 218->208. 
Nothing crazy I know, but many of the warnings are repeats of Obsolete warnings that require restructuring of parameters
of functions and how we call them which seems like a lot of work for not much payoff (at least at the moment)

## Why / Balance
Just a small addition to #33279 that cleans up various warnings.

## Technical details
* Removes a grid intersection check that serves so function
* Removes unused 'using's from a couple of files
* Cleans up a few CS0618 warnings (mostly by using the ResolvedPathSpecifier on sound files paths)
* Cleans a few CS0414 warnings by matching build flags to field to a group of fields and removing unused fields


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
