### PR TITLE
Increase minimum population for wizard

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/StartEndGameRulesTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/StartEndGameRulesTest.cs
@@ -18,18 +18,13 @@ public sealed class StartEndGameRulesTest
         await using var pair = await PoolManager.GetServerClient(new PoolSettings
         {
             Dirty = true,
-            InLobby = true,
+            DummyTicker = false
         });
         var server = pair.Server;
         await server.WaitIdleAsync();
         var gameTicker = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<GameTicker>();
         var cfg = server.ResolveDependency<IConfigurationManager>();
         Assert.That(cfg.GetCVar(CCVars.GridFill), Is.False);
-
-        // Add several dummy players
-        await server.AddDummySessions(30);
-        await pair.RunTicksSync(5);
-        gameTicker.ToggleReadyAll(true);
 
         await server.WaitAssertion(() =>
         {
@@ -52,8 +47,6 @@ public sealed class StartEndGameRulesTest
             gameTicker.ClearGameRules();
             Assert.That(!gameTicker.GetAddedGameRules().Any());
         });
-
-        await server.RemoveAllDummySessions();
 
         await pair.CleanReturnAsync();
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Raises the minimum population for wizard from 10 to 30

Same as #39074 except I am increasing the wizard minimum pop to 30.

## Why / Balance
Wizard on lowpop has little to no resistance from security or from the rest of the players. On mid to highpop, wizard can alteast be relied on to have some security force to fight or enough ~~validhunters~~ other players to go after them.

## Technical details
Changes a number in the relevant yaml.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Crude Oil
- tweak: The wizard gamemode minimum player count has been increased from 10 to 30
