### PR TITLE
Remove the dynamic game mode from player votes

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -103,7 +103,7 @@
   - multiantag
   - director
   name: dynamic-title
-  showInVote: true
+  showInVote: false # admin-only for now until we fix some bugs
   description: dynamic-description
   rules:
   - DynamicRule


### PR DESCRIPTION
## About the PR
Apparently it has a few bugs that can get the round stuck in a greenshift.
I talked to @EmoGarbage404 and we are opting to disable it from the player vote for now so that we can still do debugging in live rounds instead of a full revert. It probably only needs some thresholds adjusted, but figuring that out will take some time.
Supercedes https://github.com/space-wizards/space-station-14/pull/39899
See https://github.com/space-wizards/space-station-14/pull/37783

## Technical details
1 line of yaml.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Removed the dynamic game mode from player votes.
