### PR TITLE
Fix: Water Bottles Verb Priority and Prediction

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
@@ -117,7 +117,7 @@ public sealed partial class IngestionSystem
 
     private void OnOpenableEdible(Entity<OpenableComponent> ent, ref EdibleEvent args)
     {
-        if (_openable.IsClosed(ent, args.User, ent.Comp))
+        if (_openable.IsClosed(ent, args.User, ent.Comp, predicted: true))
             args.Cancelled = true;
     }
 

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
@@ -7,6 +7,7 @@ using Content.Shared.Interaction.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Storage;
+using Content.Shared.Weapons.Ranged.Systems;
 
 namespace Content.Shared.Nutrition.EntitySystems;
 
@@ -117,6 +118,9 @@ public sealed partial class IngestionSystem
 
     private void OnOpenableEdible(Entity<OpenableComponent> ent, ref EdibleEvent args)
     {
+        if (args.Cancelled)
+            return;
+
         if (_openable.IsClosed(ent, args.User, ent.Comp, predicted: true))
             args.Cancelled = true;
     }

--- a/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
@@ -104,7 +104,7 @@ public sealed partial class OpenableSystem : EntitySystem
                 Text = Loc.GetString(comp.CloseVerbText),
                 Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/close.svg.192dpi.png")),
                 Act = () => TryClose(args.Target, comp, args.User),
-                Priority = 2
+                Priority = 3
             };
         }
         else

--- a/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
@@ -104,7 +104,7 @@ public sealed partial class OpenableSystem : EntitySystem
                 Text = Loc.GetString(comp.CloseVerbText),
                 Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/close.svg.192dpi.png")),
                 Act = () => TryClose(args.Target, comp, args.User),
-                // this verb is lower priority than drink verb (2) so it doesn't conflict
+                Priority = 2
             };
         }
         else
@@ -113,7 +113,8 @@ public sealed partial class OpenableSystem : EntitySystem
             {
                 Text = Loc.GetString(comp.OpenVerbText),
                 Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/open.svg.192dpi.png")),
-                Act = () => TryOpen(args.Target, comp, args.User)
+                Act = () => TryOpen(args.Target, comp, args.User),
+                Priority = 3
             };
         }
         args.Verbs.Add(verb);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes #39480

PR is not as cool as the title sounds, fixed popups for openable not being predicted in IngestionSystem, and changed verb priority for opening and closing to feel a bit better.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
You'd think you could use alt interact to close something but you can't. Opening and closing now takes priority over eating and drinking when alt interacting over drinking and removed the comment that said it was lower priority because I'm not sure why it was ever the case? Mice can still alt interact to drink from bottles because they don't have hands so they never get the verb. 

## Technical details
<!-- Summary of code changes for easier review. -->
Added predicted: true to IsClosed check.

Increased the priority of opening and closing verbs by to 3 for open and 2 for close.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
