### PR TITLE
Make engineering cyborgs able to pick up power cells

### DIFF
--- a/Resources/Locale/en-US/robotics/borg_modules.ftl
+++ b/Resources/Locale/en-US/robotics/borg_modules.ftl
@@ -12,3 +12,4 @@ borg-slot-instruments-empty = Instruments
 borg-slot-beakers-empty = Beakers
 borg-slot-inflatable-door-empty = Inflatable Door
 borg-slot-inflatable-wall-empty = Inflatable Wall
+borg-slot-powercells-empty = Power Cells

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -692,6 +692,12 @@
         whitelist:
           components:
           - FloorTile
+    - hand:
+        emptyRepresentative: PowerCellSmall
+        emptyLabel: borg-slot-powercells-empty
+        whitelist:
+          components:
+          - PowerCell
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: construction-module }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Engineering cyborgs are able to pick up power cells in a dedicated hand slot in the starter construction module.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #40056

## Technical details
<!-- Summary of code changes for easier review. -->
Added a hand slot in the borg modules yml for power cells.
Added "Power Cells" text appear when selecting the hand (edited the ftl file).

## Media

https://github.com/user-attachments/assets/a0d91e41-016f-4554-a5fc-32d24b152265



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Engineering cyborgs can now pick up power cells
