### PR TITLE
fix lightbulb color

### DIFF
--- a/Content.Shared/Light/EntitySystems/SharedLightBulbSystem.cs
+++ b/Content.Shared/Light/EntitySystems/SharedLightBulbSystem.cs
@@ -22,8 +22,7 @@ public abstract class SharedLightBulbSystem : EntitySystem
     private void OnInit(EntityUid uid, LightBulbComponent bulb, ComponentInit args)
     {
         // update default state of bulbs
-        SetColor(uid, bulb.Color, bulb);
-        SetState(uid, bulb.State, bulb);
+        UpdateAppearance(uid, bulb);
     }
 
     private void HandleLand(EntityUid uid, LightBulbComponent bulb, ref LandEvent args)


### PR DESCRIPTION
## About the PR
Fixes https://github.com/space-wizards/space-station-14/issues/39618

## Why / Balance
bugfix

## Technical details
`SetColor` and `SetState` were setting the datafields to their current value which got caught by the guard statement because nothing changes.
Instead we directly update the appearance data after initializing.

## Media
<img width="381" height="293" alt="grafik" src="https://github.com/user-attachments/assets/f819e19b-17d1-4697-b097-59b34af4fb05" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed light bulb color.
