### PR TITLE
Add disclaimer about AI generated content to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Just make sure your changes and pull requests are in accordance with the [contri
 
 We are not currently accepting translations of the game on our main repository. If you would like to translate the game into another language, consider creating a fork or contributing to a fork.
 
+We do not accept any form of AI-generated content in this repository, including but not limited to:
+- Code (including yaml)
+- Artwork, sound files and or other assets
+- Pull request descriptions or issue reports written by AI
+- Documentation or comments generated using AI assistance
+
 ## Building
 
 1. Clone this repo:


### PR DESCRIPTION
Contributors tried a few times so far and we always rejected the changes, so we should have it written down somewhere so that we can point at it when it happens again.
AI generated content is sometimes straight up lying to you and requires human supervision from someone who knows what they are doing when coding. It's not the job of maintainers to filter out AI slop, so contributors should be aware that we don't accept this.
Feedback about the phrasing is welcome.