### PR TITLE
implement crayon rotation

### DIFF
--- a/Content.Client/Crayon/CrayonComponent.cs
+++ b/Content.Client/Crayon/CrayonComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.ViewVariables;
 
 namespace Content.Client.Crayon
 {
-    [RegisterComponent, AutoGenerateComponentState]
+    [RegisterComponent]
     public sealed partial class CrayonComponent : SharedCrayonComponent
     {
         [ViewVariables(VVAccess.ReadWrite)] public bool UIUpdateNeeded;

--- a/Content.Client/Crayon/CrayonComponent.cs
+++ b/Content.Client/Crayon/CrayonComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.ViewVariables;
 
 namespace Content.Client.Crayon
 {
-    [RegisterComponent]
+    [RegisterComponent, AutoGenerateComponentState]
     public sealed partial class CrayonComponent : SharedCrayonComponent
     {
         [ViewVariables(VVAccess.ReadWrite)] public bool UIUpdateNeeded;

--- a/Content.Client/Crayon/CrayonSystem.cs
+++ b/Content.Client/Crayon/CrayonSystem.cs
@@ -41,8 +41,8 @@ public sealed class CrayonSystem : SharedCrayonSystem
 
         SubscribeLocalEvent<LocalPlayerDetachedEvent>(OnLocalPlayerDetached);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
-        SubscribeLocalEvent<CrayonComponent, UnequippedHandEvent>(OnUnequippedHand);
         SubscribeLocalEvent<CrayonComponent, HandDeselectedEvent>(OnHandDeselected);
+        SubscribeLocalEvent<CrayonComponent, GotUnequippedHandEvent>(OnUnequip);
         SubscribeLocalEvent<CrayonComponent, ComponentShutdown>(OnComponentShutdown);
     }
 
@@ -111,30 +111,30 @@ public sealed class CrayonSystem : SharedCrayonSystem
 
     private void OnLocalPlayerDetached(LocalPlayerDetachedEvent args)
     {
-        OnClose();
+        RemoveOverlay();
     }
 
     private void OnRoundRestartCleanup(RoundRestartCleanupEvent args)
     {
-        OnClose();
+        RemoveOverlay();
     }
 
     private void OnHandDeselected(EntityUid uid, CrayonComponent component, ref HandDeselectedEvent args)
     {
-        _overlay.RemoveOverlay<CrayonDecalGhostOverlay>();
+        RemoveOverlay();
     }
 
-    private void OnUnequippedHand(EntityUid uid, CrayonComponent component, ref UnequippedHandEvent args)
+    private void OnUnequip(EntityUid uid, CrayonComponent component, ref GotUnequippedHandEvent args)
     {
-        _overlay.RemoveOverlay<CrayonDecalGhostOverlay>();
+        if(args.Unequipped==uid) RemoveOverlay();
     }
 
     private void OnComponentShutdown(EntityUid uid, CrayonComponent component, ComponentShutdown args)
     {
-        OnClose();
+        RemoveOverlay();
     }
 
-    private void OnClose()
+    private void RemoveOverlay()
     {
         _overlay.RemoveOverlay<CrayonDecalGhostOverlay>();
     }

--- a/Content.Client/Crayon/CrayonSystem.cs
+++ b/Content.Client/Crayon/CrayonSystem.cs
@@ -1,29 +1,56 @@
+using Content.Client.Crayon.Overlays;
+using Content.Client.Decals;
 using Content.Client.Items;
 using Content.Client.Message;
 using Content.Client.Stylesheets;
 using Content.Shared.Crayon;
+using Content.Shared.Decals;
+using Content.Shared.GameTicking;
+using Content.Shared.Hands;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Interaction;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
-using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
-using Robust.Shared.Localization;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Client.Crayon;
 
 public sealed class CrayonSystem : SharedCrayonSystem
 {
+    [Dependency] private readonly IOverlayManager _overlay = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly DecalPlacementSystem _placement = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+
     // Didn't do in shared because I don't think most of the server stuff can be predicted.
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<CrayonComponent, ComponentHandleState>(OnCrayonHandleState);
         Subs.ItemStatus<CrayonComponent>(ent => new StatusControl(ent));
+
+        SubscribeLocalEvent<LocalPlayerDetachedEvent>(OnLocalPlayerDetached);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
+        SubscribeLocalEvent<CrayonComponent, UnequippedHandEvent>(OnUnequippedHand);
+        SubscribeLocalEvent<CrayonComponent, HandDeselectedEvent>(OnHandDeselected);
+        SubscribeLocalEvent<CrayonComponent, ComponentShutdown>(OnComponentShutdown);
     }
 
-    private static void OnCrayonHandleState(EntityUid uid, CrayonComponent component, ref ComponentHandleState args)
+    private void OnCrayonHandleState(EntityUid uid, CrayonComponent component, ref ComponentHandleState args)
     {
         if (args.Current is not CrayonComponentState state) return;
+
+        UpdateOverlay(uid, component, state.State, state.Rotation, state.Color, state.PreviewEnabled, state.PreviewVisible, state.OpaqueGhost);
 
         component.Color = state.Color;
         component.SelectedState = state.State;
@@ -61,9 +88,54 @@ public sealed class CrayonSystem : SharedCrayonSystem
             _label.SetMarkup(Robust.Shared.Localization.Loc.GetString("crayon-drawing-label",
                 ("color",_parent.Color),
                 ("rotation",_parent.Rotation),
+                ("previewEnabled",_parent.PreviewEnabled),
+                ("previewVisible",_parent.PreviewVisible),
                 ("state",_parent.SelectedState),
                 ("charges", _parent.Charges),
                 ("capacity",_parent.Capacity)));
         }
+    }
+
+    private void UpdateOverlay(EntityUid uid, CrayonComponent component, ProtoId<DecalPrototype>? state, float rotation, Color color, bool preview, bool previewVisible, bool opaqueGhost)
+    {
+        if (_player.LocalEntity == null || _handsSystem.GetActiveItem(_player.LocalEntity.Value) != uid)
+            return;
+        _overlay.RemoveOverlay<CrayonDecalGhostOverlay>();
+        if (!preview||!previewVisible)
+            return;
+        var decal = state is { } id ? _prototypeManager.Index(id) : null;
+        if (opaqueGhost)
+            color.A = 0.5f;
+        _overlay.AddOverlay(new CrayonDecalGhostOverlay(_placement, _transform, _sprite, _interaction, decal, -rotation, color));
+    }
+
+    private void OnLocalPlayerDetached(LocalPlayerDetachedEvent args)
+    {
+        OnClose();
+    }
+
+    private void OnRoundRestartCleanup(RoundRestartCleanupEvent args)
+    {
+        OnClose();
+    }
+
+    private void OnHandDeselected(EntityUid uid, CrayonComponent component, ref HandDeselectedEvent args)
+    {
+        _overlay.RemoveOverlay<CrayonDecalGhostOverlay>();
+    }
+
+    private void OnUnequippedHand(EntityUid uid, CrayonComponent component, ref UnequippedHandEvent args)
+    {
+        _overlay.RemoveOverlay<CrayonDecalGhostOverlay>();
+    }
+
+    private void OnComponentShutdown(EntityUid uid, CrayonComponent component, ComponentShutdown args)
+    {
+        OnClose();
+    }
+
+    private void OnClose()
+    {
+        _overlay.RemoveOverlay<CrayonDecalGhostOverlay>();
     }
 }

--- a/Content.Client/Crayon/CrayonSystem.cs
+++ b/Content.Client/Crayon/CrayonSystem.cs
@@ -29,6 +29,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
         component.SelectedState = state.State;
         component.Charges = state.Charges;
         component.Capacity = state.Capacity;
+        component.Rotation = state.Rotation;
 
         component.UIUpdateNeeded = true;
     }
