### PR TITLE
Nukeops disk-centric win condition

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -109,8 +109,7 @@ public enum WinType : byte
     /// </summary>
     OpsMajor,
     /// <summary>
-    ///     Minor win. All nukies were alive at the end of the round.
-    ///     Alternatively, some nukies were alive, but the disk was left behind.
+    ///     Operative minor win. At least one nukie survived, and the disk was left behind.
     /// </summary>
     OpsMinor,
     /// <summary>

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -232,14 +232,14 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
 
         if (_antag.AllAntagsAlive(ent.Owner))
         {
-            SetWinType(ent, WinType.OpsMinor);
             ent.Comp.WinConditions.Add(WinCondition.AllNukiesAlive);
-            return;
         }
-
-        ent.Comp.WinConditions.Add(_antag.AnyAliveAntags(ent.Owner)
-            ? WinCondition.SomeNukiesAlive
-            : WinCondition.AllNukiesDead);
+        else
+        {
+            ent.Comp.WinConditions.Add(_antag.AnyAliveAntags(ent.Owner)
+                ? WinCondition.SomeNukiesAlive
+                : WinCondition.AllNukiesDead);
+        }
 
         var diskAtCentCom = false;
         var diskQuery = AllEntityQuery<NukeDiskComponent, TransformComponent>();
@@ -254,7 +254,6 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         }
 
         // If the disk is currently at Central Command, the crew wins - just slightly.
-        // This also implies that some nuclear operatives have died.
         SetWinType(ent,
             diskAtCentCom
             ? WinType.CrewMinor

--- a/Resources/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml
@@ -105,8 +105,7 @@
   - The nuke is armed and delivered to Central Command on the evac shuttle.
 
   [bold][color=red]Syndicate Minor Victory[/color][/bold]
-  - The crew escapes on evac, but every operative survives.
-  - The crew escapes and some operatives die, but the crew loses the disk.
+  - At least one operative survives, and the crew escapes, leaving the disk behind.
 
   [bold][color=#999999]Neutral Victory[/color][/bold]
   - The nuke detonates off the station.


### PR DESCRIPTION
## About the PR
Nuclear operatives no longer get a minor win just for surviving.
If crew escapes, winner is decided based on the location of the disk:
* Syndicate wins if at least one operative survives and the disk is left behind
* Crew wins if they take the disk to Centcomm, no matter how many operatives stay standing.


## Why / Balance
Nuclear operatives must get the disk, or die trying. If crew escapes with the disk, the mission is failed, no matter how many operatives are still standing.

## Technical details
Removed a `SetWinType()` and early return in nukeops `OnRoundEnd()`, updated documentation.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes


**Changelog**
:cl:
- tweak: Nuclear operatives no longer get a minor win just for surviving. If crew escapes, winner is decided based on the location of the disk.
