### PR TITLE
Atmospherics/Temperature HeatContainers

### DIFF
--- a/Content.Shared/Temperature/HeatContainer.cs
+++ b/Content.Shared/Temperature/HeatContainer.cs
@@ -1,0 +1,37 @@
+using Content.Shared.Atmos;
+using Content.Shared.Atmos.EntitySystems;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Temperature;
+
+/// <summary>
+/// A general-purpose container for heat energy.
+/// Any object that contains, stores, or transfers heat should use a <see cref="HeatContainer"/>
+/// instead of implementing its own system.
+/// This allows for consistent heat transfer mechanics across different objects and systems.
+/// </summary>
+[Serializable, NetSerializable, DataDefinition]
+[Access(typeof(HeatContainerHelpers), typeof(SharedAtmosphereSystem))]
+public partial record struct HeatContainer
+{
+    /// <summary>
+    /// The heat capacity of this container.
+    /// This determines how much energy is required to change the temperature of the container.
+    /// Higher values mean the container can absorb or reject more heat energy
+    /// without a significant change in temperature.
+    /// </summary>
+    [DataField]
+    public float HeatCapacity = 4f;
+
+    /// <summary>
+    /// The current temperature of the container in Kelvin.
+    /// </summary>
+    [DataField]
+    public float Temperature = Atmospherics.T20C;
+
+    /// <summary>
+    /// The current thermal energy of the container in Joules.
+    /// </summary>
+    [ViewVariables]
+    public float ThermalEnergy => Temperature * HeatCapacity;
+}

