### PR TITLE
fix: Atmos dP Window Inheritance

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -107,7 +107,7 @@
 
 - type: entity
   id: ShuttersNormal
-  parent: [BaseShutter, BaseDeltaPressureGlass]
+  parent: [BaseDeltaPressureGlass, BaseShutter]
   components:
   - type: Occluder
   - type: Construction
@@ -134,7 +134,7 @@
 
 - type: entity
   id: ShuttersRadiation
-  parent: [BaseShutter, BaseDeltaPressureGlass]
+  parent: [BaseDeltaPressureGlass, BaseShutter]
   name: radiation shutters
   description: Why did they make these shutters radioactive?
   components:
@@ -172,7 +172,7 @@
 
 - type: entity
   id: ShuttersWindow
-  parent: [BaseShutter, BaseDeltaPressureGlass]
+  parent: [BaseDeltaPressureGlass, BaseShutter]
   name: window shutters
   description: The Best (TM) place to see your friends explode!
   components:

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -1,7 +1,7 @@
 #Normal windoors
 - type: entity
   id: BaseWindoor
-  parent: [BaseStructure, BaseDeltaPressureGlassQuarter]
+  parent: [BaseDeltaPressureGlassQuarter, BaseStructure]
   abstract: true
   placement:
     mode: SnapgridCenter
@@ -174,7 +174,7 @@
 
 - type: entity
   id: BaseSecureWindoor
-  parent: [BaseWindoor, BaseDeltaPressureReinforcedGlassQuarter]
+  parent: [BaseDeltaPressureReinforcedGlassQuarter, BaseWindoor]
   abstract: true
   components:
   - type: Sprite
@@ -246,7 +246,7 @@
 #Plasma Windoors
 - type: entity
   id: BasePlasmaWindoor
-  parent: [BaseWindoor, BaseDeltaPressurePlasmaQuarter]
+  parent: [BaseDeltaPressurePlasmaQuarter, BaseWindoor]
   abstract: true
   components:
   - type: Sprite
@@ -311,7 +311,7 @@
 
 - type: entity
   id: BaseSecurePlasmaWindoor
-  parent: [BaseSecureWindoor, BaseDeltaPressureReinforcedPlasmaQuarter]
+  parent: [BaseDeltaPressureReinforcedPlasmaQuarter, BaseSecureWindoor]
   abstract: true
   components:
   - type: Sprite
@@ -383,7 +383,7 @@
 #Uranium Windoors
 - type: entity
   id: BaseUraniumWindoor
-  parent: [BaseWindoor, BaseDeltaPressurePlasmaQuarter]
+  parent: [BaseDeltaPressurePlasmaQuarter, BaseWindoor]
   abstract: true
   components:
   - type: Sprite
@@ -448,7 +448,7 @@
 
 - type: entity
   id: BaseSecureUraniumWindoor
-  parent: [BaseSecureWindoor, BaseDeltaPressureReinforcedPlasmaQuarter]
+  parent: [BaseDeltaPressureReinforcedPlasmaQuarter, BaseSecureWindoor]
   abstract: true
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: PlasmaWindow
   name: plasma window
-  parent: [WindowRCDResistant, BaseDeltaPressurePlasma]
+  parent: [BaseDeltaPressurePlasma, WindowRCDResistant]
   components:
   - type: Sprite
     drawdepth: WallTops
@@ -55,7 +55,7 @@
 
 - type: entity
   id: PlasmaWindowDirectional
-  parent: [WindowDirectionalRCDResistant, BaseDeltaPressurePlasmaQuarter]
+  parent: [BaseDeltaPressurePlasmaQuarter, WindowDirectionalRCDResistant]
   name: directional plasma window
   description: Don't smudge up the glass down there.
   placement:

--- a/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ReinforcedWindow
   name: reinforced window
-  parent: [Window, BaseDeltaPressureReinforcedGlass]
+  parent: [BaseDeltaPressureReinforcedGlass, Window]
   components:
   - type: Sprite
     drawdepth: WallTops
