### PR TITLE
Refactor lights.yml

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -1,22 +1,24 @@
+# Lighting color values gathered from
+# https://andi-siess.de/rgb-to-color-temperature/
+# https://academo.org/demos/colour-temperature-relationship/
+
+# Index:
 # 1. ROUND LIGHTBULBS
 # 2. TUBE LIGHTBULBS (Light tubes)
 
 # 1. ROUND LIGHTBULBS
 - type: entity
+  abstract: true
   parent: BaseItem
   id: BaseLightbulb
-  abstract: true
   components:
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        collection: GlassSmash
   - type: Sprite
     sprite: Objects/Power/light_bulb.rsi
     layers:
     - map: [ enum.LightBulbVisualLayers.Base ]
       state: normal
   - type: LightBulb
+  - type: Appearance
   - type: Damageable
     damageContainer: Inorganic
   - type: DamageOnLand
@@ -42,8 +44,6 @@
       - !type:PlaySoundBehavior
         sound:
           collection: GlassBreak
-          params:
-            volume: -8
       - !type:DoActsBehavior
         acts: [ "Breakage" ]
     - trigger:
@@ -53,8 +53,6 @@
       - !type:PlaySoundBehavior
         sound:
           collection: GlassBreak
-          params:
-            volume: -8
       - !type:SpawnEntitiesBehavior
         spawn:
           ShardGlass:
@@ -62,25 +60,25 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: Appearance
+  - type: MeleeSound
+    soundGroups:
+      Brute:
+        collection: GlassSmash
   - type: Tag
     tags:
     - Trash
+  - type: SpaceGarbage
   - type: PhysicalComposition
     materialComposition:
       Glass: 25
-  - type: SpaceGarbage
   - type: ToolRefinable
     refineResult:
     - id: SheetGlass1
 
-# Lighting color values gathered from
-# https://andi-siess.de/rgb-to-color-temperature/
-# https://academo.org/demos/colour-temperature-relationship/
 - type: entity
   parent: BaseLightbulb
-  name: incandescent light bulb
   id: LightBulb
+  name: incandescent light bulb
   description: A light bulb.
   components:
   - type: LightBulb
@@ -96,8 +94,8 @@
 
 - type: entity
   parent: BaseLightbulb
-  name: led light bulb
   id: LedLightBulb
+  name: led light bulb
   description: A power efficient light bulb.
   components:
   - type: LightBulb
@@ -115,8 +113,8 @@
 
 - type: entity
   parent: BaseLightbulb
-  name: dim light bulb
   id: DimLightBulb
+  name: dim light bulb
   description: A dim light bulb for populating the darkness of maintenance.
   components:
   - type: LightBulb
@@ -132,8 +130,8 @@
 
 - type: entity
   parent: BaseLightbulb
-  name: warm light bulb
   id: WarmLightBulb
+  name: warm light bulb
   description: A warm light bulb for a more cozy atmosphere.
   components:
   - type: LightBulb
@@ -149,8 +147,8 @@
 
 - type: entity
   parent: LightBulb
-  name: old incandescent light bulb
   id: LightBulbOld
+  name: old incandescent light bulb
   description: An aging light bulb.
   components:
   - type: LightBulb
@@ -161,10 +159,10 @@
     lightSoftness: 1.1
 
 - type: entity
-  suffix: Broken
   parent: BaseLightbulb
-  name: incandescent light bulb
   id: LightBulbBroken
+  name: incandescent light bulb
+  suffix: Broken
   description: A light bulb.
   components:
   - type: LightBulb
@@ -173,8 +171,8 @@
 
 - type: entity
   parent: BaseLightbulb
-  name: service light bulb
   id: ServiceLightBulb
+  name: service light bulb
   description: A low-brightness green lightbulb used in janitorial service lights.
   components:
   - type: LightBulb
@@ -189,11 +187,11 @@
     - Trash
 
 - type: entity
+  abstract: true
   parent: BaseLightbulb
+  id: BaseLightbulbCrystal
   name: crystal light bulb
   description: A high power high energy bulb which has a small colored crystal inside.
