### PR TITLE
Can't crawl over counters

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -59,6 +59,9 @@ public enum CollisionGroup
     TableMask = Impassable | MidImpassable,
     TableLayer = MidImpassable,
 
+    // Tables that SmallMobs can't go under
+    CounterLayer = MidImpassable | LowImpassable,
+
     // Tabletop machines, windoors, firelocks
     TabletopMachineMask = Impassable | HighImpassable,
     // Tabletop machines

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
@@ -57,4 +57,4 @@
         mask:
         - TableMask
         layer:
-        - TableLayer
+        - CounterLayer

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -77,7 +77,7 @@
         mask:
         - TableMask
         layer:
-        - TableLayer
+        - CounterLayer
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Wood
@@ -201,7 +201,7 @@
 
 - type: entity
   id: TableReinforced
-  parent: TableBase
+  parent: CounterBase
   name: reinforced table
   description: A square piece of metal standing on four metal legs. Extra robust.
   components:
@@ -471,7 +471,7 @@
 
 - type: entity
   id: TableBrass
-  parent: TableBase
+  parent: CounterBase
   name: brass table
   description: A shiny, corrosion resistant brass table. Steampunk!
   components:
@@ -615,7 +615,7 @@
 
 - type: entity
   id: TableStone
-  parent: TableBase
+  parent: CounterBase
   name: stone table
   description: Literally the sturdiest thing you have ever seen.
   components:
@@ -675,7 +675,7 @@
       collection: FootstepCarpet
 
 - type: entity
-  parent: TableBase
+  parent: CounterBase
   id: TableXeno
   name: xeno table
   description: I wouldn't put the silverware on it.

--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -105,7 +105,7 @@
           mask:
             - TableMask
           layer:
-            - TableLayer
+            - CounterLayer
     - type: TimedDespawn
       lifetime: 180
     - type: PointLight

--- a/Resources/Prototypes/Entities/Structures/conveyor.yml
+++ b/Resources/Prototypes/Entities/Structures/conveyor.yml
@@ -29,10 +29,7 @@
           - 0.50,0.50
           - -0.50,0.50
         layer:
-        - Impassable
-        - MidImpassable
-        - LowImpassable
-        - DoorPassable
+        - ConveyorMask
         hard: False
   - type: Conveyor
   - type: DeviceNetwork


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Separates Counters and Tables and disables crawling over counters specifically. I determined something was a counter if the sprite looked like you couldn't crawl underneath. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Prevents crawling under something that is solid. 

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new fixture preset, added it to some things.
Also added it to sec barrier, 1984.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Additional notes
I have an alternative PR available that disables crawling under all tables but I haven't opened it since I was told this would be preferred.

In addition I noticed we have an usused fixture layer "DoorPassable" that only collides with the singularity (Which collides with basically everything) that we could reuse in case we want to tweak things a bit more such that mice can go under sec barriers/tables but not crawling players. 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: You can no longer crawl under counters, or tables without space underneath.

