### PR TITLE
Remove redundant return statement in InventoryUIController

### DIFF
--- a/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
+++ b/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
@@ -194,8 +194,6 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
             }
         }
 
-        return;
-
         int GetIndex(Vector2i position)
         {
             return position.Y * maxWidth + position.X;


### PR DESCRIPTION
## Summary
Cleaned up a pointless return statement in the inventory hotbar update method.

## Changes
- Removed the `return;` on line 197 in `UpdateInventoryHotbar` method

## Why?
I was reading through this code and noticed there's a return statement that doesn't actually do anything. The method ends naturally after the for loop anyway, so the explicit return just makes it look like there's some conditional flow happening when there really isn't.

It's sitting right before the local `GetIndex` function too, which made me do a double-take wondering if I was missing something. Since local functions get hoisted in C#, removing this doesn't change anything functionally.

Small cleanup but should make the code flow clearer for anyone else reading it.

## Testing
No behavior changes - just removed dead code.