### PR TITLE
Display alerts from one entity to another entity

### DIFF
--- a/Content.Server/Alert/ServerAlertsSystem.cs
+++ b/Content.Server/Alert/ServerAlertsSystem.cs
@@ -14,7 +14,17 @@ internal sealed class ServerAlertsSystem : AlertsSystem
 
     private void OnGetState(Entity<AlertsComponent> alerts, ref ComponentGetState args)
     {
+        // Relay: build display alerts for owner, optionally including relay-source alerts.
+        var display = new Dictionary<AlertKey, AlertState>(alerts.Comp.Alerts);
+
+        if (TryComp<AlertsDisplayRelayComponent>(alerts.Owner, out var relay) && relay.Source is { } src &&
+            TryComp<AlertsComponent>(src, out var srcAlerts))
+        {
+            foreach (var (key, state) in srcAlerts.Alerts)
+                display[key] = state;
+        }
+
         // TODO: Use sourcegen when clone-state bug fixed.
-        args.State = new AlertComponentState(new(alerts.Comp.Alerts));
+        args.State = new AlertComponentState(display);
     }
 }

--- a/Content.Shared/Alert/AlertsComponent.cs
+++ b/Content.Shared/Alert/AlertsComponent.cs
@@ -18,6 +18,30 @@ public sealed partial class AlertsComponent : Component
     public override bool SendOnlyToOwner => true;
 }
 
+/// <summary>
+/// When present on a controlled entity, indicates that its HUD should display alerts
+/// of another source entity (e.g., the pilot while controlling a vehicle), and clicks should
+/// be proxied back to that source.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class AlertsDisplayRelayComponent : Component
+{
+    public override bool SendOnlyToOwner => true;
+
+    /// <summary>
+    /// The entity whose alerts should be displayed is the local entity.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? Source;
+
+    /// <summary>
+    /// If true and this entity is displaying alerts for <see cref="Source"/>, clicking alerts will activate them
+    /// as if the click originated from <see cref="Source"/>.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool InteractAsSource = false;
+}
+
 [Serializable, NetSerializable]
 public sealed class AlertComponentState : ComponentState
 {

--- a/Content.Shared/Alert/AlertsSystem.cs
+++ b/Content.Shared/Alert/AlertsSystem.cs
@@ -67,8 +67,8 @@ public abstract class AlertsSystem : EntitySystem
                 autoComp.AlertKeys.Remove(alertKey);
             }
 
-            Dirty(uid, alertComp);
-            Dirty(uid, autoComp);
+            OnAlertsDirty(uid, alertComp);
+            OnAlertsDirty(uid, autoComp);
         }
     }
 
@@ -140,9 +140,9 @@ public abstract class AlertsSystem : EntitySystem
         short? severity = null,
         (TimeSpan, TimeSpan)? cooldown = null,
         bool autoRemove = false,
-        bool showCooldown = true )
+        bool showCooldown = true)
     {
-        ShowAlert(entity, new AlertState { Type = alertType, Severity = severity, Cooldown = cooldown, AutoRemove = autoRemove, ShowCooldown = showCooldown});
+        ShowAlert(entity, new AlertState { Type = alertType, Severity = severity, Cooldown = cooldown, AutoRemove = autoRemove, ShowCooldown = showCooldown });
     }
 
     public void ShowAlert(Entity<AlertsComponent?> entity, AlertState state)
@@ -179,12 +179,11 @@ public abstract class AlertsSystem : EntitySystem
             EnsureComp<AlertAutoRemoveComponent>(entity, out var autoComp);
 
             if (autoComp.AlertKeys.Add(alert.AlertKey))
-                Dirty (entity, autoComp);
+                OnAlertsDirty(entity, autoComp);
         }
 
         AfterShowAlert((entity, entity.Comp));
-
-        Dirty(entity);
+        OnAlertsDirty(entity);
     }
 
     /// <summary>
@@ -233,7 +232,7 @@ public abstract class AlertsSystem : EntitySystem
     /// </summary>
     public void ClearAlertCategory(Entity<AlertsComponent?> entity, ProtoId<AlertCategoryPrototype> category)
     {
-        if(!_alertsQuery.Resolve(entity, ref entity.Comp, false))
+        if (!_alertsQuery.Resolve(entity, ref entity.Comp, false))
             return;
 
         var key = AlertKey.ForCategory(category);
@@ -243,8 +242,7 @@ public abstract class AlertsSystem : EntitySystem
         }
 
         AfterClearAlert((entity, entity.Comp));
-
-        Dirty(entity);
+        OnAlertsDirty(entity);
     }
 
     /// <summary>
@@ -266,8 +264,7 @@ public abstract class AlertsSystem : EntitySystem
             }
 
             AfterClearAlert((entity, entity.Comp));
-
-            Dirty(entity);
+            OnAlertsDirty(entity);
         }
         else
         {
@@ -306,7 +303,7 @@ public abstract class AlertsSystem : EntitySystem
         }
 
         if (dirty)
