### PR TITLE
Thief steal money objective

### DIFF
--- a/Content.Server/Inventory/CarryCounterSystem.cs
+++ b/Content.Server/Inventory/CarryCounterSystem.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using Content.Shared.Stacks;
+using Robust.Shared.Containers;
+
+namespace Content.Server.Inventory;
+
+/// <summary>
+/// Read-only helper to count what a mob is carrying, recursively,
+/// with support for stackable items (cash, sheets, etc.).
+/// "Carrying" = anything in the mob's containers (inventory slots, hands,
+/// backpack, boxes, wallets, nested containers, implants, etc.).
+/// </summary>
+public sealed class CarryCounterSystem : EntitySystem
+{
+    private EntityQuery<ContainerManagerComponent> _containerQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _containerQuery = GetEntityQuery<ContainerManagerComponent>();
+    }
+
+    /// <summary>
+    /// Overload that accepts a nullable EntityUid (e.g., Mind.OwnedEntity).
+    /// Returns 0 if null; otherwise forwards to the non-nullable overload.
+    /// </summary>
+    public int CountByStackType(EntityUid? maybeMob, string stackTypeId, int valuePerUnit = 1)
+    {
+        if (!maybeMob.HasValue)
+            return 0;
+
+        return CountByStackType(maybeMob.Value, stackTypeId, valuePerUnit);
+    }
+
+    /// <summary>
+    /// Returns the total amount of items carried by mob whose
+    /// stack type (if present) matches <paramref name="stackTypeId"/>.
+    ///
+    /// If an entity has a StackComponent with a matching StackTypeId,
+    /// contributes stack.Count * valuePerUnit. Non-stack entities contribute 0 in this overload.
+    /// </summary>
+    public int CountByStackType(EntityUid mob, string stackTypeId, int valuePerUnit = 1)
+    {
+        if (!_containerQuery.TryGetComponent(mob, out var currentManager))
+            return 0;
+
+        valuePerUnit = Math.Max(1, valuePerUnit);
+
+        var total = 0;
+        var managerStack = new Stack<ContainerManagerComponent>();
+
+        // Walk all containers owned by the mob (inventory, hands, implants, etc.)
+        do
+        {
+            foreach (var container in currentManager.Containers.Values)
+            {
+                foreach (var entity in container.ContainedEntities)
+                {
+                    total += CountEntityByStackType(entity, stackTypeId, valuePerUnit);
+
+                    // Recurse into nested containers (bags, boxes, wallets, etc.)
+                    if (_containerQuery.TryGetComponent(entity, out var childManager))
+                        managerStack.Push(childManager);
+                }
+            }
+        } while (managerStack.TryPop(out currentManager));
+
+        return total;
+    }
+
+    /// <summary>
+    /// Generic counter
+    /// For stacks, contributes Count by default; for non-stacks contributes 1.
+    /// </summary>
+    public int CountWhere(
+        EntityUid mob,
+        Func<EntityUid, bool> predicate,
+        Func<EntityUid, int>? valueSelector = null)
+    {
+        if (!_containerQuery.TryGetComponent(mob, out var currentManager))
+            return 0;
+
+        valueSelector ??= DefaultValueSelector;
+
+        var total = 0;
+        var managerStack = new Stack<ContainerManagerComponent>();
+
+        do
+        {
+            foreach (var container in currentManager.Containers.Values)
+            {
+                foreach (var entity in container.ContainedEntities)
+                {
+                    if (predicate(entity))
+                        total += Math.Max(0, valueSelector(entity));
+
+                    if (_containerQuery.TryGetComponent(entity, out var childManager))
+                        managerStack.Push(childManager);
+                }
+            }
+        } while (managerStack.TryPop(out currentManager));
+
+        return total;
+
+        int DefaultValueSelector(EntityUid ent)
+        {
+            if (TryComp(ent, out StackComponent? s))
+                return Math.Max(0, s.Count);
+            return 1;
+        }
+    }
+
+    // --- helpers ---
+
+    private int CountEntityByStackType(EntityUid entity, string stackTypeId, int valuePerUnit)
+    {
+        var sum = 0;
+
+        // If it's the right kind of stack, add its amount.
+        if (TryComp(entity, out StackComponent? stack) && stack.StackTypeId == stackTypeId)
+            sum += Math.Max(0, stack.Count) * valuePerUnit;
+
+        // Also check any nested containers owned by this entity.
+        if (_containerQuery.TryGetComponent(entity, out var nested))
+        {
+            foreach (var container in nested.Containers.Values)
+            {
+                foreach (var child in container.ContainedEntities)
+                    sum += CountEntityByStackType(child, stackTypeId, valuePerUnit);
+            }
+        }
+
+        return sum;
+    }
+}

