### PR TITLE
Cleanup warnings: CS0067, CS8509, CS8073

### DIFF
--- a/Content.Client/UserInterface/Controls/MainViewport.cs
+++ b/Content.Client/UserInterface/Controls/MainViewport.cs
@@ -66,7 +66,8 @@ namespace Content.Client.UserInterface.Controls
                     Viewport.StretchMode = filterMode switch
                     {
                         "nearest" => ScalingViewportStretchMode.Nearest,
-                        "bilinear" => ScalingViewportStretchMode.Bilinear
+                        "bilinear" => ScalingViewportStretchMode.Bilinear,
+                        _ => ScalingViewportStretchMode.Nearest
                     };
                     Viewport.IgnoreDimension = verticalFit ? ScalingViewportIgnoreDimension.Horizontal : ScalingViewportIgnoreDimension.None;
 

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -823,7 +823,7 @@ public abstract class SharedActionsSystem : EntitySystem
 
         if (!_actionsQuery.Resolve(performer, ref performer.Comp, false))
         {
-            DebugTools.Assert(performer == null || TerminatingOrDeleted(performer));
+            DebugTools.Assert(TerminatingOrDeleted(performer));
             ent.Comp.AttachedEntity = null;
             // TODO: should this delete the action since it's now orphaned?
             return;

--- a/Content.Shared/Clothing/MagbootsSystem.cs
+++ b/Content.Shared/Clothing/MagbootsSystem.cs
@@ -14,7 +14,6 @@ namespace Content.Shared.Clothing;
 public sealed class SharedMagbootsSystem : EntitySystem
 {
     [Dependency] private readonly AlertsSystem _alerts = default!;
-    [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly ItemToggleSystem _toggle = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedGravitySystem _gravity = default!;

--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.CCVar;
 using Content.Shared.Construction.Components;
 using Content.Shared.Database;
 using Content.Shared.Friction;
-using Content.Shared.Gravity;
 using Content.Shared.Projectiles;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
@@ -30,7 +29,6 @@ public sealed class ThrowingSystem : EntitySystem
     private float _airDamping;
 
     [Dependency] private readonly IGameTiming _gameTiming = default!;
-    [Dependency] private readonly SharedGravitySystem _gravity = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly ThrownItemSystem _thrownSystem = default!;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -8,7 +8,6 @@ using Content.Shared.CombatMode;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
-using Content.Shared.Gravity;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Popups;
@@ -57,7 +56,6 @@ public abstract partial class SharedGunSystem : EntitySystem
     [Dependency] protected readonly SharedAudioSystem Audio = default!;
     [Dependency] private   readonly SharedCombatModeSystem _combatMode = default!;
     [Dependency] protected readonly SharedContainerSystem Containers = default!;
-    [Dependency] private   readonly SharedGravitySystem _gravity = default!;
     [Dependency] protected readonly SharedPointLightSystem Lights = default!;
     [Dependency] protected readonly SharedPopupSystem PopupSystem = default!;
     [Dependency] protected readonly SharedPhysicsSystem Physics = default!;


### PR DESCRIPTION
## About the PR
Remove 1x `CS0067`, 1x `CS8509`, 2x `CS8073` warnings.


[CS0067](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0067): The event 'event' is never used.
The `AssignSlot` event in `ActionsSystem.cs` is never called, because it was lost during the actions refactor. It is responsible for arranging actions in the correct order. Without it, actions are added after existing ones, rather than replacing them, as was originally intended. Used in the `mappingclientsidesetup` and `loadacts` commands. (See the media for comparison). _Do I need a changelog for this since it is a fix? Well, I will do it just in case._


[CS8509](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/pattern-matching-warnings): The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '...' is not covered.
Just added a fallback method with the `ScalingViewportStretchMode.Nearest` value (since it is the default value).


[CS8073](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves): The result of the expression is always 'false' (or 'true').
1) `Entity<ActionsComponent?>` is a structure, and the code attempts to compare it with null, although the structure cannot be null. The useless check was simply removed, it won't affect anything in the context of the code, as it is used in `DebugTools.Assert`.
2) It is a similar story with `EntityUid`, I just replaced the check with the correct one.

<br><br>

**Bonus** (fresh warnings)
Remove 3x `CS0414` warnings.

[CS0414](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0414): The private field 'field' is assigned but its value is never used.


## Why / Balance
[https://github.com/space-wizards/space-station-14/issues/33279](https://github.com/space-wizards/space-station-14/issues/33279)

## Media
Before fix:
<img width="462" height="1016" alt="image" src="https://github.com/user-attachments/assets/692428df-ccba-4aa5-8a6a-3f24836e481f" />

After fix:
<img width="462" height="1016" alt="image" src="https://github.com/user-attachments/assets/d6239fa8-5b4c-4c68-ad11-3e93a0c8f88f" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: B_Kirill
ADMIN:
- fix: Fixed action presets not properly assigning actions to toolbar slots, adding them on top of existing ones instead of overwriting them.