### PR TITLE
Swap the behavior of backpacks and satchels.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -15,7 +15,9 @@
     - back
   - type: Storage
     grid:
-    - 0,0,6,3
+    - 0,0,1,3
+    - 3,0,6,3
+    - 8,0,9,3
     maxItemSize: Huge
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -8,9 +8,7 @@
     sprite: Clothing/Back/Satchels/satchel.rsi
   - type: Storage
     grid:
-    - 0,0,1,3
-    - 3,0,6,3
-    - 8,0,9,3
+    - 0,0,6,3
 
 - type: entity
   parent: ClothingBackpackSatchel


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Gives the backpack the 2x4, 4x4, 2x4 split inventory and the satchel the 7x4 single inventory, essentially swapping their behavior.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Both in real life and in game visually, backpacks are larger than satchels. In addition, backpacks generally have multiple pockets while satchels tend to have a single pocket. The goal of this PR is to make satchels and backpacks behave a bit more sensibly without changing the balance or meta.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Nox38
- tweak: Backpacks now have a larger, split inventory while satchels have a smaller combined inventory.
