### PR TITLE
Convert `ThrownItemComponent.Thrower` to `WeakEntityReference`

### DIFF
--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -37,7 +37,7 @@ namespace Content.Server.Damage.Systems
             if (TerminatingOrDeleted(args.Target))
                 return;
 
-            var dmg = _damageable.TryChangeDamage(args.Target, component.Damage * _damageable.UniversalThrownDamageModifier, component.IgnoreResistances, origin: args.Component.Thrower);
+            var dmg = _damageable.TryChangeDamage(args.Target, component.Damage * _damageable.UniversalThrownDamageModifier, component.IgnoreResistances, origin: Resolve(args.Component.Thrower));
 
             // Log damage only for mobs. Useful for when people throw spears at each other, but also avoids log-spam when explosions send glass shards flying.
             if (dmg != null && HasComp<MobStateComponent>(args.Target))

--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -153,7 +153,7 @@ public sealed class ThrowingSystem : EntitySystem
 
         var comp = new ThrownItemComponent
         {
-            Thrower = user,
+            Thrower = GetWeakReference(user),
             Animate = animated,
         };
 

--- a/Content.Shared/Throwing/ThrownItemComponent.cs
+++ b/Content.Shared/Throwing/ThrownItemComponent.cs
@@ -17,8 +17,8 @@ namespace Content.Shared.Throwing
         /// <summary>
         ///     The entity that threw this entity.
         /// </summary>
-        [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-        public EntityUid? Thrower;
+        [DataField, AutoNetworkedField]
+        public WeakEntityReference? Thrower;
 
         /// <summary>
         ///     The <see cref="IGameTiming.CurTime"/> timestamp at which this entity was thrown.

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -64,7 +64,7 @@ namespace Content.Shared.Throwing
             if (!args.OtherFixture.Hard)
                 return;
 
-            if (args.OtherEntity == component.Thrower)
+            if (args.OtherEntity == Resolve(component.Thrower))
                 return;
 
             ThrowCollideInteraction(component, args.OurEntity, args.OtherEntity);
@@ -72,7 +72,7 @@ namespace Content.Shared.Throwing
 
         private void PreventCollision(EntityUid uid, ThrownItemComponent component, ref PreventCollideEvent args)
         {
-            if (args.OtherEntity == component.Thrower)
+            if (args.OtherEntity == Resolve(component.Thrower))
             {
                 args.Cancelled = true;
             }
@@ -110,7 +110,7 @@ namespace Content.Shared.Throwing
                 }
             }
 
-            var ev = new StopThrowEvent(thrownItemComponent.Thrower);
+            var ev = new StopThrowEvent(Resolve(thrownItemComponent.Thrower));
             RaiseLocalEvent(uid, ref ev);
             RemComp<ThrownItemComponent>(uid);
         }
@@ -127,7 +127,7 @@ namespace Content.Shared.Throwing
                 _adminLogger.Add(LogType.Landed, LogImpact.Low, $"{ToPrettyString(uid):entity} thrown by {ToPrettyString(thrownItem.Thrower.Value):thrower} landed.");
 
             _broadphase.RegenerateContacts((uid, physics));
-            var landEvent = new LandEvent(thrownItem.Thrower, playSound);
+            var landEvent = new LandEvent(Resolve(thrownItem.Thrower), playSound);
             RaiseLocalEvent(uid, ref landEvent);
         }
 

--- a/Content.Shared/Weapons/Melee/MeleeThrowOnHitSystem.cs
+++ b/Content.Shared/Weapons/Melee/MeleeThrowOnHitSystem.cs
@@ -82,7 +82,7 @@ public sealed class MeleeThrowOnHitSystem : EntitySystem
         weapon.Comp.HitWhileThrown = true;
         DirtyField(weapon, weapon.Comp, nameof(MeleeThrowOnHitComponent.HitWhileThrown));
 
-        ThrowOnHitHelper(weapon, args.Component.Thrower, args.Target, weaponPhysics.LinearVelocity);
+        ThrowOnHitHelper(weapon, Resolve(args.Component.Thrower), args.Target, weaponPhysics.LinearVelocity);
     }
 
     private void ThrowOnHitHelper(Entity<MeleeThrowOnHitComponent> ent, EntityUid? user, EntityUid target, Vector2 direction)

--- a/Content.Shared/Weapons/Misc/SharedTetherGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedTetherGunSystem.cs
@@ -221,7 +221,7 @@ public abstract partial class SharedTetherGunSystem : EntitySystem
         _physics.SetAngularVelocity(target, SpinVelocity, body: targetPhysics);
         _physics.WakeBody(target, body: targetPhysics);
         var thrown = EnsureComp<ThrownItemComponent>(component.Tethered.Value);
-        thrown.Thrower = gunUid;
+        thrown.Thrower = GetWeakReference(gunUid);
         _blocker.UpdateCanMove(target);
 
         // Invisible tether entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The `Thrower` field of `ThrownItemComponent` is now a `WeakEntityReference?` instead of an `EntityUid?`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This fixes PVS error spam in the server logs when a thrown item's thrower is deleted.
```
Can't resolve "Robust.Shared.GameObjects.MetaDataComponent" on entity 640737!
   at System.Environment.get_StackTrace()
   at Robust.Shared.GameObjects.EntityManager.GetNetEntity(EntityUid uid, MetaDataComponent metadata) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Network.cs:line 186
   at Content.Shared.Throwing.ThrownItemComponent.ThrownItemComponent_AutoNetworkSystem.OnGetState(EntityUid uid, ThrownItemComponent component, ComponentGetState& args) in /home/runner/work/space-station-14/space-station-14/Content.Shared/obj/Release/Robust.Shared.CompNetworkGenerator/Robust.Shared.CompNetworkGenerator.ComponentNetworkGenerator/ThrownItemComponent_CompNetwork.g.cs:line 49
...
```

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the type of `Thrower` from `EntityUid?` to `WeakEntityReference?` and updated places where it was used to call `Resolve` or `GetWeakReference` as needed.

Requires https://github.com/space-wizards/RobustToolbox/pull/6114.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
The `Thrower` field of `ThrownItemComponent` is now a `WeakEntityReference?` instead of an `EntityUid?`. Use the `Resolve` or `GetWeakReference` methods of `EntityManager` (or their proxies in `EntitySystem`) to read or write to the field.