### PR TITLE
Ignore non-content commands in AllCommandsHavePermissions

### DIFF
--- a/Content.IntegrationTests/Tests/Toolshed/AdminTest.cs
+++ b/Content.IntegrationTests/Tests/Toolshed/AdminTest.cs
@@ -25,6 +25,11 @@ public sealed class AdminTest : ToolshedTest
                     if (ignored.Contains(cmd.Cmd.GetType().Assembly))
                         continue;
 
+                    // Only care about content commands.
+                    var assemblyName = cmd.Cmd.GetType().Assembly.FullName;
+                    if (assemblyName == null || !assemblyName.StartsWith("Content."))
+                        continue;
+
                     Assert.That(admin.TryGetCommandFlags(cmd, out _), $"Command does not have admin permissions set up: {cmd.FullName()}");
                 }
             });


### PR DESCRIPTION
Causing a test failure every time a Toolshed command gets added to engine is ridiculous.
