### PR TITLE
Makes droppers printable by autolathes and medfabs

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -16,6 +16,7 @@
   - PillCanister
   - HandLabeler
   - BaseChemistryEmptyVial
+  - Dropper
 
 - type: latheRecipePack
   parent: BasicChemistryStatic

--- a/Resources/Prototypes/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/Recipes/Lathes/chemistry.yml
@@ -31,10 +31,9 @@
 - type: latheRecipe
   id: Dropper
   result: Dropper
-  completetime: 2
+  completetime: .8
   materials:
-    Glass: 200
-    Plastic: 100
+    Plastic: 50
 
 - type: latheRecipe
   id: Syringe


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made droppers printable by autolathes and medfabs alongside lessening preexisting time and material requirements

## Why / Balance
Easier access to droppers for chemists and doctors makes more precise measurements/dosages respectively easier

## Technical details
Minor recipe file changes, yaml only

## Media
<img width="1071" height="230" alt="b96bf7c3a2853c0a93103321455f37be" src="https://github.com/user-attachments/assets/e84de9c6-3d13-44fa-b380-86e8926e5bb4" />
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
There shouldn't be any from this

**Changelog**
- add: Added the ability for droppers to be printed via autolathes and medfabs
-->