### PR TITLE
Fix RGB staff not working

### DIFF
--- a/Resources/Prototypes/Magic/staves.yml
+++ b/Resources/Prototypes/Magic/staves.yml
@@ -70,6 +70,7 @@
   parent: BaseAction
   id: ActionRgbLight
   components:
+  - type: TargetAction
   - type: EntityTargetAction
     whitelist: { components: [ PointLight ] }
     event: !type:ChangeComponentsSpellEvent


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR fixes the ***RGB staff*** not working.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Getting a RGB staff from an event Wizard when everybody else got a fun staff was boring, so I felt like fixing it.

I don't think it will affect game balance, as it's only a cosmetic effect.

## Technical details
<!-- Summary of code changes for easier review. -->

This PR adds a `TargetAction` to `ActionRgbLight`, the `ActionOnInteract` called when using a `RGBStaff` on an entity.

This prevents `ValidateEntityTarget` from throwing a `KeyNotFoundException` when attempting to get the `TargetActionComponent` via `Comp<TargetActionComponent>`.

The remarks of `EntityTargetActionComponent`, used by `ActionRgbLight`, mention:

> ```cs
> /// <remarks>
> /// Requires <see cref="TargetActionComponent"/>.
> /// </remarks>
> ```

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/3f7dbd4a-4563-41f7-a9d6-722e8e0bbe46

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed the RGB staff not working.