--- a/Content.Shared/Temperature/HeatContainerHelpers.cs
+++ b/Content.Shared/Temperature/HeatContainerHelpers.cs
@@ -1,0 +1,174 @@
+using JetBrains.Annotations;
+
+namespace Content.Shared.Temperature;
+
+/// <summary>
+/// Class containing helper methods for working with <see cref="HeatContainer"/>s.
+/// Use these classes instead of implementing your own heat transfer logic.
+/// </summary>
+public static class HeatContainerHelpers
+{
+    /// <summary>
+    /// Adds or removes heat energy from the container.
+    /// Positive values add heat, negative values remove heat.
+    /// </summary>
+    /// <param name="c">The <see cref="HeatContainer"/> to add or remove energy.</param>
+    /// <param name="dQ">The energy in joules to remove.</param>
+    [PublicAPI]
+    public static void ChangeHeat(this HeatContainer c, float dQ)
+    {
+        c.Temperature = c.ChangeHeatQuery(dQ);
+    }
+
+    /// <summary>
+    /// Calculates the resulting temperature of the container after adding or removing heat energy.
+    /// Positive values add heat, negative values remove heat. This method doesn't change the container's state.
+    /// </summary>
+    /// <param name="c">The <see cref="HeatContainer"/> to query.</param>
+    /// <param name="dQ">The energy in joules to add or remove.</param>
+    /// <returns>The resulting temperature after the heat change.</returns>
+    [PublicAPI]
+    public static float ChangeHeatQuery(this HeatContainer c, float dQ)
+    {
+        return c.Temperature + dQ / c.HeatCapacity;
+    }
+
+    /// <summary>
+    /// Determines the amount of heat energy that must be transferred between two containers
+    /// to bring them to thermal equilibrium. Heat will be exchanged from c1 to c2.
+    /// </summary>
+    /// <param name="c1">The first <see cref="HeatContainer"/> to exchange heat.</param>
+    /// <param name="c2">The second <see cref="HeatContainer"/> to exchange heat with.</param>
+    /// <returns>The amount of heat in joules that is needed
+    /// to bring the containers to thermal equilibrium.</returns>
+    [PublicAPI]
+    public static float FullyExchangeHeatQuery(this HeatContainer c1, HeatContainer c2)
+    {
+        /*
+         The solution is derived from the following facts:
+         1. Let Q be the amount of heat energy transferred from c1 to c2.
+         2. T_A > T_B, so heat will flow from c1 to c2.
+         3. The energy lost by T_A is equal to Q = C_A * (T_A_initial - T_A_final)
+         4. The energy gained by T_B is equal to Q = C_B * (T_B_final - T_B_initial)
+         5. Energy is conserved. So T_A_final and T_B_final can be expressed as:
+            T_A_final = T_A_initial - Q / C_A
+            T_B_final = T_B_initial + Q / C_B
+         6. At thermal equilibrium, T_A_final = T_B_final.
+         7. Solve for Q.
+         */
+        return (c2.Temperature - c1.Temperature) *
+               ((c1.HeatCapacity * c2.HeatCapacity) / (c1.HeatCapacity + c2.HeatCapacity));
+    }
+
+    /// <summary>
+    /// Brings two <see cref="HeatContainer"/>s to thermal equilibrium by exchanging heat.
+    /// Heat will be exchanged from c1 to c2.
+    /// </summary>
+    /// <param name="c1">The first <see cref="HeatContainer"/> to exchange heat.</param>
+    /// <param name="c2">The second <see cref="HeatContainer"/> to exchange heat with.</param>
+    /// <returns>The amount of heat in joules that is exchanged between the two containers.</returns>
+    [PublicAPI]
+    public static float FullyExchangeHeat(this HeatContainer c1, HeatContainer c2)
+    {
+        var q = FullyExchangeHeatQuery(c1, c2);
+        c1.ChangeHeat(q);
+        c2.ChangeHeat(-q);
+        return q;
+    }
+
+    /// <summary>
+    /// Conducts heat between a <see cref="HeatContainer"/> and some body with a different temperature,
+    /// given some conductivity constant k and a time delta.
+    /// </summary>
+    /// <param name="c">The <see cref="HeatContainer"/> to conduct heat to.</param>
+    /// <param name="temp">The temperature of the second object that we are conducting heat with.</param>
+    /// <param name="deltaTime">The amount of time that the heat is allowed to conduct, in seconds.</param>
+    /// <param name="k">The conductivity constant. This describes how well heat flows between the bodies.</param>
+    /// <returns>The amount of heat in joules that is exchanged between the bodies.</returns>
+    [PublicAPI]
+    public static float ConductHeat(this HeatContainer c, float temp, float deltaTime, float k)
+    {
+        var dQ = k * (temp - c.Temperature) * deltaTime;
+        c.ChangeHeat(dQ);
+        return dQ;
+    }
+
+    /// <summary>
+    /// Conducts heat between a <see cref="HeatContainer"/> and another <see cref="HeatContainer"/>,
+    /// given some conductivity constant k and a time delta.
+    /// </summary>
+    /// <param name="c1">The first <see cref="HeatContainer"/> to conduct heat to.</param>
+    /// <param name="c2">The second <see cref="HeatContainer"/> to conduct heat to.</param>
+    /// <param name="deltaTime">The amount of time that the heat is allowed to conduct, in seconds.</param>
+    /// <param name="k">The conductivity constant. This describes how well heat flows between the bodies.</param>
+    /// <returns>The amount of heat in joules that is exchanged between the bodies.</returns>
+    [PublicAPI]
+    public static float ConductHeat(this HeatContainer c1, HeatContainer c2, float deltaTime, float k)
+    {
+        var dQ = ConductHeatQuery(c1, c2.Temperature, deltaTime, k);
+        c1.ChangeHeat(dQ);
+        c2.ChangeHeat(-dQ);
+        return dQ;
+    }
+
+    /// <summary>
+    /// Calculates the amount of heat that would be conducted from a <see cref="HeatContainer"/> to
+    /// some body with a different temperature,
+    /// given some conductivity constant k and a time delta. Does not modify the container.
+    /// </summary>
+    /// <param name="c">The <see cref="HeatContainer"/> to conduct heat to.</param>
+    /// <param name="temp">The temperature of the second object that we are conducting heat with.</param>
+    /// <param name="deltaTime">The amount of time that the heat is allowed to conduct, in seconds.</param>
+    /// <param name="k">The conductivity constant. This describes how well heat flows between the bodies.</param>
+    /// <returns>The amount of heat in joules that would be exchanged between the bodies.</returns>
+    [PublicAPI]
+    public static float ConductHeatQuery(this HeatContainer c, float temp, float deltaTime, float k)
+    {
+        return k * (temp - c.Temperature) * deltaTime;
+    }
+
+    /// <summary>
+    /// Calculates the amount of heat that would be conducted between two <see cref="HeatContainer"/>s,
+    /// given some conductivity constant k and a time delta. Does not modify the containers.
+    /// </summary>
+    /// <param name="c1">The first <see cref="HeatContainer"/> to conduct heat to.</param>
+    /// <param name="c2">The second <see cref="HeatContainer"/> to conduct heat to.</param>
+    /// <param name="deltaTime">The amount of time that the heat is allowed to conduct, in seconds.</param>
+    /// <param name="k">The conductivity constant. This describes how well heat flows between the bodies.</param>
+    /// <returns>The amount of heat in joules that would be exchanged between the bodies.</returns>
+    [PublicAPI]
+    public static float ConductHeatQuery(this HeatContainer c1, HeatContainer c2, float deltaTime, float k)
+    {
+        return ConductHeatQuery(c1, c2.Temperature, deltaTime, k);
+    }
+
+    /// <summary>
+    /// Changes the temperature of a <see cref="HeatContainer"/> to a target temperature by
+    /// adding or removing the necessary amount of heat.
+    /// </summary>
+    /// <param name="c">The <see cref="HeatContainer"/> to change the temperature of.</param>
+    /// <param name="targetTemp">The desired temperature to reach.</param>
+    /// <returns>The amount of heat in joules that was transferred to or from the <see cref="HeatContainer"/>
+    /// to reach the target temperature.</returns>
+    [PublicAPI]
+    public static float ConductHeatToTemp(this HeatContainer c, float targetTemp)
+    {
+        var dQ = ConductHeatToTempQuery(c, targetTemp);
+        c.ChangeHeat(dQ);
+        return dQ;
+    }
+
+    /// <summary>
+    /// Determines the amount of heat that must be transferred to or from a <see cref="HeatContainer"/>
+    /// to reach a target temperature.
+    /// </summary>
+    /// <param name="c">The <see cref="HeatContainer"/> to query.</param>
+    /// <param name="targetTemp">The desired temperature to reach.</param>
+    /// <returns>The amount of heat in joules that must be transferred to or from the <see cref="HeatContainer"/>
+    /// to reach the target temperature.</returns>
+    [PublicAPI]
+    public static float ConductHeatToTempQuery(this HeatContainer c, float targetTemp)
+    {
+        return (targetTemp - c.Temperature) * c.HeatCapacity;
+    }
+}

