### PR TITLE
Clip the WindowTitle of FancyWindows, so close buttons don't get hidden

### DIFF
--- a/Content.Client/UserInterface/Controls/FancyWindow.xaml
+++ b/Content.Client/UserInterface/Controls/FancyWindow.xaml
@@ -10,7 +10,7 @@
             <PanelContainer StyleClasses="WindowHeadingBackground" />
             <BoxContainer Margin="4 2 8 0" Orientation="Horizontal">
                 <Label Name="WindowTitle"
-                       HorizontalExpand="True" VAlign="Center" StyleClasses="FancyWindowTitle" />
+                       HorizontalExpand="True" VAlign="Center" StyleClasses="FancyWindowTitle" ClipText="true" />
                 <TextureButton Name="HelpButton" StyleClasses="windowHelpButton" VerticalAlignment="Center" Disabled="True" Visible="False" Access="Public" />
                 <TextureButton Name="CloseButton" StyleClasses="windowCloseButton"
                                VerticalAlignment="Center" />


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

The overly-long window title "Plasteel Chef's Dinnerware Vendor" was annoyingly blocking the close button:
![plasteel_old](https://github.com/user-attachments/assets/32327383-baac-4fdd-8d43-4af0cfe2a2b2)

but now long titles are clipped:
![plasteel_new2](https://github.com/user-attachments/assets/f2355fc5-914e-4449-b41a-23dd18c6b025)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Super annoying to have to resize this window when you want to close it.

## Technical details
<!-- Summary of code changes for easier review. -->

`FancyWindow.WindowTitle.ClipText` is now `true` by default. We can override it with further PRs if we find any special FancyWindow cases where this is not desired (but given how bad the overrun looks I don't see why you'd ever want `false`).

Clipping the title is a better solution than changing the title, per https://github.com/space-wizards/space-station-14/pull/40238

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
