### PR TITLE
make proximity sensors actually sense, and add more signal keys to proximity triggers

### DIFF
--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnProximityComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnProximityComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Physics;
+using Content.Shared.Trigger.Systems;
 using Robust.Shared.GameStates;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
@@ -12,9 +13,33 @@ namespace Content.Shared.Trigger.Components.Triggers;
 /// The user is the entity that collided with the fixture.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-[AutoGenerateComponentState, AutoGenerateComponentPause]
+[AutoGenerateComponentState(fieldDeltas: true), AutoGenerateComponentPause]
 public sealed partial class TriggerOnProximityComponent : BaseTriggerOnXComponent
 {
+    /// <summary>
+    /// The keys that, upon being triggered, will enable the proximity trigger.
+    /// If this shares a key with <see cref="DisablingKeysIn"/>, this trigger
+    /// will be enabled when that key gets triggered.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<string> EnablingKeysIn = new();
+
+    /// <summary>
+    /// The keys that, upon being triggered, will disable the proximity trigger.
+    /// If this shares a key with <see cref="EnablingKeysIn"/>, this proximity
+    /// will be enabled when that key gets triggered.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<string> DisablingKeysIn = new();
+
+    /// <summary>
+    /// The keys that, upon being triggered, will enable the proximity trigger
+    /// if it is disabled, and disable it if it is enabled. Processes after
+    /// <see cref="DisablingKeysIn"/> and <see cref="EnablingKeysIn"/>.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<string> ToggleKeysIn = new();
+
     /// <summary>
     /// The ID if the fixture that is observed for collisions.
     /// </summary>
@@ -38,6 +63,20 @@ public sealed partial class TriggerOnProximityComponent : BaseTriggerOnXComponen
     /// </summary>
     [DataField, AutoNetworkedField]
     public TimeSpan AnimationDuration = TimeSpan.FromSeconds(0.6f);
+
+    /// <summary>
+    /// Whether an unoccluded line of sight between the proximity trigger and any
+    /// colliding objects is required for it to be triggered.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool RequiresLineOfSight = true;
+
+    /// <summary>
+    /// Should an examiner be told whether this proximity trigger is enabled
+    /// or not?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Examinable = false;
 
     /// <summary>
     /// Whether the entity needs to be anchored for the proximity to work.

--- a/Content.Shared/Trigger/Systems/TriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.cs
@@ -11,6 +11,8 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 using Robust.Shared.Random;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Physics.Components;
+using Content.Shared.Examine;
 
 
 namespace Content.Shared.Trigger.Systems;
@@ -38,12 +40,15 @@ public sealed partial class TriggerSystem : EntitySystem
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
     [Dependency] private readonly ItemToggleSystem _itemToggle = default!;
     [Dependency] private readonly SharedDeviceLinkSystem _deviceLink = default!;
+    [Dependency] private readonly ExamineSystemShared _examineSystem = default!;
 
     public const string DefaultTriggerKey = "trigger";
+    private EntityQuery<PhysicsComponent> _physicsQuery;
 
     public override void Initialize()
     {
         base.Initialize();
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
 
         InitializeCollide();
         InitializeCondition();

--- a/Resources/Locale/en-US/triggers/trigger-on-proximity.ftl
+++ b/Resources/Locale/en-US/triggers/trigger-on-proximity.ftl
@@ -1,0 +1,4 @@
+proximity-trigger-examine = The proximity trigger is {$enabled ->
+[true] [color=red]enabled[/color]
+*[false] [color=green]disabled[/color]
+}.

--- a/Resources/Prototypes/Entities/Objects/Misc/botparts.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/botparts.yml
@@ -2,13 +2,65 @@
   parent: BaseItem
   id: ProximitySensor
   name: proximity sensor
-  description: Senses things in close proximity.
+  description: Senses moving things in close proximity and sends a signal when active. Can be remotely enabled with a signal, bypassing the timer.
   components:
   - type: Sprite
     sprite: Objects/Misc/proximity_sensor.rsi
     state: icon
   - type: Tag
     tags:
-      - ProximitySensor
+    - ProximitySensor
   - type: StaticPrice
     price: 40
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 50
+  - type: TriggerOnUse
+    keyOut: trigger
+  - type: TimerTrigger
+    keysIn:
+    - trigger
+    keyOut: toggle # TODO: add an accompanying popup for proxsensor being toggled, when `PopupOnTrigger` gets added.
+    delay: 3 # borrowed from timertrigger
+    delayOptions: [3, 5, 10, 15, 30, 45, 60]
+    initialBeepDelay: 0
+    beepSound:
+      path: /Audio/Machines/quickbeep.ogg
+      params:
+        volume: -3
+  - type: TriggerOnProximity
+    enabled: false
+    cooldown: 1
+    triggerSpeed: 1.5
+    shape:
+      !type:PhysShapeCircle
+        radius: 3
+    repeating: true
+    examinable: true
+    keyOut: sensor
+    enablingKeysIn:
+    - enable
+    toggleKeysIn:
+    - toggle
+  - type: EmitSoundOnTrigger
+    keysIn:
+    - sensor
+    sound:
+      path: /Audio/Effects/double_beep.ogg
+      params:
+        volume: -1.5
+  - type: DeviceLinkSink
+    ports:
+    - On
+  - type: TriggerOnSignal
+    port: On
+    keyOut: enable
+  - type: DeviceLinkSource
+    ports:
+    - Trigger
+  - type: SignalOnTrigger
+    port: Trigger
+    keysIn:
+    - sensor


### PR DESCRIPTION
## About the PR
proximity sensors are functional now:

prox sensors can be used in-hand to start a timer that will toggle them (enable them if they're disabled, or disable them if they're already enabled), or you can link them up to a signaler to instantly enable them
when enabled, they will send a device signal and beep upon sensing anything moving near them
walking + crawling at full health is enough to avoid it

## Why / Balance
it lets you do cool things
the worst balance concern i could possibly imagine with this is that signals can be used to instantly enable them and bypass the timer but i don't think that really matters

## Technical details
added `EnablingKeysIn` and `DisablingKeysIn` to `TriggerOnProximityComponent`to enable/disable it with triggers. Ditto with `TogglingKeysIn`.

`TriggerOnProximityComponent` now also generates field deltas

also changed a few `TryComp<PhysicsComponent>`s in triggersystem.proximity to use an entityquery instead
rest is either insignificant or just yaml

## Media
https://github.com/user-attachments/assets/97832138-c55e-4a98-b602-39b23c55f5db

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Proximity sensors can now be activated like, similar to a modular grenade, to start a timer to enable/disable them. When enabled, they will send a signal upon sensing movement.
- tweak: Portable flashers now require line of sight with moving objects to actually flash them.
