### PR TITLE
Fix resin windows inheriting wrong dP values

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/xenoresin.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/xenoresin.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: Window
+  parent: ReinforcedWindow
   id: XenoResinWindow
   name: resin window
   description: Transparent and hardened, yet slightly sticky to the touch. Slightly stronger than a normal reinforced window.
@@ -9,16 +9,6 @@
     sprite: Structures/Windows/xeno_resin.rsi
   - type: Icon
     sprite: Structures/Windows/xeno_resin.rsi
-  - type: Repairable
-    fuelCost: 10
-    doAfterDelay: 2
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: RGlass
-  - type: RCDDeconstructable
-    cost: 6
-    delay: 6
-    fx: EffectRCDDeconstruct6
   - type: Destructible
     thresholds:
     - trigger:
@@ -46,10 +36,6 @@
         acts: [ "Destruction" ]
   - type: IconSmooth
     base: xwindow
-  - type: Construction
-    graph: Window
-    node: reinforcedWindow
-  - type: Appearance
   - type: DamageVisuals
     thresholds: [5, 10, 20]
     damageDivisor: 4


### PR DESCRIPTION
## About the PR
This PR makes resin windows inherit the dP properties of the reinforced window

They had greater strength than a reinforced window but inherited from the regular non-reinforced window.

Slam commented that it was probably just an oversight.

## Why / Balance
Makes it so that the gas chamber windows on Exo don't explode into a million pieces on roundstart

Gas storage chambers cap out at 9,000 kPa realistically due to the air injector but hot air could potentially screw you over. But that's a different issue.

## Technical details
changed parent

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- fix: Resin windows (exo windows) now inherit Delta-Pressure damage values and pressure thresholds from reinforced windows.
