### PR TITLE
place stored changeling identities next to each other

### DIFF
--- a/Content.Shared/Changeling/ChangelingIdentitySystem.cs
+++ b/Content.Shared/Changeling/ChangelingIdentitySystem.cs
@@ -23,6 +23,7 @@ public sealed class ChangelingIdentitySystem : EntitySystem
     [Dependency] private readonly SharedPvsOverrideSystem _pvsOverrideSystem = default!;
 
     public MapId? PausedMapId;
+    private int _numberOfStoredIdentities = 0; // TODO: remove this
 
     public override void Initialize()
     {
@@ -101,7 +102,11 @@ public sealed class ChangelingIdentitySystem : EntitySystem
             return null;
 
         EnsurePausedMap();
-        var mob = Spawn(speciesPrototype.Prototype, new MapCoordinates(Vector2.Zero, PausedMapId!.Value));
+        // TODO: Setting the spawn location is a shitty bandaid to prevent admins from crashing our servers.
+        // Movercontrollers and mob collisions are currently being calculated even for paused entities.
+        // Spawning all of them in the same spot causes severe performance problems.
+        // Cryopods and Polymorph have the same problem.
+        var mob = Spawn(speciesPrototype.Prototype, new MapCoordinates(new Vector2(2 * _numberOfStoredIdentities++, 0), PausedMapId!.Value));
 
         var storedIdentity = EnsureComp<ChangelingStoredIdentityComponent>(mob);
         storedIdentity.OriginalEntity = target; // TODO: network this once we have WeakEntityReference or the autonetworking source gen is fixed


### PR DESCRIPTION
## About the PR
This is a shitty baindaids but I can't stop admins from using the antag crtl verb and making our servers lag or even crash without reverting the full changeling PR.

This correct solution is to not make paused input movers update in the first place, but https://github.com/space-wizards/space-station-14/pull/39444 is awaiting changes.

But I guess this is nice to have on its own for debugging purposes as well since you can inspect them easier after teleporting to the paused map.

## Why / Balance
See #39440

## Technical details
Just place them next to each other.

## Media
nicely lined up

<img width="726" height="222" alt="grafik" src="https://github.com/user-attachments/assets/dfc3db82-285d-4e72-a462-d47342c88db4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
nope
