### PR TITLE
Edible Sound Specifier Override

### DIFF
--- a/Content.Shared/Nutrition/Components/EdibleComponent.cs
+++ b/Content.Shared/Nutrition/Components/EdibleComponent.cs
@@ -2,6 +2,7 @@
 using Content.Shared.FixedPoint;
 using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Nutrition.Prototypes;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
@@ -77,6 +78,13 @@ public sealed partial class EdibleComponent : Component
     /// </summary>
     [DataField]
     public bool RequireDead = true;
+
+    /// <summary>
+    /// An optional override for the sound made when consuming this item.
+    /// Useful for if an edible type doesn't justify a new prototype, like with plushies.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? UseSound;
 
     /// <summary>
     /// Verb, icon, and sound data for our edible.

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -449,7 +449,7 @@ public sealed partial class IngestionSystem : EntitySystem
 
         var edible = _proto.Index(entity.Comp.Edible);
 
-        _audio.PlayPredicted(edible.UseSound, args.Target, args.User);
+        _audio.PlayPredicted(entity.Comp.UseSound ?? edible.UseSound, args.Target, args.User);
 
         var flavors = _flavorProfile.GetLocalizedFlavorsMessage(entity.Owner, args.Target, args.Split);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a sound specifier override to the edible component. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Needed for killing food and drink component, specifically with plushies and some other edge cases.

## Technical details
<!-- Summary of code changes for easier review. -->
One new nullable datafield. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
