### PR TITLE
Rename "trash" reagent to "reprocessed material"

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/reagents/meta/toxins.ftl
@@ -82,5 +82,5 @@ reagent-desc-lipolicide = A powerful toxin that will destroy fat cells, massivel
 reagent-name-mechanotoxin = mechanotoxin
 reagent-desc-mechanotoxin = A neurotoxin used as venom by some species of spider. Degrades movement when built up.
 
-reagent-name-toxintrash = trash 
-reagent-desc-toxintrash = An awful-smelling fluid. Deadly to non-vox.
+reagent-name-toxintrash = reprocessed material
+reagent-desc-toxintrash = An awfully-smelling, nutrient-dense slurry efficiently refined from discarded matter. It represents a perfect, zero-waste conversion of salvage into Vox sustenance, though it is a violent poison to others.

--- a/Resources/Locale/en-US/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/reagents/meta/toxins.ftl
@@ -83,4 +83,4 @@ reagent-name-mechanotoxin = mechanotoxin
 reagent-desc-mechanotoxin = A neurotoxin used as venom by some species of spider. Degrades movement when built up.
 
 reagent-name-toxintrash = reprocessed material
-reagent-desc-toxintrash = An awfully-smelling, nutrient-dense slurry efficiently refined from discarded matter. It represents a perfect, zero-waste conversion of salvage into Vox sustenance, though it is a violent poison to others.
+reagent-desc-toxintrash = An awfully-smelling slurry efficiently refined from discarded matter. It represents a perfect, zero-waste conversion of salvage into Vox sustenance, though it is a violent poison to others.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Renames the trash reagent to "reprocessed material"

## Why / Balance
Vox being reduced to "trash birds" sucks and I hate it. I saw this reagent's name/description in the guidebook and audibly sighed. I decided to change it to something that sounds a bit more refined and doesn't reduce Vox to "trash-eaters"

## Technical details
this simply just changes strings in the toxins.ftl

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Renamed "trash" reagent to "reprocessed material"
