### PR TITLE
Fix tile heat overlay invisible for some tiles

### DIFF
--- a/Content.Client/Atmos/Overlays/GasTileHeatOverlay.cs
+++ b/Content.Client/Atmos/Overlays/GasTileHeatOverlay.cs
@@ -127,7 +127,8 @@ public sealed class GasTileHeatOverlay : Overlay
                     worldHandle.SetTransform(gridEntToViewportLocal);
 
                     // We only care about tiles that fit in these bounds
-                    var floatBounds = worldToViewportLocal.TransformBox(worldBounds).Enlarged(grid.Comp.TileSize);
+                    var worldToGridEnt = _xformSys.GetInvWorldMatrix(grid.Owner);
+                    var floatBounds = worldToGridEnt.TransformBox(worldBounds).Enlarged(grid.Comp.TileSize);
                     var localBounds = new Box2i(
                         (int)MathF.Floor(floatBounds.Left),
                         (int)MathF.Floor(floatBounds.Bottom),


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

The tile heat distortion overlay wasn't visible in some parts of the map.

Fixes #40221

## Technical details

The result of the bounds computation wasn't in the grid's tile coordinate space, resulting in tiles visible on screen getting skipped based on their tile coordinates.

The bounds were instead typically from (-1,-1) to some numbers in the thousands, plus some floating point imprecision.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None?

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: opl
- fix: Distortion from heat is no longer invisible in some grid parts.
