### PR TITLE
Fix post-mapinit NPC exception

### DIFF
--- a/Content.Server/NPC/Components/NPCComponent.cs
+++ b/Content.Server/NPC/Components/NPCComponent.cs
@@ -9,4 +9,5 @@ public abstract partial class NPCComponent : SharedNPCComponent
     /// </summary>
     [DataField("blackboard", customTypeSerializer: typeof(NPCBlackboardSerializer))]
     public NPCBlackboard Blackboard = new();
+    // TODO FULL GAME SAVE Serialize this
 }

--- a/Content.Server/NPC/HTN/HTNComponent.cs
+++ b/Content.Server/NPC/HTN/HTNComponent.cs
@@ -24,6 +24,7 @@ public sealed partial class HTNComponent : NPCComponent
     /// </summary>
     [ViewVariables]
     public HTNPlan? Plan;
+    // TODO FULL GAME SAVE serialize this?
 
     /// <summary>
     /// How long to wait after having planned to try planning again.

--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -33,6 +33,7 @@ public sealed class HTNSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<HTNComponent, MobStateChangedEvent>(_npc.OnMobStateChange);
         SubscribeLocalEvent<HTNComponent, MapInitEvent>(_npc.OnNPCMapInit);
+        SubscribeLocalEvent<HTNComponent, ComponentStartup>(_npc.OnNPCStartup);
         SubscribeLocalEvent<HTNComponent, PlayerAttachedEvent>(_npc.OnPlayerNPCAttach);
         SubscribeLocalEvent<HTNComponent, PlayerDetachedEvent>(_npc.OnPlayerNPCDetach);
         SubscribeLocalEvent<HTNComponent, ComponentShutdown>(OnHTNShutdown);

--- a/Content.Server/NPC/Systems/NPCSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSystem.cs
@@ -63,9 +63,13 @@ namespace Content.Server.NPC.Systems
             WakeNPC(uid, component);
         }
 
-        public void OnNPCMapInit(EntityUid uid, HTNComponent component, MapInitEvent args)
+        public void OnNPCStartup(EntityUid uid, HTNComponent component, ComponentStartup args)
         {
             component.Blackboard.SetValue(NPCBlackboard.Owner, uid);
+        }
+
+        public void OnNPCMapInit(EntityUid uid, HTNComponent component, MapInitEvent args)
+        {
             WakeNPC(uid, component);
         }
 


### PR DESCRIPTION
## About the PR

This bandaids an issue that causes NPCs to throw exceptions when loading a postinit map by ensuring that `NPCBlackboard.Owner` is set during startup. Properly fixing this requires serializing NPC data for proper persitence / full-save support.