### PR TITLE
Fix visual bug with masks appearing to be pulled down after re-equipping

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
@@ -62,27 +62,7 @@ public sealed class MaskSystem : EntitySystem
 
     private void OnGotUnequipped(EntityUid uid, MaskComponent mask, GotUnequippedEvent args)
     {
-        if (!mask.IsToggled || !mask.IsToggleable)
-            return;
-
-        mask.IsToggled = false;
-        ToggleMaskComponents(uid, mask, args.Equipee, mask.EquippedPrefix, true);
-    }
-
-    /// <summary>
-    /// Called after setting IsToggled, raises events and dirties.
-    /// </summary>
-    private void ToggleMaskComponents(EntityUid uid, MaskComponent mask, EntityUid wearer, string? equippedPrefix = null, bool isEquip = false)
-    {
-        Dirty(uid, mask);
-        if (mask.ToggleActionEntity is { } action)
-            _actionSystem.SetToggled(action, mask.IsToggled);
-
-        var maskEv = new ItemMaskToggledEvent((uid, mask), wearer);
-        RaiseLocalEvent(uid, ref maskEv);
-
-        var wearerEv = new WearerMaskToggledEvent((uid, mask));
-        RaiseLocalEvent(wearer, ref wearerEv);
+        SetToggled(uid, false);
     }
 
     private void OnFolded(Entity<MaskComponent> ent, ref FoldedEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #39998.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
``MaskSystem.ToggleMaskComponents`` - Was removed, use ``MaskSystem.SetToggled`` instead.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
