### PR TITLE
predict StackSystem GetVerbsEvent and stack splitting

### DIFF
--- a/Content.Client/Stack/StackSystem.cs
+++ b/Content.Client/Stack/StackSystem.cs
@@ -28,13 +28,6 @@ namespace Content.Client.Stack
 
             base.SetCount(uid, amount, component);
 
-            // TODO PREDICT ENTITY DELETION: This should really just be a normal entity deletion call.
-            if (component.Count <= 0)
-            {
-                Xform.DetachEntity(uid, Transform(uid));
-                return;
-            }
-
             component.UiUpdateNeeded = true;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Stack splitting verbs (such as <i>halve</i>) now appear instantly on the client when right clicking a stackable item.
Stacks are now split instantly after stack splitting verbs are used.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
See https://github.com/space-wizards/space-station-14/issues/39286
## Technical details
<!-- Summary of code changes for easier review. -->
- `OnStackAlternativeInteract()`, `UserSplit()`, and `Split()` methods have been moved from `StackSystem.cs` (Content.Server) to `SharedStackSystem.cs`. 
- `StackSystem.cs` (Content.Server) no longer subscribes to GetVerbsEvent, now `SharedStackSystem.cs` does.
- The `Split()` method is now virtual. `StackSystem.cs` (Content.Server) now overrides this method. This override method first calls the base method, and then raises a local StackSplitEvent. (Originally, `Split()` on Content.Server raised this event locally, so in moving `Split()` to the shared StackSystem, I've kept this functionality on the server in order to avoid potential weirdness caused by a method being raised on the client when it shouldn't)
- `SetCount()` methods inside of `StackSystem.cs` (Content.Client AND Content.Server) have been simplified. Entity deletion is no longer handled by these methods, instead by `SetCount()` inside of `SharedStackSystem.cs`, in order to facilitate prediction of entity deletion (instead of the workaround that was used before)
-  Some `PopupCursor()` calls are now `PopupPredictedCursor()` calls.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<i>Before (Note that verbs pop up after a moment on the right click menu, and that splitting takes a moment to occur once the verbs are selected)</i>

https://github.com/user-attachments/assets/39fa3640-0a7b-4762-a951-71d70aa52828

<i>After (Verbs are present as soon as the right click menu is open, splitting occurs instantaneously)</i>

https://github.com/user-attachments/assets/5d74baed-5330-47e2-8d3b-fea435a09e69

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
None needed