### PR TITLE
Add examinable clothing

### DIFF
--- a/Content.Shared/Clothing/Components/ExaminableClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ExaminableClothingComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Inventory;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Clothing.Components;
+
+/// <summary>
+/// Clothing that contributes to the wearer's examine message when worn
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ExaminableClothingComponent : Component
+{
+    /// <summary>
+    /// Localization ID of the examine text to display. It will be slotted into a sentence of the form "PRONOUN(Wearer) is wearing INDEFINITE(ExaminableClothing)." If unspecified, defaults to the item's name.
+    /// </summary>
+    [DataField]
+    public LocId? ExamineText = null;
+
+    /// <summary>
+    /// Only adds the examine text in the given slots.
+    /// </summary>
+    [DataField]
+    public SlotFlags AllowedSlots = SlotFlags.WITHOUT_POCKET;
+}

--- a/Content.Shared/Clothing/EntitySystems/ExaminableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ExaminableClothingSystem.cs
@@ -1,0 +1,50 @@
+using Content.Shared.Clothing.Components;
+using Content.Shared.Examine;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Inventory;
+using Robust.Shared.Containers;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Clothing.EntitySystems;
+
+public sealed class ExaminableClothingSystem : EntitySystem
+{
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ExaminableClothingComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<ExaminableClothingComponent, InventoryRelayedEvent<ExaminedEvent>>(OnExaminedWorn);
+    }
+
+    private string ExamineText(Entity<ExaminableClothingComponent> ent, EntityUid wearer)
+    {
+        if (ent.Comp.ExamineText is { } examineText)
+        {
+            return Loc.GetString("examinable-clothing-examine", ("wearer", wearer), ("item", Loc.GetString(examineText, ("wearer", wearer))));
+        }
+        else
+        {
+            return Loc.GetString("examinable-clothing-examine", ("wearer", wearer), ("item", FormattedMessage.EscapeText(Identity.Name(ent, EntityManager))));
+        }
+    }
+
+    private void OnExamined(Entity<ExaminableClothingComponent> ent, ref ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("examinable-clothing-when-worn", ("message", ExamineText(ent, args.Examiner))));
+    }
+
+    private void OnExaminedWorn(Entity<ExaminableClothingComponent> ent, ref InventoryRelayedEvent<ExaminedEvent> args)
+    {
+        if (!_inventory.TryGetContainingSlot(ent.Owner, out var slot) || (slot.SlotFlags & ent.Comp.AllowedSlots) == SlotFlags.NONE)
+            return;
+
+        if (!_container.TryGetContainingContainer((ent.Owner, null, null), out var container))
+            return;
+
+        args.Args.PushMarkup(ExamineText(ent, container.Owner));
+    }
+}

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Ghost;
 using Content.Shared.Interaction;
+using Content.Shared.Inventory;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using JetBrains.Annotations;
@@ -293,7 +294,7 @@ namespace Content.Shared.Examine
     ///     If you're pushing multiple messages that should be grouped together (or ordered in some way),
     ///     call <see cref="PushGroup"/> before pushing and <see cref="PopGroup"/> when finished.
     /// </summary>
