### PR TITLE
GameRuleOnTrigger

### DIFF
--- a/Content.Server/Trigger/Systems/GameRuleTriggerSystem.cs
+++ b/Content.Server/Trigger/Systems/GameRuleTriggerSystem.cs
@@ -29,12 +29,14 @@ public sealed class GameRuleTriggerSystem : EntitySystem
 
         var rule = _ticker.AddGameRule(ent.Comp.GameRule);
 
+        _adminLogger.Add(LogType.EventStarted,
+            $"{ToPrettyString(args.User):entity} added a game rule [{ent.Comp.GameRule}]" +
+            $" via a trigger on {ToPrettyString(ent.Owner):entity}.");
+
         if (ent.Comp.StartRule && _ticker.RunLevel == GameRunLevel.InRound)
         {
             _ticker.StartGameRule(rule);
-            _adminLogger.Add(LogType.EventStarted,
-                $"{ToPrettyString(args.User):entity} started a game rule [{ent.Comp.GameRule}]" +
-                        $" using {ToPrettyString(ent.Owner):entity} via a trigger.");
+            _adminLogger.Add(LogType.EventStarted, $"{ToPrettyString(args.User):entity} started game rule [{ent.Comp.GameRule}].");
         }
 
         args.Handled = true;

--- a/Content.Shared/Trigger/Components/Effects/AddGameRuleOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/AddGameRuleOnTriggerComponent.cs
@@ -12,10 +12,10 @@ namespace Content.Shared.Trigger.Components.Effects;
 public sealed partial class AddGameRuleOnTriggerComponent : BaseXOnTriggerComponent
 {
     /// <summary>
-    /// The game rule that will be added. Entity requires <see cref="GameRuleComponent"/> to work.
+    /// The game rule that will be added. Entity requires <see cref="GameRuleComponent"/>.
     /// </summary>
     [DataField(required: true), AutoNetworkedField]
-    public EntProtoId GameRule = "CockroachMigration";
+    public EntProtoId<GameRuleComponent> GameRule;
 
     /// <summary>
     /// Whether to also start the game rule when adding it.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a new component which adds and starts a game rule on receiving a trigger.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Advances #39354

## Technical details
<!-- Summary of code changes for easier review. -->
Homework was copied from `AddGameRuleCommand`. We require a datafield for the game rule to add (but leave a default so VV doesn't get mad). We add the game rule, then optionally (though not really optionally) start the game rule. An admin log is always created. 

There's no sanitization of the provided EntProtoId, but it doesn't appear to be a problem? Running a game rule with a garbage entity didn't create any visible issues, and sanitizing the input should probably be handled by `AddGameRule` anyway.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/87f10e14-da86-4401-857b-1a18745e55e2


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no changes