### PR TITLE
Add admin logging to Wireless entertainment cameras

### DIFF
--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSystem.cs
@@ -1,6 +1,8 @@
+using Content.Server.Administration.Logs;
 using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Emp;
 using Content.Shared.ActionBlocker;
+using Content.Shared.Database;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.DeviceNetwork.Events;
 using Content.Shared.Power;
@@ -21,6 +23,8 @@ public sealed class SurveillanceCameraSystem : EntitySystem
     [Dependency] private readonly DeviceNetworkSystem _deviceNetworkSystem = default!;
     [Dependency] private readonly UserInterfaceSystem _userInterface = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+
 
     // Pings a surveillance camera subnet. All cameras will always respond
     // with a data message if they are on the same subnet.
@@ -170,6 +174,7 @@ public sealed class SurveillanceCameraSystem : EntitySystem
         component.CameraId = args.Name;
         component.NameSet = true;
         UpdateSetupInterface(uid, component);
+        _adminLogger.Add(LogType.Chat, LogImpact.Low, $"{ToPrettyString(args.Actor)} set the name of {ToPrettyString(uid)} to \"{args.Name}.\"");
     }
 
     private void OnSetNetwork(EntityUid uid, SurveillanceCameraComponent component,


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR adds more admin logging for wireless entertainment cameras, since yes, that wasn't logged before.

## Why / Balance
Admin logging good.

## Technical details
Just a singular import extra with the admin log manager.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**

