### PR TITLE
InflictStaminaOnTrigger

### DIFF
--- a/Content.Shared/Trigger/Components/Effects/InflictStaminaOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/InflictStaminaOnTriggerComponent.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Damage;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Effects;
+
+/// <summary>
+/// Will damage an entity when triggered.
+/// If TargetUser is true it the user will take damage instead.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class InflictStaminaOnTriggerComponent : BaseXOnTriggerComponent
+{
+    /// <summary>
+    /// Should the damage ignore resistances?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool IgnoreResistances;
+
+
+    /// <summary>
+    /// The stamina amount that is dealt.
+    /// May be further modified by <see cref="Systems.BeforeDamageOnTriggerEvent"/> subscriptions.
+    /// </summary>
+    [DataField(required: true), AutoNetworkedField]
+    public float Stamina;
+}

--- a/Content.Shared/Trigger/Systems/InflictStaminaOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/InflictStaminaOnTriggerSystem.cs
@@ -1,0 +1,42 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Trigger.Components.Effects;
+
+namespace Content.Shared.Trigger.Systems;
+
+public sealed class InflictStaminaOnTrigger : EntitySystem
+{
+    [Dependency] private readonly SharedStaminaSystem _stamina = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<InflictStaminaOnTriggerComponent, TriggerEvent>(OnTrigger);
+    }
+
+    private void OnTrigger(Entity<InflictStaminaOnTriggerComponent> ent, ref TriggerEvent args)
+    {
+        if (args.Key != null && !ent.Comp.KeysIn.Contains(args.Key))
+            return;
+
+        var target = ent.Comp.TargetUser ? args.User : ent.Owner;
+
+        if (target == null)
+            return;
+
+        var ev = new BeforeInflictStaminaOnTriggerEvent(ent.Comp.Stamina, target.Value);
+        RaiseLocalEvent(ent.Owner, ref ev);
+
+        _stamina.TakeStaminaDamage(target.Value, ev.Stamina, source: ent.Owner, ignoreResist: ent.Comp.IgnoreResistances);
+
+        args.Handled = true;
+    }
+}
+
+/// <summary>
+/// Raised on an entity before it inflicts stamina using InflictStaminaOnTriggerEvent.
+/// Used to modify the stamina that will be inflicted.
+/// </summary>
+[ByRefEvent]
+public record struct BeforeInflictStaminaOnTriggerEvent(float Stamina, EntityUid Tripper);


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Surprised this wasn't done alongside the damage one.

Inflicts some amount of stamina to the owner or target, same as DamageOnTrigger.

## Why / Balance
Sometimes people should have a lie down at the Immovable Rod's expense.

## Technical details
Triggers are cool. I like how we're sneaking in this as it's pretty close to "coding in YAML" but is going to allow for some really jank hardcoded systems to be deleted.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
Nah
