### PR TITLE
Hand pickup and drop triggers

### DIFF
--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnDidEquipHandComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnDidEquipHandComponent.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Triggers an entity when it is equips an item into one of its hand slots.
+/// The user is the entity that was equipped.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnDidEquipHandComponent : BaseTriggerOnXComponent;

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnDidUnequipHandComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnDidUnequipHandComponent.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Triggers an entity when it is drops an item from one of its hand slots.
+/// The user is the entity that was dropped.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnDidUnequipHandComponent : BaseTriggerOnXComponent;

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnDroppedComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnDroppedComponent.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Triggers an entity when it is dropped from a users hands, or directly removed from a users inventory, but not when moved between hands & inventory.
+/// The user is the player that was holding or wearing the item.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnDroppedComponent : BaseTriggerOnXComponent;

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnGotEquippedHandComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnGotEquippedHandComponent.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Triggers an item when it is equipped into a hand slot.
+/// The user is the entity that picked the item up.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnGotEquippedHandComponent : BaseTriggerOnXComponent;

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnGotUnequippedHandComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnGotUnequippedHandComponent.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Triggers an item when it is dropped from a hand slot.
+/// The user is the entity that dropped the item.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnGotUnequippedHandComponent : BaseTriggerOnXComponent;

--- a/Content.Shared/Trigger/Systems/HandTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/HandTriggerSystem.cs
@@ -1,0 +1,64 @@
+using Content.Shared.Hands;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Trigger.Components.Triggers;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.Trigger.Systems;
+
+public sealed partial class HandTriggerSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly TriggerSystem _trigger = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TriggerOnGotEquippedHandComponent, GotEquippedHandEvent>(OnGotEquipped);
+        SubscribeLocalEvent<TriggerOnGotUnequippedHandComponent, GotUnequippedHandEvent>(OnGotUnequipped);
+        SubscribeLocalEvent<TriggerOnDidEquipHandComponent, DidEquipHandEvent>(OnDidEquip);
+        SubscribeLocalEvent<TriggerOnDidUnequipHandComponent, DidUnequipHandEvent>(OnDidUnequip);
+        SubscribeLocalEvent<TriggerOnDroppedComponent, DroppedEvent>(OnDropped);
+    }
+
+    private void OnGotEquipped(Entity<TriggerOnGotEquippedHandComponent> ent, ref GotEquippedHandEvent args)
+    {
+        // If the entity was equipped on the server (without prediction) then the container change is networked to the client
+        // which will raise the same event, but the effect of the trigger is already networked on its own. So this guard statement
+        // prevents triggering twice on the client.
+        if (_timing.ApplyingState)
+            return;
+
+        _trigger.Trigger(ent.Owner, args.User, ent.Comp.KeyOut);
+    }
+
+    private void OnGotUnequipped(Entity<TriggerOnGotUnequippedHandComponent> ent, ref GotUnequippedHandEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        _trigger.Trigger(ent.Owner, args.User, ent.Comp.KeyOut);
+    }
+
+    private void OnDidEquip(Entity<TriggerOnDidEquipHandComponent> ent, ref DidEquipHandEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        _trigger.Trigger(ent.Owner, args.Equipped, ent.Comp.KeyOut);
+    }
+
+    private void OnDidUnequip(Entity<TriggerOnDidUnequipHandComponent> ent, ref DidUnequipHandEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        _trigger.Trigger(ent.Owner, args.Unequipped, ent.Comp.KeyOut);
+    }
+
+    private void OnDropped(Entity<TriggerOnDroppedComponent> ent, ref DroppedEvent args)
+    {
+        // We don't need the guard statement here because this one is not a container event, but raised directly when interacting.
+        _trigger.Trigger(ent.Owner, args.User, ent.Comp.KeyOut);
+    }
+}


### PR DESCRIPTION
## About the PR
TriggerOnDidEquipHandComponent
TriggerOnDidUnequipHandComponent
TriggerOnGotEquippedHandComponent
TriggerOnGotUnequippedHandComponent
TriggerOnDroppedComponent

## Why / Balance
see #39354
needed for the game tutorial

## Technical details
simple event subscription

## Testing prototypes
```
- type: entity
  parent: BaseItem
  id: TriggerTestItem1
  name: TriggerOnDropped
  components:
  - type: Sprite
    sprite: Objects/Fun/Plushies/lizard.rsi
    state: icon
  - type: TriggerOnDropped
  - type: ToggleComponentsOnTrigger
    components:
    - type: PointLight

- type: entity
  parent: BaseItem
  id: TriggerTestItem2
  name: TriggerOnGotEquippedHand
  components:
  - type: Sprite
    sprite: Objects/Fun/Plushies/lizard.rsi
    state: icon
  - type: TriggerOnGotEquippedHand
  - type: ToggleComponentsOnTrigger
    components:
    - type: PointLight

- type: entity
  parent: BaseItem
  id: TriggerTestItem3
  name: TriggerOnGotUnequippedHand
  components:
  - type: Sprite
    sprite: Objects/Fun/Plushies/lizard.rsi
    state: icon
  - type: TriggerOnGotUnequippedHand
  - type: ToggleComponentsOnTrigger
    components:
    - type: PointLight

- type: entity
  parent: MobHuman
  id: UristMcTrigger1
  name: Urist Mc TriggerOnDidEquipHand
  components:
  - type: TriggerOnDidEquipHand
  - type: ToggleComponentsOnTrigger
    components:
    - type: PointLight

- type: entity
  parent: MobHuman
  id: UristMcTrigger2
  name: Urist Mc TriggerOnDidUnequipHand
  components:
  - type: TriggerOnDidUnequipHand
  - type: ToggleComponentsOnTrigger
    components:
    - type: PointLight

```

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
not player facing
