### PR TITLE
Fix DoAfter casing inconsistencies

### DIFF
--- a/Content.Shared/Buckle/Components/StrapComponent.cs
+++ b/Content.Shared/Buckle/Components/StrapComponent.cs
@@ -83,7 +83,7 @@ public sealed partial class StrapComponent : Component
     /// How long it takes to buckle someone else into a chair
     /// </summary>
     [DataField]
-    public float BuckleDoafterTime = 2f;
+    public float BuckleDoAfterTime = 2f;
 
     /// <summary>
     /// Whether InteractHand will buckle the user to the strap.

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -51,10 +51,10 @@ public abstract partial class SharedBuckleSystem
         SubscribeLocalEvent<BuckleComponent, ThrowPushbackAttemptEvent>(OnBuckleThrowPushbackAttempt);
         SubscribeLocalEvent<BuckleComponent, UpdateCanMoveEvent>(OnBuckleUpdateCanMove);
 
-        SubscribeLocalEvent<BuckleComponent, BuckleDoAfterEvent>(OnBuckleDoafter);
+        SubscribeLocalEvent<BuckleComponent, BuckleDoAfterEvent>(OnBuckleDoAfter);
         SubscribeLocalEvent<BuckleComponent, DoAfterAttemptEvent<BuckleDoAfterEvent>>((uid, comp, ev) =>
         {
-            BuckleDoafterEarly((uid, comp), ev.Event, ev);
+            BuckleDoAfterEarly((uid, comp), ev.Event, ev);
         });
     }
 
@@ -540,7 +540,7 @@ public abstract partial class SharedBuckleSystem
     /// <param name="args.User"> The person putting a person in a chair/bed</param>
     /// <param name="args.Used"> The chair/bed </param>
 
-    private void OnBuckleDoafter(Entity<BuckleComponent> entity, ref BuckleDoAfterEvent args)
+    private void OnBuckleDoAfter(Entity<BuckleComponent> entity, ref BuckleDoAfterEvent args)
     {
         if (args.Cancelled || args.Handled || args.Target == null || args.Used == null)
             return;
@@ -555,7 +555,7 @@ public abstract partial class SharedBuckleSystem
     /// <param name="args.Target"> The person being put in the chair/bed</param>
     /// <param name="args.User"> The person putting a person in a chair/bed</param>
     /// <param name="args.Used"> The chair/bed </param>
-    private void BuckleDoafterEarly(Entity<BuckleComponent> entity, BuckleDoAfterEvent args, CancellableEntityEventArgs ev)
+    private void BuckleDoAfterEarly(Entity<BuckleComponent> entity, BuckleDoAfterEvent args, CancellableEntityEventArgs ev)
     {
         if (args.Target == null || args.Used == null)
             return;

--- a/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
@@ -47,7 +47,7 @@ public abstract partial class SharedBuckleSystem
                 !CanBuckle(args.Dragged, args.User, uid, true, out var _, buckle))
                 return;
 
-            var doAfterArgs = new DoAfterArgs(EntityManager, args.User, component.BuckleDoafterTime, new BuckleDoAfterEvent(), args.Dragged, args.Dragged, uid)
+            var doAfterArgs = new DoAfterArgs(EntityManager, args.User, component.BuckleDoAfterTime, new BuckleDoAfterEvent(), args.Dragged, args.Dragged, uid)
             {
                 BreakOnMove = true,
                 BreakOnDamage = true,

--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -61,17 +61,17 @@ public abstract class ClothingSystem : EntitySystem
                 if (TryComp(slotEntity, out ClothingComponent? item) && !item.QuickEquip)
                     continue;
 
-                if (!_invSystem.TryUnequip(userEnt, slotDef.Name, true, inventory: userEnt, checkDoafter: true))
+                if (!_invSystem.TryUnequip(userEnt, slotDef.Name, true, inventory: userEnt, checkDoAfter: true))
                     continue;
 
-                if (!_invSystem.TryEquip(userEnt, toEquipEnt, slotDef.Name, inventory: userEnt, clothing: toEquipEnt, checkDoafter: true, triggerHandContact: true))
+                if (!_invSystem.TryEquip(userEnt, toEquipEnt, slotDef.Name, inventory: userEnt, clothing: toEquipEnt, checkDoAfter: true, triggerHandContact: true))
                     continue;
 
                 _handsSystem.PickupOrDrop(userEnt, slotEntity.Value, handsComp: userEnt);
             }
             else
             {
-                if (!_invSystem.TryEquip(userEnt, toEquipEnt, slotDef.Name, inventory: userEnt, clothing: toEquipEnt, checkDoafter: true, triggerHandContact: true))
+                if (!_invSystem.TryEquip(userEnt, toEquipEnt, slotDef.Name, inventory: userEnt, clothing: toEquipEnt, checkDoAfter: true, triggerHandContact: true))
                     continue;
             }
 
@@ -120,14 +120,14 @@ public abstract class ClothingSystem : EntitySystem
     {
         if (args.Handled || args.Cancelled || args.Target is not { } target)
             return;
-        args.Handled = _invSystem.TryEquip(args.User, target, ent, args.Slot, clothing: ent.Comp, predicted: true, checkDoafter: false);
+        args.Handled = _invSystem.TryEquip(args.User, target, ent, args.Slot, clothing: ent.Comp, predicted: true, checkDoAfter: false);
     }
 
     private void OnUnequipDoAfter(Entity<ClothingComponent> ent, ref ClothingUnequipDoAfterEvent args)
     {
         if (args.Handled || args.Cancelled || args.Target is not { } target)
             return;
-        args.Handled = _invSystem.TryUnequip(args.User, target, args.Slot, clothing: ent.Comp, predicted: true, checkDoafter: false, triggerHandContact: true);
+        args.Handled = _invSystem.TryUnequip(args.User, target, args.Slot, clothing: ent.Comp, predicted: true, checkDoAfter: false, triggerHandContact: true);
         if (args.Handled)
             _handsSystem.TryPickup(args.User, ent);
     }

--- a/Content.Shared/Engineering/Systems/DisassembleOnAltVerbSystem.cs
+++ b/Content.Shared/Engineering/Systems/DisassembleOnAltVerbSystem.cs
@@ -22,7 +22,7 @@ public sealed partial class DisassembleOnAltVerbSystem : EntitySystem
 
     public void StartDisassembly(Entity<DisassembleOnAltVerbComponent> entity, EntityUid user)
     {
-        // Doafter setup
+        // DoAfter setup
         var doAfterArgs = new DoAfterArgs(EntityManager,
             user,
             entity.Comp.DisassembleTime,

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -122,7 +122,7 @@ public sealed class SmartEquipSystem : EntitySystem
             }
 
             _hands.TryDrop((uid, hands), hands.ActiveHandId!);
-            _inventory.TryEquip(uid, handItem.Value, equipmentSlot, predicted: true, checkDoafter:true);
+            _inventory.TryEquip(uid, handItem.Value, equipmentSlot, predicted: true, checkDoAfter:true);
             return;
         }
 
@@ -218,7 +218,7 @@ public sealed class SmartEquipSystem : EntitySystem
             return;
         }
 
