### PR TITLE
Fix_dump_user_data_ORDER_BY_in_schema_check

### DIFF
--- a/Tools/dump_user_data.py
+++ b/Tools/dump_user_data.py
@@ -48,7 +48,8 @@ def main():
 
 
 def check_schema_version(cur: "psycopg2.cursor", ignore_mismatch: bool):
-    cur.execute('SELECT "MigrationId" FROM "__EFMigrationsHistory" ORDER BY "__EFMigrationsHistory" DESC LIMIT 1')
+    # Order by the MigrationId column (not the table name) to get the latest entry.
+    cur.execute('SELECT "MigrationId" FROM "__EFMigrationsHistory" ORDER BY "MigrationId" DESC LIMIT 1')
     schema_version = cur.fetchone()
     if schema_version == None:
         print("Unable to read database schema version.")


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a runtime error in the user-data dump tool by correcting the SQL ORDER BY clause used to detect the latest EF migration in `Tools/dump_user_data.py`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is a tooling fix only and does not affect gameplay. The previous query attempted to order by the table name instead of a column, which would cause the script to fail when used for GDPR/user data dumps.

## Technical details
<!-- Summary of code changes for easier review. -->
- In `check_schema_version`, changed:
  - `ORDER BY "__EFMigrationsHistory" DESC` → `ORDER BY "MigrationId" DESC`.
  - Ensures the query correctly selects the latest migration row.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A (small tooling fix; no ingame changes).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

