### PR TITLE
Fix backgrounds of radial menu buttons obstructing button sprites

### DIFF
--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -507,8 +507,6 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
     /// <inheritdoc />
     protected override void Draw(DrawingHandleScreen handle)
     {
-        base.Draw(handle);
-
         if (_parentCenter == null)
         {
             return;
@@ -540,6 +538,9 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
         {
             DrawSeparatorLines(handle, containerCenter, _innerRadius * UIScale, _outerRadius * UIScale, angleFrom, angleTo, SeparatorColor);
         }
+
+        // Draw the sprite of this TextureButton after the background.
+        base.Draw(handle);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

The sprites in a radial menu are no longer obstructed by the button's background.

## Why / Balance

Because it looks horrible and makes the buttons difficult to read.

## Technical details

The `base.Draw` call was moved to the end of the function, causing the sprite to be drawing over the background.

This change will be made redundant by #39223. It solves this problem by making the texture a child control of the radial menu button.

## Media

Before:
<img width="491" height="491" alt="image" src="https://github.com/user-attachments/assets/d0282d69-c6a9-4b92-ad04-9c9057a41ceb" />

After:
<img width="491" height="491" alt="image" src="https://github.com/user-attachments/assets/0a61bcdf-cf4d-409f-ab5d-b3f929677955" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Unlikely - it's not a public API, and the only effect is a change in the order of draw calls

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: opl
- fix: Images in radial menus are easier to see.
