### PR TITLE
Remove stun resistance from epinephrine

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -363,14 +363,6 @@
         reagent: Histamine
         amount: 4
       - !type:GenericStatusEffect
-        key: Stun
-        time: 0.75
-        type: Remove
-      - !type:GenericStatusEffect
-        key: KnockedDown
-        time: 0.75
-        type: Remove
-      - !type:GenericStatusEffect
         key: Adrenaline # Guess what epinephrine is...
         component: IgnoreSlowOnDamage
         time: 5 # lingers less than hivemind reagent to give it a niche


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR removes the stun/knockdown resistance from epinephrine. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Epipens have become a meta item for shitters/raiders that use them to avoid arrests. If you are at risk of being stunned, just quickly pop an epipen and if the SecOff is not fast enough the stun ends before the cuffing finishes. The reaction time between completing the stun and starting the cuff becomes around 1 second.

Resisting stuncuffs is not an issue in itself, but the issue here is that it primarily screws over new SecOffs. Shitters/raiders already overwhelmingly target new SecOffs and by lowering the reaction time to cuff it becomes fairly reliable to escape via the epipen. It's not uncommon to arrest a shitter and see they have 3-4 epipens in their inventory; not to prevent going crit or save crewmates, but just to avoid arrest.

The tight timespan also puts more emphasis on ping which should be avoided as a determinant factor. 

While it's valid to escalate to lethals when someone does this, it can feel unjustified compared to the crime committed, and it also permits escalation in return; crew will feel more justified using lethals back on Sec if Sec feels more comfortable using lethals just because someone popped an epipen. 

In summary, this PR should make epipens solely a "save yourself/someone else from death tool" rather than "escape Sec" tool.

## Technical details
<!-- Summary of code changes for easier review. -->

Removed some yaml lines.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Epinephrine no longer reduces stun/knocked down duration. 
