### PR TITLE
Rules tab in changelog

### DIFF
--- a/Resources/Changelog/Admin.yml
+++ b/Resources/Changelog/Admin.yml
@@ -1381,4 +1381,4 @@ Entries:
   time: '2025-09-04T13:03:47.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/40053
 Name: Admin
-Order: 2
+Order: 3

--- a/Resources/Changelog/Maps.yml
+++ b/Resources/Changelog/Maps.yml
@@ -653,4 +653,4 @@
   id: 78
   time: '2025-09-06T06:02:26.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/40152
-Order: 1
+Order: 2

--- a/Resources/Changelog/Rules.yml
+++ b/Resources/Changelog/Rules.yml
@@ -1,0 +1,8 @@
+﻿Entries:
+- author: Errant
+  changes:
+  - message: Changes to Rules can now be tracked here. You like reading rules, don't you, you are a Rulesreader.
+    type: Add
+  id: 1
+  time: '2025-09-10'
+Order: 1

--- a/Resources/Locale/en-US/changelog/changelog-window.ftl
+++ b/Resources/Locale/en-US/changelog/changelog-window.ftl
@@ -14,6 +14,7 @@ changelog-button-new-entries = Changelog (new!)
 changelog-tab-title-Changelog = Changelog
 changelog-tab-title-Admin = Admin
 changelog-tab-title-Maps = Maps
+changelog-tab-title-Rules = Rules
 
 cmd-changelog-desc = Opens the changelog.
 cmd-changelog-help = Usage: changelog


### PR DESCRIPTION
## About the PR
title

Ideally this would be automated, but rule changes are infrequent enough that it's probably not a big deal to write them by hand? Do not merge until the admin team confirms they are okay with it being manual (at least at first)

## Why / Balance
"I just realized that we make rule changes for people not on the forums, discord, or that haven't played in a while pain and suffering 
The rules popup should have a "recently changed" section near the top
Otherwise we're asking people to re read all of the rules whenever anything changes"
[link](https://discord.com/channels/310555209753690112/1281461283157184532/1415088027755347998)

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
![Screenshot_2025-09-10_122540](https://github.com/user-attachments/assets/3ae7de9f-2cb8-4630-b1ae-7e0f3241d6e2)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Errant
- add: Rule changes are now tracked, on a new tab in the changelog window.
