### PR TITLE
Crawling & Buckling Fixes

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -42,8 +42,6 @@ public abstract partial class SharedBuckleSystem
         SubscribeLocalEvent<BuckleComponent, BeingPulledAttemptEvent>(OnBeingPulledAttempt);
         SubscribeLocalEvent<BuckleComponent, PullStartedMessage>(OnPullStarted);
         SubscribeLocalEvent<BuckleComponent, UnbuckleAlertEvent>(OnUnbuckleAlert);
-        SubscribeLocalEvent<BuckleComponent, KnockDownAttemptEvent>(OnCrawlAttempt);
-
 
         SubscribeLocalEvent<BuckleComponent, InsertIntoEntityStorageAttemptEvent>(OnBuckleInsertIntoEntityStorageAttempt);
         SubscribeLocalEvent<BuckleComponent, PreventCollideEvent>(OnBucklePreventCollide);
@@ -93,12 +91,6 @@ public abstract partial class SharedBuckleSystem
             return;
         args.Handled = TryUnbuckle(ent, ent, ent);
     }
-
-    private void OnCrawlAttempt(Entity<BuckleComponent> ent, ref KnockDownAttemptEvent args)
-    {
-         Unbuckle(ent!, null);
-    }
-
     #endregion
 
     #region Transform

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -42,9 +42,10 @@ public abstract partial class SharedBuckleSystem
         SubscribeLocalEvent<BuckleComponent, BeingPulledAttemptEvent>(OnBeingPulledAttempt);
         SubscribeLocalEvent<BuckleComponent, PullStartedMessage>(OnPullStarted);
         SubscribeLocalEvent<BuckleComponent, UnbuckleAlertEvent>(OnUnbuckleAlert);
+        SubscribeLocalEvent<BuckleComponent, KnockDownAttemptEvent>(Penis);  //crawl makes you drop from the seat
+
 
         SubscribeLocalEvent<BuckleComponent, InsertIntoEntityStorageAttemptEvent>(OnBuckleInsertIntoEntityStorageAttempt);
-
         SubscribeLocalEvent<BuckleComponent, PreventCollideEvent>(OnBucklePreventCollide);
         SubscribeLocalEvent<BuckleComponent, DownAttemptEvent>(OnBuckleDownAttempt);
         SubscribeLocalEvent<BuckleComponent, StandAttemptEvent>(OnBuckleStandAttempt);
@@ -91,6 +92,11 @@ public abstract partial class SharedBuckleSystem
         if (args.Handled)
             return;
         args.Handled = TryUnbuckle(ent, ent, ent);
+    }
+
+    private void Penis(Entity<BuckleComponent> ent, ref KnockDownAttemptEvent args)
+    {
+        TryUnbuckle(ent, ent, ent);
     }
 
     #endregion

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -30,7 +30,6 @@ public abstract partial class SharedBuckleSystem
     public static ProtoId<AlertCategoryPrototype> BuckledAlertCategory = "Buckled";
 
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
-    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
 
     private void InitializeBuckle()
     {
@@ -43,7 +42,7 @@ public abstract partial class SharedBuckleSystem
         SubscribeLocalEvent<BuckleComponent, BeingPulledAttemptEvent>(OnBeingPulledAttempt);
         SubscribeLocalEvent<BuckleComponent, PullStartedMessage>(OnPullStarted);
         SubscribeLocalEvent<BuckleComponent, UnbuckleAlertEvent>(OnUnbuckleAlert);
-        SubscribeLocalEvent<BuckleComponent, KnockDownAttemptEvent>(OnCrawlAttempt);  //crawl makes you drop from the seat
+        SubscribeLocalEvent<BuckleComponent, KnockDownAttemptEvent>(OnCrawlAttempt);
 
 
         SubscribeLocalEvent<BuckleComponent, InsertIntoEntityStorageAttemptEvent>(OnBuckleInsertIntoEntityStorageAttempt);

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -22,7 +22,6 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
-using Content.Shared.Stunnable;
 
 namespace Content.Shared.Buckle;
 
@@ -96,10 +95,9 @@ public abstract partial class SharedBuckleSystem
         args.Handled = TryUnbuckle(ent, ent, ent);
     }
 
