### PR TITLE
Change ApcToggleBreaker to ApcSetBreaker

### DIFF
--- a/Content.Client/Power/APC/ApcBoundUserInterface.cs
+++ b/Content.Client/Power/APC/ApcBoundUserInterface.cs
@@ -22,7 +22,7 @@ namespace Content.Client.Power.APC
             base.Open();
             _menu = this.CreateWindow<ApcMenu>();
             _menu.SetEntity(Owner);
-            _menu.OnBreaker += BreakerPressed;
+            _menu.OnBreaker += on => BreakerPressed(on);
 
             var hasAccess = false;
             if (PlayerManager.LocalEntity != null)
@@ -41,9 +41,9 @@ namespace Content.Client.Power.APC
             _menu?.UpdateState(castState);
         }
 
-        public void BreakerPressed()
+        public void BreakerPressed(bool on)
         {
-            SendMessage(new ApcToggleMainBreakerMessage());
+            SendMessage(new ApcSetMainBreakerMessage(on));
         }
     }
 }

--- a/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
@@ -18,14 +18,14 @@ namespace Content.Client.Power.APC.UI
     [GenerateTypedNameReferences]
     public sealed partial class ApcMenu : FancyWindow
     {
-        public event Action? OnBreaker;
+        public event Action<bool>? OnBreaker;
 
         public ApcMenu()
         {
             IoCManager.InjectDependencies(this);
             RobustXamlLoader.Load(this);
 
-            BreakerButton.OnPressed += _ => OnBreaker?.Invoke();
+            BreakerButton.OnPressed += args => OnBreaker?.Invoke(args.Button.Pressed);
         }
 
         public void SetEntity(EntityUid entity)

--- a/Content.Server/Emp/EmpSystem.cs
+++ b/Content.Server/Emp/EmpSystem.cs
@@ -18,7 +18,7 @@ public sealed class EmpSystem : SharedEmpSystem
 
         SubscribeLocalEvent<EmpDisabledComponent, RadioSendAttemptEvent>(OnRadioSendAttempt);
         SubscribeLocalEvent<EmpDisabledComponent, RadioReceiveAttemptEvent>(OnRadioReceiveAttempt);
-        SubscribeLocalEvent<EmpDisabledComponent, ApcToggleMainBreakerAttemptEvent>(OnApcToggleMainBreaker);
+        SubscribeLocalEvent<EmpDisabledComponent, ApcSetMainBreakerAttemptEvent>(OnApcSetMainBreaker);
         SubscribeLocalEvent<EmpDisabledComponent, SurveillanceCameraSetActiveAttemptEvent>(OnCameraSetActive);
     }
 
@@ -110,7 +110,7 @@ public sealed class EmpSystem : SharedEmpSystem
         args.Cancelled = true;
     }
 
-    private void OnApcToggleMainBreaker(EntityUid uid, EmpDisabledComponent component, ref ApcToggleMainBreakerAttemptEvent args)
+    private void OnApcSetMainBreaker(EntityUid uid, EmpDisabledComponent component, ref ApcSetMainBreakerAttemptEvent args)
     {
         args.Cancelled = true;
     }

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -33,7 +33,7 @@ public sealed class ApcSystem : EntitySystem
         SubscribeLocalEvent<ApcComponent, BoundUIOpenedEvent>(OnBoundUiOpen);
         SubscribeLocalEvent<ApcComponent, ComponentStartup>(OnApcStartup);
         SubscribeLocalEvent<ApcComponent, ChargeChangedEvent>(OnBatteryChargeChanged);
-        SubscribeLocalEvent<ApcComponent, ApcToggleMainBreakerMessage>(OnToggleMainBreaker);
+        SubscribeLocalEvent<ApcComponent, ApcSetMainBreakerMessage>(OnSetMainBreaker);
         SubscribeLocalEvent<ApcComponent, GotEmaggedEvent>(OnEmagged);
 
         SubscribeLocalEvent<ApcComponent, EmpPulseEvent>(OnEmpPulse);
@@ -75,9 +75,9 @@ public sealed class ApcSystem : EntitySystem
         UpdateApcState(uid, component);
     }
 
