### PR TITLE
Predict EmitterSystem ExamineEvent and GetVerbsEvent

### DIFF
--- a/Content.Client/Singularity/Systems/EmitterSystem.cs
+++ b/Content.Client/Singularity/Systems/EmitterSystem.cs
@@ -12,6 +12,8 @@ public sealed class EmitterSystem : SharedEmitterSystem
     /// <inheritdoc/>
     public override void Initialize()
     {
+        base.Initialize();
+
         SubscribeLocalEvent<EmitterComponent, AppearanceChangeEvent>(OnAppearanceChange);
     }
 

--- a/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
+++ b/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
@@ -3,11 +3,10 @@ using Content.Shared.DeviceLinking;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
 
 namespace Content.Shared.Singularity.Components;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class EmitterComponent : Component
 {
     public CancellationTokenSource? TimerCancel;
@@ -26,7 +25,7 @@ public sealed partial class EmitterComponent : Component
     /// <summary>
     /// The entity that is spawned when the emitter fires.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public EntProtoId BoltType = "EmitterBolt";
 
     [DataField]
@@ -95,8 +94,8 @@ public sealed partial class EmitterComponent : Component
     /// <summary>
     /// Map of signal ports to entity prototype IDs of the entity that will be fired.
     /// </summary>
-    [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<string, SinkPortPrototype>))]
-    public Dictionary<string, string> SetTypePorts = new();
+    [DataField]
+    public Dictionary<ProtoId<SinkPortPrototype>, EntProtoId> SetTypePorts = new();
 }
 
 [NetSerializable, Serializable]

--- a/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
+++ b/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
@@ -3,7 +3,6 @@ using Content.Shared.DeviceLinking;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
 
 namespace Content.Shared.Singularity.Components;
@@ -27,8 +26,8 @@ public sealed partial class EmitterComponent : Component
     /// <summary>
     /// The entity that is spawned when the emitter fires.
     /// </summary>
-    [DataField("boltType", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string BoltType = "EmitterBolt";
+    [DataField]
+    public EntProtoId BoltType = "EmitterBolt";
 
     [DataField]
     public List<EntProtoId> SelectableTypes = new();
@@ -36,67 +35,67 @@ public sealed partial class EmitterComponent : Component
     /// <summary>
     /// The current amount of power being used.
     /// </summary>
-    [DataField("powerUseActive")]
+    [DataField]
     public int PowerUseActive = 600;
 
     /// <summary>
     /// The amount of shots that are fired in a single "burst"
     /// </summary>
-    [DataField("fireBurstSize")]
+    [DataField]
     public int FireBurstSize = 3;
 
     /// <summary>
     /// The time between each shot during a burst.
     /// </summary>
-    [DataField("fireInterval")]
+    [DataField]
     public TimeSpan FireInterval = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// The current minimum delay between bursts.
     /// </summary>
-    [DataField("fireBurstDelayMin")]
+    [DataField]
     public TimeSpan FireBurstDelayMin = TimeSpan.FromSeconds(4);
 
     /// <summary>
     /// The current maximum delay between bursts.
     /// </summary>
-    [DataField("fireBurstDelayMax")]
+    [DataField]
     public TimeSpan FireBurstDelayMax = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// The visual state that is set when the emitter is turned on
     /// </summary>
-    [DataField("onState")]
+    [DataField]
     public string? OnState = "beam";
 
     /// <summary>
     /// The visual state that is set when the emitter doesn't have enough power.
     /// </summary>
-    [DataField("underpoweredState")]
+    [DataField]
     public string? UnderpoweredState = "underpowered";
 
     /// <summary>
     /// Signal port that turns on the emitter.
     /// </summary>
-    [DataField("onPort", customTypeSerializer: typeof(PrototypeIdSerializer<SinkPortPrototype>))]
-    public string OnPort = "On";
+    [DataField]
+    public ProtoId<SinkPortPrototype> OnPort = "On";
 
     /// <summary>
     /// Signal port that turns off the emitter.
     /// </summary>
-    [DataField("offPort", customTypeSerializer: typeof(PrototypeIdSerializer<SinkPortPrototype>))]
-    public string OffPort = "Off";
+    [DataField]
+    public ProtoId<SinkPortPrototype> OffPort = "Off";
 
     /// <summary>
     /// Signal port that toggles the emitter on or off.
     /// </summary>
-    [DataField("togglePort", customTypeSerializer: typeof(PrototypeIdSerializer<SinkPortPrototype>))]
-    public string TogglePort = "Toggle";
+    [DataField]
+    public ProtoId<SinkPortPrototype> TogglePort = "Toggle";
 
     /// <summary>
     /// Map of signal ports to entity prototype IDs of the entity that will be fired.
     /// </summary>
-    [DataField("setTypePorts", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<string, SinkPortPrototype>))]
+    [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<string, SinkPortPrototype>))]
     public Dictionary<string, string> SetTypePorts = new();
 }
 

