### PR TITLE
fix for #39480: Alt-Interact now prefers open/close over drink;

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
@@ -352,6 +352,7 @@ public sealed partial class IngestionSystem
             },
             Icon = proto.VerbIcon,
             Text = Loc.GetString(proto.VerbName),
+            // Make ingest lower priority than open/close (3) so Alt-Interact prefers toggle when present
             Priority = 2
         };
 

--- a/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
@@ -104,7 +104,8 @@ public sealed partial class OpenableSystem : EntitySystem
                 Text = Loc.GetString(comp.CloseVerbText),
                 Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/close.svg.192dpi.png")),
                 Act = () => TryClose(args.Target, comp, args.User),
-                // this verb is lower priority than drink verb (2) so it doesn't conflict
+                // Ensure open/close takes precedence over ingest (priority 2)
+                Priority = 3
             };
         }
         else
@@ -113,7 +114,9 @@ public sealed partial class OpenableSystem : EntitySystem
             {
                 Text = Loc.GetString(comp.OpenVerbText),
                 Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/open.svg.192dpi.png")),
-                Act = () => TryOpen(args.Target, comp, args.User)
+                Act = () => TryOpen(args.Target, comp, args.User),
+                // Ensure open takes precedence over ingest (priority 2)
+                Priority = 3
             };
         }
         args.Verbs.Add(verb);

--- a/Content.Shared/Nutrition/EntitySystems/SharedDrinkSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SharedDrinkSystem.cs
@@ -170,10 +170,24 @@ public abstract partial class SharedDrinkSystem : EntitySystem
         if (args.Cancelled || args.Solution != null)
             return;
 
-        if (!_solutionContainer.TryGetSolution(drink.Owner, drink.Comp.Solution, out args.Solution) || IsEmpty(drink))
+        if (!_solutionContainer.TryGetSolution(drink.Owner, drink.Comp.Solution, out args.Solution))
         {
             args.Cancelled = true;
+            _popup.PopupClient(Loc.GetString("ingestion-try-use-is-empty", ("entity", drink)), drink, args.User);
+            return;
+        }
 
+        // If the container is closed, prefer the closed message and return early to avoid double popups
+        if (TryComp<OpenableComponent>(drink, out var openable) && !openable.Opened)
+        {
+            args.Cancelled = true;
+            _popup.PopupClient(Loc.GetString(openable.ClosedPopup, ("owner", drink.Owner)), drink, args.User);
+            return;
+        }
+
+        if (IsEmpty(drink))
+        {
+            args.Cancelled = true;
             _popup.PopupClient(Loc.GetString("ingestion-try-use-is-empty", ("entity", drink)), drink, args.User);
             return;
         }


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

fix for #39480
Alt-Interact now prefers open/close over drink; avoid double popups on closed+empty bottles
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The issue was that pressing alt-interact was not doing what it was supposed to be doing. My fixes address this:

Expectation: Bottle is closed
Actual: Attempt to begin drinking

Has now been fixed


## Technical details
<!-- Summary of code changes for easier review. -->
https://github.com/space-wizards/space-station-14/commit/cbc3cead3b74dd726e63d0345f9d47dc9bb2b29a

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
