### PR TITLE
feat: add damage transfer destructible entities

### DIFF
--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Actions;
+using Content.Server.Destructible;
 using Content.Server.Humanoid;
 using Content.Server.Inventory;
 using Content.Server.Polymorph.Components;
@@ -33,6 +34,7 @@ public sealed partial class PolymorphSystem : EntitySystem
     [Dependency] private readonly SharedBuckleSystem _buckle = default!;
     [Dependency] private readonly ContainerSystem _container = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly DestructibleSystem _destructible = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoid = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
@@ -220,8 +222,7 @@ public sealed partial class PolymorphSystem : EntitySystem
         //Transfers all damage from the original to the new one
         if (configuration.TransferDamage &&
             TryComp<DamageableComponent>(child, out var damageParent) &&
-            _mobThreshold.GetScaledDamage(uid, child, out var damage) &&
-            damage != null)
+            _destructible.GetScaledDamage(uid, child, out var damage))
         {
             _damageable.SetDamage(child, damageParent, damage);
         }
@@ -307,8 +308,7 @@ public sealed partial class PolymorphSystem : EntitySystem
 
         if (component.Configuration.TransferDamage &&
             TryComp<DamageableComponent>(parent, out var damageParent) &&
-            _mobThreshold.GetScaledDamage(uid, parent, out var damage) &&
-            damage != null)
+            _destructible.GetScaledDamage(uid, parent, out var damage))
         {
             _damageable.SetDamage(parent, damageParent, damage);
         }

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
@@ -248,24 +248,24 @@ public sealed class MobThresholdSystem : EntitySystem
     /// <summary>
     /// Takes the damage from one entity and scales it relative to the health of another
     /// </summary>
-    /// <param name="target1">The entity whose damage will be scaled</param>
-    /// <param name="target2">The entity whose health the damage will scale to</param>
+    /// <param name="original">The entity whose damage will be scaled</param>
+    /// <param name="target">The entity whose health the damage will scale to</param>
     /// <param name="damage">The newly scaled damage. Can be null</param>
-    public bool GetScaledDamage(EntityUid target1, EntityUid target2, out DamageSpecifier? damage)
+    public bool GetScaledDamage(EntityUid original, EntityUid target, [NotNullWhen(true)] out DamageSpecifier? damage)
     {
         damage = null;
 
-        if (!TryComp<DamageableComponent>(target1, out var oldDamage))
+        if (!TryComp<DamageableComponent>(original, out var oldDamage))
             return false;
 
-        if (!TryComp<MobThresholdsComponent>(target1, out var threshold1) ||
-            !TryComp<MobThresholdsComponent>(target2, out var threshold2))
+        if (!TryComp<MobThresholdsComponent>(original, out var threshold1) ||
+            !TryComp<MobThresholdsComponent>(target, out var threshold2))
             return false;
 
-        if (!TryGetThresholdForState(target1, MobState.Dead, out var ent1DeadThreshold, threshold1))
+        if (!TryGetThresholdForState(original, MobState.Dead, out var ent1DeadThreshold, threshold1))
             ent1DeadThreshold = 0;
 
-        if (!TryGetThresholdForState(target2, MobState.Dead, out var ent2DeadThreshold, threshold2))
+        if (!TryGetThresholdForState(target, MobState.Dead, out var ent2DeadThreshold, threshold2))
             ent2DeadThreshold = 0;
 
         damage = (oldDamage.Damage / ent1DeadThreshold.Value) * ent2DeadThreshold.Value;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This makes it so polymorphs that transfer damage (the default) will still succeed when the entities are destructible but don't have MobThresholds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I noticed damage transfer wasn't working for luminous entities, which don't have MobThresholds, when working on #38410.

## Technical details
<!-- Summary of code changes for easier review. -->
This just adds a new destructible system method which is like the mob thresholds one but it'll try to grab the destructible destroyed-at value if an entity doesn't have MobThresholds.

Steps to reproduce:
1. Spawn in.
2. Run `damage Blunt 80`
3. Run `self polymorph ArtifactLuminous`
4. View-variables yourself and check that your damageable component has a non-zero damage value. (Pre-fix it would be zero.)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Literally no one will notice. (Affects just the luminous person artifact polymorph and the tree polymorph. The wall to door polymorph doesn't transfer damage.)