-    private void OnCrawlAttempt(Entity<BuckleComponent> entity, ref KnockDownAttemptEvent args)
+    private void OnCrawlAttempt(Entity<BuckleComponent> ent, ref KnockDownAttemptEvent args)
     {
-        TryUnbuckle(entity, entity, entity);
-        _standing.Down(entity, true, false);
+         Unbuckle(ent!, null);
     }
 
     #endregion

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -30,6 +30,7 @@ public abstract partial class SharedBuckleSystem
     public static ProtoId<AlertCategoryPrototype> BuckledAlertCategory = "Buckled";
 
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
 
     private void InitializeBuckle()
     {
@@ -42,7 +43,7 @@ public abstract partial class SharedBuckleSystem
         SubscribeLocalEvent<BuckleComponent, BeingPulledAttemptEvent>(OnBeingPulledAttempt);
         SubscribeLocalEvent<BuckleComponent, PullStartedMessage>(OnPullStarted);
         SubscribeLocalEvent<BuckleComponent, UnbuckleAlertEvent>(OnUnbuckleAlert);
-        SubscribeLocalEvent<BuckleComponent, KnockDownAttemptEvent>(Penis);  //crawl makes you drop from the seat
+        SubscribeLocalEvent<BuckleComponent, KnockDownAttemptEvent>(OnCrawlAttempt);  //crawl makes you drop from the seat
 
 
         SubscribeLocalEvent<BuckleComponent, InsertIntoEntityStorageAttemptEvent>(OnBuckleInsertIntoEntityStorageAttempt);
@@ -94,9 +95,10 @@ public abstract partial class SharedBuckleSystem
         args.Handled = TryUnbuckle(ent, ent, ent);
     }
 
-    private void Penis(Entity<BuckleComponent> ent, ref KnockDownAttemptEvent args)
+    private void OnCrawlAttempt(Entity<BuckleComponent> entity, ref KnockDownAttemptEvent args)
     {
-        TryUnbuckle(ent, ent, ent);
+        TryUnbuckle(entity, entity, entity);
+        _standingState.Stand(entity);
     }
 
     #endregion

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Content.Shared.Stunnable;
 
 namespace Content.Shared.Buckle;
 
@@ -98,7 +99,7 @@ public abstract partial class SharedBuckleSystem
     private void OnCrawlAttempt(Entity<BuckleComponent> entity, ref KnockDownAttemptEvent args)
     {
         TryUnbuckle(entity, entity, entity);
-        _standingState.Stand(entity);
+        _standing.Down(entity, true, false);
     }
 
     #endregion

--- a/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
+++ b/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
@@ -51,7 +51,6 @@ namespace Content.Shared.Movement.Systems
         private void OnStand(Entity<MovementSpeedModifierComponent> entity, ref StoodEvent args)
         {
             RefreshFrictionModifiers(entity);
-            RefreshMovementSpeedModifiers(entity);
         }
 
         /// <summary>

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -541,9 +541,10 @@ public abstract partial class SharedStunSystem
 
     private void OnBuckle(Entity<KnockedDownComponent> entity, ref BuckledEvent args)
     {
-        if (entity.Comp.DoAfterId is { } doAfterId)
-            DoAfter.Cancel(entity.Owner, doAfterId);
+        if (entity.Comp.DoAfterId is not { } doAfterId)
+            return;
 
+        DoAfter.Cancel(entity.Owner, doAfterId);
         RemComp<KnockedDownComponent>(entity);
     }
 

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -542,7 +542,6 @@ public abstract partial class SharedStunSystem
     private void OnBuckle(Entity<KnockedDownComponent> entity, ref BuckledEvent args)
     {
         RemComp<KnockedDownComponent>(entity);
-        //reference component shutdown, it makes you visually stand but not crawl :p
     }
 
     #endregion

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -14,7 +14,6 @@ using Content.Shared.Popups;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Standing;
 using Robust.Shared.Audio;
