### PR TITLE
Remove duplicate food component in entities with edible component

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -317,6 +317,7 @@
     - HEAD
   - type: Edible
     edible: Drink
+    utensil: Spoon
     solution: drink
     delay: 0.5
     forceFeedDelay: 1.5

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -203,6 +203,7 @@
   - type: StepTrigger
   - type: Edible
     edible: Drink
+    utensil: Spoon
     delay: 3
     transferAmount: 1
     solution: puddle

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -9,7 +9,6 @@
   - type: FlavorProfile
     flavors:
       - bread
-  - type: Food
   - type: Sprite
     sprite: Objects/Consumable/Food/Baked/bread.rsi
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -9,7 +9,6 @@
   - type: FlavorProfile
     flavors:
       - sweet
-  - type: Food
   - type: Sprite
     sprite: Objects/Consumable/Food/Baked/cake.rsi
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
@@ -6,7 +6,6 @@
   abstract: true
   description: Goes great with robust coffee.
   components:
-  - type: Food
   - type: Tag
     tags:
     - Donut

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -6,7 +6,6 @@
   id: FoodBakedBase
   abstract: true
   components:
-  - type: Food
   - type: Sprite
     sprite: Objects/Consumable/Food/Baked/misc.rsi
   - type: SolutionContainerManager
@@ -27,7 +26,7 @@
   id: FoodBakedMuffin
   description: A delicious and spongy little cake.
   components:
-  - type: Food
+  - type: Edible
     trash:
     - FoodPlateMuffinTin
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
@@ -24,7 +24,7 @@
           Quantity: 14
         - ReagentId: Sugar
           Quantity: 5
-  - type: Food #All pies here made with a pie tin; unless you're some kind of savage, you're probably not destroying this when you eat or slice the pie!
+  - type: Edible #All pies here made with a pie tin; unless you're some kind of savage, you're probably not destroying this when you eat or slice the pie!
     trash:
     - FoodPlateTin
   - type: SliceableFood

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
@@ -10,7 +10,6 @@
     flavors:
       - oily
       - bread
-  - type: Food
   - type: Sprite
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
   - type: SolutionContainerManager
@@ -42,7 +41,6 @@
     flavors:
       - oily
       - bread
-  - type: Food
   - type: Sprite
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -87,7 +87,7 @@
     flavors:
     - sweet
     - funny
-  - type: Food
+  - type: Edible
     trash: 
     - FoodTinPeachesTrash
   - type: Tag
@@ -148,7 +148,8 @@
     - savory
     - salty
     - cheap
-  - type: Food
+  - type: Edible
+    utensil: Spoon
     trash: 
     - FoodTinBeansTrash
 
@@ -178,7 +179,7 @@
     - meaty
     - salty
     - cheap
-  - type: Food
+  - type: Edible
     trash: 
     - FoodTinMRETrash
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/breakfast.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/breakfast.yml
@@ -10,7 +10,6 @@
   components:
   - type: Item
     storedRotation: -90
-  - type: Food
   - type: Sprite
     sprite: Objects/Consumable/Food/breakfast.rsi
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
@@ -10,7 +10,7 @@
     tags:
       - Egg
       - Meat
-  - type: Food
+  - type: Edible
     trash:
     - Eggshells
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -6,7 +6,6 @@
   id: FoodFrozenBase
   abstract: true
   components:
-  - type: Food
   - type: Sprite
     sprite: Objects/Consumable/Food/frozen.rsi
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -12,7 +12,6 @@
   components:
   - type: Item
     storedRotation: -90
-  - type: Food
   - type: Sprite
     sprite: Objects/Consumable/Food/meals.rsi
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -6,7 +6,6 @@
   id: FoodSnackBase
   abstract: true
   components:
-  - type: Food
   - type: Tag
     tags:
       - FoodSnack
@@ -41,7 +40,7 @@
     state: boritos
   - type: Item
     heldPrefix: boritos
-  - type: Food
+  - type: Edible
     trash:
     - FoodPacketBoritosTrash
 
@@ -58,7 +57,7 @@
     state: cnds
   - type: Item
     heldPrefix: cnds
-  - type: Food
+  - type: Edible
     trash:
     - FoodPacketCnDsTrash
 
@@ -76,7 +75,7 @@
     state: cheesiehonkers
   - type: Item
     heldPrefix: cheesiehonkers
-  - type: Food
+  - type: Edible
     trash:
     - FoodPacketCheesieTrash
 
