### PR TITLE
Move solution examine subscription from DrinkComponent to ExaminableSolutionComponent

### DIFF
--- a/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
@@ -1,4 +1,6 @@
-﻿namespace Content.Shared.Chemistry.Components.SolutionManager;
+﻿using Robust.Shared.Serialization;
+
+namespace Content.Shared.Chemistry.Components.SolutionManager;
 
 /// <summary>
 ///     Component for examining a solution with shift click or through <see cref="SolutionScanEvent"/>.
@@ -26,29 +28,29 @@ public sealed partial class ExaminableSolutionComponent : Component
     public bool ExactVolume;
 
     [DataField]
-    public LocId MessageEmptyVolume = "shared-solution-container-component-on-examine-empty-container";
+    public LocId LocEmptyVolume = "shared-solution-container-component-on-examine-empty-container";
 
     [DataField]
-    public LocId MessageExactVolume = "drink-component-on-examine-exact-volume";
+    public LocId LocVolume = "examinable-solution-on-examine-volume";
 
     [DataField]
-    public LocId MessageVagueVolumeFull = "drink-component-on-examine-is-full";
+    public LocId LocPhysicalQuality = "shared-solution-container-component-on-examine-main-text";
 
     [DataField]
-    public LocId MessageVagueVolumeMostlyFull = "drink-component-on-examine-is-mostly-full";
+    public LocId LocRecognizableReagents = "examinable-solution-has-recognizable-chemicals";
+}
 
-    [DataField]
-    public LocId MessageVagueVolumeHalfFull = "drink-component-on-examine-is-half-full";
-
-    [DataField]
-    public LocId MessageVagueVolumeHalfEmpty = "drink-component-on-examine-is-half-empty";
-
-    [DataField]
-    public LocId MessageVagueVolumeMostlyEmpty = "drink-component-on-examine-is-mostly-empty";
-
-    [DataField]
-    public LocId MessagePhysicalQuality = "shared-solution-container-component-on-examine-main-text";
-
-    [DataField]
-    public LocId MessageRecognizableReagents = "examinable-solution-has-recognizable-chemicals";
+/// <summary>
+///     Used to choose how to display a volume.
+/// </summary>
+[Serializable, NetSerializable]
+public enum ExaminedVolumeDisplay
+{
+    Exact,
+    Full,
+    MostlyFull,
+    HalfFull,
+    HalfEmpty,
+    MostlyEmpty,
+    Empty,
 }

--- a/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
@@ -24,4 +24,31 @@ public sealed partial class ExaminableSolutionComponent : Component
     /// </summary>
     [DataField]
     public bool ExactVolume;
+
+    [DataField]
+    public LocId MessageEmptyVolume = "shared-solution-container-component-on-examine-empty-container";
+
+    [DataField]
+    public LocId MessageExactVolume = "drink-component-on-examine-exact-volume";
+
+    [DataField]
+    public LocId MessageVagueVolumeFull = "drink-component-on-examine-is-full";
+
+    [DataField]
+    public LocId MessageVagueVolumeMostlyFull = "drink-component-on-examine-is-mostly-full";
+
+    [DataField]
+    public LocId MessageVagueVolumeHalfFull = "drink-component-on-examine-is-half-full";
+
+    [DataField]
+    public LocId MessageVagueVolumeHalfEmpty = "drink-component-on-examine-is-half-empty";
+
+    [DataField]
+    public LocId MessageVagueVolumeMostlyEmpty = "drink-component-on-examine-is-mostly-empty";
+
+    [DataField]
+    public LocId MessagePhysicalQuality = "shared-solution-container-component-on-examine-main-text";
+
+    [DataField]
+    public LocId MessageRecognizableReagents = "examinable-solution-has-recognizable-chemicals";
 }

--- a/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
@@ -1,14 +1,27 @@
 ﻿namespace Content.Shared.Chemistry.Components.SolutionManager;
 
