### PR TITLE
Make command glasses same functionality as security glasses

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -194,7 +194,7 @@
     coverage: EYES
 
 - type: entity
-  parent: [ClothingEyesBase, BaseCommandContraband]
+  parent: [ClothingEyesBase, ShowSecurityIcons, BaseCommandContraband]
   id: ClothingEyesGlassesCommand
   name: administration glasses
   description: Upgraded sunglasses that provide flash immunity and show ID card status.
@@ -213,7 +213,6 @@
     - WhitelistChameleon
   - type: IdentityBlocker
     coverage: EYES
-  - type: ShowJobIcons
 
 - type: entity
   parent: ClothingEyesBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Make command glasses same functionality as security glasses. Give it ShowCriminalRecordIconComponent and ShowMindShieldIconsComponent.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Captains always roundstart get security glasses instead of command glasses. So why force them to do this instead of just give to their glasses same functionality?

## Technical details
<!-- Summary of code changes for easier review. -->
Added ShowSecurityIcons to parents of ClothingEyesGlassesCommand.
Removed ShowJobIcons from ClothingEyesGlassesCommand.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="650" height="389" alt="image" src="https://github.com/user-attachments/assets/9afd1a34-0b89-4389-b92d-da09bcd2b24e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
I don't think it's breaking.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Command glasses now can show criminal record and mind shield icons.
