### PR TITLE
Network StationMember properly

### DIFF
--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -343,6 +343,7 @@ public sealed partial class StationSystem : SharedStationSystem
         stationMember.Station = station;
         stationData.Grids.Add(mapGrid);
         Dirty(station, stationData);
+        Dirty(mapGrid, stationMember);
 
         RaiseLocalEvent(station, new StationGridAddedEvent(mapGrid, station, false), true);
 

--- a/Content.Shared/Station/Components/StationMemberComponent.cs
+++ b/Content.Shared/Station/Components/StationMemberComponent.cs
@@ -5,12 +5,12 @@ namespace Content.Shared.Station.Components;
 /// <summary>
 /// Indicates that a grid is a member of the given station.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class StationMemberComponent : Component
 {
     /// <summary>
     /// Station that this grid is a part of.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public EntityUid Station = EntityUid.Invalid;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When i put all the station stuff in shared, StationMember got networked to clients but the data wasn't ever replicated. This replicates it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl on fun