### PR TITLE
fix DoAfter DistanceThreshold

### DIFF
--- a/Content.Shared/DoAfter/DoAfterArgs.cs
+++ b/Content.Shared/DoAfter/DoAfterArgs.cs
@@ -122,7 +122,7 @@ public sealed partial class DoAfterArgs
     ///     Threshold for distance user from the used OR target entities.
     /// </summary>
     [DataField]
-    public float? DistanceThreshold;
+    public float? DistanceThreshold = 1.5f;
 
     /// <summary>
     ///     Whether damage will cancel the DoAfter. See also <see cref="DamageThreshold"/>.

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -192,11 +192,6 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
                 if (!_interaction.InRangeUnobstructed(args.User, args.Target.Value, args.DistanceThreshold.Value))
                     return true;
             }
-            else
-            {
-                if (!_interaction.InRangeUnobstructed(args.User, args.Target.Value))
-                    return true;
-            }
         }
 
         // Whether the distance between the tool and the user has grown too much.
@@ -207,11 +202,6 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
                 if (!_interaction.InRangeUnobstructed(args.User,
                         args.Used.Value,
                         args.DistanceThreshold.Value))
-                    return true;
-            }
-            else
-            {
-                if (!_interaction.InRangeUnobstructed(args.User,args.Used.Value))
                     return true;
             }
         }


### PR DESCRIPTION
## About the PR
The `DistanceThreshold` in `DoafterArgs` is a nullable float, but setting it to null calls `InRangeUnobstructed` with the default range value of 1.5 instead of disabling the check like you would expect.
So having no range checks for a DoAfter is currently impossible.
We set the default value to 1.5 so that all existing DoAfters that don't overwrite this value will behave the same as before.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Should have exactly the same behaviour as before.

**Changelog**
no cl no fun
