### PR TITLE
Average min+max in MaterialArbitrageTest 

### DIFF
--- a/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
+++ b/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
@@ -31,7 +31,7 @@ public sealed class MaterialArbitrageTest
     // These recipes are currently broken and need fixing. You should not be adding to these sets.
     private readonly HashSet<string> _destructionArbitrageIgnore =
     [
-        "BaseChemistryEmptyVial", "DrinkShotGlass", "SodiumLightTube", "DrinkGlassCoupeShaped",
+        "DrinkShotGlass", "SodiumLightTube", "DrinkGlassCoupeShaped",
         "LedLightBulb", "ExteriorLightTube", "LightTube", "DrinkGlass", "DimLightBulb", "LightBulb", "LedLightTube",
         "SheetRGlass1", "ChemistryEmptyBottle01", "WarmLightBulb",
     ];

--- a/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
+++ b/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
@@ -145,7 +145,7 @@ public sealed class MaterialArbitrageTest
 
         Dictionary<string, double> priceCache = new();
 
-        Dictionary<string, (Dictionary<string, int> Ents, Dictionary<string, int> Mats)> spawnedOnDestroy = new();
+        Dictionary<string, (Dictionary<string, float> Ents, Dictionary<string, float> Mats)> spawnedOnDestroy = new();
 
         // cache the compositions of entities
         // If the entity is refineable (i.e. glass shared can be turned into glass, we take the greater of the two compositions.
@@ -217,8 +217,8 @@ public sealed class MaterialArbitrageTest
 
             var comp = (DestructibleComponent) destructible.Component;
 
-            var spawnedEnts = new Dictionary<string, int>();
-            var spawnedMats = new Dictionary<string, int>();
+            var spawnedEnts = new Dictionary<string, float>();
+            var spawnedMats = new Dictionary<string, float>();
 
             // This test just blindly assumes that ALL spawn entity behaviors get triggered. In reality, some entities
             // might only trigger a subset. If that starts being a problem, this test either needs fixing or needs to
@@ -233,14 +233,14 @@ public sealed class MaterialArbitrageTest
 
                     foreach (var (key, value) in spawn.Spawn)
                     {
-                        spawnedEnts[key] = spawnedEnts.GetValueOrDefault(key) + value.Max;
+                        spawnedEnts[key] = spawnedEnts.GetValueOrDefault(key) + (value.Min + value.Max) / 2;
 
                         if (!compositions.TryGetValue(key, out var composition))
                             continue;
 
                         foreach (var (matId, amount) in composition)
                         {
-                            spawnedMats[matId] = value.Max * amount + spawnedMats.GetValueOrDefault(matId);
+                            spawnedMats[matId] = (value.Min + value.Max) / 2 * amount + spawnedMats.GetValueOrDefault(matId);
                         }
                     }
                 }
@@ -451,7 +451,7 @@ public sealed class MaterialArbitrageTest
         await server.WaitPost(() => mapSystem.DeleteMap(testMap.MapId));
         await pair.CleanReturnAsync();
 
-        async Task<double> GetSpawnedPrice(Dictionary<string, int> ents)
+        async Task<double> GetSpawnedPrice(Dictionary<string, float> ents)
         {
             double price = 0;
             foreach (var (id, num) in ents)

--- a/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
+++ b/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
@@ -31,7 +31,7 @@ public sealed class MaterialArbitrageTest
     // These recipes are currently broken and need fixing. You should not be adding to these sets.
     private readonly HashSet<string> _destructionArbitrageIgnore =
     [
-        "DrinkShotGlass", "SodiumLightTube", "DrinkGlassCoupeShaped",
+        "BaseChemistryEmptyVial", "DrinkShotGlass", "SodiumLightTube", "DrinkGlassCoupeShaped",
         "LedLightBulb", "ExteriorLightTube", "LightTube", "DrinkGlass", "DimLightBulb", "LightBulb", "LedLightTube",
         "SheetRGlass1", "ChemistryEmptyBottle01", "WarmLightBulb",
     ];

--- a/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
+++ b/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
@@ -233,14 +233,14 @@ public sealed class MaterialArbitrageTest
 
                     foreach (var (key, value) in spawn.Spawn)
                     {
-                        spawnedEnts[key] = spawnedEnts.GetValueOrDefault(key) + (value.Min + value.Max) / 2;
+                        spawnedEnts[key] = spawnedEnts.GetValueOrDefault(key) + (float)(value.Min + value.Max) / 2;
 
                         if (!compositions.TryGetValue(key, out var composition))
                             continue;
 
                         foreach (var (matId, amount) in composition)
                         {
-                            spawnedMats[matId] = (value.Min + value.Max) / 2 * amount + spawnedMats.GetValueOrDefault(matId);
+                            spawnedMats[matId] = (float)(value.Min + value.Max) / 2 * amount + spawnedMats.GetValueOrDefault(matId);
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR makes a small change to `MaterialArbitrageTest` to account for the chance of an entity spawning during destruction.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
When looking into #36535 and the test, `BaseChemistryEmptyVial` stuck out to me as an item that has an incorrect output. The test claims it produces 100 glass because it spawns a glass shard, but it only spawns a shard half the time. It's true the the entity *can* produce 100 glass, but en masse it's net 50. This PR makes it so that a chance to spawn is properly replicated in the test. Accounting for chance will be needed in the future as well if entity tables get added to destruction.


## Technical details
<!-- Summary of code changes for easier review. -->
When getting the items from `SpawnEntitiesBehavior`, the min and the max are added together and divided by 2 to create a mid-range average. `SpawnEntitiesBehavior` does not implement any control over the odds and uses `IRobustRandom.Next()`, which is assumed to have an even distribution of odds for all integer values between min and max, which a mid-range effectively estimate.

The dictionaries used to hold these values were changed from int to float.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Not player facing.