### PR TITLE
Predict cryopods

### DIFF
--- a/Content.Client/Medical/Cryogenics/CryoPodSystem.cs
+++ b/Content.Client/Medical/Cryogenics/CryoPodSystem.cs
@@ -1,7 +1,5 @@
 ﻿using System.Numerics;
-using Content.Shared.Emag.Systems;
 using Content.Shared.Medical.Cryogenics;
-using Content.Shared.Verbs;
 using Robust.Client.GameObjects;
 
 namespace Content.Client.Medical.Cryogenics;

--- a/Content.Client/Medical/Cryogenics/CryoPodSystem.cs
+++ b/Content.Client/Medical/Cryogenics/CryoPodSystem.cs
@@ -15,11 +15,6 @@ public sealed class CryoPodSystem : SharedCryoPodSystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<CryoPodComponent, ComponentInit>(OnComponentInit);
-        SubscribeLocalEvent<CryoPodComponent, GetVerbsEvent<AlternativeVerb>>(AddAlternativeVerbs);
-        SubscribeLocalEvent<CryoPodComponent, GotEmaggedEvent>(OnEmagged);
-        SubscribeLocalEvent<CryoPodComponent, CryoPodPryFinished>(OnCryoPodPryFinished);
-
         SubscribeLocalEvent<CryoPodComponent, AppearanceChangeEvent>(OnAppearanceChange);
         SubscribeLocalEvent<InsideCryoPodComponent, ComponentStartup>(OnCryoPodInsertion);
         SubscribeLocalEvent<InsideCryoPodComponent, ComponentRemove>(OnCryoPodRemoval);
@@ -53,8 +48,8 @@ public sealed class CryoPodSystem : SharedCryoPodSystem
             return;
         }
 
-        if (!_appearance.TryGetData<bool>(uid, CryoPodComponent.CryoPodVisuals.ContainsEntity, out var isOpen, args.Component)
-            || !_appearance.TryGetData<bool>(uid, CryoPodComponent.CryoPodVisuals.IsOn, out var isOn, args.Component))
+        if (!_appearance.TryGetData<bool>(uid, CryoPodVisuals.ContainsEntity, out var isOpen, args.Component)
+            || !_appearance.TryGetData<bool>(uid, CryoPodVisuals.IsOn, out var isOn, args.Component))
         {
             return;
         }

--- a/Content.Server/Medical/CryoPodEjectLockWireAction.cs
+++ b/Content.Server/Medical/CryoPodEjectLockWireAction.cs
@@ -1,4 +1,3 @@
-using Content.Server.Medical.Components;
 using Content.Server.Wires;
 using Content.Shared.Medical.Cryogenics;
 using Content.Shared.Wires;

--- a/Content.Server/Medical/CryoPodEjectLockWireAction.cs
+++ b/Content.Server/Medical/CryoPodEjectLockWireAction.cs
@@ -8,7 +8,7 @@ namespace Content.Server.Medical;
 /// <summary>
 /// Causes a failure in the cryo pod ejection system when cut. A crowbar will be needed to pry open the pod.
 /// </summary>