@@ -58,7 +58,7 @@
 
 - type: entity
   id: WindowReinforcedDirectional
-  parent: [WindowDirectional, BaseDeltaPressureReinforcedGlassQuarter]
+  parent: [BaseDeltaPressureReinforcedGlassQuarter, WindowDirectional]
   name: directional reinforced window
   description: Don't smudge up the glass down there.
   placement:

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ReinforcedPlasmaWindow
   name: reinforced plasma window
-  parent: [WindowRCDResistant, BaseDeltaPressureReinforcedPlasma]
+  parent: [BaseDeltaPressureReinforcedPlasma, WindowRCDResistant]
   components:
   - type: Sprite
     drawdepth: WallTops
@@ -58,7 +58,7 @@
 
 - type: entity
   id: PlasmaReinforcedWindowDirectional
-  parent: [WindowDirectionalRCDResistant, BaseDeltaPressureReinforcedPlasmaQuarter]
+  parent: [BaseDeltaPressureReinforcedPlasmaQuarter, WindowDirectionalRCDResistant]
   name: directional reinforced plasma window
   description: Don't smudge up the glass down there.
   placement:

--- a/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ReinforcedUraniumWindow
   name: reinforced uranium window
-  parent: [WindowRCDResistant, BaseDeltaPressureReinforcedPlasma]
+  parent: [BaseDeltaPressureReinforcedPlasma, WindowRCDResistant]
   components:
   - type: Sprite
     drawdepth: WallTops
@@ -55,7 +55,7 @@
 
 - type: entity
   id: UraniumReinforcedWindowDirectional
-  parent: [WindowDirectionalRCDResistant, BaseDeltaPressureReinforcedPlasmaQuarter]
+  parent: [BaseDeltaPressureReinforcedPlasmaQuarter, WindowDirectionalRCDResistant]
   name: directional reinforced uranium window
   description: Don't smudge up the glass down there.
   placement:

--- a/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ShuttleWindow
   name: shuttle window
-  parent: [WindowRCDResistant, BaseDeltaPressureReinforcedGlass]
+  parent: [BaseDeltaPressureReinforcedGlass, WindowRCDResistant]
   components:
   - type: Sprite
     drawdepth: WallTops

--- a/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: UraniumWindow
   name: uranium window
-  parent: [WindowRCDResistant, BaseDeltaPressurePlasma]
+  parent: [BaseDeltaPressurePlasma, WindowRCDResistant]
   components:
   - type: Sprite
     drawdepth: WallTops
@@ -53,7 +53,7 @@
 
 - type: entity
   id: UraniumWindowDirectional
-  parent: [WindowDirectionalRCDResistant, BaseDeltaPressurePlasmaQuarter]
+  parent: [BaseDeltaPressurePlasmaQuarter, WindowDirectionalRCDResistant]
   name: directional uranium window
   description: Don't smudge up the glass down there.
   placement:

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: Window
-  parent: [BaseStructure, BaseDeltaPressureGlass]
+  parent: [BaseDeltaPressureGlass, BaseStructure]
   name: window
   description: Don't smudge up the glass down there.
   placement:
@@ -126,7 +126,7 @@
 
 - type: entity
   id: WindowDirectional
-  parent: [BaseStructure, BaseDeltaPressureGlassQuarter]
+  parent: [BaseDeltaPressureGlassQuarter, BaseStructure]
   name: directional window
   description: Don't smudge up the glass down there.
   placement:


### PR DESCRIPTION
## About the PR
Fixed silly YAML window inheritance causing a lot of things to inherit the wrong things

## Why / Balance
This would have been bad to experience on vulture

## Technical details
Previously we had the base parent defined last so it would just get overwritten with whatever `Window` or whatever had (which was the base values) so this fixes that to make it so that the base prototypes properly get inherited first.

## Media
I actually tested it I swear

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
wasnt on master long enough to justify
