### PR TITLE
StationRecords: Use substring match for fingerprint/DNA filters

### DIFF
--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -407,7 +407,9 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
 
     private bool IsFilterWithSomeCodeValue(string value, string filter)
     {
-        return !value.ToLower().StartsWith(filter);
+        // Use contains like other filters (name/job/species) instead of a stricter starts-with check.
+        // This fixes filtering for fingerprints/DNA requiring only prefixes to match.
+        return !value.ToLower().Contains(filter);
     }
 
     /// <summary>


### PR DESCRIPTION
…ad of prefix to align with other filters and improve search usability

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

StationRecords: Use substring match for fingerprint/DNA filters

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->



Previously, `IsFilterWithSomeCodeValue` used `StartsWith` for fingerprint/DNA
filtering, while other filters (Name/Job/Species) used substring matching.
This made searches for prints/DNA fail unless the query matched from the
beginning of the value, leading to inconsistent UX and poor discoverability.

This change switches to `Contains` for fingerprint/DNA, aligning behavior
across all filters and making partial/middle searches work as expected.

- File: `Content.Server/StationRecords/Systems/StationRecordsSystem.cs`
- Change: `StartsWith` -> `Contains` in `IsFilterWithSomeCodeValue`
- Impact: Case-insensitive, server-side only; no UI/API changes; same O(n)
  scan as before.
## Technical details
<!-- Summary of code changes for easier review. -->

- **File**: `Content.Server/StationRecords/Systems/StationRecordsSystem.cs`
- **Method**: `IsFilterWithSomeCodeValue(string value, string filter)`
- **Change**: Relaxed match from prefix-only to substring.
  - Before: `!value.ToLower().StartsWith(filter)`
  - After: `!value.ToLower().Contains(filter)`
- **Scope**: Affects fingerprint and DNA filters only; other filters unchanged.
- **Behavior**: Fingerprint/DNA searches now match any part of the value, aligning with Name/Job/Species filters.



## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
