### PR TITLE
Fixed exception thrown when user with 'Free' patron clicks on Patron …

### DIFF
--- a/Content.Client/Credits/CreditsWindow.xaml.cs
+++ b/Content.Client/Credits/CreditsWindow.xaml.cs
@@ -288,14 +288,23 @@ public sealed partial class CreditsWindow : DefaultWindow
         }
 
         var first = true;
-        foreach (var tier in patrons.GroupBy(p => p.Tier).OrderBy(p => PatronTierPriority[p.Key]))
+
+        var grouped = patrons
+            .Where(p => !string.IsNullOrWhiteSpace(p.Tier) && PatronTierPriority.ContainsKey(p.Tier))
+            .GroupBy(p => p.Tier)
+            .OrderBy(g => PatronTierPriority[g.Key]);
+
+        foreach (var tier in grouped)
         {
             if (!first)
                 patronsContainer.AddChild(new Control { MinSize = new Vector2(0, 10) });
 
             first = false;
             patronsContainer.AddChild(new Label
-                { StyleClasses = { StyleBase.StyleClassLabelHeading }, Text = $"{tier.Key}" });
+            {
+                StyleClasses = { StyleBase.StyleClassLabelHeading },
+                Text = $"{tier.Key}"
+            });
 
             var msg = string.Join(", ", tier.OrderBy(p => p.Name).Select(p => p.Name));
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When a user clicks on Patron tab in Credits window, the application would crash (if user was not a Patron member?) Patron tab now ignores the 'Free' option and displays Patron Tiers.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
User should be able to see Patron Tiers when not subscribed

## Technical details
<!-- Summary of code changes for easier review. -->
created a variable which ignores any "Null or Whitespace" tiers

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="609" height="620" alt="Screenshot 2025-08-15 140047" src="https://github.com/user-attachments/assets/2373ff28-bb18-4ee3-a845-5f1e8b8c5457" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
none

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Fixed: Crashed upon clicking on Patron tab in the Credits window for non-patron members
