### PR TITLE
Fix chameleon backpacks not being able to be opened when locked

### DIFF
--- a/Content.Shared/Lock/LockStorageWhenLockedComponent.cs
+++ b/Content.Shared/Lock/LockStorageWhenLockedComponent.cs
@@ -1,9 +1,0 @@
-using Robust.Shared.GameStates;
-
-namespace Content.Shared.Lock;
-
-/// <summary>
-/// When this component is added to an entity, its storage will be locked when the item is locked.
-/// </summary>
-[RegisterComponent, NetworkedComponent]
-public sealed partial class LockStorageWhenLockedComponent : Component;

--- a/Content.Shared/Lock/LockStorageWhenLockedComponent.cs
+++ b/Content.Shared/Lock/LockStorageWhenLockedComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Lock;
+
+/// <summary>
+/// When this component is added to an entity, its storage will be locked when the item is locked.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class LockStorageWhenLockedComponent : Component;

--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -49,11 +49,11 @@ public sealed class LockSystem : EntitySystem
         SubscribeLocalEvent<LockComponent, LockDoAfter>(OnDoAfterLock);
         SubscribeLocalEvent<LockComponent, UnlockDoAfter>(OnDoAfterUnlock);
 
-        SubscribeLocalEvent<LockStorageWhenLockedComponent, StorageInteractAttemptEvent>(OnStorageInteractAttempt);
 
         SubscribeLocalEvent<LockedWiresPanelComponent, LockToggleAttemptEvent>(OnLockToggleAttempt);
         SubscribeLocalEvent<LockedWiresPanelComponent, AttemptChangePanelEvent>(OnAttemptChangePanel);
         SubscribeLocalEvent<LockedAnchorableComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
+        SubscribeLocalEvent<LockedStorageComponent, StorageInteractAttemptEvent>(OnStorageInteractAttempt);
 
         SubscribeLocalEvent<UIRequiresLockComponent, ActivatableUIOpenAttemptEvent>(OnUIOpenAttempt);
         SubscribeLocalEvent<UIRequiresLockComponent, LockToggledEvent>(LockToggled);
@@ -359,7 +359,7 @@ public sealed class LockSystem : EntitySystem
         TryUnlock(uid, args.User, skipDoAfter: true);
     }
 
-    private void OnStorageInteractAttempt(Entity<LockStorageWhenLockedComponent> ent, ref StorageInteractAttemptEvent args)
+    private void OnStorageInteractAttempt(Entity<LockedStorageComponent> ent, ref StorageInteractAttemptEvent args)
     {
         if (IsLocked(ent.Owner))
             args.Cancelled = true;

--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -48,7 +48,8 @@ public sealed class LockSystem : EntitySystem
         SubscribeLocalEvent<LockComponent, GotEmaggedEvent>(OnEmagged);
         SubscribeLocalEvent<LockComponent, LockDoAfter>(OnDoAfterLock);
         SubscribeLocalEvent<LockComponent, UnlockDoAfter>(OnDoAfterUnlock);
-        SubscribeLocalEvent<LockComponent, StorageInteractAttemptEvent>(OnStorageInteractAttempt);
+
+        SubscribeLocalEvent<LockStorageWhenLockedComponent, StorageInteractAttemptEvent>(OnStorageInteractAttempt);
 
         SubscribeLocalEvent<LockedWiresPanelComponent, LockToggleAttemptEvent>(OnLockToggleAttempt);
         SubscribeLocalEvent<LockedWiresPanelComponent, AttemptChangePanelEvent>(OnAttemptChangePanel);
@@ -358,9 +359,9 @@ public sealed class LockSystem : EntitySystem
         TryUnlock(uid, args.User, skipDoAfter: true);
     }
 
-    private void OnStorageInteractAttempt(Entity<LockComponent> ent, ref StorageInteractAttemptEvent args)
+    private void OnStorageInteractAttempt(Entity<LockStorageWhenLockedComponent> ent, ref StorageInteractAttemptEvent args)
     {
-        if (ent.Comp.Locked)
+        if (IsLocked(ent.Owner))
             args.Cancelled = true;
     }
 

--- a/Content.Shared/Lock/LockedStorageComponent.cs
+++ b/Content.Shared/Lock/LockedStorageComponent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.Storage;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Lock;
+
+/// <summary>
+/// Prevents using an entity's <see cref="StorageComponent"/> if its <see cref="LockComponent"/> is locked.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class LockedStorageComponent : Component;

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -138,7 +138,7 @@
   - type: AccessReader
     access: [["Research"], ["Cargo"]]
   - type: Lock
-  - type: LockStorageWhenLocked
+  - type: LockedStorage
   - type: SuppressArtifactContainer
   - type: RadiationBlockingContainer
     resistance: 5

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -138,6 +138,7 @@
   - type: AccessReader
     access: [["Research"], ["Cargo"]]
   - type: Lock
+  - type: LockStorageWhenLocked
   - type: SuppressArtifactContainer
   - type: RadiationBlockingContainer
     resistance: 5

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/shelfs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/shelfs.yml
@@ -45,7 +45,7 @@
   description: It looks as strong as reality itself.
   components:
   - type: Lock
-  - type: LockStorageWhenLocked
+  - type: LockedStorage
   - type: LockVisuals
   - type: Sprite
     sprite: Structures/Storage/Shelfs/wood.rsi

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/shelfs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/shelfs.yml
@@ -45,6 +45,7 @@
   description: It looks as strong as reality itself.
   components:
   - type: Lock
+  - type: LockStorageWhenLocked
   - type: LockVisuals
   - type: Sprite
     sprite: Structures/Storage/Shelfs/wood.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title! Not good
resolves #39898

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new component that will lock storage when the item is locked. Before it was just any item that had the lock component. If you want to get a list of all items that have both the lock component and storage component try this amazing code (it works but omega sus):
```
if (!net.IsServer)
    return true;

var allItems = "";

var allEnts = _prototype.EnumeratePrototypes<EntityPrototype>();

foreach (var ent in allEnts)
{
    EntityUid item;
    try
    {
        item = Spawn(ent.ID);
    }
    catch
    {
        continue;
    }

    if (HasComp<LockComponent>(item) && HasComp<StorageComponent>(item))
    {
        allItems += ent.ID + " ";
    }
    Del(item);
}

Log.Fatal(allItems);
```
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

The `LockComponent` will now no longer lock storage items unless they have the `LockedStorageComponent`. Add that component if you want your storage to lock when locked. This only affects `StorageComponent`, not `EntityStorageComponent`.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Locked chameleon storage items can now still be used as storage even when locked.