-            Dirty(entity, alertComp);
+            OnAlertsDirty(entity, alertComp);
     }
 
     protected virtual void HandleComponentShutdown(EntityUid uid, AlertsComponent component, ComponentShutdown args)
@@ -352,7 +349,17 @@ public abstract class AlertsSystem : EntitySystem
         if (player is null || !HasComp<AlertsComponent>(player))
             return;
 
-        if (!IsShowingAlert(player.Value, msg.Type))
+        // Relay: if this entity is displaying alerts for another source via relay.
+        var target = player.Value;
+        if (TryComp<AlertsDisplayRelayComponent>(player.Value, out var relay) && relay.Source is { } src)
+        {
+            if (relay.InteractAsSource)
+                target = src;
+            else
+                target = player.Value;
+        }
+
+        if (!IsShowingAlert(target, msg.Type))
         {
             Log.Debug($"User {ToPrettyString(player.Value)} attempted to click alert {msg.Type} which is not currently showing for them");
             return;
@@ -364,7 +371,7 @@ public abstract class AlertsSystem : EntitySystem
             return;
         }
 
-        if (ActivateAlert(player.Value, alert) && _timing.IsFirstTimePredicted)
+        if (ActivateAlert(target, alert) && _timing.IsFirstTimePredicted)
         {
             HandledAlert();
         }
@@ -384,12 +391,31 @@ public abstract class AlertsSystem : EntitySystem
         clickEvent.User = user;
         clickEvent.AlertId = alert.ID;
 
-        RaiseLocalEvent(user, (object) clickEvent, true);
+        RaiseLocalEvent(user, (object)clickEvent, true);
         return clickEvent.Handled;
     }
 
     private void OnPlayerAttached(EntityUid uid, AlertsComponent component, PlayerAttachedEvent args)
     {
-        Dirty(uid, component);
+        OnAlertsDirty(uid, component);
+    }
+
+    private void OnAlertsDirty(EntityUid uid, AlertsComponent? component = null)
+    {
+        if (component != null)
+            Dirty(uid, component);
+        else
+            Dirty(uid);
+
+        // Relay: dirty for all connected relays.
+        var relayQuery = EntityQueryEnumerator<AlertsDisplayRelayComponent>();
+        while (relayQuery.MoveNext(out var relayUid, out var relayComp))
+        {
+            if (relayComp.Source == uid)
+            {
+                if (TryComp<AlertsComponent>(relayUid, out var relayAlertsComp))
+                    Dirty(relayUid, relayAlertsComp);
+            }
+        }
     }
 }

--- a/Content.Shared/Alert/AlertsSystem.cs
+++ b/Content.Shared/Alert/AlertsSystem.cs
@@ -68,7 +68,7 @@ public abstract class AlertsSystem : EntitySystem
             }
 
             OnAlertsDirty(uid, alertComp);
-            OnAlertsDirty(uid, autoComp);
+            Dirty(uid, autoComp);
         }
     }
 
@@ -179,11 +179,11 @@ public abstract class AlertsSystem : EntitySystem
             EnsureComp<AlertAutoRemoveComponent>(entity, out var autoComp);
 
             if (autoComp.AlertKeys.Add(alert.AlertKey))
-                OnAlertsDirty(entity, autoComp);
+                Dirty(entity, autoComp);
         }
 
         AfterShowAlert((entity, entity.Comp));
-        OnAlertsDirty(entity);
+        OnAlertsDirty(entity, entity.Comp);
     }
 
     /// <summary>
@@ -242,7 +242,7 @@ public abstract class AlertsSystem : EntitySystem
         }
 
         AfterClearAlert((entity, entity.Comp));
-        OnAlertsDirty(entity);
+        OnAlertsDirty(entity, entity.Comp);
     }
 
     /// <summary>
@@ -264,7 +264,7 @@ public abstract class AlertsSystem : EntitySystem
             }
 
             AfterClearAlert((entity, entity.Comp));
-            OnAlertsDirty(entity);
+            OnAlertsDirty(entity, entity.Comp);
         }
         else
         {
@@ -400,12 +400,9 @@ public abstract class AlertsSystem : EntitySystem
         OnAlertsDirty(uid, component);
     }
 
-    private void OnAlertsDirty(EntityUid uid, AlertsComponent? component = null)
+    private void OnAlertsDirty(EntityUid uid, AlertsComponent component)
     {
-        if (component != null)
-            Dirty(uid, component);
-        else
-            Dirty(uid);
+        Dirty(uid, component);
 
         // Relay: dirty for all connected relays.
         var relayQuery = EntityQueryEnumerator<AlertsDisplayRelayComponent>();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a component to display alerts from one entity for another entity, with the optional ability to use active alerts on its behalf. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Required for #39958
Can also be used to transfer ss13 mechanics with entity monitoring, displaying its alerts/actions/HUD or some admin functions.

## Technical details
<!-- Summary of code changes for easier review. -->
Added `AlertsDisplayRelayComponent`

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
