### PR TITLE
TriggerOnSimpleToolUsage and add tool locks to syndicate items

### DIFF
--- a/Content.Shared/Tools/Components/SimpleToolUsageComponent.cs
+++ b/Content.Shared/Tools/Components/SimpleToolUsageComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Tools.Components;
 
 /// <summary>
 /// Component responsible for simple tool interactions.
-/// Using a tool with the correct quality on an entity with this component will start a doAfter and raise events.
+/// Using a tool with the correct quality on an entity with this component will start a DoAfter and raise the <see cref="SimpleToolDoAfterEvent"/> other systems can subscribe to.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(SimpleToolUsageSystem))]
@@ -40,8 +40,15 @@ public sealed partial class SimpleToolUsageComponent : Component
     public LocId BlockedMessage = "simple-tool-usage-blocked-message";
 }
 
+/// <summary>
+/// Cancelable event that can be used to prevent tool interaction.
+/// </summary>
 [ByRefEvent]
 public record struct AttemptSimpleToolUseEvent(EntityUid User, bool Cancelled = false);
 
+/// <summary>
+/// Raised after the right tool is used on an entity with <see cref="SimpleToolUsageComponent"/>
+/// and the DoAfter has finished.
+/// </summary>
 [Serializable, NetSerializable]
 public sealed partial class SimpleToolDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnSimpleToolUsage.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnSimpleToolUsage.cs
@@ -1,0 +1,12 @@
+using Content.Shared.Tools.Components;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Triggers an entity with <see cref="SimpleToolUsageComponent"/> when the correct tool
+/// is used on it and the DoAfter has finished.
+/// The user is the player using the tool.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TriggerOnSimpleToolUsageComponent : BaseTriggerOnXComponent;

--- a/Content.Shared/Trigger/Systems/TriggerOnToolUseSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerOnToolUseSystem.cs
@@ -1,0 +1,21 @@
+using Content.Shared.Tools.Components;
+using Content.Shared.Trigger.Components.Triggers;
+
+namespace Content.Shared.Trigger.Systems;
+
+public sealed class TriggerOnToolUseSystem : EntitySystem
+{
+    [Dependency] private readonly TriggerSystem _trigger = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TriggerOnSimpleToolUsageComponent, SimpleToolDoAfterEvent>(OnToolUse);
+    }
+
+    private void OnToolUse(Entity<TriggerOnSimpleToolUsageComponent> ent, ref SimpleToolDoAfterEvent args)
+    {
+        _trigger.Trigger(ent.Owner, args.User, ent.Comp.KeyOut);
+    }
+}

--- a/Resources/Locale/en-US/locks/selectable-locks.ftl
+++ b/Resources/Locale/en-US/locks/selectable-locks.ftl
@@ -1,3 +1,16 @@
 selectable-lock-verb-category-name = Add lock
-selectable-lock-verb-no-lock = No lock
-selectable-lock-verb-no-lock-popup = No lock has been added to {THE($target)}.
+
+selectable-lock-no-lock-verb = No lock
+selectable-lock-no-lock-popup = No lock has been added to {THE($target)}.
+
+selectable-lock-voice-verb = Voice Lock
+selectable-lock-voice-popup = A voice lock has been added to {THE($target)}.
+
+selectable-lock-tool-prying-verb = Tool Lock (Crowbar)
+selectable-lock-tool-prying-popup = A prying tool lock has been added to {THE($target)}.
+
+selectable-lock-tool-screwing-verb = Tool Lock (Screwdriver)
+selectable-lock-tool-screwing-popup = A screwing tool lock has been added to {THE($target)}.
+
+selectable-lock-tool-cutting-verb = Tool Lock (Wirecutter)
+selectable-lock-tool-cutting-popup = A cutting tool lock has been added to {THE($target)}.

--- a/Resources/Locale/en-US/locks/voice-trigger-lock.ftl
+++ b/Resources/Locale/en-US/locks/voice-trigger-lock.ftl
@@ -1,6 +1,3 @@
-voice-trigger-lock-add-verb = Voice Lock
-voice-trigger-lock-add-verb-popup = A voice lock has been added to {THE($target)}.
-
 voice-trigger-lock-verb-record = Record lock phrase
 voice-trigger-lock-verb-message = Locking the item will disable features that reveal its true nature!
 

--- a/Resources/Prototypes/Entities/Objects/Specific/locks.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/locks.yml
@@ -15,18 +15,46 @@
     lockTime: 0
     unlockTime: 0
   - type: LockOnTrigger
+    keysIn: [ lock ]
   - type: SelectableComponentAdder
     selections: 1
+    verbCategoryName: selectable-lock-verb-category-name
     entries:
-    - verbName: selectable-lock-verb-no-lock
-      popup: selectable-lock-verb-no-lock-popup
-      priority: 0
-      componentsToAdd: null
-    - verbName: voice-trigger-lock-add-verb
-      popup: voice-trigger-lock-add-verb-popup
+    - verbName: selectable-lock-tool-prying-verb
+      popup: selectable-lock-tool-prying-popup
+      priority: 4
+      componentsToAdd:
+      - type: TriggerOnSimpleToolUsage
+        keyOut: lock
+      - type: SimpleToolUsage
+        quality: Prying
+        doAfter: 1
+    - verbName: selectable-lock-tool-screwing-verb
+      popup: selectable-lock-tool-screwing-popup
+      priority: 3
+      componentsToAdd:
+      - type: TriggerOnSimpleToolUsage
+        keyOut: lock
+      - type: SimpleToolUsage
+        quality: Screwing
+        doAfter: 1
+    - verbName: selectable-lock-tool-cutting-verb
+      popup: selectable-lock-tool-cutting-popup
+      priority: 2
+      componentsToAdd:
+      - type: TriggerOnSimpleToolUsage
+        keyOut: lock
+      - type: SimpleToolUsage
+        quality: Cutting
+        doAfter: 1
+    # no anchoring since some objects might be anchorable
+    # no pulsing because it conflicts with the linking ability of the multitool
+    - verbName: selectable-lock-voice-verb
+      popup: selectable-lock-voice-popup
       priority: 1
       componentsToAdd:
       - type: TriggerOnVoice
+        keyOut: lock
         listenRange: 2 # more fun
         startRecordingVerb: voice-trigger-lock-verb-record
         recordingVerbMessage: voice-trigger-lock-verb-message
@@ -34,4 +62,8 @@
         inspectInitializedLoc: voice-trigger-lock-on-examine
       - type: ActiveListener
       - type: VoiceTriggerLock
-    verbCategoryName: selectable-lock-verb-category-name
+    - verbName: selectable-lock-no-lock-verb
+      popup: selectable-lock-no-lock-popup
+      priority: 0
+      componentsToAdd: null
+


### PR DESCRIPTION
## About the PR
Allows syndicate stealth items to be locked using a tool of your choice.
Before we only had the voice lock, but some players might be mute.
Follow-up to https://github.com/space-wizards/space-station-14/pull/39532
Resolves https://github.com/space-wizards/space-station-14/issues/39528

## Why / Balance
Anti-meta gaming measure.

## Technical details
Added a `TriggerOnSimpleToolUsageComponent` and use it to toggle the lock.
Added the corresponding selection verbs for cutting, prying, and screwing.

## Media

https://github.com/user-attachments/assets/b7edeb6c-05a2-46cf-89e4-ed6469110bbc

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- add: Syndicate stealth items now have a selection of tool locks you can choose from to hide their activation from others.
