### PR TITLE
Atmospherics Delta-Pressure initial perf improvements

### DIFF
--- a/Content.Server/Atmos/Components/DeltaPressureComponent.cs
+++ b/Content.Server/Atmos/Components/DeltaPressureComponent.cs
@@ -1,4 +1,5 @@
 using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Atmos;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 
@@ -34,11 +35,13 @@ public sealed partial class DeltaPressureComponent : Component
     public bool IsTakingDamage;
 
     /// <summary>
-    /// The current cached position of this entity on the grid.
-    /// Updated via MoveEvent.
+    /// The current cached offset position(s) of the entity on the grid.
+    /// This is used to determine which tiles to check for pressure differences,
+    /// as checking this every operation is expensive.
+    /// Updated via MoveEvent in the system.
     /// </summary>
     [DataField(readOnly: true)]
-    public Vector2i CurrentPosition = Vector2i.Zero;
+    public Vector2i[] OffsetPositions = new Vector2i[Atmospherics.Directions];
 
     /// <summary>
     /// The grid this entity is currently joined to for processing.

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
@@ -355,9 +355,7 @@ public partial class AtmosphereSystem
         grid.Comp.DeltaPressureEntityLookup[ent.Owner] = grid.Comp.DeltaPressureEntities.Count;
         grid.Comp.DeltaPressureEntities.Add(ent);
 
-        ent.Comp.CurrentPosition = _map.CoordinatesToTile(grid,
-            Comp<MapGridComponent>(grid),
-            xform.Coordinates);
+        CacheAirtightStructureOffsets(ent, Comp<MapGridComponent>(grid), xform);
 
         ent.Comp.GridUid = grid.Owner;
         ent.Comp.InProcessingList = true;

