### PR TITLE
Removed a unused magazine from the devmap

### DIFF
--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -3910,46 +3910,6 @@
   id: 8899
   time: '2025-08-28T17:14:44.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/39927
-- author: Southbridge
-  changes:
-  - message: On Amber, added a pressure relief valve to the TEG burn chamber.
-    type: Add
-  - message: On Amber, added latejoin spawns to arrivals.
-    type: Tweak
-  id: 8900
-  time: '2025-08-29T05:39:23.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39943
-- author: Southbridge
-  changes:
-  - message: On Marathon, gave the containment area some much needed love.
-    type: Add
-  - message: On Marathon, redesigned the TEG burn chamber in preparation for the atmos
-      pressure update.
-    type: Tweak
-  - message: On Marathon, touched up a couple areas in Atmos and expanded the burn
-      chamber area.
-    type: Tweak
-  id: 8901
-  time: '2025-08-29T05:40:38.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39955
-- author: Southbridge
-  changes:
-  - message: On Box, redesigned the burn chambers to be ready for the atmos pressure
-      update.
-    type: Tweak
-  id: 8902
-  time: '2025-08-29T05:42:00.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39954
-- author: Southbridge
-  changes:
-  - message: On Bagel, ensured there were late join spawners at arrivals
-    type: Add
-  - message: On Bagel, overhauled the TEG so it's a bit more ready for the pressure
-      update
-    type: Tweak
-  id: 8903
-  time: '2025-08-29T06:03:54.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39945
 - author: FungiFellow
   changes:
   - message: Sentience Event no longer targets Zombified creatures

--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -3914,6 +3914,6 @@
   changes:
   - message: Sentience Event no longer targets Zombified creatures
     type: Fix
-  id: 8904
+  id: 8900
   time: '2025-08-29T11:48:31.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/39950

--- a/Resources/Changelog/Maps.yml
+++ b/Resources/Changelog/Maps.yml
@@ -581,4 +581,42 @@
   id: 70
   time: '2025-08-28T17:40:36.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/39215
+- author: Southbridge
+  changes:
+  - message: On Amber, added a pressure relief valve to the TEG burn chamber.
+    type: Add
+  - message: On Amber, added latejoin spawns to arrivals.
+    type: Tweak
+  id: 71
+  time: '2025-08-29T05:39:23.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/39943
+- author: Southbridge
+  changes:
+  - message: On Marathon, gave the containment area some much needed love.
+    type: Add
+  - message: On Marathon, redesigned the TEG burn chamber in preparation for the atmos
+      pressure update.
+    type: Tweak
+  - message: On Marathon, touched up a couple areas in Atmos and expanded the burn
+      chamber area.
+    type: Tweak
+  id: 72
+  time: '2025-08-29T05:40:38.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/39955
+- author: Southbridge
+  changes:
+  - message: On Box, redesigned the burn chambers to be ready for the atmos pressure
+      update.
+    type: Tweak
+  id: 73
+  time: '2025-08-29T05:42:00.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/39954
+- author: Southbridge
+  changes:
+  - message: On Bagel, ensured there were late join spawners at arrivals
+    type: Add
+  - message: On Bagel, overhauled the TEG so it's a bit more ready for the pressure
+      update
+    type: Tweak
+  id: 74
 Order: 1

--- a/Resources/Maps/Test/dev_map.yml
+++ b/Resources/Maps/Test/dev_map.yml
@@ -12105,15 +12105,6 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: MagazineLightRifleMaxim
-  entities:
-  - uid: 2115
-    components:
-    - type: Transform
-      parent: 2107
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: MagazineLightRiflePractice
   entities:
   - uid: 2110


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
There was a magazine for a gun that was removed due to it having no use. It still persisted in the devmap which the PR removes.
## Why / Balance
Whenever you built a dev environment the server put out that warning 


## Original warning message
<img width="1086" height="20" alt="image" src="https://github.com/user-attachments/assets/20cca76b-b621-4470-8557-40372f8dcabc" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
no cl no fun
