### PR TITLE
[Mald PR] Plushie sound 1984

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/FoodSystem.cs
@@ -289,7 +289,7 @@ public sealed class FoodSystem : EntitySystem
             _adminLogger.Add(LogType.Ingestion, LogImpact.Low, $"{ToPrettyString(args.User):target} ate {ToPrettyString(entity.Owner):food}");
         }
 
-        _audio.PlayPredicted(entity.Comp.UseSound, args.Target.Value, args.User, AudioParams.Default.WithVolume(-1f).WithVariation(0.20f));
+        _audio.PlayPredicted(entity.Comp.UseSound, args.Target.Value, args.User, entity.Comp.UseSound.Params.WithVolume(-1f).WithVariation(0.20f));
 
         // Try to break all used utensils
         foreach (var utensil in utensils)

--- a/Content.Shared/Weapons/Melee/MeleeSoundSystem.cs
+++ b/Content.Shared/Weapons/Melee/MeleeSoundSystem.cs
@@ -48,17 +48,17 @@ public sealed class MeleeSoundSystem : EntitySystem
         {
             if (damageType == null && damageSoundComp.NoDamageSound != null)
             {
-                _audio.PlayPredicted(damageSoundComp.NoDamageSound, coords, userUid, AudioParams.Default.WithVariation(DamagePitchVariation));
+                _audio.PlayPredicted(damageSoundComp.NoDamageSound, coords, userUid, damageSoundComp.NoDamageSound.Params.WithVariation(DamagePitchVariation));
                 playedSound = true;
             }
             else if (damageType != null && damageSoundComp.SoundTypes?.TryGetValue(damageType, out var damageSoundType) == true)
             {
-                _audio.PlayPredicted(damageSoundType, coords, userUid, AudioParams.Default.WithVariation(DamagePitchVariation));
+                _audio.PlayPredicted(damageSoundType, coords, userUid, damageSoundType.Params.WithVariation(DamagePitchVariation));
                 playedSound = true;
             }
             else if (damageType != null && damageSoundComp.SoundGroups?.TryGetValue(damageType, out var damageSoundGroup) == true)
             {
-                _audio.PlayPredicted(damageSoundGroup, coords, userUid, AudioParams.Default.WithVariation(DamagePitchVariation));
+                _audio.PlayPredicted(damageSoundGroup, coords, userUid, damageSoundGroup.Params.WithVariation(DamagePitchVariation));
                 playedSound = true;
             }
         }
@@ -68,17 +68,17 @@ public sealed class MeleeSoundSystem : EntitySystem
         {
             if (hitSoundOverride != null)
             {
-                _audio.PlayPredicted(hitSoundOverride, coords, userUid, AudioParams.Default.WithVariation(DamagePitchVariation));
+                _audio.PlayPredicted(hitSoundOverride, coords, userUid, hitSoundOverride.Params.WithVariation(DamagePitchVariation));
                 playedSound = true;
             }
             else if (hitSound != null)
             {
-                _audio.PlayPredicted(hitSound, coords, userUid, AudioParams.Default.WithVariation(DamagePitchVariation));
+                _audio.PlayPredicted(hitSound, coords, userUid, hitSound.Params.WithVariation(DamagePitchVariation));
                 playedSound = true;
             }
             else
             {
-                _audio.PlayPredicted(noDamageSound, coords, userUid, AudioParams.Default.WithVariation(DamagePitchVariation));
+                _audio.PlayPredicted(noDamageSound, coords, userUid, noDamageSound.Params.WithVariation(DamagePitchVariation));
                 playedSound = true;
             }
         }

--- a/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
@@ -6,26 +6,24 @@
   id: BasePlushie
   components:
   - type: EmitSoundOnUse
-    sound:
+    sound: &BasePlushieSound
       collection: ToySqueak
+      params:
+        volume: -4
   - type: EmitSoundOnActivate
-    sound:
-      collection: ToySqueak
+    sound: *BasePlushieSound
   - type: EmitSoundOnCollide
-    sound:
-      collection: ToySqueak
+    sound: *BasePlushieSound
   - type: EmitSoundOnLand
-    sound:
-      collection: ToyFall
+    sound: *BasePlushieSound
   - type: EmitSoundOnTrigger
