### PR TITLE
Fix QM Golden Knuckledusters not being a objective

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -18,6 +18,7 @@
     MagbootsStealObjective: 1
     CorgiMeatStealObjective: 1
     ClipboardStealObjective: 1
+    KnuckleDustersStealObjective: 1
     CaptainGunStealObjective: 0.5
     CaptainJetpackStealObjective: 0.5
     HandTeleporterStealObjective: 0.5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed bug with QM Golden Knuckledusters not being a Syndicate objective. Originally intended in PR https://github.com/space-wizards/space-station-14/pull/33470.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Originally intended in PR https://github.com/space-wizards/space-station-14/pull/33470. Adds variety to Syndicate objectives with a similar difficulty compared to other steal objectives like the RD teleporter & Digiboard. Has the same weight as RD teleporter & Digiboard due to being similar in the difficulty of obtaining.

## Technical details
<!-- Summary of code changes for easier review. -->
One line of YAML to add the objective code already merged in https://github.com/space-wizards/space-station-14/pull/33470 as a obtainable objective with weight.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="406" height="552" alt="image" src="https://github.com/user-attachments/assets/7d868ee9-bc14-486b-8911-27a4abfa791a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [Y ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [Y ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: QM Golden Knuckledusters can be properly obtained as a Syndicate steal objective 
