### PR TITLE
Added AI turrets to bagel's AI core and vault

### DIFF
--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -156535,6 +156535,74 @@ entities:
       parent: 60
     - type: Physics
       canCollide: False
+- proto: WeaponEnergyTurretAI
+  entities:
+  - uid: 16096
+    components:
+    - type: Transform
+      pos: -115.5,21.5
+      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 7195
+  - uid: 16131
+    components:
+    - type: Transform
+      pos: -107.5,21.5
+      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 7195
+  - uid: 16132
+    components:
+    - type: Transform
+      pos: -107.5,30.5
+      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 7195
+  - uid: 16145
+    components:
+    - type: Transform
+      pos: -115.5,30.5
+      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 7195
+- proto: WeaponEnergyTurretAIControlPanel
+  entities:
+  - uid: 7195
+    components:
+    - type: Transform
+      pos: -113.5,20.5
+      parent: 60
+    - type: DeviceList
+      devices:
+      - 16096
+      - 16131
+      - 16132
+      - 16145
+- proto: WeaponEnergyTurretCommand
+  entities:
+  - uid: 16095
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 15900
+- proto: WeaponEnergyTurretCommandControlPanel
+  entities:
+  - uid: 15900
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 60
+    - type: DeviceList
+      devices:
+      - 16095
 - proto: WeaponEnergyTurretSecurity
   entities:
   - uid: 1506


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added turrets into bagel station

## Why / Balance
They just didn't have it

## Technical details
mapping

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="6848" height="5312" alt="image" src="https://github.com/user-attachments/assets/d39e9a2a-6667-4191-b81e-7409d007efce" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl:
MAPS:
- add: On bagel, added turrets to the AI core and vault
