### PR TITLE
ExtinguishOnTrigger and TriggerOnInteractHand

### DIFF
--- a/Content.Server/Trigger/Systems/FireStackOnTriggerSystem.cs
+++ b/Content.Server/Trigger/Systems/FireStackOnTriggerSystem.cs
@@ -5,10 +5,10 @@ using Content.Shared.Trigger.Components.Effects;
 namespace Content.Server.Trigger.Systems;
 
 /// <summary>
-/// Trigger system for adding or removing fire from an entity with <see cref="FlammableComponent"/>.
+/// Trigger system for adding or removing fire stacks from an entity with <see cref="FlammableComponent"/>.
 /// </summary>
 /// <seealso cref="IgniteOnTriggerSystem"/>
-public sealed class FlameStackOnTriggerSystem : EntitySystem
+public sealed class FireStackOnTriggerSystem : EntitySystem
 {
     [Dependency] private readonly FlammableSystem _flame = default!;
 
@@ -17,11 +17,11 @@ public sealed class FlameStackOnTriggerSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<FlameStackOnTriggerComponent, TriggerEvent>(OnTriggerFlame);
+        SubscribeLocalEvent<FireStackOnTriggerComponent, TriggerEvent>(OnTriggerFlame);
         SubscribeLocalEvent<ExtinguishOnTriggerComponent, TriggerEvent>(OnTriggerExtinguish);
     }
 
-    private void OnTriggerFlame(Entity<FlameStackOnTriggerComponent> ent, ref TriggerEvent args)
+    private void OnTriggerFlame(Entity<FireStackOnTriggerComponent> ent, ref TriggerEvent args)
     {
         if (args.Key != null && !ent.Comp.KeysIn.Contains(args.Key))
             return;

--- a/Content.Server/Trigger/Systems/IgniteOnTriggerSystem.cs
+++ b/Content.Server/Trigger/Systems/IgniteOnTriggerSystem.cs
@@ -8,7 +8,7 @@ namespace Content.Server.Trigger.Systems;
 /// <summary>
 /// Handles igniting when triggered and stopping ignition after the delay.
 /// </summary>
-/// <seealso cref="FlameStackOnTriggerSystem"/>
+/// <seealso cref="FireStackOnTriggerSystem"/>
 public sealed class IgniteOnTriggerSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;

--- a/Content.Shared/Trigger/Components/Effects/ExtinguishOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/ExtinguishOnTriggerComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Effects;
+
+/// <summary>
+/// This trigger removes all the flame stacks on a target with <see cref="FlammableComponent"/>.
+/// If TargetUser is true, the entity that caused this trigger will be extinguished instead.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ExtinguishOnTriggerComponent : BaseXOnTriggerComponent
+{
+
+}

--- a/Content.Shared/Trigger/Components/Effects/ExtinguishOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/ExtinguishOnTriggerComponent.cs
@@ -3,11 +3,8 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Trigger.Components.Effects;
 
 /// <summary>
-/// This trigger removes all the flame stacks on a target with <see cref="FlammableComponent"/>.
+/// This trigger removes all the fire stacks on a target with <see cref="FlammableComponent"/>.
 /// If TargetUser is true, the entity that caused this trigger will be extinguished instead.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class ExtinguishOnTriggerComponent : BaseXOnTriggerComponent
-{
-
-}
+public sealed partial class ExtinguishOnTriggerComponent : BaseXOnTriggerComponent;

--- a/Content.Shared/Trigger/Components/Effects/FireStackOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/FireStackOnTriggerComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Trigger.Components.Effects;
 /// </summary>
 /// <seealso cref="IgniteOnTriggerComponent"/>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class FlameStackOnTriggerComponent : BaseXOnTriggerComponent
+public sealed partial class FireStackOnTriggerComponent : BaseXOnTriggerComponent
 {
     /// <summary>
     /// How many fire stacks to add or remove.

--- a/Content.Shared/Trigger/Components/Effects/IgniteOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/IgniteOnTriggerComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Trigger.Components.Effects;
 /// Requires <see cref="IgnitionSourceComponent"/> along with triggering components.
 /// The if TargetUser is true they will be ignited instead (they need IgnitionSourceComponent as well).
 /// </summary>
-/// <seealso cref="FlameStackOnTriggerComponent"/>
+/// <seealso cref="FireStackOnTriggerComponent"/>
 [RegisterComponent, NetworkedComponent]
 [AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class IgniteOnTriggerComponent : BaseXOnTriggerComponent

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnInteractHandComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnInteractHandComponent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Interaction;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Trigger on <see cref="InteractHandEvent"/>, aka clicking on an entity with an empty hand.
+/// User is the player with the hand doing the clicking.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnInteractHandComponent : BaseTriggerOnXComponent;

--- a/Content.Shared/Trigger/Systems/TriggerSystem.Interaction.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Interaction.cs
@@ -12,6 +12,7 @@ public sealed partial class TriggerSystem
     {
         SubscribeLocalEvent<TriggerOnActivateComponent, ActivateInWorldEvent>(OnActivate);
         SubscribeLocalEvent<TriggerOnUseComponent, UseInHandEvent>(OnUse);
+        SubscribeLocalEvent<TriggerOnInteractHandComponent, InteractHandEvent>(OnInteractHand);
 
         SubscribeLocalEvent<ItemToggleOnTriggerComponent, TriggerEvent>(HandleItemToggleOnTrigger);
         SubscribeLocalEvent<AnchorOnTriggerComponent, TriggerEvent>(HandleAnchorOnTrigger);
@@ -31,6 +32,15 @@ public sealed partial class TriggerSystem
     }
 
     private void OnUse(Entity<TriggerOnUseComponent> ent, ref UseInHandEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        Trigger(ent.Owner, args.User, ent.Comp.KeyOut);
+        args.Handled = true;
+    }
+
+    private void OnInteractHand(Entity<TriggerOnInteractHandComponent> ent, ref InteractHandEvent args)
     {
         if (args.Handled)
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR adds two triggers. One for extinguishing fire stacks, and one for triggering on `InteractHandEvent`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Advances #39354

## Technical details
<!-- Summary of code changes for easier review. -->
`TriggerOnInteractHand` is an empty component (besides the base) and simply listens to the namesake event to call `Trigger()`.

`ExtinguishOnTrigger` is also an empty component, and calls `FlammableSystem.Extinguish()` after the boilerplate. Because it doesn't use the extinguish event, the extinguish will not be relayed to things like lit cigarettes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/57a26d3d-2daa-4b6b-b44c-f3e5a2d89275

(Sound trigger had to be added due to the event getting handled before interaction popup component could play its sound)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking Changes
`FlameStackOnTriggerComponent` has been renamed to `FireStackOnTriggerComponent`.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
nothing for players