-  id: BaseLightbulbCrystal
-  abstract: true
   components:
   - type: LightBulb
     color: "#47f8ff"
@@ -206,8 +204,8 @@
 
 - type: entity
   parent: BaseLightbulbCrystal
-  name: cyan crystal light bulb
   id: LightBulbCrystalCyan
+  name: cyan crystal light bulb
   components:
   - type: LightBulb
     color: "#47f8ff"
@@ -221,8 +219,8 @@
 
 - type: entity
   parent: BaseLightbulbCrystal
-  name: blue crystal light bulb
   id: LightBulbCrystalBlue
+  name: blue crystal light bulb
   components:
   - type: LightBulb
     color: "#39a1ff"
@@ -236,8 +234,8 @@
 
 - type: entity
   parent: BaseLightbulbCrystal
-  name: yellow crystal light bulb
   id: LightBulbCrystalYellow
+  name: yellow crystal light bulb
   components:
   - type: LightBulb
     color: "#ffde46"
@@ -251,8 +249,8 @@
 
 - type: entity
   parent: BaseLightbulbCrystal
-  name: pink crystal light bulb
   id: LightBulbCrystalPink
+  name: pink crystal light bulb
   components:
   - type: LightBulb
     color: "#ff66cc"
@@ -266,8 +264,8 @@
 
 - type: entity
   parent: BaseLightbulbCrystal
-  name: orange crystal light bulb
   id: LightBulbCrystalOrange
+  name: orange crystal light bulb
   components:
   - type: LightBulb
     color: "#ff8227"
@@ -281,9 +279,9 @@
 
 - type: entity
   parent: BaseLightbulbCrystal
+  id: LightBulbCrystalBlack
   name: black crystal light bulb
   description: A high power high energy bulb which has a small colored crystal inside. It isn't very bright.
-  id: LightBulbCrystalBlack
   components:
   - type: LightBulb
     color: "#363636"
@@ -299,8 +297,8 @@
 
 - type: entity
   parent: BaseLightbulbCrystal
-  name: red crystal light bulb
   id: LightBulbCrystalRed
+  name: red crystal light bulb
   components:
   - type: LightBulb
     color: "#fb4747"
@@ -314,8 +312,8 @@
 
 - type: entity
   parent: BaseLightbulbCrystal
-  name: green crystal light bulb
   id: LightBulbCrystalGreen
+  name: green crystal light bulb
   components:
   - type: LightBulb
     color: "#52ff39"
@@ -329,50 +327,19 @@
 
 # 2. TUBE LIGHTBULBS (Light tubes)
 - type: entity
+  abstract: true
   parent: BaseLightbulb
   id: BaseLightTube
-  abstract: true
   components:
   - type: Sprite
     sprite:  Objects/Power/light_tube.rsi
   - type: LightBulb
     bulb: Tube
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 100
-      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-    - trigger:
-        !type:DamageTrigger
-        damage: 5
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
-      - !type:DoActsBehavior
-        acts: [ "Breakage" ]
-    - trigger:
-        !type:DamageTrigger
-        damage: 10
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          ShardGlass:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
 
 - type: entity
   parent: BaseLightTube
-  name: fluorescent light tube
   id: LightTube
+  name: fluorescent light tube
   description: A light fixture.
   components:
   - type: LightBulb
@@ -384,8 +351,8 @@
 
 - type: entity
   parent: LightTube
-  name: old fluorescent light tube
   id: LightTubeOld
+  name: old fluorescent light tube
   description: An aging light fixture.
   components:
   - type: LightBulb
@@ -396,10 +363,10 @@
     PowerUse: 10
 
 - type: entity
-  suffix: Broken
   parent: BaseLightTube
-  name: fluorescent light tube
   id: LightTubeBroken
+  name: fluorescent light tube
+  suffix: Broken
   description: A light fixture.
   components:
   - type: LightBulb
@@ -407,9 +374,9 @@
 
 - type: entity
   parent: BaseLightTube
