### PR TITLE
Moths cannot eject items from military boots

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -55,6 +55,7 @@
           tags:
           - Knife
           - Sidearm
+        priority: 4
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The moth 'eat' verb has a higher priority to the 'eject' verb, which leads to unexpected behavior when alt-clicking military boots. This PR adds a priority of 4 to item slots in ClothingShoesMilitaryBase, so ejecting takes precedence over eating.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This fixes unintuitive interaction caused by a species-specific characteristics. Players, especially those who do not main moth, expect to be able to remove a item from their boots, instead of jumping straight to eating them.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a priority key-value pair to ClothingShoesMilitaryBase

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Moths can now properly remove knives and other items from military boots.
