### PR TITLE
Disable greentext display on Salamander

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -1,30 +1,44 @@
-﻿# Configuration preset used on Wizard's Den Salamander
+﻿[game]
+# Straight in-game baby
+lobbyenabled = false
+# Dev map for faster loading & convenience
+map = "Dev"
+role_timers = false
 
-[game]
-desc = "Official English Space Station 14 servers. Medium roleplay ruleset. you must be whitelisted by playing on other Wizard's Den servers if there are more than 15 online players."
-hostname = "[EN][MRP] Wizard's Den Salamander [US West]"
-round_restart_time = 300
-showgreentext = false
+[events]
+enabled = false
 
-[server]
-rules_file = "MRPRuleset"
+[ghost]
+role_time = 0.5
+quick_lottery = true
 
-[whitelist]
-enabled = true
-prototype_list = "salamanderMrpWhitelist"
+[gateway]
+generator_enabled = false
+
+[movement]
+mob_pushing = true
+
+[physics]
+# Makes mapping annoying
+grid_splitting = false
+
+[procgen]
+preload = false
+
+[salvage]
+expedition_cooldown = 30.0
 
 [shuttle]
-emergency_early_launch_allowed = true
+grid_fill = false
+auto_call_time = 0
+emergency = false
+arrivals = false
+preload_grids = false
 
-[biomass]
-easy_mode = false
-
-[ooc]
-enable_during_round = false
+[admin]
+see_own_notes = true
 
 [ic]
-flavor_text = true
-
-[hub]
-tags = "lang:en,region:am_n_w,rp:med"
-
+random_characters = true
+random_species_weights = ""
+ssd_sleep_time = 3600

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -1,44 +1,30 @@
-﻿[game]
-# Straight in-game baby
-lobbyenabled = false
-# Dev map for faster loading & convenience
-map = "Dev"
-role_timers = false
+﻿# Configuration preset used on Wizard's Den Salamander
 
-[events]
-enabled = false
+[game]
+desc = "Official English Space Station 14 servers. Medium roleplay ruleset. you must be whitelisted by playing on other Wizard's Den servers if there are more than 15 online players."
+hostname = "[EN][MRP] Wizard's Den Salamander [US West]"
+round_restart_time = 300
+showgreentext = false
 
-[ghost]
-role_time = 0.5
-quick_lottery = true
+[server]
+rules_file = "MRPRuleset"
 
-[gateway]
-generator_enabled = false
-
-[movement]
-mob_pushing = true
-
-[physics]
-# Makes mapping annoying
-grid_splitting = false
-
-[procgen]
-preload = false
-
-[salvage]
-expedition_cooldown = 30.0
+[whitelist]
+enabled = true
+prototype_list = "salamanderMrpWhitelist"
 
 [shuttle]
-grid_fill = false
-auto_call_time = 0
-emergency = false
-arrivals = false
-preload_grids = false
+emergency_early_launch_allowed = true
 
-[admin]
-see_own_notes = true
+[biomass]
+easy_mode = false
+
+[ooc]
+enable_during_round = false
 
 [ic]
-random_characters = true
-random_species_weights = ""
-ssd_sleep_time = 3600
+flavor_text = true
+
+[hub]
+tags = "lang:en,region:am_n_w,rp:med"
+

--- a/Resources/ConfigPresets/WizardsDen/salamander.toml
+++ b/Resources/ConfigPresets/WizardsDen/salamander.toml
@@ -4,6 +4,7 @@
 desc = "Official English Space Station 14 servers. Medium roleplay ruleset. you must be whitelisted by playing on other Wizard's Den servers if there are more than 15 online players."
 hostname = "[EN][MRP] Wizard's Den Salamander [US West]"
 round_restart_time = 300
+showgreentext = false
 
 [server]
 rules_file = "MRPRuleset"


### PR DESCRIPTION
## About the PR
Set game.showgreentext = false on Salamander.

## Why / Balance
[Quoting](https://forum.spacestation14.com/t/salamander-mrp-feedback-request/23050/13) AdmiralObvious:

> The game, in my opinion is currently geared towards ensuring that you win or lose. This works fine for LRP, but ends up causing a lot of friction on MRP, and also ends up with there being a noticeably small antagonist pool on MRP of people who are more or less dedicated to it. I’m not sure if this is because of greentext chasing, or something else, but one thing that we can try immediately, is disabling the end of round greentext readout. Nobody needs to know if you “won” on MRP, people are there for the stories. It’s one cvar.

In general, I think that MRP suffers from "greentext no matter what" mentality. In an environment where roleplay is encouraged, this leads to problems, often resulting in OOC/LOOC conflicts - which is one of the main problems of Salamander.

## Technical details
If you want to test the changes, you can copy salamander configuration and paste it into the development configuration. Check commit history for an example.

## Media
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/385e68ee-2eeb-4a7f-8818-d6bdf1c9a1f5" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: On Salamander, objective success status no longer shows in the round-end window.