@@ -59,6 +60,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
             _parent.UIUpdateNeeded = false;
             _label.SetMarkup(Robust.Shared.Localization.Loc.GetString("crayon-drawing-label",
                 ("color",_parent.Color),
+                ("rotation",_parent.Rotation),
                 ("state",_parent.SelectedState),
                 ("charges", _parent.Charges),
                 ("capacity",_parent.Capacity)));

--- a/Content.Client/Crayon/Overlays/CrayonDecalGhostOverlay.cs
+++ b/Content.Client/Crayon/Overlays/CrayonDecalGhostOverlay.cs
@@ -1,0 +1,51 @@
+using Content.Client.Decals;
+using Content.Client.Decals.Overlays;
+using Content.Shared.Decals;
+using Content.Shared.Interaction;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Input;
+using Robust.Client.Player;
+
+namespace Content.Client.Crayon.Overlays;
+
+public sealed class CrayonDecalGhostOverlay : DecalPlacementOverlay
+{
+    [Dependency] private readonly IEyeManager _eyeManager = default!;
+    [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    private readonly SharedInteractionSystem _interaction;
+    private readonly DecalPrototype? _decalPrototype;
+    private readonly Angle _rotation;
+    private readonly Color _color;
+
+    public CrayonDecalGhostOverlay(DecalPlacementSystem placement, SharedTransformSystem transform, SpriteSystem sprite, SharedInteractionSystem interaction, DecalPrototype? decalPrototype, Angle rotation, Color color) : base(placement, transform, sprite)
+    {
+        IoCManager.InjectDependencies(this);
+        _interaction = interaction;
+        _decalPrototype = decalPrototype;
+        _rotation = rotation;
+        _color = color;
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        var mouseScreenPos = _inputManager.MouseScreenPosition;
+        var mousePos = _eyeManager.PixelToMap(mouseScreenPos);
+
+        var player = _playerManager.LocalEntity;
+        if (player is null)
+            return false;
+        return _interaction.InRangeUnobstructed(mousePos,
+            player.Value,
+            collisionMask: Shared.Physics.CollisionGroup.None);
+    }
+
+    protected override void LoadDecal()
+    {
+        decal = _decalPrototype;
+        snap = false;
+        rotation = _rotation;
+        color = _color;
+    }
+}

--- a/Content.Client/Crayon/UI/CrayonBoundUserInterface.cs
+++ b/Content.Client/Crayon/UI/CrayonBoundUserInterface.cs
@@ -24,6 +24,7 @@ namespace Content.Client.Crayon.UI
             _menu = this.CreateWindowCenteredLeft<CrayonWindow>();
             _menu.OnColorSelected += SelectColor;
             _menu.OnRotationSelected += SelectRotation;
+            _menu.OnPreviewToggled += TogglePreview;
             _menu.OnSelected += Select;
             PopulateCrayons();
         }
