### PR TITLE
Fix SSD text delay on examine

### DIFF
--- a/Content.Shared/Mind/Components/MindStatusComponent.cs
+++ b/Content.Shared/Mind/Components/MindStatusComponent.cs
@@ -1,0 +1,56 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Mind.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class MindStatusComponent : Component
+{
+    /// <summary>
+    /// The current status of this entity's mind/player connection
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public MindStatus Status = MindStatus.Catatonic;
+}
+
+public enum MindStatus : byte
+{
+    /// <summary>
+    /// Entity was never controlled by a player (no mind)
+    /// </summary>
+    Catatonic,
+
+    /// <summary>
+    /// Player is connected and alive
+    /// </summary>
+    Active,
+
+    /// <summary>
+    /// Player disconnected while alive (SSD)
+    /// </summary>
+    SSD,
+
+    /// <summary>
+    /// Player is dead but still connected
+    /// </summary>
+    Dead,
+
+    /// <summary>
+    /// Player died and disconnected
+    /// </summary>
+    DeadAndSSD,
+
+    /// <summary>
+    /// Entity is permanently dead with no player ever attached
+    /// </summary>
+    DeadAndIrrecoverable
+}
+
+public sealed class ForceUpdateMindStatusEvent : EntityEventArgs
+{
+    public EntityUid Entity { get; }
+
+    public ForceUpdateMindStatusEvent(EntityUid entity)
+    {
+        Entity = entity;
+    }
+}

--- a/Content.Shared/Mind/MindExamineSystem.cs
+++ b/Content.Shared/Mind/MindExamineSystem.cs
@@ -1,0 +1,55 @@
+using Content.Shared.Examine;
+using Content.Shared.Mind.Components;
+
+namespace Content.Shared.Mind;
+
+/// <summary>
+/// Handles examine text for mind status.
+/// </summary>
+public sealed class MindExamineSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<MindStatusComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(EntityUid uid, MindStatusComponent component, ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        // Check if the entity has MindContainerComponent with ShowExamineInfo enabled
+        if (!TryComp<MindContainerComponent>(uid, out var container) || !container.ShowExamineInfo)
+            return;
+
+        var text = component.Status switch
+        {
+            MindStatus.DeadAndIrrecoverable => Loc.GetString("comp-mind-examined-dead-and-irrecoverable", ("ent", uid)),
+            MindStatus.DeadAndSSD => Loc.GetString("comp-mind-examined-dead-and-ssd", ("ent", uid)),
+            MindStatus.Dead => Loc.GetString("comp-mind-examined-dead", ("ent", uid)),
+            MindStatus.Catatonic => Loc.GetString("comp-mind-examined-catatonic", ("ent", uid)),
+            MindStatus.SSD => Loc.GetString("comp-mind-examined-ssd", ("ent", uid)),
+            MindStatus.Active => null, // No special text for active players
+            _ => null
+        };
+
+        if (text != null)
+        {
+            args.PushMarkup($"[color={GetColorForStatus(component.Status)}]{text}[/color]");
+        }
+    }
+
+    private static string GetColorForStatus(MindStatus status)
+    {
+        return status switch
+        {
+            MindStatus.DeadAndIrrecoverable => "mediumpurple",
+            MindStatus.DeadAndSSD => "yellow",
+            MindStatus.Dead => "red",
+            MindStatus.Catatonic => "mediumpurple",
+            MindStatus.SSD => "yellow",
+            _ => "white"
+        };
+    }
+}

