### PR TITLE
Adjust bureaucratic error to prevent only passenger being available

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -157,6 +157,10 @@
   - type: BureaucraticErrorRule
     ignoredJobs:
     - StationAi
+    - ResearchAssistant
+    - MedicalIntern
+    - SecurityCadet
+    - TechnicalAssistant
 
 - type: entity
   id: ClericalError


### PR DESCRIPTION
## About the PR
Adds intern/learner roles to the ignored list for the Bureaucratic Error event. This is a problem on more populated and well played servers because it makes the only available job latejoins can pick passenger which isn't interesting at all.

## Why / Balance
Resolves [#39957](https://github.com/space-wizards/space-station-14/issues/39957)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: Interns will no longer be hired infinitely
