### PR TITLE
[HOTFIX] Stop players from clipping through Windoors

### DIFF
--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -122,7 +122,7 @@ public sealed class StandingStateSystem : EntitySystem
         {
             foreach (var (key, fixture) in fixtureComponent.Fixtures)
             {
-                if ((fixture.CollisionMask & StandingCollisionLayer) == 0)
+                if ((fixture.CollisionMask & StandingCollisionLayer) == 0 || !fixture.Hard)
                     continue;
 
                 standingState.ChangedFixtures.Add(key);
@@ -177,7 +177,7 @@ public sealed class StandingStateSystem : EntitySystem
         {
             foreach (var key in standingState.ChangedFixtures)
             {
-                if (fixtureComponent.Fixtures.TryGetValue(key, out var fixture))
+                if (fixtureComponent.Fixtures.TryGetValue(key, out var fixture) && fixture.Hard)
                     _physics.SetCollisionMask(uid, key, fixture, fixture.CollisionMask | StandingCollisionLayer, fixtureComponent);
             }
         }

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Climbing.Events;
 using Content.Shared.Hands.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
@@ -26,6 +27,7 @@ public sealed class StandingStateSystem : EntitySystem
         SubscribeLocalEvent<StandingStateComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeedModifiers);
         SubscribeLocalEvent<StandingStateComponent, RefreshFrictionModifiersEvent>(OnRefreshFrictionModifiers);
         SubscribeLocalEvent<StandingStateComponent, TileFrictionEvent>(OnTileFriction);
+        SubscribeLocalEvent<StandingStateComponent, EndClimbEvent>(OnEndClimb);
     }
 
     private void OnMobTargetCollide(Entity<StandingStateComponent> ent, ref AttemptMobTargetCollideEvent args)
@@ -63,6 +65,14 @@ public sealed class StandingStateSystem : EntitySystem
     {
         if (!entity.Comp.Standing)
             args.Modifier *= entity.Comp.FrictionModifier;
+    }
+
+    private void OnEndClimb(Entity<StandingStateComponent> entity, ref EndClimbEvent args)
+    {
+        if (entity.Comp.Standing)
+            return;
+
+        ChangeLayers(entity);
     }
 
     public bool IsDown(EntityUid uid, StandingStateComponent? standingState = null)
@@ -118,17 +128,7 @@ public sealed class StandingStateSystem : EntitySystem
         _appearance.SetData(uid, RotationVisuals.RotationState, RotationState.Horizontal, appearance);
 
         // Change collision masks to allow going under certain entities like flaps and tables
-        if (TryComp(uid, out FixturesComponent? fixtureComponent))
-        {
-            foreach (var (key, fixture) in fixtureComponent.Fixtures)
-            {
-                if ((fixture.CollisionMask & StandingCollisionLayer) == 0 || !fixture.Hard)
-                    continue;
-
-                standingState.ChangedFixtures.Add(key);
-                _physics.SetCollisionMask(uid, key, fixture, fixture.CollisionMask & ~StandingCollisionLayer, manager: fixtureComponent);
-            }
-        }
+        ChangeLayers((uid, standingState));
 
         // check if component was just added or streamed to client
         // if true, no need to play sound - mob was down before player could seen that
@@ -173,17 +173,41 @@ public sealed class StandingStateSystem : EntitySystem
 
         _appearance.SetData(uid, RotationVisuals.RotationState, RotationState.Vertical, appearance);
 
-        if (TryComp(uid, out FixturesComponent? fixtureComponent))
-        {
-            foreach (var key in standingState.ChangedFixtures)
-            {
-                if (fixtureComponent.Fixtures.TryGetValue(key, out var fixture) && fixture.Hard)
-                    _physics.SetCollisionMask(uid, key, fixture, fixture.CollisionMask | StandingCollisionLayer, fixtureComponent);
-            }
-        }
-        standingState.ChangedFixtures.Clear();
+        RevertLayers((uid, standingState));
 
         return true;
+    }
+
+    private void ChangeLayers(Entity<StandingStateComponent, FixturesComponent?> entity)
+    {
+        if (!Resolve(entity, ref entity.Comp2, false))
+            return;
+
+        foreach (var (key, fixture) in entity.Comp2.Fixtures)
+        {
+            if ((fixture.CollisionMask & StandingCollisionLayer) == 0 || !fixture.Hard)
+                continue;
+
+            entity.Comp1.ChangedFixtures.Add(key);
+            _physics.SetCollisionMask(entity, key, fixture, fixture.CollisionMask & ~StandingCollisionLayer, manager: entity.Comp2);
+        }
+    }
+
+    private void RevertLayers(Entity<StandingStateComponent, FixturesComponent?> entity)
+    {
+        if (!Resolve(entity, ref entity.Comp2, false))
+        {
+            entity.Comp1.ChangedFixtures.Clear();
+            return;
+        }
+
+        foreach (var key in entity.Comp1.ChangedFixtures)
+        {
+            if (entity.Comp2.Fixtures.TryGetValue(key, out var fixture) && fixture.Hard)
+                _physics.SetCollisionMask(entity, key, fixture, fixture.CollisionMask | StandingCollisionLayer, entity.Comp2);
+        }
+
+        entity.Comp1.ChangedFixtures.Clear();
     }
 }
 

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -72,6 +72,7 @@ public sealed class StandingStateSystem : EntitySystem
         if (entity.Comp.Standing)
             return;
 
+        // Currently only Climbing also edits fixtures layers like this so this is fine for now.
         ChangeLayers(entity);
     }
 
@@ -178,6 +179,7 @@ public sealed class StandingStateSystem : EntitySystem
         return true;
     }
 
+    // TODO: This should be moved to a PhysicsModifierSystem which raises events so multiple systems can modify fixtures at once
     private void ChangeLayers(Entity<StandingStateComponent, FixturesComponent?> entity)
     {
         if (!Resolve(entity, ref entity.Comp2, false))
@@ -193,6 +195,7 @@ public sealed class StandingStateSystem : EntitySystem
         }
     }
 
+    // TODO: This should be moved to a PhysicsModifierSystem which raises events so multiple systems can modify fixtures at once
     private void RevertLayers(Entity<StandingStateComponent, FixturesComponent?> entity)
     {
         if (!Resolve(entity, ref entity.Comp2, false))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made it so standing state only affects hard fixtures. 

Added an event listener to Standing State for EndClimbEvent 

Stable targeted version of:  #39445

Fixes #39429
Fixes #39564

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Here's my breakdown of the issue:

You climb onto a fixture, it removes some layers from you and adds a soft fixture to check when you stop climbing.
You go into the down standing state and it removes the standing state fixture from all your fixtures, including the soft climbing fixture...
You are now no longer colliding with the thing you're climbing on, so it gives you all your layers back!
You clip into the thing you're climbing on.
You get pushed into or through walls.

Solution is to 
1: Make it so standing state doesn't affect soft sensor fixtures.
2: Make it so when we stop climbing and we're down, we edit the fixtures to the down state fixtures.

Because standing state has checks for when you try standing for collision, you can't stand to fuck up the climbing fixtures. 

A better solution would be a system that handles fixture modification across multiple components but the scope of that is very large, will be complicated and performance intensive, and standing state shouldn't be editing soft fixtures anyways.

## Technical details
<!-- Summary of code changes for easier review. --> 

Added a check for if a fixture is hard to StandingStateSystem for its fixture changes

Moved them to their own separate private methods for easier readability and no code copy-pasting.

Made it so OnEndClimb, StandingState sets its fixtures again if you are down.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Media in:  #39445

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: You can no longer clip into walls and windoors by climbing and crawling.

