### PR TITLE
Updated Aseprite Tools

### DIFF
--- a/Tools/SS14 Aseprite Plugins/Displacement Map Flip.lua
+++ b/Tools/SS14 Aseprite Plugins/Displacement Map Flip.lua
@@ -30,8 +30,8 @@ diag:button{
         local selection = sprite.selection
         local image = cel.image:clone()
 
-        for x = 0, selection.bounds.width do
-            for y = 0, selection.bounds.height do
+        for x = 0, selection.bounds.width - 1 do
+            for y = 0, selection.bounds.height - 1 do
                 local xSel = x + selection.origin.x
                 local ySel = y + selection.origin.y
 

--- a/Tools/SS14 Aseprite Plugins/Displacement Map Shift.lua
+++ b/Tools/SS14 Aseprite Plugins/Displacement Map Shift.lua
@@ -1,0 +1,63 @@
+local sprite = app.editor.sprite
+local cel = app.cel
+
+function Shift(dx, dy)
+    if sprite.selection.isEmpty then
+        sprite.selection:selectAll()
+    end
+
+    local selection = sprite.selection
+    local image = cel.image:clone()
+
+    for it in image:pixels(selection) do
+        local color = Color(it())
+        local position = Point(it.x, it.y) -- gets the position
+
+        if not selection:contains(position.x + cel.position.x, position.y + cel.position.y) then
+            goto continue
+        end
+
+        color.red = math.min(255, math.max(0, color.red + dx))
+        color.green = math.min(255, math.max(0, color.green + dy))
+
+        it(color.rgbaPixel)
+
+        ::continue::
+    end
+    cel.image = image
+    app.refresh()
+end
+
+local diag = Dialog{
+    title = "Shift Displacement Map"
+}
+
+diag
+    :button{
+        text="↑",
+        onclick=function()
+            Shift(0,1)
+        end
+    }
+    :newrow()
+    :button{
+        text="←",
+        onclick=function()
+            Shift(1,0)
+        end
+    }
+    :button{
+        text="→",
+        onclick=function()
+            Shift(-1,0)
+        end
+    }
+    :newrow()
+    :button{
+        text="↓",
+        onclick=function()
+            Shift(0,-1)
+        end
+    }
+
+diag:show{wait=false}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Modified all the scripts under `Tools/SS14 Aseprite Plugins` to be a bit more user friendly, work better, and offer a couple new features.

The primary feature added here is that now you can view pixels that are "out of bounds" for the sprite sheet. In the render window the offending pixels can be highlighted any color and even be given a checker-board texture to make them easier to distinguish.

Displacement map renderer. The warning at the bottom is always there as long as there are pixels out of bounds.
<img width="441" height="477" alt="image" src="https://github.com/user-attachments/assets/cc002bb9-20fb-46a9-bdfb-01ecc9f56850" />
Checkerboard pattern
<img width="444" height="465" alt="image" src="https://github.com/user-attachments/assets/3bce2ef8-f8c4-4cc5-864d-93244e6def74" />

The selection nudging has been broken out into its own separate plugin, rather than being tucked away on the bottom of the preview window. I did this mostly since I preferred a more intuitive UI rather than looking at button names.
<img width="472" height="172" alt="image" src="https://github.com/user-attachments/assets/016d2442-3da7-45ce-bd0d-dc4ab51dd049" />

This also fixes a bug with displacement flipping which caused it to extend one pixel out of the selection down and right.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Better Displacement tools make everyone happy.

## Technical details
<!-- Summary of code changes for easier review. -->

Lua code

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
