### PR TITLE
Increase hypopen delay from 0.5 to 1.5 seconds

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -668,7 +668,7 @@
   - type: Hypospray
     onlyAffectsMobs: false
   - type: UseDelay
-    delay: 0.5
+    delay: 1.5
   - type: StaticPrice # A new shitcurity meta
     price: 75
   - type: EmitSoundOnUse


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Increase hypopen delay from 0.5 to 1.5 seconds

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I've increased the hypopen delay from 0.5 to 1.5 seconds due to the following:
- Chems too powerful at healing/poisoning
  - 0.5 delay is far faster than attacking
- Lack of changes to upstream medical (god bless the psychomed coders)
- Constant complaints about hypo and nocturine
- Other PR addressing it got closed at the time https://github.com/space-wizards/space-station-14/pull/30704

This is also technically a continuation of https://github.com/space-wizards/space-station-14/pull/13953; please read through it to avoid restating prior comments.

This does _not_ affect hyposprays. If anything, it should make the CMO and nukie hyposprays more valuable.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: hypopen delay increased from 0.5 to 1.5 seconds
