### PR TITLE
convert dwarfs to use ScaleVisualsComponent

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -17,9 +17,7 @@
     damageRecovery:
       types:
         Asphyxiation: -1.0
-  - type: Sprite
-    noRot: true
-    drawdepth: Mobs
+  - type: ScaleVisuals
     scale: 1, 0.8
   - type: Body
     prototype: Dwarf
@@ -69,7 +67,7 @@
   id: MobDwarfDummy
   categories: [ HideSpawnMenu ]
   components:
-  - type: Sprite
+  - type: ScaleVisuals
     scale: 1, 0.8
   - type: Inventory
     femaleDisplacements:


### PR DESCRIPTION
## About the PR
Converts dwarfs to use `ScaleVisualsComponent` which sets the sprite scale according to its appearance data instead of having the scale hardcoded into the `SpriteComponent`.
This allows us to change their size for all players from the server, instead of only for the local client, which is needed for changeling transforms.

## Why / Balance
AppearanceSystem compliance.
Needed for https://github.com/space-wizards/space-station-14/pull/34002

## Technical details
Replace the component. `ScaleVisualsComponent` sets the same datafield in the `SpriteComponent`, so the result is the same.
`noRot` and `drawDepth` were removed because those were already inherited from `BaseMob`.

## Media
Dwarfs are still dwarf-sized
<img width="83" height="63" alt="grafik" src="https://github.com/user-attachments/assets/2b94fbb5-bbd1-4f1e-88eb-3b71946b7a81" />

<img width="309" height="281" alt="grafik" src="https://github.com/user-attachments/assets/031a8e0d-8023-450d-b501-e9f30663c24d" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
not player facing
