### PR TITLE
Trigger on round end

### DIFF
--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnRoundEndComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnRoundEndComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Trigger.Components.Triggers;
 
 /// <summary>
-/// Creates a signal when the round ends, i.e. the scoreboard appears and post-round begins.
+/// Triggers the entity when the round ends, i.e. the scoreboard appears and post-round begins.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class TriggerOnRoundEndComponent : BaseTriggerOnXComponent;

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnRoundEndComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnRoundEndComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Creates a signal when the round ends, i.e. the scoreboard appears and post-round begins.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnRoundEndComponent : BaseTriggerOnXComponent;

--- a/Content.Shared/Trigger/Systems/TriggerOnRoundEndSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerOnRoundEndSystem.cs
@@ -1,0 +1,31 @@
+using Content.Shared.GameTicking;
+using Content.Shared.Trigger.Components.Triggers;
+
+namespace Content.Shared.Trigger.Systems;
+
+/// <summary>
+/// System for creating a trigger when the round ends.
+/// </summary>
+public sealed class TriggerOnRoundEndSystem : EntitySystem
+{
+    [Dependency] private readonly TriggerSystem _trigger = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RoundEndMessageEvent>(OnRoundEnd);
+    }
+
+    private void OnRoundEnd(RoundEndMessageEvent args)
+    {
+        var triggerQuery = EntityQueryEnumerator<TriggerOnRoundEndComponent>();
+
+        // trigger everything with the component
+        while (triggerQuery.MoveNext(out var uid, out var comp))
+        {
+            _trigger.Trigger(uid, null, comp.KeyOut);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR adds a trigger for when the round ends.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Advances #39354

## Technical details
<!-- Summary of code changes for easier review. -->
This system is a little weirder than the usual. It copies the homework of `GibOnRoundEndComponent`, creating a query in response to `RoundEndMessageEvent`, then iterating through that to send the triggers.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/80ac2837-b141-4d25-8270-1288e56e1b07


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl