### PR TITLE
Fix rebinding keys crashing the game

### DIFF
--- a/Content.Client/UserInterface/Controls/MenuButton.cs
+++ b/Content.Client/UserInterface/Controls/MenuButton.cs
@@ -25,7 +25,7 @@ public sealed class MenuButton : ContainerButton
     private Color NormalColor => HasStyleClass(StyleClassRedTopButton) ? ColorRedNormal : ColorNormal;
     private Color HoveredColor => HasStyleClass(StyleClassRedTopButton) ? ColorRedHovered : ColorHovered;
 
-    private BoundKeyFunction _function;
+    private BoundKeyFunction? _function;
     private readonly BoxContainer _root;
     private readonly TextureRect? _buttonIcon;
     private readonly Label? _buttonLabel;
@@ -33,13 +33,13 @@ public sealed class MenuButton : ContainerButton
     public string AppendStyleClass { set => AddStyleClass(value); }
     public Texture? Icon { get => _buttonIcon!.Texture; set => _buttonIcon!.Texture = value; }
 
-    public BoundKeyFunction BoundKey
+    public BoundKeyFunction? BoundKey
     {
         get => _function;
         set
         {
             _function = value;
-            _buttonLabel!.Text = BoundKeyHelper.ShortKeyName(value);
+            _buttonLabel!.Text = _function == null ? "" : BoundKeyHelper.ShortKeyName(_function.Value);
         }
     }
 
@@ -95,12 +95,12 @@ public sealed class MenuButton : ContainerButton
 
     private void OnKeyBindingChanged(IKeyBinding obj)
     {
-        _buttonLabel!.Text = BoundKeyHelper.ShortKeyName(_function);
+        _buttonLabel!.Text = _function == null ? "" : BoundKeyHelper.ShortKeyName(_function.Value);
     }
 
     private void OnKeyBindingChanged()
     {
-        _buttonLabel!.Text = BoundKeyHelper.ShortKeyName(_function);
+        _buttonLabel!.Text = _function == null ? "" : BoundKeyHelper.ShortKeyName(_function.Value);
     }
 
     protected override void StylePropertiesChanged()


### PR DESCRIPTION
## About the PR
Thanks to sien for reporting the bug on Discord!

Rebinding any key currently crashes the client:
```
An unhandled exception of type 'System.NullReferenceException' occurred in Robust.Shared.dll: 'Object reference not set to an instance of an object.'
   at Robust.Shared.Input.BoundKeyFunction.GetHashCode() in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Shared\Input\KeyFunctions.cs:line 140
   at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
   at Robust.Client.Input.InputManager.TryGetKeyBinding(BoundKeyFunction function, IKeyBinding& binding) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 703
   at Content.Client.UserInterface.BoundKeyHelper.TryGetShortKeyName(BoundKeyFunction keyFunction, String& name) in D:\Code\SS14\space-station-14\Content.Client\UserInterface\BoundKeyHelpers.cs:line 29
   at Content.Client.UserInterface.BoundKeyHelper.ShortKeyName(BoundKeyFunction keyFunction) in D:\Code\SS14\space-station-14\Content.Client\UserInterface\BoundKeyHelpers.cs:line 13
   at Content.Client.UserInterface.Controls.MenuButton.OnKeyBindingChanged(IKeyBinding obj) in D:\Code\SS14\space-station-14\Content.Client\UserInterface\Controls\MenuButton.cs:line 98
   at Robust.Client.Input.InputManager.RemoveBinding(IKeyBinding binding, Boolean markModified) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 624
   at Content.Client.Options.UI.Tabs.KeyRebindTab.<>c__DisplayClass18_0.<RebindButtonPressed>b__0() in D:\Code\SS14\space-station-14\Content.Client\Options\UI\Tabs\KeyRebindTab.xaml.cs:line 488
   at Content.Client.Options.UI.Tabs.KeyRebindTab.FrameUpdate(FrameEventArgs args) in D:\Code\SS14\space-station-14\Content.Client\Options\UI\Tabs\KeyRebindTab.xaml.cs:line 504
   at Robust.Client.UserInterface.Control.DoFrameUpdateRecursive(FrameEventArgs args) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\UserInterface\Control.cs:line 1001
   at Robust.Client.UserInterface.Control.DoFrameUpdateRecursive(FrameEventArgs args) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\UserInterface\Control.cs:line 1005
   at Robust.Client.UserInterface.Control.DoFrameUpdateRecursive(FrameEventArgs args) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\UserInterface\Control.cs:line 1005
   at Robust.Client.UserInterface.Control.DoFrameUpdateRecursive(FrameEventArgs args) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\UserInterface\Control.cs:line 1005
   at Robust.Client.UserInterface.Control.DoFrameUpdateRecursive(FrameEventArgs args) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\UserInterface\Control.cs:line 1005
   at Robust.Client.UserInterface.Control.DoFrameUpdateRecursive(FrameEventArgs args) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\UserInterface\Control.cs:line 1005
   at Robust.Client.UserInterface.Control.DoFrameUpdateRecursive(FrameEventArgs args) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\UserInterface\Control.cs:line 1005
   at Robust.Client.UserInterface.UserInterfaceManager.FrameUpdate(FrameEventArgs args) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\UserInterface\UserInterfaceManager.cs:line 227
   at Robust.Client.GameController.Update(FrameEventArgs frameEventArgs) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.cs:line 630
   at Robust.Client.GameController.<StartupContinue>b__65_3(Object sender, FrameEventArgs args) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.cs:line 272
   at Robust.Shared.Timing.GameLoop.Run() in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Shared\Timing\GameLoop.cs:line 290
   at Robust.Client.GameController.ContinueStartupAndLoop(DisplayMode mode) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.Standalone.cs:line 163
   at Robust.Client.GameController.GameThreadMain(DisplayMode mode) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.Standalone.cs:line 148
   at Robust.Client.GameController.<>c__DisplayClass107_0.<Run>b__0() in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.Standalone.cs:line 107
```

## Why / Balance
bugfix

## Technical details
The `BoundKeyFunction` is not set for the new bug report feature because it does not need a bound key.
When the keybindings are changed it will try to refresh the button name, but fails when hashing it because it's null.
So we make it a proper nullable type and handle it with an empty string, so that menu buttons properly support this.

## Media
![ss14](https://github.com/user-attachments/assets/c673a3b9-7921-47a9-9412-e48ba54bc1ab)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`BoundKey` in `MenuButton.cs` is now of type `BoundKeyFunction?`.

**Changelog**
:cl: beck-thompson, slarticodefast
- fix: Fixed rebinding keys crashing the client.