--- a/Content.Server/Atmos/EntitySystems/DeltaPressureSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/DeltaPressureSystem.cs
@@ -17,7 +17,6 @@ namespace Content.Server.Atmos.EntitySystems;
 public sealed class DeltaPressureSystem : EntitySystem
 {
     [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
-    [Dependency] private readonly SharedMapSystem _map = default!;
 
     public override void Initialize()
     {
@@ -40,7 +39,7 @@ public sealed class DeltaPressureSystem : EntitySystem
             return;
         }
 
-        ent.Comp.CurrentPosition = _map.CoordinatesToTile(xform.GridUid.Value, mapGridComponent, args.NewPosition);
+        _atmosphereSystem.CacheAirtightStructureOffsets(ent, mapGridComponent, xform);
     }
 
     private void OnComponentInit(Entity<DeltaPressureComponent> ent, ref ComponentInit args)


### PR DESCRIPTION
## About the PR
Some good perf improvements to DeltaPressure that I wanted to introduce in the original PR but I didn't want to complicate things. Some minor stuff, wanted to do more but admittedly the changes required is a lot and something I'm not really motivated to do right now.

## Why / Balance
Perf is perf

## Technical details
A pretty big hotspot in the code is performing a transform operation retrieving the current entity's position in relation to the grid it was on. The next big hotspot right after this was performing offset operations on our current position in order to get the tiles that were adjacent to the DeltaPressure entity.

Since DeltaPressure entities are expected to be static grid-based entities that rarely move at all, we can simply cache this information instead of computing it each processing cycle. Updates are handled when the entity moves via `MoveEvent`.

Tragic dict lookup for the tiles but that's something that has to be done. In the far future the Atmos workgroup wants to look into storing tiles as some form of [spatial data structure](https://opendsa-server.cs.vt.edu/ODSA/Books/Everything/html/Spatial.html) like a [kdtree](https://opendsa-server.cs.vt.edu/ODSA/Books/Everything/html/KDtree.html) but for sanity we would probably want to code an interface for accessing the Tiles array so we can swap out data structures in the backend for quick testing.

## Media
### Before, baseline
</head>
<body>
<pre><code>
BenchmarkDotNet v0.14.0, Gentoo Linux
AMD Ryzen 9 7900X, 1 CPU, 24 logical and 12 physical cores
  [Host]     : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  Job-MZCDXX : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
</code></pre>
<pre><code>Server=True  Toolchain=.NET 9.0  
</code></pre>

<table>
<thead><tr><th>Method           </th><th>EntityCount</th><th>BatchSize</th><th>EntitiesPerIteration</th><th>Mean  </th><th>Error</th><th>StdDev</th>
</tr>
</thead><tbody><tr><td>PerformFullProcess</td><td>1</td><td>10</td><td>1000</td><td>1.646 &mu;s</td><td>0.0544 &mu;s</td><td>0.1534 &mu;s</td>
</tr><tr><td>PerformSingleRunProcess</td><td>1</td><td>10</td><td>1000</td><td>1.581 &mu;s</td><td>0.0467 &mu;s</td><td>0.1318 &mu;s</td>
</tr><tr><td>PerformFullProcess</td><td>10</td><td>10</td><td>1000</td><td>3.047 &mu;s</td><td>0.0671 &mu;s</td><td>0.1848 &mu;s</td>
</tr><tr><td>PerformSingleRunProcess</td><td>10</td><td>10</td><td>1000</td><td>3.116 &mu;s</td><td>0.0679 &mu;s</td><td>0.1938 &mu;s</td>
</tr><tr><td>PerformFullProcess</td><td>100</td><td>10</td><td>1000</td><td>24.224 &mu;s</td><td>0.4727 &mu;s</td><td>0.7767 &mu;s</td>
</tr><tr><td>PerformSingleRunProcess</td><td>100</td><td>10</td><td>1000</td><td>24.723 &mu;s</td><td>0.4837 &mu;s</td><td>0.9085 &mu;s</td>
</tr><tr><td>PerformFullProcess</td><td>1000</td><td>10</td><td>1000</td><td>83.166 &mu;s</td><td>1.6509 &mu;s</td><td>4.5746 &mu;s</td>
</tr><tr><td>PerformSingleRunProcess</td><td>1000</td><td>10</td><td>1000</td><td>84.298 &mu;s</td><td>1.5178 &mu;s</td><td>1.4198 &mu;s</td>
</tr><tr><td>PerformFullProcess</td><td>5000</td><td>10</td><td>1000</td><td>374.003 &mu;s</td><td>7.4390 &mu;s</td><td>6.5945 &mu;s</td>
</tr><tr><td>PerformSingleRunProcess</td><td>5000</td><td>10</td><td>1000</td><td>376.966 &mu;s</td><td>7.4866 &mu;s</td><td>16.1157 &mu;s</td>
</tr><tr><td>PerformFullProcess</td><td>10000</td><td>10</td><td>1000</td><td>743.464 &mu;s</td><td>14.4004 &mu;s</td><td>21.1080 &mu;s</td>
</tr><tr><td>PerformSingleRunProcess</td><td>10000</td><td>10</td><td>1000</td><td>683.022 &mu;s</td><td>5.6205 &mu;s</td><td>5.2575 &mu;s</td>
</tr><tr><td>PerformFullProcess</td><td>50000</td><td>10</td><td>1000</td><td>4,169.504 &mu;s</td><td>48.6275 &mu;s</td><td>43.1070 &mu;s</td>
</tr><tr><td>PerformSingleRunProcess</td><td>50000</td><td>10</td><td>1000</td><td>2,088.741 &mu;s</td><td>28.1997 &mu;s</td><td>23.5480 &mu;s</td>
</tr><tr><td>PerformFullProcess</td><td>100000</td><td>10</td><td>1000</td><td>8,820.302 &mu;s</td><td>118.2719 &mu;s</td><td>104.8450 &mu;s</td>
</tr><tr><td>PerformSingleRunProcess</td><td>100000</td><td>10</td><td>1000</td><td>2,234.668 &mu;s</td><td>24.2944 &mu;s</td><td>21.5363 &mu;s</td>
</tr></tbody></table>
</body>
</html>

### After
```

BenchmarkDotNet v0.14.0, Gentoo Linux
AMD Ryzen 9 7900X, 1 CPU, 24 logical and 12 physical cores
  [Host]     : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  Job-IOJPIU : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

Server=True  Toolchain=.NET 9.0  

```
| Method                  | EntityCount | BatchSize | EntitiesPerIteration | Mean         | Error       | StdDev      | Median       |
|------------------------ |------------ |---------- |--------------------- |-------------:|------------:|------------:|-------------:|
| **PerformFullProcess**      | **1**           | **10**        | **1000**                 |     **1.385 μs** |   **0.0277 μs** |   **0.0743 μs** |     **1.363 μs** |
| PerformSingleRunProcess | 1           | 10        | 1000                 |     1.349 μs |   0.0265 μs |   0.0602 μs |     1.340 μs |
| **PerformFullProcess**      | **10**          | **10**        | **1000**                 |     **2.327 μs** |   **0.0457 μs** |   **0.0880 μs** |     **2.307 μs** |
| PerformSingleRunProcess | 10          | 10        | 1000                 |     2.344 μs |   0.0466 μs |   0.0739 μs |     2.337 μs |
| **PerformFullProcess**      | **100**         | **10**        | **1000**                 |    **20.930 μs** |   **0.4168 μs** |   **1.0224 μs** |    **20.895 μs** |
| PerformSingleRunProcess | 100         | 10        | 1000                 |    21.353 μs |   0.3992 μs |   0.7300 μs |    21.585 μs |
| **PerformFullProcess**      | **1000**        | **10**        | **1000**                 |    **67.303 μs** |   **0.6823 μs** |   **0.6049 μs** |    **67.503 μs** |
| PerformSingleRunProcess | 1000        | 10        | 1000                 |    67.002 μs |   0.3387 μs |   0.2828 μs |    66.976 μs |
| **PerformFullProcess**      | **5000**        | **10**        | **1000**                 |   **296.588 μs** |   **3.5391 μs** |   **2.7631 μs** |   **297.487 μs** |
| PerformSingleRunProcess | 5000        | 10        | 1000                 |   293.335 μs |   2.2887 μs |   1.9112 μs |   293.208 μs |
| **PerformFullProcess**      | **10000**       | **10**        | **1000**                 |   **575.415 μs** |   **9.1185 μs** |   **7.1191 μs** |   **573.241 μs** |
| PerformSingleRunProcess | 10000       | 10        | 1000                 |   590.120 μs |   6.4713 μs |   5.4039 μs |   588.760 μs |
| **PerformFullProcess**      | **50000**       | **10**        | **1000**                 | **2,915.119 μs** |  **29.8951 μs** |  **24.9637 μs** | **2,925.183 μs** |
| PerformSingleRunProcess | 50000       | 10        | 1000                 | 1,463.639 μs |  24.9756 μs |  20.8558 μs | 1,463.072 μs |
| **PerformFullProcess**      | **100000**      | **10**        | **1000**                 | **6,074.874 μs** | **120.0731 μs** | **168.3258 μs** | **5,984.317 μs** |
| PerformSingleRunProcess | 100000      | 10        | 1000                 | 1,498.264 μs |  27.6463 μs |  25.8604 μs | 1,489.319 μs |

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`GetBulkTileAtmospherePressures` in `AtmosphereSystem.DeltaPressure` now requires a list of `Vector2i`s instead of nullable `TileAtmosphere`s.

**Changelog**
n/a
