### PR TITLE
Add fallback check when unobstructed check for melee is insufficient

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Client.Gameplay;
 using Content.Shared.Effects;
+using Content.Shared.Physics;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Components;
 using Content.Shared.Weapons.Melee.Events;
@@ -15,7 +16,6 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
-using Content.Shared.Physics;
 using Robust.Shared.Physics;
 
 namespace Content.Client.Weapons.Melee;

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -26,10 +26,12 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private readonly IInputManager _inputManager = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IStateManager _stateManager = default!;
+    [Dependency] private readonly AnimationPlayerSystem _animation = default!;
     [Dependency] private readonly InputSystem _inputSystem = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private EntityQuery<TransformComponent> _xformQuery;
 

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,10 +1,7 @@
 using System.Linq;
 using Content.Client.Gameplay;
-using Content.Shared.CombatMode;
+using Content.Shared.Doors.Components;
 using Content.Shared.Effects;
-using Content.Shared.Hands.Components;
-using Content.Shared.Mobs.Components;
-using Content.Shared.StatusEffect;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Components;
 using Content.Shared.Weapons.Melee.Events;
@@ -16,6 +13,7 @@ using Robust.Client.Player;
 using Robust.Client.State;
 using Robust.Shared.Input;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Player;
 
 namespace Content.Client.Weapons.Melee;
@@ -27,6 +25,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IStateManager _stateManager = default!;
     [Dependency] private readonly AnimationPlayerSystem _animation = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly InputSystem _inputSystem = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
     [Dependency] private readonly MapSystem _map = default!;
@@ -158,7 +157,42 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         var targetCoordinates = xform.Coordinates;
         var targetLocalAngle = xform.LocalRotation;
 
-        return Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false);
+        // Default unobstructed check
+        if (Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false))
+            return true;
+
+        // Fallback for entities on the same tile as a porous blocker
+        var userXform = Transform(user);
+        var targetXform = xform;
+
+        // Ensure both are on the same map
+        if (userXform.MapID != targetXform.MapID || userXform.MapID == MapId.Nullspace)
+            return false;
+
+        // Perform a simple distance check
+        if ((TransformSystem.GetWorldPosition(userXform) - TransformSystem.GetWorldPosition(targetXform)).Length() > range)
+            return false;
+
+        // If within distance, check if the obstruction is a door-like entity on the same tile as the target
+        if (targetXform.GridUid is not { } gridUid || !TryComp<MapGridComponent>(gridUid, out var grid))
+            return false;
+
+        var targetTileIndices = _map.CoordinatesToTile(gridUid, grid, targetXform.Coordinates);
+
+        // Use an unambiguous overload by providing the enlargement parameter
+        var entitiesOnTile = _lookup.GetLocalEntitiesIntersecting(gridUid, targetTileIndices, 0.0f, flags: LookupFlags.Static);
+
+        foreach (var entity in entitiesOnTile)
+        {
+            if (entity == target || entity == user)
+                continue;
+
+            // If we find a DoorComponent OR a TurnstileComponent on this tile, we assume it was the blocker and allow the hit
+            if (HasComp<DoorComponent>(entity) || HasComp<TurnstileComponent>(entity))
+                return true;
+        }
+
+        return false;
     }
 
     protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform)

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Numerics;
 using Content.Server.Chat.Systems;
 using Content.Server.Movement.Systems;
 using Content.Shared.Damage.Events;
@@ -12,8 +14,6 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
-using System.Linq;
-using System.Numerics;
 
 namespace Content.Server.Weapons.Melee;
 


### PR DESCRIPTION
## About the PR
This PR changes the server and client melee hit registration logic, more specifically the `InRange()` method

## Why / Balance
A prevalent example of 'why', this needed, is when kudzu grows on turnstiles. Kudzu, in this situation, was practically impossible to target with light melee attacks. This change makes it so the kudzu can be targeted and destroyed in this situation

## Technical details
Modified the `InRange()` method on both the client and serverside `MeleeWeaponSystem.cs` in order to both trigger hit effects properly clientside and to accept kudzu in turnstile hits (and similar situations) as valid after a series of fallback checks after the trace check of `InRangeUnobstructed` fails

## Media
https://github.com/user-attachments/assets/8295d612-2908-495c-abca-c33e6dd9c4e6

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
While I attempted to test this, there could be some unintended side effects here just by the virtue of changing melee hit registration

**Changelog**
:cl:
- fix: Kudzu that covered turnstiles should now take damage from light melee attacks
