### PR TITLE
HolyWater and SpaceCleaner for mopping and minor SpaceCleaner changes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -111,6 +111,8 @@
       solution: absorbed
       preserve:
       - Water
+      - Holywater
+      - SpaceCleaner
       quantity: 10
     - type: SolutionContainerManager
       solutions:

--- a/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
@@ -267,7 +267,6 @@
           reagents:
             - ReagentId: Water
               Quantity: 600 # 3 quarters full at roundstart to make it more appealing
-    
     - type: MixableSolution
       solution: bucket
     - type: DrainableSolution

--- a/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
@@ -20,6 +20,8 @@
     solutions:
       bucket:
         maxVol: 600
+  - type: MixableSolution
+    solution: bucket
   - type: Spillable
     solution: bucket
     spillDelay: 3.0
@@ -265,6 +267,9 @@
           reagents:
             - ReagentId: Water
               Quantity: 600 # 3 quarters full at roundstart to make it more appealing
+    
+    - type: MixableSolution
+      solution: bucket
     - type: DrainableSolution
       solution: bucket
     - type: RefillableSolution

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -31,11 +31,14 @@
   physicalDesc: reagent-physical-desc-lemony-fresh
   flavor: bitter
   color: "#c8ff69"
+  absorbent: true
+  evaporationSpeed: 0.3
   recognizable: true
   boilingPoint: 147.0 # Made this up, loosely based on bleach
   meltingPoint: -11.0
   tileReactions:
-    - !type:CleanTileReaction {}
+    - !type:CleanTileReaction
+      reagent: SpaceCleaner
     - !type:CleanDecalsReaction {}
 
 - type: reagent

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1096,6 +1096,10 @@
   group: Medicine
   desc: reagent-desc-holywater
   evaporationSpeed: 0.3
+  absorbent: true
+  friction: 0.4
+  slipData:
+    requiredSlipSpeed: 3.5
   physicalDesc: reagent-physical-desc-holy
   flavor: holy
   color: "#91C3F7"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Allows to use holy water and space cleaner in mop-cleaning.

Also changes `CleanTileReaction` of space cleaner. Now if lefts space cleaner, not water.

It is possible to make holy water in mop bucket and janitorial trolley.

Also see changelog section.

### How does it work now

Water and holy water:
- [X] Slippery
- [X] Evaporating

Space cleaner:
- [ ] Slippery
- [X] Evaporating
## Why / Balance
SS13 content afaik. Janitors now have a choice what reagent to use: water or space cleaner (space cleaner seems to be better but it will be quicly spent. Water is worse but easier to find)

Also RP collaboration of janitor and chaplain seems fun.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Water

https://github.com/user-attachments/assets/68f885d7-7fb5-49d7-932d-9603e09cbb61

Holy water

https://github.com/user-attachments/assets/4bc452de-ca0e-4557-b066-1d823882a4a6

Space cleaner

https://github.com/user-attachments/assets/02168681-f11b-496d-87e0-3226d7657fa5

Spray and cleanad (space cleaner)

https://github.com/user-attachments/assets/a04c8b72-644d-4244-89e5-6c9bcba296eb

Advanced mop

https://github.com/user-attachments/assets/cb9c6352-9d68-4d10-b986-c21c3663eeae

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Holy water and space cleaner now can be used to mop puddles. Advanced mop does not remove them from its solution. Both reagents are evaporating by themselves and can be stored in mop buckets and janitorial trolleys now.
- tweak: Now it possible to make holy water in mop buckets and janitorial trolleys using bible.
- tweak: Holy water is now slippery.
- tweak: Cleanades and spray bottles with space cleaner leave space cleaner after usage (previously they have left water).