### PR TITLE
Update attributions for lightning audiofiles

### DIFF
--- a/Resources/Audio/Effects/Lightning/attributions.yml
+++ b/Resources/Audio/Effects/Lightning/attributions.yml
@@ -1,5 +1,5 @@
 - files: ["lightningshock.ogg", "lightningbolt.ogg"]
-  license: CC-BY-NC-SA-3.0
+  license: CC-BY-SA-3.0
   copyright: "/tg/station"
   source: "https://github.com/tgstation/tgstation/pull/9701/"
 

--- a/Resources/Audio/Effects/Lightning/attributions.yml
+++ b/Resources/Audio/Effects/Lightning/attributions.yml
@@ -1,7 +1,7 @@
-- files: [LightningShock.ogg]
+- files: ["lightningshock.ogg", "lightningbolt.ogg"]
   license: CC-BY-NC-SA-3.0
-  copyright: Citadel Station 13
-  source: https://github.com/Citadel-Station-13/Citadel-Station-13/commit/35a1723e98a60f375df590ca572cc90f1bb80bd5
+  copyright: "/tg/station"
+  source: "https://github.com/tgstation/tgstation/pull/9701/"
 
 - files: ["strobeepsilon.ogg"]
   license: "CC-BY-SA-3.0"


### PR DESCRIPTION
## About the PR
Improve attribution of `/tg/station` audio files (`lightningshock.ogg`, `lightningbolt.ogg`).
Addresses issue #39350

## Technical details
The files originate in the same `/tg/station` [pull request from 2015](https://github.com/tgstation/tgstation/pull/9701).
The previous attribution for `lightningshock.ogg` pointed to Citadel Station's initial commit. Citadel is based on /tg/station.
`lightningbolt.ogg` was not attributed at all.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
