### PR TITLE
Biosuit Suit Slots

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -54,7 +54,7 @@
     sprite: Clothing/Head/Hoods/Bio/security.rsi
     state: icon
   product: CrateSecurityBiosuit
-  cost: 800
+  cost: 1600
   category: cargoproduct-category-name-security
   group: market
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -61,7 +61,7 @@
     sprite: Clothing/OuterClothing/Bio/scientist.rsi
 
 - type: entity
-  parent: [ClothingOuterBioGeneral, AllowSuitStorageClothing, BaseSecurityContraband]
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSecurityContraband]
   id: ClothingOuterBioSecurity
   name: bio suit
   suffix: Security
@@ -79,7 +79,11 @@
         Piercing: 0.8
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.4
-
+  - type: GroupExamine
+  - type: ClothingSpeedModifier
+    walkModifier: 0.95
+    sprintModifier: 0.95
+    
 - type: entity
   parent: ClothingOuterBioGeneral
   id: ClothingOuterBioVirology

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -1,6 +1,6 @@
 - type: entity
   parent: ClothingOuterBaseLarge
-  id: ClothingOuterBioGeneral
+  id: [ClothingOuterBioGeneral, AllowSuitStorageClothingGasTanks]
   name: bio suit
   suffix: Generic
   description: A suit that protects against biological contamination.
@@ -61,7 +61,7 @@
     sprite: Clothing/OuterClothing/Bio/scientist.rsi
 
 - type: entity
-  parent: [ClothingOuterBioGeneral, BaseSecurityContraband]
+  parent: [ClothingOuterBioGeneral, AllowSuitStorageClothing, BaseSecurityContraband]
   id: ClothingOuterBioSecurity
   name: bio suit
   suffix: Security

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -1,6 +1,6 @@
 - type: entity
-  parent: ClothingOuterBaseLarge
-  id: [ClothingOuterBioGeneral, AllowSuitStorageClothingGasTanks]
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothingGasTanks]
+  id: ClothingOuterBioGeneral
   name: bio suit
   suffix: Generic
   description: A suit that protects against biological contamination.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added `AllowSuitStorageClothingGasTanks` to Most Biosuits and `AllowSuitStorageClothing` to the Security Biosuit
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
For Vox/QoL, the Sec Biosuit can store a gun since it's meant for combatting zeds (and evil virologists eventually)

Also doubled Sec biosuit cost at cargo since it has actual armor values aside from caustic 800->1600
## Technical details
<!-- Summary of code changes for easier review. -->
.yml edit, General Biosuit is no longer the parent of Sec Biosuit to avoid inheriting whitelisted suit storage

## Media
<img width="451" height="548" alt="image" src="https://github.com/user-attachments/assets/e4cdf278-39f5-472a-a0db-9ecff72fe02b" />
<img width="415" height="563" alt="image" src="https://github.com/user-attachments/assets/3444b75b-7e24-4a4a-8ba4-ca42e4832892" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Biosuits can now fit Gastanks in Suit Storage, the Security Biosuit can fit both Gastanks and Weapons
- tweak: Security Biosuits Cost has been increased 800->1600