### PR TITLE
Allow easier adjustment of pipe layers as aghost

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/PipeLayerTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/PipeLayerTest.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Atmos.Components;
+
+namespace Content.IntegrationTests.Tests.Atmos;
+
+[TestFixture]
+public sealed class PipeLayerTest
+{
+    [Test]
+    public async Task TestPipeLayersValid()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var layerCount = Enum.GetValues<AtmosPipeLayer>().Length;
+
+        Assert.Multiple(() =>
+        {
+            foreach (var (proto, comp) in pair.GetPrototypesWithComponent<AtmosPipeLayersComponent>())
+            {
+                Assert.That(comp.NumberOfPipeLayers,
+                    Is.AtMost(layerCount),
+                    $"Prototype {proto.ID} has a higher number of pipe layers than supported.");
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Atmos/EntitySystems/AtmosPipeLayersSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosPipeLayersSystem.cs
@@ -59,7 +59,7 @@ public sealed partial class AtmosPipeLayersSystem : SharedAtmosPipeLayersSystem
         }
 
         // If a user wasn't responsible for unanchoring the pipe, leave it be
-        if (user == null || used == null)
+        if (user == null)
             return;
 
         // Unanchor the pipe if its new layer overlaps with another pipe
@@ -68,9 +68,9 @@ public sealed partial class AtmosPipeLayersSystem : SharedAtmosPipeLayersSystem
         if (!HasComp<PipeRestrictOverlapComponent>(ent) || !_pipeRestrictOverlap.CheckOverlap((ent, nodeContainer, xform)))
             return;
 
-        RaiseLocalEvent(ent, new BeforeUnanchoredEvent(user.Value, used.Value));
+        RaiseLocalEvent(ent, new BeforeUnanchoredEvent(user.Value, used));
         _xform.Unanchor(ent, xform);
-        RaiseLocalEvent(ent, new UserUnanchoredEvent(user.Value, used.Value));
+        RaiseLocalEvent(ent, new UserUnanchoredEvent(user.Value, used));
 
         _popup.PopupEntity(Loc.GetString("pipe-restrict-overlap-popup-blocked", ("pipe", ent)), ent, user.Value);
     }

--- a/Content.Shared/Construction/Components/AnchorableComponent.cs
+++ b/Content.Shared/Construction/Components/AnchorableComponent.cs
@@ -38,7 +38,7 @@ namespace Content.Shared.Construction.Components
     public abstract class BaseAnchoredAttemptEvent : CancellableEntityEventArgs
     {
         public EntityUid User { get; }
-        public EntityUid Tool { get; }
+        public EntityUid? Tool { get; }
 
         /// <summary>
         ///     Extra delay to add to the do_after.
@@ -47,7 +47,7 @@ namespace Content.Shared.Construction.Components
         /// </summary>
         public float Delay { get; set; } = 0f;
 
-        protected BaseAnchoredAttemptEvent(EntityUid user, EntityUid tool)
+        protected BaseAnchoredAttemptEvent(EntityUid user, EntityUid? tool)
         {
             User = user;
             Tool = tool;
@@ -56,20 +56,20 @@ namespace Content.Shared.Construction.Components
 
     public sealed class AnchorAttemptEvent : BaseAnchoredAttemptEvent
     {
-        public AnchorAttemptEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
+        public AnchorAttemptEvent(EntityUid user, EntityUid? tool) : base(user, tool) { }
     }
 
     public sealed class UnanchorAttemptEvent : BaseAnchoredAttemptEvent
     {
-        public UnanchorAttemptEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
+        public UnanchorAttemptEvent(EntityUid user, EntityUid? tool) : base(user, tool) { }
     }
 
     public abstract class BaseAnchoredEvent : EntityEventArgs
     {
         public EntityUid User { get; }
-        public EntityUid Tool { get; }
+        public EntityUid? Tool { get; }
 
-        protected BaseAnchoredEvent(EntityUid user, EntityUid tool)
+        protected BaseAnchoredEvent(EntityUid user, EntityUid? tool)
         {
             User = user;
             Tool = tool;
@@ -81,7 +81,7 @@ namespace Content.Shared.Construction.Components
     /// </summary>
     public sealed class BeforeAnchoredEvent : BaseAnchoredEvent
     {
-        public BeforeAnchoredEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
+        public BeforeAnchoredEvent(EntityUid user, EntityUid? tool) : base(user, tool) { }
     }
 
     /// <summary>
@@ -91,7 +91,7 @@ namespace Content.Shared.Construction.Components
     /// </summary>
     public sealed class UserAnchoredEvent : BaseAnchoredEvent
     {
-        public UserAnchoredEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
+        public UserAnchoredEvent(EntityUid user, EntityUid? tool) : base(user, tool) { }
     }
 
     /// <summary>
@@ -99,7 +99,7 @@ namespace Content.Shared.Construction.Components
     /// </summary>
     public sealed class BeforeUnanchoredEvent : BaseAnchoredEvent
     {
-        public BeforeUnanchoredEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
+        public BeforeUnanchoredEvent(EntityUid user, EntityUid? tool) : base(user, tool) { }
     }
 
     /// <summary>
@@ -110,6 +110,6 @@ namespace Content.Shared.Construction.Components
     /// </summary>
     public sealed class UserUnanchoredEvent : BaseAnchoredEvent
     {
-        public UserUnanchoredEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
+        public UserUnanchoredEvent(EntityUid user, EntityUid? tool) : base(user, tool) { }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This lets aghosts (or anything with BypassInteractionChecks) adjust pipe layers without a screwdriver, and regardless of any floor tiles that would otherwise prevent adjustment.

Also includes a bonus test for checking that no entity prototypes have a AtmosPipeLayers.NumberOfPipeLayers set that's more than supported, since there wasn't any verification of that previously.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Easier mapping good.

## Technical details
<!-- Summary of code changes for easier review. -->
I do think there are some improvements that could be made in how AtmosPipeLayer keeps getting tossed between being an int and the actual enum, since in general it's best to avoid treating (non-flag) enums as whatever their backing type is. Unfortunately I don't have it in me right now to do a pass through all of pipe layers addressing that, but just wanted to mention it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="747" height="348" alt="image" src="https://github.com/user-attachments/assets/35ecff69-aa65-4b52-81a6-2967fdf8cf35" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- `BaseAnchoredAttemptEvent.Tool` and `BaseAnchoredEvent.Tool` are now optional EntityUids. You will need to gracefully handle instances where these events can be called with a null tool.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
ADMIN:
- add: Aghosts can now adjust pipe layers without a screwdriver as well as through floor tiles.