@@ -74,6 +75,11 @@ namespace Content.Client.Crayon.UI
         public void SelectRotation(float rotation)
         {
             SendMessage(new CrayonRotationMessage(float.DegreesToRadians(rotation)));
+        }
+
+        public void TogglePreview(bool state)
+        {
+            SendMessage(new CrayonPreviewToggleMessage(state));
         }
     }
 }

--- a/Content.Client/Crayon/UI/CrayonBoundUserInterface.cs
+++ b/Content.Client/Crayon/UI/CrayonBoundUserInterface.cs
@@ -23,6 +23,7 @@ namespace Content.Client.Crayon.UI
             base.Open();
             _menu = this.CreateWindowCenteredLeft<CrayonWindow>();
             _menu.OnColorSelected += SelectColor;
+            _menu.OnRotationSelected += SelectRotation;
             _menu.OnSelected += Select;
             PopulateCrayons();
         }
@@ -68,6 +69,11 @@ namespace Content.Client.Crayon.UI
         public void SelectColor(Color color)
         {
             SendMessage(new CrayonColorMessage(color));
+        }
+
+        public void SelectRotation(float rotation)
+        {
+            SendMessage(new CrayonRotationMessage(float.DegreesToRadians(rotation)));
         }
     }
 }

--- a/Content.Client/Crayon/UI/CrayonWindow.xaml
+++ b/Content.Client/Crayon/UI/CrayonWindow.xaml
@@ -4,6 +4,9 @@
             SetSize="450 500">
     <BoxContainer Orientation="Vertical">
         <ColorSelectorSliders Name="ColorSelector" Visible="False" />
+        <BoxContainer Name="SpinBoxContainer" Orientation="Horizontal">
+            <Label Text="{Loc 'crayon-window-rotation'}" Margin="0 0 0 1" />
+        </BoxContainer>
         <LineEdit Name="Search" Margin="0 0 0 8" PlaceHolder="{Loc 'crayon-window-placeholder'}" />
         <ScrollContainer VerticalExpand="True">
             <BoxContainer Name="Grids" Orientation="Vertical">

--- a/Content.Client/Crayon/UI/CrayonWindow.xaml
+++ b/Content.Client/Crayon/UI/CrayonWindow.xaml
@@ -4,17 +4,31 @@
             SetSize="450 500">
     <BoxContainer Orientation="Vertical">
         <ColorSelectorSliders Name="ColorSelector" Visible="False" />
-        <BoxContainer Name="ExtraOptionsContainer" Orientation="Horizontal">
-            <BoxContainer Name="SpinBoxContainer" Orientation="Horizontal">
-                <Label Text="{Loc 'crayon-window-rotation'}" Margin="0 0 0 1" />
-            </BoxContainer>
-            <Label Text="{Loc 'crayon-window-preview'}" Margin ="0 0 1 1"/>
-            <CheckBox Name="PreviewCheckbox"></CheckBox>
+        <Label Text="{Loc 'crayon-window-rotation'}" Margin="0 0 0 1" />
+        <BoxContainer Name="RotationContainer" Orientation="Horizontal" Margin="0 0 0 4">
+            <Button Name="Neg180Btn" Text="-180" SetWidth="40" SetHeight="30"></Button>
+            <Button Name="Neg90Btn" Text="-90" SetWidth="36" SetHeight="30"></Button>
+            <Button Name="Neg45Btn" Text="-45" SetWidth="36" SetHeight="30"></Button>
+            <Button Name="Neg10Btn" Text="-10" SetWidth="36" SetHeight="30"></Button>
+            <Button Name="Neg1Btn" Text="-1" SetWidth="30" SetHeight="30"></Button>
+            <LineEdit Name="RotationValue" Margin="0 0 0 0" Text="0" HorizontalExpand="True"></LineEdit>
+            <Button Name="Pos1Btn" Text="+1" SetWidth="30" SetHeight="30"></Button>
+            <Button Name="Pos10Btn" Text="+10" SetWidth="36" SetHeight="30"></Button>
+            <Button Name="Pos45Btn" Text="+45" SetWidth="36" SetHeight="30"></Button>
+            <Button Name="Pos90Btn" Text="+90" SetWidth="36" SetHeight="30"></Button>
+            <Button Name="Pos180Btn" Text="+180" SetWidth="40" SetHeight="30"></Button>
         </BoxContainer>
+        <!-- <BoxContainer Name="SpinBoxContainer" Orientation="Horizontal"> -->
+        <!--     <Label Text="{Loc 'crayon-window-rotation'}" Margin="0 0 0 1" /> -->
+        <!-- </BoxContainer> -->
         <LineEdit Name="Search" Margin="0 0 0 8" PlaceHolder="{Loc 'crayon-window-placeholder'}" />
         <ScrollContainer VerticalExpand="True">
             <BoxContainer Name="Grids" Orientation="Vertical">
             </BoxContainer>
         </ScrollContainer>
+        <BoxContainer>
+            <Label Text="{Loc 'crayon-window-preview'}" Margin="0 6 8 0" />
+            <CheckBox Name="PreviewCheckbox" Margin="0 8 0 0"></CheckBox>
+        </BoxContainer>
     </BoxContainer>
 </DefaultWindow>

