### PR TITLE
NT Pets no longer attack Wizards, Initial Infected, or Zombies on sight.

### DIFF
--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -38,10 +38,8 @@
   hostile:
   - Mouse
   - SimpleHostile
-  - Zombie
   - Xeno
   - AllHostile
-  - Wizard
   - Dragon
 
 - type: npcFaction
@@ -162,5 +160,5 @@
   - Xeno # rivalry
 
   # cause they are hostile to them
-  - SimpleHostile 
+  - SimpleHostile
   - AllHostile


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes the Wizard and Zombie factions from the enemies list of PetsNT.

## Why / Balance
Imagine you are a simple service worker attempting to do a fun gimmick, and go into sec with permission from the HoS to get some equipment. Suddenly, the II stinger plays and you immediately get critted by Shiva, and then RRd by the rest of sec. Both your original gimmick AND your fun antag round are immediately ruined.

Yes this is a mald PR, could you tell?

Also why would NT pets know what zombies are?

Also also pets attacking people who were mindswapped into a Wizard's body isn't fun either.

## Technical details
2 line yaml change.

Renault will still attack zombies if attacked first.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl: UpAndLeaves
- tweak: NT pets no longer attack Wizards, Initial Infected, or Zombies on sight.
