### PR TITLE
Auto-enable/disable auto mode on air alarms

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -232,7 +232,10 @@ public sealed class AirAlarmSystem : EntitySystem
     private void OnClose(EntityUid uid, AirAlarmComponent component, BoundUIClosedEvent args)
     {
         if (!_ui.IsUiOpen(uid, SharedAirAlarmInterfaceKey.Key))
+        {
             RemoveActiveInterface(uid);
+            component.AutoMode = true; // leaving the panel restores auto mode
+        }
     }
 
     private void OnInit(EntityUid uid, AirAlarmComponent comp, ComponentInit args)
@@ -298,6 +301,7 @@ public sealed class AirAlarmSystem : EntitySystem
             }
 
             _adminLogger.Add(LogType.AtmosDeviceSetting, LogImpact.Medium, $"{ToPrettyString(args.Actor)} changed {ToPrettyString(uid)} mode to {args.Mode}");
+            component.AutoMode = false; // setting a mode manually exits auto mode
             SetMode(uid, addr, args.Mode, false);
         }
         else


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
When setting a mode manually, auto remains enabled and confusion ensues when auto mode sets a different mode than what the atmos tech set, causing the air alarm to feel like it's doing something weird. So just disable auto mode when a mode is manually set.

While here, also automatically re-enable auto mode once the last open air alarm UI is closed. This simulates a pull station where an atmos tech has to be at the station pulling on a lever in order to keep the manual mode engaged. This makes sense, as most air alarm override modes are "dangerous" and shouldn't be left in that state.

## Why / Balance
Discussion [on Discord](https://discord.com/channels/310555209753690112/1404082000054456360/1412699168149078108).

This also increases the visibility of air alarm sabotage by requiring the saboteur to stand next to the air alarm.

## Media

Shown with two side-by-side client to shake out weird network sync issues:

https://github.com/user-attachments/assets/d48a0e22-46f4-4b9f-8814-e69c98c18575

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: notafet
- tweak: Air alarms now revert to automatic control when not being operated manually.