### PR TITLE
Fix error when deleting a toggled `ToggleableClothingComponent`

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -213,7 +213,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
         if (!TryComp(component.AttachedUid, out ToggleableClothingComponent? toggleComp))
             return;
 
-        if (toggleComp.LifeStage > ComponentLifeStage.Running)
+        if (LifeStage(component.AttachedUid) > EntityLifeStage.MapInitialized)
             return;
 
         // As unequipped gets called in the middle of container removal, we cannot call a container-insert without causing issues.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Deleting an entity with a `ToggleableClothingComponent` that has been toggled active no longer causes an error from trying to insert the item into a terminating container.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/39182.

## Technical details
<!-- Summary of code changes for easier review. -->
`OnAttachedUnequip` checks that the containing entity's `ToggleableClothingComponent` isn't terminating, but it needs to check if the containing entity itself is terminating.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->