### PR TITLE
box station: tweak hop office

### DIFF
--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/20/2025 12:00:39
-  entityCount: 28685
+  time: 08/20/2025 13:48:01
+  entityCount: 28742
 maps:
 - 780
 grids:
@@ -14938,7 +14938,6 @@ entities:
     - type: Transform
       pos: 24.5,16.5
       parent: 8364
-    - type: Door
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
@@ -90426,13 +90425,11 @@ entities:
     - type: Transform
       pos: 18.5,-13.5
       parent: 8364
-    - type: Door
   - uid: 13388
     components:
     - type: Transform
       pos: 18.5,-14.5
       parent: 8364
-    - type: Door
   - uid: 13389
     components:
     - type: Transform
@@ -90588,7 +90585,6 @@ entities:
     - type: Transform
       pos: -34.5,-14.5
       parent: 8364
-    - type: Door
   - uid: 15010
     components:
     - type: Transform
@@ -161184,7 +161180,7 @@ entities:
     - type: Transform
       pos: 18.5,-9.5
       parent: 8364
-  - uid: 28685
+  - uid: 28725
     components:
     - type: Transform
       pos: -11.5,-21.5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
tweak hop office and paperwork stuff on box station
- add fax machine
- move tables, including adding one next to hop front desk for stamps and papers.
- add camera to hop office
- change drawers and cabinets in bridge and hop from empty to random fill versions
- change station records pc to crew monitor
- change papers at hop front to paper bin

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The office is now a lot more paperwork-friendly

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="760" height="852" alt="image" src="https://github.com/user-attachments/assets/82e4288d-82f3-4acb-bd07-b46ba919c046" />
