### PR TITLE
[Hotfix] Wizard Rod doesn't gib the wizard.

### DIFF
--- a/Content.Server/Polymorph/Components/PolymorphedEntityComponent.cs
+++ b/Content.Server/Polymorph/Components/PolymorphedEntityComponent.cs
@@ -21,6 +21,12 @@ public sealed partial class PolymorphedEntityComponent : Component
     public EntityUid? Parent;
 
     /// <summary>
+    /// Whether this polymorph has been reverted.
+    /// </summary>
+    [DataField]
+    public bool Reverted;
+
+    /// <summary>
     /// The amount of time that has passed since the entity was created
     /// used for tracking the duration
     /// </summary>

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -152,10 +152,6 @@ public sealed partial class PolymorphSystem : EntitySystem
     {
         if (ent.Comp.Configuration.RevertOnDelete)
             Revert(ent.AsNullable());
-
-        // Remove our original entity too
-        // Note that Revert will set Parent to null, so reverted entities will not be deleted
-        QueueDel(ent.Comp.Parent);
     }
 
     /// <summary>
@@ -298,8 +294,6 @@ public sealed partial class PolymorphSystem : EntitySystem
         if (component.Parent is not { } parent)
             return null;
 
-        // Clear our reference to the original entity
-        component.Parent = null;
         if (Deleted(parent))
             return null;
 

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -151,7 +151,10 @@ public sealed partial class PolymorphSystem : EntitySystem
     private void OnPolymorphedTerminating(Entity<PolymorphedEntityComponent> ent, ref EntityTerminatingEvent args)
     {
         if (!ent.Comp.Configuration.RevertOnDelete)
+        {
+            QueueDel(ent.Comp.Parent);
             return;
+        }
 
         Revert(ent.AsNullable());
     }

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -150,13 +150,12 @@ public sealed partial class PolymorphSystem : EntitySystem
 
     private void OnPolymorphedTerminating(Entity<PolymorphedEntityComponent> ent, ref EntityTerminatingEvent args)
     {
-        if (!ent.Comp.Configuration.RevertOnDelete)
-        {
-            QueueDel(ent.Comp.Parent);
-            return;
-        }
+        if (ent.Comp.Configuration.RevertOnDelete)
+            Revert(ent.AsNullable());
 
-        Revert(ent.AsNullable());
+        // Remove our original entity too
+        // Note that Revert will set Parent to null, so reverted entities will not be deleted
+        QueueDel(ent.Comp.Parent);
     }
 
     /// <summary>

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -150,13 +150,10 @@ public sealed partial class PolymorphSystem : EntitySystem
 
     private void OnPolymorphedTerminating(Entity<PolymorphedEntityComponent> ent, ref EntityTerminatingEvent args)
     {
-        if (ent.Comp.Configuration.RevertOnDelete)
-        {
-            Revert(ent.AsNullable());
-            ent.Comp.Parent = null;
-        }
+        if (!ent.Comp.Configuration.RevertOnDelete)
+            return;
 
-        QueueDel(ent);
+        Revert(ent.AsNullable());
     }
 
     /// <summary>

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -151,7 +151,12 @@ public sealed partial class PolymorphSystem : EntitySystem
     private void OnPolymorphedTerminating(Entity<PolymorphedEntityComponent> ent, ref EntityTerminatingEvent args)
     {
         if (ent.Comp.Configuration.RevertOnDelete)
+        {
             Revert(ent.AsNullable());
+            ent.Comp.Parent = null;
+        }
+
+        QueueDel(ent);
     }
 
     /// <summary>

--- a/Resources/Prototypes/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/Polymorphs/polymorph.yml
@@ -215,6 +215,7 @@
     forced: true
     revertOnCrit: false
     revertOnDeath: false
+    revertOnDelete: false
 
 # Temporary Jaunt
 # Don't make permanent jaunts until action system can be reworked to allow do afters and cooldown pausing

--- a/Resources/Prototypes/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/Polymorphs/polymorph.yml
@@ -215,7 +215,6 @@
     forced: true
     revertOnCrit: false
     revertOnDeath: false
-    revertOnDelete: false
 
 # Temporary Jaunt
 # Don't make permanent jaunts until action system can be reworked to allow do afters and cooldown pausing


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Wizards currently collide with themselves upon exiting rod form due to the order in which they are transformed back versus when the rod is deleted.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Wizard rod explicity checks so it doesn't collide with an entity polymorphed as it using the Parent datafield. Clearing it when rod runs out means that it gives just enough time for it to collide with the wizard when the spell ends.

## Technical details
<!-- Summary of code changes for easier review. -->

Revert one line of code.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Wizards can no longer hit themselves when polymorphed as an immovable rod.
