### PR TITLE
Fix forensic scanner leaking fingerprints onto the scanning object if you use the verb

### DIFF
--- a/Content.Server/Forensics/Systems/ForensicScannerSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicScannerSystem.cs
@@ -125,7 +125,9 @@ namespace Content.Server.Forensics
                 Act = () => StartScan(uid, component, args.User, args.Target),
                 IconEntity = GetNetEntity(uid),
                 Text = Loc.GetString("forensic-scanner-verb-text"),
-                Message = Loc.GetString("forensic-scanner-verb-message")
+                Message = Loc.GetString("forensic-scanner-verb-message"),
+                // This is important because if its true using the scanner will count as touching the object.
+                DoContactInteraction = false
             };
 
             args.Verbs.Add(verb);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
If you use the right-click scan verb with the forensic scanner, it'll leak fingerprints onto the object you're scanning
Disables contact interaction to make this no longer the case

:cl:
- fix: The forensic scanner no longer leaks fingerprints or glove prints onto the scanning object if you use the right-click scan verb.
