### PR TITLE
Adds cartridge tag to grenade shells

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
@@ -51,6 +51,7 @@
   - type: Tag
     tags:
     - Grenade
+    - Cartridge
   - type: Item
     size: Small
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I added the cartridge tag to grenade shells

## Why / Balance
It annoyed me that grenade shells didn't fit in a trash bag

## Technical details
Single extra tag to BaseGrenade

## Media
![trash](https://github.com/user-attachments/assets/174a3f7d-0a10-42d4-a0f3-9d2c892b4827)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
I can't think of anything that this would break

**Changelog**
:cl:
- add: added the ability to put grenade shells in trash bags