--- a/Content.Shared/Mind/MindStatusSystem.cs
+++ b/Content.Shared/Mind/MindStatusSystem.cs
@@ -1,0 +1,170 @@
+using Content.Shared.Mind.Components;
+using Content.Shared.Mobs.Systems;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.Mind;
+
+public sealed class MindStatusSystem : EntitySystem
+{
+    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
+    [Dependency] private readonly SharedMindSystem _mindSystem = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly INetManager _net = default!;
+
+    private TimeSpan _nextUpdate = TimeSpan.Zero;
+    private const float UpdateInterval = 1.0f;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MindStatusComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<MindContainerComponent, ComponentStartup>(OnContainerStartup);
+        SubscribeLocalEvent<MindContainerComponent, ComponentAdd>(OnContainerAdded);
+        SubscribeLocalEvent<MindContainerComponent, MindAddedMessage>(OnMindAdded);
+        SubscribeLocalEvent<MindContainerComponent, MindRemovedMessage>(OnMindRemoved);
+        SubscribeLocalEvent<ForceUpdateMindStatusEvent>(OnForceUpdate);
+
+        if (_net.IsServer)
+        {
+            _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
+        }
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        if (_net.IsServer)
+        {
+            _playerManager.PlayerStatusChanged -= OnPlayerStatusChanged;
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_net.IsClient)
+            return;
+
+        if (_timing.CurTime < _nextUpdate) // Periodic update for edge cases
+            return;
+
+        _nextUpdate = _timing.CurTime + TimeSpan.FromSeconds(UpdateInterval);
+
+        var query = EntityQueryEnumerator<MindStatusComponent, MindContainerComponent>();
+        while (query.MoveNext(out var uid, out var status, out var container))
+        {
+            UpdateMindStatus(uid, status, container);
+        }
+    }
+
+    private void OnStartup(EntityUid uid, MindStatusComponent component, ComponentStartup args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (TryComp<MindContainerComponent>(uid, out var container))
+            UpdateMindStatus(uid, component, container);
+    }
+
+    private void OnMindAdded(EntityUid uid, MindContainerComponent component, MindAddedMessage args)
+    {
+        if (_net.IsClient)
+            return;
+
+        EnsureComp<MindStatusComponent>(uid);
+        if (TryComp<MindStatusComponent>(uid, out var status))
+            UpdateMindStatus(uid, status, component);
+    }
+
+    private void OnMindRemoved(EntityUid uid, MindContainerComponent component, MindRemovedMessage args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (TryComp<MindStatusComponent>(uid, out var status))
+            UpdateMindStatus(uid, status, component);
+    }
+
+    private void OnContainerStartup(EntityUid uid, MindContainerComponent component, ComponentStartup args)
+    {
+        if (_net.IsClient)
+            return;
+
+        // Ensure all entities with MindContainerComponent also have MindStatusComponent
+        var status = EnsureComp<MindStatusComponent>(uid);
+        UpdateMindStatus(uid, status, component);
+    }
+
+    private void OnContainerAdded(EntityUid uid, MindContainerComponent component, ComponentAdd args)
+    {
+        if (_net.IsClient)
+            return;
+
+        var status = EnsureComp<MindStatusComponent>(uid);
+        UpdateMindStatus(uid, status, component);
+    }
+
+    private void OnForceUpdate(ForceUpdateMindStatusEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!TryComp<MindStatusComponent>(args.Entity, out var status))
+            return;
+
+        if (!TryComp<MindContainerComponent>(args.Entity, out var container))
+            return;
+
+        UpdateMindStatus(args.Entity, status, container);
+    }
+
+    private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs args)
+    {
+        // When a player connects/disconnects, update all entities with their mind
+        if (!_mindSystem.TryGetMind(args.Session.UserId, out var mindId, out var mind))
+            return;
+
+        if (mind.OwnedEntity != null && TryComp<MindStatusComponent>(mind.OwnedEntity.Value, out var status) && TryComp<MindContainerComponent>(mind.OwnedEntity.Value, out var container))
+        {
+            UpdateMindStatus(mind.OwnedEntity.Value, status, container);
+        }
+
+        // Also check visiting entity
+        if (mind.VisitingEntity != null && TryComp<MindStatusComponent>(mind.VisitingEntity.Value, out var visitStatus) && TryComp<MindContainerComponent>(mind.VisitingEntity.Value, out var visitContainer))
+        {
+            UpdateMindStatus(mind.VisitingEntity.Value, visitStatus, visitContainer);
+        }
+    }
+
+    private void UpdateMindStatus(EntityUid uid, MindStatusComponent status, MindContainerComponent container)
+    {
+        var oldStatus = status.Status;
+        var dead = _mobState.IsDead(uid);
+        var mind = container.Mind != null ? CompOrNull<MindComponent>(container.Mind) : null;
+        var hasUserId = mind?.UserId;
+        var hasActiveSession = hasUserId != null && _playerManager.ValidSessionId(hasUserId.Value);
+
+        // Determine new status based on the scenarios
+        if (dead && hasUserId == null)
+            status.Status = MindStatus.DeadAndIrrecoverable;
+        else if (dead && !hasActiveSession)
+            status.Status = MindStatus.DeadAndSSD;
+        else if (dead)
+            status.Status = MindStatus.Dead;
+        else if (hasUserId == null)
+            status.Status = MindStatus.Catatonic;
+        else if (!hasActiveSession)
+            status.Status = MindStatus.SSD;
+        else
+            status.Status = MindStatus.Active;
+
+        if (oldStatus != status.Status)
+            Dirty(uid, status);
+    }
+}

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -41,7 +41,6 @@ public abstract partial class SharedMindSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<MindContainerComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<MindContainerComponent, SuicideEvent>(OnSuicide);
         SubscribeLocalEvent<VisitingMindComponent, EntityTerminatingEvent>(OnVisitingTerminating);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnReset);
