### PR TITLE
Hand labeler UI improvements

### DIFF
--- a/Content.Client/Labels/UI/HandLabelerBoundUserInterface.cs
+++ b/Content.Client/Labels/UI/HandLabelerBoundUserInterface.cs
@@ -33,6 +33,7 @@ namespace Content.Client.Labels.UI
 
             _window.OnLabelChanged += OnLabelChanged;
             Reload();
+            _window.SetInitialLabelState(); // Must be after Reload() has set the label text
         }
 
         private void OnLabelChanged(string newLabel)

--- a/Content.Client/Labels/UI/HandLabelerWindow.xaml
+++ b/Content.Client/Labels/UI/HandLabelerWindow.xaml
@@ -4,5 +4,9 @@
     <BoxContainer Orientation="Vertical" SeparationOverride="4" MinWidth="380">
         <Label Name="CurrentTextLabel" Text="{Loc 'hand-labeler-current-text-label'}" />
         <LineEdit Name="LabelLineEdit" />
+        <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Align="Center">
+            <Button Name="ResetLabelButton" Text="{Loc 'hand-labeler-ui-reset-label-text'}"/>
+            <Button Name="ClearLabelButton" Text="{Loc 'hand-labeler-ui-clear-label-text'}"/>
+        </BoxContainer>
     </BoxContainer>
 </DefaultWindow>

--- a/Content.Client/Labels/UI/HandLabelerWindow.xaml
+++ b/Content.Client/Labels/UI/HandLabelerWindow.xaml
@@ -1,7 +1,7 @@
 <DefaultWindow xmlns="https://spacestation14.io"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
             Title="{Loc 'hand-labeler-ui-header'}">
-    <BoxContainer Orientation="Vertical" SeparationOverride="4" MinWidth="150">
+    <BoxContainer Orientation="Vertical" SeparationOverride="4" MinWidth="380">
         <Label Name="CurrentTextLabel" Text="{Loc 'hand-labeler-current-text-label'}" />
         <LineEdit Name="LabelLineEdit" />
     </BoxContainer>

--- a/Content.Client/Labels/UI/HandLabelerWindow.xaml.cs
+++ b/Content.Client/Labels/UI/HandLabelerWindow.xaml.cs
@@ -16,6 +16,7 @@ namespace Content.Client.Labels.UI
         // TODO LineEdit Make this a bool on the LineEdit control
 
         private string _label = string.Empty;
+        private string _initialLabel = string.Empty;
 
         public HandLabelerWindow()
         {
@@ -25,6 +26,7 @@ namespace Content.Client.Labels.UI
             {
                 _label = e.Text;
                 OnLabelChanged?.Invoke(_label);
+                UpdateButtons();
             };
 
             LabelLineEdit.OnFocusEnter += _ => _focused = true;
@@ -33,6 +35,8 @@ namespace Content.Client.Labels.UI
                 _focused = false;
                 LabelLineEdit.Text = _label;
             };
+            ResetLabelButton.OnPressed += _ => LabelLineEdit.SetText(_initialLabel, true);
+            ClearLabelButton.OnPressed += _ => LabelLineEdit.SetText("", true);
         }
 
         protected override void Opened()
@@ -51,7 +55,10 @@ namespace Content.Client.Labels.UI
 
             _label = label;
             if (!_focused)
+            {
                 LabelLineEdit.Text = label;
+                UpdateButtons();
+            }
         }
 
         public void SetInitialLabelState()
@@ -59,6 +66,14 @@ namespace Content.Client.Labels.UI
             LabelLineEdit.Text = _label;
             LabelLineEdit.CursorPosition = _label.Length;
             LabelLineEdit.SelectionStart = 0;
+            _initialLabel = _label;
+            UpdateButtons();
+        }
+
+        public void UpdateButtons()
+        {
+            ResetLabelButton.Disabled = (LabelLineEdit.Text == _initialLabel);
+            ClearLabelButton.Disabled = (LabelLineEdit.Text == "");
         }
 
         public void SetMaxLabelLength(int maxLength)

--- a/Content.Client/Labels/UI/HandLabelerWindow.xaml.cs
+++ b/Content.Client/Labels/UI/HandLabelerWindow.xaml.cs
@@ -38,7 +38,7 @@ namespace Content.Client.Labels.UI
         protected override void Opened()
         {
             base.Opened();
-            
+
             // Give the editor keyboard focus, since that's the only
             // thing the user will want to be doing with this UI
             LabelLineEdit.GrabKeyboardFocus();
@@ -52,6 +52,13 @@ namespace Content.Client.Labels.UI
             _label = label;
             if (!_focused)
                 LabelLineEdit.Text = label;
+        }
+
+        public void SetInitialLabelState()
+        {
+            LabelLineEdit.Text = _label;
+            LabelLineEdit.CursorPosition = _label.Length;
+            LabelLineEdit.SelectionStart = 0;
         }
 
         public void SetMaxLabelLength(int maxLength)

--- a/Resources/Locale/en-US/hand-labeler/hand-labeler.ftl
+++ b/Resources/Locale/en-US/hand-labeler/hand-labeler.ftl
@@ -3,6 +3,12 @@ hand-labeler-ui-header = Hand Labeler
 # The content of the label in the UI above the text entry input.
 hand-labeler-current-text-label = Label:
 
+# The text on the button in the UI to reset the text entry input to the content it had when the UI was opened
+hand-labeler-ui-reset-label-text = Reset
+
+# The text on the button in the UI to clear the text entry input
+hand-labeler-ui-clear-label-text = Clear
+
 # When the hand labeler applies a label successfully
 hand-labeler-successfully-applied = Applied label successfully
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes to the hand labeler UI:
* The LineEdit populated with current label text on open, but selected so the user can still just start typing to replace it
* The window is now wide enough for long-ish labels
* Added a Reset button that resets the LineEdit to the text it had when the window was open
* Added a Clear button that clears the LineEdit

## Why / Balance
I like being able to see all of the label text, and also being reassured that it didn't somehow disappear while I had the window closed.

The buttons probably aren't needed super frequently but I felt like they'd be nice to have occasionally.

## Technical details
Updated the hand labeler window xaml to have the wider width and the new buttons. Added a function to set up the LineEdit and store the initial text after the window's `_label` is initially set. Added handling for the new buttons. Added a function to disable the new buttons when appropriate, and called it when the LineEdit contents have changed.

## Media
<img width="382" height="139" alt="image" src="https://github.com/user-attachments/assets/f3b99502-7ca3-471a-9364-215f41c933b1" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Minor hand labeler UI improvements