### PR TITLE
Medical chems rebalance

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -85,13 +85,26 @@
         type: Remove
       - !type:ModifyStatusEffect
         effectProto: StatusEffectDrowsiness
-        time: 1.5
+        time: 3.0
         type: Add
         refresh: false
       - !type:HealthChange
         damage:
           types:
             Poison: -3
+      - !type:ModifyStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          min: 15.5
+        effectProto: StatusEffectSeeingRainbow
+        type: Add
+        time: 5
+        refresh: false
+      - !type:ChemVomit
+        conditions:
+        - !type:ReagentThreshold
+          min: 15.5
+        probability: 0.1
 
 - type: reagent
   id: Ethylredoxrazine
@@ -129,7 +142,7 @@
           types:
             Radiation: -3
           groups:
-            Brute: 1.5
+            Brute: 0.9
 
 - type: reagent
   id: Bicaridine
@@ -142,13 +155,14 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:EvenHealthChange
+      - !type:HealthChange
         damage:
-          Brute: -1.5
+          groups:
+            Brute: -4.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 15
+          min: 10
         damage:
           types:
             Asphyxiation: 0.5
@@ -156,12 +170,12 @@
       - !type:ChemVomit
         conditions:
         - !type:ReagentThreshold
-          min: 30
+          min: 20
         probability: 0.02
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
-          min: 15
+          min: 10
       - !type:Drunk
 
 - type: reagent
@@ -181,18 +195,17 @@
   metabolisms:
     Medicine:
       effects:
-        - !type:HealthChange
+        - !type:EvenHealthChange
           conditions:
           - !type:Temperature
             # this is a little arbitrary but they gotta be pretty cold
             max: 213.0
           damage:
           # todo scale with temp like SS13
-            groups:
-              Airloss: -6
-              Brute: -4
-              Burn: -6
-              Toxin: -4
+            Brute: -2
+            Burn: -2
+            Toxin: -2
+            Airloss: -2
 
 - type: reagent
   id: Doxarubixadone
@@ -211,7 +224,9 @@
             max: 213.0
           damage:
             types:
-             Cellular: -2
+             Cellular: -1.5
+            groups:
+             Brute: 0.6
 
 - type: reagent
   id: Dermaline
@@ -284,8 +299,8 @@
       - !type:HealthChange
         damage:
           types:
-            Asphyxiation: -3.5
-            Bloodloss: -3
+            Asphyxiation: -3
+            Bloodloss: -1.5
       - !type:AdjustReagent
         conditions:
         - !type:ReagentThreshold
@@ -296,7 +311,7 @@
       - !type:HealthChange
         conditions:
           - !type:ReagentThreshold
-            min: 25
+            min: 20
         damage:
           types:
             Asphyxiation: 5
@@ -391,18 +406,18 @@
           types:
             Radiation: -1
       - !type:ChemVomit
-        probability: 0.02
+        probability: 0.01
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 30
+          min: 20
         damage:
           types:
            Heat: 2
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
-          min: 30
+          min: 20
 
 - type: reagent
   id: Ipecac
@@ -487,21 +502,22 @@
   color: "#ff7db5"
   metabolisms:
     Medicine:
+      metabolismRate: 0.25
       effects:
       - !type:HealthChange
         damage:
           types:
-            Cold: -4
+            Cold: -2
       - !type:AdjustTemperature
         conditions:
         - !type:Temperature
           max: 293.15
-        amount: 100000 # thermal energy, not temperature!
+        amount: 50000 # thermal energy, not temperature!
       - !type:AdjustTemperature
         conditions:
         - !type:Temperature
           min: 293.15
-        amount: -10000
+        amount: -5000
       - !type:PopupMessage
         type: Local
         visualType: Medium
@@ -572,29 +588,21 @@
         min: 4
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.25
       effects:
       - !type:HealthChange
         damage:
           types:
