### PR TITLE
Damage user on trigger and Step Trigger refactor [Part 1]

### DIFF
--- a/Content.Server/Damage/Systems/DamageOnTriggerSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnTriggerSystem.cs
@@ -1,0 +1,54 @@
+using Content.Server.Explosion.EntitySystems;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
+
+namespace Content.Server.Damage.Systems;
+
+/// <summary>
+/// Applies damage to the entity that has the <see cref="TriggerEvent"/>.
+/// </summary>
+/// <remarks>
+/// The triggering entity must have a <see cref="DamageableComponent"/> (e.g. being a creature or player) to receive damage.
+/// Unlike <see cref="DamageUserOnTriggerSystem"/>, this applies damage directly to the triggering entity itself,
+/// not to the user.
+/// </remarks>
+public sealed class DamageOnTriggerSystem : EntitySystem
+{
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<DamageOnTriggerComponent, TriggerEvent>(OnTrigger);
+    }
+
+    private void OnTrigger(Entity<DamageOnTriggerComponent> ent, ref TriggerEvent args)
+    {
+        var comp = ent.Comp;
+
+        args.Handled |= TryDamageTarget(ent.Owner, comp.Damage, comp.IgnoreResistances, ent.Owner);
+    }
+
+    private bool TryDamageTarget(EntityUid uid, DamageSpecifier damage, bool ignoreResistances, EntityUid target)
+    {
+        var ev = new BeforeDamageOnTriggerEvent(damage, target);
+        RaiseLocalEvent(uid, ev);
+
+        return _damageableSystem.TryChangeDamage(target, ev.Damage, ignoreResistances, origin: uid) is not null;
+    }
+}
+
+/// <summary>
+/// Raised before applying damage to the triggered entity itself (i.e., the one with the <see cref="DamageOnTriggerComponent"/>).
+/// Allows other systems to modify the damage.
+/// </summary>
+public sealed class BeforeDamageOnTriggerEvent : EntityEventArgs
+{
+    public DamageSpecifier Damage { get; set; }
+    public EntityUid Tripper { get; }
+
+    public BeforeDamageOnTriggerEvent(DamageSpecifier damage, EntityUid target)
+    {
+        Damage = damage;
+        Tripper = target;
+    }
+}

--- a/Content.Shared/Damage/Components/DamageOnTriggerComponent.cs
+++ b/Content.Shared/Damage/Components/DamageOnTriggerComponent.cs
@@ -1,0 +1,16 @@
+namespace Content.Shared.Damage.Components;
+
+/// <summary>
+/// Deals damage to the triggered entity itself.
+/// </summary>
+/// <remarks>
+/// The triggered entity must have a <see cref="DamageableComponent"/> (e.g., be a creature or a player) to receive damage.
+/// </remarks>
+[RegisterComponent]
+public sealed partial class DamageOnTriggerComponent : Component
+{
+    [DataField] public bool IgnoreResistances;
+
+    [DataField(required: true)]
+    public DamageSpecifier Damage = default!;
+}

--- a/Content.Shared/Damage/Components/DamageUserOnTriggerComponent.cs
+++ b/Content.Shared/Damage/Components/DamageUserOnTriggerComponent.cs
@@ -1,10 +1,16 @@
 namespace Content.Shared.Damage.Components;
 
+/// <summary>
+/// Deals damage to the user (the entity that triggered the entity), such as a player stepping on a mousetrap.
+/// </summary>
+/// <remarks>
+/// This component should be attached to the triggering object (e.g., a mousetrap).
+/// </remarks>
 [RegisterComponent]
 public sealed partial class DamageUserOnTriggerComponent : Component
 {
-    [DataField("ignoreResistances")] public bool IgnoreResistances;
+    [DataField] public bool IgnoreResistances;
 
-    [DataField("damage", required: true)]
+    [DataField(required: true)]
     public DamageSpecifier Damage = default!;
 }