+  id: LedLightTube
   name: led light tube
   description: A high power high energy bulb.
-  id: LedLightTube
   components:
   - type: LightBulb
     color: "#EEEEFF"
@@ -421,9 +388,9 @@
 
 - type: entity
   parent: BaseLightTube
+  id: ExteriorLightTube
   name: exterior light tube
   description: A high power high energy bulb for the depths of space. May contain mercury.
-  id: ExteriorLightTube
   components:
   - type: LightBulb
     color: "#B4FCF0"
@@ -435,9 +402,9 @@
 
 - type: entity
   parent: BaseLightTube
+  id: SodiumLightTube
   name: sodium light tube
   description: A high power high energy bulb for the depths of space. Salty.
-  id: SodiumLightTube
   components:
   - type: LightBulb
     color: "#FFAF38"
@@ -448,11 +415,11 @@
     PowerUse: 100
 
 - type: entity
+  abstract: true
   parent: BaseLightTube
+  id: BaseLightTubeCrystal
   name: crystal light tube
   description: A high power high energy bulb which has a small colored crystal inside.
-  id: BaseLightTubeCrystal
-  abstract: true
   components:
   - type: LightBulb
     lightEnergy: 3
@@ -463,8 +430,8 @@
 
 - type: entity
   parent: BaseLightTubeCrystal
-  name: cyan crystal light tube
   id: LightTubeCrystalCyan
+  name: cyan crystal light tube
   components:
   - type: LightBulb
     color: "#47f8ff"
@@ -478,8 +445,8 @@
 
 - type: entity
   parent: BaseLightTubeCrystal
-  name: blue crystal light tube
   id: LightTubeCrystalBlue
+  name: blue crystal light tube
   components:
   - type: LightBulb
     color: "#39a1ff"
@@ -493,8 +460,8 @@
 
 - type: entity
   parent: BaseLightTubeCrystal
-  name: yellow crystal light tube
   id: LightTubeCrystalYellow
+  name: yellow crystal light tube
   components:
   - type: LightBulb
     color: "#ffde46"
@@ -508,8 +475,8 @@
 
 - type: entity
   parent: BaseLightTubeCrystal
-  name: pink crystal light tube
   id: LightTubeCrystalPink
+  name: pink crystal light tube
   components:
   - type: LightBulb
     color: "#ff66cc"
@@ -523,8 +490,8 @@
 
 - type: entity
   parent: BaseLightTubeCrystal
-  name: orange crystal light tube
   id: LightTubeCrystalOrange
+  name: orange crystal light tube
   components:
   - type: LightBulb
     color: "#ff8227"
@@ -538,9 +505,9 @@
 
 - type: entity
   parent: BaseLightTubeCrystal
+  id: LightTubeCrystalBlack
   name: black crystal light tube
   description: A high power high energy bulb which has a small colored crystal inside. It isn't very bright.
-  id: LightTubeCrystalBlack
   components:
   - type: LightBulb
     color: "#363636"
@@ -556,8 +523,8 @@
 
 - type: entity
   parent: BaseLightTubeCrystal
-  name: red crystal light tube
   id: LightTubeCrystalRed
+  name: red crystal light tube
   components:
   - type: LightBulb
     color: "#fb4747"
@@ -571,8 +538,8 @@
 
 - type: entity
   parent: LightTubeCrystalCyan
-  name: green crystal light tube
   id: LightTubeCrystalGreen
+  name: green crystal light tube
   components:
   - type: LightBulb
     color: "#52ff39"

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -66,10 +66,10 @@
   - type: Tag
     tags:
     - Trash
-  - type: SpaceGarbage
   - type: PhysicalComposition
     materialComposition:
       Glass: 25
+  - type: SpaceGarbage
   - type: ToolRefinable
     refineResult:
     - id: SheetGlass1

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -2,7 +2,6 @@
 # https://andi-siess.de/rgb-to-color-temperature/
 # https://academo.org/demos/colour-temperature-relationship/
 
