### PR TITLE
Fix_Actions_changelogs_since_last_run_Accept_header

### DIFF
--- a/Tools/actions_changelogs_since_last_run.py
+++ b/Tools/actions_changelogs_since_last_run.py
@@ -93,7 +93,8 @@ def get_last_changelog() -> str:
 
     session = requests.Session()
     session.headers["Authorization"] = f"Bearer {github_token}"
-    session.headers["Accept"] = "Accept: application/vnd.github+json"
+    # Correct Accept header value for GitHub API; no field name prefix.
+    session.headers["Accept"] = "application/vnd.github+json"
     session.headers["X-GitHub-Api-Version"] = "2022-11-28"
 
     most_recent = get_most_recent_workflow(session, github_repository, github_run)

--- a/Tools/dump_user_data.py
+++ b/Tools/dump_user_data.py
@@ -48,7 +48,8 @@ def main():
 
 
 def check_schema_version(cur: "psycopg2.cursor", ignore_mismatch: bool):
-    cur.execute('SELECT "MigrationId" FROM "__EFMigrationsHistory" ORDER BY "__EFMigrationsHistory" DESC LIMIT 1')
+    # Order by the MigrationId column (not the table name) to get the latest entry.
+    cur.execute('SELECT "MigrationId" FROM "__EFMigrationsHistory" ORDER BY "MigrationId" DESC LIMIT 1')
     schema_version = cur.fetchone()
     if schema_version == None:
         print("Unable to read database schema version.")


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes incorrect GitHub API Accept header usage in `Tools/actions_changelogs_since_last_run.py`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Tooling-only fix; ensures the GitHub API requests use a valid `Accept` header. No gameplay impact.

## Technical details
<!-- Summary of code changes for easier review. -->
- Set `session.headers["Accept"] = "application/vnd.github+json"` (previously incorrectly included the literal `"Accept: "` prefix).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

