### PR TITLE
Reworded the Galoshes description to be more clear about what they actually do.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -108,7 +108,7 @@
   parent: [ ClothingShoesBase, BaseJanitorContraband ]
   id: ClothingShoesGaloshes
   name: galoshes
-  description: Rubber boots.
+  description: Specialised non-slip rubber boots, designed to reduce janitorial workplace accidents; a tider's treasure.
   components:
   - type: Sprite
     sprite: Clothing/Shoes/Specific/galoshes.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I reworded the Galoshes description from "Rubber boots." to "Specialised non-slip rubber boots designed to reduce janitorial accidents, a tider's treasure."

## Why / Balance
It's a more beginner friendly description; a new player otherwise has no idea what they do, and (like me) might not realise slipping even *is* a mechanic, if they started playing as a janitor.

## Technical details
one description line change

## Media

<img width="757" height="548" alt="galoshes-knowledge" src="https://github.com/user-attachments/assets/b350bb00-7886-43cb-9447-c55530f7090c" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Changed the Galoshes description to be more descriptive of what they actually do.
