### PR TITLE
rolebriefingcomponent bugfix

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -125,8 +125,8 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         if (traitorRole is not null)
         {
             Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - Add traitor briefing components");
-            AddComp<RoleBriefingComponent>(traitorRole.Value.Owner);
-            Comp<RoleBriefingComponent>(traitorRole.Value.Owner).Briefing = briefing;
+            EnsureComp<RoleBriefingComponent>(traitorRole.Value.Owner, out var briefingComp);
+            briefingComp.Briefing = briefing;
         }
         else
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
RoleBriefingComponent is attached to a mind, the same mind getting "made traitor" by `MakeTraitor` method does not lead to an error after my fix

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
before my bugfix there was `AddComp`, which does not check if the component already is here. I changed it to `EnsureComp`
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:

https://github.com/user-attachments/assets/ae81a9a9-8a16-46ca-92d7-f8cf04cbd9c4

log: 
```
System.InvalidOperationException: Component reference type RoleBriefing already occupied by Content.Server.Roles.RoleBriefingComponent
   at Robust.Shared.GameObjects.EntityManager.AddComponentInternal[T](EntityUid uid, T component, ComponentRegistration reg, Boolean overwrite, Boolean skipInit, MetaDataComponent metadata)
   at Robust.Shared.GameObjects.EntityManager.AddComponent[T](EntityUid uid)
   at Content.Server.GameTicking.Rules.TraitorRuleSystem.MakeTraitor(EntityUid traitor, TraitorRuleComponent component) in TraitorRuleSystem.cs:line 128
```

After:


https://github.com/user-attachments/assets/55ce9a32-813a-47c1-a91c-daa6e7e22f4c



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
