### PR TITLE
Emitters now give alerts if interfered with.

### DIFF
--- a/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
@@ -11,7 +11,6 @@ using Content.Shared.Construction;
 using Content.Shared.Database;
 using Content.Shared.Destructible;
 using Content.Shared.DeviceLinking.Events;
-using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Lock;
 using Content.Shared.Popups;
@@ -41,7 +40,6 @@ namespace Content.Server.Singularity.EntitySystems
         [Dependency] private readonly GunSystem _gun = default!;
         [Dependency] private readonly RadioSystem _radio = default!;
         [Dependency] private readonly NavMapSystem _navMap = default!;
-        [Dependency] private readonly LockSystem _lock = default!;
 
         public override void Initialize()
         {

--- a/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
+++ b/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using Content.Shared.DeviceLinking;
+using Content.Shared.Radio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -96,6 +97,14 @@ public sealed partial class EmitterComponent : Component
     /// </summary>
     [DataField]
     public Dictionary<ProtoId<SinkPortPrototype>, EntProtoId> SetTypePorts = new();
+
+    [DataField]
+    public ProtoId<RadioChannelPrototype> RadioChannel = "Engineering";
+
+    [DataField]
+    public bool AlertRadio = false; // is this emitter critical to the station to the point a radio channel should be alerted if anything happens to it (i.e. emitters near singularity/tesla containment)
+
+    public string LastLockInteractingPlayer = "Unknown"; // used to transfer info between LockToggleAttemptEvent and LockToggledEvent.
 }
 
 [NetSerializable, Serializable]

--- a/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
+++ b/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
@@ -103,8 +103,6 @@ public sealed partial class EmitterComponent : Component
 
     [DataField]
     public bool AlertRadio = false; // is this emitter critical to the station to the point a radio channel should be alerted if anything happens to it (i.e. emitters near singularity/tesla containment)
-
-    public string LastLockInteractingPlayer = "Unknown"; // used to transfer info between LockToggleAttemptEvent and LockToggledEvent.
 }
 
 [NetSerializable, Serializable]

--- a/Resources/Locale/en-US/singularity/components/emitter-component.ftl
+++ b/Resources/Locale/en-US/singularity/components/emitter-component.ftl
@@ -13,3 +13,8 @@ comp-emitter-not-anchored = The {$target} isn't anchored to the ground!
 
 emitter-component-current-type = The current selected type is: {$type}.
 emitter-component-type-set = Type set to: {$type}
+
+emitter-destroyed-broadcast = An emitter {$location} has been destroyed.
+emitter-deconstructed-broadcast = An emitter {$location} has been deconstructed.
+emitter-unlocked-broadcast = An emitter {$location} has been unlocked.
+emitter-unpowered-broadcast = An emitter {$location} has lost power.

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -36,6 +36,7 @@
       visible: false
       map: ["enum.LockVisualLayers.Lock"]
   - type: Emitter
+    alertRadio: true
   - type: Gun
     showExamineText: false
     fireRate: 10 #just has to be fast enough to keep up with upgrades
@@ -55,6 +56,9 @@
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: StructuralMetallicStrong
+  - type: ActiveRadio
+    channels:
+    - Engineering
   - type: Destructible
     thresholds:
       - trigger:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Emitters will now tell the Engineering radio if they are destroyed, deconstructed, unlocked or if they lose power, as these actions may end up resulting in a loose. The alert includes the location of the emitter so Engineering know if it's actually an emitter near the containment field or not. The alert is only given if the emitter is both powered and turned on.

## Why / Balance
Serves as a form of mechanical enforcement regarding loosing a Singularity or Tesla by making it harder, as all engineers will now instantly be alerted if the emitters are interfered with, whether sabotage or meteors are responsible. Previously, it was incredibly easy as all it took was cutting a wire, or using a crowbar on an emitter, and if Engineering were not keeping a constant eye on the engine (which, while that's a good idea, never really happens), it would usualyl loose.

## Technical details
The emitter prototype now has an ActiveRadio component.

EmitterComponent now has the AlertRadio field; false by default, but set to true for the emitters used for containment engines. They also have a RadioChannel field, defaulting to Engineering.

EmitterSystem now listens for LockToggledEvent, MachineDeconstructedEvent and DestructionAttemptEvent and alerts the radio accordingly when they happen.

## Media
https://github.com/user-attachments/assets/a92b112e-2788-44e9-b9a9-460ff5c23c17

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
add: Emitters now alert the Engineering radio channel if they are destroyed, deconstructed, lose power or are unlocked.