### PR TITLE
Status Effect Alerts and Time Bugfixes

### DIFF
--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.API.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.API.cs
@@ -69,7 +69,7 @@ public sealed partial class StatusEffectsSystem
         if (!TryGetStatusEffect(target, effectProto, out statusEffect))
             return TryAddStatusEffect(target, effectProto, out statusEffect, duration);
 
-        SetStatusEffectTime(statusEffect.Value, duration);
+        SetStatusEffectEndTime(statusEffect.Value, duration);
 
         return true;
     }
@@ -291,7 +291,7 @@ public sealed partial class StatusEffectsSystem
             var meta = MetaData(effect);
             if (meta.EntityPrototype is not null && meta.EntityPrototype == effectProto)
             {
-                SetStatusEffectTime(effect, time);
+                SetStatusEffectEndTime(effect, time);
                 return true;
             }
         }

--- a/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
@@ -217,8 +217,8 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         if (effect.Comp.EndEffectTime is null)
             return;
 
-        // If we don't have an end time set, we want to just make the status effect end in delta time from now.
-        SetStatusEffectEndTime((effect, effect.Comp), (effect.Comp.EndEffectTime ?? _timing.CurTime) + delta);
+        // Add to the current end effect time, if we're here we should have one set already, and if it's null it's probably infinite.
+        SetStatusEffectEndTime((effect, effect.Comp), effect.Comp.EndEffectTime.Value + delta);
     }
 
     private void SetStatusEffectEndTime(Entity<StatusEffectComponent?> ent, TimeSpan? endTime)

--- a/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
@@ -125,47 +125,6 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         PredictedQueueDel(ent.Owner);
     }
 
-    private void SetStatusEffectTime(EntityUid effect, TimeSpan? duration)
-    {
-        if (!_effectQuery.TryComp(effect, out var effectComp))
-            return;
-
-        if (duration is null)
-        {
-            if(effectComp.EndEffectTime is null)
-                return;
-
-            effectComp.EndEffectTime = null;
-        }
-        else
-            effectComp.EndEffectTime = _timing.CurTime + duration;
-
-        Dirty(effect, effectComp);
-    }
-
-    private void UpdateStatusEffectTime(EntityUid effect, TimeSpan? duration)
-    {
-        if (!_effectQuery.TryComp(effect, out var effectComp))
-            return;
-
-        // It's already infinitely long
-        if (effectComp.EndEffectTime is null)
-            return;
-
-        if (duration is null)
-            effectComp.EndEffectTime = null;
-        else
-        {
-            var newEndTime = _timing.CurTime + duration;
-            if (effectComp.EndEffectTime >= newEndTime)
-                return;
-
-            effectComp.EndEffectTime = newEndTime;
-        }
-
-        Dirty(effect, effectComp);
-    }
-
     public bool CanAddStatusEffect(EntityUid uid, EntProtoId effectProto)
     {
         if (!_proto.TryIndex(effectProto, out var effectProtoData))
@@ -227,13 +186,39 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         return true;
     }
 
-    private void AddStatusEffectTime(EntityUid effect, TimeSpan delta)
+    private void UpdateStatusEffectTime(Entity<StatusEffectComponent?> effect, TimeSpan? duration)
     {
-        if (!_effectQuery.TryComp(effect, out var effectComp))
+        if (!_effectQuery.Resolve(effect, ref effect.Comp))
+            return;
+
+        // It's already infinitely long
+        if (effect.Comp.EndEffectTime is null)
+            return;
+
+        TimeSpan? newEndTime = null;
+
+        if (duration is not null)
+        {
+            // Don't update time to a smaller timespan...
+            newEndTime = _timing.CurTime + duration;
+            if (effect.Comp.EndEffectTime >= newEndTime)
+                return;
+        }
+
+        SetStatusEffectEndTime(effect, newEndTime);
+    }
+
+    private void AddStatusEffectTime(Entity<StatusEffectComponent?> effect, TimeSpan delta)
+    {
+        if (!_effectQuery.Resolve(effect, ref effect.Comp))
+            return;
+
+        // It's already infinitely long can't add or subtract from infinity...
+        if (effect.Comp.EndEffectTime is null)
             return;
 
         // If we don't have an end time set, we want to just make the status effect end in delta time from now.
-        SetStatusEffectEndTime((effect, effectComp), (effectComp.EndEffectTime ?? _timing.CurTime) + delta);
+        SetStatusEffectEndTime((effect, effect.Comp), (effect.Comp.EndEffectTime ?? _timing.CurTime) + delta);
     }
 
     private void SetStatusEffectEndTime(Entity<StatusEffectComponent?> ent, TimeSpan? endTime)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
There appears to have been some hidden merge conflicts within status effects systems between some API updates and structural changes resulting in weird behavior with alerts.

This PR fixes them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I don't think having two nearly identical "SetStatusEffectTime" methods is super helpful... especially when one doesn't update alerts properly.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed SetStatusEffectTime in favor of SetStatusEffectEndTime 

Updated UpdateStatusEffectTime to use SetStatusEffectEndTime so it updates alerts properly.

AddStatusEffect time no longer adds or subtracts time if EndEffectTime is null, that way we don't break infinite duration effects.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Not having crawlerComp means stun gets applied twice, this shows the alert updating properly to use the longer duration.

https://github.com/user-attachments/assets/1659318b-0b74-4bf5-a310-54127b3c5283

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None of this is public API so...

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
