### PR TITLE
Make Anti-Narcoleptic Meds Good

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -927,6 +927,7 @@
   color: "#d5d5e4"
   metabolisms:
     Medicine:
+      metabolismRate: 0.02
       effects:
       - !type:Jitter
       - !type:GenericStatusEffect
@@ -956,6 +957,7 @@
   color: "#b0abaa"
   metabolisms:
     Medicine:
+      metabolismRate: 0.02
       effects:
       - !type:ModifyStatusEffect
         effectProto: StatusEffectDrowsiness


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed the metabolism rates on Ethyloxyphedrine and Diphenylmethylamine to last an actual amount of time from one pill.
Previously one (20u) pill of either drug would last 30 seconds before losing effectiveness and needing another dose, now they last 12 and a half minutes (target was 10 but this is the closest the game can manage with only two decimal places) before losing effectiveness.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Chemists don't make either of these drugs for generally three reasons:
1. nobody remembers they exist
2. they can take more steps to make than even the most advanced healing meds, and need botanicals
3. keeping one character topped off for a shift requires an incredible amount of the stuff, and requires redosing so often that narcoleptic characters generally don't ask

This pr aims to fix issue 3 by making the chemical last an actually game affecting amount of time. With the new metabolism rate one bottle of either can last an entire hour and a half shift, or a small handful of pills can handle shorter ones.

## Technical details
changes to the metabolism rate of two medicines

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Ethyloxyphedrine and Diphenylmethylamine now last significantly longer.
-->