-    sound:
-      collection: ToySqueak
+    sound: *BasePlushieSound
   - type: UseDelay
-    delay: 1.0
+    delay: 3.0
   - type: MeleeWeapon
+    attackRate: 0.333
     wideAnimationRotation: 180
-    soundHit:
-      collection: ToySqueak
+    soundHit: *BasePlushieSound
     damage:
       types:
         Blunt: 0
@@ -37,8 +35,7 @@
     price: 5
   - type: Food
     requiresSpecialDigestion: true
-    useSound:
-      collection: ToySqueak
+    useSound: *BasePlushieSound
     delay: 2
   - type: SolutionContainerManager
     solutions:
@@ -356,28 +353,24 @@
   - type: Item
     sprite: Objects/Fun/Plushies/lizard.rsi
   - type: EmitSoundOnUse
-    sound:
+    sound: &PlushieLizardSound
       path: /Audio/Items/Toys/weh.ogg
+      params:
+        volume: -5
   - type: EmitSoundOnLand
-    sound:
-      path: /Audio/Items/Toys/weh.ogg
+    sound: *PlushieLizardSound
   - type: EmitSoundOnActivate
-    sound:
-      path: /Audio/Items/Toys/weh.ogg
+    sound: *PlushieLizardSound
   - type: EmitSoundOnTrigger
-    sound:
-      path: /Audio/Items/Toys/weh.ogg
+    sound: *PlushieLizardSound
   - type: EmitSoundOnCollide
-    sound:
-      path: /Audio/Items/Toys/weh.ogg
+    sound: *PlushieLizardSound
   - type: Food
     requiresSpecialDigestion: true
-    useSound:
-      path: /Audio/Items/Toys/weh.ogg
+    useSound: *PlushieLizardSound
   - type: MeleeWeapon
     wideAnimationRotation: 180
-    soundHit:
-      path: /Audio/Items/Toys/weh.ogg
+    soundHit: *PlushieLizardSound
   - type: Extractable
     juiceSolution:
       reagents:
@@ -427,28 +420,24 @@
       - state: inhand-right
         shader: shaded
   - type: EmitSoundOnUse
-    sound:
+    sound: &PlushieExperimentSound
       path: /Audio/Items/Toys/arf.ogg
+      params:
+        volume: -5
   - type: EmitSoundOnLand
-    sound:
-      path: /Audio/Items/Toys/arf.ogg
+    sound: *PlushieExperimentSound
   - type: EmitSoundOnActivate
-    sound:
-      path: /Audio/Items/Toys/arf.ogg
+    sound: *PlushieExperimentSound
   - type: EmitSoundOnTrigger
-    sound:
-      path: /Audio/Items/Toys/arf.ogg
+    sound: *PlushieExperimentSound
   - type: EmitSoundOnCollide
-    sound:
-      path: /Audio/Items/Toys/arf.ogg
+    sound: *PlushieExperimentSound
   - type: Food
     requiresSpecialDigestion: true
-    useSound:
-      path: /Audio/Items/Toys/arf.ogg
+    useSound: *PlushieExperimentSound
   - type: MeleeWeapon
     wideAnimationRotation: 180
-    soundHit:
-      path: /Audio/Items/Toys/arf.ogg
+    soundHit: *PlushieExperimentSound
   - type: Clothing
     clothingVisuals:
       head:
@@ -515,28 +504,24 @@
     sprite: Objects/Fun/Plushies/lizard.rsi
     heldPrefix: spacelizard
   - type: EmitSoundOnUse
-    sound:
+    sound: &PlushieSpaceLizardSound
       path: /Audio/Items/Toys/muffled_weh.ogg
+      params:
+        volume: -5
   - type: EmitSoundOnLand
-    sound:
-      path: /Audio/Items/Toys/muffled_weh.ogg
+    sound: *PlushieSpaceLizardSound
   - type: EmitSoundOnActivate
-    sound:
-      path: /Audio/Items/Toys/muffled_weh.ogg
+    sound: *PlushieSpaceLizardSound
   - type: EmitSoundOnTrigger
-    sound:
-      path: /Audio/Items/Toys/muffled_weh.ogg
+    sound: *PlushieSpaceLizardSound
   - type: EmitSoundOnCollide
