### PR TITLE
fix: hide timer trigger's cycle time verb if DelayOptions is empty

### DIFF
--- a/Content.Shared/Trigger/Systems/TriggerSystem.Timer.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Timer.cs
@@ -63,7 +63,7 @@ public sealed partial class TriggerSystem
         if (!args.CanInteract || !args.CanAccess || args.Hands == null)
             return;
 
-        if (ent.Comp.DelayOptions == null || ent.Comp.DelayOptions.Count == 1)
+        if (ent.Comp.DelayOptions.Count <= 1)
             return;
 
         var user = args.User;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This makes things with a timer trigger component not show a verb menu if there are zero options, instead of if there is just one.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Borgs had a cycle time option which was silly. (They have a TimerTrigger so they can blow up via the robotics console.)

## Technical details
<!-- Summary of code changes for easier review. -->
Also remove unneeded null check.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<details>
<summary><h2>PROOF (REAL (NOT CLICKBAIT))</h2></summary>
<h3>BEFORE!!!</h3>
<img width="1390" height="416" alt="image" src="https://github.com/user-attachments/assets/f3b0a12a-b054-4b03-b0f1-24afb2018b95" />
<h3>AFTER?!?</h3>
<img width="930" height="472" alt="image" src="https://github.com/user-attachments/assets/982d79ac-c2e2-40c8-bce4-cb861292caac" />
</details>


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Players no longer have the ability to cycle a timer in the verb menu on a cyborg.