+/// <summary>
+///     Component for examining a solution with shift click.
+/// </summary>
 [RegisterComponent]
 public sealed partial class ExaminableSolutionComponent : Component
 {
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    /// <summary>
+    ///     The solution being examined.
+    /// </summary>
+    [DataField]
     public string Solution = "default";
 
     /// <summary>
-    /// If false then the hidden solution is always visible.
+    ///     If true, the solution must be held to be examined.
     /// </summary>
     [DataField]
     public bool HeldOnly;
+
+    /// <summary>
+    ///     If true, the examine text will give an approximation of the remaining solution.
+    ///     If false, the exact unit count will be shown.
+    /// </summary>
+    [DataField]
+    public bool VagueExamine;
 }

--- a/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
@@ -27,6 +27,11 @@ public sealed partial class ExaminableSolutionComponent : Component
     [DataField]
     public bool ExactVolume;
 
+    /// <summary>
+    ///     If true, the solution can't be examined when this entity is closed.
+    /// </summary>
+    public bool CantSeeWhenClosed;
+
     [DataField]
     public LocId LocEmptyVolume = "shared-solution-container-component-on-examine-empty-container";
 

--- a/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
@@ -1,7 +1,7 @@
 ﻿namespace Content.Shared.Chemistry.Components.SolutionManager;
 
 /// <summary>
-///     Component for examining a solution with shift click.
+///     Component for examining a solution with shift click or through <see cref="SolutionScanEvent"/>.
 /// </summary>
 [RegisterComponent]
 public sealed partial class ExaminableSolutionComponent : Component
@@ -19,9 +19,9 @@ public sealed partial class ExaminableSolutionComponent : Component
     public bool HeldOnly;
 
     /// <summary>
-    ///     If true, the examine text will give an approximation of the remaining solution.
-    ///     If false, the exact unit count will be shown.
+    ///     If false, the examine text will give an approximation of the remaining solution.
+    ///     If true, the exact unit count will be shown.
     /// </summary>
     [DataField]
-    public bool VagueExamine;
+    public bool ExactVolume;
 }

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.Capabilities.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.Capabilities.cs
@@ -1,9 +1,7 @@
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Kitchen.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
-using Content.Shared.Chemistry.Reaction;
 using Content.Shared.FixedPoint;
-using Robust.Shared.Utility;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
@@ -139,6 +137,14 @@ public abstract partial class SharedSolutionContainerSystem
 
     #endregion Solution Modifiers
 
+    public float PercentFull(EntityUid uid)
+    {
+        if (!TryGetDrainableSolution(uid, out _, out var solution) || solution.MaxVolume.Equals(FixedPoint2.Zero))
+            return 0;
+
+        return solution.FillFraction * 100;
+    }
+
     #region Static Methods
 
     public static string ToPrettyString(Solution solution)
@@ -167,6 +173,7 @@ public abstract partial class SharedSolutionContainerSystem
         return sb.ToString();
     }
 
+    /// <returns>A value between 0 and 100 inclusive.</returns>
     public static float PercentFull(Solution sol)
     {
         if (sol.MaxVolume.Equals(FixedPoint2.Zero))

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.Capabilities.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.Capabilities.cs
@@ -139,14 +139,6 @@ public abstract partial class SharedSolutionContainerSystem
 
     #endregion Solution Modifiers
 
-    public float PercentFull(EntityUid uid)
-    {
-        if (!TryGetDrainableSolution(uid, out _, out var solution) || solution.MaxVolume.Equals(FixedPoint2.Zero))
-            return 0;
-
-        return solution.FillFraction * 100;
-    }
-
     #region Static Methods
 
     public static string ToPrettyString(Solution solution)
@@ -173,6 +165,14 @@ public abstract partial class SharedSolutionContainerSystem
 
         sb.Append(']');
         return sb.ToString();
+    }
+
+    public static float PercentFull(Solution sol)
+    {
+        if (sol.MaxVolume.Equals(FixedPoint2.Zero))
+            return 0;
+
+        return sol.FillFraction * 100;
     }
 
     #endregion Static Methods

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -801,8 +801,10 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
     {
         if (!args.IsInDetailsRange ||
             !CanSeeHiddenSolution(entity, args.Examiner) ||
-            !TryGetSolution(entity.Owner, entity.Comp.Solution, out _, out var solution) ||
-            Openable.IsClosed(entity.Owner, predicted: true))
+            !TryGetSolution(entity.Owner, entity.Comp.Solution, out _, out var solution))
+            return;
+
+        if (entity.Comp.CantSeeWhenClosed && Openable.IsClosed(entity.Owner, predicted: true))
             return;
 
         var primaryReagent = solution.GetPrimaryReagentId();

