### PR TITLE
adds encryption key capacity for headphones

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Multiple/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/misc.yml
@@ -10,7 +10,6 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyCommon
   - type: Headset
   - type: EncryptionKeyHolder
     keySlots: 4

--- a/Resources/Prototypes/Entities/Clothing/Multiple/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/misc.yml
@@ -4,6 +4,16 @@
   name: headphones
   description: Quality headphones from Drunk Masters, with good sound insulation.
   components:
+  - type: ContainerContainer
+    containers:
+      key_slots: !type:Container
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommon
+  - type: Headset
+  - type: EncryptionKeyHolder
+    keySlots: 4
   - type: Sprite
     sprite: Clothing/Multiple/headphones.rsi
     layers:

--- a/Resources/Prototypes/Entities/Clothing/Multiple/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/misc.yml
@@ -8,8 +8,6 @@
     containers:
       key_slots: !type:Container
   - type: ContainerFill
-    containers:
-      key_slots:
   - type: Headset
   - type: EncryptionKeyHolder
     keySlots: 4


### PR DESCRIPTION
## About the PR
added container components to allow headphones to take and use encryption keys as radio if worn in ear slot.

## Why / Balance
headphones have the functionality to be worn on the ear, but would never replace a comms headpiece as is.
edit: integrated headphones are a thing and not remotely uncommon. I'd expect the future would have good enough if not better background noise cancellation that these would be completely feasible. This is a simple addition that, if need be could be reverted and few would notice. I just want drip.

## Technical details
copy-pasted the headset components from the default headset

## Media

<img width="1918" height="1017" alt="headphone works ss1" src="https://github.com/user-attachments/assets/1df0f7d4-e0a9-4abd-af18-372326a53c33" />
<img width="546" height="336" alt="image" src="https://github.com/user-attachments/assets/0f63b028-c23d-4421-b854-524a36637f7a" />
<img width="480" height="233" alt="headphone no EC 1" src="https://github.com/user-attachments/assets/32147897-8e5f-4e96-a484-586144b4e3d2" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

🆑 

- add: Can now insert encryption keys into headphones.