-# Index:
 # 1. ROUND LIGHTBULBS
 # 2. TUBE LIGHTBULBS (Light tubes)
 
@@ -194,7 +193,6 @@
   description: A high power high energy bulb which has a small colored crystal inside.
   components:
   - type: LightBulb
-    color: "#47f8ff"
     lightEnergy: 1
     lightRadius: 6
     lightSoftness: 0.5
@@ -204,48 +202,18 @@
 
 - type: entity
   parent: BaseLightbulbCrystal
-  id: LightBulbCrystalCyan
-  name: cyan crystal light bulb
+  id: LightBulbCrystalRed
+  name: red crystal light bulb
   components:
   - type: LightBulb
-    color: "#47f8ff"
+    color: "#fb4747"
   - type: Construction
-    graph: CyanLightBulb
+    graph: RedLightBulb
     node: icon
   - type: ToolRefinable
     refineResult:
     - id: SheetGlass1
-    - id: ShardCrystalCyan
-
-- type: entity
-  parent: BaseLightbulbCrystal
-  id: LightBulbCrystalBlue
-  name: blue crystal light bulb
-  components:
-  - type: LightBulb
-    color: "#39a1ff"
-  - type: Construction
-    graph: BlueLightBulb
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalBlue
-
-- type: entity
-  parent: BaseLightbulbCrystal
-  id: LightBulbCrystalYellow
-  name: yellow crystal light bulb
-  components:
-  - type: LightBulb
-    color: "#ffde46"
-  - type: Construction
-    graph: YellowLightBulb
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalYellow
+    - id: ShardCrystalRed
 
 - type: entity
   parent: BaseLightbulbCrystal
@@ -279,36 +247,18 @@
 
 - type: entity
   parent: BaseLightbulbCrystal
-  id: LightBulbCrystalBlack
-  name: black crystal light bulb
-  description: A high power high energy bulb which has a small colored crystal inside. It isn't very bright.
+  id: LightBulbCrystalYellow
+  name: yellow crystal light bulb
   components:
   - type: LightBulb
-    color: "#363636"
-    lightEnergy: 1
-    lightRadius: 8
+    color: "#ffde46"
   - type: Construction
-    graph: BlackLightBulb
+    graph: YellowLightBulb
     node: icon
   - type: ToolRefinable
     refineResult:
     - id: SheetGlass1
-    - id: ShardCrystalBlack
-
-- type: entity
-  parent: BaseLightbulbCrystal
-  id: LightBulbCrystalRed
-  name: red crystal light bulb
-  components:
-  - type: LightBulb
-    color: "#fb4747"
-  - type: Construction
-    graph: RedLightBulb
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalRed
+    - id: ShardCrystalYellow
 
 - type: entity
   parent: BaseLightbulbCrystal
@@ -325,7 +275,55 @@
     - id: SheetGlass1
     - id: ShardCrystalGreen
 
-# 2. TUBE LIGHTBULBS (Light tubes)
+- type: entity
+  parent: BaseLightbulbCrystal
+  id: LightBulbCrystalCyan
+  name: cyan crystal light bulb
+  components:
+  - type: LightBulb
+    color: "#47f8ff"
+  - type: Construction
+    graph: CyanLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalCyan
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  id: LightBulbCrystalBlue
+  name: blue crystal light bulb
+  components:
+  - type: LightBulb
+    color: "#39a1ff"
+  - type: Construction
+    graph: BlueLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalBlue
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  id: LightBulbCrystalBlack
+  name: black crystal light bulb
+  description: A high power high energy bulb which has a small colored crystal inside. It isn't very bright.
+  components:
+  - type: LightBulb
+    color: "#363636"
+    lightEnergy: 1
+    lightRadius: 8
+  - type: Construction
+    graph: BlackLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalBlack
+
+# 2. TUBE LIGHTBULBS
 - type: entity
   abstract: true
   parent: BaseLightbulb
@@ -430,6 +428,81 @@
 
 - type: entity
   parent: BaseLightTubeCrystal