-    sound:
-      path: /Audio/Items/Toys/muffled_weh.ogg
+    sound: *PlushieSpaceLizardSound
   - type: Food
     requiresSpecialDigestion: true
-    useSound:
-      path: /Audio/Items/Toys/muffled_weh.ogg
+    useSound: *PlushieSpaceLizardSound
   - type: MeleeWeapon
     wideAnimationRotation: 180
-    soundHit:
-      path: /Audio/Items/Toys/muffled_weh.ogg
+    soundHit: *PlushieSpaceLizardSound
   - type: Clothing
     sprite: Objects/Fun/Plushies/lizard.rsi
     slots:
@@ -561,25 +546,22 @@
   - type: Item
     heldPrefix: plushielizardinversed
   - type: EmitSoundOnUse
-    sound:
+    sound: &PlushieLizardInversedSound
       path: /Audio/Items/Toys/hew.ogg
+      params:
+        volume: -5
   - type: EmitSoundOnLand
-    sound:
-      path: /Audio/Items/Toys/hew.ogg
+    sound: *PlushieLizardInversedSound
   - type: EmitSoundOnActivate
-    sound:
-      path: /Audio/Items/Toys/hew.ogg
+    sound: *PlushieLizardInversedSound
   - type: EmitSoundOnTrigger
-    sound:
-      path: /Audio/Items/Toys/hew.ogg
+    sound: *PlushieLizardInversedSound
   - type: Food
     requiresSpecialDigestion: true
-    useSound:
-      path: /Audio/Items/Toys/hew.ogg
+    useSound: *PlushieLizardInversedSound
   - type: MeleeWeapon
     wideAnimationRotation: 180
-    soundHit:
-      path: /Audio/Items/Toys/hew.ogg
+    soundHit: *PlushieLizardInversedSound
   - type: Extractable
     juiceSolution:
       reagents:
@@ -619,28 +601,24 @@
       map: [ "enum.SolutionContainerLayers.Fill" ]
       visible: false
   - type: EmitSoundOnUse
-    sound:
+    sound: &PlushieDionaSound
       path: /Audio/Items/Toys/toy_rustle.ogg
+      params:
+        volume: -5
   - type: EmitSoundOnLand
-    sound:
-      path: /Audio/Items/Toys/toy_rustle.ogg
+    sound: *PlushieDionaSound
   - type: EmitSoundOnActivate
-    sound:
-      path: /Audio/Items/Toys/toy_rustle.ogg
+    sound: *PlushieDionaSound
   - type: EmitSoundOnTrigger
-    sound:
-      path: /Audio/Items/Toys/toy_rustle.ogg
+    sound: *PlushieDionaSound
   - type: EmitSoundOnCollide
-    sound:
-      path: /Audio/Items/Toys/toy_rustle.ogg
+    sound: *PlushieDionaSound
   - type: MeleeWeapon
     wideAnimationRotation: 180
-    soundHit:
-      path: /Audio/Items/Toys/toy_rustle.ogg
+    soundHit: *PlushieDionaSound
   - type: Food
     requiresSpecialDigestion: true
-    useSound:
-      path: /Audio/Items/Toys/toy_rustle.ogg
+    useSound: *PlushieDionaSound
   - type: SolutionContainerManager
     solutions:
       plushie:
@@ -1066,28 +1044,24 @@
     sprite: Objects/Fun/Plushies/vox.rsi
     state: icon
   - type: EmitSoundOnUse
-    sound:
+    sound: &PlushieVoxSound
       path: /Audio/Voice/Vox/shriek1.ogg
+      params:
+        volume: -5
   - type: EmitSoundOnLand
-    sound:
-      path: /Audio/Voice/Vox/shriek1.ogg
+    sound: *PlushieVoxSound
   - type: EmitSoundOnActivate
-    sound:
-      path: /Audio/Voice/Vox/shriek1.ogg
+    sound: *PlushieVoxSound
   - type: EmitSoundOnTrigger
-    sound:
-      path: /Audio/Voice/Vox/shriek1.ogg
+    sound: *PlushieVoxSound
   - type: EmitSoundOnCollide