-public sealed partial class CryoPodEjectLockWireAction: ComponentWireAction<CryoPodComponent>
+public sealed partial class CryoPodEjectLockWireAction : ComponentWireAction<CryoPodComponent>
 {
     public override Color Color { get; set; } = Color.Red;
     public override string Name { get; set; } = "wire-name-lock";
@@ -18,7 +18,10 @@ public sealed partial class CryoPodEjectLockWireAction: ComponentWireAction<Cryo
     public override bool Cut(EntityUid user, Wire wire, CryoPodComponent cryoPodComponent)
     {
         if (!cryoPodComponent.PermaLocked)
+        {
             cryoPodComponent.Locked = true;
+            EntityManager.Dirty(wire.Owner, cryoPodComponent);
+        }
 
         return true;
     }
@@ -26,7 +29,10 @@ public sealed partial class CryoPodEjectLockWireAction: ComponentWireAction<Cryo
     public override bool Mend(EntityUid user, Wire wire, CryoPodComponent cryoPodComponent)
     {
         if (!cryoPodComponent.PermaLocked)
+        {
             cryoPodComponent.Locked = false;
+            EntityManager.Dirty(wire.Owner, cryoPodComponent);
+        }
 
         return true;
     }

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -1,8 +1,6 @@
-using Content.Server.Administration.Logs;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
 using Content.Server.Atmos.Piping.Unary.EntitySystems;
-using Content.Server.Body.Systems;
 using Content.Server.Medical.Components;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.NodeContainer.NodeGroups;
@@ -10,29 +8,11 @@ using Content.Server.NodeContainer.Nodes;
 using Content.Server.Temperature.Components;
 using Content.Shared.Atmos;
 using Content.Shared.Body.Components;
-using Content.Shared.Chemistry;
-using Content.Shared.Chemistry.Components;
-using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
-using Content.Shared.Climbing.Systems;
-using Content.Shared.Containers.ItemSlots;
-using Content.Shared.Database;
-using Content.Shared.DoAfter;
-using Content.Shared.DragDrop;
-using Content.Shared.Emag.Systems;
-using Content.Shared.Examine;
-using Content.Shared.Interaction;
 using Content.Shared.Medical.Cryogenics;
 using Content.Shared.MedicalScanner;
-using Content.Shared.Power;
-using Content.Shared.Tools;
-using Content.Shared.Tools.Systems;
 using Content.Shared.UserInterface;
-using Content.Shared.Verbs;
-using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Timing;
 
 namespace Content.Server.Medical;
 
@@ -40,144 +20,18 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
 {
     [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
     [Dependency] private readonly GasCanisterSystem _gasCanisterSystem = default!;
-    [Dependency] private readonly ClimbSystem _climbSystem = default!;
-    [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;
-    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
-    [Dependency] private readonly BloodstreamSystem _bloodstreamSystem = default!;
-    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
-    [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
-    [Dependency] private readonly SharedToolSystem _toolSystem = default!;
-    [Dependency] private readonly IGameTiming _gameTiming = default!;
-    [Dependency] private readonly MetaDataSystem _metaDataSystem = default!;
-    [Dependency] private readonly ReactiveSystem _reactiveSystem = default!;
-    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
-
-    private static readonly ProtoId<ToolQualityPrototype> PryingQuality = "Prying";
+    [Dependency] private readonly SharedUserInterfaceSystem _uiSystem = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<CryoPodComponent, ComponentInit>(OnComponentInit);
-        SubscribeLocalEvent<CryoPodComponent, GetVerbsEvent<AlternativeVerb>>(AddAlternativeVerbs);
-        SubscribeLocalEvent<CryoPodComponent, GotEmaggedEvent>(OnEmagged);
-        SubscribeLocalEvent<CryoPodComponent, CryoPodDragFinished>(OnDragFinished);
-        SubscribeLocalEvent<CryoPodComponent, CryoPodPryFinished>(OnCryoPodPryFinished);
-
-        SubscribeLocalEvent<CryoPodComponent, AtmosDeviceUpdateEvent>(OnCryoPodUpdateAtmosphere);
-        SubscribeLocalEvent<CryoPodComponent, DragDropTargetEvent>(HandleDragDropOn);
-        SubscribeLocalEvent<CryoPodComponent, InteractUsingEvent>(OnInteractUsing);
-        SubscribeLocalEvent<CryoPodComponent, PowerChangedEvent>(OnPowerChanged);
-        SubscribeLocalEvent<CryoPodComponent, GasAnalyzerScanEvent>(OnGasAnalyzed);
-        SubscribeLocalEvent<CryoPodComponent, ActivatableUIOpenAttemptEvent>(OnActivateUIAttempt);
         SubscribeLocalEvent<CryoPodComponent, AfterActivatableUIOpenEvent>(OnActivateUI);
+        SubscribeLocalEvent<CryoPodComponent, AtmosDeviceUpdateEvent>(OnCryoPodUpdateAtmosphere);
+        SubscribeLocalEvent<CryoPodComponent, GasAnalyzerScanEvent>(OnGasAnalyzed);
         SubscribeLocalEvent<CryoPodComponent, EntRemovedFromContainerMessage>(OnEjected);
-    }
-
-    public override void Update(float frameTime)
-    {
-        base.Update(frameTime);
-
-        var curTime = _gameTiming.CurTime;
-        var bloodStreamQuery = GetEntityQuery<BloodstreamComponent>();
-        var metaDataQuery = GetEntityQuery<MetaDataComponent>();
-        var itemSlotsQuery = GetEntityQuery<ItemSlotsComponent>();
-        var fitsInDispenserQuery = GetEntityQuery<FitsInDispenserComponent>();
-        var solutionContainerManagerQuery = GetEntityQuery<SolutionContainerManagerComponent>();
-        var query = EntityQueryEnumerator<ActiveCryoPodComponent, CryoPodComponent>();
-
-        while (query.MoveNext(out var uid, out _, out var cryoPod))
-        {
-            metaDataQuery.TryGetComponent(uid, out var metaDataComponent);
-            if (curTime < cryoPod.NextInjectionTime + _metaDataSystem.GetPauseTime(uid, metaDataComponent))
-                continue;
-            cryoPod.NextInjectionTime = curTime + TimeSpan.FromSeconds(cryoPod.BeakerTransferTime);
-
-            if (!itemSlotsQuery.TryGetComponent(uid, out var itemSlotsComponent))
-            {
-                continue;
-            }
-            var container = _itemSlotsSystem.GetItemOrNull(uid, cryoPod.SolutionContainerName, itemSlotsComponent);
-            var patient = cryoPod.BodyContainer.ContainedEntity;
-            if (container != null
-                && container.Value.Valid
-                && patient != null
-                && fitsInDispenserQuery.TryGetComponent(container, out var fitsInDispenserComponent)
-                && solutionContainerManagerQuery.TryGetComponent(container,
-                    out var solutionContainerManagerComponent)
-                && _solutionContainerSystem.TryGetFitsInDispenser((container.Value, fitsInDispenserComponent, solutionContainerManagerComponent),
-                    out var containerSolution, out _))
-            {
-                if (!bloodStreamQuery.TryGetComponent(patient, out var bloodstream))
-                {
-                    continue;
-                }
-
-                var solutionToInject = _solutionContainerSystem.SplitSolution(containerSolution.Value, cryoPod.BeakerTransferAmount);
-                _bloodstreamSystem.TryAddToChemicals((patient.Value, bloodstream), solutionToInject);
-                _reactiveSystem.DoEntityReaction(patient.Value, solutionToInject, ReactionMethod.Injection);
-            }
-        }
-    }
-
-    public override EntityUid? EjectBody(EntityUid uid, CryoPodComponent? cryoPodComponent)
-    {
-        if (!Resolve(uid, ref cryoPodComponent))
-            return null;
-        if (cryoPodComponent.BodyContainer.ContainedEntity is not { Valid: true } contained)
-            return null;
-        base.EjectBody(uid, cryoPodComponent);
-        _climbSystem.ForciblySetClimbing(contained, uid);
-        return contained;
-    }
-
-    #region Interaction
-
-    private void HandleDragDropOn(Entity<CryoPodComponent> entity, ref DragDropTargetEvent args)
-    {
-        if (entity.Comp.BodyContainer.ContainedEntity != null)
-            return;
-
-        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, entity.Comp.EntryDelay, new CryoPodDragFinished(), entity, target: args.Dragged, used: entity)
-        {
-            BreakOnDamage = true,
-            BreakOnMove = true,
-            NeedHand = false,
-        };
-        _doAfterSystem.TryStartDoAfter(doAfterArgs);
-        args.Handled = true;
-    }
-
-    private void OnDragFinished(Entity<CryoPodComponent> entity, ref CryoPodDragFinished args)
-    {
-        if (args.Cancelled || args.Handled || args.Args.Target == null)
-            return;
-
-        if (InsertBody(entity.Owner, args.Args.Target.Value, entity.Comp))
-        {
-            if (!TryComp(entity.Owner, out CryoPodAirComponent? cryoPodAir))
-                _adminLogger.Add(LogType.Action, LogImpact.Medium,
-                    $"{ToPrettyString(args.User)} inserted {ToPrettyString(args.Args.Target.Value)} into {ToPrettyString(entity.Owner)}");
-
-            _adminLogger.Add(LogType.Action, LogImpact.Medium,
-                $"{ToPrettyString(args.User)} inserted {ToPrettyString(args.Args.Target.Value)} into {ToPrettyString(entity.Owner)} which contains gas: {cryoPodAir!.Air.ToPrettyString():gasMix}");
-        }
-        args.Handled = true;
-    }
-
-    private void OnActivateUIAttempt(Entity<CryoPodComponent> entity, ref ActivatableUIOpenAttemptEvent args)
-    {
-        if (args.Cancelled)
-        {
-            return;
-        }
-
-        var containedEntity = entity.Comp.BodyContainer.ContainedEntity;
-        if (containedEntity == null || containedEntity == args.User || !HasComp<ActiveCryoPodComponent>(entity))
-        {
-            args.Cancel();
-        }
     }
 
     private void OnActivateUI(Entity<CryoPodComponent> entity, ref AfterActivatableUIOpenEvent args)
@@ -208,38 +62,6 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
             null
         ));
     }
