### PR TITLE
Remove holopad projection verb on station AI core

### DIFF
--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -401,6 +401,9 @@ public sealed class HolopadSystem : SharedHolopadSystem
         if (!this.IsPowered(entity, EntityManager))
             return;
 
+        if (HasComp<StationAiCoreComponent>(entity))
+            return;
+
         if (!TryComp<TelephoneComponent>(entity, out var entityTelephone) ||
             _telephoneSystem.IsTelephoneEngaged((entity, entityTelephone)))
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed the AI getting a holopad projection verb on its own core

## Why / Balance
Doesn't belong on the AI core. Also interfered with the customization since the customization verb would jump down, but that's a holopad verb prediction issue.

## Technical details
Added a check to see if the entity with a `HolopadComponent` getting a verb added has a `StationAiCoreComponent`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
old:
<img width="549" height="355" alt="image" src="https://github.com/user-attachments/assets/2e434ba7-3891-47cc-ac9f-18b6382109c6" />



new: 
<img width="549" height="355" alt="image" src="https://github.com/user-attachments/assets/7da36afa-8fd5-4a0f-b457-3bededde44a2" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Crude Oil
- fix: Removed 'Activate Holopad Projector' verb from the station AI core.