--- a/Content.Shared/StepTrigger/Components/StepTriggerComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerComponent.cs
@@ -57,6 +57,16 @@ public sealed partial class StepTriggerComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool StepOn = false;
+
+    /// <summary>
+    /// If true, the trigger will activate regardless of whether <see cref="StepTriggerAttemptEvent.Continue"/> is true or false,
+    /// unless the event is explicitly <see cref="StepTriggerAttemptEvent.Cancelled"/>.
+    /// </summary>
+    /// <remarks>
+    /// Disabled by default.
+    /// </remarks>
+    [DataField, AutoNetworkedField]
+    public bool ForceIgnoreTriggerContinue = false;
 }
 
 [RegisterComponent]

--- a/Content.Shared/StepTrigger/Components/StepTriggerOnAliveComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerOnAliveComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.StepTrigger.Components;
+
+/// <summary>
+///     This is used for marking step trigger events that require the entity alive or crit.
+/// </summary>
+/// <remarks>
+///     Works only with <see cref="StepTriggerComponent"/>.
+/// </remarks>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class StepTriggerOnAliveComponent : Component;

--- a/Content.Shared/StepTrigger/Components/StepTriggerOnSizeComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerOnSizeComponent.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Physics;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.StepTrigger.Components;
+
+/// <summary>
+///     This is used for marking step trigger events that require the user to be
+///     some specific <see cref="CollisionGroup"/> (e.g., CollisionGroup.MobMask, CollisionGroup.LargeMobMask).
+///     Useful for making small creatures like cockroaches only react to being stepped on by mobs or players,
+///     but not by other small entities.
+/// </summary>
+/// <remarks>
+///     Works only with <see cref="StepTriggerComponent"/>.
+/// </remarks>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class StepTriggerOnSizeComponent : Component
+{
+    /// <summary>
+    ///     The collision mask an entity must match in order to activate the step trigger.
+    ///     By default, is <see cref="CollisionGroup.MobMask"/> and <see cref="CollisionGroup.LargeMobMask"/>,
+    ///     to allow activation by players and mobs and mechs.
+    /// </summary>
+    [DataField]
+    public CollisionGroup CollisionMask = CollisionGroup.MobMask | CollisionGroup.LargeMobMask;
+}

--- a/Content.Shared/StepTrigger/Systems/StepTriggerOnAliveSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerOnAliveSystem.cs
@@ -1,0 +1,24 @@
+using Content.Shared.Mobs.Systems;
+using Content.Shared.StepTrigger.Components;
+
+namespace Content.Shared.StepTrigger.Systems;
+
+/// <inheritdoc cref="StepTriggerOnAliveComponent"/>
+public sealed class StepTriggerOnAliveSystem : EntitySystem
+{
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<StepTriggerOnAliveComponent, StepTriggerAttemptEvent>(OnStepTriggerOnAliveAttempt);
+    }
+
+    private void OnStepTriggerOnAliveAttempt(Entity<StepTriggerOnAliveComponent> ent, ref StepTriggerAttemptEvent args)
+    {
+        var alive = _mobState.IsAlive(ent);
+
+        args.Continue = alive;
+        args.Cancelled = !alive;
+    }
+}

--- a/Content.Shared/StepTrigger/Systems/StepTriggerOnSizeSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerOnSizeSystem.cs
@@ -28,7 +28,7 @@ public sealed class StepTriggerOnSizeSystem : EntitySystem
 
         /// Check if the tripper's collision layer matches any of the allowed <see cref="StepTriggerOnSizeComponent.CollisionMask"/>.
         /// Bitwise AND to determine if any bits overlap.
