### PR TITLE
fix: make IdentityComp.IdentityEntitySlot optional

### DIFF
--- a/Content.Server/IdentityManagement/IdentitySystem.cs
+++ b/Content.Server/IdentityManagement/IdentitySystem.cs
@@ -62,11 +62,17 @@ public sealed class IdentitySystem : SharedIdentitySystem
     // This is where the magic happens
     private void OnMapInit(EntityUid uid, IdentityComponent component, MapInitEvent args)
     {
+        if (component.IdentityEntitySlot is not { } slot)
+        {
+            Log.Error($"Uninitialized IdentityEntitySlot for {ToPrettyString(uid)}.");
+            return;
+        }
+
         var ident = Spawn(null, Transform(uid).Coordinates);
 
         _metaData.SetEntityName(ident, "identity");
         QueueIdentityUpdate(uid);
-        _container.Insert(ident, component.IdentityEntitySlot);
+        _container.Insert(ident, slot);
     }
 
     /// <summary>
@@ -84,7 +90,7 @@ public sealed class IdentitySystem : SharedIdentitySystem
     /// </summary>
     private void UpdateIdentityInfo(EntityUid uid, IdentityComponent identity)
     {
-        if (identity.IdentityEntitySlot.ContainedEntity is not { } ident)
+        if (identity.IdentityEntitySlot?.ContainedEntity is not { } ident)
             return;
 
         var representation = GetIdentityRepresentation(uid);

--- a/Content.Shared/IdentityManagement/Components/IdentityComponent.cs
+++ b/Content.Shared/IdentityManagement/Components/IdentityComponent.cs
@@ -13,8 +13,12 @@ namespace Content.Shared.IdentityManagement.Components;
 [RegisterComponent]
 public sealed partial class IdentityComponent : Component
 {
+    /// <summary>
+    /// The slot which carries around the entity representing the carrier's
+    /// perceived identity. May be null if the component is not initialized.
+    /// </summary>
     [ViewVariables]
-    public ContainerSlot IdentityEntitySlot = default!;
+    public ContainerSlot? IdentityEntitySlot = default!;
 }
 
 /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This fixes a rare edge case where if the client handles some event that depends on identity in response to that entity's spawning it would end up dying to a NRE.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugs bad.

## Technical details
<!-- Summary of code changes for easier review. -->
`IdentityEntitySlot` is ensured on ComponentInit, so it's possible to have stuff that depends on identity occur while the IdentityComponent is still in its Added lifestage. This changes the nullability of the slot to accurately represent that.

This does mean there's an extreme edge case where Identity.Name/Entity can return the real identity buuuuuut I feel like that's probably fine. (As far as I know this could only really happen on an entity entering a client's PVS for the first time.)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<details>
<summary>Identity still works</summary>
<img width="600" alt="image" src="https://github.com/user-attachments/assets/c2570caf-d22c-4e8d-8066-8e4d8f2ea826" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/ee100151-d790-4067-b89b-c74f2f521318" />
</details>


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- `IdentityComponent.IdentityEntitySlot` is now optional.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
wawaa
