### PR TITLE
Make sinks less powerful

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -16,9 +16,7 @@
       state: fill-1
       visible: false
   - type: Item
-    size: Large
-    shape:
-    - 0,0,2,2
+    size: Normal
   - type: Clothing
     sprite: Objects/Tools/bucket.rsi
     slots:

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -16,7 +16,9 @@
       state: fill-1
       visible: false
   - type: Item
-    size: Ginormous
+    size: Large
+    shape:
+    - 0,0,2,2
   - type: Clothing
     sprite: Objects/Tools/bucket.rsi
     slots:

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -16,7 +16,7 @@
       state: fill-1
       visible: false
   - type: Item
-    size: Normal
+    size: Ginormous
   - type: Clothing
     sprite: Objects/Tools/bucket.rsi
     slots:

--- a/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
@@ -25,13 +25,13 @@
       drainBuffer:
         maxVol: 100
       tank:
-        maxVol: 500
+        maxVol: 200
   - type: SolutionRegeneration
     solution: tank
     generated:
       reagents:
       - ReagentId: Water
-        Quantity: 1
+        Quantity: 0.5
   - type: DrainableSolution
     solution: tank
   - type: ReagentTank

--- a/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
@@ -76,16 +76,17 @@
   - type: SolutionContainerManager
     solutions:
       drainBuffer:
-        maxVol: 200
+        maxVol: 100
       tank:
         reagents:
         - ReagentId: Water
-          Quantity: 500
+          Quantity: 200
 
 - type: entity
   name: wide sink
-  id: SinkWide
-  parent: Sink
+  id: SinkWideEmpty
+  parent: SinkEmpty
+  suffix: Empty
   components:
     - type: Sprite
       sprite: Structures/Furniture/sink.rsi
@@ -98,6 +99,27 @@
       maxFillLevels: 1
       fillBaseName: sink_wide-fill-
       solutionName: drainBuffer
+    - type: SolutionContainerManager
+      solutions:
+        drainBuffer:
+          maxVol: 200
+        tank:
+          maxVol: 400
+
+- type: entity
+  name: wide sink
+  id: SinkWide
+  parent: SinkWideEmpty
+  suffix: Water
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drainBuffer:
+        maxVol: 200
+      tank:
+        reagents:
+        - ReagentId: Water
+          Quantity: 400
 
 #Stemless Sink
 
@@ -127,4 +149,4 @@
       tank:
         reagents:
         - ReagentId: Water
-          Quantity: 500
+          Quantity: 200


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Sinks are less powerful now. 2x slower and they can hold 200 units of water (it was 500)

## Why / Balance
Originally this PR exists cause of #15812. But it seems it doesn't resolve it fully for now.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Sinks are changed. Now they generate water 2 times slower and can hold up to 200 units of water. Previously they could hold up to 500 units. Wide sink can hold up to 400 units (500 previously).