### PR TITLE
Fix tabletop grids rarely spawning on top of another

### DIFF
--- a/Content.Server/Tabletop/TabletopSystem.Map.cs
+++ b/Content.Server/Tabletop/TabletopSystem.Map.cs
@@ -37,7 +37,7 @@ namespace Content.Server.Tabletop
         /// <returns></returns>
         private Vector2 GetNextTabletopPosition()
         {
-            return UlamSpiral(_tabletops++) * TabletopSeparation;
+            return UlamSpiral(++_tabletops) * TabletopSeparation;
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Content.Server.Tabletop
         /// <summary>
         ///     Algorithm for mapping scalars to 2D positions in the same pattern as an Ulam Spiral.
         /// </summary>
-        /// <param name="n">Scalar to map to a 2D position.</param>
+        /// <param name="n">Scalar to map to a 2D position. Must be greater than or equal to 1.</param>
         /// <returns>The mapped 2D position for the scalar.</returns>
         private Vector2i UlamSpiral(int n)
         {

--- a/Content.Server/Tabletop/TabletopSystem.Map.cs
+++ b/Content.Server/Tabletop/TabletopSystem.Map.cs
@@ -66,7 +66,7 @@ namespace Content.Server.Tabletop
         /// <returns>The mapped 2D position for the scalar.</returns>
         private Vector2i UlamSpiral(int n)
         {
-            var k = (int)MathF.Ceiling(MathF.Sqrt(n) - 1) / 2;
+            var k = (int)MathF.Ceiling((MathF.Sqrt(n) - 1) / 2);
             var t = 2 * k + 1;
             var m = (int)MathF.Pow(t, 2);
             t--;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This fixes an issue where the first and the eighth (or maybe it was the seventh, I forget) tabletop boards opened would overlap each other in the tabletop map.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #39298.

## Technical details
<!-- Summary of code changes for easier review. -->
Ulam spirals start at 1 so, do that.

Also yeah I know it's technically a rectangle spiral but uhhh go away

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed board game areas sometimes overlapping with those of other board games.
