### PR TITLE
parallelize GasTileOverlaySystem.UpdateOverlayData

### DIFF
--- a/Content.Client/Atmos/EntitySystems/GasTileOverlaySystem.cs
+++ b/Content.Client/Atmos/EntitySystems/GasTileOverlaySystem.cs
@@ -7,12 +7,14 @@ using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Shared.GameStates;
+using Robust.Shared.Threading;
 
 namespace Content.Client.Atmos.EntitySystems
 {
     [UsedImplicitly]
     public sealed class GasTileOverlaySystem : SharedGasTileOverlaySystem
     {
+        [Dependency] private readonly IParallelManager _parallelManager = default!;
         [Dependency] private readonly IResourceCache _resourceCache = default!;
         [Dependency] private readonly IOverlayManager _overlayMan = default!;
         [Dependency] private readonly SpriteSystem _spriteSys = default!;

--- a/Content.Shared/Atmos/EntitySystems/SharedGasTileOverlaySystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedGasTileOverlaySystem.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Atmos.Prototypes;
 using Content.Shared.CCVar;
@@ -5,6 +6,7 @@ using Robust.Shared.Configuration;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
 
 namespace Content.Shared.Atmos.EntitySystems
 {
@@ -103,10 +105,18 @@ namespace Content.Shared.Atmos.EntitySystems
             args.State = new GasTileOverlayDeltaState(data, new(component.Chunks.Keys));
         }
 
+        /// <summary>
+        /// Converts a (1-dimensional) tile index to that of it's corresponding gas-tile-overlay chunk.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int TileIndexToChunk(int index)
+            => index >= 0 ? index / ChunkSize : (index - (ChunkSize - 1)) / ChunkSize;
+
+        /// <summary>
+        /// Gets the indices of a gas-tile-overlay chunk corresponding to the given indices.
+        /// </summary>
         public static Vector2i GetGasChunkIndices(Vector2i indices)
-        {
-            return new((int) MathF.Floor((float) indices.X / ChunkSize), (int) MathF.Floor((float) indices.Y / ChunkSize));
-        }
+            => new(TileIndexToChunk(indices.X), TileIndexToChunk(indices.Y));
 
         [Serializable, NetSerializable]
         public readonly struct GasOverlayData : IEquatable<GasOverlayData>


### PR DESCRIPTION
## About the PR
title, made the method use an IParallelRobustJob executed on every grid

## Why / Balance
there was a TODO for it and it seemed rather reasonable

## Technical details
used new job for it
i didn't know what i should put for batchsize so i just set it to 4

changed implementation of `SharedGasTileOverlaySystem.GetGasChunkIndices` because it looked odd with that approach, it still does the same thing

## Media

blur still works
<img height="250" alt="image" src="https://github.com/user-attachments/assets/328b0ebc-c17a-44f0-a254-8a606c4486dc" />

fire still works
<img height="250" alt="image" src="https://github.com/user-attachments/assets/a39241cc-d2b6-45d2-9857-2da097477706" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

