### PR TITLE
Fix benchmark

### DIFF
--- a/Content.Benchmarks/MapLoadBenchmark.cs
+++ b/Content.Benchmarks/MapLoadBenchmark.cs
@@ -47,7 +47,7 @@ public class MapLoadBenchmark
         PoolManager.Shutdown();
     }
 
-    public static readonly string[] MapsSource = { "Empty", "Saltern", "Box", "Bagel", "Dev", "CentComm", "Core", "TestTeg", "Packed", "Omega", "Reach", "Meta", "Marathon", "MeteorArena", "Fland", "Oasis", "Convex"};
+    public static string[] MapsSource { get; } = { "Empty", "Saltern", "Box", "Bagel", "Dev", "CentComm", "Core", "TestTeg", "Packed", "Omega", "Reach", "Meta", "Marathon", "MeteorArena", "Fland", "Oasis", "Convex"};
 
     [ParamsSource(nameof(MapsSource))]
     public string Map;


### PR DESCRIPTION
## About the PR
Benchmark validation fails.

Steps to reproduce: `dotnet run --project Content.Benchmarks -c Release --filter '*'`

```
Unhandled exception. BenchmarkDotNet.Running.InvalidBenchmarkDeclarationException: MapLoadBenchmark has no public, accessible method/property called MapsSource, unable to read values for [ParamsSource]
   at BenchmarkDotNet.Running.BenchmarkConverter.GetValidValuesForParamsSource(Type parentType, String sourceName)
   at BenchmarkDotNet.Running.BenchmarkConverter.<>c__DisplayClass11_0.<GetParameterDefinitions>b__2(ParamsSourceAttribute attribute, Type parameterType)
   at BenchmarkDotNet.Running.BenchmarkConverter.<>c__DisplayClass11_1`1.<GetParameterDefinitions>b__4(ValueTuple`4 member)
   at System.Linq.Enumerable.ArraySelectIterator`2.Fill(ReadOnlySpan`1 source, Span`1 destination, Func`2 func)
   at System.Linq.Enumerable.ArraySelectIterator`2.ToArray()
   at BenchmarkDotNet.Running.BenchmarkConverter.GetParameterDefinitions(Type type)
   at BenchmarkDotNet.Running.BenchmarkConverter.MethodsToBenchmarksWithFullConfig(Type type, MethodInfo[] benchmarkMethods, IConfig config)
   at BenchmarkDotNet.Running.BenchmarkConverter.TypeToBenchmarks(Type type, IConfig config)
   at BenchmarkDotNet.Running.TypeFilter.<>c__DisplayClass1_0.<Filter>b__0(Type type)
   at System.Linq.Enumerable.ListSelectIterator`2.MoveNext()
   at System.Linq.Enumerable.IEnumerableWhereIterator`1.ToArray()
   at BenchmarkDotNet.Running.TypeFilter.Filter(IConfig effectiveConfig, IEnumerable`1 types)
   at BenchmarkDotNet.Running.BenchmarkSwitcher.RunWithDirtyAssemblyResolveHelper(String[] args, IConfig config, Boolean askUserForInput)
   at BenchmarkDotNet.Running.BenchmarkSwitcher.Run(String[] args, IConfig config)
   at Content.Benchmarks.Program.Main(String[] args) in Content.Benchmarks/Program.cs:line 25
```

At some point, we should probably run benchmark validation as a part of the standard workflow (without actually running any benchmarks) just to make sure benchmarks will run.