-
-    private void OnInteractUsing(Entity<CryoPodComponent> entity, ref InteractUsingEvent args)
-    {
-        if (args.Handled || !entity.Comp.Locked || entity.Comp.BodyContainer.ContainedEntity == null)
-            return;
-
-        args.Handled = _toolSystem.UseTool(args.Used, args.User, entity.Owner, entity.Comp.PryDelay, PryingQuality, new CryoPodPryFinished());
-    }
-
-    private void OnPowerChanged(Entity<CryoPodComponent> entity, ref PowerChangedEvent args)
-    {
-        // Needed to avoid adding/removing components on a deleted entity
-        if (Terminating(entity))
-        {
-            return;
-        }
-
-        if (args.Powered)
-        {
-            EnsureComp<ActiveCryoPodComponent>(entity);
-        }
-        else
-        {
-            RemComp<ActiveCryoPodComponent>(entity);
-            _uiSystem.CloseUi(entity.Owner, HealthAnalyzerUiKey.Key);
-        }
-        UpdateAppearance(entity.Owner, entity.Comp);
-    }
-
-    #endregion
-
-    #region Atmos handler
 
     private void OnCryoPodUpdateAtmosphere(Entity<CryoPodComponent> entity, ref AtmosDeviceUpdateEvent args)
     {
@@ -285,6 +107,4 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
         // if body is ejected - no need to display health-analyzer
         _uiSystem.CloseUi(cryoPod.Owner, HealthAnalyzerUiKey.Key);
     }
