### PR TITLE
Adds comms functionality to headphones

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Multiple/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/misc.yml
@@ -4,6 +4,16 @@
   name: headphones
   description: Quality headphones from Drunk Masters, with good sound insulation.
   components:
+  - type: ContainerContainer
+    containers:
+      key_slots: !type:Container
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommon
+  - type: Headset
+  - type: EncryptionKeyHolder
+    keySlots: 4
   - type: Sprite
     sprite: Clothing/Multiple/headphones.rsi
     layers:


### PR DESCRIPTION
## About the PR
added container components to allow headphones to take and use encryption keys as radio.

## Why / Balance
headphones have the functionality to be worn on the ear, but would never replace a comms headpiece as is.

## Technical details
copy-pasted the headset components from the default headset

## Media
<img width="1918" height="1017" alt="headphone works ss1" src="https://github.com/user-attachments/assets/504ed13a-1f53-471f-9a60-93101e7581ef" />

<img width="268" height="191" alt="image" src="https://github.com/user-attachments/assets/b560b2a6-4a8c-45fa-b201-c48a78fa20a9" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
-add can now insert encryption keys into headphones