@@ -151,39 +150,6 @@ public abstract partial class SharedMindSystem : EntitySystem
     {
         if (component.MindId != null)
             UnVisit(component.MindId.Value);
-    }
-
-    private void OnExamined(EntityUid uid, MindContainerComponent mindContainer, ExaminedEvent args)
-    {
-        if (!mindContainer.ShowExamineInfo || !args.IsInDetailsRange)
-            return;
-
-        // TODO: Move this out of the SharedMindSystem into its own comp and predict it
-        if (_net.IsClient)
-            return;
-
-        var dead = _mobState.IsDead(uid);
-        var mind = CompOrNull<MindComponent>(mindContainer.Mind);
-        var hasUserId = mind?.UserId;
-        var hasActiveSession = hasUserId != null && _playerManager.ValidSessionId(hasUserId.Value);
-
-        // Scenarios:
-        // 1. Dead + No User ID: Entity is permanently dead with no player ever attached
-        // 2. Dead + Has User ID + No Session: Player died and disconnected
-        // 3. Dead + Has Session: Player is dead but still connected
-        // 4. Alive + No User ID: Entity was never controlled by a player
-        // 5. Alive + No Session: Player disconnected while alive (SSD)
-
-        if (dead && hasUserId == null)
-            args.PushMarkup($"[color=mediumpurple]{Loc.GetString("comp-mind-examined-dead-and-irrecoverable", ("ent", uid))}[/color]");
-        else if (dead && !hasActiveSession)
-            args.PushMarkup($"[color=yellow]{Loc.GetString("comp-mind-examined-dead-and-ssd", ("ent", uid))}[/color]");
-        else if (dead)
-            args.PushMarkup($"[color=red]{Loc.GetString("comp-mind-examined-dead", ("ent", uid))}[/color]");
-        else if (hasUserId == null)
-            args.PushMarkup($"[color=mediumpurple]{Loc.GetString("comp-mind-examined-catatonic", ("ent", uid))}[/color]");
-        else if (!hasActiveSession)
-            args.PushMarkup($"[color=yellow]{Loc.GetString("comp-mind-examined-ssd", ("ent", uid))}[/color]");
     }
 
     /// <summary>

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.CCVar;
+using Content.Shared.Mind.Components;
 using Content.Shared.StatusEffectNew;
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
@@ -17,6 +18,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly EntityManager _entityManager = default!;
 
     private bool _icSsdSleep;
     private float _icSsdSleepTime;
@@ -43,6 +45,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
         }
 
         Dirty(uid, component);
+        _entityManager.EventBus.RaiseEvent(EventSource.Local, new ForceUpdateMindStatusEvent(uid));
     }
 
     private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args)
@@ -56,6 +59,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
         }
 
         Dirty(uid, component);
+        _entityManager.EventBus.RaiseEvent(EventSource.Local, new ForceUpdateMindStatusEvent(uid));
     }
 
     // Prevents mapped mobs to go to sleep immediately


### PR DESCRIPTION
## About the PR
This PR refactors the way mind status text on examine is handled to use a client-predicted component.

## Why / Balance
Removes the delay on SSD/death text populating when examining entities that is caused by waiting for the server to provide mind status information. This fix was asked for in the SharedMindSystem code by a TODO comment. See Media for comparison.

## Technical details
Mind status OnExamine logic removed from SharedMindSystem and handled by a new component and systems - MindStatusComponent, MindExamineSystem, and MindStatusSystem. Tested on localhost and no issues found, but you never know. Might contain some strange or unnecessary code, I'm coming from a C++ background, so feel free to ask for revisions.

## Media

https://github.com/user-attachments/assets/31b6d24d-6180-4c98-872f-90ffb3b76bc5


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Content.Shared.SharedMindSystem.cs - Removed OnExamine method and refactored into MindStatusSystem.cs

**Changelog**
:cl:
- fix: Fixed SSD/death examine text not being predicted
