### PR TITLE
Added "yw" to speech-chatsan.ftl

### DIFF
--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -189,3 +189,6 @@ chatsan-replacement-66 = something
 
 chatsan-word-67 = allg
 chatsan-replacement-67 = all good
+
+chatsan-word-68 = yw
+chatsan-replacement-68 = your welcome


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added "yw" to speech-chatsan.ftl

## Why / Balance
I can't tell you how many times I've accidently typed in ""yw" in response to someone thanking me for something only to remember that it doesn't automatically auto-correct to say "your  welcome". Breaking immersion. 

## Technical details
Added "yw" to speech-chatsan.ftl

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: "yw" now auto-completes to "your welcome"
