### PR TITLE
Make wallmount screen, telescreen, and signal timer destructible

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/telescreens.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/telescreens.yml
@@ -15,8 +15,8 @@
   - type: Destructible
     thresholds:
     - trigger:
-      !type:DamageTrigger
-      damage: 200
+        !type:DamageTrigger
+        damage: 200
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/telescreens.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/telescreens.yml
@@ -12,6 +12,25 @@
         state: telescreen_frame
       - map: ["computerLayerScreen"]
         state: telescreen
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 200
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+          - !type:PlaySoundBehavior
+            sound:
+              collection: MetalGlassBreak
+              params:
+                volume: -4
   - type: Construction
     graph: WallmountTelescreen
     node: Telescreen

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/telescreens.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/telescreens.yml
@@ -20,17 +20,9 @@
         behaviors:
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
-      - trigger:
-          !type:DamageTrigger
-          damage: 100
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
           - !type:PlaySoundBehavior
             sound:
               collection: MetalGlassBreak
-              params:
-                volume: -4
   - type: Construction
     graph: WallmountTelescreen
     node: Telescreen

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/telescreens.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/telescreens.yml
@@ -14,15 +14,15 @@
         state: telescreen
   - type: Destructible
     thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 200
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-          - !type:PlaySoundBehavior
-            sound:
-              collection: MetalGlassBreak
+    - trigger:
+      !type:DamageTrigger
+      damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
   - type: Construction
     graph: WallmountTelescreen
     node: Telescreen

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
@@ -17,8 +17,8 @@
   - type: Destructible
     thresholds:
     - trigger:
-      !type:DamageTrigger
-      damage: 200
+        !type:DamageTrigger
+        damage: 200
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
@@ -14,6 +14,25 @@
     sprite: Structures/Wallmounts/screen.rsi
     state: screen
     noRot: true
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 200
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+          - !type:PlaySoundBehavior
+            sound:
+              collection: MetalGlassBreak
+              params:
+                volume: -4
   - type: ApcPowerReceiver
     powerLoad: 100
   - type: ExtensionCableReceiver

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
@@ -16,15 +16,15 @@
     noRot: true
   - type: Destructible
     thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 200
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-          - !type:PlaySoundBehavior
-            sound:
-              collection: MetalGlassBreak
+    - trigger:
+      !type:DamageTrigger
+      damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
   - type: ApcPowerReceiver
     powerLoad: 100
   - type: ExtensionCableReceiver

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
@@ -22,17 +22,9 @@
         behaviors:
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
-      - trigger:
-          !type:DamageTrigger
-          damage: 100
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
           - !type:PlaySoundBehavior
             sound:
               collection: MetalGlassBreak
-              params:
-                volume: -4
   - type: ApcPowerReceiver
     powerLoad: 100
   - type: ExtensionCableReceiver

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
@@ -14,15 +14,15 @@
   - type: Appearance
   - type: Destructible
     thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 200
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-          - !type:PlaySoundBehavior
-            sound:
-              collection: MetalGlassBreak
+    - trigger:
+      !type:DamageTrigger
+      damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
   - type: Rotatable
   - type: SignalTimer
     canEditLabel: false

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
@@ -15,8 +15,8 @@
   - type: Destructible
     thresholds:
     - trigger:
-      !type:DamageTrigger
-      damage: 200
+        !type:DamageTrigger
+        damage: 200
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
@@ -12,6 +12,25 @@
     sprite: Structures/Wallmounts/switch.rsi
     state: on
   - type: Appearance
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 200
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+          - !type:PlaySoundBehavior
+            sound:
+              collection: MetalGlassBreak
+              params:
+                volume: -4
   - type: Rotatable
   - type: SignalTimer
     canEditLabel: false

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
@@ -20,17 +20,9 @@
         behaviors:
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
-      - trigger:
-          !type:DamageTrigger
-          damage: 100
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
           - !type:PlaySoundBehavior
             sound:
               collection: MetalGlassBreak
-              params:
-                volume: -4
   - type: Rotatable
   - type: SignalTimer
     canEditLabel: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About
Make wallmount screen, telescreen, and signal timer destructible.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
There should probably be no indestructible appliances, especially those that are non-critical.

old:

https://github.com/user-attachments/assets/7a262099-dd9c-4bef-809e-f421dfd4de46
