### PR TITLE
add a corpse crate to the cargo catalog

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -147,3 +147,13 @@
   cost: 750
   category: cargoproduct-category-name-medical
   group: market
+
+- type: cargoProduct
+  id: CrateUnidentifiedCorpse
+  icon:
+   sprite: Structures/Storage/Crates/freezer.rsi
+   state: icon
+  product: CrateUnidentifiedCorpse
+  cost: 3000
+  category: cargoproduct-category-name-medical
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -176,7 +176,7 @@
   id: CrateUnidentifiedCorpse
   parent: CrateFreezer
   name: cadaver crate
-  description: placeholder
+  description: a single corpse, that definitely died of natural causes.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -171,3 +171,13 @@
         amount: 2
       - id: ClothingMaskSterile
         amount: 2
+
+- type: entity
+  id: CrateUnidentifiedCorpse
+  parent: CrateFreezer
+  name: cadaver crate
+  description: placeholder
+  components:
+  - type: StorageFill
+    contents:
+    - id: SalvageHumanCorpse


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a crate with an unidentified corpse to the cargo catalog, under the medical tab.

## Why / Balance
adds another "ethical" way to obtain corpses, other than salv maybe bringing them back from trips
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="313" height="204" alt="image" src="https://github.com/user-attachments/assets/5f75ab04-eb76-4e07-8af2-93b1c7614928" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
