### PR TITLE
No more warping to nukie outpost

### DIFF
--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -97,6 +97,9 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         destComp.BeaconsOnly = true;
         destComp.RequireCoordinateDisk = true;
         destComp.Enabled = true;
+        // No reason to allow self-jumps; it'll get deleted during ftl
+        destComp.DisallowCoordinateFTLJumps = true;
+        _entManager.Dirty(mapUid, destComp);
         _metaData.SetEntityName(
             mapUid,
             _entManager.System<SharedSalvageSystem>().GetFTLName(_prototypeManager.Index(SalvageSystem.PlanetNames), _missionParams.Seed));

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Numerics;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
+using Content.Server.Station.Components;
 using Content.Server.Station.Events;
 using Content.Shared.Body.Components;
 using Content.Shared.CCVar;
@@ -478,12 +479,28 @@ public sealed partial class ShuttleSystem
 
         if (!Exists(entity.Comp1.TargetCoordinates.EntityId))
         {
-            // Uhh good luck
-            // Pick earliest map?
-            var maps = EntityQuery<MapComponent>().Select(o => o.MapId).ToList();
-            var map = maps.Min(o => o.GetHashCode());
+            // Fallback time.
+            // Try to find a map with a station. Otherwise just find /any/ map.
+            // It's possible for stations to have no grids so we also have to
+            // check for that. Stations don't inherently have a map they
+            // "belong" to.
+            var currentMap = Transform(entity).MapID;
+            var fallback = _station.GetStations()
+                .Select(station => _station.GetLargestGrid(Comp<StationDataComponent>(station)))
+                .Where(grid => grid is not null)
+                .Select(grid => Transform(grid!.Value).MapID) // above .Where justifies the !
+                .Where(map => map != currentMap) // Exclude ftl map
+                .FirstOrNull();
+            fallback ??= EntityQuery<MapComponent>().MinBy(map => map.MapId)?.MapId;
 
-            mapId = new MapId(map);
+            if (fallback is null)
+            {
+                // There's no maps soooooo. Yeah that's really sucks for you.
+                Log.Error($"Couldn't find a fallback map to warp to for {ToPrettyString(entity)}!");
+                return;
+            }
+
+            mapId = fallback.Value;
             TryFTLProximity(uid, _mapSystem.GetMap(mapId));
         }
         // Docking FTL

--- a/Content.Shared/Shuttles/Components/FTLDestinationComponent.cs
+++ b/Content.Shared/Shuttles/Components/FTLDestinationComponent.cs
@@ -29,4 +29,11 @@ public sealed partial class FTLDestinationComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
     public bool RequireCoordinateDisk = false;
+
+    /// <summary>
+    /// If true, this will prevent FTL jumps that are made from this destination
+    /// and are to this destination. (That is, short distance hops.)
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool DisallowCoordinateFTLJumps;
 }

--- a/Content.Shared/Shuttles/Components/FTLDestinationComponent.cs
+++ b/Content.Shared/Shuttles/Components/FTLDestinationComponent.cs
@@ -31,8 +31,8 @@ public sealed partial class FTLDestinationComponent : Component
     public bool RequireCoordinateDisk = false;
 
     /// <summary>
-    /// If true, this will prevent FTL jumps that are made from this destination
-    /// and are to this destination. (That is, short distance hops.)
+    /// If true, this will prevent sub-map FTL jumps. That is, it prevents FTL
+    /// jumping to this map if you are already in that map.
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool DisallowCoordinateFTLJumps;

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -59,11 +59,13 @@ public abstract partial class SharedShuttleSystem : EntitySystem
     {
         var mapUid = Maps.GetMapOrInvalid(targetMap);
         var shuttleMap = _xformQuery.GetComponent(shuttleUid).MapID;
+        TryComp<FTLDestinationComponent>(mapUid, out var destination);
 
-        if (shuttleMap == targetMap)
+        // Allow coordinate ('repositioning') jumps if no FTLDestination
+        if (shuttleMap == targetMap && destination?.DisallowCoordinateFTLJumps == false)
             return true;
 
-        if (!TryComp<FTLDestinationComponent>(mapUid, out var destination) || !destination.Enabled)
+        if (destination?.Enabled != true)
             return false;
 
         if (destination.RequireCoordinateDisk)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This 1) improves the FTL destination fallback code to prioritize maps that have stations instead of going to the lowest map id map, and 2) prevents warping from an expedition planet to the same expedition planet because that didn't make sense anyway.

These both fix the warping to nukie planet issue but figured it's worth having both since 1) covers any scenario where you warp to a map that got deleted mid FTL and 2) is nice since trying to warp to a map that will be immediately deleted is silly.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #37287.

## Technical details
<!-- Summary of code changes for easier review. -->
Not too special though the LINQ query is a little messy, but so are stations. For testing I recommend applying the below diff. To test the change to map fallback you'll want to checkout just the first commit.
<details>
<summary>Diffdump</summary>

```diff
diff --git a/Content.Shared/Shuttles/Components/FTLComponent.cs b/Content.Shared/Shuttles/Components/FTLComponent.cs
index bce33492b9..89ece6e9e0 100644
--- a/Content.Shared/Shuttles/Components/FTLComponent.cs
+++ b/Content.Shared/Shuttles/Components/FTLComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class FTLComponent : Component
     public float TravelTime = 0f;
 
     [DataField]
-    public EntProtoId? VisualizerProto = "FtlVisualizerEntity";
+    public EntProtoId? VisualizerProto = null;
 
     [DataField, AutoNetworkedField]
     public EntityUid? VisualizerEntity;
diff --git a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
index 8e95a8b1a4..7edacbba31 100644
--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -22,7 +22,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
     [Dependency] protected readonly SharedTransformSystem XformSystem = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
-    public const float FTLRange = 256f;
+    public const float FTLRange = 256f*10;
     public const float FTLBufferRange = 8f;
     public const float TileDensityMultiplier = 0.5f;
 
diff --git a/Resources/ConfigPresets/Build/development.toml b/Resources/ConfigPresets/Build/development.toml
index cad04c66c2..ace8a2dcb7 100644
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -29,11 +29,15 @@ preload = false
 expedition_cooldown = 30.0
 
 [shuttle]
-grid_fill = false
+grid_fill = true
 auto_call_time = 0
 emergency = false
 arrivals = false
 preload_grids = false
+arrival_time = 1
+travel_time = 1
+startup_time = 1
+cooldown = 1
 
 [admin]
 see_own_notes = true
diff --git a/Resources/Prototypes/GameRules/roundstart.yml b/Resources/Prototypes/GameRules/roundstart.yml
index 08d088a08c..938a59c7e5 100644
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -114,7 +114,7 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 0
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml
   - type: AntagSelection
```

</details>

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed a rare scenario that allowed expedition shuttles to warp to the nukie planet.