### PR TITLE
Stop derelict borgs from duplicating their ghost roles.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -491,6 +491,7 @@
     rules: ghost-role-information-silicon-rules
     raffle:
       settings: default
+    reregister: false
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -524,6 +525,7 @@
       rules: ghost-role-information-silicon-rules
       raffle:
         settings: default
+      reregister: false
     - type: GhostTakeoverAvailable
 
 - type: entity
@@ -559,6 +561,7 @@
     rules: ghost-role-information-silicon-rules
     raffle:
       settings: default
+    reregister: false
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -595,6 +598,7 @@
     rules: ghost-role-information-silicon-rules
     raffle:
       settings: default
+    reregister: false
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -630,6 +634,7 @@
     rules: ghost-role-information-silicon-rules
     raffle:
       settings: default
+    reregister: false
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -664,4 +669,5 @@
     rules: ghost-role-information-silicon-rules
     raffle:
       settings: default
+    reregister: false
   - type: GhostTakeoverAvailable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR fixes #39990. This PR ensures that when a brain is pulled out the chassis doesn't turn it self into a ghost role again. This is done by setting the ReregisterOnGhost (in yaml as ``reregister``) bool to false.

## Why / Balance
As funny as it is, having a brainless cyborg probably isn't a good idea to keep around.

## Technical details
just a yaml change.

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Derelict cyborgs can no longer duplicate their ghost role.
