### PR TITLE
Moving Zombie Components to Shared

### DIFF
--- a/Content.Shared/Zombies/ZombieImmuneComponent.cs
+++ b/Content.Shared/Zombies/ZombieImmuneComponent.cs
@@ -1,4 +1,4 @@
-namespace Content.Server.Zombies;
+namespace Content.Shared.Zombies;
 
 /// <summary>
 /// Entities with this component cannot be zombified.

--- a/Content.Shared/Zombies/ZombieImmuneComponent.cs
+++ b/Content.Shared/Zombies/ZombieImmuneComponent.cs
@@ -1,9 +1,11 @@
+using Robust.Shared.GameStates;
+
 namespace Content.Shared.Zombies;
 
 /// <summary>
 /// Entities with this component cannot be zombified.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class ZombieImmuneComponent : Component
 {
     //still no

--- a/Content.Shared/Zombies/ZombifyOnDeathComponent.cs
+++ b/Content.Shared/Zombies/ZombifyOnDeathComponent.cs
@@ -1,4 +1,4 @@
-namespace Content.Server.Zombies
+namespace Content.Shared.Zombies
 {
     [RegisterComponent]
     public sealed partial class ZombifyOnDeathComponent : Component

--- a/Content.Shared/Zombies/ZombifyOnDeathComponent.cs
+++ b/Content.Shared/Zombies/ZombifyOnDeathComponent.cs
@@ -1,8 +1,12 @@
-namespace Content.Shared.Zombies
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Zombies;
+
+/// <summary>
+/// Entities with this component zombify on death.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ZombifyOnDeathComponent : Component
 {
-    [RegisterComponent]
-    public sealed partial class ZombifyOnDeathComponent : Component
-    {
-        //this is not the component you are looking for
-    }
+    //this is not the component you are looking for
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
For #39749

## Technical details
<!-- Summary of code changes for easier review. -->
Moved  `ZombifyOnDeathComponent` & `ZombieImmuneComponent` to Shared. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

No Media Cause no Ingame Change

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Moved `ZombifyOnDeathComponent` from `Content.Server/Zombies` to `Content.Shared/Zombies`
Moved `ZombieImmuneComponent`  from `Content.Server/Zombies` to `Content.Shared/Zombies`



**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No CL