-        if (((CollisionGroup)physics.CollisionLayer & ent.Comp.CollisionMask) != 0)
+        if (((CollisionGroup)physics.CollisionLayer & ent.Comp.CollisionMask) == 0)
         {
             args.Continue = true;
             return;

--- a/Content.Shared/StepTrigger/Systems/StepTriggerOnSizeSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerOnSizeSystem.cs
@@ -1,0 +1,40 @@
+using Content.Shared.Physics;
+using Content.Shared.StepTrigger.Components;
+using Robust.Shared.Physics.Components;
+
+namespace Content.Shared.StepTrigger.Systems;
+
+/// <inheritdoc cref="StepTriggerOnSizeComponent"/>
+public sealed class StepTriggerOnSizeSystem : EntitySystem
+{
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+
+        SubscribeLocalEvent<StepTriggerOnSizeComponent, StepTriggerAttemptEvent>(OnStepTriggerOnSizeAttempt);
+    }
+
+    /// <summary>
+    /// Called when an entity attempts to trigger a step event on an entity that has a <see cref="StepTriggerOnSizeComponent"/>.
+    /// Cancels the event if the triggering entity's collision group doesn't match the allowed mask.
+    /// </summary>
+    private void OnStepTriggerOnSizeAttempt(Entity<StepTriggerOnSizeComponent> ent, ref StepTriggerAttemptEvent args)
+    {
+        if (!_physicsQuery.TryComp(args.Tripper, out var physics))
+            return;
+
+        /// Check if the tripper's collision layer matches any of the allowed <see cref="StepTriggerOnSizeComponent.CollisionMask"/>.
+        /// Bitwise AND to determine if any bits overlap.
+        if (((CollisionGroup)physics.CollisionLayer & ent.Comp.CollisionMask) != 0)
+        {
+            args.Continue = true;
+            return;
+        }
+
+        // If it's not passes CollisionMask then Cancel
+        args.Cancelled = true;
+    }
+}

--- a/Content.Shared/StepTrigger/Systems/StepTriggerOnSizeSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerOnSizeSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Mobs;
 using Content.Shared.Physics;
 using Content.Shared.StepTrigger.Components;
 using Robust.Shared.Physics.Components;
@@ -34,6 +35,7 @@ public sealed class StepTriggerOnSizeSystem : EntitySystem
             return;
         }
 
+        args.Cancelled = true;
         args.Continue = false;
     }
 }

--- a/Content.Shared/StepTrigger/Systems/StepTriggerOnSizeSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerOnSizeSystem.cs
@@ -34,7 +34,6 @@ public sealed class StepTriggerOnSizeSystem : EntitySystem
             return;
         }
 
-        // If it's not passes CollisionMask then Cancel
-        args.Cancelled = true;
+        args.Continue = false;
     }
 }

--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -146,7 +146,7 @@ public sealed class StepTriggerSystem : EntitySystem
 
         RaiseLocalEvent(uid, ref msg);
 
-        return msg.Continue && !msg.Cancelled;
+        return (component.ForceIgnoreTriggerContinue || msg.Continue) && !msg.Cancelled;
     }
 
     private void OnStartCollide(EntityUid uid, StepTriggerComponent component, ref StartCollideEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Two step's PR with the goal that I've doin, that players can squash cockroaches by stepping/walk on them, and add red blooded cockroaches with gib sound on death, and add hauberoach. This refactor adds a lot of possibilities to step triggers, like walking on plushies will make some sound.

- [x] Refactor `DamageUserOnTrigger` into `DamageOnTrigger` and add `StepTriggerOnSizeComponent`.
- [ ] Make cockroach die when player's stepped on it (or something big enough).

And my *wishes*:
- [ ] Transfer player's DNA to a cockroach when squashed and if the player's without shoes.
- [ ] Blood cockroaches that drops red blood on death (yml only tho).
- [ ] Transfer fibers to a cockroach that's squashed by the player's **with** shoes. Dunno how to do it tho', probably long-term thing. Maybe related to this issue #14744 .
- [ ] Pacified entities can't squash cockroaches.

<!-- What did you change? -->

## Why / Balance
Cockroaches have to die when player's walk on 'em.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
- Add reliable comments for `DamageUserOnTriggerSystem` and `DamageUserOnTriggerComponent`.
- Add `DamageOnTriggerComponent` and System that deals damage to triggering entity.
- Add `ForceIgnoreTriggerContinue` to `StepTriggerComponent` so it's able to be used by yml devs. By default, `StepTriggerAttemptEvent.Continue` is never true (i.e., the mousetraps are manually from code sets `StepTriggerAttemptEvent.Continue` to true), so I've added this workaround.
- Add `StepTriggerOnSizeComponent` and System that checks size of the tripper/stepped/walked entity.
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`StepTriggerComponent` now has `ForceIgnoreTriggerContinue` field, that's when true skips `StepTriggerAttemptEvent.Continue` check.
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl, no fun
