### PR TITLE
TriggerOnMeleeHit and more

### DIFF
--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeHitComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeHitComponent.cs
@@ -1,6 +1,4 @@
-using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared.Trigger.Components.Triggers;
 

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeHitComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeHitComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Trigger.Components.Triggers;
 
 /// <summary>
-/// Creates a trigger when this entity is swung as a melee weapon and hits at least one target.
+/// Triggers when this entity is swung as a melee weapon and hits at least one target.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class TriggerOnMeleeHitComponent : BaseTriggerOnXComponent
@@ -19,7 +19,7 @@ public sealed partial class TriggerOnMeleeHitComponent : BaseTriggerOnXComponent
 
     /// <summary>
     /// If true, the "user" of the trigger is the entity hit by the melee.
-    /// if false, user is the entity which attacked with the melee weapon.
+    /// If false, user is the entity which attacked with the melee weapon.
     /// </summary>
     /// <remarks>If TriggerEveryHit is false, the user is randomly chosen from hit entities.</remarks>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeHitComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeHitComponent.cs
@@ -29,9 +29,14 @@ public sealed partial class TriggerOnMeleeHitComponent : BaseTriggerOnXComponent
 public enum TriggerOnMeleeHitMode
 {
     /// <summary>
+    /// One trigger is created only when nothing is hit.
+    /// </summary>
+    OnMiss,
+
+    /// <summary>
     /// One trigger is always created when swinging the weapon.
     /// </summary>
-    OnceOnSwing,
+    OnSwing,
 
     /// <summary>
     /// One trigger is created only when hitting a target.

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeHitComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeHitComponent.cs
@@ -1,0 +1,45 @@
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Creates a trigger when this entity melees, i.e. <see cref="MeleeHitEvent"/>.
+/// </summary>
+/// <remarks>Despite the name this event happens on every melee swing, even if nothing is hit.</remarks>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnMeleeHitComponent : BaseTriggerOnXComponent
+{
+    /// <summary>
+    /// The mode in which this component chooses how to trigger.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TriggerOnMeleeHitMode Mode = TriggerOnMeleeHitMode.OnceOnHit;
+
+    /// <summary>
+    /// If true, the "user" of the trigger is the first entity hit by the melee. "First" is arbitrary.
+    /// if false, user is the entity which attacked with the melee weapon.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool TargetIsUser;
+}
+
+[Serializable, NetSerializable]
+public enum TriggerOnMeleeHitMode
+{
+    /// <summary>
+    /// One trigger is always created when swinging the weapon.
+    /// </summary>
+    OnceOnSwing,
+
+    /// <summary>
+    /// One trigger is created only when hitting a target.
+    /// </summary>
+    OnceOnHit,
+
+    /// <summary>
+    /// A trigger is created only when hitting a target, and for every target.
+    /// </summary>
+    EveryHit,
+}

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeHitComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeHitComponent.cs
@@ -5,46 +5,23 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Trigger.Components.Triggers;
 
 /// <summary>
-/// Creates a trigger when this entity melees, i.e. <see cref="MeleeHitEvent"/>.
+/// Creates a trigger when this entity is swung as a melee weapon and hits at least one target.
 /// </summary>
-/// <remarks>Despite the name this event happens on every melee swing, even if nothing is hit.</remarks>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class TriggerOnMeleeHitComponent : BaseTriggerOnXComponent
 {
     /// <summary>
-    /// The mode in which this component chooses how to trigger.
+    /// If true, this trigger will activate individually for each entity hit.
+    /// If false, this trigger will always activate only once.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public TriggerOnMeleeHitMode Mode = TriggerOnMeleeHitMode.OnceOnHit;
+    public bool TriggerEveryHit;
 
     /// <summary>
-    /// If true, the "user" of the trigger is the first entity hit by the melee. "First" is arbitrary.
+    /// If true, the "user" of the trigger is the entity hit by the melee.
     /// if false, user is the entity which attacked with the melee weapon.
     /// </summary>
+    /// <remarks>If TriggerEveryHit is false, the user is randomly chosen from hit entities.</remarks>
     [DataField, AutoNetworkedField]
     public bool TargetIsUser;
-}
-
-[Serializable, NetSerializable]
-public enum TriggerOnMeleeHitMode
-{
-    /// <summary>
-    /// One trigger is created only when nothing is hit.
-    /// </summary>
-    OnMiss,
-
-    /// <summary>
-    /// One trigger is always created when swinging the weapon.
-    /// </summary>
-    OnSwing,
-
-    /// <summary>
-    /// One trigger is created only when hitting a target.
-    /// </summary>
-    OnceOnHit,
-
-    /// <summary>
-    /// A trigger is created only when hitting a target, and for every target.
-    /// </summary>
-    EveryHit,
 }

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeMissComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeMissComponent.cs
@@ -1,6 +1,4 @@
-using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared.Trigger.Components.Triggers;
 

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeMissComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeMissComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Creates a trigger when this entity is swung as a melee weapon and hits nothing.
+/// User is the entity swinging the weapon.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnMeleeMissComponent : BaseTriggerOnXComponent;

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeMissComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeMissComponent.cs
@@ -5,8 +5,8 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Trigger.Components.Triggers;
 
 /// <summary>
-/// Creates a trigger when this entity is swung as a melee weapon and hits nothing.
-/// User is the entity swinging the weapon.
+/// Triggers when this entity is swung as a melee weapon and hits nothing.
+/// The user is the entity swinging the weapon.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class TriggerOnMeleeMissComponent : BaseTriggerOnXComponent;

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeSwingComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeSwingComponent.cs
@@ -1,0 +1,19 @@
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Creates a trigger when this entity is swung as a melee weapon, regardless of whether it hits something.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnMeleeSwingComponent : BaseTriggerOnXComponent
+{
+    /// <summary>
+    /// If true, the "user" of the trigger is the first entity hit by the melee. User is null if nothing is hit.
+    /// if false, user is the entity which attacked with the melee weapon.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool TargetIsUser;
+}

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeSwingComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeSwingComponent.cs
@@ -1,6 +1,4 @@
-using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared.Trigger.Components.Triggers;
 

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeSwingComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeSwingComponent.cs
@@ -5,14 +5,14 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Trigger.Components.Triggers;
 
 /// <summary>
-/// Creates a trigger when this entity is swung as a melee weapon, regardless of whether it hits something.
+/// Triggers when this entity is swung as a melee weapon, regardless of whether it hits something.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class TriggerOnMeleeSwingComponent : BaseTriggerOnXComponent
 {
     /// <summary>
     /// If true, the "user" of the trigger is the entity hit by the melee. User is null if nothing is hit.
-    /// if false, user is the entity which attacked with the melee weapon.
+    /// If false, user is the entity which attacked with the melee weapon.
     /// </summary>
     /// <remarks>If true and multiple targets are hit, the user is randomly chosen from hit entities.</remarks>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeSwingComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMeleeSwingComponent.cs
@@ -11,9 +11,10 @@ namespace Content.Shared.Trigger.Components.Triggers;
 public sealed partial class TriggerOnMeleeSwingComponent : BaseTriggerOnXComponent
 {
     /// <summary>
-    /// If true, the "user" of the trigger is the first entity hit by the melee. User is null if nothing is hit.
+    /// If true, the "user" of the trigger is the entity hit by the melee. User is null if nothing is hit.
     /// if false, user is the entity which attacked with the melee weapon.
     /// </summary>
+    /// <remarks>If true and multiple targets are hit, the user is randomly chosen from hit entities.</remarks>
     [DataField, AutoNetworkedField]
     public bool TargetIsUser;
 }

--- a/Content.Shared/Trigger/Systems/MeleeTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/MeleeTriggerSystem.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using Content.Shared.Trigger.Components.Triggers;
+using Content.Shared.Weapons.Melee.Events;
+
+namespace Content.Shared.Trigger.Systems;
+
+public sealed class MeleeTriggerSystem : EntitySystem
+{
+    [Dependency] private readonly TriggerSystem _trigger = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TriggerOnMeleeHitComponent, MeleeHitEvent>(OnTrigger);
+    }
+
+    private void OnTrigger(Entity<TriggerOnMeleeHitComponent> ent, ref MeleeHitEvent args)
+    {
+        if (args.HitEntities.Count == 0 && ent.Comp.Mode != TriggerOnMeleeHitMode.OnceOnSwing)
+            return;
+
+        if (ent.Comp.Mode is TriggerOnMeleeHitMode.OnceOnSwing
+                          or TriggerOnMeleeHitMode.OnceOnHit )
+        {
+            var target = ent.Comp.TargetIsUser ? args.HitEntities.FirstOrDefault() : args.User;
+            _trigger.Trigger(ent.Owner, target, ent.Comp.KeyOut);
+            return;
+        }
+
+        // if TriggerOnMeleeHitMode.EveryHit
+        foreach (var target in args.HitEntities)
+            _trigger.Trigger(ent.Owner, ent.Comp.TargetIsUser ? target : args.User, ent.Comp.KeyOut);
+    }
+}

--- a/Content.Shared/Trigger/Systems/MeleeTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/MeleeTriggerSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Shared.Trigger.Components.Triggers;
 using Content.Shared.Weapons.Melee.Events;
 
@@ -29,7 +28,12 @@ public sealed class MeleeTriggerSystem : EntitySystem
 
     private void OnSwingTrigger(Entity<TriggerOnMeleeSwingComponent> ent, ref MeleeHitEvent args)
     {
-        var target = ent.Comp.TargetIsUser ? args.HitEntities.FirstOrDefault() : args.User;
+        EntityUid? target;
+        if  (args.HitEntities.Count == 0)
+            target = ent.Comp.TargetIsUser ? null : args.User;
+        else
+            target = ent.Comp.TargetIsUser ? args.HitEntities[0] : args.User;
+
         _trigger.Trigger(ent.Owner, target, ent.Comp.KeyOut);
     }
 
@@ -40,13 +44,15 @@ public sealed class MeleeTriggerSystem : EntitySystem
 
         if (!ent.Comp.TriggerEveryHit)
         {
-            var target = ent.Comp.TargetIsUser ? args.HitEntities.First() : args.User;
+            var target = ent.Comp.TargetIsUser ? args.HitEntities[0] : args.User;
             _trigger.Trigger(ent.Owner, target, ent.Comp.KeyOut);
             return;
         }
 
         // if TriggerEveryHit
         foreach (var target in args.HitEntities)
+        {
             _trigger.Trigger(ent.Owner, ent.Comp.TargetIsUser ? target : args.User, ent.Comp.KeyOut);
+        }
     }
 }

