### PR TITLE
Consistent grenade fuses

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -207,7 +207,6 @@
   - type: Sprite
     sprite: Objects/Weapons/Grenades/singularitygrenade.rsi
   - type: TimerTrigger
-    delay: 3
     beepInterval: 0.46
     beepSound:
       path: /Audio/Effects/Grenades/Supermatter/smbeep.ogg
@@ -277,7 +276,6 @@
   - type: Sprite
     sprite: Objects/Weapons/Grenades/whiteholegrenade.rsi
   - type: TimerTrigger
-    delay: 3
     beepInterval: 0.69
   - type: EmitSoundOnTrigger
     keysIn:
@@ -531,8 +529,6 @@
   components:
   - type: Sprite
     sprite: Objects/Weapons/Grenades/metalfoam.rsi
-  - type: TimerTrigger
-    delay: 5
   - type: SmokeOnTrigger
     keysIn:
     - timer
@@ -557,8 +553,6 @@
   - type: TimerTriggerVisuals
     primingSound:
       path: /Audio/Items/smoke_grenade_prime.ogg
-  - type: TimerTrigger
-    delay: 3
   - type: ReleaseGasOnTrigger
     keysIn:
     - timer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -16,7 +16,7 @@
     - Belt
   - type: TriggerOnUse
   - type: TimerTrigger
-    delay: 3
+    delay: 3.5
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -335,7 +335,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Grenades/nukenade.rsi
   - type: TimerTrigger
-    delay: 5
+    delay: 5 # Just long enough to escape the blast radius
   - type: ExplodeOnTrigger
     keysIn:
     - timer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -70,7 +70,7 @@
   - type: TimerTrigger
     initialBeepDelay: 0
     beepInterval: 2
-    delay: 3.5
+    delay: 3
   - type: TimerTriggerVisuals
     primingSound:
       path: /Audio/Effects/countdown.ogg
@@ -97,7 +97,7 @@
         volume: 5
     initialBeepDelay: 0
     beepInterval: 2
-    delay: 3.5
+    delay: 3
   - type: EmitSoundOnTrigger
     keysIn:
     - timer
@@ -128,7 +128,7 @@
         volume: 5
     initialBeepDelay: 0
     beepInterval: 2
-    delay: 3.5
+    delay: 3
   - type: EmitSoundOnTrigger
     keysIn:
     - timer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -21,6 +21,8 @@
     containers:
       cluster-payload: !type:Container
   - type: ProjectileGrenade
+  - type: TimerTrigger
+    delay: 3.5
   - type: AnimationPlayer
   - type: GenericVisualizer
     visuals:
@@ -70,7 +72,6 @@
   - type: TimerTrigger
     initialBeepDelay: 0
     beepInterval: 2
-    delay: 3
   - type: TimerTriggerVisuals
     primingSound:
       path: /Audio/Effects/countdown.ogg
@@ -97,7 +98,6 @@
         volume: 5
     initialBeepDelay: 0
     beepInterval: 2
-    delay: 3
   - type: EmitSoundOnTrigger
     keysIn:
     - timer
@@ -128,7 +128,6 @@
         volume: 5
     initialBeepDelay: 0
     beepInterval: 2
-    delay: 3
   - type: EmitSoundOnTrigger
     keysIn:
     - timer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
@@ -21,7 +21,7 @@
   - type: ScatteringGrenade
   - type: TriggerOnUse
   - type: TimerTrigger
-    delay: 3
+    delay: 3.5
   - type: Tag
     tags:
     - HandGrenade
@@ -82,6 +82,13 @@
         enum.ConstructionVisuals.Layer:
           Primed: { state: primed }
           Unprimed: { state: icon }
+  - type: TimerTrigger
+    beepSound:
+      path: "/Audio/Effects/beep1.ogg"
+      params:
+        volume: 5
+    initialBeepDelay: 0
+    beepInterval: 0.5
   - type: EmitSoundOnTrigger
     keysIn:
     - timer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made all hand grenade fuses (besides a select few, like the holy hand grenade) 3.5 seconds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With half the grenades having 3.5 second fuses and some having 3 second fuses, it was rather difficult to learn how to cook them properly. 3.5 seconds also sounds better with all of the grenade noises, with the 3 second fuses tending to cut them off.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Nox38
- tweak: Made hand grenade fuses consistently 3.5 seconds.