### PR TITLE
Trigger On Cancelled Trigger

### DIFF
--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnCancelledTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnCancelledTriggerComponent.cs
@@ -1,0 +1,21 @@
+using Content.Shared.Trigger.Systems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Translates a cancelled trigger into a new trigger.
+/// The user of the new trigger is the same as the cancelled trigger.
+/// </summary>
+/// <remarks> WARNING: Has the potential to cause an infinite loop by listening for its own trigger. </remarks>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnCancelledTriggerComponent : Component
+{
+    /// <summary>
+    /// KeyIn followed by KeyOut. Does not support a KeyIn being identical to KeyOut.
+    /// KeyIn: The key that will trigger the KeyOut.
+    /// KeyOut: The trigger key that will activate.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Dictionary<string, string> KeyInOut = new(){ [TriggerSystem.DefaultTriggerKey] = TriggerSystem.CancelledTriggerKey };
+}

--- a/Content.Shared/Trigger/Systems/TriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.cs
@@ -40,6 +40,7 @@ public sealed partial class TriggerSystem : EntitySystem
     [Dependency] private readonly SharedDeviceLinkSystem _deviceLink = default!;
 
     public const string DefaultTriggerKey = "trigger";
+    public const string CancelledTriggerKey = "cancelled";
 
     public override void Initialize()
     {
@@ -67,7 +68,11 @@ public sealed partial class TriggerSystem : EntitySystem
         var attemptTriggerEvent = new AttemptTriggerEvent(user, key);
         RaiseLocalEvent(trigger, ref attemptTriggerEvent);
         if (attemptTriggerEvent.Cancelled)
+        {
+            var cancelledTriggerEvent = new CancelledTriggerEvent(user, key);
+            RaiseLocalEvent(trigger, ref cancelledTriggerEvent);
             return false;
+        }
 
         var triggerEvent = new TriggerEvent(user, key);
         RaiseLocalEvent(trigger, ref triggerEvent, true);

--- a/Content.Shared/Trigger/TriggerEvent.cs
+++ b/Content.Shared/Trigger/TriggerEvent.cs
@@ -21,9 +21,20 @@ public record struct TriggerEvent(EntityUid? User = null, string? Key = null, bo
 /// Allows to have multiple independent triggers on the same entity.
 /// Setting this to null will activate all triggers.
 /// </param>
-/// <param name="Handled">Marks the event as handled if at least one trigger effect was activated.</param>
+/// <param name="Cancelled">Marks if the attempt has failed and to not go through with the trigger.</param>
 [ByRefEvent]
 public record struct AttemptTriggerEvent(EntityUid? User, string? Key = null, bool Cancelled = false);
+
+/// <summary>
+/// Raised after an AttemptTriggerEvent is cancelled.
+/// </summary>
+/// <param name="User">The entity that activated the trigger.</param>
+/// <param name="Key">
+/// Allows to have multiple independent triggers on the same entity.
+/// Setting this to null will activate all triggers.
+/// </param>
+[ByRefEvent]
+public record struct CancelledTriggerEvent(EntityUid? User, string? Key = null);
 
 /// <summary>
 /// Raised when a timer trigger becomes active.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a new trigger, which triggers a trigger when the first trigger is <del>triggered</del> cancelled.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Advances #39354

This trigger is not actually listed in that issue, but I feel it has a lot of potential. It enables player feedback when a trigger fails such as a sound or popup, or the possibility of catastrophic failure via a different trigger than what the player was hoping for.

## Technical details
<!-- Summary of code changes for easier review. -->
`TriggerOnCancelledTriggerComponent` does not inherit from the existing bases. Instead it uses a `dictionary<string, string>` to translate a `KeyIn` to a `KeyOut`.

A new event `CancelledTriggerEvent` is called when an `AttemptTriggerEvent` is cancelled, using the same args the attempt event did. `TriggerOnCancelledTriggerComponent` listens for it, takes the `args.Key`, and triggers the `KeyOut` associated with it.

This will probably need a little bit more work to be pretty.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


https://github.com/user-attachments/assets/5b28c394-3d05-4970-9edb-db1627aade7b



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl