### PR TITLE
Fix macro bomb implants not acidifying the user

### DIFF
--- a/Content.Shared/Trigger/Systems/TriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.cs
@@ -90,6 +90,8 @@ public sealed partial class TriggerSystem : EntitySystem
         {
             _adminLogger.Add(LogType.Trigger,
                 $"{ToPrettyString(user.Value):user} started a {ent.Comp.Delay} second timer trigger on entity {ToPrettyString(ent.Owner):timer}");
+
+            ent.Comp.User = user;
         }
         else
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Or whatever other cases. A macrobomb may not acidify the user when they are detonated, leaving a corpse behind.

Fixes #40006

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
They should do so, since they have a `GibOnTriggerComponent` with the `deleteItems` parameter set to `true`, but this fails to actually trigger.

## Technical details
The `TriggerSystem.Timer` was not setting the `User` field of the `TimerTriggerComponent` on activation.

There is an awkward moment right before the explosion where the acidification happens. That's something to be looked at but I guess it's a prediction thing.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

### Broken:


https://github.com/user-attachments/assets/3495de34-deec-4baa-b894-0617926a8775

### Fixed:


https://github.com/user-attachments/assets/86513fdb-f6cb-470c-aed7-be1b65f42ec4




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Crude Oil
- fix: Macrobomb implants will now consistently acidify the user