--- a/Content.Client/Crayon/UI/CrayonWindow.xaml
+++ b/Content.Client/Crayon/UI/CrayonWindow.xaml
@@ -4,8 +4,12 @@
             SetSize="450 500">
     <BoxContainer Orientation="Vertical">
         <ColorSelectorSliders Name="ColorSelector" Visible="False" />
-        <BoxContainer Name="SpinBoxContainer" Orientation="Horizontal">
-            <Label Text="{Loc 'crayon-window-rotation'}" Margin="0 0 0 1" />
+        <BoxContainer Name="ExtraOptionsContainer" Orientation="Horizontal">
+            <BoxContainer Name="SpinBoxContainer" Orientation="Horizontal">
+                <Label Text="{Loc 'crayon-window-rotation'}" Margin="0 0 0 1" />
+            </BoxContainer>
+            <Label Text="{Loc 'crayon-window-preview'}" Margin ="0 0 1 1"/>
+            <CheckBox Name="PreviewCheckbox"></CheckBox>
         </BoxContainer>
         <LineEdit Name="Search" Margin="0 0 0 8" PlaceHolder="{Loc 'crayon-window-placeholder'}" />
         <ScrollContainer VerticalExpand="True">

--- a/Content.Client/Crayon/UI/CrayonWindow.xaml.cs
+++ b/Content.Client/Crayon/UI/CrayonWindow.xaml.cs
@@ -29,12 +29,14 @@ namespace Content.Client.Crayon.UI
         private string? _selected;
         private Color _color;
         private float _rotation;
+        private bool _preview;
 
         private FloatSpinBox RotationSpinBox;
 
         public event Action<Color>? OnColorSelected;
         public event Action<float>? OnRotationSelected;
         public event Action<string>? OnSelected;
+        public event Action<bool>? OnPreviewToggled;
 
         public CrayonWindow()
         {
@@ -51,6 +53,7 @@ namespace Content.Client.Crayon.UI
             Search.OnTextChanged += SearchChanged;
             ColorSelector.OnColorChanged += SelectColor;
             RotationSpinBox.OnValueChanged += SelectRotation;
+            PreviewCheckbox.OnToggled += TogglePreview;
         }
 
         private void SelectColor(Color color)
@@ -65,6 +68,12 @@ namespace Content.Client.Crayon.UI
         {
             _rotation = args.Value;
             OnRotationSelected?.Invoke(args.Value);
+        }
+
+        private void TogglePreview(ButtonToggledEventArgs args)
+        {
+            _preview = args.Pressed;
+            OnPreviewToggled?.Invoke(args.Pressed);
         }
 
         private void RefreshList()
@@ -119,7 +128,7 @@ namespace Content.Client.Crayon.UI
                         Name = name,
                         ToolTip = name,
                         Modulate = _color,
-                        Scale = new System.Numerics.Vector2(2, 2)
+                        Scale = new System.Numerics.Vector2(2, 2),
                     };
                     button.OnPressed += ButtonOnPressed;
 
@@ -169,6 +178,8 @@ namespace Content.Client.Crayon.UI
             _color = state.Color;
             _rotation = float.RadiansToDegrees(state.Rotation);
             RotationSpinBox.Value = _rotation;
+            _preview = state.PreviewEnabled;
+            PreviewCheckbox.Pressed = _preview;
 
             if (ColorSelector.Visible)
             {

--- a/Content.Client/Crayon/UI/CrayonWindow.xaml.cs
+++ b/Content.Client/Crayon/UI/CrayonWindow.xaml.cs
@@ -28,8 +28,12 @@ namespace Content.Client.Crayon.UI
         private string? _autoSelected;
         private string? _selected;
         private Color _color;
+        private float _rotation;
+
+        private FloatSpinBox RotationSpinBox;
 
         public event Action<Color>? OnColorSelected;
+        public event Action<float>? OnRotationSelected;
         public event Action<string>? OnSelected;
 
         public CrayonWindow()
@@ -38,8 +42,15 @@ namespace Content.Client.Crayon.UI
             IoCManager.InjectDependencies(this);
             _spriteSystem = _entitySystem.GetEntitySystem<SpriteSystem>();
 
+            RotationSpinBox = new FloatSpinBox(90.0f, 0)
+            {
+                HorizontalExpand = true,
+            };
+            SpinBoxContainer.AddChild(RotationSpinBox);
+
             Search.OnTextChanged += SearchChanged;
             ColorSelector.OnColorChanged += SelectColor;
+            RotationSpinBox.OnValueChanged += SelectRotation;
         }
 
         private void SelectColor(Color color)
@@ -48,6 +59,12 @@ namespace Content.Client.Crayon.UI
 
             OnColorSelected?.Invoke(color);
             RefreshList();
+        }
+
+        private void SelectRotation(FloatSpinBox.FloatSpinBoxEventArgs args)
+        {
+            _rotation = args.Value;
+            OnRotationSelected?.Invoke(args.Value);
         }
 
         private void RefreshList()
@@ -150,6 +167,8 @@ namespace Content.Client.Crayon.UI
             _selected = state.Selected;
             ColorSelector.Visible = state.SelectableColor;
             _color = state.Color;
