### PR TITLE
Fix BiomeDunGen

### DIFF
--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Biome.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Biome.cs
@@ -14,7 +14,10 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="BiomeDunGen"/>
     /// </summary>
-    private async Task PostGen(BiomeDunGen dunGen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(BiomeDunGen dunGen,
+        List<Dungeon> dungeons,
+        HashSet<Vector2i> reservedTiles,
+        Random random)
     {
         if (!_prototype.TryIndex(dunGen.BiomeTemplate, out var indexedBiome))
             return;
@@ -24,51 +27,65 @@ public sealed partial class DungeonJob
         var seed = random.Next();
         var xformQuery = _entManager.GetEntityQuery<TransformComponent>();
 
-        var tiles = _maps.GetAllTilesEnumerator(_gridUid, _grid);
-        while (tiles.MoveNext(out var tileRef))
+        foreach (var dun in dungeons)
         {
-            var node = tileRef.Value.GridIndices;
-
-            if (reservedTiles.Contains(node))
-                continue;
-
-            if (dunGen.TileMask is not null)
+            foreach (var node in dun.AllTiles)
             {
-                if (!dunGen.TileMask.Contains(((ContentTileDefinition)_tileDefManager[tileRef.Value.Tile.TypeId]).ID))
+                var tileRef = _maps.GetTileRef(_gridUid, _grid, node);
+
+                if (reservedTiles.Contains(node))
                     continue;
-            }
 
-            // Need to set per-tile to override data.
-            if (biomeSystem.TryGetTile(node, indexedBiome.Layers, seed, (_gridUid, _grid), out var tile))
-            {
-                _maps.SetTile(_gridUid, _grid, node, tile.Value);
-            }
-
-            if (biomeSystem.TryGetDecals(node, indexedBiome.Layers, seed, (_gridUid, _grid), out var decals))
-            {
-                foreach (var decal in decals)
+                if (dunGen.TileMask is not null)
                 {
-                    _decals.TryAddDecal(decal.ID, new EntityCoordinates(_gridUid, decal.Position), out _);
-                }
-            }
-
-            if (biomeSystem.TryGetEntity(node, indexedBiome.Layers, tile ?? tileRef.Value.Tile, seed, (_gridUid, _grid), out var entityProto))
-            {
-                var ent = _entManager.SpawnEntity(entityProto, new EntityCoordinates(_gridUid, node + _grid.TileSizeHalfVector));
-                var xform = xformQuery.Get(ent);
-
-                if (!xform.Comp.Anchored)
-                {
-                    _transform.AnchorEntity(ent, xform);
+                    if (!dunGen.TileMask.Contains(((ContentTileDefinition)_tileDefManager[tileRef.Tile.TypeId]).ID))
+                        continue;
                 }
 
-                // TODO: Engine bug with SpawnAtPosition
-                DebugTools.Assert(xform.Comp.Anchored);
-            }
+                if (dunGen.TileMask is not null)
+                {
+                    if (!dunGen.TileMask.Contains(((ContentTileDefinition)_tileDefManager[tileRef.Tile.TypeId]).ID))
+                        continue;
+                }
 
-            await SuspendDungeon();
-            if (!ValidateResume())
-                return;
+                // Need to set per-tile to override data.
+                if (biomeSystem.TryGetTile(node, indexedBiome.Layers, seed, (_gridUid, _grid), out var tile))
+                {
+                    _maps.SetTile(_gridUid, _grid, node, tile.Value);
+                }
+
+                if (biomeSystem.TryGetDecals(node, indexedBiome.Layers, seed, (_gridUid, _grid), out var decals))
+                {
+                    foreach (var decal in decals)
+                    {
+                        _decals.TryAddDecal(decal.ID, new EntityCoordinates(_gridUid, decal.Position), out _);
+                    }
+                }
+
+                if (biomeSystem.TryGetEntity(node,
+                        indexedBiome.Layers,
+                        tile ?? tileRef.Tile,
+                        seed,
+                        (_gridUid, _grid),
+                        out var entityProto))
+                {
+                    var ent = _entManager.SpawnEntity(entityProto,
+                        new EntityCoordinates(_gridUid, node + _grid.TileSizeHalfVector));
+                    var xform = xformQuery.Get(ent);
+
+                    if (!xform.Comp.Anchored)
+                    {
+                        _transform.AnchorEntity(ent, xform);
+                    }
+
+                    // TODO: Engine bug with SpawnAtPosition
+                    DebugTools.Assert(xform.Comp.Anchored);
+                }
+
+                await SuspendDungeon();
+                if (!ValidateResume())
+                    return;
+            }
         }
     }
 }

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.cs
@@ -223,7 +223,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
                 await PostGen(markerPost, dungeons[^1], reservedTiles, random);
                 break;
             case BiomeDunGen biome:
-                await PostGen(biome, dungeons[^1], reservedTiles, random);
+                await PostGen(biome, dungeons, reservedTiles, random);
                 break;
             case BoundaryWallDunGen boundary:
                 await PostGen(boundary, dungeons[^1], reservedTiles, random);


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
No more _maps.GetAllTilesEnumerator iterations! Iterate only through all dungeons tiles now.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfix

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
