### PR TITLE
Make instruments playing music globally override PVS

### DIFF
--- a/Content.Server/Instruments/InstrumentSystem.cs
+++ b/Content.Server/Instruments/InstrumentSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Physics;
 using Content.Shared.Popups;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
+using Robust.Server.GameStates;
 using Robust.Shared.Audio.Midi;
 using Robust.Shared.Collections;
 using Robust.Shared.Configuration;
@@ -37,6 +38,7 @@ public sealed partial class InstrumentSystem : SharedInstrumentSystem
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly ExamineSystemShared _examineSystem = default!;
     [Dependency] private readonly IAdminLogManager _admingLogSystem = default!;
+    [Dependency] private readonly PvsOverrideSystem _pvsOverride = default!;
 
     private const float MaxInstrumentBandRange = 10f;
 
@@ -116,6 +118,9 @@ public sealed partial class InstrumentSystem : SharedInstrumentSystem
     {
         var uid = GetEntity(msg.Uid);
 
+        // DOOM TOOTS AS HE PLEASES
+        _pvsOverride.AddGlobalOverride(uid);
+
         if (!TryComp(uid, out InstrumentComponent? instrument))
             return;
 
@@ -129,6 +134,9 @@ public sealed partial class InstrumentSystem : SharedInstrumentSystem
     private void OnMidiStop(InstrumentStopMidiEvent msg, EntitySessionEventArgs args)
     {
         var uid = GetEntity(msg.Uid);
+
+        // DOOM RESPECTFULLY PUTS THE TRUMPET BACK IN ITS CASE
+        _pvsOverride.RemoveGlobalOverride(uid);
 
         if (!TryComp(uid, out InstrumentComponent? instrument))
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes https://github.com/space-wizards/space-station-14/issues/39224 via a dirty PVS hack

## Why / Balance
MIDIs not audible in certain circumstances makes being a musician lame

## Technical details
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/c22636c0-3cd4-4fde-a799-80d5b5953380

## Requirements

<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
me, I am the breaking change

<img width="640" height="480" alt="590" src="https://github.com/user-attachments/assets/a7d53f56-aec8-4e56-b381-6d2c5090d8d9" />


**Changelog**
:cl:
- fix: Instruments now won't be silent if you walk away from them and then come back, at the cost of @FairlySadPanda's sanity