+            _rotation = float.RadiansToDegrees(state.Rotation);
+            RotationSpinBox.Value = _rotation;
 
             if (ColorSelector.Visible)
             {

--- a/Content.Client/Decals/Overlays/DecalPlacementOverlay.cs
+++ b/Content.Client/Decals/Overlays/DecalPlacementOverlay.cs
@@ -1,14 +1,15 @@
 using System.Numerics;
+using Content.Shared.Decals;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Decals.Overlays;
 
-public sealed class DecalPlacementOverlay : Overlay
+[Virtual]
+public class DecalPlacementOverlay : Overlay
 {
     [Dependency] private readonly IEyeManager _eyeManager = default!;
     [Dependency] private readonly IInputManager _inputManager = default!;
@@ -19,6 +20,11 @@ public sealed class DecalPlacementOverlay : Overlay
 
     public override OverlaySpace Space => OverlaySpace.WorldSpaceEntities;
 
+    protected DecalPrototype? decal;
+    protected bool snap;
+    protected Angle rotation;
+    protected Color? color;
+
     public DecalPlacementOverlay(DecalPlacementSystem placement, SharedTransformSystem transform, SpriteSystem sprite)
     {
         IoCManager.InjectDependencies(this);
@@ -28,9 +34,14 @@ public sealed class DecalPlacementOverlay : Overlay
         ZIndex = 1000;
     }
 
+    protected virtual void LoadDecal()
+    {
+        (decal, snap, rotation, color) = _placement.GetActiveDecal();
+    }
+
     protected override void Draw(in OverlayDrawArgs args)
     {
-        var (decal, snap, rotation, color) = _placement.GetActiveDecal();
+        LoadDecal();
 
         if (decal == null)
             return;

--- a/Content.Server/Crayon/CrayonSystem.cs
+++ b/Content.Server/Crayon/CrayonSystem.cs
@@ -6,8 +6,12 @@ using Content.Server.Popups;
 using Content.Shared.Crayon;
 using Content.Shared.Database;
 using Content.Shared.Decals;
+using Content.Shared.Hands;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Inventory.Events;
 using Content.Shared.Nutrition.EntitySystems;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
@@ -25,6 +29,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+    [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
 
     public override void Initialize()
     {
@@ -33,6 +38,13 @@ public sealed class CrayonSystem : SharedCrayonSystem
         SubscribeLocalEvent<CrayonComponent, CrayonSelectMessage>(OnCrayonBoundUI);
         SubscribeLocalEvent<CrayonComponent, CrayonColorMessage>(OnCrayonBoundUIColor);
         SubscribeLocalEvent<CrayonComponent, CrayonRotationMessage>(OnCrayonBoundUIRotation);
+        SubscribeLocalEvent<CrayonComponent, BoundUIOpenedEvent>(OnBoundUIOpened);
+        SubscribeLocalEvent<CrayonComponent, BoundUIClosedEvent>(OnBoundUIClosed);
+        SubscribeLocalEvent<CrayonComponent, HandSelectedEvent>(OnHandSelected);
+        SubscribeLocalEvent<CrayonComponent, HandDeselectedEvent>(OnHandDeselected);
+        SubscribeLocalEvent<CrayonComponent, GotEquippedEvent>(OnGotEquipped);
+        SubscribeLocalEvent<CrayonComponent, GotUnequippedEvent>(OnGotUnequipped);
+        SubscribeLocalEvent<CrayonComponent, CrayonPreviewToggleMessage>(OnCrayonBoundUIPreviewToggle);
         SubscribeLocalEvent<CrayonComponent, UseInHandEvent>(OnCrayonUse, before: new[] { typeof(FoodSystem) });
         SubscribeLocalEvent<CrayonComponent, AfterInteractEvent>(OnCrayonAfterInteract, after: new[] { typeof(FoodSystem) });
         SubscribeLocalEvent<CrayonComponent, DroppedEvent>(OnCrayonDropped);
@@ -41,7 +53,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
 
     private static void OnCrayonGetState(EntityUid uid, CrayonComponent component, ref ComponentGetState args)
     {
-        args.State = new CrayonComponentState(component.Color, component.SelectedState, component.Charges, component.Capacity, component.Rotation);
+        args.State = new CrayonComponentState(component.Color, component.SelectedState, component.Charges, component.Capacity, component.Rotation, component.PreviewEnabled, component.PreviewVisible, component.OpaqueGhost);
     }
 
     private void OnCrayonAfterInteract(EntityUid uid, CrayonComponent component, AfterInteractEvent args)
@@ -100,7 +112,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
 
         _uiSystem.TryToggleUi(uid, SharedCrayonComponent.CrayonUiKey.Key, args.User);
 
-        _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation));
+        _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation, component.PreviewEnabled, component.PreviewVisible, component.OpaqueGhost));
         args.Handled = true;
     }
 
