### PR TITLE
Set Sentience Target Weight to Zero on Pun-Pun & Monkey derivatives

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1479,7 +1479,7 @@
   - type: NameIdentifier
     group: Monkey
   - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-primate
+    weight: 0.00
   - type: Speech
     speechSounds: Monkey
     speechVerb: Monkey
@@ -1660,6 +1660,8 @@
       0: Alive
       100: Critical
       200: Dead
+  - type: SentienceTarget
+    weight: 0.00
   - type: NpcFactionMember
     factions:
     - Syndicate

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -870,6 +870,8 @@
     name: ghost-role-information-punpun-name
     description: ghost-role-information-punpun-description
     rules: ghost-role-information-nonantagonist-rules
+  - type: SentienceTarget
+    weight: 0.00
   - type: GhostTakeoverAvailable
   - type: Butcherable
     butcheringType: Spike


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Set Sentience Target Weight to Zero on Pun-Pun & Monkey derivatives
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Partially Addresses https://github.com/space-wizards/space-station-14/issues/39270 

Sentience Event Targetting stacking ghostroles is bad
## Technical details
<!-- Summary of code changes for easier review. -->
.yml edit
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: