### PR TITLE
Fix explosion grid alignment for static grids

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.TileFill.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.TileFill.cs
@@ -275,7 +275,7 @@ public sealed partial class ExplosionSystem
         radius = Math.Min(radius, MaxIterations / 4);
 
         EntityUid? referenceGrid = null;
-        float mass = 0;
+        var mass = float.MinValue;
 
         // First attempt to find a grid that is relatively close to the explosion's center. Instead of looking in a
         // diameter x diameter sized box, use a smaller box with radius sized sides:
@@ -285,7 +285,7 @@ public sealed partial class ExplosionSystem
         _mapManager.FindGridsIntersecting(epicenter.MapId, box, ref _grids);
         foreach (var grid in _grids)
         {
-            if (TryComp(grid.Owner, out PhysicsComponent? physics) && physics.Mass > mass)
+            if (TryComp(grid.Owner, out PhysicsComponent? physics) && physics.FixturesMass > mass)
             {
                 mass = physics.Mass;
                 referenceGrid = grid.Owner;
@@ -315,7 +315,7 @@ public sealed partial class ExplosionSystem
         {
             if (TryComp(grid.Owner, out PhysicsComponent? physics) && physics.Mass > mass)
             {
-                mass = physics.Mass;
+                mass = physics.FixturesMass;
                 referenceGrid = grid.Owner;
             }
         }


### PR DESCRIPTION
## About the PR

Make explosions use `FixturesMass` instead of `Mass` to determine the size/importance of a grid. Ensures that explosions are aligned with grids even if they are static bodies (e.g., the dev station grid)