@@ -130,6 +142,64 @@ public sealed class CrayonSystem : SharedCrayonSystem
     {
         component.Rotation = args.Rotation;
         Dirty(uid, component);
+    }
+
+    private void OnCrayonBoundUIPreviewToggle(EntityUid uid, CrayonComponent component, CrayonPreviewToggleMessage args)
+    {
+        if(_handsSystem.GetActiveItem(args.Actor)==uid)
+        {
+            component.PreviewEnabled = args.State;
+            Dirty(uid, component);
+        }
+        else
+        {
+            _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation, component.PreviewEnabled, component.PreviewVisible, component.OpaqueGhost));
+        }
+    }
+
+    private void OnBoundUIOpened(EntityUid uid, CrayonComponent component, ref BoundUIOpenedEvent args)
+    {
+        component.OpaqueGhost = false;
+        Dirty(uid, component);
+        _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation, component.PreviewEnabled, component.PreviewVisible, component.OpaqueGhost));
+    }
+
+    private void OnBoundUIClosed(EntityUid uid, CrayonComponent component, ref BoundUIClosedEvent args)
+    {
+        component.OpaqueGhost = true;
+        Dirty(uid, component);
+        _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation, component.PreviewEnabled, component.PreviewVisible, component.OpaqueGhost));
+    }
+
+    private void OnHandSelected(EntityUid uid, CrayonComponent component, ref HandSelectedEvent args)
+    {
+        if (_handsSystem.GetActiveItem(args.User) != uid)
+            return;
+        SetPreviewVisible(uid, component, true);
+    }
+
+    private void OnGotEquipped(EntityUid uid, CrayonComponent component, ref GotEquippedEvent args)
+    {
+        if (_handsSystem.GetActiveItem(args.Equipee) != uid)
+            return;
+        SetPreviewVisible(uid, component, true);
+    }
+
+    private void OnHandDeselected(EntityUid uid, CrayonComponent component, ref HandDeselectedEvent args)
+    {
+        SetPreviewVisible(uid, component, false);
+    }
+
+    private void OnGotUnequipped(EntityUid uid, CrayonComponent component, ref GotUnequippedEvent args)
+    {
+        SetPreviewVisible(uid, component, false);
+    }
+
+    private void SetPreviewVisible(EntityUid uid, CrayonComponent component, bool visible)
+    {
+        component.PreviewVisible = visible;
+        Dirty(uid, component);
+        _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation, component.PreviewEnabled, component.PreviewVisible, component.OpaqueGhost));
     }
 
     private void OnCrayonInit(EntityUid uid, CrayonComponent component, ComponentInit args)

--- a/Content.Server/Crayon/CrayonSystem.cs
+++ b/Content.Server/Crayon/CrayonSystem.cs
@@ -112,7 +112,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
 
         _uiSystem.TryToggleUi(uid, SharedCrayonComponent.CrayonUiKey.Key, args.User);
 
-        _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation, component.PreviewEnabled, component.PreviewVisible, component.OpaqueGhost));
+        SetUIState(uid, component);
         args.Handled = true;
     }
 
@@ -151,24 +151,21 @@ public sealed class CrayonSystem : SharedCrayonSystem
             component.PreviewEnabled = args.State;
             Dirty(uid, component);
         }
-        else
-        {
-            _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation, component.PreviewEnabled, component.PreviewVisible, component.OpaqueGhost));
-        }
+        else SetUIState(uid, component);
     }
 
     private void OnBoundUIOpened(EntityUid uid, CrayonComponent component, ref BoundUIOpenedEvent args)
     {
         component.OpaqueGhost = false;
         Dirty(uid, component);
-        _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation, component.PreviewEnabled, component.PreviewVisible, component.OpaqueGhost));
+        SetUIState(uid, component);
     }
 
     private void OnBoundUIClosed(EntityUid uid, CrayonComponent component, ref BoundUIClosedEvent args)
     {
         component.OpaqueGhost = true;
         Dirty(uid, component);
-        _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation, component.PreviewEnabled, component.PreviewVisible, component.OpaqueGhost));
+        SetUIState(uid, component);
     }
 
     private void OnHandSelected(EntityUid uid, CrayonComponent component, ref HandSelectedEvent args)
@@ -195,11 +192,16 @@ public sealed class CrayonSystem : SharedCrayonSystem
         SetPreviewVisible(uid, component, false);
     }
 
+    private void SetUIState(EntityUid uid, CrayonComponent component)
+    {
+        _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation, component.PreviewEnabled, component.PreviewVisible, component.OpaqueGhost));
+    }
+
     private void SetPreviewVisible(EntityUid uid, CrayonComponent component, bool visible)
     {
         component.PreviewVisible = visible;
         Dirty(uid, component);
-        _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation, component.PreviewEnabled, component.PreviewVisible, component.OpaqueGhost));
+        SetUIState(uid, component);
     }
 
     private void OnCrayonInit(EntityUid uid, CrayonComponent component, ComponentInit args)

--- a/Content.Server/Crayon/CrayonSystem.cs
+++ b/Content.Server/Crayon/CrayonSystem.cs
@@ -32,6 +32,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
         SubscribeLocalEvent<CrayonComponent, ComponentInit>(OnCrayonInit);
         SubscribeLocalEvent<CrayonComponent, CrayonSelectMessage>(OnCrayonBoundUI);
         SubscribeLocalEvent<CrayonComponent, CrayonColorMessage>(OnCrayonBoundUIColor);
+        SubscribeLocalEvent<CrayonComponent, CrayonRotationMessage>(OnCrayonBoundUIRotation);
         SubscribeLocalEvent<CrayonComponent, UseInHandEvent>(OnCrayonUse, before: new[] { typeof(FoodSystem) });
         SubscribeLocalEvent<CrayonComponent, AfterInteractEvent>(OnCrayonAfterInteract, after: new[] { typeof(FoodSystem) });
         SubscribeLocalEvent<CrayonComponent, DroppedEvent>(OnCrayonDropped);
