### PR TITLE
Automatic voting for map and preset on round restart (controllable via CVars)

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -677,6 +677,10 @@ namespace Content.Server.GameTicking
                 SendStatusToAll();
                 UpdateInfoText();
 
+                var ev = new RoundRestartingEvent();
+
+                RaiseLocalEvent(ref ev);
+
                 ReqWindowAttentionAll();
             }
         }

--- a/Content.Server/Voting/VotingSystem.cs
+++ b/Content.Server/Voting/VotingSystem.cs
@@ -13,7 +13,10 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
 using System.Threading.Tasks;
+using Content.Server.Voting.Managers;
+using Content.Shared.GameTicking;
 using Content.Shared.Players.PlayTimeTracking;
+using System.Linq;
 
 namespace Content.Server.Voting;
 
@@ -28,12 +31,15 @@ public sealed class VotingSystem : EntitySystem
     [Dependency] private readonly JobSystem _jobs = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly ISharedPlaytimeManager _playtimeManager = default!;
+    [Dependency] private readonly IVoteManager _voteManager = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeNetworkEvent<VotePlayerListRequestEvent>(OnVotePlayerListRequestEvent);
+
+        SubscribeLocalEvent<RoundRestartingEvent>(OnRoundRestartEvent);
     }
 
     private async void OnVotePlayerListRequestEvent(VotePlayerListRequestEvent msg, EntitySessionEventArgs args)
@@ -134,5 +140,24 @@ public sealed class VotingSystem : EntitySystem
             return false;
 
         return true;
+    }
+
+    public void OnRoundRestartEvent(ref RoundRestartingEvent ev)
+    {
+        TryCreateVote(CCVars.VoteAutoMapEnabled, "ui-vote-map-title", StandardVoteType.Map);
+        TryCreateVote(CCVars.VoteAutoPresetEnabled, "ui-vote-gamemode-title", StandardVoteType.Preset);
+    }
+
+    private void TryCreateVote(CVarDef<bool> enabledCVar, string titleKey, StandardVoteType type)
+    {
+        if (!_cfg.GetCVar(enabledCVar))
+            return;
+
+        var title = Loc.GetString(titleKey);
+
+        if (_voteManager.ActiveVotes.All(v => !v.Title.Contains(title)))
+        {
+            _voteManager.CreateStandardVote(null, type);
+        }
     }
 }

--- a/Content.Shared/CCVar/CCVars.Vote.cs
+++ b/Content.Shared/CCVar/CCVars.Vote.cs
@@ -53,6 +53,18 @@ public sealed partial class CCVars
         CVarDef.Create("vote.restart_not_allowed_when_admin_online", true, CVar.SERVERONLY);
 
     /// <summary>
+    ///     Whether automatic voting for a new map is enabled.
+    /// </summary>
+    public static readonly CVarDef<bool> VoteAutoMapEnabled =
+        CVarDef.Create("vote.auto_map_enabled", true, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Whether automatic voting for a new preset is enabled.
+    /// </summary>
+    public static readonly CVarDef<bool> VoteAutoPresetEnabled =
+        CVarDef.Create("vote.auto_preset_enabled", true, CVar.SERVERONLY);
+
+    /// <summary>
     ///     The delay which two votes of the same type are allowed to be made by separate people, in seconds.
     /// </summary>
     public static readonly CVarDef<float> VoteSameTypeTimeout =

--- a/Content.Shared/GameTicking/RoundRestartingEvent.cs
+++ b/Content.Shared/GameTicking/RoundRestartingEvent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.GameTicking;
+
+/// <summary>
+/// Event notifying about the restart of the round
+/// </summary>
+[ByRefEvent]
+public readonly record struct RoundRestartingEvent();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR adds two new CVars and corresponding mechanisms for automatically creating a vote for a new map and/or preset.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Automatic voting is a simple mechanism that is being implemented in individual forks. However, it has not yet been added to the main repository. My PR was created to address this issue.

## Technical details / Breaking changes
<!-- Summary of code changes for easier review. -->
- Two CVars of type bool have been added: `vote.auto_map_enabled` and `vote.auto_preset_enabled`. They control automatic voting for the map and preset separately.
- Added the `Content.Shared.GameTicking.RoundRestartingEvent` event to notify about the restart of the current round.
- The event mentioned above is handled directly in `Content.Server.Voting` (

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: Nikitosych
- add: The game can now automatically start a map vote at the beginning of each round.
- add: The game can now automatically start a gamemode vote at the beginning of each round.