### PR TITLE
Toilet fixes: Exception when constructing, proper seat layering

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -1,9 +1,9 @@
 - type: entity
-  name: toilet
-  id: BaseToilet
-  parent: [ DisposalUnitBase, SeatBase ]
-  description: The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably clean.
   abstract: true
+  parent: [ DisposalUnitBase, SeatBase ]
+  id: BaseToilet
+  name: toilet
+  description: The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably clean.
   components:
   - type: Sprite
     sprite: Structures/Furniture/toilet.rsi
@@ -24,8 +24,6 @@
       map: [ "enum.DisposalUnitVisualLayers.OverlayFull" ]
     - state: dispover-handle
       map: [ "enum.DisposalUnitVisualLayers.OverlayEngaged" ]
-    - map: [ "DoorVisualState.DoorOpen" ]
-    - map: [ "SeatVisualState.SeatUp" ]
   - type: Rotatable
   - type: Transform
     noRot: false
@@ -107,32 +105,32 @@
     utensil: Spoon
   - type: GenericVisualizer
     visuals:
-      enum.ToiletVisuals.SeatVisualState:
-        SeatVisualState.SeatUp:
-          SeatUp: { state: disposal-up }
-          SeatDown: { state: disposal-down }
       enum.ToolOpenableVisuals.ToolOpenableVisualState:
         ToolOpenableVisualState.StashOpen:
           Open: { state: disposal-open }
           Closed: { state: disposal-closed }
+      enum.ToiletVisuals.SeatVisualState:
+        SeatVisualState.SeatUp:
+          SeatUp: { state: disposal-up }
+          SeatDown: { state: disposal-down }
 
 - type: entity
+  parent: BaseToilet
+  id: ToiletEmpty
   name: toilet
   description: The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably clean.
-  id: ToiletEmpty
-  parent: BaseToilet
   suffix: Empty
   components:
   - type: Construction
     graph: Toilet
     node: toilet
 
-# so theres not actually any way to replenish the gastrotoxin / gold in these. 
+# so theres not actually any way to replenish the gastrotoxin / gold in these.
 # I wouldn't add it to the solutionregeneration comp because that doesn't make a lot of sense imo.
 # I guess we just need to add shitting?
 - type: entity
-  id: ToiletDirtyWater
   parent: ToiletEmpty
+  id: ToiletDirtyWater
   suffix: Dirty Water
   components:
   - type: SolutionContainerManager
@@ -148,8 +146,8 @@
           Quantity: 20
 
 - type: entity
-  id: ToiletGoldenEmpty
   parent: BaseToilet
+  id: ToiletGoldenEmpty
   name: golden toilet
   description: The HT-451G is the gold version of the device. It says on the side that it is made of the purest Mercurian gold and a real leather seat.
   suffix: Empty
@@ -184,8 +182,8 @@
             max: 5
 
 - type: entity
-  id: ToiletGoldenDirtyWater
   parent: ToiletGoldenEmpty
