### PR TITLE
fix NetEntity datafield in JointVisualsComponent

### DIFF
--- a/Content.Client/Physics/JointVisualsOverlay.cs
+++ b/Content.Client/Physics/JointVisualsOverlay.cs
@@ -36,7 +36,7 @@ public sealed class JointVisualsOverlay : Overlay
             if (xform.MapID != args.MapId)
                 continue;
 
-            var other = _entManager.GetEntity(visuals.Target);
+            var other = visuals.Target;
 
             if (!xformQuery.TryGetComponent(other, out var otherXform))
                 continue;
@@ -45,7 +45,7 @@ public sealed class JointVisualsOverlay : Overlay
                 continue;
 
             var texture = spriteSystem.Frame0(visuals.Sprite);
-            var width = texture.Width / (float) EyeManager.PixelsPerMeter;
+            var width = texture.Width / (float)EyeManager.PixelsPerMeter;
 
             var coordsA = xform.Coordinates;
             var coordsB = otherXform.Coordinates;
@@ -58,7 +58,7 @@ public sealed class JointVisualsOverlay : Overlay
 
             var posA = xformSystem.ToMapCoordinates(coordsA).Position;
             var posB = xformSystem.ToMapCoordinates(coordsB).Position;
-            var diff = (posB - posA);
+            var diff = posB - posA;
             var length = diff.Length();
 
             var midPoint = diff / 2f + posA;

--- a/Content.Shared/Physics/JointVisualsComponent.cs
+++ b/Content.Shared/Physics/JointVisualsComponent.cs
@@ -10,21 +10,30 @@ namespace Content.Shared.Physics;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class JointVisualsComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite), DataField("sprite", required: true), AutoNetworkedField]
+    /// <summary>
+    /// The sprite to use for the line.
+    /// </summary>
+    [DataField(required: true), AutoNetworkedField]
     public SpriteSpecifier Sprite = default!;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("target"), AutoNetworkedField]
-    public NetEntity? Target;
+    /// <summary>
+    /// The line is drawn between this target and the entity owning the component.
+    /// </summary>
+    /// <summary>
+    /// TODO: WeakEntityReference.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? Target;
 
     /// <summary>
     /// Offset from Body A.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("offsetA"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public Vector2 OffsetA;
 
     /// <summary>
     /// Offset from Body B.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("offsetB"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public Vector2 OffsetB;
 }

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -65,7 +65,7 @@ public abstract class SharedGrapplingGunSystem : EntitySystem
             var visuals = EnsureComp<JointVisualsComponent>(shotUid.Value);
             visuals.Sprite = component.RopeSprite;
             visuals.OffsetA = new Vector2(0f, 0.5f);
-            visuals.Target = GetNetEntity(uid);
+            visuals.Target = uid;
             Dirty(shotUid.Value, visuals);
         }
 


### PR DESCRIPTION
## About the PR
`NetEntity` is not serializable and should not be a datafield. 
We need to clean up the content repo so we can mark it as `NotYamlSerializable`.

## Why / Balance
Progress for https://github.com/space-wizards/space-station-14/issues/37464

## Technical details
Replace the `NetEntity` with an `EntityUid`. The source generator for autonetworking automatically converts it to a net entity and back.

## Media
The grappling gun still works
![ss14](https://github.com/user-attachments/assets/c8f542a8-2bb4-426f-8452-4a610fe050fc)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The `Target` datafield in `JointVisualsComponent` is now an `EntityUid?`.

**Changelog**
not player facing
