### PR TITLE
fix singulo generator triggering failsafe when field is obstructed

### DIFF
--- a/Content.Server/Singularity/EntitySystems/SingularityGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/SingularityGeneratorSystem.cs
@@ -176,9 +176,10 @@ public sealed class SingularityGeneratorSystem : SharedSingularityGeneratorSyste
 
         foreach (var result in rayCastResults)
         {
-            if (genQuery.HasComponent(result.HitEntity))
-                closestResult = result;
+            if (!genQuery.HasComponent(result.HitEntity))
+                continue;
 
+            closestResult = result;
             break;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The singulo generator, when ready to create a singularity, will check all cardinal directions for a containment field using raycasting. The thing is, it stops at the first entity with a fitting collision mask. So if anything with the specific collision mask is between the generator and the field, Singulo will not start.

I change it so the ray cast checks all entities for a containment field, not just the first fitting one.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I believe the collision ray should check all entities in the range, not just the first entity, and the singulo/tesla should start and sacrifice the blocking entities and prevent a possible blackout.

Example: someone left a grounding rod inside the field. The generator kept going into failsafe, and the entire station went without power for 30 minutes until evac was called.

<img width="1403" height="1274" alt="Image" src="https://github.com/user-attachments/assets/32250874-2f7f-46f0-9bbc-6b5fe88c3e36" />

## Technical details
The loop in `CheckContainmentField` would iterate over entities and check if they have the containment field component, but then... break on the first iteration where it does not? And also keep going if it finds more containment fields? Honestly, this might just be an oversight. I invert the loop to break when it finds a containment field instead.


<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
