### PR TITLE
shortened Plasteel Chef's Dinnerware Vendor UI title, so X button is visible

### DIFF
--- a/Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs
+++ b/Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs
@@ -24,7 +24,10 @@ namespace Content.Client.VendingMachines
             base.Open();
 
             _menu = this.CreateWindowCenteredLeft<VendingMachineMenu>();
-            _menu.Title = EntMan.GetComponent<MetaDataComponent>(Owner).EntityName;
+            _menu.Title = (
+                EntMan.GetComponent<VendingMachineComponent>(Owner).CustomWindowTitle
+                ?? EntMan.GetComponent<MetaDataComponent>(Owner).EntityName
+            );
             _menu.OnItemSelected += OnItemSelected;
             Refresh();
         }

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -141,6 +141,13 @@ namespace Content.Shared.VendingMachines
 
         #region Client Visuals
         /// <summary>
+        /// Text to display at the top of the vending machine's user interface window, 
+        /// in cases where the default (machine prototype's name) is not desired.
+        /// </summary>
+        [DataField]
+        public string? CustomWindowTitle;
+
+        /// <summary>
         /// RSI state for when the vending machine is unpowered.
         /// Will be displayed on the layer <see cref="VendingMachineVisualLayers.Base"/>
         /// </summary>

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -790,6 +790,7 @@
   description: A kitchen and restaurant equipment vendor.
   components:
   - type: VendingMachine
+    customWindowTitle: Plasteel Chef Dinnerware
     pack: DinnerwareInventory
     offState: off
     brokenState: broken


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

The overly-long window title "Plasteel Chef's Dinnerware Vendor":
![plasteel_old](https://github.com/user-attachments/assets/4389713c-9b76-46f9-bebe-507e069464f5)

has now been shortened, so that the corner close button is actually clickable:
![plasteel_new](https://github.com/user-attachments/assets/251a4cb8-e82a-4d77-b57f-54205a8c6384)

The vendor itself has not been renamed - inspecting it still shows "Plasteel Chef's Dinnerware Vendor".

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Nanotrasen chefs EVERYWHERE are FED UP with CONSTANTLY resizing this window to close it. This *essential* quality of life improvement eliminates the risk of an expensively-litigated Chef Union strike due to these debilitating workplace conditions, securing quality nutrition for our future workforce.


## Technical details
VendingMachineComponent now has a DataField "CustomWindowTitle" that is used for the UI title when present (instead of the vending machine prototype's name).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

I don't think this PR needs a changelog entry.

<!--
:cl:
- fix: Attempting to close the Plasteel Chef's Dinnerware Vendor UI no longer deals 60 psychic damage to the user.
-->