--- a/Content.Shared/Nutrition/EntitySystems/SharedDrinkSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SharedDrinkSystem.cs
@@ -37,7 +37,6 @@ public abstract partial class SharedDrinkSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<DrinkComponent, AttemptShakeEvent>(OnAttemptShake);
-        SubscribeLocalEvent<DrinkComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<DrinkComponent, GetVerbsEvent<AlternativeVerb>>(AddDrinkVerb);
     }
 
@@ -45,38 +44,6 @@ public abstract partial class SharedDrinkSystem : EntitySystem
     {
         if (IsEmpty(entity, entity.Comp))
             args.Cancelled = true;
-    }
-
-    protected void OnExamined(Entity<DrinkComponent> entity, ref ExaminedEvent args)
-    {
-        TryComp<OpenableComponent>(entity, out var openable);
-        if (_openable.IsClosed(entity.Owner, null, openable, true) || !args.IsInDetailsRange || !entity.Comp.Examinable)
-            return;
-
-        var empty = IsEmpty(entity, entity.Comp);
-        if (empty)
-        {
-            args.PushMarkup(Loc.GetString("drink-component-on-examine-is-empty"));
-            return;
-        }
-
-        if (HasComp<ExaminableSolutionComponent>(entity))
-        {
-            //provide exact measurement for beakers
-            args.PushText(Loc.GetString("drink-component-on-examine-exact-volume", ("amount", DrinkVolume(entity, entity.Comp))));
-        }
-        else
-        {
-            //general approximation
-            var remainingString = (int) _solutionContainer.PercentFull(entity) switch
-            {
-                100 => "drink-component-on-examine-is-full",
-                > 66 => "drink-component-on-examine-is-mostly-full",
-                > 33 => HalfEmptyOrHalfFull(args),
-                _ => "drink-component-on-examine-is-mostly-empty",
-            };
-            args.PushMarkup(Loc.GetString(remainingString));
-        }
     }
 
     private void AddDrinkVerb(Entity<DrinkComponent> entity, ref GetVerbsEvent<AlternativeVerb> ev)
@@ -128,18 +95,6 @@ public abstract partial class SharedDrinkSystem : EntitySystem
             return true;
 
         return DrinkVolume(uid, component) <= 0;
