### PR TITLE
scale ammonia and nitrous oxide damage with gas quantity

### DIFF
--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -228,9 +228,10 @@
           reagent: Ammonia
           min: 1
         ignoreResistances: true
+        scaleByQuantity: true
         damage:
           types:
-            Poison: 0.25
+            Poison: 1
       - !type:ChemVomit
         probability: 0.12
         conditions:

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -380,9 +380,10 @@
           type: Slime
           shouldHave: false
         ignoreResistances: true
+        scaleByQuantity: true
         damage:
           types:
-            Poison: 0.25
+            Poison: 1
 
 - type: reagent
   id: Frezon


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Make the damage from inhaling nitrous oxide and ammonia proportional to the gas amount. Also, increase their damage because it was very low even with the scaling. This upgrades the two gases from **harmless** to **very rarely dangerous**. It also aligns the two gases with all others, which all scale damage with gas amount.

This is me with the new tweaked ammonia, entering a fresh ammonia leak in a room with no scrubbers and closing the door behind — maximum possible ammonia. Nitrous oxide caused the same amount of damage. It gives you a good dozen seconds to realize something is wrong and get out of there, if the huge amounts of purple gas were not enough.

https://github.com/user-attachments/assets/4b147e53-1d03-4536-866a-39a578d72a86



## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Old ammonia, without scaling by quantity:

https://github.com/user-attachments/assets/083c7ca3-7d31-4934-b1d1-5de7ffe4162f


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

It's so rare that probably nobody even knew those two gases deal tiny damage.