### PR TITLE
Stop packaging `Resources/ServerInfo` and `Resources/Changelog` on the server

### DIFF
--- a/Content.Packaging/ServerPackaging.cs
+++ b/Content.Packaging/ServerPackaging.cs
@@ -27,8 +27,8 @@ public static class ServerPackaging
 
     private static IReadOnlySet<string> ServerContentIgnoresResources { get; } = new HashSet<string>
     {
-        // Despite its name, this is only used by the client. And people keep thinking this is how they edit the guidebook.
         "ServerInfo",
+        "Changelog",
     };
 
     private static List<string> PlatformRids => Platforms


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Stop the packager from packaging the serverinfo resource on the server. As it is useless and creates confusion.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This is only used by the client, it is unneccery to pack into the server. 

Plus it keeps getting people to think that just editing the server resources will modify the guidebook even though that needs a custom dev enviroment and a new packaged client.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

I doupt this but if anyone actually uses this on the server for something i guess remove `, ServerContentIgnoresResources` in line 220
