### PR TITLE
Predict Mind Roles

### DIFF
--- a/Content.Server/Roles/ParadoxCloneRoleSystem.cs
+++ b/Content.Server/Roles/ParadoxCloneRoleSystem.cs
@@ -19,11 +19,13 @@ public sealed class ParadoxCloneRoleSystem : EntitySystem
 
     private void OnRefreshNameModifiers(Entity<ParadoxCloneRoleComponent> ent, ref MindRelayedEvent<RefreshNameModifiersEvent> args)
     {
-        if (!TryComp<MindRoleComponent>(ent.Owner, out var roleComp))
+        var mindId = Transform(ent).ParentUid; // the mind role entity is in a container in the mind entity
+
+        if (!TryComp<MindComponent>(mindId, out var mindComp))
             return;
 
         // only show for ghosts
-        if (!HasComp<GhostComponent>(roleComp.Mind.Comp.OwnedEntity))
+        if (!HasComp<GhostComponent>(mindComp.OwnedEntity))
             return;
 
         if (ent.Comp.NameModifier != null)

--- a/Content.Server/Roles/RoleSystem.cs
+++ b/Content.Server/Roles/RoleSystem.cs
@@ -36,7 +36,7 @@ public sealed class RoleSystem : SharedRoleSystem
 
         // Briefing is no longer raised on the mind entity itself
         // because all the components that briefings subscribe to should be on Mind Role Entities
-        foreach(var role in mindComp.MindRoles)
+        foreach (var role in mindComp.MindRoleContainer.ContainedEntities)
         {
             RaiseLocalEvent(role, ref ev);
         }

--- a/Content.Shared/EntityEffects/EffectConditions/JobCondition.cs
+++ b/Content.Shared/EntityEffects/EffectConditions/JobCondition.cs
@@ -16,13 +16,13 @@ public sealed partial class JobCondition : EntityEffectCondition
     {
         args.EntityManager.TryGetComponent<MindContainerComponent>(args.TargetEntity, out var mindContainer);
 
-        if ( mindContainer is null
-             || !args.EntityManager.TryGetComponent<MindComponent>(mindContainer.Mind, out var mind))
+        if (mindContainer is null
+            || !args.EntityManager.TryGetComponent<MindComponent>(mindContainer.Mind, out var mind))
             return false;
 
-        foreach (var roleId in mind.MindRoles)
+        foreach (var roleId in mind.MindRoleContainer.ContainedEntities)
         {
-            if(!args.EntityManager.HasComponent<JobRoleComponent>(roleId))
+            if (!args.EntityManager.HasComponent<JobRoleComponent>(roleId))
                 continue;
 
             if (!args.EntityManager.TryGetComponent<MindRoleComponent>(roleId, out var mindRole))

--- a/Content.Shared/Mind/MindComponent.cs
+++ b/Content.Shared/Mind/MindComponent.cs
@@ -1,8 +1,7 @@
-using Content.Shared.GameTicking;
 using Content.Shared.Mind.Components;
+using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Network;
-using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Mind;
@@ -100,10 +99,16 @@ public sealed partial class MindComponent : Component
     public bool PreventSuicide { get; set; }
 
     /// <summary>
-    ///     Mind Role Entities belonging to this Mind
+    /// Mind Role Entities belonging to this Mind are stored in this container.
     /// </summary>
-    [DataField, AutoNetworkedField]
-    public List<EntityUid> MindRoles = new List<EntityUid>();
+    [ViewVariables]
+    public Container MindRoleContainer = default!;
+
+    /// <summary>
+    /// The id for the MindRoleContainer.
+    /// </summary>
+    [ViewVariables]
+    public const string MindRoleContainerId = "mind_roles";
 
     /// <summary>
     ///     The mind's current antagonist/special role, or lack thereof;

--- a/Content.Shared/Mind/SharedMindSystem.Relay.cs
+++ b/Content.Shared/Mind/SharedMindSystem.Relay.cs
@@ -23,7 +23,7 @@ public abstract partial class SharedMindSystem : EntitySystem
         {
             RaiseLocalEvent(mindId, ref ev);
 
-            foreach (var role in mindComp.MindRoles)
+            foreach (var role in mindComp.MindRoleContainer.ContainedEntities)
                 RaiseLocalEvent(role, ref ev);
         }
     }
@@ -36,7 +36,7 @@ public abstract partial class SharedMindSystem : EntitySystem
         {
             RaiseLocalEvent(mindId, ref ev);
 
-            foreach (var role in mindComp.MindRoles)
+            foreach (var role in mindComp.MindRoleContainer.ContainedEntities)
                 RaiseLocalEvent(role, ref ev);
         }
 

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -15,8 +15,8 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Objectives.Systems;
 using Content.Shared.Players;
 using Content.Shared.Speech;
-
 using Content.Shared.Whitelist;
+using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
@@ -36,6 +36,7 @@ public abstract partial class SharedMindSystem : EntitySystem
     [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
     [Dependency] private readonly MetaDataSystem _metadata = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
 
     [ViewVariables]
     protected readonly Dictionary<NetUserId, EntityUid> UserMinds = new();
@@ -64,6 +65,8 @@ public abstract partial class SharedMindSystem : EntitySystem
 
     private void OnMindStartup(EntityUid uid, MindComponent component, ComponentStartup args)
     {
+        component.MindRoleContainer = _container.EnsureContainer<Container>(uid, MindComponent.MindRoleContainerId);
+
         if (component.UserId == null)
             return;
 


### PR DESCRIPTION
## About the PR
Resolves https://github.com/space-wizards/space-station-14/issues/39590
and needed for https://github.com/space-wizards/space-station-14/issues/39286

## Why / Balance
Needed for prediction reasons. Also helps with a future admin role/objective editor UI.

## Technical details
Stores the mind role entities belonging to a mind entity inside a container in the `MindComponent`.
These has several advantages:
- The mind entity has a PVS override for the owner of the mind. The entity itself is stored in nullspace and will not be networked to other clients, preventing cheat clients from reading information about others' antag status. With how PVS and containers work, storing the mind role entities in a container will network it along with the override, allowing the player to see their own mind roles.
- This allows us to use `MindHasRole<T>` in shared. This is needed for predicting some items only certain antags can use, for example thieving beacons and spider charges.
- We can get rid of the awkward two-way referencing between the role entity and the mind entity. The are automatically removed from the container when deleted.
- This should also fix the errors we sometimes get on during end-of-round cleanup, where the entities are deleted in the wrong order.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The `MindRoles` datafield in `MindComponent` was removed. Use `MindRoleContainer` instead.
The `Mind` datafield in `MindRoleComponent` was removed. Get the mind role entity's containing entity instead.

**Changelog**
not player facing