### PR TITLE
Buttons are now Free-placeable (again)

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
@@ -29,25 +29,27 @@
     - Status
     lastSignals:
       Status: false
+  - type: Transform
+    anchored: false
   - type: Destructible
     thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 80
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-      - trigger:
-          !type:DamageTrigger
-          damage: 40
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-          - !type:PlaySoundBehavior
-            sound:
-              collection: MetalBreak
-              params:
-                volume: -8
+    - trigger:
+        !type:DamageTrigger
+        damage: 80
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 40
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+          params:
+            volume: -8
 
 - type: entity
   parent: BaseWallmountMetallic
@@ -79,25 +81,27 @@
   - type: DeviceLinkSource
     ports:
       - Pressed
+  - type: Transform
+    anchored: false
   - type: Destructible
     thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 80
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-      - trigger:
-          !type:DamageTrigger
-          damage: 40
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-          - !type:PlaySoundBehavior
-            sound:
-              collection: MetalBreak
-              params:
-                volume: -8
+    - trigger:
+        !type:DamageTrigger
+        damage: 80
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 40
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+          params:
+            volume: -8
 
 - type: entity
   parent: BaseWallmountMetallic
@@ -118,6 +122,8 @@
     transmitFrequencyId: SmartLight # assuming people want to use it for light switches.
   - type: ApcNetworkConnection
   - type: ApcNetSwitch
+  - type: Transform
+    anchored: false
   - type: Construction
     graph: LightSwitchGraph
     node: LightSwitchNode
@@ -125,10 +131,10 @@
 #directional
 
 - type: entity
+  parent: SignalSwitch
   id: SignalSwitchDirectional
   name: signal switch
   suffix: directional
-  parent: SignalSwitch
   components:
   - type: WallMount
     arc: 175
@@ -137,10 +143,10 @@
     node: SignalSwitchDirectionalNode
 
 - type: entity
+  parent: SignalButton
   id: SignalButtonDirectional
   name: signal button
   suffix: directional
-  parent: SignalButton
   components:
   - type: WallMount
     arc: 175
@@ -149,10 +155,10 @@
     node: SignalButtonDirectionalNode
 
 - type: entity
+  parent: ApcNetSwitch
   id: ApcNetSwitchDirectional
   name: apc net switch
   suffix: directional
-  parent: ApcNetSwitch
   components:
   - type: WallMount
     arc: 175
@@ -163,9 +169,9 @@
 # lockable buttons
 
 - type: entity
+  parent: SignalButtonDirectional
   id: LockableButton
   name: lockable button
-  parent: SignalButtonDirectional
   categories: [ HideSpawnMenu ]
   components:
   - type: Appearance
@@ -182,249 +188,249 @@
       shader: unshaded
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonCaptain
   suffix: Captain
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Captain"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonHeadOfPersonnel
   suffix: HeadOfPersonnel
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["HeadOfPersonnel"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonChiefEngineer
   suffix: ChiefEngineer
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["ChiefEngineer"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonChiefMedicalOfficer
   suffix: ChiefMedicalOfficer
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["ChiefMedicalOfficer"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonHeadOfSecurity
   suffix: HeadOfSecurity
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["HeadOfSecurity"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonResearchDirector
   suffix: ResearchDirector
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["ResearchDirector"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonCommand
   suffix: Command
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Command"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonCryogenics
   suffix: Cryogenics
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Cryogenics"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonSecurity
   suffix: Security
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Security"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonDetective
   suffix: Detective
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Detective"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonArmory
   suffix: Armory
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Armory"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonBrig
   suffix: Brig
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Brig"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonLawyer
   suffix: Lawyer
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Lawyer"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonEngineering
   suffix: Engineering
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Engineering"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonMedical
   suffix: Medical
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Medical"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonQuartermaster
   suffix: Quartermaster
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Quartermaster"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonSalvage
   suffix: Salvage
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Salvage"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonCargo
   suffix: Cargo
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Cargo"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonResearch
   suffix: Research
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Research"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonService
   suffix: Service
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Service"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonMaintenance
   suffix: Maintenance
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Maintenance"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonExternal
   suffix: External
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["External"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonJanitor
   suffix: Janitor
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Janitor"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonTheatre
   suffix: Theatre
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Theatre"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonBar
   suffix: Bar
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Bar"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonChemistry
   suffix: Chemistry
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Chemistry"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonKitchen
   suffix: Kitchen
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Kitchen"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonChapel
   suffix: Chapel
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Chapel"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonHydroponics
   suffix: Hydroponics
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Hydroponics"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonAtmospherics
   suffix: Atmospherics
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["Atmospherics"]]
 
 - type: entity
+  parent: LockableButton
   id: LockableButtonCentcomm
   suffix: CentComm
-  parent: LockableButton
   components:
   - type: AccessReader
     access: [["CentralCommand"]]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Another oversight from #34329, buttons weren't able to be placed off-center anymore. 

This needs to be pushed to stable since this will affect maps with offset buttons.

The issue is that the cleanup in #34329 added `anchored: true` to all the buttons through inheritance, which caused them to anchor themselves when placed. I've changed that back, and cleaned up the file a bit more.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

fix

## Technical details
<!-- Summary of code changes for easier review. -->

yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="143" height="148" alt="image" src="https://github.com/user-attachments/assets/0aabc1a2-050a-41c0-8d64-325a08fa94d8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
