### PR TITLE
Make hand labeller window wider by default

### DIFF
--- a/Content.Client/Labels/UI/HandLabelerWindow.xaml
+++ b/Content.Client/Labels/UI/HandLabelerWindow.xaml
@@ -1,7 +1,9 @@
 <DefaultWindow xmlns="https://spacestation14.io"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            Title="{Loc 'hand-labeler-ui-header'}">
-    <BoxContainer Orientation="Vertical" SeparationOverride="4" MinWidth="150">
+            Title="{Loc 'hand-labeler-ui-header'}"
+            MinWidth="150"
+            SetWidth="400">
+    <BoxContainer Orientation="Vertical" SeparationOverride="4" HorizontalExpand="True">
         <Label Name="CurrentTextLabel" Text="{Loc 'hand-labeler-current-text-label'}" />
         <LineEdit Name="LabelLineEdit" />
     </BoxContainer>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

The hand labeler window is now wider by default, making it easier to enter text. This is probably most useful to chemists.

Also fixes the label and line edit becoming partially hidden when window is made smaller.

## Why / Balance

Looks better, makes labeling things easier. The window was already possible to resize before, so doesn't remove existing limits.

## Media

Before above, after below:
<img width="630" height="284" alt="hand labeler window comparison" src="https://github.com/user-attachments/assets/b4aec1ad-b476-4246-ab61-169eee0f3eb4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: opl
- tweak: Hand labeler window is now wider by default.
