### PR TITLE
Revert "Disable vulpkanin human hair (#40144)"

### DIFF
--- a/Content.Client/DisplacementMap/DisplacementMapSystem.cs
+++ b/Content.Client/DisplacementMap/DisplacementMapSystem.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Content.Shared.DisplacementMap;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
@@ -10,6 +11,11 @@ public sealed class DisplacementMapSystem : EntitySystem
     [Dependency] private readonly ISerializationManager _serialization = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
 
+    private static string? BuildDisplacementLayerKey(object key)
+    {
+        return key.ToString() is null ? null : $"{key}-displacement";
+    }
+
     /// <summary>
     /// Attempting to apply a displacement map to a specific layer of SpriteComponent
     /// </summary>
@@ -19,21 +25,20 @@ public sealed class DisplacementMapSystem : EntitySystem
     /// <param name="key">Unique layer key, which will determine which layer to apply displacement map to</param>
     /// <param name="displacementKey">The key of the new displacement map layer added by this function.</param>
     /// <returns></returns>
-    public bool TryAddDisplacement(DisplacementData data,
+    public bool TryAddDisplacement(
+        DisplacementData data,
         Entity<SpriteComponent> sprite,
         int index,
         object key,
-        out string displacementKey)
+        [NotNullWhen(true)] out string? displacementKey
+    )
     {
-        displacementKey = $"{key}-displacement";
-
-        if (key.ToString() is null)
+        displacementKey = BuildDisplacementLayerKey(key);
+        if (displacementKey is null)
             return false;
 
-        if (data.ShaderOverride != null)
-            sprite.Comp.LayerSetShader(index, data.ShaderOverride);
-
-        _sprite.RemoveLayer(sprite.AsNullable(), displacementKey, false);
+        if (!TryRemoveDisplacement(sprite, key))
+            return false;
 
         //allows you not to write it every time in the YML
         foreach (var pair in data.SizeMaps)
@@ -70,7 +75,11 @@ public sealed class DisplacementMapSystem : EntitySystem
         }
 
         var displacementLayer = _serialization.CreateCopy(displacementDataLayer, notNullableOverride: true);
-        displacementLayer.CopyToShaderParameters!.LayerKey = key.ToString() ?? "this is impossible";
+
+        // This previously assigned a string reading "this is impossible" if key.ToString eval'd to false.
+        // However, for the sake of sanity, we've changed this to assert non-null - !.
+        // If this throws an error, we're not sorry. Nanotrasen thanks you for your service fixing this bug.
+        displacementLayer.CopyToShaderParameters!.LayerKey = key.ToString()!;
 
         _sprite.AddLayer(sprite.AsNullable(), displacementLayer, index);
         _sprite.LayerMapSet(sprite.AsNullable(), displacementKey, index);
@@ -78,14 +87,16 @@ public sealed class DisplacementMapSystem : EntitySystem
         return true;
     }
 
-    /// <inheritdoc cref="TryAddDisplacement"/>
-    [Obsolete("Use the Entity<SpriteComponent> overload")]
-    public bool TryAddDisplacement(DisplacementData data,
-        SpriteComponent sprite,
-        int index,
-        object key,
-        out string displacementKey)
+    /// <summary>
+    /// Attempts to remove the displacement layer specified.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="key"></param>
+    /// <returns>False if the key is invalid or the layer didn't exist. Otherwise true.</returns>
+    public bool TryRemoveDisplacement(Entity<SpriteComponent> sprite, object key)
     {
-        return TryAddDisplacement(data, (sprite.Owner, sprite), index, key, out displacementKey);
+        var displacementLayerKey = BuildDisplacementLayerKey(key);
+
+        return displacementLayerKey is not null && _sprite.RemoveLayer(sprite.AsNullable(), displacementLayerKey);
     }
 }

--- a/Resources/Prototypes/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Species/vulpkanin.yml
@@ -41,7 +41,6 @@
   points:
     Hair:
       points: 1
-      onlyWhitelisted: true # TODO: Vulps are meant to use human hair, however something causes hair to break if affected by a displacement map and removed. Allow human hair again when #40135 is resolved.
       required: false
     FacialHair:
       points: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This reverts commit d02aa1a.

Resolves an oversight in the marking system which allows for adding displacement maps for markings but forgets to then remove displacement maps on removal of the marking.

Resolves https://github.com/space-wizards/space-station-14/issues/40135

## Why / Balance
Having known ways to completely brick the client inside the Content codebase is a bad idea and Vulps deserve the same anime-ass haircuts as humans do.

Also I'm being held at gunpoint by the furry mafia please help

## Technical details
The blackscreen itself can be Blamed to https://github.com/space-wizards/RobustToolbox/pull/5602 which is understandable given the comment prior reads `// Multiple atrocities to god being committed right here.`

The CopyToShaderParameters for the displacement layer that has been added by DisplacementMapSystem on behalf of HumanoidAppearanceSystem contains the target layer that needs to be referenced for rendering the displaced layer. Removing that target layer means that Clyde just gives up on life once it attempts to handle the displacement layer next. Which, honestly, understandable.

## Media
N/A, a boring fix and a boring reversion.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`DisplacementMapSystem.TryAddDisplacement` has had its signature slightly modified; the displacement layer key it returns is now optional, and will be null if no displacement layer was added. This may cause logic errors in code using displacements.

**Changelog**
:cl:
- fix: Shaving Vulpkanin no longer causes the renderer to regret its life choices and join the circus.
- fix: Vulpkanin can once again use normal human hair. Be free.
