### PR TITLE
Make drop range same as actual interaction range

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -6,6 +6,7 @@ using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Tag;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
@@ -183,17 +184,42 @@ public abstract partial class SharedHandsSystem
     /// <summary>
     ///     Calculates the final location a dropped item will end up at, accounting for max drop range and collision along the targeted drop path, Does a check to see if a user should bypass those checks as well.
     /// </summary>
-    private Vector2 GetFinalDropCoordinates(EntityUid user, MapCoordinates origin, MapCoordinates target, EntityUid held)
+    private Vector2 GetFinalDropCoordinates(EntityUid user, MapCoordinates origin, MapCoordinates target, EntityUid held, FixturesComponent? xfA = null, FixturesComponent? xfB = null)
     {
         var dropVector = target.Position - origin.Position;
         var requestedDropDistance = dropVector.Length();
         var dropLength = dropVector.Length();
+        var range = SharedInteractionSystem.InteractionRange;
+
+        if (Resolve(user, ref xfA) && xfA.FixtureCount != 0)
+        {
+            var maxRange = 0f;
+            foreach (var fixture in xfA.Fixtures.Values)
+            {
+                var newRange = fixture.Shape.Radius + SharedInteractionSystem.InteractionRange;
+                if (newRange > maxRange)
+                    maxRange = fixture.Shape.Radius;
+            }
+            range += maxRange;
+        }
+
+        if (Resolve(held, ref xfB) && xfB.FixtureCount != 0)
+        {
+            var maxRange = 0f;
+            foreach (var fixture in xfB.Fixtures.Values)
+            {
+                var newRange = fixture.Shape.Radius + SharedInteractionSystem.InteractionRange;
+                if (newRange > maxRange)
+                    maxRange = fixture.Shape.Radius;
+            }
+            range += maxRange;
+        }
 
         if (ShouldIgnoreRestrictions(user))
         {
-            if (dropVector.Length() > SharedInteractionSystem.InteractionRange)
+            if (dropVector.Length() > range)
             {
-                dropVector = dropVector.Normalized() * SharedInteractionSystem.InteractionRange;
+                dropVector = dropVector.Normalized() * range;
                 target = new MapCoordinates(origin.Position + dropVector, target.MapId);
             }
 


### PR DESCRIPTION
## About the PR
This pr makes drop range same as interaction range with objects.

## Why / Balance
I'm tired. Everyone tired. This is awful bug. Fixes #38847.

## Technical details
Now `GetFinalDropCoordinates` also uses fixtures for calculating interaction range.

## Media
https://github.com/user-attachments/assets/43d20729-775a-4bb8-9a37-e3e943d07599

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Now the range of droping objects is equal to the range of interaction with them