--- a/Content.Shared/Trigger/Systems/MeleeTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/MeleeTriggerSystem.cs
@@ -18,10 +18,19 @@ public sealed class MeleeTriggerSystem : EntitySystem
 
     private void OnTrigger(Entity<TriggerOnMeleeHitComponent> ent, ref MeleeHitEvent args)
     {
-        if (args.HitEntities.Count == 0 && ent.Comp.Mode != TriggerOnMeleeHitMode.OnceOnSwing)
+        // Return if we're a "hit" mode and hit nothing
+        if (args.HitEntities.Count == 0 && ent.Comp.Mode is TriggerOnMeleeHitMode.OnceOnHit or TriggerOnMeleeHitMode.EveryHit)
             return;
 
-        if (ent.Comp.Mode is TriggerOnMeleeHitMode.OnceOnSwing
+        if (args.HitEntities.Count == 0 && ent.Comp.Mode == TriggerOnMeleeHitMode.OnMiss)
+        {
+            // You missed! Hope this trigger doesn't do something bad to you.
+            _trigger.Trigger(ent.Owner, args.User, ent.Comp.KeyOut);
+            return;
+        }
+
+        // Single trigger modes
+        if (ent.Comp.Mode is TriggerOnMeleeHitMode.OnSwing
                           or TriggerOnMeleeHitMode.OnceOnHit )
         {
             var target = ent.Comp.TargetIsUser ? args.HitEntities.FirstOrDefault() : args.User;

--- a/Content.Shared/Trigger/Systems/MeleeTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/MeleeTriggerSystem.cs
@@ -4,6 +4,9 @@ using Content.Shared.Weapons.Melee.Events;
 
 namespace Content.Shared.Trigger.Systems;
 
+/// <summary>
+/// Trigger system for melee related triggers.
+/// </summary>
 public sealed class MeleeTriggerSystem : EntitySystem
 {
     [Dependency] private readonly TriggerSystem _trigger = default!;
@@ -13,26 +16,9 @@ public sealed class MeleeTriggerSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<TriggerOnMeleeHitComponent, MeleeHitEvent>(OnHitTrigger);
         SubscribeLocalEvent<TriggerOnMeleeMissComponent, MeleeHitEvent>(OnMissTrigger);
         SubscribeLocalEvent<TriggerOnMeleeSwingComponent, MeleeHitEvent>(OnSwingTrigger);
-    }
-
-    private void OnHitTrigger(Entity<TriggerOnMeleeHitComponent> ent, ref MeleeHitEvent args)
-    {
-        if (args.HitEntities.Count == 0)
-            return;
-
-        if (!ent.Comp.TriggerEveryHit)
-        {
-            var target = ent.Comp.TargetIsUser ? args.HitEntities.FirstOrDefault() : args.User;
-            _trigger.Trigger(ent.Owner, target, ent.Comp.KeyOut);
-            return;
-        }
-
-        // if TriggerEveryHit
-        foreach (var target in args.HitEntities)
-            _trigger.Trigger(ent.Owner, ent.Comp.TargetIsUser ? target : args.User, ent.Comp.KeyOut);
+        SubscribeLocalEvent<TriggerOnMeleeHitComponent, MeleeHitEvent>(OnHitTrigger);
     }
 
     private void OnMissTrigger(Entity<TriggerOnMeleeMissComponent> ent, ref MeleeHitEvent args)
@@ -45,5 +31,22 @@ public sealed class MeleeTriggerSystem : EntitySystem
     {
         var target = ent.Comp.TargetIsUser ? args.HitEntities.FirstOrDefault() : args.User;
         _trigger.Trigger(ent.Owner, target, ent.Comp.KeyOut);
+    }
+
+    private void OnHitTrigger(Entity<TriggerOnMeleeHitComponent> ent, ref MeleeHitEvent args)
+    {
+        if (args.HitEntities.Count == 0)
+            return;
+
+        if (!ent.Comp.TriggerEveryHit)
+        {
+            var target = ent.Comp.TargetIsUser ? args.HitEntities.First() : args.User;
+            _trigger.Trigger(ent.Owner, target, ent.Comp.KeyOut);
+            return;
+        }
+
+        // if TriggerEveryHit
+        foreach (var target in args.HitEntities)
+            _trigger.Trigger(ent.Owner, ent.Comp.TargetIsUser ? target : args.User, ent.Comp.KeyOut);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
New triggers for when you smack someone (or miss someone) with a stick.



## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Advances #39354, with two bonus triggers.

## Technical details
<!-- Summary of code changes for easier review. -->
Originally this PR included all of these options in on trigger through an enum. This was because `MeleeHitEvent` gets raised on any melee swing and I lacked vision trying to cram them into one.

Now I have three separate triggers all subscribed to the same event for more flexibility. 

- `OnMeleeMiss` is a simple and empty component: `if (HitEntities.Count == 0) Trigger();`
- `OnMeleeSwing` is also relatively simple. It uses `bool TargetIsUser` to mode switch the user, and always triggers.
- `OnMeleeHit` uses the above `bool TargetIsUser`, and another `bool TriggerEveryHit` to mode switch between triggering for all targets or just once. It uses `if (args.HitEntities.Count == 0) return;` to ensure that something was hit.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Trigger on miss:

https://github.com/user-attachments/assets/a7a55719-72be-4252-a307-fc797cf06101

Trigger on swing:

https://github.com/user-attachments/assets/aa89f422-d0e1-4b56-b298-da7ea3834a92

Trigger on hit:

https://github.com/user-attachments/assets/93398c1d-3345-4e0b-8525-ddae14a33913



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
I'm allergic to cl