### PR TITLE
fix two warnings in integration tests

### DIFF
--- a/Content.IntegrationTests/Tests/ContrabandTest.cs
+++ b/Content.IntegrationTests/Tests/ContrabandTest.cs
@@ -27,7 +27,7 @@ public sealed class ContrabandTest
                     if (!proto.TryGetComponent<ContrabandComponent>(out var contraband, componentFactory))
                         continue;
 
-                    Assert.That(protoMan.TryIndex(contraband.Severity, out var severity, false),
+                    Assert.That(protoMan.Resolve(contraband.Severity, out var severity),
                         @$"{proto.ID} has a ContrabandComponent with a unknown severity.");
 
                     if (!severity.ShowDepartmentsAndJobs)

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -266,7 +266,7 @@ namespace Content.IntegrationTests.Tests
                     var protoId = yamlEntity["proto"].AsString();
 
                     // This doesn't properly handle prototype migrations, but thats not a significant issue.
-                    if (!protoManager.TryIndex(protoId, out var proto, false))
+                    if (!protoManager.Resolve(protoId, out var proto))
                         continue;
 
                     Assert.That(!proto.Categories.Contains(dnmCategory),
@@ -333,7 +333,7 @@ namespace Content.IntegrationTests.Tests
                 MapId mapId;
                 try
                 {
-                    var opts = DeserializationOptions.Default with {InitializeMaps = true};
+                    var opts = DeserializationOptions.Default with { InitializeMaps = true };
                     ticker.LoadGameMap(protoManager.Index<GameMapPrototype>(mapProto), out mapId, opts);
                 }
                 catch (Exception ex)
@@ -440,7 +440,7 @@ namespace Content.IntegrationTests.Tests
 #nullable enable
             while (queryPoint.MoveNext(out T? comp, out var xform))
             {
-                var spawner = (ISpawnPoint) comp;
+                var spawner = (ISpawnPoint)comp;
 
                 if (spawner.SpawnType is not SpawnPointType.LateJoin
                 || xform.GridUid == null


### PR DESCRIPTION
## About the PR
I'm running integration tests at the moment and the warnings are spamming my console.

## Why / Balance
clean code is happy code

## Technical details
`TryIndex` without a suppressed warning is deprecated. We have `Resolve` for that now which is doing exactly the same.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
no cl no fun
