### PR TITLE
Bring vulpkanin in-line with other species on hugging

### DIFF
--- a/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
+++ b/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
@@ -101,9 +101,6 @@ hugging-success-generic = You hug {THE($target)}.
 hugging-success-generic-others = { CAPITALIZE(THE($user)) } hugs {THE($target)}.
 hugging-success-generic-target = { CAPITALIZE(THE($user)) } hugs you.
 
-petting-success-soft-floofy-vulp = You pet { THE($target) } on {POSS-ADJ($target)} soft floofy head.
-petting-success-soft-floofy-vulp-others = { CAPITALIZE(THE($user)) } pets {THE($target)} on {POSS-ADJ($target)} soft floofy head.
-
 ## Other
 
 petting-success-tesla = You pet {THE($target)}, violating the laws of nature and physics.

--- a/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
@@ -58,11 +58,6 @@
         pitch: 1.33
         volume: -5
         variation: 0.05
-  - type: InteractionPopup # Crucial detail.
-    successChance: 1
-    interactSuccessString: petting-success-soft-floofy-vulp
-    messagePerceivedByOthers: petting-success-soft-floofy-vulp-others
-    interactFailureString: petting-failure-generic
   - type: Sprite # Drawlayers. Top to bottom in order I believe.
     netsync: false
     layers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Vulpkanin now use the standard hugging popup for their interaction, rather than a petting one.

## Why / Balance
Vulpkanin should be huggable.

Also, we don't really want to encourage people to think about vulpkanin as Literal Animals to pet instead of a humanoid like every other roundstart species in the game.

## Technical details
- kill the unique strings

## Media
<img width="144" height="184" alt="grafik" src="https://github.com/user-attachments/assets/3053c99d-b1c0-4a74-acfd-ff59efc8de07" />

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Vulpkanin use the standard hugging emote now
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