--- a/Content.Server/Objectives/Components/StealConditionComponent.cs
+++ b/Content.Server/Objectives/Components/StealConditionComponent.cs
@@ -1,6 +1,8 @@
 using Content.Server.Objectives.Systems;
 using Content.Shared.Objectives;
+using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 
 namespace Content.Server.Objectives.Components;
 
@@ -53,6 +55,28 @@ public sealed partial class StealConditionComponent : Component
     public int CollectionSize;
 
     /// <summary>
+    /// OPTIONAL: When set, StealCondition switches to a "carry N of a stacked item" mode.
+    /// The value must match the StackTypeId used by the stackable item (e.g., "Credit")
+    /// If null, the condition behaves exactly as before (non-currency/object-steal path).
+    /// </summary>
+    [DataField]
+    public string? CurrencyStackId;
+
+    /// <summary>
+    /// OPTIONAL: Target amount of the stacked item the mob must carry to satisfy the condition.
+    /// If null, the condition behaves exactly as before.
+    /// </summary>
+    [DataField]
+    public int? CurrencyTargetAmount;
+
+    /// <summary>
+    /// OPTIONAL: Per-unit value multiplier if one stack "unit" represents multiple logical units.
+    /// Leave as 1 for most stacks (including Spesos if 1 unit = 1 Speso).
+    /// </summary>
+    [DataField]
+    public int CurrencyValuePerUnit = 1;
+
+    /// <summary>
     /// Help newer players by saying e.g. "steal the chief engineer's advanced magboots"
     /// instead of "steal advanced magboots. Should be a loc string.
     /// </summary>
@@ -62,10 +86,13 @@ public sealed partial class StealConditionComponent : Component
     // All this need to be loc string
     [DataField(required: true)]
     public LocId ObjectiveText;
+
     [DataField(required: true)]
     public LocId ObjectiveNoOwnerText;
+
     [DataField(required: true)]
     public LocId DescriptionText;
+
     [DataField(required: true)]
     public LocId DescriptionMultiplyText;
 }

--- a/Resources/Locale/en-US/objectives/conditions/steal.ftl
+++ b/Resources/Locale/en-US/objectives/conditions/steal.ftl
@@ -6,6 +6,9 @@ objective-condition-steal-description = We need you to steal {$itemName}. Don't 
 objective-condition-steal-station = station
 objective-condition-steal-Ian = head of personnel's corgi
 
+objective-steal-currency-title = Steal 10,000 spesos
+objective-steal-currency-desc = Some people on the station are too rich for their own good. Luckily they have me to give them a hand.
+
 objective-condition-thief-description = The {$itemName} would be a great addition to my collection!
 objective-condition-thief-animal-description = The {$itemName} would be a great addition to my collection! Most importantly, alive.
 objective-condition-thief-multiply-description = I need to get {$count} {MAKEPLURAL($itemName)} (any) and take them with me.

--- a/Resources/Locale/en-US/thief/backpack.ftl
+++ b/Resources/Locale/en-US/thief/backpack.ftl
@@ -54,7 +54,7 @@ thief-backpack-category-communicator-description =
     Money is power, and secrets are money. Use your silver tongue
     and wealth to subvert the station.
     Includes: Master key for all station channels, a CyberSun pen,
-    voice chameleon mask, and 20k spesos inside a briefcase.
+    voice chameleon mask, and gold bars inside a briefcase.
 
 thief-backpack-category-smuggler-name = Smuggler Kit
 thief-backpack-category-smuggler-description =

--- a/Resources/Prototypes/Catalog/Fills/Items/briefcases.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/briefcases.yml
@@ -55,7 +55,7 @@
   - type: StorageFill
     contents:
       - id: ClothingEyesGlassesSunglasses