@@ -95,7 +94,7 @@
     state: chips
   - type: Item
     heldPrefix: chips
-  - type: Food
+  - type: Edible
     trash:
     - FoodPacketChipsTrash
 
@@ -198,7 +197,8 @@
     state: pistachio
   - type: Item
     heldPrefix: pistachio
-  - type: Food
+  - type: Edible
+    utensil: Spoon
     trash:
     - FoodPacketPistachioTrash
   - type: Tag
@@ -221,7 +221,7 @@
     state: popcorn
   - type: Item
     heldPrefix: popcorn
-  - type: Food
+  - type: Edible
     trash:
     - FoodPacketPopcornTrash
 
@@ -238,7 +238,8 @@
     state: raisins
   - type: Item
     heldPrefix: raisins
-  - type: Food
+  - type: Edible
+    utensil: Spoon
     trash:
     - FoodPacketRaisinsTrash
   - type: Tag
@@ -258,7 +259,8 @@
     state: semki
   - type: Item
     heldPrefix: semki
-  - type: Food
+  - type: Edible
+    utensil: Spoon
     trash:
     - FoodPacketSemkiTrash
 
@@ -275,7 +277,7 @@
     state: susjerky
   - type: Item
     heldPrefix: susjerky
-  - type: Food
+  - type: Edible
     trash:
     - FoodPacketSusTrash
   - type: Tag
@@ -295,10 +297,11 @@
     state: syndicakes
   - type: Item
     heldPrefix: syndicakes
-  - type: Food
+  - type: Edible
     trash:
     - FoodPacketSyndiTrash
 
+# Weird that this is refillable, but also destroys itself on empty
 - type: entity
   parent: FoodSnackBase
   id: DrinkRamen
@@ -320,7 +323,7 @@
           Quantity: 5
   - type: Sprite
     state: ramen
-  - type: Food
+  - type: Edible
     trash:
     - FoodPacketCupRamenTrash
   - type: Item
@@ -366,7 +369,7 @@
           Quantity: 10
         - ReagentId: Soysauce
           Quantity: 2
-  - type: Food
+  - type: Edible
     trash:
     - FoodPacketChowMeinTrash
 
@@ -396,7 +399,7 @@
           Quantity: 2
         - ReagentId: Soysauce
           Quantity: 2
-  - type: Food
+  - type: Edible
     trash:
     - FoodPacketDanDanTrash
 
@@ -422,7 +425,7 @@
     sprite: Objects/Consumable/Food/snacks.rsi
     heldPrefix: cookie_fortune
     size: Tiny
-  - type: Food
+  - type: Edible
     trash:
     - FoodCookieFortune
 
@@ -585,7 +588,7 @@
         reagents:
         - ReagentId: ToxinTrash
           Quantity: 5
-  - type: Food
+  - type: Edible
     requiresSpecialDigestion: true
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -7,7 +7,7 @@
   components:
   - type: Item
     storedRotation: -90
-  - type: Food
+  - type: Edible
     trash:
     - FoodBowlBig
     utensil: Spoon

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/taco.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/taco.yml
@@ -46,7 +46,7 @@
     flavors:
       - meaty
       - cheesy
-  - type: Food
+  - type: Edible
     transferAmount: 3
   - type: Sprite
     sprite: Objects/Consumable/Food/taco.rsi

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -205,7 +205,7 @@
   suffix: Full
   components:
   - type: Material
-  - type: Food
+  - type: Edible
     transferAmount: 10
   - type: BadFood
   - type: PhysicalComposition

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -226,13 +226,6 @@
     state: durathread
   - type: Stack
     count: 1
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents: #Hell if I know what durathread is made out of.
-        - ReagentId: Fiber
-          Quantity: 6
 
 - type: entity
   parent: MaterialBase

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -7,6 +7,7 @@
   - type: Clickable
   - type: Edible
     edible: Drink
+    utensil: Spoon
     solution: bucket
     destroyOnEmpty: false
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Several entities have both `Food` and `Edible`, creating problems explained in the linked issue. This PR addresses all the ones I could find. Not guaranteed to have caught all of them, though.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Advances #40046

## Technical details
<!-- Summary of code changes for easier review. -->
Mostly a find/replace PR. Some foods also had their utensil changed, and several bases were adding `Food` unnecessarily when they already got it from their parent. Items which changed transfer amount or created trash were some obvious offenders.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
