### PR TITLE
fix: fix lights not always enabling correctly

### DIFF
--- a/Content.Shared/Light/EntitySystems/SharedPoweredLightSystem.cs
+++ b/Content.Shared/Light/EntitySystems/SharedPoweredLightSystem.cs
@@ -263,6 +263,14 @@ public abstract class SharedPoweredLightSystem : EntitySystem
         AppearanceComponent? appearance = null,
         EntityUid? user = null)
     {
+        // We don't do anything during state application on the client as if
+        // it's due to an entity spawn, we'd have to wait for component init to
+        // be able to do anything, despite the server having already sent us the
+        // state that we need. On the other hand, we still want this to run in
+        // prediction so we can, well, predict lights turning on.
+        if (GameTiming.ApplyingState)
+            return;
+
         if (!Resolve(uid, ref light, false))
             return;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This fixes lights not turning on (on the client) when getting initially spawned in, among other circumstances.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #39577.

## Technical details
<!-- Summary of code changes for easier review. -->
Probably the UpdateLight in the component init could be made clientside only. Also the on insert/remove do still seem needed.

The issue seems to be that on the light spawning on the client, it gets the lamp insert event raised before its container slot is actually initialized since entity state is handled before component initialization, causing it to assume it must be off because it has no lamp (`GetBulb` called from `UpdateLight`).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="700" height="252" alt="image" src="https://github.com/user-attachments/assets/fecda1dc-bd77-48d7-9d6a-1a1278510157" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed lights sometimes not emitting light when spawning them or when they enter PVS.
