### PR TITLE
Fix: Hamster clothing is properly displaced on Mothroaches

### DIFF
--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -331,7 +331,7 @@ public sealed class ClientClothingSystem : ClothingSystem
             if (displacementData is not null)
             {
                 //Checking that the state is not tied to the current race. In this case we don't need to use the displacement maps.
-                if (layerData.State is not null && inventory.SpeciesId is not null && layerData.State.EndsWith(inventory.SpeciesId))
+                if (inventory.DisplaceSpeciesAppropriateClothing == false && layerData.State is not null && inventory.SpeciesId is not null && layerData.State.EndsWith(inventory.SpeciesId))
                     continue;
 
                 if (_displacement.TryAddDisplacement(displacementData, (equipee, sprite), index, key, out var displacementKey))

--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -331,7 +331,7 @@ public sealed class ClientClothingSystem : ClothingSystem
             if (displacementData is not null)
             {
                 //Checking that the state is not tied to the current race. In this case we don't need to use the displacement maps.
-                if (inventory.DisplaceSpeciesAppropriateClothing == false && layerData.State is not null && inventory.SpeciesId is not null && layerData.State.EndsWith(inventory.SpeciesId))
+                if (!inventory.DisplaceSpeciesAppropriateClothing && layerData.State is not null && inventory.SpeciesId is not null && layerData.State.EndsWith(inventory.SpeciesId))
                     continue;
 
                 if (_displacement.TryAddDisplacement(displacementData, (equipee, sprite), index, key, out var displacementKey))

--- a/Content.Shared/Inventory/InventoryComponent.cs
+++ b/Content.Shared/Inventory/InventoryComponent.cs
@@ -30,6 +30,8 @@ public sealed partial class InventoryComponent : Component
     [DataField, AutoNetworkedField]
     public string? SpeciesId;
 
+    [DataField, AutoNetworkedField]
+    public bool DisplaceSpeciesAppropriateClothing = false;
 
     [ViewVariables]
     public SlotDefinition[] Slots = Array.Empty<SlotDefinition>();

--- a/Content.Shared/Inventory/InventoryComponent.cs
+++ b/Content.Shared/Inventory/InventoryComponent.cs
@@ -30,6 +30,16 @@ public sealed partial class InventoryComponent : Component
     [DataField, AutoNetworkedField]
     public string? SpeciesId;
 
+    /// <summary>
+    /// For determining whether worn clothing will be displaced, if the clothing has a species-specific state that is related to this component's SpeciesID.
+    /// </summary>
+    /// <remarks>
+    /// This datafield is here to fix a mothroach bug:
+    /// Currently, mothroaches have an InventoryComponent with the SpeciesID and TemplateID set to hamster. This allows them to use the same slots as, and wear the same clothing as, hamsters.
+    /// Most of the hats which hamsters can wear have hamster-specific sprite-states. These sprites need to be affected by the mothroaches' displacement map in order to appear in the correct position on the mothroach.
+    /// However, because the mothroaches' SpeciesID is hamster, and because the sprite being displayed has a hamster-state, the game will not displace the clothing, under the assumption that a hamster-specific sprite should be placed correctly on our "hamster" (mothroach).
+    /// Setting this datafield to `true` will ignore the check that looks for a matching SpeciesID and sprite-state, allowing hamster clothing to be displaced properly on mothroaches.
+    /// </remarks>
     [DataField, AutoNetworkedField]
     public bool DisplaceSpeciesAppropriateClothing = false;
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -608,6 +608,7 @@
   - type: Inventory
     speciesId: hamster
     templateId: hamster
+    displaceSpeciesAppropriateClothing: true
     displacements:
       head:
         sizeMaps:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR is intended to fix the way that displacements are applied for mothroaches. Currently, mothroaches are considered hamsters by their `InventoryComponent`, so when they wear hats with hamster specific sprites, those hats are not displaced according to the mothroach displacement map.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I intended to make a PR to Goobstation which allowed mothroaches to wear the propeller cap, but came across this bug. Upon further inspection this bug was mentioned approximately one year ago in [this](https://github.com/space-wizards/space-station-14/issues/31595) issue. I figured that I should make this PR here as it is a bug which originates from here.
## Technical details
<!-- Summary of code changes for easier review. -->
`InventoryComponent` has recieved a new member variable, `DisplaceSpeciesAppropriateClothing`, which is set to `false` by default. When `DisplaceSpeciesAppropriateClothing` is `true`, an `if` statement, which checks for species appropriate clothing in order to prevent applying a displacement, is skipped.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<i>Before: A mothroach is wearing a command beret. The command beret has a hamster-specific sprite, so the beret sits awkwardly on the roach. It is one pixel too far left in the north/south views and not even close to the roaches' head in the east/west view.</i>
<img width="128" height="128" alt="mothroach_command_beret_before" src="https://github.com/user-attachments/assets/62b55dba-559d-4e2e-96bc-a7afe6bfdb83"/>
<i>After: The beret still uses the hamster sprite, but sits appropriately on the roaches' head. The beret is hardly visible in the north view, which is consistent with the mothroaches' displacement map. Little touches, such as the beret not covering the left ear, are now apparent in all views.</i>
<img width="128" height="128" alt="mothroach_command_beret_after" src="https://github.com/user-attachments/assets/567a3aaa-73ac-46e0-a67c-80a6e2e483e5" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Mothroach hats now appear on the mothroaches' head.