### PR TITLE
Made smart fridges airtight

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/smartfridge.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/smartfridge.yml
@@ -117,6 +117,7 @@
       collection: MetalThud
   - type: ExplosionResistance
     damageCoefficient: 0.1
+  - type: Airtight
 
 - type: entity
   parent: SmartFridge


### PR DESCRIPTION
## About the PR
Addes the Airtight component to smart fridges.

## Why / Balance
Several maps have smart fridges with firelocks under them that don't close, meaning adjacent rooms' spacing or plasma fires freely affect them. Rather than digging around in firelock/door code, something I'm not really able to do, I opted for this.

## Technical details
One line of YAML

## Media
<img width="672" height="388" alt="Screenshot 2025-09-07 124446" src="https://github.com/user-attachments/assets/97d65cf2-57dc-455e-a20d-dfe85533e977" />


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Smart fridges are now airtight.


