### PR TITLE
GridPacks and DungeonPacks for GridSpawn

### DIFF
--- a/Content.Server/Shuttles/Components/GridSpawnComponent.cs
+++ b/Content.Server/Shuttles/Components/GridSpawnComponent.cs
@@ -1,8 +1,7 @@
 using Content.Server.Shuttles.Systems;
 using Content.Shared.Dataset;
-using Content.Shared.Procedural;
+using Content.Shared.Shuttles.Prototypes;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Utility;
 
 namespace Content.Server.Shuttles.Components;
 
@@ -65,9 +64,9 @@ public interface IGridSpawnGroup
 public sealed partial class DungeonSpawnGroup : IGridSpawnGroup
 {
     /// <summary>
-    /// Prototypes we can choose from to spawn.
+    /// Dungeon Packs to use when spawning.
     /// </summary>
-    public List<ProtoId<DungeonConfigPrototype>> Protos = new();
+    public List<ProtoId<DungeonPackPrototype>> DungeonPacks = new();
 
     /// <inheritdoc />
     public float MinimumDistance { get; }
@@ -99,7 +98,7 @@ public sealed partial class DungeonSpawnGroup : IGridSpawnGroup
 [DataRecord]
 public sealed partial class GridSpawnGroup : IGridSpawnGroup
 {
-    public List<ResPath> Paths = new();
+    public List<ProtoId<GridPackPrototype>> GridPacks = new();
 
     /// <inheritdoc />
     public float MinimumDistance { get; }
@@ -114,5 +113,4 @@ public sealed partial class GridSpawnGroup : IGridSpawnGroup
     public bool NameGrid { get; set; } = true;
     public bool StationGrid { get; set; } = true;
 }
-
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Server.Shuttles.Components;
 using Content.Server.Station.Events;
 using Content.Shared.CCVar;
+using Content.Shared.Procedural;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Station.Components;
 using Robust.Shared.Collections;
@@ -87,12 +88,26 @@ public sealed partial class ShuttleSystem
             return false;
         }
 
-        var dungeonProtoId = _random.Pick(group.Protos);
-
-        if (!_protoManager.TryIndex(dungeonProtoId, out var dungeonProto))
+        var dungeonProtos = new List<DungeonConfigPrototype>();
+        foreach (var dungeonPackId in group.DungeonPacks)
         {
-            return false;
+            if (!_protoManager.TryIndex(dungeonPackId, out var dungeonProto))
+            {
+                Log.Error(dungeonPackId + "is an invalid prototype.");
+                return false;
+            }
+
+            foreach (var configId in dungeonProto.DungeonConfigs)
+            {
+                if (_protoManager.TryIndex(configId, out var configProto))
+                {
+                    dungeonProtos.Add(configProto);
+                }
+            }
         }
+        var dungeonProtoId = _random.Pick(dungeonProtos);
+
+
 
         var targetPhysics = _physicsQuery.Comp(targetGrid);
         var spawnCoords = new EntityCoordinates(targetGrid, targetPhysics.LocalCenter);
@@ -108,7 +123,7 @@ public sealed partial class ShuttleSystem
         var spawnedGrid = _mapManager.CreateGridEntity(mapId);
 
         _transform.SetMapCoordinates(spawnedGrid, new MapCoordinates(Vector2.Zero, mapId));
-        _dungeon.GenerateDungeon(dungeonProto, spawnedGrid.Owner, spawnedGrid.Comp, Vector2i.Zero, _random.Next(), spawnCoords);
+        _dungeon.GenerateDungeon(dungeonProtoId, spawnedGrid.Owner, spawnedGrid.Comp, Vector2i.Zero, _random.Next(), spawnCoords);
 
         spawned = spawnedGrid.Owner;
         return true;