-            Cellular: -0.3
-            Radiation: 0.15
-            Caustic: 0.15
+            Cellular: -0.75
+            Radiation: 0.25
+            Caustic: 0.25
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 11
         damage:
           types:
-            Radiation: 0.2
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Arithrazine
-          min: 1
-        damage:
-          types:
-            Caustic: 0.3
+            Radiation: 0.3
 
 - type: reagent
   id: PolypyryliumOligomers
@@ -844,25 +852,35 @@
   color: "#520e30"
   metabolisms:
     Medicine:
-      metabolismRate: 0.25
       effects:
+      - !type:EvenHealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 0
+          max: 20
+        damage:
+          Toxin: -6
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 0
-          max: 30
+          max: 20
         damage:
           groups:
-            Toxin: -1.5
-            Brute: 0.25
+            Brute: 1.5
+      - !type:EvenHealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 20
+        damage:
+          Toxin: -2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 30
+          min: 20
         damage:
           groups:
-            Toxin: -0.5
-            Brute: 3
+            Brute: 6
       - !type:AdjustReagent
         conditions:
         - !type:ReagentThreshold
@@ -971,19 +989,19 @@
   color: "#e0a5b9"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.25
       effects:
       - !type:HealthChange
         damage:
           types:
-            Caustic: -0.6 # 6 per u
+            Caustic: -1.25
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 21
+          min: 16
         damage:
           types:
-            Heat: 0.2
+            Heat: 1
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
@@ -1001,21 +1019,6 @@
         - !type:ReagentThreshold
           min: 30
         probability: 0.02
-      - !type:ChemVomit
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Arithrazine
-          min: 1
-        probability: 0.1
-      - !type:PopupMessage
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Arithrazine
-          min: 1
-        type: Local
-        visualType: Medium
-        messages: [ "generic-reagent-effect-nauseous" ]
-        probability: 0.2
 
 - type: reagent
   id: Lacerinol
@@ -1027,19 +1030,19 @@
   color: "#283332"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.25
       effects:
       - !type:HealthChange
         damage:
           types:
-            Slash: -0.6 # 6 Per u
+            Slash: -2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 21
+          min: 12
         damage:
           types:
-            Cold: 1.5 #15 per u
+            Cold: 1.5
 
 - type: reagent
   id: Puncturase
@@ -1051,20 +1054,20 @@
   color: "#b9bf93"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.25
       effects:
       - !type:HealthChange
         damage:
           types:
-            Piercing: -0.6 # 6 per u
-            Blunt: 0.05 # 0.5 per u
+            Piercing: -2.5
+            Blunt: 0.25
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 21
+          min: 12
         damage:
           types:
-            Blunt: 1 # 10 per u plus base effect
+            Blunt: 3
 
 - type: reagent
   id: Bruizine
@@ -1076,19 +1079,19 @@
   color: "#ff3636"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.25
       effects:
       - !type:HealthChange
         damage:
           types:
-            Blunt: -0.6 # 6 per u
+            Blunt: -2.25
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 19
+          min: 10.5
         damage:
           types:
-            Poison: 1.5 # 15 per u
+            Poison: 2.5
 
 - type: reagent
   id: Holywater
@@ -1146,12 +1149,12 @@
   color: "#aa4308"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1 # slow metabolism to not be a godly combat med, its for treating burn victims efficiently
+      metabolismRate: 0.25
       effects:
       - !type:HealthChange
         damage:
           types:
-            Heat: -1
+            Heat: -2
       # od causes massive bleeding
       - !type:HealthChange
         conditions:
@@ -1159,12 +1162,12 @@
           min: 20
         damage:
           types:
-            Slash: 0.5
-            Piercing: 0.5
+            Slash: 1
+            Piercing: 1
       - !type:ChemVomit
         conditions:
         - !type:ReagentThreshold
-          min: 15
+          min: 16
         probability: 0.1
       - !type:Emote
         conditions:
@@ -1183,34 +1186,34 @@
   color: "#8147ff"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.25
       effects:
       # heals shocks and removes shock chems
       - !type:HealthChange
         damage:
           types:
-            Shock: -0.5 # 5 per u
+            Shock: -1.5
       - !type:AdjustReagent
         reagent: Licoxide
-        amount: -4
+        amount: -2
       - !type:AdjustReagent
         reagent:  Tazinide
-        amount: -4
+        amount: -2
       # makes you a little chilly when not oding
       - !type:AdjustTemperature
-        amount: -5000
+        amount: -2500
       # od makes you freeze to death
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 15.5
+          min: 12
         damage:
           types:
-            Cold: 0.2 # 2 per u but lethal with cooling OD effect below
+            Cold: 1
       - !type:AdjustTemperature
         conditions:
         - !type:ReagentThreshold
-          min: 15.5
+          min: 12
         amount: -30000
       - !type:Jitter
         conditions:
@@ -1256,16 +1259,15 @@
   metabolisms:
     Medicine:
       effects:
-        - !type:HealthChange
+        - !type:EvenHealthChange
           conditions:
           - !type:Temperature
             max: 213.0
           damage:
-            groups:
-              Brute: -4
-              Burn: -5
-            types:
-              Poison: -2
+            Brute: -4
+            Burn: -4
+            Toxin: -4
+            Airloss: -4
 
 - type: reagent
   id : Aloxadone
@@ -1279,16 +1281,12 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:HealthChange
+      - !type:EvenHealthChange
         conditions:
         - !type:Temperature
           max: 213.0
         damage:
-          types:
-            Cold: -4.0
-            Heat: -4.0
-            Shock: -4.0
-            Caustic: -1.5
+          Burn: -8
 
 - type: reagent
   id : Mannitol # currently this is just a way to create psicodine


### PR DESCRIPTION
## About the PR

This PR aims to (constructively) address the balance changes made to certain chemicals in #38811. At least that was the original goal, before this PR turned into a rebalance of most medical chems.

## Why / Balance

The #38811 PR made a couple of changes that simplify medical gameplay. Namely, bicaridine was made significantly faster than the advanced brute chemicals, making them mostly obsolete.

If a patient comes to the medbay with 45 or less total brute damage, the fastest and easiest way to treat them is to inject 15u of bicaridine. Even in situations with more than 45 brute damage, using advanced brute chems seems pointless, given how slow they are.

The PR's intention seemed to have been to make the advanced brute and burn chemicals behave similarly to pyrazine, however, all the changed chemicals have ended up having significantly worse healing than pyrazine, and, by many, pyrazine was never perceived to be that good in the first place.

The PR's author also stated that healing per unit values stayed largely similar. This is untrue, and you can see by the tables below that several chemicals had their healing per unit nerfed, and only bicaridine was buffed. I would argue that slowing down chemicals so significantly necessitates increasing their healing per unit.

There are also some strange decisions made in the PR, such as nerfing ultravasculine, a chemical that is basically never used, as opposed to more powerful poison chemicals such as diphenhydramine and stellibinin.

The changes made are not universally bad though, with some of the players I asked about them liking the fact that cryo treatment became more useful as a result.

With this PR, I intend to strike a middleground between the pre-#38811 and post-#38811 healing values, as well as balancing several other chemicals. The goal is to make all the chemicals on the following list useful in some way.

The values from the #39472 PR have been included in the following tables for comparison.

### Bicaridine

| Bicaridine              | Pre-#38811             | Post-#38811 & Slam's PR | This PR                |
|-------------------------|------------------------|-------------------------|------------------------|
|              Healing/5u | ~6.7 each brute        | 15 brute evenly         | 15 each brute          |
|               Healing/s | ~0.67 each brute       | 1.5 brute evenly        | 1.5 each brute         |
|         Metabolism rate | 0.5u/s                 | 0.5u/s                  | 0.5u/s                 |
|                      OD | 15                     | 15                      | 10                     |