-        _inventory.TryUnequip(uid, equipmentSlot, inventory: inventory, predicted: true, checkDoafter: true);
+        _inventory.TryUnequip(uid, equipmentSlot, inventory: inventory, predicted: true, checkDoAfter: true);
         _hands.TryPickup(uid, slotItem, handsComp: hands);
     }
 }

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -97,7 +97,7 @@ public abstract partial class InventorySystem
         // unequip the item.
         if (itemUid != null)
         {
-            if (!TryUnequip(actor, ev.Slot, out var item, predicted: true, inventory: inventory, checkDoafter: true, triggerHandContact: true))
+            if (!TryUnequip(actor, ev.Slot, out var item, predicted: true, inventory: inventory, checkDoAfter: true, triggerHandContact: true))
                 return;
 
             _handsSystem.PickupOrDrop(actor, item.Value);
@@ -120,15 +120,15 @@ public abstract partial class InventorySystem
 
         RaiseLocalEvent(held.Value, new HandDeselectedEvent(actor));
 
-        TryEquip(actor, actor, held.Value, ev.Slot, predicted: true, inventory: inventory, force: true, checkDoafter: true, triggerHandContact: true);
+        TryEquip(actor, actor, held.Value, ev.Slot, predicted: true, inventory: inventory, force: true, checkDoAfter: true, triggerHandContact: true);
     }
 
     public bool TryEquip(EntityUid uid, EntityUid itemUid, string slot, bool silent = false, bool force = false, bool predicted = false,
-        InventoryComponent? inventory = null, ClothingComponent? clothing = null, bool checkDoafter = false, bool triggerHandContact = false) =>
-        TryEquip(uid, uid, itemUid, slot, silent, force, predicted, inventory, clothing, checkDoafter, triggerHandContact);
+        InventoryComponent? inventory = null, ClothingComponent? clothing = null, bool checkDoAfter = false, bool triggerHandContact = false) =>
+        TryEquip(uid, uid, itemUid, slot, silent, force, predicted, inventory, clothing, checkDoAfter, triggerHandContact);
 
     public bool TryEquip(EntityUid actor, EntityUid target, EntityUid itemUid, string slot, bool silent = false, bool force = false, bool predicted = false,
-        InventoryComponent? inventory = null, ClothingComponent? clothing = null, bool checkDoafter = false, bool triggerHandContact = false)
+        InventoryComponent? inventory = null, ClothingComponent? clothing = null, bool checkDoAfter = false, bool triggerHandContact = false)
     {
         if (!Resolve(target, ref inventory, false))
         {
@@ -155,7 +155,7 @@ public abstract partial class InventorySystem
             return false;
         }
 
-        if (checkDoafter &&
+        if (checkDoAfter &&
             clothing != null &&
             clothing.EquipDelay > TimeSpan.Zero &&
             (clothing.Slots & slotDefinition.SlotFlags) != 0 &&
@@ -320,10 +320,10 @@ public abstract partial class InventorySystem
         InventoryComponent? inventory = null,
         ClothingComponent? clothing = null,
         bool reparent = true,
-        bool checkDoafter = false,
+        bool checkDoAfter = false,
         bool triggerHandContact = false)
     {
-        return TryUnequip(uid, uid, slot, silent, force, predicted, inventory, clothing, reparent, checkDoafter, triggerHandContact);
+        return TryUnequip(uid, uid, slot, silent, force, predicted, inventory, clothing, reparent, checkDoAfter, triggerHandContact);
     }
 
     public bool TryUnequip(
@@ -336,10 +336,10 @@ public abstract partial class InventorySystem
         InventoryComponent? inventory = null,
         ClothingComponent? clothing = null,
         bool reparent = true,
-        bool checkDoafter = false,
+        bool checkDoAfter = false,
         bool triggerHandContact = false)
     {
-        return TryUnequip(actor, target, slot, out _, silent, force, predicted, inventory, clothing, reparent, checkDoafter, triggerHandContact);
+        return TryUnequip(actor, target, slot, out _, silent, force, predicted, inventory, clothing, reparent, checkDoAfter, triggerHandContact);
     }
 
     public bool TryUnequip(
@@ -352,10 +352,10 @@ public abstract partial class InventorySystem
         InventoryComponent? inventory = null,
         ClothingComponent? clothing = null,
         bool reparent = true,
-        bool checkDoafter = false,
+        bool checkDoAfter = false,
         bool triggerHandContact = false)
     {
-        return TryUnequip(uid, uid, slot, out removedItem, silent, force, predicted, inventory, clothing, reparent, checkDoafter, triggerHandContact);
+        return TryUnequip(uid, uid, slot, out removedItem, silent, force, predicted, inventory, clothing, reparent, checkDoAfter, triggerHandContact);
     }
 
     public bool TryUnequip(
@@ -369,12 +369,12 @@ public abstract partial class InventorySystem
         InventoryComponent? inventory = null,
         ClothingComponent? clothing = null,
         bool reparent = true,
-        bool checkDoafter = false,
+        bool checkDoAfter = false,
         bool triggerHandContact = false)
     {
         var itemsDropped = 0;
         return TryUnequip(actor, target, slot, out removedItem, ref itemsDropped,
-            silent, force, predicted, inventory, clothing, reparent, checkDoafter);
+            silent, force, predicted, inventory, clothing, reparent, checkDoAfter);
     }
 
     private bool TryUnequip(
@@ -389,7 +389,7 @@ public abstract partial class InventorySystem
         InventoryComponent? inventory = null,
         ClothingComponent? clothing = null,
         bool reparent = true,
-        bool checkDoafter = false,
+        bool checkDoAfter = false,
         bool triggerHandContact = false)
     {
         removedItem = null;
@@ -427,7 +427,7 @@ public abstract partial class InventorySystem
         if (!force && !_containerSystem.CanRemove(removedItem.Value, slotContainer))
             return false;
 
-        if (checkDoafter &&
+        if (checkDoAfter &&
             Resolve(removedItem.Value, ref clothing, false) &&
             (clothing.Slots & slotDefinition.SlotFlags) != 0 &&
             clothing.UnequipDelay > TimeSpan.Zero)


### PR DESCRIPTION
## About the PR
Fixed inconsistent casing of "Doafter" to "DoAfter" across multiple systems to follow C# naming conventions.

## Technical details
Performed a case-sensitive search for all "Doafter" variations and fixed all instances across the codebase:
- **StrapComponent.cs**: `BuckleDoafterTime` → `BuckleDoAfterTime` (1 variable)
- **SharedBuckleSystem.Buckle.cs**: Method names `OnBuckleDoafter` → `OnBuckleDoAfter`, `BuckleDoafterEarly` → `BuckleDoAfterEarly` (4 instances)
- **SharedBuckleSystem.Interaction.cs**: `component.BuckleDoafterTime` → `component.BuckleDoAfterTime` (1 instance)
- **ClothingSystem.cs**: `checkDoafter` → `checkDoAfter` parameters (5 instances)
- **DisassembleOnAltVerbSystem.cs**: Comment fix (1 instance)
- **SmartEquipSystem.cs**: `checkDoafter` → `checkDoAfter` parameters (2 instances)
- **InventorySystem.Equip.cs**: `checkDoafter` → `checkDoAfter` parameters and declarations (16 instances)

I ran the entire test suite to verify functionality is unchanged. Screenshot attached below:
<img width="1326" height="255" alt="ran_full_test_suite" src="https://github.com/user-attachments/assets/b42f1637-f211-4876-a68e-03f02d958495" />

Total: 30 fixes across 7 files.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None - internal naming changes only.

**Changelog**
No player-facing changes.