@@ -40,7 +41,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
 
     private static void OnCrayonGetState(EntityUid uid, CrayonComponent component, ref ComponentGetState args)
     {
-        args.State = new CrayonComponentState(component.Color, component.SelectedState, component.Charges, component.Capacity);
+        args.State = new CrayonComponentState(component.Color, component.SelectedState, component.Charges, component.Capacity, component.Rotation);
     }
 
     private void OnCrayonAfterInteract(EntityUid uid, CrayonComponent component, AfterInteractEvent args)
@@ -66,7 +67,8 @@ public sealed class CrayonSystem : SharedCrayonSystem
             return;
         }
 
-        if (!_decals.TryAddDecal(component.SelectedState, args.ClickLocation.Offset(new Vector2(-0.5f, -0.5f)), out _, component.Color, cleanable: true))
+        uint decalId;
+        if (!_decals.TryAddDecal(component.SelectedState, args.ClickLocation.Offset(new Vector2(-0.5f, -0.5f)), out decalId, component.Color, rotation:-component.Rotation, cleanable: true))
             return;
 
         if (component.UseSound != null)
@@ -98,7 +100,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
 
         _uiSystem.TryToggleUi(uid, SharedCrayonComponent.CrayonUiKey.Key, args.User);
 
-        _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color));
+        _uiSystem.SetUiState(uid, SharedCrayonComponent.CrayonUiKey.Key, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color, component.Rotation));
         args.Handled = true;
     }
 
@@ -122,6 +124,12 @@ public sealed class CrayonSystem : SharedCrayonSystem
         component.Color = args.Color;
         Dirty(uid, component);
 
+    }
+
+    private void OnCrayonBoundUIRotation(EntityUid uid, CrayonComponent component, CrayonRotationMessage args)
+    {
+        component.Rotation = args.Rotation;
+        Dirty(uid, component);
     }
 
     private void OnCrayonInit(EntityUid uid, CrayonComponent component, ComponentInit args)

--- a/Content.Shared/Crayon/SharedCrayonComponent.cs
+++ b/Content.Shared/Crayon/SharedCrayonComponent.cs
@@ -24,16 +24,16 @@ namespace Content.Shared.Crayon
         /// <summary>
         /// Rotation of the resulting decal
         /// </summary>
-        [DataField("rotation")]
+        [DataField]
         public float Rotation;
 
-        [DataField("previewEnabled")]
+        [DataField]
         public bool PreviewEnabled;
 
-        [DataField("previewVisible")]
+        [DataField]
         public bool PreviewVisible;
 
-        [DataField("opaqueGhost")]
+        [DataField]
         public bool OpaqueGhost;
 
         [Serializable, NetSerializable]

--- a/Content.Shared/Crayon/SharedCrayonComponent.cs
+++ b/Content.Shared/Crayon/SharedCrayonComponent.cs
@@ -27,6 +27,15 @@ namespace Content.Shared.Crayon
         [DataField("rotation")]
         public float Rotation;
 
+        [DataField("previewEnabled")]
+        public bool PreviewEnabled;
+
+        [DataField("previewVisible")]
+        public bool PreviewVisible;
+
+        [DataField("opaqueGhost")]
+        public bool OpaqueGhost;
+
         [Serializable, NetSerializable]
         public enum CrayonUiKey : byte
         {
@@ -70,6 +79,17 @@ namespace Content.Shared.Crayon
         }
     }
 
+    [Serializable, NetSerializable]
+    public sealed class CrayonPreviewToggleMessage : BoundUserInterfaceMessage
+    {
+        public readonly bool State;
+
+        public CrayonPreviewToggleMessage(bool state)
+        {
+            State = state;
+        }
+    }
+
     /// <summary>
     /// Server to CLIENT. Notifies the BUI that a decal with given ID has been drawn.
     /// Allows the client UI to advance forward in the client-only ephemeral queue,
@@ -97,14 +117,20 @@ namespace Content.Shared.Crayon
         public readonly int Charges;
         public readonly int Capacity;
         public readonly float Rotation;
+        public readonly bool PreviewEnabled;
+        public readonly bool PreviewVisible;
+        public readonly bool OpaqueGhost;
 
-        public CrayonComponentState(Color color, string state, int charges, int capacity, float rotation)
+        public CrayonComponentState(Color color, string state, int charges, int capacity, float rotation, bool previewEnabled, bool previewVisible, bool opaqueGhost)
         {
             Color = color;
             State = state;
             Charges = charges;
             Capacity = capacity;
             Rotation = rotation;
+            PreviewEnabled = previewEnabled;
+            PreviewVisible = previewVisible;
+            OpaqueGhost = opaqueGhost;
         }
     }
 
@@ -121,13 +147,19 @@ namespace Content.Shared.Crayon
         public bool SelectableColor;
         public Color Color;
         public float Rotation;
+        public bool PreviewEnabled;
+        public bool PreviewVisible;
+        public bool OpaqueGhost;
 
-        public CrayonBoundUserInterfaceState(string selected, bool selectableColor, Color color, float rotation)
+        public CrayonBoundUserInterfaceState(string selected, bool selectableColor, Color color, float rotation, bool previewEnabled, bool previewVisible, bool opaqueGhost)
         {
             Selected = selected;
             SelectableColor = selectableColor;
             Color = color;
             Rotation = rotation;
+            PreviewEnabled = previewEnabled;
+            PreviewVisible = previewVisible;
+            OpaqueGhost = opaqueGhost;
         }
     }
 }

