### PR TITLE
Fix kudzu reactivation by checking contents of grid and not grid itself

### DIFF
--- a/Content.Server/Spreader/SpreaderSystem.cs
+++ b/Content.Server/Spreader/SpreaderSystem.cs
@@ -332,7 +332,7 @@ public sealed class SpreaderSystem : EntitySystem
         for (var i = 0; i < Atmospherics.Directions; i++)
         {
             var direction = (AtmosDirection) (1 << i);
-            var adjacentTile = tile.Offset(direction.ToDirection());
+            var adjacentTile = SharedMapSystem.GetDirection(tile, direction.ToDirection());
             anchored = _map.GetAnchoredEntitiesEnumerator(ent, grid, adjacentTile);
 
             while (anchored.MoveNext(out var entity))


### PR DESCRIPTION
## About the PR
This fixes a bug in SpreaderSystem that prevented kudzu from regrowing into cleared spaces. Specifically there was an issue in ActivateSpreadableNeighbors, where it seemed to have targeted the map grid instead of neighboring entities

## Why / Balance
This re-enables kudzu to spread as intended. Kudzu is funner when it works right!

## Technical details
A bug in the ActivateSpreadableNeighbors method made this kudzu reactivating non-functional. The logic was checking if the map grid itself had a spreader component, which is always false, thereby preventing dormant kudzu from ever being reactivated

## Media
Before:
https://github.com/user-attachments/assets/e08437c5-1440-4aaf-9d7b-02380be116b8

After:
https://github.com/user-attachments/assets/13522bfd-a53e-4c59-a948-260c151f99da

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Fixed an issue where kudzu would not regrow into cleared spaces or after adjacent walls were removed, making it permanently dormant after reaching a local maximum. Kudzu will now correctly reactivate and spread as intended. The kudzu spreads!