### PR TITLE
Make cyborgs magnetize items

### DIFF
--- a/Content.Shared/Storage/Components/MagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MagnetPickupComponent.cs
@@ -16,7 +16,7 @@ public sealed partial class MagnetPickupComponent : Component
     /// What container slot the magnet needs to be in to work.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("slotFlags")]
-    public SlotFlags SlotFlags = SlotFlags.BELT;
+    public SlotFlags? SlotFlags = Inventory.SlotFlags.BELT;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("range")]
     public float Range = 1f;

--- a/Content.Shared/Storage/Components/MagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MagnetPickupComponent.cs
@@ -8,16 +8,19 @@ namespace Content.Shared.Storage.Components;
 [RegisterComponent, AutoGenerateComponentPause]
 public sealed partial class MagnetPickupComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite), DataField("nextScan")]
+    [DataField]
     [AutoPausedField]
     public TimeSpan NextScan = TimeSpan.Zero;
 
     /// <summary>
     /// What container slot the magnet needs to be in to work.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("slotFlags")]
+    [DataField]
     public SlotFlags? SlotFlags = Inventory.SlotFlags.BELT;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("range")]
+    [DataField]
+    public bool RequireActiveHand = false;
+
+    [DataField]
     public float Range = 1f;
 }

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -1,6 +1,4 @@
-using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Inventory;
-using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared.Storage.Components;
 using Content.Shared.Whitelist;
 using Robust.Shared.Physics.Components;
@@ -14,13 +12,11 @@ namespace Content.Shared.Storage.EntitySystems;
 public sealed class MagnetPickupSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
-    [Dependency] private readonly SharedHandsSystem _hands = default!;
 
 
     private static readonly TimeSpan ScanDelay = TimeSpan.FromSeconds(1);
@@ -52,9 +48,7 @@ public sealed class MagnetPickupSystem : EntitySystem
 
             comp.NextScan += ScanDelay;
 
-            var parentUid = xform.ParentUid;
-
-            if (!_entityManager.TryGetComponent<BorgSwitchableTypeComponent>(parentUid, out _) || !_hands.TryGetActiveItem(parentUid, out var activeItem) && activeItem != uid)
+            if (comp.SlotFlags != null)
             {
                 if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
                     continue;
@@ -67,6 +61,7 @@ public sealed class MagnetPickupSystem : EntitySystem
             if (!_storage.HasSpace((uid, storage)))
                 continue;
 
+            var parentUid = xform.ParentUid;
             var playedSound = false;
             var finalCoords = xform.Coordinates;
             var moverCoords = _transform.GetMoverCoordinates(uid, xform);

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Inventory;
 using Content.Shared.Storage.Components;
 using Content.Shared.Whitelist;
@@ -17,6 +18,7 @@ public sealed class MagnetPickupSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
 
 
     private static readonly TimeSpan ScanDelay = TimeSpan.FromSeconds(1);
@@ -48,7 +50,9 @@ public sealed class MagnetPickupSystem : EntitySystem
 
             comp.NextScan += ScanDelay;
 
-            if (comp.SlotFlags != null)
+            var parentUid = xform.ParentUid;
+
+            if (comp.SlotFlags != null || !_hands.TryGetActiveItem(parentUid, out var activeItem) && activeItem != uid)
             {
                 if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
                     continue;
@@ -61,7 +65,6 @@ public sealed class MagnetPickupSystem : EntitySystem
             if (!_storage.HasSpace((uid, storage)))
                 continue;
 
-            var parentUid = xform.ParentUid;
             var playedSound = false;
             var finalCoords = xform.Coordinates;
             var moverCoords = _transform.GetMoverCoordinates(uid, xform);

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -52,7 +52,10 @@ public sealed class MagnetPickupSystem : EntitySystem
 
             var parentUid = xform.ParentUid;
 
-            if (comp.SlotFlags != null || !_hands.TryGetActiveItem(parentUid, out var activeItem) && activeItem != uid)
+            if (comp.RequireActiveHand && (!_hands.TryGetActiveItem(parentUid, out var activeItem) || activeItem != uid))
+                continue;
+
+            if (comp.SlotFlags != null)
             {
                 if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
                     continue;

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -573,7 +573,7 @@
     - item: MiningDrillDiamond
     - item: Shovel
     - item: AdvancedMineralScannerUnpowered
-    - item: OreBagOfHolding
+    - item: BorgOreBagOfHolding
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: adv-mining-module }
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -31,7 +31,7 @@
   parent: OreBag
   id: BorgOreBag
   name: integrated ore bag
-  description: A large ore bag built into the frame of a mining cyborg. Magnetises any nearby ores.
+  description: A large ore bag built into the frame of a mining cyborg. Magnetises any nearby ores when held.
   components:
     - type: MagnetPickup
       slotFlags: null

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -31,8 +31,10 @@
   parent: OreBag
   id: BorgOreBag
   name: integrated ore bag
-  description: A large ore bag built into the frame of a mining cyborg.
+  description: A large ore bag built into the frame of a mining cyborg. Magnetises any nearby ores.
   components:
+    - type: MagnetPickup
+      slotFlags: null
     - type: Storage
       grid:
       - 0,0,9,5

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -35,6 +35,7 @@
   components:
     - type: MagnetPickup
       slotFlags: null
+      requireActiveHand: true
     - type: Storage
       grid:
       - 0,0,9,5

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
@@ -24,3 +24,4 @@
     - type: MagnetPickup
       slotFlags: null
       range: 2
+      requireActiveHand: true

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
@@ -14,3 +14,13 @@
   - type: Storage
     grid:
     - 0,0,19,9
+
+- type: entity
+  parent: OreBagOfHolding
+  id: BorgOreBagOfHolding
+  name: integrated ore bag of holding
+  description: A very large ore bag built into the frame of a rich mining cyborg. Magnetises any nearby ores.
+  components:
+    - type: MagnetPickup
+      slotFlags: null
+      range: 2

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
@@ -19,7 +19,7 @@
   parent: OreBagOfHolding
   id: BorgOreBagOfHolding
   name: integrated ore bag of holding
-  description: A very large ore bag built into the frame of a rich mining cyborg. Magnetises any nearby ores.
+  description: A very large ore bag built into the frame of a rich mining cyborg. Magnetises any nearby ores when held.
   components:
     - type: MagnetPickup
       slotFlags: null


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes cyborgs magnetize ore with integrated ore bags.

## Why / Balance
Fixes #39906
Saves the time and annoyance of manually clicking to pickup ores when playing as a salvage cyborg.

## Technical details
<!-- Summary of code changes for easier review. -->
Modifies the MagnetPickupSystem.
Adds an if statement that checks if the SlotFlags datafield is null.
If it is, the checks for Inventory SlotFlags (if the ore bags are in belt slots) get skipped.

Adds a new integrated bag of holding item and adds it to the advanced mining module.

Currently cyborgs always magnetize ore, even when the module is not selected.

## Media
https://github.com/user-attachments/assets/b289b936-a16c-43c1-8697-babe14dc98ff



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Note
I am still learning the codebase and the conventions and coding like this in general so if I did something horrible or unwanted please let me know.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Salvage cyborgs can now magnetize ore with integrated ore bags.
