### PR TITLE
add: air alarm scrubber select all gases button

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
@@ -30,7 +30,7 @@
                     <CollapsibleHeading Title="Gas filters" />
                     <CollapsibleBody Margin="20 0 0 0">
                         <BoxContainer Orientation="Vertical">
-                            <BoxContainer Orientation="Horizontal" Margin="5" >
+                            <BoxContainer Orientation="Horizontal" Margin="2" >
                                 <Button Name="CSelectAll" Text="select all"></Button>
                                 <Button Name="CDeselectAll" Text="deselect all"></Button>
                             </BoxContainer>

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
@@ -30,9 +30,9 @@
                     <CollapsibleHeading Title="Gas filters" />
                     <CollapsibleBody Margin="20 0 0 0">
                         <BoxContainer Orientation="Vertical">
-                            <BoxContainer Orientation="Horizontal" Margin="2" >
-                                <Button Name="CSelectAll" Text="{Loc 'air-alarm-ui-scrubber-select-all-gases-label'}"></Button>
-                                <Button Name="CDeselectAll" Text="{Loc 'air-alarm-ui-scrubber-deselect-all-gases-label'}"></Button>
+                            <BoxContainer Orientation="Horizontal" Margin="2">
+                                <Button Name="CSelectAll" Text="{Loc 'air-alarm-ui-scrubber-select-all-gases-label'}" />
+                                <Button Name="CDeselectAll" Text="{Loc 'air-alarm-ui-scrubber-deselect-all-gases-label'}" />
                             </BoxContainer>
                             <GridContainer HorizontalExpand="True" Name="CGasContainer" Columns="3" />
                         </BoxContainer>

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
@@ -29,7 +29,13 @@
                 <Collapsible Margin="2 2 2 2">
                     <CollapsibleHeading Title="Gas filters" />
                     <CollapsibleBody Margin="20 0 0 0">
-                        <GridContainer HorizontalExpand="True" Name="CGasContainer" Columns="3" />
+                        <BoxContainer Orientation="Vertical">
+                            <BoxContainer Orientation="Horizontal" Margin="5" >
+                                <Button Name="CSelectAll" Text="select all"></Button>
+                                <Button Name="CDeselectAll" Text="deselect all"></Button>
+                            </BoxContainer>
+                            <GridContainer HorizontalExpand="True" Name="CGasContainer" Columns="3" />
+                        </BoxContainer>
                     </CollapsibleBody>
                 </Collapsible>
             </BoxContainer>

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
@@ -31,8 +31,8 @@
                     <CollapsibleBody Margin="20 0 0 0">
                         <BoxContainer Orientation="Vertical">
                             <BoxContainer Orientation="Horizontal" Margin="2" >
-                                <Button Name="CSelectAll" Text="select all"></Button>
-                                <Button Name="CDeselectAll" Text="deselect all"></Button>
+                                <Button Name="CSelectAll" Text="{Loc 'air-alarm-ui-scrubber-select-all-gases-label'}"></Button>
+                                <Button Name="CDeselectAll" Text="{Loc 'air-alarm-ui-scrubber-deselect-all-gases-label'}"></Button>
                             </BoxContainer>
                             <GridContainer HorizontalExpand="True" Name="CGasContainer" Columns="3" />
                         </BoxContainer>

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
@@ -22,6 +22,8 @@ public sealed partial class ScrubberControl : BoxContainer
     private FloatSpinBox _volumeRate => CVolumeRate;
     private CheckBox _wideNet => CWideNet;
     private Button _copySettings => CCopySettings;
+    private Button _selectAll => CSelectAll;
+    private Button _deselectAll => CDeselectAll;
 
     private GridContainer _gases => CGasContainer;
     private Dictionary<Gas, Button> _gasControls = new();
@@ -76,6 +78,17 @@ public sealed partial class ScrubberControl : BoxContainer
         _copySettings.OnPressed += _ =>
         {
             ScrubberDataCopied?.Invoke(_data);
+        };
+
+        _selectAll.OnPressed += _ =>
+        {
+            _data.FilterGases = new HashSet<Gas>(Enum.GetValues<Gas>());
+            ScrubberDataChanged?.Invoke(_address, _data);
+        };
+        _deselectAll.OnPressed += _ =>
+        {
+            _data.FilterGases = [];
+            ScrubberDataChanged?.Invoke(_address, _data);
         };
 
         foreach (var value in Enum.GetValues<Gas>())

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -69,6 +69,8 @@ air-alarm-ui-vent-internal-bound-label = Internal bound
 air-alarm-ui-scrubber-pump-direction-label = Direction
 air-alarm-ui-scrubber-volume-rate-label = Rate (L)
 air-alarm-ui-scrubber-wide-net-label = WideNet
+air-alarm-ui-scrubber-select-all-gases-label = Select all
+air-alarm-ui-scrubber-deselect-all-gases-label = Deselect all
 
 ### Thresholds
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Add buttons in the air alarm window to select and deselect all gases scrubbed by an air scrubber.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Saves time, good stuff. You can quickly deselect all gases, then select a specific gas you want to scrub, and more.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="647" height="458" alt="25-07-31_625_Content Client" src="https://github.com/user-attachments/assets/6e03d81c-85a3-456e-8d72-50cf1bb85e94" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: The air alarm window scrubber controller now has buttons to select and deselect all gases.