### PR TITLE
Hardsuit helmet text fix + CBurn Vox Fix

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -196,6 +196,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
+#Goliath Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitGoliath
@@ -249,6 +250,7 @@
     - CorgiWearable
     - WhitelistChameleon
 
+#Maxim Hardsuit
 - type: entity
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitMaxim
@@ -883,6 +885,10 @@
       head:
       - state: equipped-head
       - state: equipped-head-unshaded
+        shader: unshaded
+      head:
+      - state: equipped-head-vox
+      - state: equipped-head-unshaded-vox
         shader: unshaded
   - type: PointLight
     color: orange

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -886,7 +886,7 @@
       - state: equipped-head
       - state: equipped-head-unshaded
         shader: unshaded
-      head:
+      head-vox:
       - state: equipped-head-vox
       - state: equipped-head-unshaded-vox
         shader: unshaded


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Goliath and Maxim hardsuits weren't properly labeled in hardsuit helmets for some reason. This fixes that. The Cburn helmet also has unshaded vox sprites it wasn't using.

## Why / Balance
Things should be properly labeled and assigned.

## Technical details
i wrote text

## Media
<img width="243" height="226" alt="Screenshot 2025-08-02 230612" src="https://github.com/user-attachments/assets/044cd19f-b2f7-45fa-b7f0-929454e02d9d" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
no
