### PR TITLE
Meat spike conjugation error

### DIFF
--- a/Resources/Locale/en-US/kitchen/components/kitchen-spike-component.ftl
+++ b/Resources/Locale/en-US/kitchen/components/kitchen-spike-component.ftl
@@ -1,7 +1,7 @@
 comp-kitchen-spike-deny-collect = { CAPITALIZE(THE($this)) } already has something on it, finish collecting its meat first!
 comp-kitchen-spike-deny-butcher = { CAPITALIZE(THE($victim)) } can't be butchered on { THE($this) }.
 comp-kitchen-spike-deny-butcher-knife = { CAPITALIZE(THE($victim)) } can't be butchered on { THE($this) }, you need to butcher it using a knife.
-comp-kitchen-spike-deny-not-dead = { CAPITALIZE(THE($victim)) } can't be butchered. { CAPITALIZE(SUBJECT($victim)) } { CONJUGATE-BE($victim) } is not dead!
+comp-kitchen-spike-deny-not-dead = { CAPITALIZE(THE($victim)) } can't be butchered. { CAPITALIZE(SUBJECT($victim)) } { CONJUGATE-BE($victim) } not dead!
 
 comp-kitchen-spike-begin-hook-victim = { CAPITALIZE(THE($user)) } begins dragging you onto { THE($this) }!
 comp-kitchen-spike-begin-hook-self = You begin dragging yourself onto { THE($this) }!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes the conjugation error when failing to meat spike a living thing.
## Why / Balance
It was syntactically incorrect.
## Technical details
Deleted 3 characters in `kitchen-spike-component.ftl`.
## Media
<img width="423" height="174" alt="image" src="https://github.com/user-attachments/assets/09311f17-3294-480d-8508-a6956fcf4513" />
<img width="367" height="134" alt="image" src="https://github.com/user-attachments/assets/dc095134-e3c2-4127-a70b-fe4d7371d13b" />
<img width="364" height="122" alt="image" src="https://github.com/user-attachments/assets/fa5a55cd-45bf-462f-9d67-4ab8c042b78c" />
<img width="310" height="132" alt="image" src="https://github.com/user-attachments/assets/4e524b7b-f5db-4cbc-a76f-41738261ac2f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.... surely...

