### PR TITLE
fix repeated scale visuals removal/ensuring

### DIFF
--- a/Content.Shared/Sprite/SharedScaleVisualsSystem.cs
+++ b/Content.Shared/Sprite/SharedScaleVisualsSystem.cs
@@ -27,6 +27,7 @@ public abstract class SharedScaleVisualsSystem : EntitySystem
 
     protected virtual void ResetScale(Entity<ScaleVisualsComponent> ent)
     {
+        _appearance.RemoveData(ent.Owner, ScaleVisuals.Scale);
         var ev = new ScaleEntityEvent(ent.Owner, Vector2.One);
         RaiseLocalEvent(ent.Owner, ref ev);
     }


### PR DESCRIPTION
## About the PR
Small bug I found with `ScaleVisualsComponent`.
Needed for https://github.com/space-wizards/space-station-14/pull/34002

## Why / Balance
bugfix

## Technical details
When transforming from a human into a dwarf the component is first added, and setting the appearance data adjusts the `SpriteComponent` accordingly in `OnAppearanceChanged`. When transforming back into a human the component is removed, and the scale in the `SpriteComponent` reset without deleting the now unused appearance data. When adding the component again with the same settings, then `AppearanceChangedEvent` is not raised since the appearance data remains the same. To fix this we properly clear the appearance data when the component is removed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
nope