-    public sealed class ExaminedEvent : EntityEventArgs
+    public sealed class ExaminedEvent : EntityEventArgs, IInventoryRelayEvent
     {
         /// <summary>
         ///     The message that will be displayed as the examine text.
@@ -331,6 +332,8 @@ namespace Content.Shared.Examine
         private bool _hasDescription;
 
         private ExamineMessagePart? _currentGroupPart;
+
+        SlotFlags IInventoryRelayEvent.TargetSlots => SlotFlags.All;
 
         public ExaminedEvent(FormattedMessage message, EntityUid examined, EntityUid examiner, bool isInDetailsRange, bool hasDescription)
         {

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -9,6 +9,7 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Events;
 using Content.Shared.Electrocution;
 using Content.Shared.Emoting;
+using Content.Shared.Examine;
 using Content.Shared.Explosion;
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.Flash;
@@ -72,6 +73,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, FlashAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, WieldAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, UnwieldAttemptEvent>(RefRelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, ExaminedEvent>(RefRelayInventoryEvent);
 
         // Eye/vision events
         SubscribeLocalEvent<InventoryComponent, CanSeeAttemptEvent>(RelayInventoryEvent);

--- a/Resources/Locale/en-US/clothing/badge.ftl
+++ b/Resources/Locale/en-US/clothing/badge.ftl
@@ -1,0 +1,1 @@
+clothing-badge-lawyer = lawyer badge, indicating {DAT-OBJ($wearer)} as a certified [color=#FFD700]lawyer[/color]

--- a/Resources/Locale/en-US/clothing/components/examinable-clothing.ftl
+++ b/Resources/Locale/en-US/clothing/components/examinable-clothing.ftl
@@ -1,0 +1,2 @@
+examinable-clothing-when-worn = When worn, others will see: {$message}
+examinable-clothing-examine = {CAPITALIZE(SUBJECT($wearer))} {CONJUGATE-BE($wearer)} wearing {INDEFINITE($item)} {$item}.

--- a/Resources/Locale/en-US/clothing/medal.ftl
+++ b/Resources/Locale/en-US/clothing/medal.ftl
@@ -1,0 +1,8 @@
+clothing-medal-bronzeheart = bronzeheart medal, indicating {POSS-ADJ($wearer)} exemplary bravery in the face of danger
+clothing-medal-crewmanship = gold medal of crewmanship, indicating {POSS-ADJ($wearer)} excellent crewmanship
+clothing-medal-cargo = cargo medal, indicating {POSS-ADJ($wearer)} exemplary work in the cargo department
+clothing-medal-engineer = engineer medal, indicating {POSS-ADJ($wearer)} exemplary work in the engineering department
+clothing-medal-medical = medical medal, indicating {POSS-ADJ($wearer)} exemplary work in the medical department
+clothing-medal-science = science medal, indicating {POSS-ADJ($wearer)} exemplary work in the science department
+clothing-medal-security = science medal, indicating {POSS-ADJ($wearer)} exemplary work in the security department
+clothing-medal-clown = science medal, indicating {POSS-ADJ($wearer)} exemplary jokes

--- a/Resources/Locale/en-US/clothing/pride.ftl
+++ b/Resources/Locale/en-US/clothing/pride.ftl
@@ -1,0 +1,50 @@
+-clothing-pride-type-lgbt = [color=#d479d4]LGBT[/color] pride
+-clothing-pride-type-aromantic = [color=#3DA542]aromantic[/color] pride
+-clothing-pride-type-asexual = [color=#efefef]asexual[/color] [color=#800080]pride[/color]
+-clothing-pride-type-aroace = [color=#efc337]aroace[/color] [color=#45bcee]pride[/color]
+-clothing-pride-type-lesbian = [color=#EF7627]lesbian[/color] [color=#B55690]pride[/color]
+-clothing-pride-type-bisexual = [color=#D60270]bisexual[/color] [color=#0038A8]pride[/color]
+-clothing-pride-type-pansexual = [color=#FF218C]pansexual[/color] [color=#21B1FF]pride[/color]
+-clothing-pride-type-gay = [color=#078D70]gay[/color] [color=#5049CC]pride[/color]
+-clothing-pride-type-omnisexual = [color=#FE9ACE]omnisexual[/color] [color=#8EA6FF]pride[/color]
+-clothing-pride-type-intersex = [color=#FFD800]intersex[/color] [color=#7902AA]pride[/color]
+-clothing-pride-type-nonbinary = [color=#FCF434]nonbinary[/color] [color=#9C59D1]pride[/color]
+-clothing-pride-type-transgender = [color=#5BCEFA]transgender[/color] [color=#F5A9B8]pride[/color]
+-clothing-pride-type-genderfluid = [color=#FF76A4]genderfluid[/color] [color=#2F3CBE]pride[/color]
+-clothing-pride-type-autism = [color=#FFD700]autism[/color] pride
+-clothing-pride-type-straight-ally = [color=#7c7c7c]straight[/color] [color=#d479d4]LGBTQ ally[/color]
+-clothing-pride-type-genderqueer = [color=#B57EDC]genderqueer[/color] [color=#4A8123]pride[/color]
+-clothing-pride-type-plural = [color=#31C69E]plural[/color] [color=#6B3FBD]pride[/color]
+
+
+clothing-pin-lgbt = {-clothing-pride-type-lgbt} pin
+clothing-pin-aromantic = {-clothing-pride-type-aromantic} pin
+clothing-pin-asexual = {-clothing-pride-type-asexual} pin
+clothing-pin-aroace = {-clothing-pride-type-aroace} pin
+clothing-pin-lesbian = {-clothing-pride-type-lesbian} pin
+clothing-pin-bisexual = {-clothing-pride-type-bisexual} pin
+clothing-pin-pansexual = {-clothing-pride-type-pansexual} pin
+clothing-pin-gay = {-clothing-pride-type-gay} pin
+clothing-pin-omnisexual = {-clothing-pride-type-omnisexual} pin
+clothing-pin-intersex = {-clothing-pride-type-intersex} pin
+clothing-pin-nonbinary = {-clothing-pride-type-nonbinary} pin
+clothing-pin-transgender = {-clothing-pride-type-transgender} pin
+clothing-pin-genderfluid = {-clothing-pride-type-genderfluid} pin
+clothing-pin-autism = {-clothing-pride-type-autism} pin
+clothing-pin-straight-ally = {-clothing-pride-type-straight-ally} pin
+clothing-pin-genderqueer = {-clothing-pride-type-genderqueer} pin
+clothing-pin-plural = {-clothing-pride-type-plural} pin
+
+clothing-scarf-lgbt = {-clothing-pride-type-lgbt} scarf
+clothing-scarf-aromantic = {-clothing-pride-type-aromantic} scarf
+clothing-scarf-asexual = {-clothing-pride-type-asexual} scarf
+clothing-scarf-aroace = {-clothing-pride-type-aroace} scarf
+clothing-scarf-lesbian = {-clothing-pride-type-lesbian} scarf
+clothing-scarf-bisexual = {-clothing-pride-type-bisexual} scarf
+clothing-scarf-pansexual = {-clothing-pride-type-pansexual} scarf
+clothing-scarf-gay = {-clothing-pride-type-gay} scarf
+clothing-scarf-intersex = {-clothing-pride-type-intersex} scarf
+clothing-scarf-nonbinary = {-clothing-pride-type-nonbinary} scarf
+clothing-scarf-transgender = {-clothing-pride-type-transgender} scarf
+
+clothing-scarf-long-bacon = piece of [color=#EF7627]long[/color] [color=white]ba[/color][color=#B55690]con[/color]

--- a/Resources/Prototypes/Entities/Clothing/Neck/medals.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/medals.yml
@@ -1,6 +1,6 @@
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseExaminableClothing]
   id: ClothingNeckBronzeheart
   name: bronzeheart medal
   description: Given to crewmates for exemplary bravery in the face of danger.
@@ -13,9 +13,11 @@
     tags:
       - Medal
       - WhitelistChameleon
+  - type: ExaminableClothing
+    examineText: clothing-medal-bronzeheart
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseExaminableClothing]
   id: ClothingNeckGoldmedal
   name: gold medal of crewmanship
   description: Given to crewmates who display excellent crewmanship.
@@ -30,9 +32,11 @@
     tags:
       - Medal
       - WhitelistChameleon
+  - type: ExaminableClothing
+    examineText: clothing-medal-crewmanship
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseExaminableClothing]
   id: ClothingNeckCargomedal
   name: cargo medal
   description: Given for the best work in the cargo department.
@@ -45,9 +49,11 @@
     tags:
       - Medal
       - WhitelistChameleon
+  - type: ExaminableClothing
+    examineText: clothing-medal-cargo
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseExaminableClothing]
   id: ClothingNeckEngineermedal
   name: engineer medal
   description: Given for the best work in the engineering department.
@@ -60,9 +66,11 @@
     tags:
       - Medal
       - WhitelistChameleon
+  - type: ExaminableClothing
+    examineText: clothing-medal-engineer
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseExaminableClothing]
   id: ClothingNeckMedicalmedal
   name: medical medal
   description: Given for the best work in the medical department.
@@ -75,9 +83,11 @@
     tags:
       - Medal
       - WhitelistChameleon
+  - type: ExaminableClothing
+    examineText: clothing-medal-medical
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseExaminableClothing]
   id: ClothingNeckSciencemedal
   name: science medal
   description: Given for the best work in the science department.
@@ -90,9 +100,11 @@
     tags:
       - Medal
       - WhitelistChameleon
+  - type: ExaminableClothing
+    examineText: clothing-medal-science
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseExaminableClothing]
   id: ClothingNeckSecuritymedal
   name: security medal
   description: Given for the best work in the security department.
@@ -105,9 +117,11 @@
     tags:
       - Medal
       - WhitelistChameleon
+  - type: ExaminableClothing
+    examineText: clothing-medal-security
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseExaminableClothing]
   id: ClothingNeckClownmedal
   name: clown medal
   description: Given for the best joke in the universe. HONK!
@@ -122,3 +136,5 @@
     tags:
       - Medal
       - WhitelistChameleon
+  - type: ExaminableClothing
+    examineText: clothing-medal-clown

--- a/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
@@ -46,7 +46,7 @@
     sprite: Clothing/Neck/Misc/bling.rsi
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseExaminableClothing]
   id: ClothingNeckLawyerbadge
   name: lawyer badge
   description: A badge to show that the owner is a 'legitimate' lawyer who passed the NT bar exam required to practice law.
@@ -57,6 +57,8 @@
     sprite: Clothing/Neck/Misc/lawyerbadge.rsi
   - type: TypingIndicatorClothing
     proto: lawyer
+  - type: ExaminableClothing
+    examineText: clothing-badge-lawyer
 
 - type: entity
   parent: ClothingNeckBase

--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseExaminableClothing]
   id: ClothingNeckPinBase
   abstract: true
   name: pin
@@ -22,6 +22,8 @@
     state: lgbt
   - type: Clothing
     equippedPrefix: lgbt
+  - type: ExaminableClothing
+    examineText: clothing-pin-lgbt
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -33,6 +35,8 @@
     state: ally
   - type: Clothing
     equippedPrefix: ally
+  - type: ExaminableClothing
+    examineText: clothing-pin-straight-ally
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -44,6 +48,8 @@
     state: aro
   - type: Clothing
     equippedPrefix: aro
+  - type: ExaminableClothing
+    examineText: clothing-pin-aromantic
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -55,6 +61,8 @@
     state: aroace
   - type: Clothing
     equippedPrefix: aroace
+  - type: ExaminableClothing
+    examineText: clothing-pin-aroace
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -66,6 +74,8 @@
     state: asex
   - type: Clothing
     equippedPrefix: asex
+  - type: ExaminableClothing
+    examineText: clothing-pin-asexual
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -77,6 +87,8 @@
     state: bi
   - type: Clothing
     equippedPrefix: bi
+  - type: ExaminableClothing
+    examineText: clothing-pin-bisexual
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -88,6 +100,8 @@
     state: gay
   - type: Clothing
     equippedPrefix: gay
+  - type: ExaminableClothing
+    examineText: clothing-pin-gay
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -99,6 +113,8 @@
     state: inter
   - type: Clothing
     equippedPrefix: inter
+  - type: ExaminableClothing
+    examineText: clothing-pin-intersex
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -110,6 +126,8 @@
     state: les
   - type: Clothing
     equippedPrefix: les
+  - type: ExaminableClothing
+    examineText: clothing-pin-lesbian
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -121,6 +139,8 @@
     state: non
   - type: Clothing
     equippedPrefix: non
+  - type: ExaminableClothing
+    examineText: clothing-pin-nonbinary
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -132,6 +152,8 @@
     state: pan
   - type: Clothing
     equippedPrefix: pan
+  - type: ExaminableClothing
+    examineText: clothing-pin-pansexual
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -143,6 +165,8 @@
     state: plural
   - type: Clothing
     equippedPrefix: plural
+  - type: ExaminableClothing
+    examineText: clothing-pin-plural
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -154,6 +178,8 @@
     state: omni
   - type: Clothing
     equippedPrefix: omni
+  - type: ExaminableClothing
+    examineText: clothing-pin-omnisexual
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -165,6 +191,8 @@
     state: gender
   - type: Clothing
     equippedPrefix: gender
+  - type: ExaminableClothing
+    examineText: clothing-pin-genderqueer
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -176,6 +204,8 @@
     state: fluid
   - type: Clothing
     equippedPrefix: fluid
+  - type: ExaminableClothing
+    examineText: clothing-pin-genderfluid
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -187,6 +217,8 @@
     state: trans
   - type: Clothing
     equippedPrefix: trans
+  - type: ExaminableClothing
+    examineText: clothing-pin-transgender
 
 - type: entity
   parent: ClothingNeckPinBase
@@ -209,3 +241,5 @@
     state: goldautism
   - type: Clothing
     equippedPrefix: goldautism
+  - type: ExaminableClothing
+    examineText: clothing-pin-autism

--- a/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
@@ -136,7 +136,7 @@
 
 # Pride Scarves
 - type: entity
-  parent: ClothingScarfBase
+  parent: [ClothingScarfBase, BaseExaminableClothing]
   id: ClothingNeckScarfStripedAce
   name: striped asexual scarf
   description: A stylish striped asexual scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -145,9 +145,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/ace.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/ace.rsi
+  - type: ExaminableClothing
+    examineText: clothing-scarf-asexual
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: [ClothingScarfBase, BaseExaminableClothing]
   id: ClothingNeckScarfStripedAro
   name: striped aromantic scarf
   description: A stylish striped aromantic scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -156,9 +158,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/aro.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/aro.rsi
+  - type: ExaminableClothing
+    examineText: clothing-scarf-aromantic
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: [ClothingScarfBase, BaseExaminableClothing]
   id: ClothingNeckScarfStripedAroace
   name: striped aroace scarf
   description: A stylish striped aroace scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -167,9 +171,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/aroace.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/aroace.rsi
+  - type: ExaminableClothing
+    examineText: clothing-scarf-aroace
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: [ClothingScarfBase, BaseExaminableClothing]
   id: ClothingNeckScarfStripedBiSexual
   name: striped bisexual scarf
   description: A stylish striped bisexual scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -178,9 +184,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/bi.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/bi.rsi
+  - type: ExaminableClothing
+    examineText: clothing-scarf-bisexual
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: [ClothingScarfBase, BaseExaminableClothing]
   id: ClothingNeckScarfStripedGay
   name: striped gay scarf
   description: A stylish striped gay scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -189,9 +197,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/gay.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/gay.rsi
+  - type: ExaminableClothing
+    examineText: clothing-scarf-gay
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: [ClothingScarfBase, BaseExaminableClothing]
   id: ClothingNeckScarfStripedInter
   name: striped intersex scarf
   description: A stylish striped intersex scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -200,9 +210,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/inter.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/inter.rsi
+  - type: ExaminableClothing
+    examineText: clothing-scarf-intersex
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: [ClothingScarfBase, BaseExaminableClothing]
   id: ClothingNeckScarfStripedLesbian
   name: striped lesbian scarf
   description: A stylish striped lesbian scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -211,9 +223,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/lesbian.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/lesbian.rsi
+  - type: ExaminableClothing
+    examineText: clothing-scarf-lesbian
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: [ClothingScarfBase, BaseExaminableClothing]
   id: ClothingNeckScarfStripedPan
   name: striped pan scarf
   description: A stylish striped pan scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -222,9 +236,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/pan.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/pan.rsi
+  - type: ExaminableClothing
+    examineText: clothing-scarf-pansexual
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: [ClothingScarfBase, BaseExaminableClothing]
   id: ClothingNeckScarfStripedNonBinary
   name: striped non-binary scarf
   description: A stylish striped non-binary scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -233,9 +249,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/non.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/non.rsi
+  - type: ExaminableClothing
+    examineText: clothing-scarf-nonbinary
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: [ClothingScarfBase, BaseExaminableClothing]
   id: ClothingNeckScarfStripedRainbow
   name: rainbow scarf
   description: A stylish rainbow scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -244,9 +262,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/rainbow.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/rainbow.rsi
+  - type: ExaminableClothing
+    examineText: clothing-scarf-lgbt
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: [ClothingScarfBase, BaseExaminableClothing]
   id: ClothingNeckScarfStripedTrans
   name: striped trans scarf
   description: A stylish striped trans scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -255,9 +275,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/trans.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/trans.rsi
+  - type: ExaminableClothing
+    examineText: clothing-scarf-transgender
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: [ClothingScarfBase, BaseExaminableClothing]
   id: ClothingNeckScarfStripedLesbianLong
   name: long bacon
   description: Long bacon! Perfect for sharing with your girlfriend!
@@ -266,3 +288,5 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/lesbian-long.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/lesbian-long.rsi
+  - type: ExaminableClothing
+    examineText: clothing-scarf-long-bacon

--- a/Resources/Prototypes/Entities/Clothing/base_clothing.yml
+++ b/Resources/Prototypes/Entities/Clothing/base_clothing.yml
@@ -69,3 +69,10 @@
   - type: ItemToggle
     onUse: false # can't really wear it like that
   - type: ToggleClothing
+
+# a piece of clothing that is obvious when worn
+- type: entity
+  abstract: true
+  id: BaseExaminableClothing
+  components:
+  - type: ExaminableClothing


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the ability for clothing to be marked as examinable, which results in it being indicated textually on examining the wearer. Also scaffolds examine inventory relay events, which could be used for e.g. examinable internals state on other people later down the line.

## Why / Balance
This is a middle point between the current "only hands" examination and ss13-style "everything" examination, allowing specific pieces of clothing to be marked as examinable, optionally with a unique string. Currently, this is used to flag:
- pride items
- medals
- lawyer's badge

## Technical details
- set up `ExaminedEvent` as an inventory relay event
- `ExaminableClothingComponent`/`ExaminableClothingSystem` to handle the `ExaminedEvent`

## Media
<img width="521" height="341" alt="grafik" src="https://github.com/user-attachments/assets/35d3ceda-774b-4b84-91d1-653650398fe5" />
<img width="494" height="293" alt="grafik" src="https://github.com/user-attachments/assets/63114482-433f-426f-a147-04966d198b7f" />
<img width="489" height="311" alt="grafik" src="https://github.com/user-attachments/assets/d978a5c1-c6a4-426c-a7f5-910c858cacaa" />
<img width="499" height="246" alt="grafik" src="https://github.com/user-attachments/assets/0beb5a4b-43ed-4d06-b0f1-3001849476e2" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

Pride examine texts authored by & used with permission from @jtfg-dev, originally part of aer work on Impstation.

**Changelog**
:cl:
- add: Medals, pride pins and scarves, and lawyer badges are now visible on examination
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
