### PR TITLE
Fix docstring typo starts -> stops

### DIFF
--- a/Content.Shared/Movement/Pulling/Events/PullStoppedMessage.cs
+++ b/Content.Shared/Movement/Pulling/Events/PullStoppedMessage.cs
@@ -1,6 +1,6 @@
-﻿namespace Content.Shared.Movement.Pulling.Events;
+namespace Content.Shared.Movement.Pulling.Events;
 
 /// <summary>
-/// Event raised directed BOTH at the puller and pulled entity when a pull starts.
+/// Event raised directed BOTH at the puller and pulled entity when a pull stops.
 /// </summary>
 public sealed class PullStoppedMessage(EntityUid pullerUid, EntityUid pulledUid) : PullMessage(pullerUid, pulledUid);


### PR DESCRIPTION
## About the PR
Fixed typo in PullStoppedMessage.cs: "Event raised directed BOTH at the puller and the pulled entity when a pull **starts**." for class "PullStoppedMessage" has been changed to "...when a pull **stops**"

## Why / Balance
Improving documentation.

## Technical details
Changed a single word in a docstring. I was unable to determine the reason line 1 shows a diff despite line endings seeming unchanged, while verifying BOM is not appearing as an invisible symbol in the file.

## Media
Exempt from media requirements.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No breaking changes.
