### PR TITLE
Reagents now drop when dispensers are deconstructed

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -79,5 +79,5 @@
   - type: WiresPanel
   - type: EmptyOnMachineDeconstruct
     containers:
-      - storagebase
-      - beakerSlot
+    - storagebase
+    - beakerSlot

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -77,3 +77,6 @@
   - type: StaticPrice
     price: 1000
   - type: WiresPanel
+  - type: EmptyOnMachineDeconstruct
+    containers:
+      - storagebase

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -80,3 +80,4 @@
   - type: EmptyOnMachineDeconstruct
     containers:
       - storagebase
+      - beakerSlot


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When dispensers are deconstructed, it will now drop the items that were inside

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
see #39658
Items should not disappear when a player deconstructs a dispenser.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="392" height="302" alt="Screenshot 2025-08-15 190344" src="https://github.com/user-attachments/assets/31e31f73-da45-41e0-a803-7377b5f921b8" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
none

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed bug where items would not drop if a dispenser was deconstructed.