### PR TITLE
Change listplayers command permissions to require the PII flag

### DIFF
--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -16,7 +16,6 @@
   - inrangeunoccluded
   - lsgrid
   - lsmap
-  - listplayers
   - loc
   - mem
   - netaudit
@@ -71,7 +70,6 @@
   - pvs_override_info
   - merge_grids
 
-
 - Flags: MAPPING
   Commands:
   - addmap
@@ -91,9 +89,12 @@
 
 - Flags: ADMIN
   Commands:
-  - listplayers
   - tp
   - tpto
+
+- Flags: PII
+  Commands:
+  - listplayers
 
 - Flags: FUN
   Commands:


### PR DESCRIPTION
## About the PR
It shows the players' IP addresses, which are PII.

<img width="808" height="118" alt="grafik" src="https://github.com/user-attachments/assets/f75927cc-33a9-4f85-bf85-9a7238c16ddb" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
ADMIN:
- tweak: The listplayers command now requires PII permissions due to showing IP addresses.