-    }
-
-    // some see half empty, and others see half full
-    private string HalfEmptyOrHalfFull(ExaminedEvent args)
-    {
-        string remainingString = "drink-component-on-examine-is-half-full";
-
-        if (TryComp(args.Examiner, out MetaDataComponent? examiner) && examiner.EntityName.Length > 0
-            && string.Compare(examiner.EntityName.Substring(0, 1), "m", StringComparison.InvariantCultureIgnoreCase) > 0)
-            remainingString = "drink-component-on-examine-is-half-empty";
-
-        return remainingString;
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
+++ b/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
@@ -14,6 +14,11 @@ examinable-solution-on-examine-volume = The contained solution is { $fillLevel -
    *[other] { -solution-vague-fill-level(fillLevel: $fillLevel) }.
 }
 
+examinable-solution-on-examine-volume-no-max = The contained solution is { $fillLevel ->
+    [exact] holding [color=white]{$current}u[/color].
+   *[other] { -solution-vague-fill-level(fillLevel: $fillLevel) }.
+}
+
 -solution-vague-fill-level =
     { $fillLevel ->
         [full] [color=white]Full[/color]

--- a/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
+++ b/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
@@ -1,19 +1,25 @@
 shared-solution-container-component-on-examine-empty-container = [color=gray]Contains no chemicals.[/color]
 shared-solution-container-component-on-examine-main-text = It contains {INDEFINITE($desc)} [color={$color}]{$desc}[/color] { $chemCount ->
     [1] chemical.
-    *[other] mixture of chemicals.
+   *[other] mixture of chemicals.
     }
-
-# Legacy names
-drink-component-on-examine-is-full = The solution is [color=white]full[/color].
-drink-component-on-examine-is-mostly-full = The solution is [color=white]mostly full[/color].
-drink-component-on-examine-is-half-full = The solution is [color=white]halfway full[/color].
-drink-component-on-examine-is-half-empty = The solution is [color=white]halfway empty[/color].
-drink-component-on-examine-is-mostly-empty = The solution is [color=white]mostly empty[/color].
-drink-component-on-examine-exact-volume = The solution contains [color=white]{$amount}u[/color].
 
 examinable-solution-has-recognizable-chemicals = You can recognize {$recognizedString} in the solution.
 examinable-solution-recognized-first = [color={$color}]{$chemical}[/color]
 examinable-solution-recognized-next = , [color={$color}]{$chemical}[/color]
-# Special handling to include a space at the start of the line
 examinable-solution-recognized-last = {" "}and [color={$color}]{$chemical}[/color]
+
+examinable-solution-on-examine-volume = The contained solution is { $fillLevel ->
+    [exact] holding [color=white]{$current}/{$max}u[/color].
+   *[other] { -solution-vague-fill-level(fillLevel: $fillLevel) }.
+}
+
+-solution-vague-fill-level =
+    { $fillLevel ->
+        [full] [color=white]Full[/color]
+        [mostlyfull] [color=white]Mostly Full[/color]
+        [halffull] [color=white]Half Full[/color]
+        [halfempty] [color=white]Half Empty[/color]
+        [mostlyempty] [color=white]Mostly Empty[/color]
+       *[empty] [color=gray]Empty[/color]
+    }

--- a/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
+++ b/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
@@ -1,9 +1,19 @@
-shared-solution-container-component-on-examine-empty-container = Contains no chemicals.
-shared-solution-container-component-on-examine-main-text = It contains {INDEFINITE($desc)} [color={$color}]{$desc}[/color] {$wordedAmount}
-shared-solution-container-component-on-examine-worded-amount-one-reagent = chemical.
-shared-solution-container-component-on-examine-worded-amount-multiple-reagents = mixture of chemicals.
+shared-solution-container-component-on-examine-empty-container = [color=gray]Contains no chemicals.[/color]
+shared-solution-container-component-on-examine-main-text = It contains {INDEFINITE($desc)} [color={$color}]{$desc}[/color] { $chemCount ->
+    [1] chemical.
+    *[other] mixture of chemicals.
+    }
+
+# Legacy names
+drink-component-on-examine-is-full = The solution is [color=white]full[/color].
+drink-component-on-examine-is-mostly-full = The solution is [color=white]mostly full[/color].
+drink-component-on-examine-is-half-full = The solution is [color=white]halfway full[/color].
+drink-component-on-examine-is-half-empty = The solution is [color=white]halfway empty[/color].
+drink-component-on-examine-is-mostly-empty = The solution is [color=white]mostly empty[/color].
+drink-component-on-examine-exact-volume = The solution contains [color=white]{$amount}u[/color].
 
 examinable-solution-has-recognizable-chemicals = You can recognize {$recognizedString} in the solution.
 examinable-solution-recognized-first = [color={$color}]{$chemical}[/color]
 examinable-solution-recognized-next = , [color={$color}]{$chemical}[/color]
-examinable-solution-recognized-last = and [color={$color}]{$chemical}[/color]
+# Special handling to include a space at the start of the line
+examinable-solution-recognized-last = {" "}and [color={$color}]{$chemical}[/color]

--- a/Resources/Locale/en-US/nutrition/components/drink-component.ftl
+++ b/Resources/Locale/en-US/nutrition/components/drink-component.ftl
@@ -1,14 +1,7 @@
 drink-component-on-use-is-empty = {CAPITALIZE(THE($owner))} is empty!
-drink-component-on-examine-is-empty = [color=gray]Empty[/color]
 drink-component-on-examine-is-opened = [color=yellow]Opened[/color]
 drink-component-on-examine-is-sealed = The seal is intact.
 drink-component-on-examine-is-unsealed = The seal is broken.
-drink-component-on-examine-is-full = Full
-drink-component-on-examine-is-mostly-full = Mostly Full
-drink-component-on-examine-is-half-full = Halfway Full
-drink-component-on-examine-is-half-empty = Halfway Empty
-drink-component-on-examine-is-mostly-empty = Mostly Empty
-drink-component-on-examine-exact-volume = It contains {$amount}u.
 drink-component-try-use-drink-not-open = Open {$owner} first!
 drink-component-try-use-drink-is-empty = {CAPITALIZE(THE($entity))} is empty!
 drink-component-try-use-drink-cannot-drink = You can't drink anything!

--- a/Resources/Prototypes/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/specific.yml
@@ -75,6 +75,7 @@
     solution: tank
   - type: ExaminableSolution
     solution: tank
+    exactVolume: true
 
 - type: entity
   parent: ClothingBackpack

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -209,6 +209,7 @@
   - type: ExaminableSolution
     solution: puddle
     exactVolume: true
+    locVolume: "examinable-solution-on-examine-volume-no-max"
   - type: DrawableSolution
     solution: puddle
   - type: BadDrink

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -208,6 +208,7 @@
     examinable: false
   - type: ExaminableSolution
     solution: puddle
+    exactVolume: true
   - type: DrawableSolution
     solution: puddle
   - type: BadDrink

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -77,6 +77,7 @@
       Glass: 25
   - type: ExaminableSolution
     solution: drink
+    exactVolume: true
   - type: FitsInDispenser
     solution: drink
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Misc/arabianlamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/arabianlamp.yml
@@ -110,6 +110,8 @@
     solution: Welder
   - type: ExaminableSolution
     solution: Welder
+    heldOnly: true
+    exactVolume: true
   - type: SolutionRegeneration
     solution: Welder
     generated:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -42,6 +42,7 @@
     solution: spray
   - type: ExaminableSolution
     solution: spray
+    exactVolume: true
 
 - type: entity
   name: mega spray bottle

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -22,6 +22,8 @@
     solution: hypospray
   - type: ExaminableSolution
     solution: hypospray
+    heldOnly: true
+    exactVolume: true
   - type: Hypospray
     onlyAffectsMobs: false
   - type: UseDelay
@@ -63,6 +65,8 @@
     solution: hypospray
   - type: ExaminableSolution
     solution: hypospray
+    heldOnly: true
+    exactVolume: true
   - type: Hypospray
     onlyAffectsMobs: false
   - type: UseDelay
@@ -92,6 +96,7 @@
     solution: hypospray
   - type: ExaminableSolution
     solution: hypospray
+    exactVolume: true
   - type: Hypospray
     onlyAffectsMobs: false
   - type: UseDelay
@@ -142,6 +147,8 @@
         maxVol: 15
   - type: ExaminableSolution
     solution: pen
+    heldOnly: true
+    exactVolume: true
   - type: Hypospray
     solutionName: pen
     transferAmount: 15
@@ -661,6 +668,7 @@
   - type: ExaminableSolution
     solution: hypospray
     heldOnly: true # Allow examination only when held in hand.
+    exactVolume: true
   - type: Hypospray
     onlyAffectsMobs: false
   - type: UseDelay

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -26,6 +26,7 @@
       solution: beaker
     - type: ExaminableSolution
       solution: beaker
+      exactVolume: true
     - type: DrawableSolution
       solution: beaker
     - type: InjectableSolution

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -37,6 +37,7 @@
     solution: drink
   - type: ExaminableSolution
     solution: drink
+    exactVolume: true
   - type: DrawableSolution
     solution: drink
   - type: SolutionTransfer

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
@@ -43,6 +43,7 @@
     solution: beaker
   - type: ExaminableSolution
     solution: beaker
+    exactVolume: true
   - type: DrawableSolution
     solution: beaker
   - type: SolutionTransfer
@@ -137,6 +138,7 @@
     solution: beaker
   - type: ExaminableSolution
     solution: beaker
+    exactVolume: true
   - type: DrawableSolution
     solution: beaker
   - type: SolutionTransfer

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -35,6 +35,7 @@
     solution: beaker
   - type: ExaminableSolution
     solution: beaker
+    exactVolume: true
   - type: DrawableSolution
     solution: beaker
   - type: InjectableSolution
@@ -133,6 +134,7 @@
     solution: beaker
   - type: ExaminableSolution
     solution: beaker
+    exactVolume: true
   - type: DrawableSolution
     solution: beaker
   - type: InjectableSolution
@@ -189,6 +191,7 @@
     solution: beaker
   - type: ExaminableSolution
     solution: beaker
+    exactVolume: true
   - type: DrawableSolution
     solution: beaker
   - type: InjectableSolution
@@ -348,6 +351,7 @@
     toggleState: 1 # draw
   - type: ExaminableSolution
     solution: dropper
+    exactVolume: true
   - type: UserInterface
     interfaces:
       enum.TransferAmountUiKey.Key:
@@ -420,6 +424,7 @@
     injectOnly: false
   - type: ExaminableSolution
     solution: injector
+    exactVolume: true
   - type: Spillable
     solution: injector
   - type: TrashOnSolutionEmpty

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
@@ -44,6 +44,7 @@
     solution: chamber
   - type: ExaminableSolution
     solution: chamber
+    heldOnly: true
   - type: StaticPrice
     price: 100
   - type: PhysicalComposition

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -979,6 +979,7 @@
     solution: anomaly
   - type: ExaminableSolution
     solution: anomaly
+    exactVolume: true
   - type: RefillableSolution
     solution: anomaly
   - type: InjectableSolution

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -980,6 +980,7 @@
   - type: ExaminableSolution
     solution: anomaly
     exactVolume: true
+    locVolume: "examinable-solution-on-examine-volume-no-max"
   - type: RefillableSolution
     solution: anomaly
   - type: InjectableSolution


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Currently solutions get examine text from two components, `DrinkComponent` and `ExaminableSolutionComponent`. ExaminableSolution adds a description of the reagents and the recognizable reagents. Drink adds the text for the current fill level, and calls `HasComp<ExaminableSolutionComponent>` to mode switch between seeing the exact amount or a vague amount.

This PR moves that examine text out of `DrinkComponent` and adds it as a bool to `ExaminableSolutionComponent`. Makes the blocking of examining the solution while closed opt-in. Also moves LocIds to the component.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Examining a solution should be tied to `ExaminableSolutionComponent`. This change makes it so that now you can always approximate the fill level of a solution if you can recognize space cola in the solution. It also gives more flexibility by moving an implicit connection between the two components to a bool.

## Technical details
<!-- Summary of code changes for easier review. -->
The structure of the code from `DrinkComponent` is mostly the same moved over to `ExaminableSolutionComponent`. Previously we used a switch with the solution percentage to get different LocIds. Now we use a switch to pass an enum into one LocId. In that LocId we use another switch for each option. I also use a parameterized term to make it more reusable for #

With the physical description of the reagent, we pass the reagent count directly to ftl to lower from three LocId to one. Moved a hardcoded space in recognizable reagents string to ftl.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/ee0edba1-69b6-40e8-ad15-3324e6234f90

- Opaque drinks like soda cans don't always show you the reagent count.
- Opaque drinks like buckets can have an approximate fill level.
- Non-drinks like fuel tanks can have a fill level.
- Max volume now shows in the examine text.

<img width="448" height="238" alt="image" src="https://github.com/user-attachments/assets/4ea50adb-1f1e-4ff5-91f5-8676993146a5" />

- Max volume doesn't have to show in examine text by using a different LocId.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: aada
- add: You can examine fuel tanks to see how much they're filled.