### PR TITLE
Fix sericulture zombies

### DIFF
--- a/Content.Shared/Sericulture/SericultureSystem.cs
+++ b/Content.Shared/Sericulture/SericultureSystem.cs
@@ -68,8 +68,8 @@ public abstract partial class SharedSericultureSystem : EntitySystem
 
     private void OnSericultureStart(EntityUid uid, SericultureComponent comp, SericultureActionEvent args)
     {
-        if (TryComp<HungerComponent>(uid, out var hungerComp)
-            && _hungerSystem.IsHungerBelowState(uid,
+        if (!TryComp<HungerComponent>(uid, out var hungerComp)
+            || _hungerSystem.IsHungerBelowState(uid,
                 comp.MinHungerThreshold,
                 _hungerSystem.GetHunger(hungerComp) - comp.HungerCost,
                 hungerComp))
@@ -95,9 +95,9 @@ public abstract partial class SharedSericultureSystem : EntitySystem
         if (args.Cancelled || args.Handled || comp.Deleted)
             return;
 
-        if (TryComp<HungerComponent>(uid,
+        if (!TryComp<HungerComponent>(uid,
                 out var hungerComp) // A check, just incase the doafter is somehow performed when the entity is not in the right hunger state.
-            && _hungerSystem.IsHungerBelowState(uid,
+            || _hungerSystem.IsHungerBelowState(uid,
                 comp.MinHungerThreshold,
                 _hungerSystem.GetHunger(hungerComp) - comp.HungerCost,
                 hungerComp))
@@ -106,7 +106,7 @@ public abstract partial class SharedSericultureSystem : EntitySystem
             return;
         }
 
-        _hungerSystem.ModifyHunger(uid, -comp.HungerCost);
+        _hungerSystem.ModifyHunger(uid, -comp.HungerCost, hungerComp);
 
         if (!_netManager.IsClient) // Have to do this because spawning stuff in shared is CBT.
         {


### PR DESCRIPTION
## About the PR
Zombies loose the `HungerComponent`, meaning zombified spiders were able to spam infinite items quite quickly, which is a performance problem. It also spammed errors from a failing `Resolve`.
This PR makes sericulture attempts fail if you don't have any hunger.
The alternative would be to code a zombie hunger mechanic that refills when they bite someone.
But that is a more involved refactor and zombie code needs work in general.

## Why / Balance
infinite items bad

## Technical details
Adjust the guard statement to fail when you don't have the `HungerComponent`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The `SericultureComponent` action now fails if you don't have the `HungerComponent` to prevent item spam.

**Changelog**
:cl:
- fix: Zombified arachnids can no longer spam infinite silk due to having no hunger.
