### PR TITLE
Quieter Meat Kudzu 

### DIFF
--- a/Content.Server/Chat/Systems/AutoEmoteSystem.cs
+++ b/Content.Server/Chat/Systems/AutoEmoteSystem.cs
@@ -46,7 +46,11 @@ public sealed class AutoEmoteSystem : EntitySystem
 
                 if (autoEmotePrototype.WithChat)
                 {
-                    _chatSystem.TryEmoteWithChat(uid, autoEmotePrototype.EmoteId, autoEmotePrototype.HiddenFromChatWindow ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal);
+                    _chatSystem.TryEmoteWithChat(uid,
+                        autoEmotePrototype.EmoteId,
+                        autoEmotePrototype.HiddenFromChatWindow ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal,
+                        ignoreActionBlocker: autoEmotePrototype.IgnoreActionBlocker,
+                        forceEmote: autoEmotePrototype.Force);
                 }
                 else
                 {

--- a/Content.Shared/Chat/Prototypes/AutoEmotePrototype.cs
+++ b/Content.Shared/Chat/Prototypes/AutoEmotePrototype.cs
@@ -14,30 +14,44 @@ public sealed partial class AutoEmotePrototype : IPrototype
     /// The ID of the emote prototype.
     /// </summary>
     [DataField("emote", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<EmotePrototype>))]
-    public string EmoteId = String.Empty;
+    public string EmoteId = string.Empty;
 
     /// <summary>
     /// How often an attempt at the emote will be made.
     /// </summary>
-    [DataField("interval", required: true)]
+    [DataField(required: true)]
     public TimeSpan Interval;
 
     /// <summary>
     /// Probability of performing the emote each interval.
-    /// <summary>
+    /// </summary>
     [DataField("chance")]
     public float Chance = 1;
 
     /// <summary>
     /// Also send the emote in chat.
-    /// <summary>
-    [DataField("withChat")]
+    /// </summary>
+    [DataField]
     public bool WithChat = true;
+
+    /// <summary>
+    /// Should we ignore action blockers?
+    /// This does nothing if WithChat is false.
+    /// </summary>
+    [DataField]
+    public bool IgnoreActionBlocker;
+
+    /// <summary>
+    /// Should we ignore whitelists and force the emote?
+    /// This does nothing if WithChat is false.
+    /// </summary>
+    [DataField]
+    public bool Force;
 
     /// <summary>
     /// Hide the chat message from the chat window, only showing the popup.
     /// This does nothing if WithChat is false.
-    /// <summary>
-    [DataField("hiddenFromChatWindow")]
-    public bool HiddenFromChatWindow = false;
+    /// </summary>
+    [DataField]
+    public bool HiddenFromChatWindow;
 }

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -253,13 +253,9 @@
             Quantity: 2
           - ReagentId: Protein
             Quantity: 1
-    - type: Respirator
-      damage:
-        types:
-          Asphyxiation: 0.25
-      damageRecovery:
-        types:
-          Asphyxiation: -0.25
+    - type: AutoEmote # Meat Kudzu used to have respirator, but couldn't breathe so all it would do is gasp.
+      emotes:
+      - MeatGasp
     - type: Tag
       tags:
       - Meat

--- a/Resources/Prototypes/Voice/auto_emotes.yml
+++ b/Resources/Prototypes/Voice/auto_emotes.yml
@@ -12,3 +12,12 @@
   interval: 5.0
   chance: 0.5
   withChat: false
+# Kudzu
+- type: autoEmote
+  id: MeatGasp
+  emote: Gasp
+  interval: 4.0 # Same interval as a full breathing cycle
+  chance: 0.01 # Make it very rare
+  ignoreActionBlocker: true
+  force: true
+  hiddenFromChatWindow: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made it so meat kudzu still gasps, just less often.

Alternative(?) to: #38910 (PR also includes nullable gasping emotes which is good)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Apparently meat kudzu was supposed to breathe, but it never could, then it could breathe but couldn't oxygenate, so it would suffocate. This resulted in a lot of creepy emote spam that from a vote people generally liked. (Vote: https://forum.spacestation14.com/t/meat-tendrils-gasping/22680)

Rather than remove this, it's been canonized and cleaned up.

## Technical details
<!-- Summary of code changes for easier review. -->
- Removed RespiratorComponent from Meat Kudzu

- Added AutoEmoteComponent instead so meat kudzu can gasp

- Added two new datafield to AutoEmoteComponent to ignore emote whitelist and action blockers

- Reduced the chance to emote to 1% every "breathing" cycle.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/74a15a16-397d-470e-b465-56fa9628de1a


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Meat Kudzu gasps less often.

