### PR TITLE
Fix grapple's rope disappears due to PVS

### DIFF
--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
+using Robust.Shared.GameStates;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
@@ -32,6 +33,7 @@ public abstract class SharedGrapplingGunSystem : VirtualController
     [Dependency] private readonly SharedJointSystem _joints = default!;
     [Dependency] private readonly SharedGunSystem _gun = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedPvsOverrideSystem _pvs = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
 
@@ -74,6 +76,10 @@ public abstract class SharedGrapplingGunSystem : VirtualController
             visuals.Sprite = component.RopeSprite;
             visuals.Target = uid;
             Dirty(shotUid.Value, visuals);
+
+            // Prevent the grapple's rope from disappearing once it leaves PVS.
+            // Global instead of per-session to allow other players to also see the rope.
+            _pvs.AddGlobalOverride(shotUid.Value);
         }
 
         TryComp<AppearanceComponent>(uid, out var appearance);

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
+using Robust.Shared.GameStates;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
@@ -32,6 +33,7 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
     [Dependency] private SharedJointSystem _joints = default!;
     [Dependency] private SharedGunSystem _gun = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
+    [Dependency] private SharedPvsOverrideSystem _pvs = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedContainerSystem _container = default!;
 
@@ -74,6 +76,13 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
             visuals.Sprite = component.RopeSprite;
             visuals.Target = uid;
             Dirty(shotUid.Value, visuals);
+
+            // Prevent the grapple's rope from disappearing once it leaves PVS.
+            // Global instead of per-session to allow other players to also see the rope.
+            // TODO: global PVS override should be removed once a better alternative exists
+            _pvs.AddGlobalOverride(shotUid.Value);
+            // Include the gun so other clients know the position of the entity at other end of the rope.
+            _pvs.AddGlobalOverride(uid);
         }
 
         TryComp<AppearanceComponent>(uid, out var appearance);
@@ -144,6 +153,9 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         grapple.Comp.Projectile = null;
         DirtyField(grapple.Owner, grapple.Comp, nameof(GrapplingGunComponent.Projectile));
         _gun.ChangeBasicEntityAmmoCount(grapple.Owner, 1);
+
+        // TODO: global PVS override should be removed once a better alternative exists
+        _pvs.RemoveGlobalOverride(grapple.Owner);
     }
 
     private void OnGunActivate(EntityUid uid, GrapplingGunComponent component, ActivateInWorldEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

The grappling gun's hook projectile currently disappears when it moves too far away from the player. This PR fixes it by forcing it to always be sent to everyone.

Closes #39353

## Why / Balance

The rope disappearing when shooting a hook off into space is a very confusing player experience. This is further compounded by the lack of feedback when it finally embeds in something (I'm working on improving this, but ran into some issues so that PR will have to wait).

This fix also allows players to understand that another player or a grappling gun on the ground is currently attached.

## Technical details

The hook projectile gets added to PVS overrides, effectively making it always visible to everyone.

This fix does leak the player's (well, grappling gun's) position to every client, but as far as I can tell this is the least intrusive option we currently have.

## Media

(Imagine the rope not disappearing after it moves too far.)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: opl
- fix: The grappling gun's rope no longer disappears when its hook is too far away.