### PR TITLE
Revert antique laser and appraisal tool sizes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/appraisal.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/appraisal.yml
@@ -9,10 +9,7 @@
     state: icon
   - type: Item
     sprite: Objects/Tools/appraisal-tool.rsi
-    shape:
-    - 0,0,1,0
-    - 0,1,0,1
-    storedOffset: -3,-3
+    size: Small
   - type: PriceGun
   - type: UseDelay
     delay: 3

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -641,9 +641,10 @@
   description: This is an antique laser pistol. All craftsmanship is of the highest quality. It is decorated with a mahogany grip and chrome filigree. The object menaces with spikes of energy. On the item is an image of a captain and a clown. The clown is dead. The captain is striking a heroic pose.
   components:
   - type: Item
-    size: Normal
+    sprite: Objects/Tools/appraisal-tool.rsi
     shape:
-    - 0,0,1,1
+    - 0,0,1,0
+    - 0,1,0,1
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/antiquelasergun.rsi
     layers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Reverted antique laser pistol back to an L and appraisal tool to a 1x2


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The original changes had a lot of unintended balance changes, such as disallowing antique laser pistol in the pockets and breaking a lot of belt layouts because of the appraisal tool size.

Microbalance approved by @SlamBamActionman


## Technical details
<!-- Summary of code changes for easier review. -->
yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="211" height="114" alt="image" src="https://github.com/user-attachments/assets/4fc103af-bee6-4a4b-a3c0-27fbc14ef9b2" />
<img width="123" height="75" alt="image" src="https://github.com/user-attachments/assets/282693e5-6dbc-4525-892d-f592eb1ea677" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The size of the antique laser pistol and appraisal tool have been reverted to an L and 1x2 respectfully.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
