### PR TITLE
Make tritium a new variant of fuel for a radiation collector

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
@@ -64,7 +64,7 @@
         reactantBreakdownRate: 0.0001
       - reactantPrototype: Tritium
         powerGenerationEfficiency: 1.5
-        reactantBreakdownRate: 0.0001
+        reactantBreakdownRate: 0.00005
   - type: RadiationReceiver
   - type: PowerSupplier
   - type: Anchorable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Tritium now can be used as fuel for radiation collectors as more poerful atelrnative to a plasma

## Why / Balance
becouse singularity now become not very popural becouse of It's not very big energy outputs and how it's more difficult to maintain comparing to tesla, and that tritium dosent has that much use besides making freezone and flamethrowers. I desided to make it's useful for upgrading energy output from singularity and also you need change canisters less friqantly, so it's should encurage atmoses to colaborate with engineering

## Technical details
tritium has 1.5 generation efficiency and stays 2 times longer than plasma

## Media
energy output with plasma
<img width="578" height="336" alt="image" src="https://github.com/user-attachments/assets/db4d0c86-2d85-4e15-82bc-4c6ab13e7fb6" />
energy output with tirtium
<img width="523" height="358" alt="image" src="https://github.com/user-attachments/assets/a83147ff-334c-47bf-aed1-a0bb5bd8ac9d" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nothing is breaking

**Changelog**
:cl:
- tweak: Now radiation collectors can use tritium to increase energy output!
