### PR TITLE
give paused maps from polymorph and cryostorage a name

### DIFF
--- a/Content.Server/Polymorph/Systems/PolymorphSystem.Map.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.Map.cs
@@ -31,7 +31,9 @@ public sealed partial class PolymorphSystem
         if (PausedMap != null && Exists(PausedMap))
             return;
 
-        PausedMap = _map.CreateMap();
-        _map.SetPaused(PausedMap.Value, true);
+        var mapUid = _map.CreateMap();
+        _metaData.SetEntityName(mapUid, "Polymorph body storage map");
+        _map.SetPaused(mapUid, true);
+        PausedMap = mapUid;
     }
 }

--- a/Content.Shared/Bed/Cryostorage/SharedCryostorageSystem.cs
+++ b/Content.Shared/Bed/Cryostorage/SharedCryostorageSystem.cs
@@ -25,6 +25,7 @@ public abstract class SharedCryostorageSystem : EntitySystem
     [Dependency] protected readonly IGameTiming Timing = default!;
     [Dependency] protected readonly ISharedAdminLogManager AdminLog = default!;
     [Dependency] protected readonly SharedMindSystem Mind = default!;
+    [Dependency] private readonly MetaDataSystem _meta = default!;
 
     protected EntityUid? PausedMap { get; private set; }
 
@@ -167,8 +168,10 @@ public abstract class SharedCryostorageSystem : EntitySystem
         if (PausedMap != null && Exists(PausedMap))
             return;
 
-        PausedMap = _map.CreateMap();
-        _map.SetPaused(PausedMap.Value, true);
+        var mapUid = _map.CreateMap();
+        _meta.SetEntityName(mapUid, "Cryosleeper body storage map");
+        _map.SetPaused(mapUid, true);
+        PausedMap = mapUid;
     }
 
     public bool IsInPausedMap(Entity<TransformComponent?> entity)


### PR DESCRIPTION
## About the PR
Gives the map entity a name so that it's easier to find when debugging.

## Technical details
just set the name for the entity.

## Media
<img width="879" height="248" alt="grafik" src="https://github.com/user-attachments/assets/7b11af27-561f-4e76-a1d4-07be7be4d47a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
ADMIN:
- tweak: Paused maps from cryostorage and polymorphing are now named to make them easier to find when debugging.
