### PR TITLE
Revert "Fix: Untoggle removed actions"

### DIFF
--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -832,8 +832,7 @@ public abstract class SharedActionsSystem : EntitySystem
         performer.Comp.Actions.Remove(ent.Owner);
         Dirty(performer, performer.Comp);
         ent.Comp.AttachedEntity = null;
-        ent.Comp.Toggled = false;
-        DirtyFields(ent, ent.Comp, null, nameof(ActionComponent.AttachedEntity), nameof(ActionComponent.Toggled));
+        DirtyField(ent, ent.Comp, nameof(ActionComponent.AttachedEntity));
         ActionRemoved((performer, performer.Comp), ent);
 
         if (ent.Comp.Temporary)


### PR DESCRIPTION
Reverts https://github.com/space-wizards/space-station-14/pull/39526

The action status should always be the same as the entity's component status, but always disabling it when removing the action may cause them to desync.
For example:
- Pick up a flashlight

<img width="56" height="66" alt="grafik" src="https://github.com/user-attachments/assets/99266769-e1e5-42f0-a256-0aa4d2d5fb8f" />

- Toggle it on

<img width="65" height="64" alt="grafik" src="https://github.com/user-attachments/assets/98dc4ea1-9005-46e9-b91a-cdcdd288653a" />

- drop it, which removes the action and toggles it off, but keeps the light itself on
- pick up the flashlight again

<img width="75" height="69" alt="grafik" src="https://github.com/user-attachments/assets/7857b3cd-1233-4320-838a-967273522825" />

The big icon is just the preview sprite, but the small one shows the action status