### PR TITLE
parrotMemory is onGetVerbs now in shared

### DIFF
--- a/Content.Server/Animals/Systems/ParrotMemorySystem.cs
+++ b/Content.Server/Animals/Systems/ParrotMemorySystem.cs
@@ -8,10 +8,10 @@ using Content.Server.Radio;
 using Content.Server.Speech;
 using Content.Server.Speech.Components;
 using Content.Server.Vocalization.Systems;
+using Content.Shared.Animals.Components;
+using Content.Shared.Animals.Systems;
 using Content.Shared.Database;
 using Content.Shared.Mobs.Systems;
-using Content.Shared.Popups;
-using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
 using Robust.Shared.Network;
 using Robust.Shared.Random;
@@ -25,7 +25,7 @@ namespace Content.Server.Animals.Systems;
 /// (radiovocalizer) and stores them in a list. When an entity with a VocalizerComponent attempts to vocalize, this will
 /// try to set the message from memory.
 /// </summary>
-public sealed partial class ParrotMemorySystem : EntitySystem
+public sealed partial class ParrotMemorySystem : SharedParrotMemorySystem
 {
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
@@ -42,8 +42,6 @@ public sealed partial class ParrotMemorySystem : EntitySystem
 
         SubscribeLocalEvent<EraseEvent>(OnErase);
 
-        SubscribeLocalEvent<ParrotMemoryComponent, GetVerbsEvent<Verb>>(OnGetVerbs);
-
         SubscribeLocalEvent<ParrotListenerComponent, MapInitEvent>(ListenerOnMapInit);
 
         SubscribeLocalEvent<ParrotListenerComponent, ListenEvent>(OnListen);
@@ -55,30 +53,6 @@ public sealed partial class ParrotMemorySystem : EntitySystem
     private void OnErase(ref EraseEvent args)
     {
         DeletePlayerMessages(args.PlayerNetUserId);
-    }
-
-    private void OnGetVerbs(Entity<ParrotMemoryComponent> entity, ref GetVerbsEvent<Verb> args)
-    {
-        var user = args.User;
-
-        // limit this to admins
-        if (!_admin.IsAdmin(user))
-            return;
-
-        // simple verb that just clears the memory list
-        var clearMemoryVerb = new Verb()
-        {
-            Text = Loc.GetString("parrot-verb-clear-memory"),
-            Category = VerbCategory.Admin,
-            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/clear-parrot.png")),
-            Act = () =>
-            {
-                entity.Comp.SpeechMemories.Clear();
-                _popup.PopupEntity(Loc.GetString("parrot-popup-memory-cleared"), entity, user, PopupType.Medium);
-            },
-        };
-
-        args.Verbs.Add(clearMemoryVerb);
     }
 
     private void ListenerOnMapInit(Entity<ParrotListenerComponent> entity, ref MapInitEvent args)

--- a/Content.Shared/Animals/Components/SharedParrotMemoryComponent.cs
+++ b/Content.Shared/Animals/Components/SharedParrotMemoryComponent.cs
@@ -1,57 +1,56 @@
-using Robust.Shared.Network;
+using Content.Shared.Animals.Systems;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
-namespace Content.Server.Animals.Components;
+namespace Content.Shared.Animals.Components;
 
 /// <summary>
-/// Makes an entity able to memorize chat/radio messages
+/// Makes an entity able to memorize chat/radio messages.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent]
 [AutoGenerateComponentPause]
 public sealed partial class ParrotMemoryComponent : Component
 {
     /// <summary>
-    /// List of SpeechMemory records this entity has learned
+    /// List of SpeechMemory records this entity has learned.
     /// </summary>
     [DataField]
-    public List<SpeechMemory> SpeechMemories = [];
+    public List<SpeechMemory> SpeechMemories = new();
 
     /// <summary>
-    /// The % chance an entity with this component learns a phrase when learning is off cooldown
+    /// The % chance an entity with this component learns a phrase when learning is off cooldown.
     /// </summary>
     [DataField]
     public float LearnChance = 0.6f;
 
     /// <summary>
-    /// Time after which another attempt can be made at learning a phrase
+    /// Time after which another attempt can be made at learning a phrase.
     /// </summary>
     [DataField]
     public TimeSpan LearnCooldown = TimeSpan.FromMinutes(1);
 
     /// <summary>
-    /// Next time at which the parrot can attempt to learn something
+    /// Next time at which the parrot can attempt to learn something.
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoPausedField]
     public TimeSpan NextLearnInterval = TimeSpan.Zero;
 
     /// <summary>
-    /// The number of speech entries that are remembered
+    /// The number of speech entries that are remembered.
     /// </summary>
     [DataField]
     public int MaxSpeechMemory = 50;
 
     /// <summary>
-    /// Minimum length of a speech entry
+    /// Minimum length of a speech entry.
     /// </summary>
     [DataField]
     public int MinEntryLength = 4;
 
     /// <summary>
-    /// Maximum length of a speech entry
+    /// Maximum length of a speech entry.
     /// </summary>
     [DataField]
     public int MaxEntryLength = 50;
 }
-
-public record struct SpeechMemory(NetUserId? NetUserId, string Message);

--- a/Content.Shared/Animals/Systems/SharedParrotMemorySystem.cs
+++ b/Content.Shared/Animals/Systems/SharedParrotMemorySystem.cs
@@ -1,0 +1,53 @@
+using Content.Shared.Administration.Managers;
+using Content.Shared.Animals.Components;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
+using Robust.Shared.Network;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Animals.Systems;
+
+public abstract class SharedParrotMemorySystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ISharedAdminManager _admin = default!;
+    [Dependency] private readonly INetManager _net = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ParrotMemoryComponent, GetVerbsEvent<Verb>>(OnGetVerbs);
+    }
+
+    private void OnGetVerbs(Entity<ParrotMemoryComponent> entity, ref GetVerbsEvent<Verb> args)
+    {
+        var user = args.User;
+
+        // limit this to admins
+        if (!_admin.IsAdmin(user))
+            return;
+
+        // simple verb that just clears the memory list
+        var clearMemoryVerb = new Verb()
+        {
+            Text = Loc.GetString("parrot-verb-clear-memory"),
+            Category = VerbCategory.Admin,
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/clear-parrot.png")),
+            Act = () =>
+            {
+                if (_net.IsClient)
+                    return;
+
+                entity.Comp.SpeechMemories.Clear();
+                _popup.PopupClient(Loc.GetString("parrot-popup-memory-cleared"), entity.Owner, user);
+            },
+        };
+
+        args.Verbs.Add(clearMemoryVerb);
+    }
+}
+
+
+[Serializable, NetSerializable]
+public record struct SpeechMemory(NetUserId? NetUserId, string Message);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Refactors **ParrotMemorySystem** to support prediction for `GetVerbsEvent` when right-clicking a parrot to view admin verbs. I've tested and it's works.

## Why / Balance
See #39286

## Technical details
<!-- Summary of code changes for easier review. -->
This is `GetVerbsEvent` for admins on right click predicted on Content.Shared.
* Added `SharedParrotMemorySystem` containing `GetVerbsEvent` subscription.
* Updated `ParrotMemoryComponent` to be `[NetworkedComponent]` with generated component state.

## Media

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
refactor.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

* `ParrotMemorySystem` OnGetVerb handling moved to `SharedParrotMemorySystem`.

**Changelog**

no cl no fun
