### PR TITLE
add scale:multiplyvector toolshed command

### DIFF
--- a/Content.Server/Toolshed/Commands/Misc/ScaleCommand.cs
+++ b/Content.Server/Toolshed/Commands/Misc/ScaleCommand.cs
@@ -41,6 +41,19 @@ public sealed class ScaleCommand : ToolshedCommand
         }
     }
 
+    [CommandImplementation("multiplyvector")]
+    public IEnumerable<EntityUid> Multiply([PipedArgument] IEnumerable<EntityUid> input, Vector2 factor)
+    {
+        _scaleVisuals ??= GetSys<SharedScaleVisualsSystem>();
+
+        foreach (var ent in input)
+        {
+            var scale = _scaleVisuals.GetSpriteScale(ent) * factor;
+            _scaleVisuals.SetSpriteScale(ent, scale);
+            yield return ent;
+        }
+    }
+
     [CommandImplementation("multiplywithfixture")]
     public IEnumerable<EntityUid> MultiplyWithFixture([PipedArgument] IEnumerable<EntityUid> input, float factor)
     {

--- a/Resources/Locale/en-US/commands/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/commands/toolshed-commands.ftl
@@ -102,5 +102,7 @@ command-description-scale-get =
     Get an entity's sprite scale as set by ScaleVisualsComponent. Does not include any changes directly made in the SpriteComponent.
 command-description-scale-multiply =
     Multiply an entity's sprite size with a certain factor (without changing its fixture).
+command-description-scale-multiplyvector =
+    Multiply an entity's sprite size with a certain 2d vector (without changing its fixture).
 command-description-scale-multiplywithfixture =
     Multiply an entity's sprite size with a certain factor (including its fixture).


### PR DESCRIPTION
## About the PR
Allows to multiply the sprite scale in both dimensions separately.

## Why / Balance
~~admemes~~ debugging purposes

## Technical details
same as the other command, but takes a `Vector2` as a parameter

## Media
running `self scale:multiplyvector [1.05, 1]` repeatedly
![ss14](https://github.com/user-attachments/assets/56104555-83b4-455b-aaf1-607cb45a260d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
ADMIN:
- add: Added the "scale:multiplyvector" toolshed command.