-      - id: SpaceCash20000
-        amount: 1
+      - id: IngotGold
+        amount: 30
       - id: ClothingOuterCoatJensen
       - id: ClothingHandsGlovesColorBlack

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -5,6 +5,7 @@
   - type: ThiefRule
   - type: AntagObjectives
     objectives:
+    - StealMoneyObjective
     - EscapeThiefShuttleObjective
   - type: AntagRandomObjectives
     sets:

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -50,6 +50,11 @@
     ThiefObjectiveGroupItem: 1
 
 - type: weightedRandom
+  id: ThiefObjectiveGroupMoney
+  weights:
+    StealMoneyObjective: 1
+
+- type: weightedRandom
   id: ThiefBigObjectiveGroups
   weights:
     ThiefObjectiveGroupStructure: 1

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -48,6 +48,7 @@
   weights:
     ThiefObjectiveGroupCollection: 1
     ThiefObjectiveGroupItem: 1
+    ThiefObjectiveGroupMoney: 1
 
 - type: weightedRandom
   id: ThiefObjectiveGroupMoney

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -1,4 +1,10 @@
 # Traitor single items
+- type: stealTargetGroup
+  id: Money
+  name: steal-target-groups-money
+  sprite:
+    sprite: Objects/Economy/cash.rsi
+    state: cash_100
 
 - type: stealTargetGroup
   id: Hypospray

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -152,6 +152,21 @@
     difficulty: 0.5 # just for fun, collectings LAMP on Moth
 
 # steal item
+- type: entity
+  parent: BaseThiefStealObjective
+  id: StealMoneyObjective
+  description: Steal 10,000 Spesos
+  components:
+  - type: Objective
+    difficulty: 0                         # doesn't contribute toward difficulty score since all thieves will have this objective
+  - type: StealCondition
+    stealGroup: Money
+    currencyStackId: Credit               # must match your money's StackTypeId (!!!!)
+    currencyTargetAmount: 10000
+    currencyValuePerUnit: 1
+    verifyMapExistence: false
+    objectiveNoOwnerText: objective-steal-currency-title
+    descriptionText: objective-steal-currency-desc
 
 - type: entity                                      #Security subgroup
   parent: BaseThiefStealObjective


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Thieves now have an objective to steal 10,000 spesos.  Spesos have been removed from the communicator bundle and replaced with gold bars.  

## Why / Balance
I like to play thief but the objectives are often lackluster.  Stealing money is fundamental to thieving, and we have more gameplay surrounding money than we used to with departmental request computers, lockboxes, etc.  This objective will encourage thieves to interact more with departments and gives them more impact on the station's economy, especially cargo.

10,000 was picked as a difficult but achievable goal.  AFAIK there is no way for a thief to get 10,000 spesos all at once, so it will encourage them to keep their cover and be stealthy as they look for sources of revenue.  Hopefully if cargo sees someone withdraw 10k from their account, they will freak out accordingly.

It doesn't really make sense for a thief to just have 20,000 spesos on hand for bribes, so I replaced them with gold bars, which they can use to bargain/gain trust with science or cargo, or sell directly.  They should be on the station to make money, not spend it.

## Technical details
Makes use of #39598 to extend functionality to StealConditionSystem.cs and StealConditionComponent.cs, allowing these objectives to track the number of spesos a player has.  Previously this was undoable as we didn't have a system to count stacked items like spesos, ointment, sheets, etc.



## Media
<img width="722" height="757" alt="Thief1" src="https://github.com/user-attachments/assets/87e9b23b-c1c0-4745-bc47-4d39d8fe9437" />
<img width="696" height="735" alt="Thief2" src="https://github.com/user-attachments/assets/f029cb34-2c1a-4090-b465-cc8dd0a4651a" />
<img width="734" height="701" alt="Thief3" src="https://github.com/user-attachments/assets/793fb661-e371-424a-ac81-87c8d11a9797" />

Objective tracking works

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None that I am aware of

**Changelog**

:cl:
- add: Thieves now have an objective to steal 10,000 spesos
- tweak: The 20,000 spesos in the thief's communicator kit have been replaced with gold bars.