### PR TITLE
Fix Polymorphed Entities Being Able To Hit Themselves

### DIFF
--- a/Content.Server/Polymorph/Components/PolymorphedEntityComponent.cs
+++ b/Content.Server/Polymorph/Components/PolymorphedEntityComponent.cs
@@ -29,4 +29,6 @@ public sealed partial class PolymorphedEntityComponent : Component
 
     [DataField]
     public EntityUid? Action;
+
+    public bool ParentWasCollidable;
 }

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.Map.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.Map.cs
@@ -26,14 +26,16 @@ public sealed partial class PolymorphSystem
     /// Used internally to ensure a paused map that is
     /// stores polymorphed entities.
     /// </summary>
-    private void EnsurePausedMap()
+    private EntityUid EnsurePausedMap()
     {
         if (PausedMap != null && Exists(PausedMap))
-            return;
+            return PausedMap.Value;
 
         var mapUid = _map.CreateMap();
         _metaData.SetEntityName(mapUid, Loc.GetString("polymorph-paused-map-name"));
         _map.SetPaused(mapUid, true);
         PausedMap = mapUid;
+
+        return mapUid;
     }
 }

--- a/Content.Shared/Polymorph/PolymorphPrototype.cs
+++ b/Content.Shared/Polymorph/PolymorphPrototype.cs
@@ -24,7 +24,6 @@ public sealed partial class PolymorphPrototype : IPrototype, IInheritingPrototyp
 
     [DataField(required: true, serverOnly: true)]
     public PolymorphConfiguration Configuration = new();
-
 }
 
 /// <summary>
@@ -164,6 +163,12 @@ public sealed partial record PolymorphConfiguration
     /// </summary>
     [DataField]
     public LocId? ExitPolymorphPopup = "polymorph-revert-popup-generic";
+
+    /// <summary>
+    ///     If not null, this will be said in the Say channel by the polymorph-er when they polymorph.
+    /// </summary>
+    [DataField]
+    public LocId? SayOnPolymorph;
 }
 
 public enum PolymorphInventoryChange : byte


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
As per title.

## Why / Balance
Fixes the fascinating bug where Wizards gib themselves with their own Immovable Rod.

## Technical details
Due to Physics Jank™️there is a race condition where the act of hotswapping of the two entities (parent and child) on the same server tick can cause them to hit each other. I have zero desire to chase down the root cause of this race condition.

This code has been atomized from a larger-scale Immovable Rod rework. This PR blocks that work.

Polymorph has a wide variety of uses. Ergo, this requires testing of various polymorphs before it can be merged.

## Media
Nope.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Wizards now no longer gib themselves with their own Immovable Rod. Probably.