### PR TITLE
Hand labeler can always remove labels

### DIFF
--- a/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
@@ -94,11 +94,9 @@ public abstract class SharedHandLabelerSystem : EntitySystem
         if (args.Target is not { Valid: true } target || _whitelistSystem.IsWhitelistFail(ent.Comp.Whitelist, target) || !args.CanAccess)
             return;
 
-        bool labelerBlank = (ent.Comp.AssignedLabel == string.Empty);
-
         var user = args.User;   // can't use ref parameter in lambdas
 
-        if (!labelerBlank)
+        if (ent.Comp.AssignedLabel != string.Empty)
         {
             var labelVerb = new UtilityVerb()
             {
@@ -122,11 +120,6 @@ public abstract class SharedHandLabelerSystem : EntitySystem
             Text = Loc.GetString("hand-labeler-remove-label-text"),
             Priority = -1,
         };
-
-        if (!labelerBlank)
-        {
-            unLabelVerb.TextStyleClass = Verb.DefaultTextStyleClass;
-        }
 
         args.Verbs.Add(unLabelVerb);
     }


### PR DESCRIPTION
## About the PR
The hand labeler can now remove labels via the verb menu on its target even when its label text is not set to blank.

## Why / Balance
Minor QoL feature.

## Technical details
Moved label removing into a separate function from label adding; fold `Labeling` function into the label adding & removing functions; modified `SharedHandLabelerSystem::OnUtilityVerb` to always add the remove label verb, but with a lower priority than the add label verb, and with the default verb text style if the add label verb is also present.

## Media
<img width="762" height="386" alt="image" src="https://github.com/user-attachments/assets/c5cd9c12-623e-4961-a224-6a04603a9ee2" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Hand labelers can now remove labels via the verb menu whether or not they have a label set.