### PR TITLE
Admin logs for batteries UI

### DIFF
--- a/Content.Server/Power/EntitySystems/BatteryInterfaceSystem.cs
+++ b/Content.Server/Power/EntitySystems/BatteryInterfaceSystem.cs
@@ -1,4 +1,6 @@
-﻿using Content.Server.Power.Components;
+﻿using Content.Server.Administration.Logs;
+using Content.Server.Power.Components;
+using Content.Shared.Database;
 using Content.Shared.Power;
 using Robust.Server.GameObjects;
 
@@ -19,6 +21,7 @@ namespace Content.Server.Power.EntitySystems;
 /// </remarks>
 public sealed class BatteryInterfaceSystem : EntitySystem
 {
+    [Dependency] private readonly IAdminLogManager _adminLog = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = null!;
 
     public override void Initialize()
@@ -43,12 +46,16 @@ public sealed class BatteryInterfaceSystem : EntitySystem
     {
         var netBattery = Comp<PowerNetworkBatteryComponent>(ent);
         netBattery.CanCharge = args.On;
+
+        _adminLog.Add(LogType.Action,$"{ToPrettyString(args.Actor):actor} set input breaker to {args.On} on {ToPrettyString(ent):target}");
     }
 
     private void HandleSetOutputBreaker(Entity<BatteryInterfaceComponent> ent, ref BatterySetOutputBreakerMessage args)
     {
         var netBattery = Comp<PowerNetworkBatteryComponent>(ent);
         netBattery.CanDischarge = args.On;
+
+        _adminLog.Add(LogType.Action,$"{ToPrettyString(args.Actor):actor} set output breaker to {args.On} on {ToPrettyString(ent):target}");
     }
 
     private void HandleSetChargeRate(Entity<BatteryInterfaceComponent> ent, ref BatterySetChargeRateMessage args)


### PR DESCRIPTION
## About the PR
Adds admin logs for SMES and substation UI

## Why / Balance
Players can turn off the power and leave no trace, which makes it difficult to find out who did it.

## Media
<img width="666" height="232" alt="image" src="https://github.com/user-attachments/assets/c953312b-fad5-42bd-a1b8-d5de9ae65a56" />
<img width="666" height="232" alt="image" src="https://github.com/user-attachments/assets/db19022f-514a-4c24-aa06-ca32d9f15a58" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
I guess it's not that important
