### PR TITLE
Messy drinker immunity and cleanup

### DIFF
--- a/Content.Shared/Nutrition/Components/MessyDrinkerComponent.cs
+++ b/Content.Shared/Nutrition/Components/MessyDrinkerComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.FixedPoint;
 using Content.Shared.Nutrition.Prototypes;
+using Content.Shared.Tag;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
@@ -25,6 +26,13 @@ public sealed partial class MessyDrinkerComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public List<ProtoId<EdiblePrototype>> SpillableTypes = new List<ProtoId<EdiblePrototype>> { "Drink" };
+
+    /// <summary>
+    /// Tag given to drinks that are immune to messy drinker.
+    /// For example, a spill-immune bottle.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ProtoId<TagPrototype> SpillImmuneTag = "MessyDrinkerImmune";
 
     [DataField, AutoNetworkedField]
     public LocId? SpillMessagePopup;

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -932,6 +932,9 @@
   id: Medkit
 
 - type: Tag
+  id: MessyDrinkerImmune
+
+- type: Tag
   id: Metal
 
 - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a new tag that makes specific bottles/bowls/whatever immune to messydrinker, allowing them to be drank from safely.
Removed a check blocking messydrinker from activating if the spill amount is higher than the amount youd drink. (Makes it possible to spill everything you drink at once if set to a high value)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Convenience and been asked by admins to introduce this for admemes. (Imagine a skeleton that spills 100% of things they drink)

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new MessyDrinkerImmune tag and a datafield storing it in MessyDrinkerComponent.
Added a check for the tag.
Removed another check.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/9df0a241-a038-48cc-a287-078f38766d92

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Not player facing.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
