### PR TITLE
Don't drop items or stop pulling when wielding

### DIFF
--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -259,7 +259,7 @@ public abstract class SharedWieldableSystem : EntitySystem
             return false;
         }
 
-        if (_hands.CountFreeableHands((user, hands)) < component.FreeHandsRequired)
+        if (_hands.CountFreeHands((user, hands)) < component.FreeHandsRequired)
         {
             if (!quiet)
             {


### PR DESCRIPTION
## About the PR
The current behaviour when wielding is to free any freeable hands when trying to do so.
This will mean dropping the item in your other hand to the floor, or stopping pulling something since the virtual item in the freeable hand is removed.
I would argue there are few cases where you want to drop an item without doing so directly via the drop key.
Also this currently leads to bad user feedback as the "you start wielding" and "You drop the item!" messages are overlapping, making both unreadable.
And this causes a `You drop the VIRTUAL ITEM YOU SHOULD NOT SEE THIS` popup when a pull is cancelled.
If this behaviour turns out to be important for combat then let me know and I'll figure out a way to silence the drop message instead.

## Why / Balance
Resolves https://github.com/space-wizards/space-station-14/issues/37517

## Technical details
freeable hands -> free hands

## Media
before:
![before](https://github.com/user-attachments/assets/51000689-550a-4ac1-90f7-b14871623769)

after:
![after](https://github.com/user-attachments/assets/349f042d-0337-4469-b149-07288d34efd0)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**

:cl:
- tweak: You can now only wield items when having free hands and you no longer drop items when doing so.
