### PR TITLE
Don't enqueue construction events without validation

### DIFF
--- a/Content.IntegrationTests/Tests/Construction/Interaction/EdgeClobbering.cs
+++ b/Content.IntegrationTests/Tests/Construction/Interaction/EdgeClobbering.cs
@@ -1,0 +1,49 @@
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Server.Construction.Components;
+using Content.Shared.Temperature;
+
+namespace Content.IntegrationTests.Tests.Construction.Interaction;
+
+public sealed class EdgeClobbering : InteractionTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: constructionGraph
+  id: ExampleGraph
+  start: A
+  graph:
+  - node: A
+    edges:
+    - to: B
+      steps:
+      - tool: Anchoring
+        doAfter: 1
+    - to: C
+      steps:
+      - tool: Screwing
+        doAfter: 1
+  - node: B
+  - node: C
+
+- type: entity
+  id: ExampleEntity
+  components:
+  - type: Construction
+    graph: ExampleGraph
+    node: A
+
+    ";
+
+    [Test]
+    public async Task EnsureNoEdgeClobbering()
+    {
+        await SpawnTarget("ExampleEntity");
+        var sTarget = SEntMan.GetEntity(Target!.Value);
+
+        await InteractUsing(Screw, false);
+        SEntMan.EventBus.RaiseLocalEvent(sTarget, new OnTemperatureChangeEvent(0f, 0f, 0f));
+        await AwaitDoAfters();
+
+        Assert.That(SEntMan.GetComponent<ConstructionComponent>(sTarget).Node, Is.EqualTo("C"));
+    }
+}

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -570,6 +570,10 @@ namespace Content.Server.Construction
                 handled.Handled = true;
             }
 
+            // Make sure the event passes validation before enqueuing it
+            if (HandleEvent(uid, args, true, construction) != HandleResult.Validated)
+                return;
+
             // Enqueue this event so it'll be handled in the next tick.
             // This prevents some issues that could occur from entity deletion, component deletion, etc in a handler.
             construction.InteractionQueue.Enqueue(args);


### PR DESCRIPTION
## About the PR
- fixes a bug where non-`HandledEntityEventArgs` events received during a construction doafter would clobber the edge index, causing the completed doafter to progress down the wrong edge

## Technical details
- validate events against the current graph before placing them in the construction queue

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