--- a/Content.Shared/Temperature/HeatContainerHelpers.cs
+++ b/Content.Shared/Temperature/HeatContainerHelpers.cs
@@ -35,12 +35,13 @@ public static class HeatContainerHelpers
 
     /// <summary>
     /// Determines the amount of heat energy that must be transferred between two containers
-    /// to bring them to thermal equilibrium. Heat will be exchanged from c1 to c2.
+    /// to bring them to thermal equilibrium.
     /// </summary>
     /// <param name="c1">The first <see cref="HeatContainer"/> to exchange heat.</param>
     /// <param name="c2">The second <see cref="HeatContainer"/> to exchange heat with.</param>
     /// <returns>The amount of heat in joules that is needed
     /// to bring the containers to thermal equilibrium.</returns>
+    /// <example>A positive value indicates heat transfer from a hot c2 to a cold c1.</example>
     [PublicAPI]
     public static float FullyExchangeHeatQuery(this HeatContainer c1, HeatContainer c2)
     {
@@ -62,11 +63,11 @@ public static class HeatContainerHelpers
 
     /// <summary>
     /// Brings two <see cref="HeatContainer"/>s to thermal equilibrium by exchanging heat.
-    /// Heat will be exchanged from c1 to c2.
     /// </summary>
     /// <param name="c1">The first <see cref="HeatContainer"/> to exchange heat.</param>
     /// <param name="c2">The second <see cref="HeatContainer"/> to exchange heat with.</param>
     /// <returns>The amount of heat in joules that is exchanged between the two containers.</returns>
+    /// <example>A positive value indicates heat transfer from a hot c2 to a cold c1.</example>
     [PublicAPI]
     public static float FullyExchangeHeat(this HeatContainer c1, HeatContainer c2)
     {
@@ -85,10 +86,11 @@ public static class HeatContainerHelpers
     /// <param name="deltaTime">The amount of time that the heat is allowed to conduct, in seconds.</param>
     /// <param name="k">The conductivity constant. This describes how well heat flows between the bodies.</param>
     /// <returns>The amount of heat in joules that is exchanged between the bodies.</returns>
+    /// <example>A positive value indicates heat transfer from a hot body to a cold c.</example>
     [PublicAPI]
     public static float ConductHeat(this HeatContainer c, float temp, float deltaTime, float k)
     {
-        var dQ = k * (temp - c.Temperature) * deltaTime;
+        var dQ = c.ConductHeatQuery(temp, deltaTime, k);
         c.ChangeHeat(dQ);
         return dQ;
     }
@@ -102,6 +104,7 @@ public static class HeatContainerHelpers
     /// <param name="deltaTime">The amount of time that the heat is allowed to conduct, in seconds.</param>
     /// <param name="k">The conductivity constant. This describes how well heat flows between the bodies.</param>
     /// <returns>The amount of heat in joules that is exchanged between the bodies.</returns>
+    /// <example>A positive value indicates heat transfer from a hot c2 to a cold c1.</example>
     [PublicAPI]
     public static float ConductHeat(this HeatContainer c1, HeatContainer c2, float deltaTime, float k)
     {
@@ -121,6 +124,7 @@ public static class HeatContainerHelpers
     /// <param name="deltaTime">The amount of time that the heat is allowed to conduct, in seconds.</param>
     /// <param name="k">The conductivity constant. This describes how well heat flows between the bodies.</param>
     /// <returns>The amount of heat in joules that would be exchanged between the bodies.</returns>
+    /// <example>A positive value indicates heat transfer from a hot body to a cold c.</example>
     [PublicAPI]
     public static float ConductHeatQuery(this HeatContainer c, float temp, float deltaTime, float k)
     {
@@ -136,6 +140,7 @@ public static class HeatContainerHelpers
     /// <param name="deltaTime">The amount of time that the heat is allowed to conduct, in seconds.</param>
     /// <param name="k">The conductivity constant. This describes how well heat flows between the bodies.</param>
     /// <returns>The amount of heat in joules that would be exchanged between the bodies.</returns>
+    /// <example>A positive value indicates heat transfer from a hot c2 to a cold c1.</example>
     [PublicAPI]
     public static float ConductHeatQuery(this HeatContainer c1, HeatContainer c2, float deltaTime, float k)
     {

--- a/Content.Shared/Temperature/IHeatContainerHolder.cs
+++ b/Content.Shared/Temperature/IHeatContainerHolder.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared.Temperature;
+
+/// <summary>
+/// Interface for all entities/components working with a <see cref="HeatContainer"/>.
+/// </summary>
+public interface IHeatContainerHolder
+{
+    HeatContainer HeatContainer { get; set; }
+}


### PR DESCRIPTION
## About the PR
This PR adds `HeatContainers`, a record struct designed to store information on any object that could contain some amount of heat. This PR also provides helper methods for manipulating the heat inside of `HeatContainer`s.

Future pull requests will introduce helper methods that operate on `GasMixture`s and `HeatContainer`s as well.

A `HeatContainer` also makes it easier to define a heat network using the Node system, which I might do.

This PR already would see use in the TEG Rework (https://github.com/space-wizards/space-station-14/pull/38208) PR, which defines pseudo-`HeatContainer`. Similarly, `TemperatureComponent` defines what is effectively a `HeatContainer`, but as I've already said it works with it incorrectly.

## Why / Balance
The codebase has many instances of thermodynamics violations - for example the logic for transferring heat between squishy humans/humanoids and the atmosphere is just completely wrong and needs to be pulled out. Temperature is not equal to heat!

It's very common to fall into many pits when working with heat. Upstream does this, sometimes downstreams also do this. By unifying heat logic to a single datatype and providing correct helper methods to work with it, we can make working with heat in the codebase easier in both upstream and downstream.

## Technical details
A `HeatContainer` is just a simple record struct that wraps the basic information necessary to describe an object capable of absorbing heat. Helper methods are provided that make absorbing/rejecting heat a simple method call using `this`.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
N/A
