### PR TITLE
Unpredict MagnetPickupSystem.cs

### DIFF
--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Storage.Components;
 using Content.Shared.Whitelist;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
+using Robust.Shared.Network;
 
 namespace Content.Shared.Storage.EntitySystems;
 
@@ -17,6 +18,7 @@ public sealed class MagnetPickupSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly INetManager _net = default!;
 
 
     private static readonly TimeSpan ScanDelay = TimeSpan.FromSeconds(1);
@@ -38,6 +40,10 @@ public sealed class MagnetPickupSystem : EntitySystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
+
+        if (_net.IsClient)
+            return;
+
         var query = EntityQueryEnumerator<MagnetPickupComponent, StorageComponent, TransformComponent, MetaDataComponent>();
         var currentTime = _timing.CurTime;
 


### PR DESCRIPTION
## About the PR
This pr unpredicts update method in the MagnetPickupSystem.cs.

## Why / Balance
Right now its causes problems with prediction and looks awful ingame.

## Technical details
Added _net.IsClient check to the MagnetPickupSystem.cs

## Media
### Before:
https://github.com/user-attachments/assets/75087fd2-eb3b-4f66-884d-93abd6a3c8f8

### After:
https://github.com/user-attachments/assets/01ed82d3-302d-4c70-92f5-cd826a98bee0

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.