### PR TITLE
Fix Loud Disposals

### DIFF
--- a/Content.Shared/Disposal/Unit/DisposalUnitComponent.cs
+++ b/Content.Shared/Disposal/Unit/DisposalUnitComponent.cs
@@ -82,6 +82,12 @@ public sealed partial class DisposalUnitComponent : Component
     [DataField, AutoNetworkedField]
     public TimeSpan LastExitAttempt;
 
+    /// <summary>
+    /// Last time an item was inserted into this disposal unit.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastInsertion;
+
     [DataField]
     public bool AutomaticEngage = true;
 

--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
@@ -30,6 +30,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -62,6 +63,7 @@ public abstract class SharedDisposalUnitSystem : EntitySystem
     [Dependency] private   readonly SharedMapSystem _map = default!;
 
     protected static TimeSpan ExitAttemptDelay = TimeSpan.FromSeconds(0.5);
+    protected static TimeSpan DisposalSoundDelay = TimeSpan.FromSeconds(0.1);
 
     // Percentage
     public const float PressurePerSecond = 0.05f;
@@ -484,7 +486,10 @@ public abstract class SharedDisposalUnitSystem : EntitySystem
         EntityUid? user = null,
         bool doInsert = false)
     {
-        Audio.PlayPredicted(component.InsertSound, uid, user: user);
+        if (GameTiming.CurTime > component.LastInsertion + DisposalSoundDelay)
+            Audio.PlayPredicted(component.InsertSound, uid, user: user);
+
+        component.LastInsertion = GameTiming.CurTime;
         if (doInsert && !Containers.Insert(inserted, component.Container))
             return;
 


### PR DESCRIPTION
## About the PR
Fixes disposals insertion sound effect stacking, which get very loud.

## Why
When inserting a trash bag into a disposal unit, it plays an increasingly loud noise the more items there are in the bag. I am aware of another pull request that fixes this issue, I was hoping this could be a faster solution without changing much of the disposals code.

## Technical details
I added an if statement that checks how recently an item has been inserted, then only allow the insertion sound effect to play if another item hasn't been inserted within 0.1 seconds. 

## Media
Without Change:
https://github.com/user-attachments/assets/6018264a-3879-4218-8b7e-5fa60e56d1fc

With Change:
https://github.com/user-attachments/assets/9b2a38b9-bf54-4489-b5a5-f29791fdcc39

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl: joeshmoe22
- fix: Fixed disposals being extremely loud when inserting many items with a trash bag
