### PR TITLE
Make ichor heal brute, burn, and toxin evenly

### DIFF
--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -168,13 +168,13 @@
         amount: 3
       - !type:EvenHealthChange
         damage:
-          Burn: -5
-          Brute: -5
+          Burn: -3
+          Brute: -3
           Toxin: -2
       - !type:HealthChange
         damage:
           types:
-            Bloodloss: -5
+            Bloodloss: -3
       - !type:ModifyBleedAmount
         amount: -1.5
   # Just in case you REALLY want to water your plants

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -166,12 +166,13 @@
     # Dragon doesn't require airloss healing, so omnizine is still best for humans.
       - !type:ModifyBloodLevel
         amount: 3
+      - !type:EvenHealthChange
+        damage:
+          Burn: -5
+          Brute: -5
+          Toxin: -2
       - !type:HealthChange
         damage:
-          groups:
-            Burn: -5
-            Brute: -5
-            Toxin: -2
           types:
             Bloodloss: -5
       - !type:ModifyBleedAmount


### PR DESCRIPTION
## About the PR

While working on #39464 I realized that when #37129 added EvenHealthChange, it was only given to omnizine, and not to ichor, which is clearly supposed to be better omnizine (minus the fact that it doesn't heal asphyxiation), so I fixed that.

## Technical details

Small YAML change

## Media

### Before
<img width="638" height="330" src="https://github.com/user-attachments/assets/62946177-5902-494a-a680-0812679d09f5" />

### After
<img width="638" height="330" src="https://github.com/user-attachments/assets/b7c3297f-71e8-4967-b971-69688dee491e" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- tweak: Ichor now heals damage evenly, similarly to omnizine
