### PR TITLE
Fix PayloadTriggerComponent & SmartFridgeComponent serialization

### DIFF
--- a/Content.Server/Payload/EntitySystems/PayloadSystem.cs
+++ b/Content.Server/Payload/EntitySystems/PayloadSystem.cs
@@ -22,6 +22,7 @@ public sealed class PayloadSystem : EntitySystem
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly ISerializationManager _serializationManager = default!;
+    [Dependency] private readonly IComponentFactory _factory = default!;
 
     private static readonly ProtoId<TagPrototype> PayloadTag = "Payload";
 
@@ -108,7 +109,7 @@ public sealed class PayloadSystem : EntitySystem
             _serializationManager.CopyTo(data.Component, ref temp);
             AddComp(uid, (Component) temp!);
 
-            trigger.GrantedComponents.Add(registration.Type);
+            trigger.GrantedComponents.Add(registration.Name);
         }
     }
 
@@ -119,9 +120,10 @@ public sealed class PayloadSystem : EntitySystem
 
         trigger.Active = false;
 
-        foreach (var type in trigger.GrantedComponents)
+        foreach (var compName in trigger.GrantedComponents)
         {
-            RemComp(uid, type);
+            var reg = _factory.GetRegistration(compName);
+            RemComp(uid, reg.Type);
         }
 
         trigger.GrantedComponents.Clear();

--- a/Content.Shared/Payload/Components/PayloadTriggerComponent.cs
+++ b/Content.Shared/Payload/Components/PayloadTriggerComponent.cs
@@ -34,14 +34,12 @@ public sealed partial class PayloadTriggerComponent : Component
     public ComponentRegistry? Components = null;
 
     /// <summary>
-    ///     Keeps track of what components this trigger has granted to the payload case.
+    ///     Set of components that this trigger has granted to the payload case.
     /// </summary>
     /// <remarks>
-    ///     This is required in case someone creates a construction graph that accepts more than one trigger, and those
-    ///     trigger grant the same type of component (or the case just innately has that component). This list is used
-    ///     when removing the component, to ensure that removal of this trigger only removes the components that it was
-    ///     responsible for adding.
+    ///     This is used to prevent the accidental removal of components that were never added by this trigger (e.g.,
+    ///     because the entity already had the specified component)
     /// </remarks>
     [DataField(serverOnly: true)]
-    public HashSet<Type> GrantedComponents = new();
+    public HashSet<string> GrantedComponents = new();
 }

--- a/Content.Shared/SmartFridge/SmartFridgeComponent.cs
+++ b/Content.Shared/SmartFridge/SmartFridgeComponent.cs
@@ -1,9 +1,6 @@
 using Content.Shared.Whitelist;
-using Robust.Shared.Analyzers;
 using Robust.Shared.Audio;
-using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.SmartFridge;
@@ -41,6 +38,8 @@ public sealed partial class SmartFridgeComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public List<SmartFridgeEntry> Entries = new();
+    // Consider replacing with a sorted dictionary?
+    // Then entries don't have to be networked & serialized twice here & in ContainedEntries
 
     /// <summary>
     /// A mapping of smart fridge entries to the actual contained contents
@@ -75,15 +74,10 @@ public sealed partial class SmartFridgeComponent : Component
     public SoundSpecifier SoundDeny = new SoundCollectionSpecifier("VendingDeny");
 }
 
-[Serializable, NetSerializable, DataRecord]
-public record struct SmartFridgeEntry
+[Serializable, NetSerializable]
+public record struct SmartFridgeEntry(string Name)
 {
-    public string Name;
-
-    public SmartFridgeEntry(string name)
-    {
-        Name = name;
-    }
+    public string Name = Name;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/SmartFridge/SmartFridgeComponent.cs
+++ b/Content.Shared/SmartFridge/SmartFridgeComponent.cs
@@ -77,6 +77,9 @@ public sealed partial class SmartFridgeComponent : Component
 [Serializable, NetSerializable]
 public record struct SmartFridgeEntry(string Name)
 {
+    // Warning: if you add more fields to this, you need to update SmartFridgeEntrySerializer
+    // This cannot simply use a DataRecord attribute, as this struct is used as a yaml dictionary key, so it must
+    // serialize to a ValueDataNode
     public string Name = Name;
 }
 

--- a/Content.Shared/SmartFridge/SmartFridgeEntrySerializer.cs
+++ b/Content.Shared/SmartFridge/SmartFridgeEntrySerializer.cs
@@ -40,7 +40,6 @@ public sealed class SmartFridgeEntrySerializer :
         return new ValidatedValueNode(node);
     }
 
-
     public ValidationNode Validate(ISerializationManager serializationManager,
         MappingDataNode node,
         IDependencyCollection dependencies,

--- a/Content.Shared/SmartFridge/SmartFridgeEntrySerializer.cs
+++ b/Content.Shared/SmartFridge/SmartFridgeEntrySerializer.cs
@@ -1,0 +1,65 @@
+﻿using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Content.Shared.SmartFridge;
+
+[TypeSerializer]
+public sealed class SmartFridgeEntrySerializer :
+    ITypeSerializer<SmartFridgeEntry, ValueDataNode>,
+    ITypeReader<SmartFridgeEntry, MappingDataNode> // For backwards compatibility with the DataRecord serializer
+{
+    public SmartFridgeEntry Read(ISerializationManager serializationManager,
+        ValueDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<SmartFridgeEntry>? instanceProvider = null)
+    {
+        return new SmartFridgeEntry(node.Value);
+    }
+
+    public DataNode Write(ISerializationManager serializationManager,
+        SmartFridgeEntry value,
+        IDependencyCollection dependencies,
+        bool alwaysWrite = false,
+        ISerializationContext? context = null)
+    {
+        return new ValueDataNode(value.Name);
+    }
+
+    public ValidationNode Validate(ISerializationManager serializationManager,
+        ValueDataNode node,
+        IDependencyCollection dependencies,
+        ISerializationContext? context = null)
+    {
+        return new ValidatedValueNode(node);
+    }
+
+
+    public ValidationNode Validate(ISerializationManager serializationManager,
+        MappingDataNode node,
+        IDependencyCollection dependencies,
+        ISerializationContext? context = null)
+    {
+        if (node.TryGetValue("name", out var valNode) && valNode is ValueDataNode)
+            return new ValidatedValueNode(valNode);
+
+        return new ErrorNode(node, "must contain name entry");
+    }
+
+    public SmartFridgeEntry Read(ISerializationManager serializationManager,
+        MappingDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<SmartFridgeEntry>? instanceProvider = null)
+    {
+        var valNode = (ValueDataNode)node["name"];
+        return new  SmartFridgeEntry(valNode.Value);
+    }
+}


### PR DESCRIPTION
## About the PR

Both of these components could generate exceptions when trying to save a map. This fixes those exceptions.

## Technical details

PayloadTriggerComponent was trying to serialize a `HashSet<Type>` of components. This PR replace that with a set of component names.

SmartFridgeComponent  was using a `SmartFridgeEntry` `DataRecord` as a dictionary key, which is no longer supported as space-wizards/RobustToolbox/pull/5783 has made it so that yaml mappings no longer support complex keys. So this PR adds a type serializer that manually handles serializing a `SmartFridgeEntry`. The serialization changes should be backwards compatible.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
