### PR TITLE
Fix: Remove debug message when wielding while pulling

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -118,7 +118,7 @@ public abstract partial class SharedHandsSystem
     }
 
     /// <summary>
-    ///     Drops a hands contents at the target location.
+    ///     Drops a hand's contents at the target location.
     /// </summary>
     public bool TryDrop(Entity<HandsComponent?> ent, string handId, EntityCoordinates? targetDropLocation = null, bool checkActionBlocker = true, bool doDropInteraction = true)
     {
@@ -133,7 +133,10 @@ public abstract partial class SharedHandsSystem
 
         // if item is a fake item (like with pulling), just delete it rather than bothering with trying to drop it into the world
         if (TryComp(entity, out VirtualItemComponent? @virtual))
+        {
             _virtualSystem.DeleteVirtualItem((entity.Value, @virtual), ent);
+            return true;
+        }
 
         if (TerminatingOrDeleted(entity))
             return true;

--- a/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
+++ b/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
@@ -128,7 +128,7 @@ public abstract class SharedVirtualItemSystem : EntitySystem
                 if (!_handsSystem.TryDrop(user, hand))
                     continue;
 
-                if (!TerminatingOrDeleted(held))
+                if (!TerminatingOrDeleted(held) && !HasComp<VirtualItemComponent>(held))
                     _popup.PopupClient(Loc.GetString("virtual-item-dropped-other", ("dropped", held)), user, user);
 
                 empty = hand;


### PR DESCRIPTION
## About the PR
Fixes a bug where the debug message "VIRTUAL ITEM YOU SHOULD NOT SEE THIS" was displayed to users when wielding a two-handed item while pulling another entity.

## Why / Balance
This was a UI bug that exposed internal debug text to players. Virtual items are implementation details that should never be visible to users.

## Technical details
Added a check for `VirtualItemComponent` in `SharedVirtualItemSystem.TrySpawnVirtualItemInHand()` to prevent showing drop messages when virtual items are dropped. Virtual items with the debug name "VIRTUAL ITEM YOU SHOULD NOT SEE THIS" were incorrectly being announced to players when dropped to make room for wielding.

## Media

https://github.com/user-attachments/assets/0362e2e0-9a90-47e5-8822-b5dd832a04b7


https://github.com/user-attachments/assets/f283b525-9e92-4787-a708-edee06f24dd6


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No breaking changes.

**Changelog**
:cl:
- fix: Fixed debug message appearing when wielding two-handed items while pulling

## Additional Notes
While testing this fix, I discovered an unrelated bug where wielding two-handed items while pulling can leave the weapon improperly restricted to only one hand, effectively bypassing two-handed restrictions. This is a separate issue that should be addressed independently. This additional issue seems similar to: Off handed item bypass #38920 