### PR TITLE
Exo fix: Link salvage recycler to the lever

### DIFF
--- a/Resources/Maps/exo.yml
+++ b/Resources/Maps/exo.yml
@@ -92784,8 +92784,6 @@ entities:
     - type: Transform
       pos: 50.5,-96.5
       parent: 2
-    - type: DeviceLinkSink
-      invokeCounter: 1
 - proto: ReinforcedGirder
   entities:
   - uid: 8650

--- a/Resources/Maps/exo.yml
+++ b/Resources/Maps/exo.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 07/22/2025 16:43:19
+  time: 07/28/2025 01:11:40
   entityCount: 19680
 maps:
 - 1
@@ -92784,6 +92784,8 @@ entities:
     - type: Transform
       pos: 50.5,-96.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
 - proto: ReinforcedGirder
   entities:
   - uid: 8650
@@ -105169,6 +105171,15 @@ entities:
     - type: Transform
       pos: 51.5,-97.5
       parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        14690:
+        - - Left
+          - Reverse
+        - - Right
+          - Forward
+        - - Middle
+          - Off
 - proto: UnfinishedMachineFrame
   entities:
   - uid: 17877


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
On exo, the recycler in the salvage room is now linked to the lever at round start.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I believe that the fact that they weren't linked is an oversight, as most other maps do start with them linked. Salvagers expect them to be linked, and, because exo's isn't, I see it used far less often. 
## Technical details
<!-- Summary of code changes for easier review. -->
Adds the DeviceLinkSource linking the recycler to the lever.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="959" height="845" alt="salvrecbefore" src="https://github.com/user-attachments/assets/f17973e8-02d4-4e5f-bfc4-b572b7c182ff" />
<img width="959" height="845" alt="salvrecafter" src="https://github.com/user-attachments/assets/514261cb-5e72-4bc3-a445-4e4c9f0741d2" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
MAPS:
- fix: On Exo, the recycler in salvage has been linked to the lever.