-    private void OnToggleMainBreaker(EntityUid uid, ApcComponent component, ApcToggleMainBreakerMessage args)
+    private void OnSetMainBreaker(EntityUid uid, ApcComponent component, ApcSetMainBreakerMessage args)
     {
-        var attemptEv = new ApcToggleMainBreakerAttemptEvent();
+        var attemptEv = new ApcSetMainBreakerAttemptEvent();
         RaiseLocalEvent(uid, ref attemptEv);
         if (attemptEv.Cancelled)
         {
@@ -88,7 +88,7 @@ public sealed class ApcSystem : EntitySystem
 
         if (_accessReader.IsAllowed(args.Actor, uid))
         {
-            ApcToggleBreaker(uid, component);
+            ApcSetBreaker(uid, args.Enabled, component);
         }
         else
         {
@@ -97,7 +97,7 @@ public sealed class ApcSystem : EntitySystem
         }
     }
 
-    public void ApcToggleBreaker(EntityUid uid, ApcComponent? apc = null, PowerNetworkBatteryComponent? battery = null)
+    public void ApcSetBreaker(EntityUid uid, bool breakerEnabled, ApcComponent? apc = null, PowerNetworkBatteryComponent? battery = null)
     {
         if (!Resolve(uid, ref apc, ref battery))
             return;
@@ -209,10 +209,10 @@ public sealed class ApcSystem : EntitySystem
         {
             args.Affected = true;
             args.Disabled = true;
-            ApcToggleBreaker(uid, component);
+            ApcSetBreaker(uid, false, component);
         }
     }
 }
 
 [ByRefEvent]
-public record struct ApcToggleMainBreakerAttemptEvent(bool Cancelled);
+public record struct ApcSetMainBreakerAttemptEvent(bool Cancelled);

--- a/Content.Server/StationEvents/Events/BreakerFlipRule.cs
+++ b/Content.Server/StationEvents/Events/BreakerFlipRule.cs
@@ -49,7 +49,7 @@ public sealed class BreakerFlipRule : StationEventSystem<BreakerFlipRuleComponen
 
         for (var i = 0; i < toDisable; i++)
         {
-            _apcSystem.ApcToggleBreaker(stationApcs[i], stationApcs[i]);
+            _apcSystem.ApcSetBreaker(stationApcs[i], false, stationApcs[i]);
         }
     }
 }

--- a/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
@@ -50,7 +50,7 @@ namespace Content.Server.StationEvents.Events
                 if (TryComp(entity, out ApcComponent? apcComponent))
                 {
                     if(!apcComponent.MainBreakerEnabled)
-                        _apcSystem.ApcToggleBreaker(entity, apcComponent);
+                        _apcSystem.ApcSetBreaker(entity, true, apcComponent);
                 }
             }
 
@@ -87,7 +87,7 @@ namespace Content.Server.StationEvents.Events
                 if (TryComp<ApcComponent>(selected, out var apcComponent))
                 {
                     if (apcComponent.MainBreakerEnabled)
-                        _apcSystem.ApcToggleBreaker(selected, apcComponent);
+                        _apcSystem.ApcSetBreaker(selected, false, apcComponent);
                 }
                 component.Unpowered.Add(selected);
             }

--- a/Content.Shared/APC/SharedApc.cs
+++ b/Content.Shared/APC/SharedApc.cs
@@ -212,8 +212,9 @@ namespace Content.Shared.APC
     }
 
     [Serializable, NetSerializable]
-    public sealed class ApcToggleMainBreakerMessage : BoundUserInterfaceMessage
+    public sealed class ApcSetMainBreakerMessage(bool enabled) : BoundUserInterfaceMessage
     {
+        public bool Enabled = enabled;
     }
 
     public enum ApcExternalPowerState : byte


### PR DESCRIPTION
## About the PR
I replaced APC breaker toggling with APC breaker setting.

## Why / Balance
I want to add prediction to the UI button for this and it seemed like this would make the prediction handling simpler.

I was going to put this and the prediction in the same PR, but then I hit a snag in implementing the prediction, so I decided to clean up this half of things and put it into its own small self-contained PR, since it doesn't rely on the prediction.

This also prevents two people/systems that try to toggle an APC at close to the same time from cancelling each other out, but I suspect that's unlikely to actually come up very often.

## Technical details
I changed the `ApcToggleBreaker` function to `ApcSetBreaker` and added a parameter for the desired APC state. I also changed `ApcToggleMainBreakerMessage` and `ApcToggleMainBreakerAttemptEvent` to `ApcSetMainBreakerMessage` and `ApcSetMainBreakerAttemptEvent`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`ApcToggleBreaker` is now `ApcSetBreaker` and has a required parameter for the new breaker state.
`ApcToggleMainBreakerMessage` is now `ApcSetMainBreakerMessage` and also has a required parameter for the new breaker state.
`ApcToggleMainBreakerAttemptEvent` is now `ApcSetMainBreakerAttemptEvent`.