### PR TITLE
Fix vor #39982 - Hivelord Remains now meat and edible by anyone who can digest it

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -302,37 +302,6 @@
     lifetime: 100
 
 - type: entity
-  id: FoodHivelordRemains
-  parent: FoodBase
-  name: hivelord remains
-  description: All that remains of a hivelord, it seems to be what allows it to break pieces of itself off without being hurt... its healing properties will soon become inert if not used quickly. Try not to think about what you're eating.
-  components:
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: Rororium
-          Quantity: 5
-  - type: Sprite
-    sprite: Objects/Consumable/Food/rorocore.rsi
-    state: boiled
-  - type: Item
-    size: Normal
-  - type: Perishable
-    rotAfter: 120 # rot after 2 minutes
-    molsPerSecondPerUnitMass: 0
-    forceRotProgression: true
-  - type: RotInto
-    entity: FoodHivelordRemainsInert
-    stage: 1
-  - type: StaticPrice
-    price: 5000
-  - type: Tag
-    tags:
-    - HivelordRemains
-
-- type: entity
   id: FoodHivelordRemainsInert
   parent: BaseItem
   name: inert hivelord remains
@@ -350,7 +319,6 @@
   - type: Tag
     tags:
     - HivelordRemains
-
 
 - type: entity
   id: MobBasilisk

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -419,6 +419,39 @@
       - state: plain-inhand-right
 
 - type: entity
+  name: hivelord remains
+  id: FoodHivelordRemains
+  parent: FoodMeatRawBase
+  description: All that remains of a hivelord, it seems to be what allows it to break pieces of itself off without being hurt... its healing properties will soon become inert if not used quickly. Try not to think about what you're eating.
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Rororium
+          Quantity: 5
+  - type: Sprite
+    sprite: Objects/Consumable/Food/rorocore.rsi
+    state: boiled
+  - type: Item
+    size: Normal
+  - type: Perishable
+    rotAfter: 120 # rot after 2 minutes
+    molsPerSecondPerUnitMass: 0
+    forceRotProgression: true
+  - type: RotInto
+    entity: FoodHivelordRemainsInert
+    stage: 1
+  - type: StaticPrice
+    price: 5000
+  - type: Tag
+    tags:
+    - HivelordRemains
+    - Meat
+    - Raw
+
+- type: entity
   name: dragon flesh
   parent: FoodMeatBase
   id: FoodMeatDragon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes the inability of reptilians to eat hivelord remains as seen in #39982 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Seems to be an unintended bug

## Technical details
<!-- Summary of code changes for easier review. -->
I changed the parent to FoodMeatRawBase and added the Meat and Raw tags.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Hivelord remains can now be eaten by everyone!

