### PR TITLE
Added new light tube prototypes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -254,7 +254,7 @@
 - type: entity
   parent: LightTube
   name: halogen light tube
-  id: LightTubeHalogen
+  id: HalogenLightTube
   description: A halogen light fixture.
   components:
   - type: LightBulb

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -252,6 +252,19 @@
     PowerUse: 10
 
 - type: entity
+  parent: LightTube
+  name: halogen light tube
+  id: LightTubeHalogen
+  description: A halogen light fixture.
+  components:
+  - type: LightBulb
+    color: "#FFBF80" # halogens are orange-2500K temp
+    lightEnergy: 0.9
+    lightRadius: 10
+    lightSoftness: 1
+    PowerUse: 10
+
+- type: entity
   suffix: Broken
   parent: BaseLightTube
   name: fluorescent light tube

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -183,7 +183,7 @@
   parent: Poweredlight
   components:
   - type: PoweredLight
-    hasLampOnSpawn: LightTubeHalogen
+    hasLampOnSpawn: HalogenLightTube
   - type: PointLight
     radius: 10
     energy: 0.9

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -157,6 +157,44 @@
         Heat: 2
     popupText: powered-light-component-burn-hand
 
+- type: entity
+  id: PoweredlightOld
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  suffix: Old
+  parent: Poweredlight
+  components:
+  - type: PoweredLight
+    hasLampOnSpawn: LightTubeOld
+  - type: PointLight
+    radius: 10
+    energy: 0.5
+    softness: 1
+    color: "#FFDABB"
+  - type: DamageOnInteract
+    damage:
+      types:
+        Heat: 2
+    popupText: powered-light-component-burn-hand
+
+- type: entity
+  id: PoweredlightHalogen
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  suffix: Halogen
+  parent: Poweredlight
+  components:
+  - type: PoweredLight
+    hasLampOnSpawn: LightTubeHalogen
+  - type: PointLight
+    radius: 10
+    energy: 0.9
+    softness: 1
+    color: "#FFBF80"
+  - type: DamageOnInteract
+    damage:
+      types:
+        Heat: 2
+    popupText: powered-light-component-burn-hand
+
 #LED lights
 - type: entity
   id: PoweredlightLED

--- a/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
@@ -20,6 +20,7 @@
   - LedLightTube
   - SodiumLightTube
   - ExteriorLightTube
+  - HalogenLightTube
   - LightBulb
   - LedLightBulb
   - DimLightBulb

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -38,6 +38,11 @@
 
 - type: latheRecipe
   parent: BaseLightRecipe
+  id: HalogenLightTube
+  result: HalogenLightTube
+
+- type: latheRecipe
+  parent: BaseLightRecipe
   id: ExteriorLightTube
   result: ExteriorLightTube
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added two new prototypes, the old light tube, which uses the existing old light tube, and the halogen light tube, a bright yellow/orange light intended to be an intermediary between the small and intense warm light, and the overbright sodium light.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
While lighting elkridge, and elkridge 2, i needed a light that had an off white yellow tint while being of comparable brightness to the default light tube.
## Technical details
<!-- Summary of code changes for easier review. -->
Just YML, the halogen light tube is craftable in the autolathe at the same cost as any other light
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
(Clockwise from the top: Warm light, Normal light, Sodium Light, Halogen Light)
<img width="1277" height="892" alt="lightsdemo" src="https://github.com/user-attachments/assets/893baf62-1c02-4bdc-8c93-76014894b5ea" />
Halogen Demo
<img width="626" height="874" alt="halogendemo" src="https://github.com/user-attachments/assets/31df7e07-8043-4aa9-a580-fa73
Normal for comparison
<img width="574" height="878" alt="normaldemo" src="https://github.com/user-attachments/assets/ea943929-a899-4397-8eb2-be679766644a" />
c3410d02" />
Sodium for comparison (ow bright)
<img width="664" height="897" alt="sodiumdemo" src="https://github.com/user-attachments/assets/e78b105c-ce3a-496a-96e6-0979796bb250" />
Warm for comparison (too dark)
<img width="631" height="885" alt="warmdemo" src="https://github.com/user-attachments/assets/03385bb0-b0f5-42dd-b2ed-10fc29e85f74" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added warm Halogen light tubes, craftable in an Autolathe