@@ -118,9 +133,9 @@ public sealed partial class ShuttleSystem
     {
         spawned = EntityUid.Invalid;
 
-        if (group.Paths.Count == 0)
+        if (group.GridPacks.Count == 0)
         {
-            Log.Error($"Found no paths for GridSpawn");
+            Log.Error($"Found no grid packs for GridSpawn");
             return false;
         }
 
@@ -129,10 +144,15 @@ public sealed partial class ShuttleSystem
         // Round-robin so we try to avoid dupes where possible.
         if (paths.Count == 0)
         {
-            paths.AddRange(group.Paths);
+            foreach (var gridPackId in group.GridPacks)
+            {
+                if (_protoManager.TryIndex(gridPackId, out var gridPack))
+                {
+                    paths.AddRange(gridPack.GridPaths);
+                }
+            }
             _random.Shuffle(paths);
         }
-
         var path = paths[^1];
         paths.RemoveAt(paths.Count - 1);
 

--- a/Content.Shared/Shuttles/Prototypes/DungeonPackPrototype.cs
+++ b/Content.Shared/Shuttles/Prototypes/DungeonPackPrototype.cs
@@ -1,0 +1,15 @@
+using Content.Shared.Procedural;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Shuttles.Prototypes;
+
+[Prototype]
+public sealed partial class DungeonPackPrototype : IPrototype
+{
+    [ViewVariables]
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    [DataField]
+    public List<ProtoId<DungeonConfigPrototype>> DungeonConfigs { get; private set; } =  new();
+}

--- a/Content.Shared/Shuttles/Prototypes/GridPackPrototype.cs
+++ b/Content.Shared/Shuttles/Prototypes/GridPackPrototype.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Shuttles.Prototypes;
+
+[Prototype]
+public sealed partial class GridPackPrototype : IPrototype
+{
+    [ViewVariables]
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    [DataField]
+    public List<ResPath> GridPaths { get; private set; } =  new();
+}

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -57,8 +57,8 @@
           addComponents:
             - type: ProtectedGrid
             - type: TradeStation
-          paths:
-            - /Maps/Shuttles/trading_outpost.yml
+          gridPacks:
+          - DefaultTradeGridPack
         # Spawn last
         ruins: !type:GridSpawnGroup
           hide: true
@@ -66,22 +66,8 @@
           minCount: 2
           maxCount: 2
           stationGrid: false
-          paths:
-          - /Maps/Ruins/abandoned_outpost.yml
-          - /Maps/Ruins/atmos_interchange.yml
-          - /Maps/Ruins/chunked_tcomms.yml
-          - /Maps/Ruins/biodome_satellite.yml
-          - /Maps/Ruins/derelict.yml
-          - /Maps/Ruins/djstation.yml
-          - /Maps/Ruins/empty_flagship.yml
-          - /Maps/Ruins/hydro_outpost.yml
-          - /Maps/Ruins/old_ai_sat.yml
-          - /Maps/Ruins/ruined_prison_ship.yml
-          - /Maps/Ruins/syndicate_dropship.yml
-          - /Maps/Ruins/whiteship_ancient.yml
-          - /Maps/Ruins/whiteship_bluespacejumper.yml
-          - /Maps/Ruins/wrecklaimer.yml
-          - /Maps/Ruins/displaced_telescience.yml
+          gridPacks:
+          - DefaultRuinGridPack
         wrecks: !type:DungeonSpawnGroup
           minimumDistance: 150
           maximumDistance: 300
@@ -95,12 +81,8 @@
           - type: IFF
             flags: HideLabel
             color: "#88b0d1"
-          protos:
-          - ChunkDebrisSmall
-          - ChunkDebrisSmall
-          - ChunkDebrisSmall
-          - ChunkDebrisSmall
-          - ChunkDebris
+          dungeonPacks:
+          - DefaultWreckDungeonPack
         vgroid: !type:DungeonSpawnGroup
           minimumDistance: 300
           maximumDistance: 350
@@ -110,8 +92,8 @@
           - type: Gravity
             enabled: true
             inherent: true
-          protos:
-          - VGRoid
+          dungeonPacks:
+          - VGRoidDungeonPack
 
 - type: entity
   id: BaseStationCentcomm

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -93,7 +93,7 @@
             enabled: true
             inherent: true
           dungeonPacks:
-          - VGRoidDungeonPack
+          - DefaultVGRoidDungeonPack
 
 - type: entity
   id: BaseStationCentcomm

--- a/Resources/Prototypes/Maps/DungeonPacks/vgroid.yml
+++ b/Resources/Prototypes/Maps/DungeonPacks/vgroid.yml
@@ -1,0 +1,4 @@
+- type: dungeonPack
+  id: DefaultVGRoidDungeonPack
+  dungeonConfigs:
+    - VGRoid

--- a/Resources/Prototypes/Maps/DungeonPacks/wrecks.yml
+++ b/Resources/Prototypes/Maps/DungeonPacks/wrecks.yml
@@ -1,0 +1,8 @@
+- type: dungeonPack
+  id: DefaultWreckDungeonPack
+  dungeonConfigs:
+    - ChunkDebrisSmall
+    - ChunkDebrisSmall
+    - ChunkDebrisSmall
+    - ChunkDebrisSmall
+    - ChunkDebris

--- a/Resources/Prototypes/Maps/GridPacks/ruins.yml
+++ b/Resources/Prototypes/Maps/GridPacks/ruins.yml
@@ -1,0 +1,18 @@
+- type: gridPack
+  id: DefaultRuinGridPack
+  gridPaths:
+    - /Maps/Ruins/abandoned_outpost.yml
+    - /Maps/Ruins/atmos_interchange.yml
+    - /Maps/Ruins/chunked_tcomms.yml
+    - /Maps/Ruins/biodome_satellite.yml
+    - /Maps/Ruins/derelict.yml
+    - /Maps/Ruins/djstation.yml
+    - /Maps/Ruins/empty_flagship.yml
+    - /Maps/Ruins/hydro_outpost.yml
+    - /Maps/Ruins/old_ai_sat.yml
+    - /Maps/Ruins/ruined_prison_ship.yml
+    - /Maps/Ruins/syndicate_dropship.yml
+    - /Maps/Ruins/whiteship_ancient.yml
+    - /Maps/Ruins/whiteship_bluespacejumper.yml
+    - /Maps/Ruins/wrecklaimer.yml
+    - /Maps/Ruins/displaced_telescience.yml

--- a/Resources/Prototypes/Maps/GridPacks/trade.yml
+++ b/Resources/Prototypes/Maps/GridPacks/trade.yml
@@ -1,0 +1,4 @@
+- type: gridPack
+  id: DefaultTradeGridPack
+  gridPaths:
+    - /Maps/Shuttles/trading_outpost.yml

--- a/Resources/Prototypes/Maps/relic.yml
+++ b/Resources/Prototypes/Maps/relic.yml
@@ -26,8 +26,8 @@
             trade: !type:GridSpawnGroup
               minCount: 0
               maxCount: 0
-              paths:
-                - /Maps/Shuttles/trading_outpost.yml
+              gridPacks:
+              - DefaultTradeGridPack
         - type: StationJobs
           availableJobs:
             #command (6)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR


## Why / Balance
Currently, the gridspawn component only supports a direct list of respaths / dungeonconfigs, which adds a lot of effort for maps that would require unique gridspawns, as you need to update the map every time new wrecks get added.
This PR lets you define packs instead, which is far more modular.

## Technical details
<!-- Summary of code changes for easier review. -->
DungeonSpawnGroup and GridSpawnGroup have been altered from storing DungeonConfigs and ResPaths to DungeonPacks and GridPacks instead, which are prototypes that contain lists of DungeonConfig and ResPaths respectively. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
DungeonSpawnGroup and GridSpawnGroup have been altered from storing DungeonConfigs and ResPaths to DungeonPacks and GridPacks instead, which are prototypes that contain lists of DungeonConfig and ResPaths respectively.  
For all instances of a unique group of DungeonConfigs and ResPaths, a prototype containing them should be created, and the repective SpawnGroup should be altered to contain it.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No player facing changes
