### PR TITLE
Fix variantize command not respecting tile rotation

### DIFF
--- a/Content.Server/Administration/Commands/VariantizeCommand.cs
+++ b/Content.Server/Administration/Commands/VariantizeCommand.cs
@@ -44,7 +44,7 @@ public sealed class VariantizeCommand : IConsoleCommand
         foreach (var tile in mapsSystem.GetAllTiles(euid.Value, gridComp))
         {
             var def = turfSystem.GetContentTileDefinition(tile);
-            var newTile = new Tile(tile.Tile.TypeId, tile.Tile.Flags, tileSystem.PickVariant(def));
+            var newTile = new Tile(tile.Tile.TypeId, tile.Tile.Flags, tileSystem.PickVariant(def), tile.Tile.RotationMirroring);
             mapsSystem.SetTile(euid.Value, gridComp, tile.GridIndices, newTile);
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

The `variantize` command did not include tile rotation info, which meant running it caused any rotated tile (such as those on Exo) to revert back to the default rotation.

*This is kind of annoying.*

So this PR fixes that.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I needed it. 

## Technical details
<!-- Summary of code changes for easier review. -->

Just includes the tile rotation info in the command!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

