### PR TITLE
Fix industrial reagent grinder bug

### DIFF
--- a/Content.Client/Instruments/MidiParser/MidiParser.cs
+++ b/Content.Client/Instruments/MidiParser/MidiParser.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
 using Content.Shared.Instruments;
 
@@ -103,13 +104,16 @@ public static class MidiParser
                         // 0x04 is InstrumentName
 
                         var text = Encoding.ASCII.GetString(metaData, 0, (int)metaLength);
+                        // remove all control characters
+                        // some of these ended up in the admin logs, causing database errors
+                        var sanitizedText = new string(text.Where(c => !char.IsControl(c)).ToArray());
                         switch (metaType)
                         {
                             case 0x03 when track.TrackName == null:
-                                track.TrackName = text;
+                                track.TrackName = sanitizedText;
                                 break;
                             case 0x04 when track.InstrumentName == null:
-                                track.InstrumentName = text;
+                                track.InstrumentName = sanitizedText;
                                 break;
                         }
 

--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -184,19 +184,22 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
 
         var xform = Transform(uid);
 
-        SpawnMaterialsFromComposition(uid, item, completion * component.Efficiency, xform: xform);
+        if (component.ReclaimMaterials)
+            SpawnMaterialsFromComposition(uid, item, completion * component.Efficiency, xform: xform);
 
         if (CanGib(uid, item, component))
         {
             var logImpact = HasComp<HumanoidAppearanceComponent>(item) ? LogImpact.Extreme : LogImpact.Medium;
             _adminLogger.Add(LogType.Gib, logImpact, $"{ToPrettyString(item):victim} was gibbed by {ToPrettyString(uid):entity} ");
-            SpawnChemicalsFromComposition(uid, item, completion, false, component, xform);
+            if (component.ReclaimSolutions)
+                SpawnChemicalsFromComposition(uid, item, completion, false, component, xform);
             _body.GibBody(item, true);
             _appearance.SetData(uid, RecyclerVisuals.Bloody, true);
         }
         else
         {
-            SpawnChemicalsFromComposition(uid, item, completion, true, component, xform);
+            if (component.ReclaimSolutions)
+                SpawnChemicalsFromComposition(uid, item, completion, true, component, xform);
         }
 
         QueueDel(item);

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -70,6 +70,20 @@ public sealed partial class MaterialReclaimerComponent : Component
     public string? SolutionContainerId;
 
     /// <summary>
+    /// Can this reclaimer reclaim materials?
+    /// They will be spawned as material stacks.
+    /// </summary>
+    [DataField]
+    public bool ReclaimMaterials = true;
+
+    /// <summary>
+    /// Can this reclaimer reclaim solutions?
+    /// The reclaimed reagents will be stored in a buffer or spilled on the ground if that is full.
+    /// </summary>
+    [DataField]
+    public bool ReclaimSolutions = true;
+
+    /// <summary>
     /// If the reclaimer should attempt to reclaim all solutions or just drainable ones
     /// Difference between Recycler and Industrial Reagent Grinder
     /// </summary>

--- a/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
@@ -73,6 +73,7 @@
       tags:
       - HighRiskItem #ian meat
     efficiency: 0.9
+    reclaimMaterials: false # Materials have ExractableComponent, which is whitelisted, so we have to avoid infinite recycling loops
     onlyReclaimDrainable: false
     solutionContainerId: output
   - type: Sprite


### PR DESCRIPTION
## About the PR
The industrial reagent grinder is whitelisted to `ExtractableComponent`, but as a MaterialRecycler it was also spawning material stacks - which have the `ExtractableComponent` and are creating an infinite recycling loop for certain items.
This bug always existed since the industrial grinder was intruded and remained unnoticed because of another bug that was fixed in https://github.com/space-wizards/space-station-14/pull/38433 causing dimishing returns.

## Why / Balance
bugs bad

## Technical details
We add two new bool datafields to be able to enable material and solution recycling separately and disable material recycling for the reagent grinder.
Ideally we would also have an integration test that makes sure that recyclers cannot spawn any items that they can recycle.

## Media
reproduction in internal staff chat

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed a game crash with the industrial reagent grinder.
