### PR TITLE
Added utility belt function to scrap armor

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/scraparmor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/scraparmor.yml
@@ -51,7 +51,7 @@
 
 # The armor itself
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseMajorContraband]
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseMajorContraband, ClothingBeltUtility]
   id: ClothingOuterArmorScrap
   name: scrap armor
   description: A tider's gleaming plate mail. Bail up, or you're a dead man.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Scrap armor now has a built in utility belt

## Why / Balance
Idea originated from Djmc216 on the #ideaguys channel, and was thumbsed up by emisse, it makes sense for this because you actually need 

## Technical details
Added the belt parent to the scrap armor, no you cannot put the armor in the belt slot.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1657" height="506" alt="image_2025-07-26_201956328" src="https://github.com/user-attachments/assets/9f985f7e-6472-4964-b946-c3c931acb576" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Toast_Enjoyer, Djmc216
- add: The scrap armor now functions as a utility belt too!
