### PR TITLE
Make git hooks work in git worktrees

### DIFF
--- a/BuildChecker/git_helper.py
+++ b/BuildChecker/git_helper.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
-# Installs git hooks, updates them, updates submodules, that kind of thing.
+"""
+Installs git hooks, updates them, updates submodules, that kind of thing.
+"""
 
-import subprocess
-import sys
 import os
 import shutil
+import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import List
 
 SOLUTION_PATH = Path("..") / "SpaceStation14.sln"
 # If this doesn't match the saved version we overwrite them all.
-CURRENT_HOOKS_VERSION = "2"
+CURRENT_HOOKS_VERSION = "3"
 QUIET = len(sys.argv) == 2 and sys.argv[1] == "--quiet"
 
 
@@ -25,12 +27,10 @@ def run_command(command: List[str], capture: bool = False) -> subprocess.Complet
 
     sys.stdout.flush()
 
-    completed = None
-
     if capture:
-        completed = subprocess.run(command, cwd="..", stdout=subprocess.PIPE)
+        completed = subprocess.run(command, stdout=subprocess.PIPE, text=True)
     else:
-        completed = subprocess.run(command, cwd="..")
+        completed = subprocess.run(command)
 
     if completed.returncode != 0:
         print("Error: command exited with code {}!".format(completed.returncode))
@@ -43,7 +43,7 @@ def update_submodules():
     Updates all submodules.
     """
 
-    if ('GITHUB_ACTIONS' in os.environ):
+    if 'GITHUB_ACTIONS' in os.environ:
         return
 
     if os.path.isfile("DISABLE_SUBMODULE_AUTOUPDATE"):
@@ -76,22 +76,21 @@ def install_hooks():
                     print("No hooks change detected.")
                 return
 
-    with open("INSTALLED_HOOKS_VERSION", "w") as f:
-        f.write(CURRENT_HOOKS_VERSION)
-
     print("Hooks need updating.")
 
-    hooks_target_dir = Path("..")/".git"/"hooks"
+    hooks_target_dir = Path(run_command(["git", "rev-parse", "--git-path", "hooks"], True).stdout.strip())
     hooks_source_dir = Path("hooks")
 
     # Clear entire tree since we need to kill deleted files too.
-    for filename in os.listdir(str(hooks_target_dir)):
-        os.remove(str(hooks_target_dir/filename))
+    for filename in os.listdir(hooks_target_dir):
+        os.remove(hooks_target_dir / filename)
 
-    for filename in os.listdir(str(hooks_source_dir)):
+    for filename in os.listdir(hooks_source_dir):
         print("Copying hook {}".format(filename))
-        shutil.copy2(str(hooks_source_dir/filename),
-                        str(hooks_target_dir/filename))
+        shutil.copy2(hooks_source_dir / filename, hooks_target_dir / filename)
+
+    with open("INSTALLED_HOOKS_VERSION", "w") as f:
+        f.write(CURRENT_HOOKS_VERSION)
 
 
 def reset_solution():
@@ -107,8 +106,7 @@ def reset_solution():
 
 def check_for_zip_download():
     # Check if .git exists,
-    cur_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-    if not os.path.isdir(os.path.join(cur_dir, ".git")):
+    if run_command(["git", "rev-parse"]).returncode != 0:
         print("It appears that you downloaded this repository directly from GitHub. (Using the .zip download option) \n"
               "When downloading straight from GitHub, it leaves out important information that git needs to function. "
               "Such as information to download the engine or even the ability to even be able to create contributions. \n"

--- a/BuildChecker/hooks/post-checkout
+++ b/BuildChecker/hooks/post-checkout
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-gitroot=`git rev-parse --show-toplevel`
+gitroot=$(git rev-parse --show-toplevel)
 
-cd "$gitroot/BuildChecker"
+cd "$gitroot/BuildChecker" || exit
 
-if [[ `uname` == MINGW* || `uname` == CYGWIN* ]]; then
+if [[ $(uname) == MINGW* || $(uname) == CYGWIN* ]]; then
     # Windows
     py -3 git_helper.py --quiet
 else

--- a/BuildChecker/hooks/post-merge
+++ b/BuildChecker/hooks/post-merge
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Just call post-checkout since it does the same thing.
-gitroot=`git rev-parse --show-toplevel`
-bash "$gitroot/.git/hooks/post-checkout"
+gitroot=$(git rev-parse --git-path hooks)
+bash "$gitroot/post-checkout"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed the Python git hook to clone submodules not working when using git worktrees.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #37877.
## Technical details
<!-- Summary of code changes for easier review. -->
The main change is that the path to the git hooks folder is no longer hardcoded. Instead, the scripts call git to find the hooks directory. Additionally, the change to the installed hooks version is written after the hooks are installed now instead of before, so the script will allow itself to run again if there is an error. The `run_command` method will no longer change directory.
Rider was showing [warnings](https://github.com/koalaman/shellcheck/wiki/SC2006) about using backticks over $, so I let it replace those. Rider also had a [warning](https://github.com/koalaman/shellcheck/wiki/SC2164) about the cd in post-checkout not having an error check, so I let it add that. I can atomize fixing those warnings out to a separate PR if that is wanted, but I didn't want to make a merge conflict with myself on the hooks version.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
No in-game changes, but I did confirm that the game now runs from a fresh worktree:
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/26a4610b-4f42-4004-a8f1-dd16a467d870" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
There is a new version of the git hooks. They should update themselves next time you check out or merge from a branch that has the new version. Git worktrees should now work properly as a result.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
