### PR TITLE
fix: don't delete items on some polymorph reverts

### DIFF
--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -325,7 +325,7 @@ public sealed partial class PolymorphSystem : EntitySystem
                 _hands.TryPickupAnyHand(parent, held, checkActionBlocker: false);
             }
         }
-        else if (component.Configuration.Inventory == PolymorphInventoryChange.Drop)
+        else
         {
             if (_inventory.TryGetContainerSlotEnumerator(uid, out var enumerator))
             {

--- a/Content.Shared/Polymorph/PolymorphPrototype.cs
+++ b/Content.Shared/Polymorph/PolymorphPrototype.cs
@@ -154,7 +154,7 @@ public sealed partial record PolymorphConfiguration
     public LocId? PolymorphPopup = "polymorph-popup-generic";
 
     /// <summary>
-    ///     If not null, this popup will be displayed when when being reverted from a polymorph.
+    ///     If not null, this popup will be displayed when being reverted from a polymorph.
     /// </summary>
     [DataField]
     public LocId? ExitPolymorphPopup = "polymorph-revert-popup-generic";
@@ -162,7 +162,21 @@ public sealed partial record PolymorphConfiguration
 
 public enum PolymorphInventoryChange : byte
 {
+    /// <summary>
+    /// On polymorph, no items are transferred. The original form's inventory is
+    /// stored in a paused map. On revert, the polymorph drops its inventory.
+    /// </summary>
     None,
+
+    /// <summary>
+    /// On polymorph and revert, all items are dropped.
+    /// </summary>
     Drop,
+
+    /// <summary>
+    /// On polymorph and revert, an attempt to transfer inventories will be
+    /// made. Currently, this doesn't handle dependent inventory slots like
+    /// jumpsuit pockets.
+    /// </summary>
     Transfer,
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This makes it so polymorphs that have "none" as the inventory transfer setting will drop items when the polymorph reverts, instead of deleting them, which was silly.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Deleting items is bad.

Only affects the wizard monkey polymorph (wand for which is gotten from the magic event spell). (Steps to reproduce: shoot someone with `WeaponWandPolymorphMonkey`, have them pick something up, kill them, that item is now deleted. Post-fix the item gets dropped.)

It doesn't cause issues with the (unused) artifact cluwne polymorph since unremovable items are deleted on forced removal, so you don't end up with the cluwne PDA on the ground which would cause (funny) problems.

## Technical details
<!-- Summary of code changes for easier review. -->
Make thing else not else if. Also document the enum behaviors.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The wand of monkey polymorph no longer deletes items in the monkey's inventory on death.