### PR TITLE
Added white towels to autolathe and uniform printer

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -124,6 +124,7 @@
     - AtmosStatic
     - CablesStatic
     - PaperworkStatic
+    - TowelsStatic
     - CargoStatic
     - MaterialsStatic
     - BasicChemistryStatic
@@ -512,6 +513,7 @@
     idleState: icon
     runningState: building
     staticPacks:
+    - TowelsStatic
     - ClothingCivilian
     - ClothingCargo
     - ClothingCommand

--- a/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
@@ -44,6 +44,11 @@
   - BoxFolderClipboardEmpty
   - BoxFolderPlasticClipboardEmpty
 
+- type: latheRecipePack
+  id: TowelsStatic # This is used for both the autolathe and the uniform printer, so "unique" towels that only HoP can print shouldn't be included!
+  recipes:
+  - TowelColorWhite
+
 ## Dynamic
 
 # Things you'd expect sci salv and engi to make use of

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -298,4 +298,4 @@
   result: TowelColorWhite
   completetime: 2
   materials:
-    Cloth: 200
+    Cloth: 300

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -292,3 +292,10 @@
   materials:
     Plastic: 100
     Steel: 25
+
+- type: latheRecipe
+  id: TowelColorWhite
+  result: TowelColorWhite
+  completetime: 2
+  materials:
+    Cloth: 200


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The autolathe and uniform printer can now both print white towels for 3 cloth each.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Towels are an item with a decent enough mechanical use (a bit worse than a mop, but also significantly smaller) and a fun aesthetic use (can be worn on the head, body, or belt). Moths can also eat them. (Actually, technically anyone can eat them, which seems like a bug I should PR a fix for.) Despite all this, there is currently no way to obtain towels other than either as loadout trinkets or as premapped spawns. Making them printable from lathes is a simple, easy, and intuitive fix.

White towels are a default trinket available to all players; other towel colors are locked behind significant playtime requirements, so they should not be printable like this.

The uniform printer was chosen because it already prints a bunch of fabric items (uniforms, of course, but also carpets and bedsheets and the like). The autolathe was mostly just included because A.) it can hold cloth anyway but mostly just uses it for utility belts, and B.) needing to meet with the HoP at their desk to get a mundane towel seems unnecessarily inconvenient. The 3 cloth cost was chosen because it's the same as the cost to make jumpsuits in the uniform printer, and both jumpsuits and towels contain 30u of fiber.

## Technical details
<!-- Summary of code changes for easier review. -->
YAML changes:
- added towel lathe recipe pack (TowelsStatic)
- added TowelStatic to autolathe and uniform printer staticPacks

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
(Screenshots are outdated, show 2 cloth cost instead of 3 cloth)
<img width="763" height="533" alt="moss-lathetowels 1" src="https://github.com/user-attachments/assets/efbc59f5-b4ff-4dd3-ae06-cf076385947c" />
<img width="778" height="531" alt="moss-lathetowels 2" src="https://github.com/user-attachments/assets/49a8ed6d-6d72-4965-9dab-97571a225dde" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The autolathe and uniform printer can now produce towels.