### PR TITLE
[Bugfix] Fix topical self healing time multiplier not working

### DIFF
--- a/Content.Shared/Medical/Healing/HealingComponent.cs
+++ b/Content.Shared/Medical/Healing/HealingComponent.cs
@@ -43,7 +43,7 @@ public sealed partial class HealingComponent : Component
     /// How long it takes to apply the damage.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float Delay = 3f;
+    public TimeSpan Delay = TimeSpan.FromSeconds(3f);
 
     /// <summary>
     /// Delay multiplier when healing yourself.

--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -112,9 +112,19 @@ public sealed class HealingSystem : EntitySystem
 
         // Logic to determine the whether or not to repeat the healing action
         args.Repeat = HasDamage((args.Used.Value, healing), target) && !dontRepeat;
-        if (!args.Repeat && !dontRepeat)
-            _popupSystem.PopupClient(Loc.GetString("medical-item-finished-using", ("item", args.Used)), target.Owner, args.User);
         args.Handled = true;
+
+        if (!args.Repeat)
+        {
+            _popupSystem.PopupClient(Loc.GetString("medical-item-finished-using", ("item", args.Used)), target.Owner, args.User);
+            return;
+        }
+
+        // Update our self heal delay so it shortens as we heal more damage.
+        if (args.User == target.Owner)
+        {
+            args.Args.Delay = healing.Delay * GetScaledHealingPenalty(target.Owner, healing.SelfHealPenaltyMultiplier);
+        }
     }
 
     private bool HasDamage(Entity<HealingComponent> healing, Entity<DamageableComponent> target)

--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -122,9 +122,7 @@ public sealed class HealingSystem : EntitySystem
 
         // Update our self heal delay so it shortens as we heal more damage.
         if (args.User == target.Owner)
-        {
             args.Args.Delay = healing.Delay * GetScaledHealingPenalty(target.Owner, healing.SelfHealPenaltyMultiplier);
-        }
     }
 
     private bool HasDamage(Entity<HealingComponent> healing, Entity<DamageableComponent> target)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Topical self healing time has been broken for a couple release cycles and tragically because of how bad topicals are it's been swept under the rug.

This PR fixes it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Unintended bug moment.

## Technical details
<!-- Summary of code changes for easier review. -->
The GetScaledHealingPenalty now correctly looks for damagable and mobstatethresholds on the target and not the topical being used, preventing it from exiting early and returning the incorrect value (It was returning the delay multiplied by the delay). 

Now it takes in the target, resolves for the needed components, and also a maximum multiplier float provided by the healing component. 

It also makes it so if the DoAfter repeats, the do after time will be properly updated after each completion instead of retaining the first and therefore longest do-after time. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

GetScaledHealingPenalty now takes a Entity\<DamageableComponent?, MobThresholdsComponent?> and a float;

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Topicals now correctly scale their self heal time with the damage you have taken.

