### PR TITLE
Add 2.25 second delay to scurret petting

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
@@ -61,6 +61,7 @@
     proto: moth
   - type: InteractionPopup
     successChance: 0.99 # Imagine not being allowed to headpat a scurret, chat
+    interactDelay: 2.25
     interactSuccessString: petting-success-scurret
     interactFailureString: petting-failure-scurret
     interactSuccessSpawn: EffectHearts


### PR DESCRIPTION
## About the PR
Added a 2.25-second delay to petting scurrets.

## Why / Balance
Addressing issue #40078 regarding scurret petting noise spam.

## Technical details
Added `interactDelay: 2.25` to scurret.yml MobBaseScurret.

## Media
Scurret pet limit (I am spam-clicking) - This shows a 3-second interaction delay:


https://github.com/user-attachments/assets/eb01e99b-c0de-4c88-b14f-66e870f94960



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Spam-petting scurrets will no longer work as fast as before.

**Changelog**
:cl:
- tweak: Scurret petting rate lowered to once per 2.25 seconds
