### PR TITLE
fix: make screens work again

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -666,6 +666,7 @@
     title: comms-console-announcement-title-station
   - type: DeviceNetwork
     transmitFrequencyId: ShuttleTimer
+    deviceNetId: Wireless
   - type: ActivatableUI
     key: enum.CommunicationsConsoleUiKey.Key
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
@@ -9,6 +9,7 @@
     textOffset: 0,3
     timerOffset: 0,-4
     rows: 2
+  - type: Appearance
   - type: Sprite
     drawdepth: WallMountedItems
     sprite: Structures/Wallmounts/screen.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes broadcast and shuttle arrival time text work again.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #39376, fixes #39015.

## Technical details
<!-- Summary of code changes for easier review. -->
The appearance comp is what killed everything and it got accidentally removed in #34329.

For broadcast not working... I went back to the start of 2025 and was still having broadcast not work and after that we're in .net 8 land and I'm not bothering to test past then. So. Who knows. It just had the wrong netid on the comms console for that.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="430" height="336" alt="image" src="https://github.com/user-attachments/assets/5ee4c3a5-5bfc-4f84-adf3-fb350ccac405" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The broadcast button the communications console should work again.
- fix: Shuttle ETA screens should work again.