-
-    #endregion
 }

--- a/Content.Shared/Medical/Cryogenics/ActiveCryoPodComponent.cs
+++ b/Content.Shared/Medical/Cryogenics/ActiveCryoPodComponent.cs
@@ -1,9 +1,9 @@
-﻿namespace Content.Shared.Medical.Cryogenics;
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Medical.Cryogenics;
 
 /// <summary>
 /// Tracking component for an enabled cryo pod (which periodically tries to inject chemicals in the occupant, if one exists)
 /// </summary>
-[RegisterComponent]
-public sealed partial class ActiveCryoPodComponent : Component
-{
-}
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ActiveCryoPodComponent : Component;

--- a/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
+++ b/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Medical.Cryogenics;
 
 /// <summary>
 /// Component for medical cryo pods.
-/// Handles trasferring reagents from a beaker slot into an inserted mob, as well as exposing them to connected atmos pipes.
+/// Handles transferring reagents from a beaker slot into an inserted mob, as well as exposing them to connected atmos pipes.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 [AutoGenerateComponentState, AutoGenerateComponentPause]
@@ -28,7 +28,7 @@ public sealed partial class CryoPodComponent : Component
     public string PortName = "port";
 
     /// <summary>
-    /// Specifies the name of the slot that holds beaker with medicine.
+    /// Specifies the name of the slot that holds the beaker with medicine.
     /// </summary>
     [DataField]
     public string SolutionContainerName = "beakerSlot";

--- a/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
+++ b/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.FixedPoint;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
@@ -5,53 +6,58 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Medical.Cryogenics;
 
+/// <summary>
+/// Component for medical cryo pods.
+/// Handles trasferring reagents from a beaker slot into an inserted mob, as well as exposing them to connected atmos pipes.
+/// </summary>
 [RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class CryoPodComponent : Component
 {
     /// <summary>
+    /// The name of the container the patient is stored in.
+    /// </summary>
+    public const string BodyContainerName = "scanner-body";
+
+    /// <summary>
     /// Specifies the name of the atmospherics port to draw gas from.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("port")]
-    public string PortName { get; set; } = "port";
+    [DataField]
+    public string PortName = "port";
 
     /// <summary>
     /// Specifies the name of the slot that holds beaker with medicine.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("solutionContainerName")]
-    public string SolutionContainerName { get; set; } = "beakerSlot";
+    [DataField]
+    public string SolutionContainerName = "beakerSlot";
 
     /// <summary>
-    /// How often (seconds) are chemicals transferred from the beaker to the body?
+    /// How often are chemicals transferred from the beaker to the body?
+    /// (injection interval)
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("beakerTransferTime")]
-    public float BeakerTransferTime = 1f;
+    [DataField]
+    public TimeSpan BeakerTransferTime = TimeSpan.FromSeconds(1);
 
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("nextInjectionTime", customTypeSerializer:typeof(TimeOffsetSerializer))]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoNetworkedField, AutoPausedField]
     public TimeSpan? NextInjectionTime;
 
     /// <summary>
     /// How many units to transfer per tick from the beaker to the mob?
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("beakerTransferAmount")]
-    public float BeakerTransferAmount = 1f;
+    [DataField]
+    public FixedPoint2 BeakerTransferAmount = 1;
 
     /// <summary>
-    ///     Delay applied when inserting a mob in the pod.
+    /// Delay applied when inserting a mob in the pod (in seconds).
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("entryDelay")]
+    [DataField]
     public float EntryDelay = 2f;
 
     /// <summary>
