### PR TITLE
Viable Canesword

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -2200,7 +2200,7 @@
   productEntity: CaneSheathFilled
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 2
   cost:
     Telecrystal: 3
   categories:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
@@ -41,7 +41,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 16
+        Slash: 17
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Buffed the cane sword to be a viable traitor weapon. Its damage has been increased from 14 to 17 (matching the captain saber), and cost from a staggering 5 TC (when you could just get a E-sword for 8) down to a more modest 3 TC.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The chef/mime's baguette sword costs 4 TC (combat bakery kit), is less conspicuous, and does 16 damage with a 1.4 attack rate. The cane sword is a fun item with a lot of mechanics, but it needs the damage to back it up.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Nox38
- tweak: Buffed the Librarian cane sword's damage and price to be more competitive. Damage 15 -> 17 slash, TC cost 5 -> 3
