### PR TITLE
Make mobs saveable

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -3,7 +3,6 @@
   id: BaseBorgChassisNotIonStormable
   name: cyborg
   description: A man-machine hybrid that assists in station activity. They love being asked to state their laws over and over.
-  save: false
   abstract: true
   components:
   - type: Reactive
@@ -430,7 +429,6 @@
   id: BaseXenoborgChassis
   name: xenoborg
   description: A man-machine hybrid that aims to replicate itself. They love extracting brains to insert into fresh Xenoborg chassis to grow their army.
-  save: false
   abstract: true
   components:
   - type: RandomMetadata

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1877,7 +1877,6 @@
 - type: entity
   parent: MobMouse
   suffix: Dead
-  save: false
   id: MobMouseDead
   name: mouse
   description: Squeak!

--- a/Resources/Prototypes/Entities/Mobs/NPCs/argocyte.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/argocyte.yml
@@ -1,5 +1,4 @@
 ﻿- type: entity
-  save: false
   parent: [ BaseSimpleMob, MobCombat ]
   id: BaseMobArgocyte
   suffix: AI

--- a/Resources/Prototypes/Entities/Mobs/NPCs/dummy_npcs.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/dummy_npcs.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: pathfinding dummy
   parent: BaseMobHuman
   id: MobHumanPathDummy

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -72,7 +72,6 @@
 - type: entity
   parent: BaseMobHuman
   suffix: Dead
-  save: false # mobs are currently not saveable.
   id: SalvageHumanCorpse
   name: unidentified corpse
   description: I think they're dead.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -1,5 +1,6 @@
 - type: entity
   id: MobRevenant
+  save: true # override Incorporeal
   parent:
   - Incorporeal
   - BaseMob

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -1,6 +1,5 @@
 # Used for generic robotic entities (like Hivelords)
 - type: entity
-  save: false
   abstract: true
   parent: BaseMob
   id: MobRobotic
@@ -53,7 +52,6 @@
 
 # Used for bots
 - type: entity
-  save: false
   abstract: true
   parent: MobRobotic
   id: MobSiliconBase

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   parent:
   - BaseMob
   - MobDamageable

--- a/Resources/Prototypes/Entities/Mobs/Player/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/arachnid.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McWeb
   parent: BaseMobArachnid
   id: MobArachnid

--- a/Resources/Prototypes/Entities/Mobs/Player/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/diona.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McPlants
   parent: BaseMobDiona
   id: MobDiona
@@ -20,4 +19,4 @@
   name: Reformed Diona
   components:
     - type: IsDeadIC
-    - type: RandomHumanoidAppearance 
+    - type: RandomHumanoidAppearance

--- a/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McHands The Dwarf
   parent: BaseMobDwarf
   id: MobDwarf

--- a/Resources/Prototypes/Entities/Mobs/Player/gingerbread.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/gingerbread.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McCookie
   parent: BaseMobGingerbread
   id: MobGingerbread
@@ -30,4 +29,3 @@
   - type: HTN
     rootTask:
       task: SimpleHostileCompound
-  

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -4,7 +4,6 @@
   name: GuardianBase
   id: MobGuardianBase
   description: guardian
-  save: false
   components:
     - type: LagCompensation
     - type: GhostRole

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McHands
   parent: BaseMobHuman
   id: MobHuman

--- a/Resources/Prototypes/Entities/Mobs/Player/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/moth.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McFluff
   parent: BaseMobMoth
   id: MobMoth

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -1,6 +1,10 @@
 - type: entity
   id: Incorporeal
-  save: false
+  # TODO PERSISTENCE enable this
+  # I'm leaving this disabled untill theres some system that prevents mapping ghosts from the saved to pre-init maps
+  # But in general various entities that need to be saveable inherit from Incorporeal (e.g., Revenant, StationAiHolo)
+  # So this really should be true to prevent people from accidentally making entities non-saveable.
+  save: false 
   abstract: true
   description: Mobs without physical bodies
   components:

--- a/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McScales
   suffix: Urisst' Mzhand
   parent: BaseMobReptilian

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -171,7 +171,7 @@
   suffix: Empty
   components:
   - type: Anchorable
-    flags: 
+    flags:
     - Anchorable
   - type: Rotatable
   - type: WarpPoint
@@ -305,6 +305,7 @@
   - Incorporeal
   - BaseMob
   id: StationAiHolo
+  save: true # override Incorporeal
   name: AI eye
   description: The AI's viewer.
   categories: [ HideSpawnMenu, DoNotMap ]

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   parent: BaseMobSkeletonPerson
   id: MobSkeletonPerson
   components:

--- a/Resources/Prototypes/Entities/Mobs/Player/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/slime.yml
@@ -1,4 +1,3 @@
 - type: entity
-  save: false
   parent: BaseMobSlimePerson
   id: MobSlimePerson

