### PR TITLE
Unpowered networks powers objects with Zero load.

### DIFF
--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -323,10 +323,12 @@ namespace Content.Server.Power.EntitySystems
 
         private bool IsPoweredCalculate(ApcPowerReceiverComponent comp)
         {
+            var receivingSufficientPower = comp.NetworkLoad.ReceivingPower > 0.0 && MathHelper.CloseToPercent(
+                comp.NetworkLoad.ReceivingPower, comp.Load
+            );
+
             return !comp.PowerDisabled
-                   && (!comp.NeedsPower
-                       || MathHelper.CloseToPercent(comp.NetworkLoad.ReceivingPower,
-                           comp.Load));
+                   && (!comp.NeedsPower || receivingSufficientPower);
         }
 
         public override bool IsPoweredCalculate(SharedApcPowerReceiverComponent comp)


### PR DESCRIPTION
## About the PR
Powered objects with a load of Zero are considered "Powered" if the network provides no power.

fixes #39911

## Technical details
A check is added to ensure that the power net delivers a positive amount of power as part of the powered check.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Inserting a lightbulb into an unpowered fixture will no longer flash that light.