-    sound:
-      path: /Audio/Voice/Vox/shriek1.ogg
+    sound: *PlushieVoxSound
   - type: Food
     requiresSpecialDigestion: true
-    useSound:
-      path: /Audio/Voice/Vox/shriek1.ogg
+    useSound: *PlushieVoxSound
   - type: MeleeWeapon
     wideAnimationRotation: 180
-    soundHit:
-      path: /Audio/Voice/Vox/shriek1.ogg
+    soundHit: *PlushieVoxSound
   - type: Clothing
     quickEquip: false
     sprite: Objects/Fun/Plushies/vox.rsi
@@ -1135,28 +1109,24 @@
   - type: Item
     size: Normal
   - type: EmitSoundOnUse
-    sound:
+    sound: &PlushieXenoSound
       path: /Audio/Weapons/Xeno/alien_spitacid.ogg
+      params:
+        volume: -8
   - type: EmitSoundOnLand
-    sound:
-      path: /Audio/Weapons/Xeno/alien_spitacid.ogg
+    sound: *PlushieXenoSound
   - type: EmitSoundOnActivate
-    sound:
-      path: /Audio/Weapons/Xeno/alien_spitacid.ogg
+    sound: *PlushieXenoSound
   - type: EmitSoundOnTrigger
-    sound:
-      path: /Audio/Weapons/Xeno/alien_spitacid.ogg
+    sound: *PlushieXenoSound
   - type: EmitSoundOnCollide
-    sound:
-      path: /Audio/Weapons/Xeno/alien_spitacid.ogg
+    sound: *PlushieXenoSound
   - type: Food
     requiresSpecialDigestion: true
-    useSound:
-      path: /Audio/Items/Toys/mousesqueek.ogg
+    useSound: *PlushieXenoSound
   - type: MeleeWeapon
     wideAnimationRotation: 180
-    soundHit:
-      path: /Audio/Weapons/Xeno/alien_spitacid.ogg
+    soundHit: *PlushieXenoSound
   - type: Clothing
     quickEquip: false
     sprite: Objects/Fun/Plushies/xeno.rsi
@@ -1198,27 +1168,41 @@
     sprite: Objects/Fun/Plushies/human.rsi
     state: icon
   - type: EmitSoundOnUse
-    sound:
+    sound: &PlushieHuman
       path: /Audio/Voice/Human/malescream_1.ogg
+      params:
+        volume: -8
   - type: EmitSoundOnLand
     sound:
       path: /Audio/Voice/Human/malescream_2.ogg
+      params:
+        volume: -8
   - type: EmitSoundOnActivate
     sound:
       path: /Audio/Voice/Human/malescream_3.ogg
+      params:
+        volume: -8
   - type: EmitSoundOnCollide
     sound:
       path: /Audio/Voice/Human/malescream_4.ogg
+      params:
+        volume: -8
   - type: Food
     requiresSpecialDigestion: true
     useSound:
       path: /Audio/Voice/Human/malescream_1.ogg
+      params:
+        volume: -8
   - type: MeleeWeapon
     soundHit:
       path: /Audio/Voice/Human/malescream_4.ogg
+      params:
+        volume: -8
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Voice/Human/malescream_5.ogg
+      params:
+        volume: -8
   - type: Clothing
     quickEquip: false
     sprite: Objects/Fun/Plushies/human.rsi


### PR DESCRIPTION
## About the PR
Most plushies have been made quieter (by varying degrees depending on how obnoxious the original sound was)

Made plushies 3x slower to use (squeak every 3 seconds / hit somebody every 3 seconds)

## Why / Balance
FUCKING LOUD AND ANNOYING

<img width="690" height="111" alt="SS14 Loader_zvhcucDxtI" src="https://github.com/user-attachments/assets/28147d9a-3098-42b3-843f-458266e4d6e7" />

## Technical details
Oh yeah I fixed `FoodComponent` and `MeleeWeaponComponent` not respecting audio parameters on their sound specifiers.

## Media

https://github.com/user-attachments/assets/ae563bd0-3507-4ba9-8a6c-bfc32417cff2

## Changelog
:cl:
- tweak: Made most plushie sounds quieter, and made plushies slower to use.
