### PR TITLE
Add guard to unbuckling to help it to not act upon terminating entities

### DIFF
--- a/Content.Shared/Bed/SharedBedSystem.cs
+++ b/Content.Shared/Bed/SharedBedSystem.cs
@@ -57,12 +57,12 @@ public abstract class SharedBedSystem : EntitySystem
     private void OnUnstrapped(Entity<HealOnBuckleComponent> bed, ref UnstrappedEvent args)
     {
         // If the entity being unbuckled is terminating, we shouldn't try to act upon it, as some components may be gone
-        if (Terminating(args.Buckle.Owner))
-            return;
-
-        _actionsSystem.RemoveAction(args.Buckle.Owner, bed.Comp.SleepAction);
-        _sleepingSystem.TryWaking(args.Buckle.Owner);
-
+        if (!Terminating(args.Buckle.Owner))
+        {
+            _actionsSystem.RemoveAction(args.Buckle.Owner, bed.Comp.SleepAction);
+            _sleepingSystem.TryWaking(args.Buckle.Owner);
+        }
+        
         RemComp<HealOnBuckleHealingComponent>(bed);
     }
 


### PR DESCRIPTION
## About the PR
Adds a small guard in `OnUnstrapped()` to prevent it from acting upon potentially null entities

## Why / Balance
To prevent errors and potential instability caused by interacting with the buckling system

## Technical details
Essentially just wraps a few lines in `if (!Terminating(args.Buckle.Owner))`

## Media
Before:

https://github.com/user-attachments/assets/957ba50d-0c0d-48ac-851f-cb5a8e97ed84

After:

https://github.com/user-attachments/assets/c5416a0a-e766-48e9-b358-05115a217d8f

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Fixed error upon exploding buckled mobs (and other near instantaneous changes)
