### PR TITLE
Fix head mappers codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 /Resources/ServerInfo/Guidebook/ServerRules/ @crazybrain23
 
 /Resources/Prototypes/Maps/** @Emisse @ArtisticRoomba
+/Resources/Maps/** @Emisse @ArtisticRoomba
 
 /Resources/Prototypes/Body/ @DrSmugleaf # suffering
 /Resources/Prototypes/Entities/Mobs/Player/ @DrSmugleaf


### PR DESCRIPTION
## About the PR
Adds the Prototypes/Maps file to the watched maps because we only get notifs if the prototypes behind the maps are changed

## Why / Balance
Expedite review. Wasn't getting notifs so mapping PRs get lost in the repo.

## Technical details
codeowners ops

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
n/a