--- a/Content.Shared/Singularity/EntitySystems/SharedEmitterSystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedEmitterSystem.cs
@@ -47,6 +47,7 @@ public abstract class SharedEmitterSystem : EntitySystem
                 Act = () =>
                 {
                     ent.Comp.BoltType = type;
+                    Dirty(ent);
                     _popup.PopupClient(Loc.GetString("emitter-component-type-set", ("type", proto.Name)), ent.Owner);
                 },
             };

--- a/Content.Shared/Singularity/EntitySystems/SharedEmitterSystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedEmitterSystem.cs
@@ -1,6 +1,65 @@
-﻿namespace Content.Shared.Singularity.EntitySystems;
+﻿using Content.Shared.Database;
+using Content.Shared.Examine;
+using Content.Shared.Lock;
+using Content.Shared.Popups;
+using Content.Shared.Singularity.Components;
+using Content.Shared.Verbs;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Singularity.EntitySystems;
 
 public abstract class SharedEmitterSystem : EntitySystem
 {
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EmitterComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<EmitterComponent, GetVerbsEvent<Verb>>(OnGetVerb);
+    }
+
+    private void OnGetVerb(Entity<EmitterComponent> ent, ref GetVerbsEvent<Verb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract || !args.CanComplexInteract || args.Hands == null)
+            return;
+
+        if (TryComp<LockComponent>(ent.Owner, out var lockComp) && lockComp.Locked)
+            return;
+
+        if (ent.Comp.SelectableTypes.Count < 2)
+            return;
+
+        foreach (var type in ent.Comp.SelectableTypes)
+        {
+            var proto = _prototype.Index<EntityPrototype>(type);
+
+            var v = new Verb
+            {
+                Priority = 1,
+                Category = VerbCategory.SelectType,
+                Text = proto.Name,
+                Disabled = type == ent.Comp.BoltType,
+                Impact = LogImpact.Medium,
+                DoContactInteraction = true,
+                Act = () =>
+                {
+                    ent.Comp.BoltType = type;
+                    _popup.PopupClient(Loc.GetString("emitter-component-type-set", ("type", proto.Name)), ent.Owner);
+                },
+            };
+            args.Verbs.Add(v);
+        }
+    }
+
+    private void OnExamined(Entity<EmitterComponent> ent, ref ExaminedEvent args)
+    {
+        if (ent.Comp.SelectableTypes.Count < 2)
+            return;
+
+        var proto = _prototype.Index<EntityPrototype>(ent.Comp.BoltType);
+        args.PushMarkup(Loc.GetString("emitter-component-current-type", ("type", proto.Name)));
+    }
 }

--- a/Content.Shared/Singularity/EntitySystems/SharedEmitterSystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedEmitterSystem.cs
@@ -34,7 +34,7 @@ public abstract class SharedEmitterSystem : EntitySystem
 
         foreach (var type in ent.Comp.SelectableTypes)
         {
-            var proto = _prototype.Index<EntityPrototype>(type);
+            var proto = _prototype.Index(type);
 
             var v = new Verb
             {
@@ -60,7 +60,7 @@ public abstract class SharedEmitterSystem : EntitySystem
         if (ent.Comp.SelectableTypes.Count < 2)
             return;
 
-        var proto = _prototype.Index<EntityPrototype>(ent.Comp.BoltType);
+        var proto = _prototype.Index(ent.Comp.BoltType);
         args.PushMarkup(Loc.GetString("emitter-component-current-type", ("type", proto.Name)));
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Predicts the ExamineEvent and GetVerbsEvent subscriptions for EmitterSystem.

I think I did this correctly. I don't normally interact with the A.P.E but in my testing the messages were indeed predicted and appearing as expected. I also took this oppurtunity to perform some cleanup and modernizing in a few areas.

## Why / Balance
See #39286

## Technical details
The gist is that the aforementioned events were moved to shared. The component was already networked and in my testing everything worked out of the box. I also took the liberty of bringing the component datafield tags up to snuff by removing the redundant tags and moving the types for prototypes from string to EntProtoId and ProtoId where relevant.

Lastly I cleaned up a few dependencies. Feelin pretty good about this one.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/257203d1-7259-4182-8aba-3e6e84dea601


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->