### PR TITLE
Give inflatable walls the DeltaPressure component

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/inflatable_wall.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/inflatable_wall.yml
@@ -35,6 +35,11 @@
     disassembleTime: 3
   - type: InflatableSafeDisassembly
   - type: Airtight
+  - type: DeltaPressure
+    minPressure: 1000
+    minPressureDelta: 750
+    scalingType: Linear
+    scalingPower: 0.0005
   - type: Transform
     anchored: true
   placement:
@@ -85,3 +90,8 @@
   - type: InflatableSafeDisassembly
   - type: Occluder
     enabled: false
+  - type: DeltaPressure
+    minPressure: 1000
+    minPressureDelta: 750
+    scalingType: Linear
+    scalingPower: 0.0005


### PR DESCRIPTION
## About the PR
Give inflatable walls the DeltaPressure component. Component parameters are the same as windows.

## Why / Balance
Notafet wasn't kidding when they said they would be merging my PR later in the day and i was eepy and was putting off fixing this until later

## Technical details
added comp

## Media
i tested it, two issues:
- no sound on destruction
- no visual feedback that its being destroyed

no i dont want to fix it ill create a seperate issue

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- fix: Inflatable walls and airlocks now actually take Delta-Pressure damage.
