### PR TITLE
Update Function Calls To SharedAbsorbentSystem From Obsolete

### DIFF
--- a/Content.Shared/Fluids/SharedAbsorbentSystem.cs
+++ b/Content.Shared/Fluids/SharedAbsorbentSystem.cs
@@ -175,9 +175,10 @@ public abstract class SharedAbsorbentSystem : EntitySystem
         }
 
         // Prioritize transferring non-evaporatives if absorbent has any
-        var contaminants = SolutionContainer.SplitSolutionWithout(absorbentSoln,
+        var contaminants = SolutionContainer.SplitSolutionWithout(
+            absorbentSoln,
             transferAmount,
-            Puddle.GetAbsorbentReagents(absorbentSoln.Comp.Solution));
+            Puddle.GetAbsorbentReagentPrototypes(absorbentSoln.Comp.Solution));
 
         SolutionContainer.TryAddSolution(refillableSoln,
             contaminants.Volume > 0
@@ -196,11 +197,10 @@ public abstract class SharedAbsorbentSystem : EntitySystem
         EntityUid user,
         EntityUid target)
     {
-        var reagentIds = Puddle.GetAbsorbentReagents(absorbentSoln.Comp.Solution)
-                .Select(s => new ProtoId<ReagentPrototype>(s))
-                .ToArray();
-        var contaminantsFromAbsorbent = SolutionContainer.SplitSolutionWithout(absorbentSoln,
-            absorbEnt.Comp.PickupAmount, reagentIds);
+        var contaminantsFromAbsorbent = SolutionContainer.SplitSolutionWithout(
+            absorbentSoln,
+            absorbEnt.Comp.PickupAmount,
+            Puddle.GetAbsorbentReagentPrototypes(absorbentSoln.Comp.Solution));
 
         var absorbentSolution = absorbentSoln.Comp.Solution;
         if (contaminantsFromAbsorbent.Volume == FixedPoint2.Zero
@@ -310,10 +310,9 @@ public abstract class SharedAbsorbentSystem : EntitySystem
 
             var transferMax = absorber.PickupAmount;
             var transferAmount = available > transferMax ? transferMax : available;
-            var reagentIds = Puddle.GetAbsorbentReagents(absorberSolution)
-                .Select(s => new ProtoId<ReagentPrototype>(s))
-                .ToArray();
-            puddleSplit = puddleSolution.SplitSolutionWithout(transferAmount, reagentIds);
+
+            puddleSplit = puddleSolution.SplitSolutionWithout(transferAmount,
+                Puddle.GetAbsorbentReagentPrototypes(puddleSolution));
             var absorberSplit =
                 absorberSolution.SplitSolutionWithOnly(puddleSplit.Volume,
                     Puddle.GetAbsorbentReagents(absorberSolution));
@@ -331,10 +330,9 @@ public abstract class SharedAbsorbentSystem : EntitySystem
         else
         {
             // Note: arguably shouldn't this get all solutions?
-            var reagentIds = Puddle.GetAbsorbentReagents(puddleSolution)
-                .Select(s => new ProtoId<ReagentPrototype>(s))
-                .ToArray();
-            puddleSplit = puddleSolution.SplitSolutionWithout(absorber.PickupAmount, reagentIds);
+            puddleSplit = puddleSolution.SplitSolutionWithout(
+                absorber.PickupAmount,
+                Puddle.GetAbsorbentReagentPrototypes(puddleSolution));
             // Despawn if we're done
             if (puddleSolution.Volume == FixedPoint2.Zero)
             {

--- a/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
@@ -1,6 +1,8 @@
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+using System.Linq;
 
 namespace Content.Shared.Fluids;
 
@@ -26,6 +28,14 @@ public abstract partial class SharedPuddleSystem
                 absorbentReagents.Add(solProto.ID);
         }
         return absorbentReagents.ToArray();
+    }
+
+    public ProtoId<ReagentPrototype>[] GetAbsorbentReagentPrototypes(Solution solution)
+    {
+        return solution.GetReagentPrototypes(_prototypeManager).Keys
+            .Where(solProto => solProto.Absorbent)
+            .Select(solProto => new ProtoId<ReagentPrototype>(solProto.ID))
+            .ToArray();
     }
 
     public bool CanFullyEvaporate(Solution solution)


### PR DESCRIPTION
## About the PR
Updated three call sites to obsolete function 'SplitSolutionWithout' to the function with an updated signature.

## Why / Balance
Code cleanup. Migrating from a function marked as obsolete to the updated version.

## Technical details
 Instead of specifying excludeReagents as an array of strings, they are instead passed as an array of ProtoId\<ReagentPrototype\>[].

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No breaking changes.

**Changelog**
No user-facing changes.