--- a/Resources/Prototypes/Entities/Mobs/Player/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/vox.yml
@@ -1,5 +1,4 @@
 ﻿- type: entity
-  save: false
   name: Uristititi McVox
   parent: BaseMobVox
   id: MobVox

--- a/Resources/Prototypes/Entities/Mobs/Player/vulpkanin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/vulpkanin.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McBark
   parent: BaseMobVulpkanin
   id: MobVulpkanin

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McWebs
   parent: BaseMobSpeciesOrganic
   id: BaseMobArachnid

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   parent:
   - BaseMob
   - MobDamageable
@@ -209,7 +208,6 @@
     - AnomalyHost
 
 - type: entity
-  save: false
   parent:
   - MobBloodstream
   - MobRespirator
@@ -278,7 +276,6 @@
   - type: StunVisuals
 
 - type: entity
-  save: false
   id: BaseSpeciesDummy
   parent: InventoryBase
   abstract: true

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McPlants
   parent: BaseMobSpeciesOrganic
   id: BaseMobDiona

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McHands The Dwarf
   parent: BaseMobSpeciesOrganic
   id: BaseMobDwarf

--- a/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McCookie
   parent: BaseMobSpeciesOrganic
   id: BaseMobGingerbread

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McFluff
   parent: BaseMobSpeciesOrganic
   id: BaseMobMoth

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urisst' Mzhand
   parent: BaseMobSpeciesOrganic
   id: BaseMobReptilian

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -1,5 +1,4 @@
 - type: entity
-  save: false
   name: Urist McSkelly
   parent:
   - MobFlammable

--- a/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
@@ -1,6 +1,5 @@
 - type: entity
   abstract: true
-  save: false
   parent: [BaseMobSpeciesOrganic]
   id: BaseMobVulpkanin
   name: Urist McBark

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -1,7 +1,6 @@
 # The progenitor. This should only container the most basic components possible.
 # Only put things on here if every mob *must* have it. This includes ghosts.
 - type: entity
-  save: false
   id: BaseMob
   abstract: true
   components:
@@ -48,7 +47,6 @@
   - type: StunVisuals
 
 - type: entity
-  save: false
   id: MobPolymorphable
   abstract: true
   components:
@@ -56,7 +54,6 @@
 
 # Used for mobs that have health and can take damage.
 - type: entity
-  save: false
   id: MobDamageable
   abstract: true
   components:
@@ -139,7 +136,6 @@
 
 # Used for mobs that can enter combat mode and can attack.
 - type: entity
-  save: false
   id: MobCombat
   abstract: true
   components:
@@ -154,7 +150,6 @@
 
 # Used for mobs that are affected by atmospherics, pressure, and heat
 - type: entity
-  save: false
   id: MobAtmosExposed
   abstract: true
   components:
@@ -212,7 +207,6 @@
 
 # Used for mobs that can be set on fire
 - type: entity
-  save: false
   id: MobFlammable
   abstract: true
   components:
@@ -228,7 +222,6 @@
 
 # Used for mobs that need to breathe
 - type: entity
-  save: false
   id: MobRespirator
   abstract: true
   components:
@@ -243,7 +236,6 @@
 
 # Used for mobs that have a bloodstream
 - type: entity
-  save: false
   id: MobBloodstream
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: BaseMech
-  save: false
+  save: false # TODO PERSISTENCE enable this. I don't know why its disabled.
   abstract: true
   components:
   - type: MobMover


### PR DESCRIPTION
## About the PR
Various mob prototypes are currently marked as unsaveable via `EntityPrototype.MapSavable`. This removes that from most mobs, allowing them to be saved.

Should only be merged after #40244
Requires an engine PR to fix ActorComponent NREs (e.g., space-wizards/RobustToolbox/pull/6189)

## Why / Balance

Required for full game saves (#34084). I'm not fully sure why they were disabled in the first place, likely due to old engine issues (e.g., old organ container issues like space-wizards/RobustToolbox/issues/3119). But I recently tested it and it largely seems to work fine as long as an NPC and ActorComponent bug is fixed.

## Technical details

This does not mark ghosts as saveable, so this shouldn't cause mappers to save their own ghosts while mapping. However, if they are spawning in mobs for whatever reason, they would need to start removing those. So maybe this needs some input from mappers?

Several mob related components are currently improperly doing some initialization during comp-init that should be getting done during mapinit. As a result making mobs saveable causes `PrototypeSaveTest` to start failing. So for now I've just added an ignored list of components to the test, as fixing all of that is beyond the scope of this PR.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
Maybe this doesn't belong in the mapping changelog as it seems to be designed for users not mappers? But its not rally for admins or users either.

:cl:
MAPS:
- tweak: Mobs are now saveable. If you are creating a map, you need to manually remove any mobs you don't want saved.
