### PR TITLE
Fix Stamina Animation Applying State Error

### DIFF
--- a/Content.Client/Stunnable/StunSystem.cs
+++ b/Content.Client/Stunnable/StunSystem.cs
@@ -104,7 +104,7 @@ public sealed class StunSystem : SharedStunSystem
         Vector2 maxJitter,
         float breathing,
         Vector2 startOffset,
-        ref Vector2 lastJitter)
+        ref Vector2? lastJitter)
     {
         // avoid animations with negative length or infinite length
         if (frequency <= 0)
@@ -125,8 +125,8 @@ public sealed class StunSystem : SharedStunSystem
             offset.X *= _random.Pick(_sign);
             offset.Y *= _random.Pick(_sign);
 
-            if (i == 1 && Math.Sign(offset.X) == Math.Sign(lastJitter.X)
-                       && Math.Sign(offset.Y) == Math.Sign(lastJitter.Y))
+            if (lastJitter != null && i == 1 && Math.Sign(offset.X) == Math.Sign(lastJitter.Value.X)
+                       && Math.Sign(offset.Y) == Math.Sign(lastJitter.Value.Y))
             {
                 // If the sign is the same as last time on both axis we flip one randomly
                 // to avoid jitter staying in one quadrant too much.

--- a/Content.Shared/Damage/Components/StaminaComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaComponent.cs
@@ -157,7 +157,7 @@ public sealed partial class StaminaComponent : Component
     /// Vector of the last Jitter so we can make sure we don't jitter in the same quadrant twice in a row.
     /// </summary>
     [DataField]
-    public Vector2 LastJitter;
+    public Vector2? LastJitter;
 
     /// <summary>
     ///     The offset that an entity had before jittering started,


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made the LastJitter vector nullable since when starting the animation, you won't have an initial jitter vector.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Prevents an error where when checking if you were in the previous quadrant and there wasn't a previous vector (i.e, an entity enters PVS the same tick the animation starts), it would throw an error causing the client to request a full game state. 

## Technical details
<!-- Summary of code changes for easier review. -->
Made a variable nullable and added checks for it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
