### PR TITLE
Make dirt non-compressible

### DIFF
--- a/Resources/Textures/Tiles/Planet/dirt.rsi/meta.json
+++ b/Resources/Textures/Tiles/Planet/dirt.rsi/meta.json
@@ -6,6 +6,7 @@
     "x": 32,
     "y": 32
   },
+  "rsic": false,
   "states": [
     {
       "name": "dirt"


### PR DESCRIPTION
This sets the new rsic: false flag in dirt.rsi. One of the interior PNGs is directly accessed by a tile definition, which would otherwise cause a game startup failure with the new packaging improvements: https://github.com/space-wizards/RobustToolbox/commit/c4dff678a9511190da2e6217992852d5e1df7985
