### PR TITLE
Cleanup warnings: Use TransformSystem for anchoring

### DIFF
--- a/Content.Client/Administration/UI/AdminCamera/AdminCameraWindow.xaml
+++ b/Content.Client/Administration/UI/AdminCamera/AdminCameraWindow.xaml
@@ -1,6 +1,5 @@
 <DefaultWindow xmlns="https://spacestation14.io"
     Title="{Loc admin-camera-window-title-placeholder}"
     SetSize="425 550"
-    MinSize="200 225"
-    Name="Window">
+    MinSize="200 225">
 </DefaultWindow>

--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -366,7 +366,11 @@ namespace Content.Server.Construction
             var newTransform = Transform(newUid);
             TransformSystem.AttachToGridOrMap(newUid, newTransform); // in case in hands or a container
             newTransform.LocalRotation = transform.LocalRotation;
-            newTransform.Anchored = transform.Anchored;
+
+            if (transform.Anchored)
+                TransformSystem.AnchorEntity(newUid, newTransform);
+            else
+                TransformSystem.Unanchor(newUid, newTransform);
 
             // Container transferring.
             if (containerManager != null)

--- a/Content.Server/StationEvents/Events/ImmovableRodRule.cs
+++ b/Content.Server/StationEvents/Events/ImmovableRodRule.cs
@@ -35,7 +35,8 @@ public sealed class ImmovableRodRule : StationEventSystem<ImmovableRodRuleCompon
             var speed = RobustRandom.NextFloat(rod.MinSpeed, rod.MaxSpeed);
             var angle = RobustRandom.NextAngle();
             var direction = angle.ToVec();
-            var spawnCoords = targetCoords.ToMap(EntityManager, _transform).Offset(-direction * speed * despawn.Lifetime / 2);
+            var mapCoords = _transform.ToMapCoordinates(targetCoords);
+            var spawnCoords = mapCoords.Offset(-direction * speed * despawn.Lifetime / 2);
             var ent = Spawn(protoName, spawnCoords);
             _gun.ShootProjectile(ent, direction, Vector2.Zero, uid, speed: speed);
         }

--- a/Content.Shared/Coordinates/Helpers/SnapgridHelper.cs
+++ b/Content.Shared/Coordinates/Helpers/SnapgridHelper.cs
@@ -9,12 +9,12 @@ namespace Content.Shared.Coordinates.Helpers
         public static EntityCoordinates SnapToGrid(this EntityCoordinates coordinates, IEntityManager? entMan = null, IMapManager? mapManager = null)
         {
             IoCManager.Resolve(ref entMan, ref mapManager);
+            var xformSys = entMan.System<SharedTransformSystem>();
 
-            var gridId = coordinates.GetGridUid(entMan);
+            var gridId = xformSys.GetGrid(coordinates.EntityId);
 
             if (gridId == null)
             {
-                var xformSys = entMan.System<SharedTransformSystem>();
                 var mapPos = xformSys.ToMapCoordinates(coordinates);
                 var mapX = (int)Math.Floor(mapPos.X) + 0.5f;
                 var mapY = (int)Math.Floor(mapPos.Y) + 0.5f;
@@ -24,11 +24,11 @@ namespace Content.Shared.Coordinates.Helpers
 
             var grid = entMan.GetComponent<MapGridComponent>(gridId.Value);
             var tileSize = grid.TileSize;
-            var localPos = coordinates.WithEntityId(gridId.Value).Position;
+            var localPos = xformSys.WithEntityId(coordinates, gridId.Value).Position;
             var x = (int)Math.Floor(localPos.X / tileSize) + tileSize / 2f;
             var y = (int)Math.Floor(localPos.Y / tileSize) + tileSize / 2f;
             var gridPos = new EntityCoordinates(gridId.Value, new Vector2(x, y));
-            return gridPos.WithEntityId(coordinates.EntityId);
+            return xformSys.WithEntityId(gridPos, coordinates.EntityId);
         }
 
         public static EntityCoordinates SnapToGrid(this EntityCoordinates coordinates, MapGridComponent grid)


### PR DESCRIPTION
## About the PR
Remove 5x `CS0618` warnings related to the use of obsolete `TransformComponent.Anchored.set`.


[CS0618](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0618): 'member' is obsolete: 'text'

<br>

**Bonus**
Remove 1x `CS0114` warning.

[CS0114](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0114): 'function1' hides inherited member 'function2'. To make the current method override that implementation, add the override keyword. Otherwise add the new keyword.
I think it is just not necessary in this case, so I deleted `Name` line.


## Why / Balance
[https://github.com/space-wizards/space-station-14/issues/33279](https://github.com/space-wizards/space-station-14/issues/33279)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.