### PR TITLE
Add multi-job exclusion support to objectives, and add more appropriate job restrictions to certain thief objectives.

### DIFF
--- a/Content.Server/Objectives/Components/NotJobRequirementComponent.cs
+++ b/Content.Server/Objectives/Components/NotJobRequirementComponent.cs
@@ -2,6 +2,7 @@ using Content.Server.Objectives.Systems;
 using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Prototypes;
 
 /// <summary>
 /// Requires that the player not have a certain job to have this objective.
@@ -10,8 +11,17 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 public sealed partial class NotJobRequirementComponent : Component
 {
     /// <summary>
-    /// ID of the job to ban from having this objective.
+    /// ID of the job to ban from having this objective, use for singular job exclusions (i.e. steal tropico for atmos tech).
     /// </summary>
-    [DataField(required: true, customTypeSerializer: typeof(PrototypeIdSerializer<JobPrototype>))]
-    public string Job = string.Empty;
+    /// <remarks>
+    /// May be worth phasing this out later, but that would be a breaking change.
+    /// </remarks>
+    [DataField]
+    public ProtoId<JobPrototype> Job = string.Empty;
+
+    /// <summary>
+    /// List of IDs to ban from having this objective, for multi-job exclusions (i.e. steal paramed's voidsuit for paramedic, chemist, doctor, psychologist)
+    /// </summary>
+    [DataField]
+    public List<ProtoId<JobPrototype>> Jobs = new List<ProtoId<JobPrototype>>();
 }

--- a/Content.Server/Objectives/Systems/NotJobRequirementSystem.cs
+++ b/Content.Server/Objectives/Systems/NotJobRequirementSystem.cs
@@ -25,7 +25,7 @@ public sealed class NotJobRequirementSystem : EntitySystem
         _jobs.MindTryGetJob(args.MindId, out var proto);
 
         // if player has no job then don't care
-        if (proto is not null && proto.ID == comp.Job)
+        if (proto is not null && (proto.ID == comp.Job || comp.Jobs.Contains(proto.ID)))
             args.Cancelled = true;
     }
 }

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -365,7 +365,7 @@
   id: FreezerHeaterStealObjective
   components:
   - type: NotJobRequirement
-    jobs: [ AtmosphericTechnician, MedicalDoctor, Chemist, Scientist ]
+    jobs: [ AtmosphericTechnician, MedicalDoctor, Chemist, Paramedic, Psychologist, Scientist, Chef ]
   - type: StealCondition
     stealGroup: FreezerHeater
   - type: Objective

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -115,7 +115,7 @@
   id: MailStealCollectionObjective
   components:
   - type: NotJobRequirement
-    job: CargoTechnician
+    jobs: [ CargoTechnician, SalvageSpecialist ]
   - type: StealCondition
     stealGroup: Mail
     minCollectionSize: 4
@@ -198,7 +198,7 @@
   id: ClothingOuterHardsuitVoidParamedStealObjective
   components:
   - type: NotJobRequirement
-    job: Paramedic
+    jobs: [ MedicalDoctor, Paramedic, Chemist, Psychologist ]
   - type: StealCondition
     stealGroup: ClothingOuterHardsuitVoidParamed
   - type: Objective
@@ -209,7 +209,7 @@
   id: MedicalTechFabCircuitboardStealObjective
   components:
   - type: NotJobRequirement
-    job: MedicalDoctor
+    jobs: [ MedicalDoctor, Paramedic, Chemist, Psychologist ]
   - type: StealCondition
     stealGroup: MedicalTechFabCircuitboard
   - type: Objective
@@ -242,7 +242,7 @@
   id: AmePartFlatpackStealObjective
   components:
   - type: NotJobRequirement
-    job: StationEngineer
+    jobs: [ StationEngineer, AtmosphericTechnician ]
   - type: StealCondition
     stealGroup: AmePartFlatpack
   - type: Objective
@@ -264,7 +264,7 @@
   id: CargoShuttleCircuitboardStealObjective
   components:
   - type: NotJobRequirement
-    job: CargoTechnician
+    jobs: [ CargoTechnician, SalvageSpecialist ]
   - type: StealCondition
     stealGroup: CargoShuttleConsoleCircuitboard
   - type: Objective
@@ -275,7 +275,7 @@
   id: ClothingEyesHudBeerStealObjective
   components:
   - type: NotJobRequirement
-    job: Bartender
+    jobs: [ Bartender, ServiceWorker ]
   - type: StealCondition
     stealGroup: ClothingEyesHudBeer
   - type: Objective
@@ -343,7 +343,7 @@
   id: ChemDispenserStealObjective
   components:
   - type: NotJobRequirement
-    job: Chemist
+    jobs: [ Chemist, Scientist ]
   - type: StealCondition
     stealGroup: ChemDispenser
   - type: Objective
@@ -365,7 +365,7 @@
   id: FreezerHeaterStealObjective
   components:
   - type: NotJobRequirement
-    job: AtmosphericTechnician
+    jobs: [ AtmosphericTechnician, MedicalDoctor, Chemist, Scientist ]
   - type: StealCondition
     stealGroup: FreezerHeater
   - type: Objective
@@ -376,7 +376,7 @@
   id: TegStealObjective
   components:
   - type: NotJobRequirement
-    job: AtmosphericTechnician
+    jobs: [ AtmosphericTechnician, StationEngineer ]
   - type: StealCondition
     stealGroup: Teg
   - type: Objective
@@ -387,7 +387,7 @@
   id: BoozeDispenserStealObjective
   components:
   - type: NotJobRequirement
-    job: Bartender
+    jobs: [ Bartender, ServiceWorker ]
   - type: StealCondition
     stealGroup: BoozeDispenser
   - type: Objective


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
NotJobRequirement now supports more than 1 job per objective.

This PR also makes the following changes:
- No Medical staff can get the medical techfab or paramedic voidsuit objectives, as only Medical access is required for these items. They also cannot get the freezer objective.
- Scientists can no longer get the chemical dispenser or freezer objective, as they can just build those machines and a freezer is sometimes mapped in the artifact lab.
- Chefs can no longer get the freezer objective, as a freezer is sometimes mapped in the chef's freezer room.
- Engineers can no longer get the TEG objective, as usually only Engineering access is needed to reach the TEG.
- Service workers can no longer get the beer goggles or booze dispenser objective, as Service Workers have bar access just like Bartenders.
- Salvage specialists can no longer get the ID, mail or cargo shuttle console board objectives, as they have Cargo access.
- Atmos techs can no longer get the AME flatpack objective, as they have Engineering access.

## Why / Balance
Previously allowing only one job to be forbidden from getting an objective led to very easy objectives, for example a Medical Doctor could just use their access to take the paramedic's voidsuit from the locker, or a Scientist could just build a chemical dispenser. Support for multi-job exclusion allows all problematic jobs from being forbidden from getting certain objectives. This contributes to making thief less boring and barely antagonistic.

## Technical details
Added new "jobs" datafield to NotJobRequirementComponent, a list of job prototype IDs that is checked similarly to the "job" field. Also changed NotJobRequirementComponent to use ProtoId<JobPrototype>s instead of strings.

## Media
<img width="1195" height="905" alt="image" src="https://github.com/user-attachments/assets/4ece20e2-c2e8-434e-871a-8c8c734c6a3d" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
NotJobRequirement now uses ProtoId<JobPrototype>s instead of strings; no idea if that breaks anything or not.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Certain thief objectives can no longer be rolled by jobs which have trivial access to the objective item.