### PR TITLE
Allow for exothermic and endothermic chemical reactions

### DIFF
--- a/Content.Shared/Chemistry/Reaction/ChemicalReactionSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/ChemicalReactionSystem.cs
@@ -171,6 +171,7 @@ namespace Content.Shared.Chemistry.Reaction
             var (uid, comp) = soln;
             var solution = comp.Solution;
 
+            // If ConserveEnergy, the solution's energy from before performing the reaction is used
             var energy = reaction.ConserveEnergy ? solution.GetThermalEnergy(_prototypeManager) : 0;
 
             //Remove reactants
@@ -191,12 +192,17 @@ namespace Content.Shared.Chemistry.Reaction
                 solution.AddReagent(product.Key, product.Value * unitReactions);
             }
 
-            if (reaction.ConserveEnergy)
+            // If not ConserveEnergy, the solution's energy from after performing the reaction is used
+            if (!reaction.ConserveEnergy)
             {
-                var newCap = solution.GetHeatCapacity(_prototypeManager);
-                if (newCap > 0)
-                    solution.Temperature = energy / newCap;
+                energy = solution.GetThermalEnergy(_prototypeManager);
             }
+
+            energy += reaction.AdjustEnergy * (float)(unitReactions);
+
+            var newCap = solution.GetHeatCapacity(_prototypeManager);
+            if (newCap > 0)
+                solution.Temperature = energy / newCap;
 
             OnReaction(soln, reaction, null, unitReactions);
 

--- a/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
@@ -40,6 +40,13 @@ namespace Content.Shared.Chemistry.Reaction
         public bool ConserveEnergy = true;
 
         /// <summary>
+        ///     The amount of thermal energy added to the solution after the reaction occurs, in joules per unit
+        ///     reactions.
+        /// </summary>
+        [DataField("adjustEnergy")]
+        public float AdjustEnergy = 0.0f;
+
+        /// <summary>
         ///     The maximum temperature the reaction can occur at.
         /// </summary>
         [DataField("maxTemp")]


### PR DESCRIPTION
## About the PR

A new field, `adjustEnergy` has been added to the reaction prototype. It dictates the amount of energy added to the solution after the reaction occurs, in joules per unit reaction. This makes it possible to make reactions exothermic or endothermic.

[Here's a video example](https://www.youtube.com/watch?v=Tj5Gj_7VMoQ). In this case, there were 10 unit reactions, so thermal energy was increased by 1000.

Generally, (assuming all the components of a solution are reactants), a reaction will increase the solution's temperature by `adjustEnergy` divided by the total heat capacity of the results of the reaction. In the case above, the hydroxide reaction produces 2 hydroxide, so it will increase temperature by 100/2 = 50 kelvin.

## Why / Balance

I'm currently working on some chem changes for #39464, and I need this feature for them.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