+  id: ToiletGoldenDirtyWater
   suffix: Dirty Water, StealTarget
   components:
   - type: StealTarget


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- The toilet seat now displays above the lid as intended
- The toilet no longer causes an error when placing a construction ghost
- Cleanup of `toilet.yml'

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- The layers were displayed incorrectly, which looked bad
- Placing a construction ghost should not crash a dev environment or *clog* the client console with errors
- Following conventions = good `:)`

## Technical details
<!-- Summary of code changes for easier review. -->

### Visualization layers
Swapped the order of the visualization layers. 

### Cleanup and conventions
Made the entity structure in `toilet.yml` comply with [the yaml conventions](https://docs.spacestation14.com/en/general-development/codebase-info/conventions.html#entities).
### Construction ghost exception
The bug triggers when placing a construction ghost of a toilet. This crashes the client in a debug build and fills the console with errors on release. the error is below:
```error.cs
Unhandled exception. System.ArgumentOutOfRangeException: Non-negative number required. (Parameter 'count')
   at System.Collections.Generic.List`1.GetRange(Int32 index, Int32 count)
   at Robust.Client.GameObjects.SpriteSystem.AddLayer(Entity`1 sprite, Layer layer, Nullable`1 index) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\GameObjects\EntitySystems\SpriteSystem.Layer.cs:line 119
   at Robust.Client.GameObjects.SpriteSystem.AddBlankLayer(Entity`1 sprite, Nullable`1 index) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\GameObjects\EntitySystems\SpriteSystem.Layer.cs:line 252
   at Content.Client.Construction.ConstructionSystem.TrySpawnGhost(ConstructionPrototype prototype, EntityCoordinates loc, Direction dir, Nullable`1& ghost) in C:\Users\my\directory\space-station-14\Content.Client\Construction\ConstructionSystem.cs:line 319
   at Content.Client.Construction.ConstructionSystem.SpawnGhost(ConstructionPrototype prototype, EntityCoordinates loc, Direction dir) in C:\Users\my\directory\space-station-14\Content.Client\Construction\ConstructionSystem.cs:line 255
   at Content.Client.Construction.ConstructionPlacementHijack.HijackPlacementRequest(EntityCoordinates coordinates) in C:\Users\my\directory\space-station-14\Content.Client\Construction\ConstructionPlacementHijack.cs:line 34
   at Robust.Client.Placement.PlacementManager.RequestPlacement(EntityCoordinates coordinates) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\Placement\PlacementManager.cs:line 809
   at Robust.Client.Placement.PlacementManager.HandlePlacement() in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\Placement\PlacementManager.cs:line 444
   at Robust.Client.Placement.PlacementManager.<SetupInput>b__111_3(ICommonSession session, EntityCoordinates coords, EntityUid uid) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\Placement\PlacementManager.cs:line 311
   at Robust.Shared.Input.Binding.PointerStateInputCmdHandler.HandleCmdMessage(IEntityManager entManager, ICommonSession session, IFullInputCmdMessage message) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Shared\Input\Binding\InputCmdHandler.cs:line 181
   at Robust.Client.GameObjects.InputSystem.HandleInputCommand(ICommonSession session, BoundKeyFunction function, IFullInputCmdMessage message, Boolean replay) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\GameObjects\EntitySystems\InputSystem.cs:line 79
   at Content.Client.Gameplay.GameplayStateBase.OnKeyBindStateChanged(ViewportBoundKeyEventArgs args) in C:\Users\my\directory\space-station-14\Content.Client\Gameplay\GameplayStateBase.cs:line 244
   at Content.Client.Gameplay.GameplayState.OnKeyBindStateChanged(ViewportBoundKeyEventArgs args) in C:\Users\my\directory\space-station-14\Content.Client\Gameplay\GameplayState.cs:line 140
   at Robust.Client.Input.InputManager.ViewportKeyEvent(Control viewport, BoundKeyEventArgs eventArgs) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 456
   at Content.Client.Viewport.ScalingViewport.KeyBindUp(GUIBoundKeyEventArgs args) in C:\Users\my\directory\space-station-14\Content.Client\Viewport\ScalingViewport.cs:line 144      
   at Robust.Client.UserInterface.UserInterfaceManager.<>c.<KeyBindUp>b__135_0(Control c, GUIBoundKeyEventArgs ev) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\UserInterface\UserInterfaceManager.Input.cs:line 132
   at Robust.Client.UserInterface.UserInterfaceManager._doGuiInput(Control control, GUIBoundKeyEventArgs guiEvent, Action`2 action, Boolean ignoreStop) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\UserInterface\UserInterfaceManager.Input.cs:line 313
   at Robust.Client.UserInterface.UserInterfaceManager.KeyBindUp(BoundKeyEventArgs args) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\UserInterface\UserInterfaceManager.Input.cs:line 132
   at Robust.Client.UserInterface.UserInterfaceManager.OnUIKeyBindStateChanged(BoundKeyEventArgs args) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\UserInterface\UserInterfaceManager.Input.cs:line 473
   at Robust.Client.Input.InputManager.SetBindState(KeyBinding binding, BoundKeyState state, Boolean uiOnly, Boolean isRepeat) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 415
   at Robust.Client.Input.InputManager.UpBind(KeyBinding binding) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 378
   at Robust.Client.Input.InputManager.KeyUp(KeyEventArgs args) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 329
   at Robust.Client.GameController.KeyUp(KeyEventArgs keyEvent) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.Input.cs:line 20  
   at Robust.Client.Graphics.Clyde.Clyde.DispatchSingleEvent(DEventBase ev) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\Graphics\Clyde\Clyde.Events.cs:line 50
   at Robust.Client.Graphics.Clyde.Clyde.DispatchEvents() in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\Graphics\Clyde\Clyde.Events.cs:line 31
   at Robust.Client.Graphics.Clyde.Clyde.ProcessInput(FrameEventArgs frameEventArgs) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\Graphics\Clyde\Clyde.Windowing.cs:line 393
   at Robust.Client.GameController.Input(FrameEventArgs frameEventArgs) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.cs:line 511
   at Robust.Client.GameController.<StartupContinue>b__65_2(Object sender, FrameEventArgs args) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.cs:line 264
   at Robust.Shared.Timing.GameLoop.Run() in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Shared\Timing\GameLoop.cs:line 187
   at Robust.Client.GameController.ContinueStartupAndLoop(DisplayMode mode) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.Standalone.cs:line 163
   at Robust.Client.GameController.GameThreadMain(DisplayMode mode) in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.Standalone.cs:line 148
   at Robust.Client.GameController.<>c__DisplayClass107_0.<Run>b__0() in C:\Users\my\directory\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.Standalone.cs:line 107
```
This error is because the ghost placement code iterates over all layers. If a layer in the yaml is invalid, it causes the exception. By removing the following layers, which aren't needed anyways, the error no longer occurs.
  ```yaml
  - map: [ "DoorVisualState.DoorOpen" ]
  - map: [ "SeatVisualState.SeatUp" ]
  ```
In the long-term it would probably be good to add checks and error handling for invalid layers.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
### Before:
<img width="332" height="333" alt="TabTip_wzhsZHMkUn" src="https://github.com/user-attachments/assets/827e8ef1-44cb-4d0a-85a2-7d19e7a4bd66" />

### After:
<img width="332" height="333" alt="TabTip_xp2p8pUPic" src="https://github.com/user-attachments/assets/a8f2d409-3bca-4c07-9f7d-e3e417c88373" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Toilet seats are now displayed on the correct layer.