Save for the OD threshold lowering, bicaridine has been buffed from both of the previous iterations. This may seem strange considering what I said above, however, I think it makes sense given the changes I made to advanced brute chems (see below).

The idea is to make bicaridine the chemical of choice for patients that have more than one type of brute damage. When a patient has two or three types of brute damage, bicaridine is faster than advanced brute chems, otherwise it's slower.

The OD has been lowered to 10 to balance the buffs, as well as to encourage doctors to mix bicaridine with advanced brute chems. I intentionally made the OD 10, as opposed to something like 10.5, since I think the patient jittering for one second and getting a tiny amount of poison damage when you inject bicaridine is kinda funny, and it's not as annoying as some of the other OD effects.

### Bruizine

| Bruizine                | Pre-#38811             | Post-#38811            | Slam's PR              | This PR                |
|-------------------------|------------------------|------------------------|------------------------|------------------------|
|              Healing/5u | 35 blunt               | 30 blunt               | 40 blunt               | 45 blunt               |
|               Healing/s | 3.5 blunt              | 0.6 blunt              | 2 blunt                | 2.25 blunt             |
|         Metabolism rate | 0.5u/s                 | 0.1u/s                 | 0.25u/s                | 0.25u/s                |
|                      OD | 10.5                   | 19                     | 12                     | 10.5                   |
|                Downside | None                   | None                   | -0.33x thirst/s        | None                   |

The advanced brute chems, as well as some other chems mentioned later had their metabolism rate decreased to 0.25u/s, while increasing their healing per unit values. This is a middleground between the original 0.5u/s rate and the #38811 0.1u/s rate. Compared to how these chems originally were, they heal slower, but heal more per unit.

The metabolism rate of 0.25u/s is also convenient for creating mixes, as it is half of the default 0.5u/s metabolism rate, meaning that a mix of a 0.5u/s and 0.25u/s chemicals would have a 2:1 ratio (compared to the 5:1 ratio of 0.5 and 0.1). Mixes of such a ratio can be created easily in a syringe (for example, 10u bicaridine and 5u bruizine for fast blunt damage healing)

OD has been reverted to the original value to balance the better healing per unit.

### Lacerinol

| Lacerinol               | Pre-#38811             | Post-#38811            | Slam's PR              | This PR                |
|-------------------------|------------------------|------------------------|------------------------|------------------------|
|              Healing/5u | 30 slash               | 30 slash               | 40 slash               | 40 slash               |
|               Healing/s | 3 slash                | 0.6 slash              | 2 slash                | 2 slash                |
|         Metabolism rate | 0.5u/s                 | 0.1u/s                 | 0.25u/s                | 0.25u/s                |
|                      OD | 12                     | 21                     | 13                     | 12                     |
|             Downside/5u | None                   | None                   | 4 heat                 | None                   |

See bruizine section. It's worth noting that, unlike #38811, I opted to keep the healing of advanced brute chems (and some similar groups of chems) inconsistent with each other, as I think it makes them feel a little less artificial/videogamey.

### Puncturase

| Puncturase              | Pre-#38811             | Post-#38811            | Slam's PR              | This PR                |
|-------------------------|------------------------|------------------------|------------------------|------------------------|
|              Healing/5u | 40 piercing            | 30 piercing            | 40 piercing            | 50 piercing            |
|               Healing/s | 4 piercing             | 0.6 piercing           | 2 piercing             | 2.5 piercing           |
|         Metabolism rate | 0.5u/s                 | 0.1u/s                 | 0.25u/s                | 0.25u/s                |
|                      OD | 12                     | 21                     | 15.5                   | 12                     |
|             Downside/5u | 1 blunt                | 2.5 blunt              | 1.2 genetic            | 5 blunt                |

See bruizine and lacerinol. The side effect blunt damage has been increased, both to compensate for better healing, and to encourage doctors to mix it with bicaridine (or alternatively just patching the side effect damage with bruise packs)

