### PR TITLE
Fix APC breaker toggle button prediction by setting ToggleMode True

### DIFF
--- a/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
@@ -25,7 +25,7 @@ namespace Content.Client.Power.APC.UI
             IoCManager.InjectDependencies(this);
             RobustXamlLoader.Load(this);
 
-            BreakerButton.OnToggled += _ => OnBreaker?.Invoke();
+            BreakerButton.OnPressed += _ => OnBreaker?.Invoke();
         }
 
         public void SetEntity(EntityUid entity)


### PR DESCRIPTION
## About the PR
APC breaker toggle button now has `ToggleMode="True"`, which magically causes prediction to be handled correctly for it.

## Why / Balance
Prediction nice.

## Technical details
I literally just added `ToggleMode="True"`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->