### PR TITLE
Add TriggerOnExamined

### DIFF
--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnExaminedComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnExaminedComponent.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Examine;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Triggers when the entity is examined (<see cref="ExaminedEvent"/>).
+/// The user is the player examining the entity.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnExaminedComponent : BaseTriggerOnXComponent
+{
+    /// <summary>
+    /// Only trigger if the examined entity is within detail range.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool RequireInDetailRange = true;
+}

--- a/Content.Shared/Trigger/Systems/TriggerOnExaminedSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerOnExaminedSystem.cs
@@ -1,0 +1,24 @@
+using Content.Shared.Examine;
+using Content.Shared.Trigger.Components.Triggers;
+
+namespace Content.Shared.Trigger.Systems;
+public sealed partial class TriggerOnExaminedSystem : EntitySystem
+{
+    [Dependency] private readonly TriggerSystem _trigger = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TriggerOnExaminedComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(Entity<TriggerOnExaminedComponent> ent, ref ExaminedEvent args)
+    {
+        if (ent.Comp.RequireInDetailRange && !args.IsInDetailsRange)
+            return;
+
+        _trigger.Trigger(ent.Owner, args.Examiner, ent.Comp.KeyOut);
+    }
+
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a trigger for when an entity is examined.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Advances [#39354](https://github.com/space-wizards/space-station-14/issues/39354)
## Technical details
<!-- Summary of code changes for easier review. -->
`TriggerOnExamined` component and system are mostly boilerplate, with a field for requiring the entity to be in detail range since that seems like common check.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/138b454c-dfc3-4b2e-a7f3-1b3ef3fa0bcd


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nuthin'