### Dermaline

| Dermaline               | (Unchanged by #38811 or this PR)                                         |
|-------------------------|--------------------------------------------------------------------------|
|              Healing/5u | 15 heat/shock/cold                                                       |
|               Healing/s | 1.5 heat/shock/cold                                                      |
|         Metabolism rate | 0.5u/s                                                                   |
|                      OD | 10                                                                       |

The original dermaline values happened to already be perfect for this rebalance. Dermaline serves the same role as bicaridine, but for heat/shock/cold damage, and, incidentally, has identical healing properties.

### Pyrazine

| Pyrazine                | Before this PR                                  | This PR                |
|-------------------------|-------------------------------------------------|------------------------|
|              Healing/5u | 50 heat                                         | 40 heat                |
|               Healing/s | 1 heat                                          | 2 heat                 |
|         Metabolism rate | 0.1u/s                                          | 0.25u/s                |
|                      OD | 15                                              | 16                     |

Pyrazine's increased speed should hopefully make it less annoying to use than its current iteration. The healing per unit has been lowered to account for that.

Pyrazine has two OD thresholds: 10% vomit chance at 15u, and damage at 20u. Personally, I think the vomiting is a significant enough effect to consider 15 to be pyrazine's OD, as vomiting removes reagents from the metabolizer, which lowers pyrazine's own healing, as well as the healing of any other chems injected. I personally found it annoying that there was a chance of the patient vomiting immediately after injecting a full syringe of pyrazine, so I increased the OD threshold to 16.

### Leporazine

| Leporazine              | Before this PR                                  | This PR                |
|-------------------------|-------------------------------------------------|------------------------|
|              Healing/5u | 40 cold                                         | 40 cold                |
|               Healing/s | 4 cold                                          | 2 cold                 |
|         Metabolism rate | 0.5u/s                                          | 0.25u/s                |
|                      OD | None                                            | None                   |

Leporazine's speed was cut in half. As it already had very strong healing, as well as no OD or side effects (kind of, more on the heat change thing later), I think it's reasonable to give it a direct nerf.

Leporazine also has a secondary effect of adjusting the metabolizer's thermal energy. This effect is known to be somewhat jank, and should probably be reworked, but at the time of writing this, I am tired of working on this PR, so I simply halved the values, the same as I did with this chemical's healing per second.

### Insuzine

| Insuzine                | Pre-#38811             | Post-#38811            | Slam's PR              | This PR                |
|-------------------------|------------------------|------------------------|------------------------|------------------------|
|              Healing/5u | 40 shock               | 25 shock               | 35 shock               | 30 shock               |
|               Healing/s | 4 shock                | 0.5 shock              | 1.4 shock              | 1.5 shock              |
|         Metabolism rate | 0.5u/s                 | 0.1u/s                 | 0.2u/s                 | 0.25u/s                |
|                      OD | 12                     | 15.5                   | 12                     | 12                     |

Insuzine was never a particularly useful chemical, as high shock damage situations are very rare. Compared to its original iteration, it has been directly nerfed. I think shock damage should be slightly harder to heal than heat and cold (see pyrazine and leporazine)

### Sigynate

| Sigynate                | Pre-#38811             | Post-#38811            | Slam's PR              | This PR                |
|-------------------------|------------------------|------------------------|------------------------|------------------------|
|              Healing/5u | 30 caustic             | 30 caustic             | 30 caustic             | 25 caustic             |
|               Healing/s | 3 cold                 | 0.6 caustic            | 1.5 caustic            | 1.25 caustic           |
|         Metabolism rate | 0.5u/s                 | 0.1u/s                 | 0.25u/s                | 0.25u/s                |
|                      OD | 16                     | 21                     | 16                     | 16                     |

Similar to insuzine. Caustic damage should be the hardest burn damage type to heal, so this chemical has been given the worst healing of the advanced burn chems.

I also removed its negative reaction with arithrazine, as many people don't even know about it, and It seems to only exist to make phalanxamine harder to use.

(insert siderlac mention here)

### Dylovene

| Dylovene                | (Unchanged by #38811 or this PR)                                         |
|-------------------------|--------------------------------------------------------------------------|
|              Healing/5u | 10 poison                                                                |
|               Healing/s | 1 poison                                                                 |
|         Metabolism rate | 0.5u/s                                                                   |
|                      OD | 20 (drunkenness at 15)                                                   |

Dylovene was, and remains, a pretty bad chemical. This is due to more powerful poison chems having significant side effects (diphenhydramine, ultravasculine), and/or requiring botany (stellibinin, ultravasculine).

I think it's good to have a side-effect-free chemical specifically for low amounts of poison damage (e.g. minor snake bites, vox breathing). For a similar case, see hyronalin.

Many medbays will only have dylovene as their poison damage option, due to the difficulties of getting other poison chems. Such medbays will have trouble dealing with, for example, alcohol poisoning. This already does, and will continue, to create interesting and stressful situations in the medbay.

### Diphenhydramine

| Diphenhydramine         | Before this PR                                  | This PR                |
|-------------------------|-------------------------------------------------|------------------------|
|              Healing/5u | 30 poison                                       | 30 poison              |
|               Healing/s | 3 poison                                        | 3 poison               |
|         Metabolism rate | 0.5u/s                                          | 0.5u/s                 |
|                      OD | None                                            | 15.5                   |
|             Downside/5u | 15 secs of drowsiness                           | 30 secs of drowsiness  |

Drowsiness side effect duration was doubled to encourage using dylovene for low poison situations, or, getting stellibinin from botany for a side-effect-free alternative.

Mostly for flavor, added an OD effect after the 15.5 threshold, causing hallucinations and vomiting, [which seems to be at least somewhat realistic](https://en.wikipedia.org/wiki/Diphenhydramine#Overdose).

### Stellibinin

| Stellibinin             | (Unchanged by #38811 or this PR)                                         |
|-------------------------|--------------------------------------------------------------------------|
|              Healing/5u | 40 poison                                                                |
|               Healing/s | 4 poison                                                                 |
|         Metabolism rate | 0.5u/s                                                                   |
|                      OD | None                                                                     |

Chems obtained through botany should be more powerful than those that chemists can create by themselves, since they are more limited in quantity, and they require interdepartmental cooperation.

### Ultravasculine

| Ultravasculine          | Pre-#38811             | Post-#38811            | Slam's PR              | This PR                |
|-------------------------|------------------------|------------------------|------------------------|------------------------|
|              Healing/5u | 15 poison/rads         | 15 poison/rads         | 30 toxin evenly        | 60 toxin evenly        |
|               Healing/s | 1.5 poison/rads        | 0.75 poison/rads       | 1.5 toxin evenly       | 6 toxin evenly         |
|         Metabolism rate | 0.5u/s                 | 0.25u/s                | 0.25u/s                | 0.5u/s                 |
|                      OD | 30                     | 30                     | 30                     | 20                     |
|             Downside/5u | ~1.7 each brute        | ~1.7 each brute        | None                   | 5 each brute           |

Ultravasculine has always been an extremely bad chemical, having only slightly better healing than dylovene and hyronalin, while also being a botany chem, making it more difficult to obtain. If you're going to ask botany for a poison chem, you might as well ask for stellibinin, as it's better for healing poison in every regard, and you get slightly more per plant.

As such, I've decided to make ultravasculine both the best poison and the best radiation chem in terms of both speed and healing per unit. I've balanced it by making its brute damage side effect more severe (it's also worth keeping in mind that any chemical that deals slash or piercing also causes bleeding).

The OD threshold has also been lowered. In my opinion, OD thresholds above 20 are basically impossible to reach accidentally, so they might as well not exist for the purposes of healing.

### Hyronalin

| Hyronalin               | Before this PR                                 | This PR                 |
|-------------------------|------------------------------------------------|-------------------------|
|              Healing/5u | 10 radiation                                   | 10 radiation            |
|               Healing/s | 1 radiation                                    | 1 radiation             |
|         Metabolism rate | 0.5u/s                                         | 0.5u/s                  |
|                      OD | 30                                             | 20                      |
|                Downside | Chance to vomit: 2%/s, ~18%/5u, ~45%/15u       | 1%/s, ~10%/5u, ~26%/15u |

Hyronalin is essentially dylovene for radiation damage. Personally, I already use it myself, since it's quite common to get patients with very small amounts of radiation damage (engineers and scientists).

Vomiting chance has been lowered to make this chem a little more viable. OD threshold lowered for the same reasons as ultravasculine.

### Arithrazine

| Arithrazine             | Before this PR                                  | This PR                |
|-------------------------|-------------------------------------------------|------------------------|
|              Healing/5u | 30 radiation                                    | 30 radiation           |
|               Healing/s | 3 radiation                                     | 3 radiation            |
|         Metabolism rate | 0.5u/s                                          | 0.5u/s                 |
|                      OD | None                                            | None                   |
|             Downside/5u | 5 each brute                                    | 3 each brute           |

   Downside made less severe in order to make arithrazine not strictly worse than ultravasculine.

### Dexalin plus

| Dexalin plus            | Before this PR                 | This PR                                 |
|-------------------------|--------------------------------|-----------------------------------------|
|              Healing/5u | 35 asphyxiation, 30 bloodloss  | 30 asphyxiation, 15 bloodloss           |
|               Healing/s | 3.5 asphyxiation, 3 bloodloss  | 3 asphyxiation, 1.5 bloodloss           |
|         Metabolism rate | 0.5u/s                         | 0.5u/s                                  |
|                      OD | 25                             | 20                                      |

I feel somewhat conflicted nerfing dexalin plus's bloodloss damage healing, as there seems to be a lot of confusion among less experienced doctors surrounding this damage type (confusing bloodloss damage and blood level loss; not knowing that bloodloss damage is a subtype of airloss damage, and thus confusing airloss and asphyxiation or thinking they are the same thing; not even knowing that dexalin plus heals bloodloss at all).

Still, I decided to do this, since getting a large amount of bloodloss damage should be a serious enough condition to be somewhat difficult to heal.

These changes also make dexalin plus exactly 3 times more effective than regular dexalin (which I left untouched by this PR, as I have no idea how to make it useful).

### Phalanxamine

| Phalanxamine            | Before this PR                                  | This PR                |
|-------------------------|-------------------------------------------------|------------------------|
|              Healing/5u | 15 genetic                                      | 15 genetic             |
|               Healing/s | 0.3 genetic                                     | 0.75 genetic           |
|         Metabolism rate | 0.1u/s                                          | 0.25u/s                |
|                      OD | 11                                              | 11                     |
|             Downside/5u | 7.5 radiation/caustic                           | 5 radiation/caustic    |

Phalanxamine is so bad, it's basically not worth making, as it's obsoleted by doxarubixadone. Currently, it basically exchanges genetic damage for radiation and caustic (two damage types that are quite annoying to heal without omnizine), and does so very slowly.

Still, I understand that genetic is supposed to be the hardest damage type to heal, so I didn't buff phalanxamine too much. My nerfs to doxarubixadone (see below) should hopefully make phalanxamine at least somewhat viable.

I also removed its negative reaction with arithrazine, as many people don't even know about it, and I think it's way too punishing for a chemical that is so hard to use already.

### Cryoxadone

| Cryoxadone              | Before this PR                                                | This PR                             |
|-------------------------|---------------------------------------------------------------|-------------------------------------|
|              Healing/5u | 30 each airloss, ~13 each brute, 15 each burn, 20 each toxin  | 20 brute/burn/toxin/airloss evenly  |
|               Healing/s | 3 each airloss, ~1.3 each brute, 1.5 each burn, 2 each toxin  | 2 brute/burn/toxin/airloss evenly   |
|         Metabolism rate | 0.5u/s                                                        | 0.5u/s                              |

By nerfing so many chemicals, #38811 made cryo much better in comparison, and a lot of people seem to enjoy that from my experience. For this reason, I'm making cryox have the same healing as omnizine. It is still by no means the fastest option for many, if not most situations, but it will be very good for patients with many types of damage, or for overloaded medbays with too many patients and not enough doctors. I also think it wasn't very intuitive that cryoxadone healed airloss and toxin better than brute and burn, and I don't think this was intended by those who programmed it to work this way.

This also makes cryoxadone much easier to label and to ration in needed quantities.

### Aloxadone

| Aloxadone               | Before this PR                                                | This PR                             |
|-------------------------|---------------------------------------------------------------|-------------------------------------|
|              Healing/5u | 40 heat/cold/shock, 15 caustic                                | 80 burn evenly                      |
|               Healing/s | 4 heat/cold/shock, 1.5 caustic                                | 8 burn evenly                       |
|         Metabolism rate | 0.5u/s                                                        | 0.5u/s                              |

Needing to heal heat or cold damage in the orders of 1000s is something that is needed occasionally, and I'd consider the original aloxadone not good enough for the task, especially since it requires botany.

As with cryoxadone, this also makes this it easier to label.

### Necrosol

| Necrosol                | Before this PR                                                | This PR                             |
|-------------------------|---------------------------------------------------------------|-------------------------------------|
|              Healing/5u | 20 poison, ~13 each brute, 12.5 each burn                     | 40 brute/burn/toxin/airloss evenly  |
|               Healing/s | 2 poison, ~1.3 each brute, 1.25 each burn                     | 4 brute/burn/toxin/airloss evenly   |
|         Metabolism rate | 0.5u/s                                                        | 0.5u/s                              |

Necrosol is a fairly strange chemical, with, ~~unironically~~, the biggest reason to use it being healing poison damage on a dead person. I've made its healing double that of cryoxadone and omnizine, given that both are precursors to it. This also means that it can now heal radiation on dead people, as well as being a better option for bloodloss than blood packs (I think most players don't even know that blood packs heal 0.5 bloodloss)

It will still likely remain a very niche chemical, as getting it in the first place requires either getting omnizine and a decent amount of blood, or killing a revenant.

### Doxarubixadone

| Doxarubixadone          | Before this PR                                                | This PR                             |
|-------------------------|---------------------------------------------------------------|-------------------------------------|
|              Healing/5u | 20 genetic                                                    | 15 genetic                          |
|               Healing/s | 2 genetic                                                     | 1.5 genetic                         |
|         Metabolism rate | 0.5u/s                                                        | 0.5u/s                              |
|             Downside/5u | None                                                          | 2 each brute                        |

See phalanxamine. As mentioned, genetic is supposed to be hard to heal, but doxarubixadone trivialized it (healing per unit may seem to be bad, but genetic rarely occurs in large quantities).

The brute damage side effect causes slight bleeding, and adds another perfect opportunity to use bicaridine.

~~dox a rubik's cube ixadone~~

(TODO: polypyrylium oligomers)

---------------------------------------------------------------

Some OD effects were changed to account for changed metabolism rates. I didn't put as much thought into those specific values, just made them more or less proportional to how they were originally.

Everyone's perspective on what is good and what is bad in medical is different, and as such, I welcome feedback regarding these changes, especially from experienced doctor/paramed/CMO players (I'm a chem main myself, so while I have a lot of experience in this topic, people who play these roles would probably know better than me).

## Technical details

YAML changes

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Many medical chems have been rebalanced by adjusting their healing and metabolism rates.