--- a/Content.Shared/Crayon/SharedCrayonComponent.cs
+++ b/Content.Shared/Crayon/SharedCrayonComponent.cs
@@ -21,6 +21,12 @@ namespace Content.Shared.Crayon
         [DataField("color")]
         public Color Color;
 
+        /// <summary>
+        /// Rotation of the resulting decal
+        /// </summary>
+        [DataField("rotation")]
+        public float Rotation;
+
         [Serializable, NetSerializable]
         public enum CrayonUiKey : byte
         {
@@ -54,6 +60,16 @@ namespace Content.Shared.Crayon
         }
     }
 
+    [Serializable, NetSerializable]
+    public sealed class CrayonRotationMessage : BoundUserInterfaceMessage
+    {
+        public readonly float Rotation;
+        public CrayonRotationMessage(float rotation)
+        {
+            Rotation = rotation;
+        }
+    }
+
     /// <summary>
     /// Server to CLIENT. Notifies the BUI that a decal with given ID has been drawn.
     /// Allows the client UI to advance forward in the client-only ephemeral queue,
@@ -80,13 +96,15 @@ namespace Content.Shared.Crayon
         public readonly string State;
         public readonly int Charges;
         public readonly int Capacity;
+        public readonly float Rotation;
 
-        public CrayonComponentState(Color color, string state, int charges, int capacity)
+        public CrayonComponentState(Color color, string state, int charges, int capacity, float rotation)
         {
             Color = color;
             State = state;
             Charges = charges;
             Capacity = capacity;
+            Rotation = rotation;
         }
     }
 
@@ -102,12 +120,14 @@ namespace Content.Shared.Crayon
         /// </summary>
         public bool SelectableColor;
         public Color Color;
+        public float Rotation;
 
-        public CrayonBoundUserInterfaceState(string selected, bool selectableColor, Color color)
+        public CrayonBoundUserInterfaceState(string selected, bool selectableColor, Color color, float rotation)
         {
             Selected = selected;
             SelectableColor = selectableColor;
             Color = color;
+            Rotation = rotation;
         }
     }
 }

--- a/Resources/Locale/en-US/crayon/crayon-component.ftl
+++ b/Resources/Locale/en-US/crayon/crayon-component.ftl
@@ -8,6 +8,7 @@ crayon-interact-invalid-location = Can't reach there!
 
 ## UI
 crayon-window-title = Crayon
+crayon-window-rotation = Glyph rotation
 crayon-window-placeholder = Search, or queue a comma-separated list of names
 crayon-category-1-brushes = Brushes
 crayon-category-2-alphanum = Numbers and letters

--- a/Resources/Locale/en-US/crayon/crayon-component.ftl
+++ b/Resources/Locale/en-US/crayon/crayon-component.ftl
@@ -9,6 +9,7 @@ crayon-interact-invalid-location = Can't reach there!
 ## UI
 crayon-window-title = Crayon
 crayon-window-rotation = Glyph rotation
+crayon-window-preview = Show preview
 crayon-window-placeholder = Search, or queue a comma-separated list of names
 crayon-category-1-brushes = Brushes
 crayon-category-2-alphanum = Numbers and letters


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Implemented the ability to rotate decals placed by crayons.
Partial credit to [themias](https://github.com/themias), turns out this was a duplicate of their PR!! Used their code as reference for adding my own implementation of the decal preview ghost. Didn't know you could do coauthor stuff with git before my initial commit, and I have no idea if it's possible to add that after the fact so I just edited this PR to give attribution here. Also added them as an author on the changelog.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Under normal circumstances, attempting to place down a decal via crayon will always result in the orientation of the decal matching whatever the "default" rotation is for the camera for whatever it is that you're standing on. (e.g. take crayon, step onto a surface, press Numpad8 to orient camera to default rotation, whatever you draw will be upright from this view)
This would make it rather difficult to write messages in certain spaces unless you want to do it manually with the brushes. To fix this, a "Glyph rotation" box has been added.

## Technical details
<!-- Summary of code changes for easier review. -->
Sort of just copied what the crayon does for setting the color of the crayon (RGB sliders) and copied the implementation of the rotation box from another UI. This involved adding a `CrayonRotationMessage` to `SharedCrayonComponent.cs` in order to relay the rotation info from client to server. Of course, changes to `CrayonWindow.xaml` and `CrayonWindow.xaml.cs` were also made, and other small additions were made in other various crayon related files in order to ensure rotation is saved properly on the server and relayed back to the client when it next opens the crayon UI.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="464" height="510" alt="image" src="https://github.com/user-attachments/assets/6976bb2e-69cd-49cf-9d1b-4a254b4be6fc" />
<img width="913" height="505" alt="image" src="https://github.com/user-attachments/assets/ee540369-35c9-4be1-a5c5-426610db4099" />
<img width="418" height="335" alt="image" src="https://github.com/user-attachments/assets/edb53a78-841a-4ebe-aa13-5bc4a2b94c71" />
<img width="115" height="125" alt="image" src="https://github.com/user-attachments/assets/651c0de3-cbcd-4fe7-8d77-da537b8203db" />

https://github.com/user-attachments/assets/b0a1754c-68c5-4ab7-8511-ca9cecdee3f0

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
**N/A**

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: neomoth, themias
- add: Ability to rotate decals placed with crayons