### PR TITLE
Fix storage UI regression

### DIFF
--- a/Content.Client/Storage/Systems/StorageSystem.cs
+++ b/Content.Client/Storage/Systems/StorageSystem.cs
@@ -19,8 +19,6 @@ public sealed class StorageSystem : SharedStorageSystem
 
     private Dictionary<EntityUid, ItemStorageLocation> _oldStoredItems = new();
 
-    private List<(StorageBoundUserInterface Bui, bool Value)> _queuedBuis = new();
-
     public override void Initialize()
     {
         base.Initialize();
@@ -81,7 +79,7 @@ public sealed class StorageSystem : SharedStorageSystem
             if (NestedStorage && player != null && ContainerSystem.TryGetContainingContainer((uid, null, null), out var container) &&
                 UI.TryGetOpenUi<StorageBoundUserInterface>(container.Owner, StorageComponent.StorageUiKey.Key, out var containerBui))
             {
-                _queuedBuis.Add((containerBui, false));
+                containerBui.Hide();
             }
         }
     }
@@ -98,7 +96,7 @@ public sealed class StorageSystem : SharedStorageSystem
     {
         if (UI.TryGetOpenUi<StorageBoundUserInterface>(uid, StorageComponent.StorageUiKey.Key, out var storageBui))
         {
-            _queuedBuis.Add((storageBui, false));
+            storageBui.Hide();
         }
     }
 
@@ -106,7 +104,7 @@ public sealed class StorageSystem : SharedStorageSystem
     {
         if (UI.TryGetOpenUi<StorageBoundUserInterface>(uid, StorageComponent.StorageUiKey.Key, out var storageBui))
         {
-            _queuedBuis.Add((storageBui, true));
+            storageBui.Show();
         }
     }
 
@@ -160,31 +158,5 @@ public sealed class StorageSystem : SharedStorageSystem
                 _entityPickupAnimation.AnimateEntityPickup(entity, GetCoordinates(initialPosition), transformComp.LocalPosition, msg.EntityAngles[i]);
             }
         }
-    }
-
-    public override void Update(float frameTime)
-    {
-        base.Update(frameTime);
-
-        if (!_timing.IsFirstTimePredicted)
-        {
-            return;
-        }
-
-        // This update loop exists just to synchronize with UISystem and avoid 1-tick delays.
-        // If deferred opens / closes ever get removed you can dump this.
-        foreach (var (bui, open) in _queuedBuis)
-        {
-            if (open)
-            {
-                bui.Show();
-            }
-            else
-            {
-                bui.Hide();
-            }
-        }
-
-        _queuedBuis.Clear();
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes a regression causing storage windows to get parented incorrectly in a 2-container setup.

## Technical details
The storage UI controller judges which of its children has no visible elements to determine where a new window should go. Deferring the visibility update interferes with this.

## Media
Intended behaviour (before faulty code, fixed after removal):
<img width="974" height="291" alt="grafik" src="https://github.com/user-attachments/assets/d0f1183b-db9e-4b1d-b85b-05a4602a7806" />

Incorrect behaviour (with faulty code):
<img width="974" height="291" alt="grafik" src="https://github.com/user-attachments/assets/10bced9c-5d72-4728-9211-611da7422095" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Storage UIs in a two-window setup no longer always stick to the right of the hotbar when opening children

<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
