### PR TITLE
Improve Gas Yaml Serialization

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/GasArrayTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/GasArrayTest.cs
@@ -57,9 +57,9 @@ public sealed class GasArrayTest
 
                 Assert.That(gasTankComponent!.Air.GetMoles(Gas.Oxygen), Is.EqualTo(10));
                 Assert.That(gasTankComponent!.Air.GetMoles(Gas.Nitrogen), Is.EqualTo(20));
-                for (var i = 3; i < Atmospherics.AdjustedNumberOfGases; i++)
+                foreach (var gas in Enum.GetValues<Gas>().Where(p => p != Gas.Oxygen && p != Gas.Nitrogen))
                 {
-                    Assert.That(gasTankComponent!.Air.GetMoles(i), Is.EqualTo(0));
+                    Assert.That(gasTankComponent!.Air.GetMoles(gas), Is.EqualTo(0));
                 }
             });
 
@@ -68,12 +68,15 @@ public sealed class GasArrayTest
             {
                 Assert.That(legacyGasTank.TryGetComponent<GasTankComponent>(out var gasTankComponent, compFactory));
 
-                Assert.That(gasTankComponent!.Air.GetMoles(Gas.Plasma), Is.EqualTo(10));
+                Assert.That(gasTankComponent!.Air.GetMoles(4), Is.EqualTo(10));
 
                 // Iterate through all other gases: check for 0 values
-                foreach (var gas in Enum.GetValues<Gas>().Where(p => p != Gas.Plasma))
+                for (var i = 0; i < Atmospherics.AdjustedNumberOfGases; i++)
                 {
-                    Assert.That(gasTankComponent!.Air.GetMoles(gas), Is.EqualTo(0));
+                    if (i == 4) // our case with a value.
+                        continue;
+
+                    Assert.That(gasTankComponent!.Air.GetMoles(i), Is.EqualTo(0));
                 }
             });
         });

--- a/Content.IntegrationTests/Tests/Atmos/GasArrayTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/GasArrayTest.cs
@@ -23,8 +23,8 @@ public sealed class GasArrayTest
     air:
       volume: 5
       moles:
+        Frezon: 20
         Oxygen: 10
-        Nitrogen: 20
 
 - type: entity
   id: {GasTankLegacyTestDummyId}
@@ -56,8 +56,8 @@ public sealed class GasArrayTest
                 Assert.That(gasTank.TryGetComponent<GasTankComponent>(out var gasTankComponent, compFactory));
 
                 Assert.That(gasTankComponent!.Air.GetMoles(Gas.Oxygen), Is.EqualTo(10));
-                Assert.That(gasTankComponent!.Air.GetMoles(Gas.Nitrogen), Is.EqualTo(20));
-                foreach (var gas in Enum.GetValues<Gas>().Where(p => p != Gas.Oxygen && p != Gas.Nitrogen))
+                Assert.That(gasTankComponent!.Air.GetMoles(Gas.Frezon), Is.EqualTo(20));
+                foreach (var gas in Enum.GetValues<Gas>().Where(p => p != Gas.Oxygen && p != Gas.Frezon))
                 {
                     Assert.That(gasTankComponent!.Air.GetMoles(gas), Is.EqualTo(0));
                 }