-    /// Delay applied when trying to pry open a locked pod.
+    /// Delay applied when trying to pry open a locked pod (in seconds).
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("pryDelay")]
+    [DataField]
     public float PryDelay = 5f;
 
     /// <summary>
@@ -63,21 +69,19 @@ public sealed partial class CryoPodComponent : Component
     /// <summary>
     /// If true, the eject verb will not work on the pod and the user must use a crowbar to pry the pod open.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("locked")]
-    public bool Locked { get; set; }
+    [DataField, AutoNetworkedField]
+    public bool Locked;
 
     /// <summary>
     /// Causes the pod to be locked without being fixable by messing with wires.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("permaLocked")]
-    public bool PermaLocked { get; set; }
+    [DataField, AutoNetworkedField]
+    public bool PermaLocked;
+}
 
-    [Serializable, NetSerializable]
-    public enum CryoPodVisuals : byte
-    {
-        ContainsEntity,
-        IsOn
-    }
+[Serializable, NetSerializable]
+public enum CryoPodVisuals : byte
+{
+    ContainsEntity,
+    IsOn
 }

--- a/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
+++ b/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
@@ -87,7 +87,7 @@ public sealed partial class CryoPodComponent : Component
     /// The tool quality needed to eject a body when the pod is locked.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public ProtoId<ToolQualityPrototype> UnlockToolQuality;
+    public ProtoId<ToolQualityPrototype> UnlockToolQuality = "Prying";
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
+++ b/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
@@ -1,6 +1,8 @@
 using Content.Shared.FixedPoint;
+using Content.Shared.Tools;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
@@ -38,12 +40,15 @@ public sealed partial class CryoPodComponent : Component
     [DataField]
     public TimeSpan BeakerTransferTime = TimeSpan.FromSeconds(1);
 
+    /// <summary>
+    /// The timestamp for the next injection.
+    /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoNetworkedField, AutoPausedField]
-    public TimeSpan? NextInjectionTime;
+    public TimeSpan NextInjectionTime = TimeSpan.Zero;
 
     /// <summary>
-    /// How many units to transfer per tick from the beaker to the mob?
+    /// How many units to transfer per injection from the beaker to the mob?
     /// </summary>
     [DataField]
     public FixedPoint2 BeakerTransferAmount = 1;
@@ -77,6 +82,12 @@ public sealed partial class CryoPodComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool PermaLocked;
+
+    /// <summary>
+    /// The tool quality needed to eject a body when the pod is locked.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ProtoId<ToolQualityPrototype> UnlockToolQuality;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
+++ b/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
@@ -1,35 +1,62 @@
 using Content.Shared.Administration.Logs;
 using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
+using Content.Shared.Chemistry;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Climbing.Systems;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Examine;
+using Content.Shared.Interaction;
+using Content.Shared.MedicalScanner;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
+using Content.Shared.Power;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
+using Content.Shared.Tools;
+using Content.Shared.Tools.Systems;
+using Content.Shared.UserInterface;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 using Robust.Shared.Serialization;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Medical.Cryogenics;
 
