### PR TITLE
Revert "Increase SpawnAndDeleteAllEntitiesOnDifferentMaps test simulation time

### DIFF
--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -56,7 +56,7 @@ namespace Content.IntegrationTests.Tests
                 }
             });
 
-            await server.WaitRunTicks(450); // 15 seconds, enough to trigger most update loops
+            await server.WaitRunTicks(15);
 
             await server.WaitPost(() =>
             {
@@ -112,7 +112,7 @@ namespace Content.IntegrationTests.Tests
                     entityMan.SpawnEntity(protoId, map.GridCoords);
                 }
             });
-            await server.WaitRunTicks(450); // 15 seconds, enough to trigger most update loops
+            await server.WaitRunTicks(15);
             await server.WaitPost(() =>
             {
                 static IEnumerable<(EntityUid, TComp)> Query<TComp>(IEntityManager entityMan)
@@ -270,7 +270,7 @@ namespace Content.IntegrationTests.Tests
             await pair.RunTicksSync(3);
 
             // We consider only non-audio entities, as some entities will just play sounds when they spawn.
-            int Count(IEntityManager ent) => ent.EntityCount - ent.Count<AudioComponent>();
+            int Count(IEntityManager ent) =>  ent.EntityCount - ent.Count<AudioComponent>();
             IEnumerable<EntityUid> Entities(IEntityManager entMan) => entMan.GetEntities().Where(entMan.HasComponent<AudioComponent>);
 
             await Assert.MultipleAsync(async () =>


### PR DESCRIPTION
This reverts commit c3ff6c9184889bf009a27e736cd4639a8d05ef93.
See #38901

Two forks reported the test failing with this unhelpful error message after they merged the latest stable release.
<img width="1160" height="573" alt="grafik" src="https://github.com/user-attachments/assets/fb1ca112-9fb3-4e8d-ad36-7c2834259735" />

I assume it has something to do with the test timing out because it takes too long, but I have no clue where to change such a setting. For now I would prefer to loose some test coverage again and not have this fail without any apparent reason.

I assume upstream will get hit by the timout as well in the future as we add more prototypes. We better figure this out until then 😄 