### PR TITLE
perf: dispose of unused render targets in lighting overlays

### DIFF
--- a/Content.Client/Light/BeforeLightTargetOverlay.cs
+++ b/Content.Client/Light/BeforeLightTargetOverlay.cs
@@ -39,6 +39,7 @@ public sealed class BeforeLightTargetOverlay : Overlay
         // This just exists to copy the lightrendertarget and write back to it.
         if (EnlargedLightTarget?.Size != size)
         {
+            EnlargedLightTarget?.Dispose();
             EnlargedLightTarget = _clyde
                 .CreateRenderTarget(size, new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb), name: "enlarged-light-copy");
         }

--- a/Content.Client/Light/LightBlurOverlay.cs
+++ b/Content.Client/Light/LightBlurOverlay.cs
@@ -33,6 +33,7 @@ public sealed class LightBlurOverlay : Overlay
 
         if (_blurTarget?.Size != size)
         {
+            _blurTarget?.Dispose();
             _blurTarget = _clyde
                 .CreateRenderTarget(size, new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb), name: "enlarged-light-blur");
         }

--- a/Content.Client/Light/SunShadowOverlay.cs
+++ b/Content.Client/Light/SunShadowOverlay.cs
@@ -57,6 +57,7 @@ public sealed class SunShadowOverlay : Overlay
 
         if (_target?.Size != targetSize)
         {
+            _target?.Dispose();
             _target = _clyde
                 .CreateRenderTarget(targetSize,
                     new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb),
@@ -64,6 +65,7 @@ public sealed class SunShadowOverlay : Overlay
 
             if (_blurTarget?.Size != targetSize)
             {
+                _blurTarget?.Dispose();
                 _blurTarget = _clyde
                     .CreateRenderTarget(targetSize, new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb), name: "sun-shadow-blur");
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
BeforeLightTargetOverlay, LightBlurOverlay, and SunShadowOverlay were not disposing previously-allocated render targets. This was causing situations when two viewports were visible simultaneously to allocate astounding amounts of memory incredibly quickly... *apparently only on Windows clients.* That part still needs investigation.

The point of discovery was #36969. This ties into space-wizards/RobustToolbox#6100.

Resolves #39470

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
N/A

## Technical details
<!-- Summary of code changes for easier review. -->
RenderTextures are unmanaged objects created by Clyde that are not garbage collected until there is high GC pressure. This makes them easy to leak by forgetting to call Dispose before banishing them to the shadow realm.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Prior to fixing:
<img width="741" height="464" alt="rider64_MbdagVAvNC" src="https://github.com/user-attachments/assets/770ab93b-65b0-422a-b950-3d4a6ef096ce" />

No screenshot for after fix because there's nothing to show. Memory increases from 2.2 GB to 2.5 GB (and falls after closing the second viewport.)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed memory leaking triggered by camera monitors and admin cameras.