### PR TITLE
Lets diona sap trigger artifact blood nodes

### DIFF
--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -242,6 +242,7 @@
     - Slime
     - AmmoniaBlood
     - ZombieBlood
+    - Sap
 
 - type: xenoArchTrigger
   id: TriggerThrow


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Diona sap can now trigger artifact nodes that need blood

## Why / Balance
Every other species can trigger the node, even slimes can (which also dont have any blood). For consistency, id say either both should be able to or not be able to, and being able to seems like the better solution

## Technical details
Just a single yaml line

## Media
[Video](https://youtu.be/HQOdbp_Z4XY)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Orbitsystem
- fix: Diona sap can now trigger artifact nodes that require blood.

