### PR TITLE
Borg mops unweildable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -1,8 +1,9 @@
 - type: entity
   parent: BaseItem
   name: mop
-  id: MopItem
+  id: BaseMopItem
   description: A mop that can't be stopped, viscera cleanup detail awaits.
+  abstract: true
   components:
   - type: Sprite
     sprite: Objects/Specific/Janitorial/mop.rsi
@@ -29,11 +30,6 @@
     preventMelee: false
   - type: DrainableSolution
     solution: absorbed
-  - type: Wieldable
-  - type: IncreaseDamageOnWield
-    damage:
-      types:
-        Blunt: 5
   - type: Item
     size: Large
     sprite: Objects/Specific/Janitorial/mop.rsi
@@ -58,10 +54,11 @@
   - type: DnaSubstanceTrace
 
 - type: entity
-  parent: BaseItem
+  parent: BaseMopItem
   name: advanced mop
-  id: AdvMopItem
+  id: BaseAdvMopItem
   description: Motorized mop that has a bigger reservoir and quickly replaces reagents inside with water. Automatic Clown Countermeasure not included.
+  abstract: true
   components:
     - type: Sprite
       sprite: Objects/Specific/Janitorial/advmop.rsi
@@ -76,31 +73,11 @@
       fillBaseName: fill-
       inHandsFillBaseName: -fill-
       inHandsMaxFillLevels: 2
-    - type: MeleeWeapon
-      damage:
-        types:
-          Blunt: 10
-      soundHit:
-         collection: MetalThud
-    - type: Spillable
-      solution: absorbed
-      spillWhenThrown: false
-      preventMelee: false
-    - type: DrainableSolution
-      solution: absorbed
-    - type: Wieldable
-    - type: IncreaseDamageOnWield
-      damage:
-        types:
-          Blunt: 5
     - type: Item
-      size: Large
       sprite: Objects/Specific/Janitorial/advmop.rsi
     - type: Absorbent
       pickupAmount: 100
       useAbsorberSolution: true
-    - type: UseDelay
-      delay: 1.0
     - type: SolutionRegeneration
       solution: absorbed
       generated:
@@ -112,15 +89,42 @@
       preserve:
       - Water
       quantity: 10
-    - type: SolutionContainerManager
-      solutions:
-        absorbed:
-          maxVol: 100
     - type: Tag
       tags:
         - Mop
         - MopAdv
-    - type: DnaSubstanceTrace
+
+- type: entity
+  parent: BaseItem
+  name: mop
+  id: MopItem
+  description: A mop that can't be stopped, viscera cleanup detail awaits.
+  components:
+  - type: Wieldable
+  - type: IncreaseDamageOnWield
+    damage:
+      types:
+        Blunt: 5
+
+- type: entity
+  parent: BaseMopItem
+  id: BorgMopItem
+  suffix: unweildable
+
+- type: entity
+  parent: BaseAdvMopItem
+  id: AdvMopItem
+  components:
+    - type: Wieldable
+    - type: IncreaseDamageOnWield
+      damage:
+        types:
+          Blunt: 5
+
+- type: entity
+  parent: BaseAdvMopItem
+  id: BorgAdvMopItem
+  suffix: unweildable
 
 - type: entity
   name: wet floor sign

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -751,7 +751,7 @@
     - state: icon-mop
   - type: ItemBorgModule
     hands:
-    - item: MopItem
+    - item: BorgMopItem
     - item: BorgBucket
     - item: BorgSprayBottle
     - item: HoloprojectorBorg
@@ -770,7 +770,7 @@
     - state: icon-mop-adv
   - type: ItemBorgModule
     hands:
-    - item: AdvMopItem
+    - item: BorgAdvMopItem
     - item: BorgMegaSprayBottle
     - item: HoloprojectorBorg
     - item: BorgDropper


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

restructured mop parenting and made it so borgs with mops cant wield them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

fixes https://github.com/space-wizards/space-station-14/issues/39860

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: borgs can no longer wield mops.