### PR TITLE
Don't network ZombifyOnDeathComponent and ZombieImmuneComponent

### DIFF
--- a/Content.Shared/Zombies/ZombieImmuneComponent.cs
+++ b/Content.Shared/Zombies/ZombieImmuneComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Zombies;
 /// <summary>
 /// Entities with this component cannot be zombified.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent]
 public sealed partial class ZombieImmuneComponent : Component
 {
     //still no

--- a/Content.Shared/Zombies/ZombifyOnDeathComponent.cs
+++ b/Content.Shared/Zombies/ZombifyOnDeathComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Zombies;
 /// <summary>
 /// Entities with this component zombify on death.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent]
 public sealed partial class ZombifyOnDeathComponent : Component
 {
     //this is not the component you are looking for


### PR DESCRIPTION
## About the PR
They were moved to shared in https://github.com/space-wizards/space-station-14/pull/39791
It was brought up that they should not be networked since cheat clients could use it to identify initial infected.
This does not cause any prediction problems since the components are only used on the server.
For the planned prediction of entity effects this won't be needed either.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
not player facing