+  id: LightTubeCrystalPink
+  name: pink crystal light tube
+  components:
+  - type: LightBulb
+    color: "#ff66cc"
+  - type: Construction
+    graph: PinkLight
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalPink
+
+- type: entity
+  parent: BaseLightTubeCrystal
+  id: LightTubeCrystalRed
+  name: red crystal light tube
+  components:
+  - type: LightBulb
+    color: "#fb4747"
+  - type: Construction
+    graph: RedLight
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalRed
+
+- type: entity
+  parent: BaseLightTubeCrystal
+  id: LightTubeCrystalOrange
+  name: orange crystal light tube
+  components:
+  - type: LightBulb
+    color: "#ff8227"
+  - type: Construction
+    graph: OrangeLight
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalOrange
+
+- type: entity
+  parent: BaseLightTubeCrystal
+  id: LightTubeCrystalYellow
+  name: yellow crystal light tube
+  components:
+  - type: LightBulb
+    color: "#ffde46"
+  - type: Construction
+    graph: YellowLight
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalYellow
+
+- type: entity
+  parent: LightTubeCrystalCyan
+  id: LightTubeCrystalGreen
+  name: green crystal light tube
+  components:
+  - type: LightBulb
+    color: "#52ff39"
+  - type: Construction
+    graph: GreenLight
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalGreen
+
+- type: entity
+  parent: BaseLightTubeCrystal
   id: LightTubeCrystalCyan
   name: cyan crystal light tube
   components:
@@ -460,51 +533,6 @@
 
 - type: entity
   parent: BaseLightTubeCrystal
-  id: LightTubeCrystalYellow
-  name: yellow crystal light tube
-  components:
-  - type: LightBulb
-    color: "#ffde46"
-  - type: Construction
-    graph: YellowLight
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalYellow
-
-- type: entity
-  parent: BaseLightTubeCrystal
-  id: LightTubeCrystalPink
-  name: pink crystal light tube
-  components:
-  - type: LightBulb
-    color: "#ff66cc"
-  - type: Construction
-    graph: PinkLight
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalPink
-
-- type: entity
-  parent: BaseLightTubeCrystal
-  id: LightTubeCrystalOrange
-  name: orange crystal light tube
-  components:
-  - type: LightBulb
-    color: "#ff8227"
-  - type: Construction
-    graph: OrangeLight
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalOrange
-
-- type: entity
-  parent: BaseLightTubeCrystal
   id: LightTubeCrystalBlack
   name: black crystal light tube
   description: A high power high energy bulb which has a small colored crystal inside. It isn't very bright.
@@ -520,33 +548,3 @@
     refineResult:
     - id: SheetGlass1
     - id: ShardCrystalBlack
-
-- type: entity
-  parent: BaseLightTubeCrystal
-  id: LightTubeCrystalRed
-  name: red crystal light tube
-  components:
-  - type: LightBulb
-    color: "#fb4747"
-  - type: Construction
-    graph: RedLight
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalRed
-
-- type: entity
-  parent: LightTubeCrystalCyan
-  id: LightTubeCrystalGreen
-  name: green crystal light tube
-  components:
-  - type: LightBulb
-    color: "#52ff39"
-  - type: Construction
-    graph: GreenLight
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalGreen

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -1,3 +1,7 @@
+# 1. ROUND LIGHTBULBS
+# 2. TUBE LIGHTBULBS (Light tubes)
+
+# 1. ROUND LIGHTBULBS
 - type: entity
   parent: BaseItem
   id: BaseLightbulb
@@ -10,8 +14,8 @@
   - type: Sprite
     sprite: Objects/Power/light_bulb.rsi
     layers:
-      - map: [ enum.LightBulbVisualLayers.Base ]
-        state: normal
+    - map: [ enum.LightBulbVisualLayers.Base ]
+      state: normal
   - type: LightBulb
   - type: Damageable
     damageContainer: Inorganic
@@ -69,47 +73,6 @@
   - type: ToolRefinable
     refineResult:
     - id: SheetGlass1
