### PR TITLE
Increase the bananium horn use delay

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/bike_horn.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/bike_horn.yml
@@ -158,6 +158,8 @@
     sprite: Objects/Fun/bananiumhorn.rsi
     slots: [Belt]
     quickEquip: false
+  - type: UseDelay
+    delay: 3
   - type: EmitSoundOnUse
     sound:
       collection: BananiumHorn


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I increased the delay between each use of the bananium horn to 3 seconds

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The sound of the bananium horn is INCREDIBLY obnoxious when played at maximum speed.
With this PR, the bananium horn is still obnoxious but slightly less often so it doesn't hurt your ears.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

before:

https://github.com/user-attachments/assets/73d55d5a-b9b0-434a-a2ee-04e998155e9b

after:

https://github.com/user-attachments/assets/f63762ca-7933-428b-b8fd-f2affc07bcd0



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The usage delay of the bananium horn is now 3 seconds.