### PR TITLE
Fix DeltaPressure damage not capping beyond a certain pressure

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.DeltaPressure.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.DeltaPressure.cs
@@ -230,7 +230,8 @@ public sealed partial class AtmosphereSystem
     private void PerformDamage(Entity<DeltaPressureComponent> ent, float pressure, float deltaPressure)
     {
         var maxPressure = Math.Max(pressure - ent.Comp.MinPressure, deltaPressure - ent.Comp.MinPressureDelta);
-        var appliedDamage = ScaleDamage(ent, ent.Comp.BaseDamage, maxPressure);
+        var maxPressureCapped = Math.Min(maxPressure, ent.Comp.MaxEffectivePressure);
+        var appliedDamage = ScaleDamage(ent, ent.Comp.BaseDamage, maxPressureCapped);
 
         _damage.TryChangeDamage(ent, appliedDamage, ignoreResistances: true, interruptsDoAfters: false);
         ent.Comp.IsTakingDamage = true;


### PR DESCRIPTION
## About the PR
DeltaPressure damage now caps out beyond a certain pressure

## Why / Balance
Originally intended so that scaling damage types (linear) don't cause windows to break literally instantly when being exposed to absurd pressures in one second so Atmospherics at least has a clue as to what broke the pane.

## Technical details
When I refactored the damage logic post-review I forgot the limiter. One of those things.

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- fix: Fixed Atmospherics Delta-Pressure damage not capping damage beyond a certain pressure for applicable windows.
