### PR TITLE
Don't purge note buffer when starting/switching MIDI songs

### DIFF
--- a/Content.Client/Instruments/InstrumentSystem.cs
+++ b/Content.Client/Instruments/InstrumentSystem.cs
@@ -294,7 +294,6 @@ public sealed partial class InstrumentSystem : SharedInstrumentSystem
         SetMaster(uid, null);
         TrySetChannels(uid, data);
 
-        instrument.MidiEventBuffer.Clear();
         instrument.Renderer.OnMidiEvent += instrument.MidiEventBuffer.Add;
         return true;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Don't purge the buffer of notes when starting or switching a MIDI song.

## Why / Balance
The event buffer is there to relay played notes (and other events, such as the renderer being told to completely stop playing which happens just before the buffer purge) to remotes. Purging it means that anything that happened before the purge on local didn't happen, which causes a remote state divergence.

## Technical details
The buffer is self-purging. There is no reason to clear it when starting a song.

## Media
N/A, small bug fix.

This has likely little impact on 2.1.0 but if the FS version is ever updated this could cause bugs, as later FS bugs fix the issue where early notes after a MIDI starts playing are dropped.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
N/A
