### PR TITLE
Fix admin objects tab

### DIFF
--- a/Content.Client/Administration/UI/Tabs/ObjectsTab/ObjectsTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/ObjectsTab/ObjectsTab.xaml.cs
@@ -57,12 +57,43 @@ public sealed partial class ObjectsTab : Control
 
     private void TeleportTo(NetEntity nent)
     {
-        _console.ExecuteCommand($"tpto {nent}");
+        var selection = _selections[ObjectTypeOptions.SelectedId];
+        switch (selection)
+        {
+            case ObjectsTabSelection.Grids:
+                {
+                    // directly teleport to the entity
+                    _console.ExecuteCommand($"tpto {nent}");
+                }
+                break;
+            case ObjectsTabSelection.Maps:
+                {
+                    // teleport to the map, not to the map entity (which is in nullspace)
+                    if (!_entityManager.TryGetEntity(nent, out var map) || !_entityManager.TryGetComponent<MapComponent>(map, out var mapComp))
+                        break;
+                    _console.ExecuteCommand($"tp 0 0 {mapComp.MapId}");
+                    break;
+                }
+            case ObjectsTabSelection.Stations:
+                {
+                    // teleport to the station's largest grid, not to the station entity (which is in nullspace)
+                    if (!_entityManager.TryGetEntity(nent, out var station))
+                        break;
+                    var largestGrid = _entityManager.EntitySysManager.GetEntitySystem<StationSystem>().GetLargestGrid(station.Value);
+                    if (largestGrid == null)
+                        break;
+                    _console.ExecuteCommand($"tpto {largestGrid.Value}");
+                    break;
+                }
+            default:
+                throw new NotImplementedException();
+        }
     }
 
     private void Delete(NetEntity nent)
     {
         _console.ExecuteCommand($"delete {nent}");
+        RefreshObjectList();
     }
 
     public void RefreshObjectList()
@@ -79,25 +110,21 @@ public sealed partial class ObjectsTab : Control
                 entities.AddRange(_entityManager.EntitySysManager.GetEntitySystem<StationSystem>().GetStationNames());
                 break;
             case ObjectsTabSelection.Grids:
-            {
-                var query = _entityManager.AllEntityQueryEnumerator<MapGridComponent, MetaDataComponent>();
-                while (query.MoveNext(out var uid, out _, out var metadata))
                 {
-                    entities.Add((metadata.EntityName, _entityManager.GetNetEntity(uid)));
-                }
+                    var query = _entityManager.AllEntityQueryEnumerator<MapGridComponent, MetaDataComponent>();
+                    while (query.MoveNext(out var uid, out _, out var metadata))
+                        entities.Add((metadata.EntityName, _entityManager.GetNetEntity(uid)));
 
-                break;
-            }
+                    break;
+                }
             case ObjectsTabSelection.Maps:
-            {
-                var query = _entityManager.AllEntityQueryEnumerator<MapComponent, MetaDataComponent>();
-                while (query.MoveNext(out var uid, out _, out var metadata))
                 {
-                    entities.Add((metadata.EntityName, _entityManager.GetNetEntity(uid)));
-                }
+                    var query = _entityManager.AllEntityQueryEnumerator<MapComponent, MetaDataComponent>();
+                    while (query.MoveNext(out var uid, out _, out var metadata))
+                        entities.Add((metadata.EntityName, _entityManager.GetNetEntity(uid)));
 
-                break;
-            }
+                    break;
+                }
             default:
                 throw new ArgumentOutOfRangeException(nameof(selection), selection, null);
         }

--- a/Content.Client/Administration/UI/Tabs/ObjectsTab/ObjectsTabEntry.xaml
+++ b/Content.Client/Administration/UI/Tabs/ObjectsTab/ObjectsTabEntry.xaml
@@ -1,5 +1,6 @@
 ﻿<PanelContainer xmlns="https://spacestation14.io"
                 xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
+                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 Name="BackgroundColorPanel">
     <BoxContainer Orientation="Horizontal"
                   HorizontalExpand="True"
@@ -20,7 +21,7 @@
                HorizontalExpand="True"
                ClipText="True"/>
         <customControls:VSeparator/>
-        <Button Name="DeleteButton"
+        <controls:ConfirmButton Name="DeleteButton"
                 Text="{Loc object-tab-entity-delete}"
                 SizeFlagsStretchRatio="3"
                 HorizontalExpand="True"


### PR DESCRIPTION
## About the PR
Fixes the teleport buttons not working for maps and stations.
Makes the delete button a confirm button because putting the option to delete the whole station a few pixels apart from the teleport button is inviting accidents.

## Why / Balance
bugfix and QOL

## Technical details
Map entities live in nullspace and don't have a parent, so we can't directly teleport there.
Same for station entities.
So we treat each option differently and teleport to the selected map or largest station grid instead.

## Media
![ss14](https://github.com/user-attachments/assets/44405361-4ed7-42b8-9a70-76f3f40abc32)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
nope

**Changelog**
:cl:
ADMIN:
- tweak: The 'Delete' button in the objects tab is now a confirm button.
- fix: Fixed the 'Teleport' button in the objects tab not working for stations and maps.
