### PR TITLE
fix: respect AllowedSlots for gogo hat

### DIFF
--- a/Content.Server/VoiceTrigger/StorageVoiceControlSystem.cs
+++ b/Content.Server/VoiceTrigger/StorageVoiceControlSystem.cs
@@ -29,10 +29,9 @@ public sealed class StorageVoiceControlSystem : EntitySystem
 
     private void VoiceTriggered(Entity<StorageVoiceControlComponent> ent, ref VoiceTriggeredEvent args)
     {
-        // Check if the component has any slot restrictions via AllowedSlots
         // If it has slot restrictions, check if the item is in a slot that is allowed
-        if (ent.Comp.AllowedSlots != null && _inventory.TryGetContainingSlot(ent.Owner, out var itemSlot) &&
-            (itemSlot.SlotFlags & ent.Comp.AllowedSlots) == 0)
+        if (ent.Comp.AllowedSlots is { } allowedSlots
+            && !_inventory.InSlotWithAnyFlags(ent.Owner, allowedSlots))
             return;
 
         // Get the storage component

--- a/Content.Shared/Inventory/InventorySystem.Helpers.cs
+++ b/Content.Shared/Inventory/InventorySystem.Helpers.cs
@@ -47,12 +47,24 @@ public partial class InventorySystem
     }
 
     /// <summary>
-    ///     Returns true if the given entity is equipped to an inventory slot with the given inventory slot flags.
+    /// Returns true if the given entity is equipped to an inventory slot with exactly matching inventory slot flags.
     /// </summary>
+    /// <seealso cref="InSlotWithAnyFlags" />
     public bool InSlotWithFlags(Entity<TransformComponent?, MetaDataComponent?> entity, SlotFlags flags)
     {
         return TryGetContainingSlot(entity, out var slot)
                && (slot.SlotFlags & flags) == flags;
+    }
+
+    /// <summary>
+    /// Returns true if the given entity is equipped to an inventory slot that
+    /// has any flags in common with the given ones.
+    /// </summary>
+    /// <seealso cref="InSlotWithFlags" />
+    public bool InSlotWithAnyFlags(Entity<TransformComponent?, MetaDataComponent?> ent, SlotFlags flags)
+    {
+        return TryGetContainingSlot(ent, out var slot)
+               && (slot.SlotFlags & flags) != 0;
     }
 
     public bool SpawnItemInSlot(EntityUid uid, string slot, string prototype, bool silent = false, bool force = false, InventoryComponent? inventory = null)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The gogo hat wasn't properly checking to see if it was worn when it heard its voice trigger, allowing you to use it when it is e.g., in your backpack. This restores the intended behavior of it only retrieving and storing items when on your head.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Unintended behavior bad.

## Technical details
<!-- Summary of code changes for easier review. -->
TryGetContainingSlot returns false if the item given isn't in an inventory slot at all, short-circuiting the if. I added a convenience InSlotWithAnyFlags method to handle checking if an item is in a slot that overlaps the supplied bitmask, since InSlotWithFlags checks for an exact match—I'm not actually sure why this is.

#### API bikeshedding

The two existing usages of InSlotWithFlags could honestly be switched to InSlotWithAnyFlags without any change in behavior for us, which means we could then just remove InSlotWithFlags. I'm not sure if there's a potential use for it that I'm not thinking of that is good enough to justify keeping it around unused.

Is there any circumstance where an inventory slot has slotFlags set with multiple flags? (Maybe a weird inventory template that is meant to allow multiple types of equipment in a slot, but there also are certain items that are meant to require that combination of flags to be equipped?) 

https://github.com/space-wizards/space-station-14/blob/092f88c16fa9768121a3b54afb5e9ea124b51f34/Content.Shared/Clothing/EntitySystems/MaskSystem.cs#L31
https://github.com/space-wizards/space-station-14/blob/b3825dce97e7debd8ea376ce7f247e050f812eb2/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs#L67

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The go go hat can now only retrieve and store items when worn.