### PR TITLE
Add test of disposal unit throw-insert behavior

### DIFF
--- a/Content.IntegrationTests/Tests/Disposal/DisposalUnitInteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Disposal/DisposalUnitInteractionTest.cs
@@ -1,0 +1,58 @@
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Server.Containers;
+using Robust.Shared.Containers;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Disposal;
+
+public sealed class DisposalUnitInteractionTest : InteractionTest
+{
+    private static readonly EntProtoId DisposalUnit = "DisposalUnit";
+    private static readonly EntProtoId TrashItem = "BrokenBottle";
+
+    private const string TestDisposalUnitId = "TestDisposalUnit";
+
+    [TestPrototypes]
+    private static readonly string TestPrototypes = $@"
+# A modified disposal unit with a 100% chance of a thrown item being inserted
+- type: entity
+  parent: {DisposalUnit.Id}
+  id: {TestDisposalUnitId}
+  components:
+  - type: ThrowInsertContainer
+    probability: 1
+";
+
+    /// <summary>
+    /// Spawns a disposal unit, gives the player a trash item, and makes the
+    /// player throw the item at the disposal unit.
+    /// After a short delay, verifies that the thrown item is contained inside
+    /// the disposal unit.
+    /// </summary>
+    [Test]
+    public async Task ThrowItemIntoDisposalUnitTest()
+    {
+        var containerSys = Server.System<SharedContainerSystem>();
+
+        // Spawn the target disposal unit
+        var disposalUnit = await SpawnTarget(TestDisposalUnitId);
+
+        // Make sure the disposal unit is empty
+        var throwInsertComp = Comp<ThrowInsertContainerComponent>();
+        var container = containerSys.GetContainer(ToServer(disposalUnit), throwInsertComp.ContainerId);
+        Assert.That(container.ContainedEntities, Is.Empty,
+            "Disposal unit was not empty at start of test");
+
+        // Give the player some trash to throw
+        var trash = await PlaceInHands(TrashItem);
+
+        // Throw the item at the disposal unit
+        await ThrowItem();
+
+        // Wait a moment
+        await RunTicks(10);
+
+        // Make sure the trash is in the disposal unit
+        Assert.That(container.ContainedEntities, Contains.Item(ToServer(trash)));
+    }
+}

--- a/Content.IntegrationTests/Tests/Disposal/DisposalUnitInteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Disposal/DisposalUnitInteractionTest.cs
@@ -37,12 +37,6 @@ public sealed class DisposalUnitInteractionTest : InteractionTest
         // Spawn the target disposal unit
         var disposalUnit = await SpawnTarget(TestDisposalUnitId);
 
-        // Make sure the disposal unit is empty
-        var throwInsertComp = Comp<ThrowInsertContainerComponent>();
-        var container = containerSys.GetContainer(ToServer(disposalUnit), throwInsertComp.ContainerId);
-        Assert.That(container.ContainedEntities, Is.Empty,
-            "Disposal unit was not empty at start of test");
-
         // Give the player some trash to throw
         var trash = await PlaceInHands(TrashItem);
 
@@ -53,6 +47,8 @@ public sealed class DisposalUnitInteractionTest : InteractionTest
         await RunTicks(10);
 
         // Make sure the trash is in the disposal unit
+        var throwInsertComp = Comp<ThrowInsertContainerComponent>();
+        var container = containerSys.GetContainer(ToServer(disposalUnit), throwInsertComp.ContainerId);
         Assert.That(container.ContainedEntities, Contains.Item(ToServer(trash)));
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds an interaction test that verifies that items can be thrown into disposal units.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This behavior has broken in the past (https://github.com/space-wizards/space-station-14/pull/38106). This simple test will help make sure it doesn't break again.

## Technical details
<!-- Summary of code changes for easier review. -->
In order make the test deterministic, the test yaml defines a new entity prototype that modifies the normal disposal unit so it has a 100% chance of a thrown item being inserted into the container.

The test itself spawns the modified disposal unit and gives the player a trash item (`BrokenBottle`). The test makes the player throw the item at the disposal unit, waits a few ticks, then verifies that the trash item is inside the disposal unit.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->