### PR TITLE
New HTN precondition: has status effect

### DIFF
--- a/Content.Server/NPC/HTN/Preconditions/HasStatusEffectPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/HasStatusEffectPrecondition.cs
@@ -11,7 +11,7 @@ public sealed partial class HasStatusEffectPrecondition : HTNPrecondition
     [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
     [Dependency] private readonly IEntityManager _entManager = default!;
 
-    [DataField(required: true)]
+    [DataField("statusEffect", required: true)]
     public EntProtoId StatusEffectId;
 
     public override bool IsMet(NPCBlackboard blackboard)

--- a/Content.Server/NPC/HTN/Preconditions/HasStatusEffectPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/HasStatusEffectPrecondition.cs
@@ -8,19 +8,21 @@ namespace Content.Server.NPC.HTN.Preconditions;
 /// </summary>
 public sealed partial class HasStatusEffectPrecondition : HTNPrecondition
 {
-    [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
-    [Dependency] private readonly IEntityManager _entManager = default!;
+    private StatusEffectsSystem _statusEffects = default!;
 
     [DataField("statusEffect", required: true)]
     public EntProtoId StatusEffectId;
 
+    public override void Initialize(IEntitySystemManager sysManager)
+    {
+        base.Initialize(sysManager);
+        _statusEffects =  sysManager.GetEntitySystem<StatusEffectsSystem>();
+    }
+
     public override bool IsMet(NPCBlackboard blackboard)
     {
-        if (!blackboard.TryGetValue<EntityUid>(NPCBlackboard.Owner, out var owner, _entManager))
-        {
-            return false;
-        }
+        var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
 
-        return _statusEffectsSystem.HasStatusEffect(owner, StatusEffectId);
+        return _statusEffects.HasStatusEffect(owner, StatusEffectId);
     }
 }

--- a/Content.Server/NPC/HTN/Preconditions/HasStatusEffectPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/HasStatusEffectPrecondition.cs
@@ -1,0 +1,26 @@
+using Content.Shared.StatusEffectNew;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.NPC.HTN.Preconditions;
+
+/// <summary>
+/// Returns true if entity have specified status effect
+/// </summary>
+public sealed partial class HasStatusEffectPrecondition : HTNPrecondition
+{
+    [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    [DataField(required: true)]
+    public EntProtoId StatusEffectId;
+
+    public override bool IsMet(NPCBlackboard blackboard)
+    {
+        if (!blackboard.TryGetValue<EntityUid>(NPCBlackboard.Owner, out var owner, _entManager))
+        {
+            return false;
+        }
+
+        return _statusEffectsSystem.HasStatusEffect(owner, StatusEffectId);
+    }
+}


### PR DESCRIPTION
## About the PR
Added new HTN precondition that checks for specified status effect

## Why / Balance
Allows mobs to exhibit special behavior when affected by effects.

## Technical details
Nothing special

## Media
https://github.com/user-attachments/assets/ed421545-faee-454a-8838-c513b68762c5

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
no cl no life
