### PR TITLE
fix foldable clothes not working while worn

### DIFF
--- a/Content.Shared/Clothing/Components/FoldableClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/FoldableClothingComponent.cs
@@ -35,11 +35,11 @@ public sealed partial class FoldableClothingComponent : Component
     /// Which layers does this hide when Unfolded? See <see cref="HumanoidVisualLayers"/> and <see cref="HideLayerClothingComponent"/>
     /// </summary>
     [DataField]
-    public HashSet<HumanoidVisualLayers>? UnfoldedHideLayers = new();
+    public HashSet<HumanoidVisualLayers> UnfoldedHideLayers = new();
 
     /// <summary>
     /// Which layers does this hide when folded? See <see cref="HumanoidVisualLayers"/> and <see cref="HideLayerClothingComponent"/>
     /// </summary>
     [DataField]
-    public HashSet<HumanoidVisualLayers>? FoldedHideLayers = new();
+    public HashSet<HumanoidVisualLayers> FoldedHideLayers = new();
 }

--- a/Content.Shared/Clothing/EntitySystems/FoldableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/FoldableClothingSystem.cs
@@ -37,7 +37,7 @@ public sealed class FoldableClothingSystem : EntitySystem
         }
 
         // Setting hidden layers while equipped is not currently supported.
-        if (ent.Comp.FoldedHideLayers != null || ent.Comp.UnfoldedHideLayers != null)
+        if (ent.Comp.FoldedHideLayers.Count != 0|| ent.Comp.UnfoldedHideLayers.Count != 0)
             args.Cancelled = true;
     }
 
@@ -65,7 +65,7 @@ public sealed class FoldableClothingSystem : EntitySystem
             // This should instead work via an event or something that gets raised to optionally modify the currently hidden layers.
             // Or at the very least it should stash the old layers and restore them when unfolded.
             // TODO CLOTHING fix this.
-            if (ent.Comp.FoldedHideLayers != null && TryComp<HideLayerClothingComponent>(ent.Owner, out var hideLayerComp))
+            if (ent.Comp.FoldedHideLayers.Count != 0 && TryComp<HideLayerClothingComponent>(ent.Owner, out var hideLayerComp))
                 hideLayerComp.Slots = ent.Comp.FoldedHideLayers;
 
         }
@@ -81,7 +81,7 @@ public sealed class FoldableClothingSystem : EntitySystem
                 _itemSystem.SetHeldPrefix(ent.Owner, null, false, itemComp);
 
             // TODO CLOTHING fix this.
-            if (ent.Comp.UnfoldedHideLayers != null && TryComp<HideLayerClothingComponent>(ent.Owner, out var hideLayerComp))
+            if (ent.Comp.UnfoldedHideLayers.Count != 0 && TryComp<HideLayerClothingComponent>(ent.Owner, out var hideLayerComp))
                 hideLayerComp.Slots = ent.Comp.UnfoldedHideLayers;
 
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a bug where foldable clothing cannot be toggled when worn by a player.

## Technical details
<!-- Summary of code changes for easier review. -->
Previous changes to this code introduced a strange regression. The UnfoldedHideLayers and FoldedHideLayers were made nullable so that the default null value could be used to check for nothing being there and certain buggy interactions could be blocked.

The issue, however, is that the component's default value is an empty hashset, which is not null. Despite this not causing the buggy behavior being guarded against, it was still getting blocked, preventing any foldable clothing from being folded while worn.

To fix this, we simply make the hashset non-nullable and use the empty list to check rather than a null value.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![471327276-e8fc76b0-360e-4b4d-8f12-438e5fc7dc19](https://github.com/user-attachments/assets/0f0d6d1e-830a-473c-9583-b631193bc4d6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`FoldableClothingComponent.UnfoldedHideLayers` and `FoldableClothingComponent.FoldedHideLayers` no longer support null values. Use empty sets instead.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed being unable to fold certain clothing while worn.
