### PR TITLE
Fix roundstart grids/shuttles name

### DIFF
--- a/Content.Server/Shuttles/Components/GridSpawnComponent.cs
+++ b/Content.Server/Shuttles/Components/GridSpawnComponent.cs
@@ -111,8 +111,6 @@ public sealed partial class GridSpawnGroup : IGridSpawnGroup
     public int MaxCount { get; set; } = 1;
     public ComponentRegistry AddComponents { get; set; } = new();
     public bool Hide { get; set; } = false;
-    public bool NameGrid { get; set; } = true;
+    public bool NameGrid { get; set; } = false;
     public bool StationGrid { get; set; } = true;
 }
-
-


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Now the basic grids appear with a proper name. I think that in `GridSpawnGroup`, the value of `NameGrid` should not be set to `true` by default.

Fixes #29743
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
When basic grids, such as ATS or previously the salvage shuttle, appear with a name taken from their file name, it looks strange. For a grid or grids where it is necessary to change or assign a name, you can simply add `NameGrid` manually.
For example, in ruins a custom value is already specified, as if it wasn’t really meant to always be `true`.
<img width="245" height="136" alt="Code_vP0uIULOh5" src="https://github.com/user-attachments/assets/cd93e615-dcf1-419c-835b-a827816cc1ab" />

## Technical details
<!-- Summary of code changes for easier review. -->
Change the default value of `NameGrid` in `GridSpawnGroup` from `true` to `false`.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="319" height="215" alt="Content Client_G90MdXgal3" src="https://github.com/user-attachments/assets/a0f05daa-554c-437a-9de7-bfc58310fe41" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
 - fix: ATS and other named grids will now show the correct name on shuttle consoles. 