@@ -68,12 +68,12 @@ public sealed class GasArrayTest
             {
                 Assert.That(legacyGasTank.TryGetComponent<GasTankComponent>(out var gasTankComponent, compFactory));
 
-                Assert.That(gasTankComponent!.Air.GetMoles(4), Is.EqualTo(10));
+                Assert.That(gasTankComponent!.Air.GetMoles(3), Is.EqualTo(10));
 
                 // Iterate through all other gases: check for 0 values
                 for (var i = 0; i < Atmospherics.AdjustedNumberOfGases; i++)
                 {
-                    if (i == 4) // our case with a value.
+                    if (i == 3) // our case with a value.
                         continue;
 
                     Assert.That(gasTankComponent!.Air.GetMoles(i), Is.EqualTo(0));

--- a/Content.IntegrationTests/Tests/Atmos/GasArrayTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/GasArrayTest.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using Content.Shared.Atmos;
+using Content.Shared.Atmos.Components;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Atmos;
+
+[TestFixture]
+[TestOf(typeof(Atmospherics))]
+public sealed class GasArrayTest
+{
+    private const string GasTankTestDummyId = "GasTankTestDummy";
+
+    private const string GasTankLegacyTestDummyId = "GasTankLegacyTestDummy";
+
+    [TestPrototypes]
+    private const string Prototypes = $@"
+- type: entity
+  id: {GasTankTestDummyId}
+  components:
+  - type: GasTank
+    air:
+      volume: 5
+      moles:
+        Oxygen: 10
+        Nitrogen: 20
+
+- type: entity
+  id: {GasTankLegacyTestDummyId}
+  components:
+  - type: GasTank
+    air:
+      volume: 5
+      moles:
+      - 0
+      - 0
+      - 0
+      - 10
+";
+
+    [Test]
+    public async Task TestGasArrayDeserialization()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var compFactory = server.ResolveDependency<IComponentFactory>();
+        var prototypeManager = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var gasTank = prototypeManager.Index(GasTankTestDummyId);
+            Assert.Multiple(() =>
+            {
+                Assert.That(gasTank.TryGetComponent<GasTankComponent>(out var gasTankComponent, compFactory));
+
+                Assert.That(gasTankComponent!.Air.GetMoles(Gas.Oxygen), Is.EqualTo(10));
+                Assert.That(gasTankComponent!.Air.GetMoles(Gas.Nitrogen), Is.EqualTo(20));
+                for (var i = 3; i < Atmospherics.AdjustedNumberOfGases; i++)
+                {
+                    Assert.That(gasTankComponent!.Air.GetMoles(i), Is.EqualTo(0));
+                }
+            });
+
+            var legacyGasTank = prototypeManager.Index(GasTankLegacyTestDummyId);
+            Assert.Multiple(() =>
+            {
+                Assert.That(legacyGasTank.TryGetComponent<GasTankComponent>(out var gasTankComponent, compFactory));
+
+                Assert.That(gasTankComponent!.Air.GetMoles(Gas.Plasma), Is.EqualTo(10));
+
+                // Iterate through all other gases: check for 0 values
+                foreach (var gas in Enum.GetValues<Gas>().Where(p => p != Gas.Plasma))
+                {
+                    Assert.That(gasTankComponent!.Air.GetMoles(gas), Is.EqualTo(0));
+                }
+            });
+        });
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -458,11 +458,8 @@ namespace Content.Server.Atmos.EntitySystems
                     continue;
 
                 var doReaction = true;
-                for (var i = 0; i < prototype.MinimumRequirements.Length; i++)
+                for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
                 {
-                    if(i >= Atmospherics.TotalNumberOfGases)
-                        throw new IndexOutOfRangeException("Reaction Gas Minimum Requirements Array Prototype exceeds total number of gases!");
-
                     var req = prototype.MinimumRequirements[i];
 
                     if (!(mixture.GetMoles(i) < req))

--- a/Content.Server/Atmos/Reactions/GasReactionPrototype.cs
+++ b/Content.Server/Atmos/Reactions/GasReactionPrototype.cs
@@ -15,7 +15,7 @@ namespace Content.Server.Atmos.Reactions
         /// <summary>
         ///     Minimum gas amount requirements.
         /// </summary>
-        [DataField("minimumRequirements")]
+        [DataField("minimumRequirements", customTypeSerializer: typeof(GasArraySerializer))]
         public float[] MinimumRequirements { get; private set; } = new float[Atmospherics.TotalNumberOfGases];
 
         /// <summary>

--- a/Content.Shared/Atmos/GasArraySerializer.cs
+++ b/Content.Shared/Atmos/GasArraySerializer.cs
@@ -72,10 +72,11 @@ public sealed class GasArraySerializer : ITypeSerializer<float[], SequenceDataNo
 
         foreach (var (gas, value) in node.Children)
         {
+            // In the event that an invalid gas got serialized into something,
+            // we simply ignore it and continue reading.
+            // Errors should already be caught by Validate().
             if (!Enum.TryParse<Gas>(gas, out var gasEnum))
-            {
-                throw new Exception($"Failed to parse Gas: {gas}");
-            }
+                continue;
 
             list[(int)gasEnum] = serializationManager.Read<float>(value, hookCtx, context);
         }

--- a/Content.Shared/Atmos/GasArraySerializer.cs
+++ b/Content.Shared/Atmos/GasArraySerializer.cs
@@ -52,8 +52,8 @@ public sealed class GasArraySerializer : ITypeSerializer<float[], SequenceDataNo
         foreach (var (key, value) in node.Children)
         {
             ValidationNode keyNode = Enum.TryParse<Gas>(key, out _)
-                ? new ValidatedValueNode(value)
-                : new ErrorNode(value, $"Failed to parse Gas: {key}");
+                ? new ValidatedValueNode(node.GetKeyNode(key))
+                : new ErrorNode(node.GetKeyNode(key), $"Failed to parse Gas: {key}");
 
             dict.Add(keyNode, serializationManager.ValidateNode<float>(value, context));
         }

--- a/Content.Shared/Atmos/GasArraySerializer.cs
+++ b/Content.Shared/Atmos/GasArraySerializer.cs
@@ -1,0 +1,104 @@
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Content.Shared.Atmos;
+
+public sealed class GasArraySerializer : ITypeSerializer<float[], SequenceDataNode>, ITypeSerializer<float[], MappingDataNode>
+{
+    public ValidationNode Validate(ISerializationManager serializationManager,
+        SequenceDataNode node,
+        IDependencyCollection dependencies,
+        ISerializationContext? context = null)
+    {
+        var list = new List<ValidationNode>();
+
+        foreach (var elem in node.Sequence)
+        {
+            list.Add(serializationManager.ValidateNode<float>(elem, context));
+        }
+
+        return new ValidatedSequenceNode(list);
+    }
+
+    public float[] Read(ISerializationManager serializationManager,
+        SequenceDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<float[]>? instanceProvider = null)
+    {
+        var list = instanceProvider != null ? instanceProvider() : new float[Atmospherics.AdjustedNumberOfGases];
+
+        for (var i = 0; i < node.Sequence.Count; i++)
+        {
+            list[i] = serializationManager.Read<float>(node.Sequence[i], hookCtx, context);
+        }
+
+        return list;
+    }
+
+    public ValidationNode Validate(ISerializationManager serializationManager,
+        MappingDataNode node,
+        IDependencyCollection dependencies,
+        ISerializationContext? context = null)
+    {
+        var dict = new Dictionary<ValidationNode, ValidationNode>();
+
+        foreach (var (key, value) in node.Children)
+        {
+            ValidationNode keyNode = Enum.TryParse<Gas>(key, out _)
+                ? new ValidatedValueNode(value)
+                : new ErrorNode(value, $"Failed to parse Gas: {key}");
+
+            dict.Add(keyNode, serializationManager.ValidateNode<float>(value, context));
+        }
+
+        return new ValidatedMappingNode(dict);
+    }
+
+    public float[] Read(ISerializationManager serializationManager,
+        MappingDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<float[]>? instanceProvider = null)
+    {
+        var list = instanceProvider != null ? instanceProvider() : new float[Atmospherics.AdjustedNumberOfGases];
+
+        foreach (var (gas, value) in node.Children)
+        {
+            if (!Enum.TryParse<Gas>(gas, out var gasEnum))
+            {
+                throw new Exception($"Failed to parse Gas: {gas}");
+            }
+
+            list[(int)gasEnum] = serializationManager.Read<float>(value, hookCtx, context);
+        }
+
+        return list;
+    }
+
+    public DataNode Write(ISerializationManager serializationManager,
+        float[] value,
+        IDependencyCollection dependencies,
+        bool alwaysWrite = false,
+        ISerializationContext? context = null)
+    {
+        var mapping = new MappingDataNode();
+
+        for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
+        {
+            if (value[i] <= 0)
+                continue;
+
+            mapping.Add(((Gas) i).ToString(), serializationManager.WriteValue(value[i], alwaysWrite, context));
+        }
+
+        return mapping;
+    }
+}

--- a/Content.Shared/Atmos/GasMixture.cs
+++ b/Content.Shared/Atmos/GasMixture.cs
@@ -20,7 +20,7 @@ namespace Content.Shared.Atmos
 
         // No access, to ensure immutable mixtures are never accidentally mutated.
         [Access(typeof(SharedAtmosphereSystem), typeof(SharedAtmosDebugOverlaySystem), typeof(GasEnumerator), Other = AccessPermissions.None)]
-        [DataField]
+        [DataField(customTypeSerializer: typeof(GasArraySerializer))]
         public float[] Moles = new float[Atmospherics.AdjustedNumberOfGases];
 
         public float this[int gas] => Moles[gas];

--- a/Resources/Prototypes/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/Atmospherics/reactions.yml
@@ -3,10 +3,8 @@
   priority: -2
   minimumTemperature: 373.149 # Same as Atmospherics.FireMinimumTemperatureToExist
   minimumRequirements: # In this case, same as minimum mole count.
-    - 0.01  # oxygen
-    - 0     # nitrogen
-    - 0     # carbon dioxide
-    - 0.01  # plasma
+    Oxygen: 0.01
+    Plasma: 0.01
   effects:
     - !type:PlasmaFireReaction {}
 
@@ -15,11 +13,8 @@
   priority: -1
   minimumTemperature: 373.149 # Same as Atmospherics.FireMinimumTemperatureToExist
   minimumRequirements: # In this case, same as minimum mole count.
-    - 0.01  # oxygen
-    - 0     # nitrogen
-    - 0     # carbon dioxide
-    - 0     # plasma
-    - 0.01  # tritium
+    Oxygen: 0.01
+    Tritium: 0.01
   effects:
     - !type:TritiumFireReaction {}
 
@@ -28,15 +23,8 @@
   priority: 1
   minimumTemperature: 23.15
   minimumRequirements:
-  - 0     # oxygen
-  - 0.01  # nitrogen
-  - 0     # carbon dioxide
-  - 0     # plasma
-  - 0     # tritium
-  - 0     # vapor
-  - 0     # ammonia
-  - 0     # n2o
-  - 0.01  # frezon
+    Nitrogen: 0.01
+    Frezon: 0.01
   effects:
   - !type:FrezonCoolantReaction {}
 
@@ -45,15 +33,9 @@
   priority: 2
   maximumTemperature: 73.15 # Cold tritium fire, basically.
   minimumRequirements:
-  - 0.01  # oxygen
-  - 0.01  # nitrogen
-  - 0     # carbon dioxide
-  - 0     # plasma
-  - 0.01  # tritium
-  - 0     # vapor
-  - 0     # ammonia
-  - 0     # n2o
-  - 0     # frezon
+    Oxygen: 0.01
+    Nitrogen: 0.01
+    Tritium: 0.01
   effects:
   - !type:FrezonProductionReaction {}
 
@@ -62,15 +44,8 @@
   priority: 2
   minimumTemperature: 323.149
   minimumRequirements:
-  - 0.01  # oxygen
-  - 0     # nitrogen
-  - 0     # carbon dioxide
-  - 0     # plasma
-  - 0     # tritium
-  - 0     # vapor
-  - 0.01  # ammonia
-  - 0     # n2o
-  - 0     # frezon
+    Oxygen: 0.01
+    Ammonia: 0.01
   effects:
   - !type:AmmoniaOxygenReaction {}
 
@@ -79,15 +54,7 @@
   priority: 0
   minimumTemperature: 850
   minimumRequirements:
-  - 0     # oxygen
-  - 0     # nitrogen
-  - 0     # carbon dioxide
-  - 0     # plasma
-  - 0     # tritium
-  - 0     # vapor
-  - 0     # ammonia
-  - 0.01  # n2o
-  - 0     # frezon
+    NitrousOxide: 0.01
   effects:
   - !type:N2ODecompositionReaction {}
 
@@ -96,12 +63,7 @@
 #  priority: 1
 #  maximumTemperature: 373.13 # Boiling point of water.
 #  minimumRequirements: # In this case, same as minimum mole count.
-#    - 0  # oxygen
-#    - 0  # nitrogen
-#    - 0  # carbon dioxide
-#    - 0  # plasma
-#    - 0  # tritium
-#    - 1  # water vapor
+#    WaterVapor: 1
 #  effects:
 #    - !type:WaterVaporReaction
 #      gas: 5

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -31,7 +31,7 @@
       # 31 minutes
       volume: 5
       moles:
-        - 2.051379050 # oxygen
+        Oxygen: 2.051379050 # oxygen
       temperature: 293.15
 
 - type: entity
@@ -45,7 +45,7 @@
       # 4 minutes
       volume: 0.66
       moles:
-        - 0.270782035 # oxygen
+        Oxygen: 0.270782035 # oxygen
       temperature: 293.15
 
 - type: entity
@@ -59,8 +59,7 @@
       # 4 minutes
       volume: 0.66
       moles:
-        - 0 # oxygen
-        - 0.270782035 # nitrogen
+        Nitrogen: 0.270782035 # nitrogen
       temperature: 293.15
 
 
@@ -75,7 +74,7 @@
       # 9 minutes
       volume: 1.5
       moles:
-        - 0.615413715 # oxygen
+        Oxygen: 0.615413715 # oxygen
       temperature: 293.15
 
 - type: entity
@@ -89,8 +88,7 @@
       # 9 minutes
       volume: 1.5
       moles:
-        - 0 # oxygen
-        - 0.615413715 # nitrogen
+        Nitrogen: 0.615413715 # nitrogen
       temperature: 293.15
 
 
@@ -105,7 +103,7 @@
       # 15 minutes
       volume: 2.5
       moles:
-        - 1.025689525 # oxygen
+        Oxygen: 1.025689525 # oxygen
       temperature: 293.15
 
 - type: entity
@@ -119,8 +117,7 @@
       # 15 minutes
       volume: 2.5
       moles:
-        - 0 # oxygen
-        - 1.025689525 # nitrogen
+        Nitrogen: 1.025689525 # nitrogen
       temperature: 293.15
 
 - type: entity
@@ -134,15 +131,9 @@
       # 4 minutes
       volume: 0.66
       moles:
-        - 0.270782035 # 95% oxygen
-        - 0 # nitrogen
-        - 0 # CO2
-        - 0 # plasma
-        - 0 # tritium
-        - 0 # water vapor
-        - 0 # ammonia
-        - 0.014251686 # 5% N2O
-        # 0.285033721       total 
+        Oxygen: 0.270782035 # 95% oxygen
+        NitrousOxide: 0.014251686 # 5% N2O
+        # 0.285033721       total
       temperature: 293.15
 
 - type: entity
@@ -156,8 +147,8 @@
       # 6 minutes due to output pressure
       volume: 5
       moles:
-        - 0.451303391 # 22% oxygen
-        - 1.600075659 # 78% nitrogen
+        Oxygen: 0.451303391 # 22% oxygen
+        Nitrogen: 1.600075659 # 78% nitrogen
         # 2.051379050       total
       temperature: 293.15
 
@@ -172,8 +163,7 @@
       # 31 minutes
       volume: 5
       moles:
-        - 0           # oxygen not included
-        - 2.051379050 # nitrogen
+        Nitrogen: 2.051379050 # nitrogen
       temperature: 293.15
 
 - type: entity
@@ -193,14 +183,8 @@
       # only 22 minutes due to pressure
       volume: 5
       moles:
-        - 1.435965335 # 70% oxygen
-        - 0 # nitrogen
-        - 0 # CO2
-        - 0 # plasma
-        - 0 # tritium
-        - 0 # water vapor
-        - 0 # ammonia
-        - 0.615413715 # 30% N2O
+        Oxygen: 1.435965335 # 70% oxygen
+        NitrousOxide: 0.615413715 # 30% N2O
         # 2.051379050       total
       temperature: 293.15
 
@@ -216,8 +200,5 @@
       # 6 minutes of agony
       volume: 5
       moles:
-        - 0           # oxygen
-        - 0           # nitrogen
-        - 0           # CO2
-        - 2.051379050 # plasma
+        Plasma: 2.051379050
       temperature: 293.15

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -108,8 +108,8 @@
       volume: 0.75
       temperature: 293.15
       moles:
-      - 0.153853429 # oxygen
-      - 0.153853429 # nitrogen
+        Oxygen: 0.153853429 # oxygen
+        Nitrogen: 0.153853429 # nitrogen
   - type: Item
     sprite: null
     size: Normal

--- a/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
@@ -77,9 +77,7 @@
         gasMixture:
           volume: 1000
           moles:
-            - 0 # oxygen
-            - 0 # nitrogen
-            - 340.5701689 # carbon dioxide
+            CarbonDioxide: 340.5701689 # carbon dioxide
           temperature: 373.15
   - type: Repairable
     doAfterDelay: 30 # you can heal the mothership core, but it takes a while

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -108,8 +108,8 @@
       volume: 5
       temperature: 293.15
       moles:
-        - 1.025689525 # oxygen
-        - 1.025689525 # nitrogen
+        Oxygen: 1.025689525 # oxygen
+        Nitrogen: 1.025689525 # nitrogen
 
 #Empty black
 - type: entity
@@ -143,8 +143,8 @@
       volume: 5
       temperature: 293.15
       moles:
-        - 1.025689525 # oxygen
-        - 1.025689525 # nitrogen
+        Oxygen: 1.025689525 # oxygen
+        Nitrogen: 1.025689525 # nitrogen
 
 #Empty captain
 - type: entity
@@ -183,8 +183,8 @@
       volume: 5
       temperature: 293.15
       moles:
-        - 1.025689525 # oxygen
-        - 1.025689525 # nitrogen
+        Oxygen: 1.025689525 # oxygen
+        Nitrogen: 1.025689525 # nitrogen
 
 #Empty mini
 - type: entity
@@ -223,8 +223,8 @@
       volume: 1.5
       temperature: 293.15
       moles:
-        - 0.307706858 # oxygen
-        - 0.307706858 # nitrogen
+        Oxygen: 0.307706858 # oxygen
+        Nitrogen: 0.307706858 # nitrogen
 
 #Empty security
 - type: entity
@@ -255,8 +255,8 @@
       volume: 1.5
       temperature: 293.15
       moles:
-      - 0.307706858 # oxygen
-      - 0.307706858 # nitrogen
+        Oxygen: 0.307706858 # oxygen
+        Nitrogen: 0.307706858 # nitrogen
 
 #Empty void
 - type: entity
@@ -290,8 +290,8 @@
       volume: 5
       temperature: 293.15
       moles:
-        - 1.025689525 # oxygen
-        - 1.025689525 # nitrogen
+        Oxygen: 1.025689525 # oxygen
+        Nitrogen: 1.025689525 # nitrogen
 
 # Infinite jetpack
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -569,8 +569,8 @@
     air:
       volume: 1000
       moles: # Target is 3117.84 mols total for filling 30 tiles (goal is 101.325 kPa @ 20C)
-      - 654.7464 # oxygen
-      - 2463.0936 # nitrogen
+        Oxygen: 654.7464 # oxygen
+        Nitrogen: 2463.0936 # nitrogen
       temperature: 293.15
   - type: StaticPrice
     price: 350

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -121,9 +121,7 @@
         gasMixture:
           volume: 1000
           moles:
-          - 0 # oxygen
-          - 0 # nitrogen
-          - 340.5701689 # carbon dioxide
+            CarbonDioxide: 340.5701689 # carbon dioxide
           temperature: 373.15
   - type: Explosive
     explosionType: Default

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -128,16 +128,6 @@
     - type: GasCanister
       gasMixture:
         volume: 1500
-        moles: # List of gasses for easy reference
-          - 0 # oxygen
-          - 0 # nitrogen
-          - 0 # CO2
-          - 0 # Plasma
-          - 0 # Tritium
-          - 0 # Water vapor
-          - 0 # Ammonia
-          - 0 # N2O
-          - 0 # Frezon
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -178,8 +168,8 @@
     gasMixture:
       volume: 1500
       moles:
-      - 581.56 # oxygen 21%
-      - 2187.79 # nitrogen 79%
+        Oxygen: 581.56 # oxygen 21%
+        Nitrogen: 2187.79 # nitrogen 79%
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -218,7 +208,7 @@
     gasMixture:
       volume: 1500
       moles:
-      - 2769.36 # oxygen
+        Oxygen: 2769.36 # oxygen
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -254,7 +244,7 @@
     gasMixture:
       volume: 1500
       moles:
-        - 18710.71051 # oxygen
+        Oxygen: 18710.71051 # oxygen
       temperature: 72
   - type: AccessReader
     access: [["Atmospherics"]]
@@ -272,8 +262,7 @@
       gasMixture:
         volume: 1500
         moles:
-          - 0 # oxygen
-          - 2769.36 # nitrogen
+          Nitrogen: 2769.36 # nitrogen
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -309,8 +298,7 @@
     gasMixture:
       volume: 1500
       moles:
-        - 0 # oxygen
-        - 18710.71051 # nitrogen
+        Nitrogen: 18710.71051 # nitrogen
       temperature: 72
   - type: AccessReader
     access: [["Atmospherics"]]
@@ -328,9 +316,7 @@
       gasMixture:
         volume: 1500
         moles:
-          - 0 # oxygen
-          - 0 # nitrogen
-          - 2769.36 # CO2
+          CarbonDioxide: 2769.36 # CO2
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -368,9 +354,7 @@
     gasMixture:
       volume: 1500
       moles:
-        - 0 # oxygen
-        - 0 # nitrogen
-        - 18710.71051 # CO2
+        CarbonDioxide: 18710.71051 # CO2
       temperature: 72
   - type: AccessReader
     access: [["Atmospherics"]]
@@ -388,10 +372,7 @@
       gasMixture:
         volume: 1500
         moles:
-          - 0 # oxygen
-          - 0 # nitrogen
-          - 0 # carbon dioxide
-          - 2769.36 # plasma
+          Plasma: 2769.36 # plasma
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -432,11 +413,7 @@
       gasMixture:
         volume: 1500
         moles:
-          - 0 # oxygen
-          - 0 # nitrogen
-          - 0 # CO2
-          - 0 # Plasma
-          - 2769.36 # Tritium
+          Tritium: 2769.36 # Tritium
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -477,12 +454,7 @@
       gasMixture:
         volume: 1500
         moles:
-          - 0 # oxygen
-          - 0 # nitrogen
-          - 0 # CO2
-          - 0 # Plasma
-          - 0 # Tritium
-          - 2769.36 # Water vapor
+          WaterVapor: 2769.36 # Water vapor
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -521,13 +493,7 @@
       gasMixture:
         volume: 1500
         moles:
-          - 0 # oxygen
-          - 0 # nitrogen
-          - 0 # CO2
-          - 0 # Plasma
-          - 0 # Tritium
-          - 0 #  Water vapor
-          - 2769.36 # Ammonia
+          Ammonia: 2769.36 # Ammonia
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -568,14 +534,7 @@
       gasMixture:
         volume: 1500
         moles:
-          - 0 # oxygen
-          - 0 # nitrogen
-          - 0 # CO2
-          - 0 # Plasma
-          - 0 # Tritium
-          - 0 #  Water vapor
-          - 0 # Ammonia
-          - 2769.36 # N2O
+          NitrousOxide: 2769.36 # N2O
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -616,15 +575,7 @@
     gasMixture:
       volume: 1500
       moles:
-      - 0 # oxygen
-      - 0 # nitrogen
-      - 0 # CO2
-      - 0 # Plasma
-      - 0 # Tritium
-      - 0 # Water vapor
-      - 0 # Ammonia
-      - 0 # N2O
-      - 2769.36 # Frezon
+        Frezon: 2769.36 # Frezon
       temperature: 293.15
   - type: Destructible
     thresholds:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
have you ever written:
```yml
moles:
- 0
- 0
- 0
- 0
- 0
- 1
```
and wondered: what the fuck? 

Now, you can just write it as:
```yml
moles:
  Ammonia: 1
```

The main appeal of this is that it decouples the yaml encoding of gases from their integer values in the code. This is nice because it means that you can actually just shuffle around gases and add new ones without explicitly breaking everything. It also means that if you remove a gas, you only need to remove relevant lines and not have to reshuffle all values in the list.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a new GasArraySerializer which can be used for any situation where we are reading/writing molar gas values as an array of floats. Currently is only used for `GasMixture` and `GasReactionPrototype`. System is backwards compatible so you do not need to immediately update all usages on your repo if you're pulling this.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Gas values on `GasMixture` and `GasReactionPrototype` can now be specified as a dictionary of `Gas` enums to `float`s. Note that the old system of using `float[]` is still compatible.

OLD:
```yml
moles:
- 0.26
- 0.14
```

NEW:
```yml
moles:
  Oxygen: 0.26
  Nitrogen: 0.14
```

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
