### PR TITLE
Crashed the snakeskin boots stock-market by removing their hidden no-slip properties

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -109,13 +109,12 @@
   parent: ClothingShoesBase
   id: ClothingShoesSnakeskinBoots
   name: snakeskin boots
-  description: Boots made of high-class snakeskin, everyone around you will be jealous.
+  description: Boots made of once-valuable snakeskin, everyone around you would have been jealous.
   components:
   - type: Sprite
     sprite: Clothing/Shoes/Misc/snakeskin.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Misc/snakeskin.rsi
-  - type: NoSlip
 
 - type: entity
   parent: [ClothingShoesBase, PowerCellSlotSmallItem, BaseToggleClothing]


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I made it so that snakeskin boots are no longer free no-slips, crashing their value & heartlessly destroying the stock market.
I also changed the description a bit to denote this change, for mild amusement.

## Why / Balance
They were free no-slips that were; better than Galoshes, without a contraband restriction, and without any description or _reason_ as to why they even *are* no-slips; so no more powergaming for free no-slips.

## Technical details
unnecessary

## Media

https://github.com/user-attachments/assets/7dc94a5b-0bfc-4dd3-a460-70bfbed47ced



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Snakeskin boots are no longer free, superior no-slips.