### PR TITLE
Added a network configurator to the Warden's locker.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -43,6 +43,7 @@
       amount: 2
     - id: RemoteSignaller
       amount: 2
+    - id: NetworkConfigurator
     - id: Binoculars
 
 - type: entityTable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a network configurator to the Warden's locker.

## Why / Balance
It's practically necessary to use the electropacks the Warden starts with and as far as I'm aware, only Exo actually gives them one at the start of the round. This means the Warden has to go out of their way to get one from Tools to be able to use them at all. Given the Warden is heavily incentivised to remain in Security outside of emergencies, this is not ideal.

## Technical details
Added `NetworkConfigurator` to `FillLockerWarden`. 1 line YAML change.

## Media
<img width="419" height="407" alt="image" src="https://github.com/user-attachments/assets/4ac553df-20b8-4106-91b9-d9c2b94fc96a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The Warden now starts with a network configurator.