### PR TITLE
Fix bar and base signs

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: BaseBarSign
-  parent: [ BaseWallmountGlass, BaseWallmountMetallic ]
+  parent: [ BaseWallmountGlass, BaseWallmountMachine ]
   name: bar sign
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
@@ -20,3 +20,5 @@
     snapCardinals: true
   - type: StaticPrice
     price: 20
+  - type: Transform
+    anchored: false

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/base_wallmount.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/base_wallmount.yml
@@ -6,6 +6,8 @@
     snap:
     - Wallmount
   components:
+  - type: Physics
+    canCollide: false
   - type: Clickable
   - type: WallMount
   - type: InteractionOutline


### PR DESCRIPTION
## About the PR
Barsign now works properly. Signs now don't autounchor themselfs.

## Why / Balance
This issue was caused pretty bad cleanup - #34329. The parent of the barsign was BaseWallmountMetallic instead of the BaseWallmountMachine. And signs have the same problem as buttons in the #39425. Also added PhysicsComponent because without them wallmounts can be rotated via verbs.
Fixes #39474

## Technical details
yml

## Media
<img width="516" height="294" alt="wall" src="https://github.com/user-attachments/assets/61ef93f6-ee8c-45bd-ac81-a328890b7b43" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
Let's just forget about this incident and pretend it doesn't affect the gameplay. Okey?