-
-- type: entity
-  parent: BaseLightbulb
-  id: BaseLightTube
-  abstract: true
-  components:
-  - type: Sprite
-    sprite:  Objects/Power/light_tube.rsi
-  - type: LightBulb
-    bulb: Tube
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 100
-      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-    - trigger:
-        !type:DamageTrigger
-        damage: 5
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
-      - !type:DoActsBehavior
-        acts: [ "Breakage" ]
-    - trigger:
-        !type:DamageTrigger
-        damage: 10
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          ShardGlass:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
 
 # Lighting color values gathered from
 # https://andi-siess.de/rgb-to-color-temperature/
@@ -224,6 +187,187 @@
     tags:
     - LightBulb
     - Trash
+
+- type: entity
+  parent: BaseLightbulb
+  name: crystal light bulb
+  description: A high power high energy bulb which has a small colored crystal inside.
+  id: BaseLightbulbCrystal
+  abstract: true
+  components:
+  - type: LightBulb
+    color: "#47f8ff"
+    lightEnergy: 1
+    lightRadius: 6
+    lightSoftness: 0.5
+    BurningTemperature: 350
+    PowerUse: 60
+    bulb: Bulb
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: cyan crystal light bulb
+  id: LightBulbCrystalCyan
+  components:
+  - type: LightBulb
+    color: "#47f8ff"
+  - type: Construction
+    graph: CyanLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalCyan
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: blue crystal light bulb
+  id: LightBulbCrystalBlue
+  components:
+  - type: LightBulb
+    color: "#39a1ff"
+  - type: Construction
+    graph: BlueLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalBlue
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: yellow crystal light bulb
+  id: LightBulbCrystalYellow
+  components:
+  - type: LightBulb
+    color: "#ffde46"
+  - type: Construction
+    graph: YellowLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalYellow
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: pink crystal light bulb
+  id: LightBulbCrystalPink
+  components:
+  - type: LightBulb
+    color: "#ff66cc"
+  - type: Construction
+    graph: PinkLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalPink
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: orange crystal light bulb
+  id: LightBulbCrystalOrange
+  components:
+  - type: LightBulb
+    color: "#ff8227"
+  - type: Construction
+    graph: OrangeLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalOrange
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: black crystal light bulb
+  description: A high power high energy bulb which has a small colored crystal inside. It isn't very bright.
+  id: LightBulbCrystalBlack
+  components:
+  - type: LightBulb
+    color: "#363636"
+    lightEnergy: 1
+    lightRadius: 8
+  - type: Construction
+    graph: BlackLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalBlack
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: red crystal light bulb
+  id: LightBulbCrystalRed
+  components:
+  - type: LightBulb
+    color: "#fb4747"
+  - type: Construction
+    graph: RedLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalRed
+
+- type: entity
+  parent: BaseLightbulbCrystal
+  name: green crystal light bulb
+  id: LightBulbCrystalGreen
+  components:
+  - type: LightBulb
+    color: "#52ff39"
+  - type: Construction
+    graph: GreenLightBulb
+    node: icon
+  - type: ToolRefinable
+    refineResult:
+    - id: SheetGlass1
+    - id: ShardCrystalGreen
+
+# 2. TUBE LIGHTBULBS (Light tubes)
+- type: entity
+  parent: BaseLightbulb
+  id: BaseLightTube
+  abstract: true
+  components:
+  - type: Sprite
+    sprite:  Objects/Power/light_tube.rsi
+  - type: LightBulb
+    bulb: Tube
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 5
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:DoActsBehavior
+        acts: [ "Breakage" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 10
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          ShardGlass:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: BaseLightTube
@@ -434,146 +578,6 @@
     color: "#52ff39"
   - type: Construction
     graph: GreenLight
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalGreen
-
-
-- type: entity
-  parent: BaseLightbulb
-  name: crystal light bulb
-  description: A high power high energy bulb which has a small colored crystal inside.
-  id: BaseLightbulbCrystal
-  abstract: true
-  components:
-  - type: LightBulb
-    color: "#47f8ff"
-    lightEnergy: 1
-    lightRadius: 6
-    lightSoftness: 0.5
-    BurningTemperature: 350
-    PowerUse: 60
-    bulb: Bulb
-
-- type: entity
-  parent: BaseLightbulbCrystal
-  name: cyan crystal light bulb
-  id: LightBulbCrystalCyan
-  components:
-  - type: LightBulb
-    color: "#47f8ff"
-  - type: Construction
-    graph: CyanLightBulb
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalCyan
-
-- type: entity
-  parent: BaseLightbulbCrystal
-  name: blue crystal light bulb
-  id: LightBulbCrystalBlue
-  components:
-  - type: LightBulb
-    color: "#39a1ff"
-  - type: Construction
-    graph: BlueLightBulb
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalBlue
-
-- type: entity
-  parent: BaseLightbulbCrystal
-  name: yellow crystal light bulb
-  id: LightBulbCrystalYellow
-  components:
-  - type: LightBulb
-    color: "#ffde46"
-  - type: Construction
-    graph: YellowLightBulb
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalYellow
-
-- type: entity
-  parent: BaseLightbulbCrystal
-  name: pink crystal light bulb
-  id: LightBulbCrystalPink
-  components:
-  - type: LightBulb
-    color: "#ff66cc"
-  - type: Construction
-    graph: PinkLightBulb
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalPink
-
-- type: entity
-  parent: BaseLightbulbCrystal
-  name: orange crystal light bulb
-  id: LightBulbCrystalOrange
-  components:
-  - type: LightBulb
-    color: "#ff8227"
-  - type: Construction
-    graph: OrangeLightBulb
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalOrange
-
-- type: entity
-  parent: BaseLightbulbCrystal
-  name: black crystal light bulb
-  description: A high power high energy bulb which has a small colored crystal inside. It isn't very bright.
-  id: LightBulbCrystalBlack
-  components:
-  - type: LightBulb
-    color: "#363636"
-    lightEnergy: 1
-    lightRadius: 8
-  - type: Construction
-    graph: BlackLightBulb
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalBlack
-
-- type: entity
-  parent: BaseLightbulbCrystal
-  name: red crystal light bulb
-  id: LightBulbCrystalRed
-  components:
-  - type: LightBulb
-    color: "#fb4747"
-  - type: Construction
-    graph: RedLightBulb
-    node: icon
-  - type: ToolRefinable
-    refineResult:
-    - id: SheetGlass1
-    - id: ShardCrystalRed
-
-- type: entity
-  parent: BaseLightbulbCrystal
-  name: green crystal light bulb
-  id: LightBulbCrystalGreen
-  components:
-  - type: LightBulb
-    color: "#52ff39"
-  - type: Construction
-    graph: GreenLightBulb
     node: icon
   - type: ToolRefinable
     refineResult:

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -2,10 +2,10 @@
 # https://andi-siess.de/rgb-to-color-temperature/
 # https://academo.org/demos/colour-temperature-relationship/
 
-# 1. ROUND LIGHTBULBS
-# 2. TUBE LIGHTBULBS (Light tubes)
+# 1. LIGHT BULBS
+# 2. LIGHT TUBES
 
-# 1. ROUND LIGHTBULBS
+# 1. LIGHT BULBS
 - type: entity
   abstract: true
   parent: BaseItem


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Updates lights.yml to current yml convention ([type > abstract > parent > id > categories > name > suffix > description > components](https://docs.spacestation14.com/en/general-development/codebase-info/conventions.html#yaml-conventions), removed indents)
- Adds headers for easier navigation (# 1. Light Bulbs, # 2. Light Tubes), places coloured light bulbs and tubes under respective headers
  - Separated coloured light bulbs and light tubes from each other, arranged them by ROYGBIV order
- Cleaned up components
  - Components in more appropriate order (appearance at top, general components in middle, specific components at bottom)
  - LightTube now inherits same Destructible component from BaseLightbulb; only change is that light tubes and light bulbs share same volume upon shattering

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Part of general clean-up.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

Not player-facing.