-using Content.Shared.Buckle;
 using Robust.Shared.Configuration;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Physics;
@@ -117,6 +116,7 @@ public abstract partial class SharedStunSystem
         // This is jank but if we don't do this it'll still use the knockedDownComponent modifiers for friction because it hasn't been deleted quite yet.
         entity.Comp.FrictionModifier = 1f;
         entity.Comp.SpeedModifier = 1f;
+        _movementSpeedModifier.RefreshMovementSpeedModifiers(entity);
 
         _standingState.Stand(entity);
         Alerts.ClearAlert(entity, KnockdownAlert);
@@ -541,6 +541,9 @@ public abstract partial class SharedStunSystem
 
     private void OnBuckle(Entity<KnockedDownComponent> entity, ref BuckledEvent args)
     {
+        if (entity.Comp.DoAfterId is { } doAfterId)
+            DoAfter.Cancel(entity.Owner, doAfterId);
+
         RemComp<KnockedDownComponent>(entity);
     }
 

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -14,6 +14,7 @@ using Content.Shared.Popups;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Standing;
 using Robust.Shared.Audio;
+using Content.Shared.Buckle;
 using Robust.Shared.Configuration;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Physics;
@@ -52,6 +53,7 @@ public abstract partial class SharedStunSystem
         // Action blockers
         SubscribeLocalEvent<KnockedDownComponent, BuckleAttemptEvent>(OnBuckleAttempt);
         SubscribeLocalEvent<KnockedDownComponent, StandAttemptEvent>(OnStandAttempt);
+        SubscribeLocalEvent<KnockedDownComponent, BuckledEvent>(OnBuckle);
 
         // Updating movement a friction
         SubscribeLocalEvent<KnockedDownComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshKnockedSpeed);
@@ -535,6 +537,12 @@ public abstract partial class SharedStunSystem
     {
         if (args.User == entity && entity.Comp.NextUpdate > GameTiming.CurTime)
             args.Cancelled = true;
+    }
+
+    private void OnBuckle(Entity<KnockedDownComponent> entity, ref BuckledEvent args)
+    {
+        RemComp<KnockedDownComponent>(entity);
+        //reference component shutdown, it makes you visually stand but not crawl :p
     }
 
     #endregion

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -54,6 +54,7 @@ public abstract partial class SharedStunSystem
         SubscribeLocalEvent<KnockedDownComponent, BuckleAttemptEvent>(OnBuckleAttempt);
         SubscribeLocalEvent<KnockedDownComponent, StandAttemptEvent>(OnStandAttempt);
         SubscribeLocalEvent<KnockedDownComponent, BuckledEvent>(OnBuckle);
+        SubscribeLocalEvent<KnockedDownComponent, UnbuckledEvent>(OnCrawlUnbuckle);
 
         // Updating movement a friction
         SubscribeLocalEvent<KnockedDownComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshKnockedSpeed);
@@ -543,6 +544,14 @@ public abstract partial class SharedStunSystem
     {
         RemComp<KnockedDownComponent>(entity);
     }
+
+    private void OnCrawlUnbuckle(Entity<KnockedDownComponent> entity, ref UnbuckledEvent args)
+    {
+        if (_standingState.Down(entity));
+            RemComp<KnockedDownComponent>(entity);
+    }
+
+
 
     #endregion
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Unbuckling while in crawl mode now keeps you standing

## Why / Balance
It's a bug that bothers me I guess.

## Technical details
-BuckledComponent listenes for OnCrawlAttempt , unbuckling you
-KnockedDownComponent listens for BuckledEvent removing the component 

## Media
https://github.com/user-attachments/assets/52b97b41-038e-45d8-9ad4-2fcc6cfb4b65



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None that I can think of (but do tell me if there are any, this is the first PR I've sent out that actually involves code)

**Changelog**
:cl:
- fix: Dismounting from a chair while in crawl mode now keeps you standing