-public abstract partial class SharedCryoPodSystem: EntitySystem
+public abstract partial class SharedCryoPodSystem : EntitySystem
 {
-    [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
-    [Dependency] private readonly StandingStateSystem _standingStateSystem = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly StandingStateSystem _standingState = default!;
     [Dependency] private readonly EmagSystem _emag = default!;
-    [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;
-    [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
-    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
-    [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
+    [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedPointLightSystem _light = default!;
-    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly ClimbSystem _climb = default!;
+    [Dependency] private readonly SharedBloodstreamSystem _bloodstream = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
+    [Dependency] private readonly SharedToolSystem _tool = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly ReactiveSystem _reactive = default!;
+
+    private EntityQuery<BloodstreamComponent> _bloodstreamQuery;
+    private EntityQuery<ItemSlotsComponent> _itemSlotsQuery;
+    private EntityQuery<FitsInDispenserComponent> _dispenserQuery;
+    private EntityQuery<SolutionContainerManagerComponent> _solutionContainerQuery;
+
+    private static readonly ProtoId<ToolQualityPrototype> PryingQuality = "Prying";
 
     public override void Initialize()
     {
@@ -37,13 +64,141 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
 
         SubscribeLocalEvent<CryoPodComponent, CanDropTargetEvent>(OnCryoPodCanDropOn);
         SubscribeLocalEvent<CryoPodComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<CryoPodComponent, ComponentInit>(OnComponentInit);
+        SubscribeLocalEvent<CryoPodComponent, GetVerbsEvent<AlternativeVerb>>(AddAlternativeVerbs);
+        SubscribeLocalEvent<CryoPodComponent, GotEmaggedEvent>(OnEmagged);
+        SubscribeLocalEvent<CryoPodComponent, CryoPodDragFinished>(OnDragFinished);
+        SubscribeLocalEvent<CryoPodComponent, CryoPodPryFinished>(OnCryoPodPryFinished);
+        SubscribeLocalEvent<CryoPodComponent, DragDropTargetEvent>(HandleDragDropOn);
+        SubscribeLocalEvent<CryoPodComponent, InteractUsingEvent>(OnInteractUsing);
+        SubscribeLocalEvent<CryoPodComponent, PowerChangedEvent>(OnPowerChanged);
+        SubscribeLocalEvent<CryoPodComponent, ActivatableUIOpenAttemptEvent>(OnActivateUIAttempt);
+
+        _bloodstreamQuery = GetEntityQuery<BloodstreamComponent>();
+        _itemSlotsQuery = GetEntityQuery<ItemSlotsComponent>();
+        _dispenserQuery = GetEntityQuery<FitsInDispenserComponent>();
+        _solutionContainerQuery = GetEntityQuery<SolutionContainerManagerComponent>();
+
         InitializeInsideCryoPod();
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        var query = EntityQueryEnumerator<ActiveCryoPodComponent, CryoPodComponent>();
+
+        while (query.MoveNext(out var uid, out _, out var cryoPod))
+        {
+            if (curTime < cryoPod.NextInjectionTime)
+                continue;
+
+            cryoPod.NextInjectionTime += cryoPod.BeakerTransferTime;
+            Dirty(uid, cryoPod);
+
+            if (!_itemSlotsQuery.TryGetComponent(uid, out var itemSlotsComponent))
+                continue;
+
+            var container = _itemSlots.GetItemOrNull(uid, cryoPod.SolutionContainerName, itemSlotsComponent);
+            var patient = cryoPod.BodyContainer.ContainedEntity;
+            if (container != null
+                && container.Value.Valid
+                && patient != null
+                && _dispenserQuery.TryGetComponent(container, out var fitsInDispenserComponent)
+                && _solutionContainerQuery.TryGetComponent(container, out var solutionContainerManagerComponent)
+                && _solutionContainer.TryGetFitsInDispenser((container.Value, fitsInDispenserComponent, solutionContainerManagerComponent),
+                    out var containerSolution, out _)
+                && _bloodstreamQuery.TryGetComponent(patient, out var bloodstream))
+            {
+                var solutionToInject = _solutionContainer.SplitSolution(containerSolution.Value, cryoPod.BeakerTransferAmount);
+                _bloodstream.TryAddToChemicals((patient.Value, bloodstream), solutionToInject);
+                _reactive.DoEntityReaction(patient.Value, solutionToInject, ReactionMethod.Injection);
+            }
+        }
+    }
+
+    private void HandleDragDropOn(Entity<CryoPodComponent> ent, ref DragDropTargetEvent args)
+    {
+        if (ent.Comp.BodyContainer.ContainedEntity != null)
+            return;
+
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, ent.Comp.EntryDelay, new CryoPodDragFinished(), ent, target: args.Dragged, used: ent)
+        {
+            BreakOnDamage = true,
+            BreakOnMove = true,
+            NeedHand = false,
+        };
+        _doAfter.TryStartDoAfter(doAfterArgs);
+        args.Handled = true;
+    }
+
+    private void OnDragFinished(Entity<CryoPodComponent> ent, ref CryoPodDragFinished args)
+    {
+        if (args.Cancelled || args.Handled || args.Args.Target == null)
+            return;
+
+        if (InsertBody(ent.Owner, args.Args.Target.Value, ent.Comp))
+        {
+            _adminLogger.Add(LogType.Action, LogImpact.Medium,
+                $"{ToPrettyString(args.User)} inserted {ToPrettyString(args.Args.Target.Value)} into {ToPrettyString(ent.Owner)}");
+        }
+        args.Handled = true;
+    }
+
+    private void OnActivateUIAttempt(Entity<CryoPodComponent> ent, ref ActivatableUIOpenAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        var containedEntity = ent.Comp.BodyContainer.ContainedEntity;
+        if (containedEntity == null || containedEntity == args.User || !HasComp<ActiveCryoPodComponent>(ent))
+            args.Cancel();
+    }
+
+    private void OnInteractUsing(Entity<CryoPodComponent> ent, ref InteractUsingEvent args)
+    {
+        if (args.Handled || !ent.Comp.Locked || ent.Comp.BodyContainer.ContainedEntity == null)
+            return;
+
+        args.Handled = _tool.UseTool(args.Used, args.User, ent.Owner, ent.Comp.PryDelay, PryingQuality, new CryoPodPryFinished());
+    }
+
+    private void OnCryoPodPryFinished(EntityUid uid, CryoPodComponent cryoPodComponent, CryoPodPryFinished args)
+    {
+        if (args.Cancelled)
+            return;
+
+        var ejected = EjectBody(uid, cryoPodComponent);
+        if (ejected != null)
+            _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ejected.Value)} pried out of {ToPrettyString(uid)} by {ToPrettyString(args.User)}");
+    }
+
+    private void OnPowerChanged(Entity<CryoPodComponent> ent, ref PowerChangedEvent args)
+    {
+        // Needed to avoid adding/removing components on a deleted entity
+        if (Terminating(ent))
+            return;
+
+        if (args.Powered)
+        {
+            EnsureComp<ActiveCryoPodComponent>(ent);
+            ent.Comp.NextInjectionTime = _timing.CurTime + ent.Comp.BeakerTransferTime;
+            Dirty(ent);
+        }
+        else
+        {
+            RemComp<ActiveCryoPodComponent>(ent);
+            _ui.CloseUi(ent.Owner, HealthAnalyzerUiKey.Key);
+        }
+
+        UpdateAppearance(ent.Owner, ent.Comp);
     }
 
     private void OnExamined(Entity<CryoPodComponent> entity, ref ExaminedEvent args)
     {
-        var container = _itemSlotsSystem.GetItemOrNull(entity.Owner, entity.Comp.SolutionContainerName);
-        if (args.IsInDetailsRange && container != null && _solutionContainerSystem.TryGetFitsInDispenser(container.Value, out _, out var containerSolution))
+        var container = _itemSlots.GetItemOrNull(entity.Owner, entity.Comp.SolutionContainerName);
+        if (args.IsInDetailsRange && container != null && _solutionContainer.TryGetFitsInDispenser(container.Value, out _, out var containerSolution))
         {
             using (args.PushGroup(nameof(CryoPodComponent)))
             {
@@ -65,12 +220,12 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
         args.Handled = true;
     }
 
-    protected void OnComponentInit(EntityUid uid, CryoPodComponent cryoPodComponent, ComponentInit args)
+    private void OnComponentInit(EntityUid uid, CryoPodComponent cryoPodComponent, ComponentInit args)
     {
-        cryoPodComponent.BodyContainer = _containerSystem.EnsureContainer<ContainerSlot>(uid, "scanner-body");
+        cryoPodComponent.BodyContainer = _container.EnsureContainer<ContainerSlot>(uid, CryoPodComponent.BodyContainerName);
     }
 
-    protected void UpdateAppearance(EntityUid uid, CryoPodComponent? cryoPod = null, AppearanceComponent? appearance = null)
+    private void UpdateAppearance(EntityUid uid, CryoPodComponent? cryoPod = null, AppearanceComponent? appearance = null)
     {
         if (!Resolve(uid, ref cryoPod))
             return;
@@ -79,14 +234,14 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
 
         if (_light.TryGetLight(uid, out var light))
         {
-            _light.SetEnabled(uid, cryoPodEnabled && cryoPod.BodyContainer.ContainedEntity != null, light);
+            _light.SetEnabled(uid, cryoPodEnabled && cryoPod.BodyContainer?.ContainedEntity != null, light);
         }
 
         if (!Resolve(uid, ref appearance))
             return;
 
-        _appearanceSystem.SetData(uid, CryoPodComponent.CryoPodVisuals.ContainsEntity, cryoPod.BodyContainer.ContainedEntity == null, appearance);
-        _appearanceSystem.SetData(uid, CryoPodComponent.CryoPodVisuals.IsOn, cryoPodEnabled, appearance);
+        _appearance.SetData(uid, CryoPodVisuals.ContainsEntity, cryoPod.BodyContainer?.ContainedEntity == null, appearance);
+        _appearance.SetData(uid, CryoPodVisuals.IsOn, cryoPodEnabled, appearance);
     }
 
     public bool InsertBody(EntityUid uid, EntityUid target, CryoPodComponent cryoPodComponent)
@@ -98,10 +253,10 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
             return false;
 
         var xform = Transform(target);
-        _containerSystem.Insert((target, xform), cryoPodComponent.BodyContainer);
+        _container.Insert((target, xform), cryoPodComponent.BodyContainer);
 
         EnsureComp<InsideCryoPodComponent>(target);
-        _standingStateSystem.Stand(target, force: true); // Force-stand the mob so that the cryo pod sprite overlays it fully
+        _standingState.Stand(target, force: true); // Force-stand the mob so that the cryo pod sprite overlays it fully
 
         UpdateAppearance(uid, cryoPodComponent);
         return true;
@@ -116,7 +271,7 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
 
         if (cryoPodComponent.Locked)
         {
-            _popupSystem.PopupEntity(Loc.GetString("cryo-pod-locked"), uid, userId);
+            _popup.PopupClient(Loc.GetString("cryo-pod-locked"), uid, userId);
             return;
         }
 
@@ -131,28 +286,25 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
     /// <param name="uid">The cryopod entity</param>
     /// <param name="cryoPodComponent">Cryopod component of <see cref="uid"/></param>
     /// <returns>Ejected entity</returns>
-    public virtual EntityUid? EjectBody(EntityUid uid, CryoPodComponent? cryoPodComponent)
+    public EntityUid? EjectBody(EntityUid uid, CryoPodComponent? cryoPodComponent)
     {
         if (!Resolve(uid, ref cryoPodComponent))
             return null;
 
-        if (cryoPodComponent.BodyContainer.ContainedEntity is not {Valid: true} contained)
+        if (cryoPodComponent.BodyContainer.ContainedEntity is not { Valid: true } contained)
             return null;
 
-        _containerSystem.Remove(contained, cryoPodComponent.BodyContainer);
+        _container.Remove(contained, cryoPodComponent.BodyContainer);
         // InsideCryoPodComponent is removed automatically in its EntGotRemovedFromContainerMessage listener
         // RemComp<InsideCryoPodComponent>(contained);
 
         // Restore the correct position of the patient. Checking the components manually feels hacky, but I did not find a better way for now.
-        if (HasComp<KnockedDownComponent>(contained) || _mobStateSystem.IsIncapacitated(contained))
-        {
-            _standingStateSystem.Down(contained);
-        }
+        if (HasComp<KnockedDownComponent>(contained) || _mobState.IsIncapacitated(contained))
+            _standingState.Down(contained);
         else
-        {
-            _standingStateSystem.Stand(contained);
-        }
+            _standingState.Stand(contained);
 
+        _climb.ForciblySetClimbing(contained, uid);
         UpdateAppearance(uid, cryoPodComponent);
         return contained;
     }
@@ -188,26 +340,13 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
 
         cryoPodComponent.PermaLocked = true;
         cryoPodComponent.Locked = true;
+        Dirty(uid, cryoPodComponent);
         args.Handled = true;
     }
 
-    protected void OnCryoPodPryFinished(EntityUid uid, CryoPodComponent cryoPodComponent, CryoPodPryFinished args)
-    {
-        if (args.Cancelled)
-            return;
-
-        var ejected = EjectBody(uid, cryoPodComponent);
-        if (ejected != null)
-            _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ejected.Value)} pried out of {ToPrettyString(uid)} by {ToPrettyString(args.User)}");
-    }
+    [Serializable, NetSerializable]
+    public sealed partial class CryoPodPryFinished : SimpleDoAfterEvent;
 
     [Serializable, NetSerializable]
-    public sealed partial class CryoPodPryFinished : SimpleDoAfterEvent
-    {
-    }
-
-    [Serializable, NetSerializable]
-    public sealed partial class CryoPodDragFinished : SimpleDoAfterEvent
-    {
-    }
+    public sealed partial class CryoPodDragFinished : SimpleDoAfterEvent;
 }

--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
@@ -87,7 +87,6 @@
         whitelist:
           components:
             - FitsInDispenser
-  - type: ItemToggle
   - type: HealthAnalyzer
     scanDelay: 0
   - type: UserInterface
@@ -110,6 +109,8 @@
       - scanner-body
   - type: CryoPod
   - type: CryoPodAir
+  - type: Climbable # so that ejected bodies don't get stuck
+    vaultable: false
   - type: ContainerTemperatureDamageThresholds
     coldDamageThreshold: 10
   - type: GuideHelp


### PR DESCRIPTION
## About the PR
Just a normal prediction PR.

## Why / Balance
#39286

## Technical details
Predicts cryopods.
Moves a bunch of subscriptions to shared, networks the datafields, and dirties where needed.
Adds the missing `ClimbableComponent` to the prototype. The system is forcing ejected bodies to climb the pod so it does not get pushed to the side when exiting, but the component was missing and it always got cancelled.
Removed the unused `ItemToggleComponent` which caused problems with opening the UI.

## Media

https://github.com/user-attachments/assets/dc78e2fb-8ec2-4c40-9e89-f48c38053bf3


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None, the component was already in shared and we are only moving private methods!

**Changelog**
nah
