### PR TITLE
Show hand labeler label text on examine

### DIFF
--- a/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
+using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Labels.Components;
 using Content.Shared.Popups;
@@ -25,6 +26,7 @@ public abstract class SharedHandLabelerSystem : EntitySystem
 
         SubscribeLocalEvent<HandLabelerComponent, AfterInteractEvent>(AfterInteractOn);
         SubscribeLocalEvent<HandLabelerComponent, GetVerbsEvent<UtilityVerb>>(OnUtilityVerb);
+        SubscribeLocalEvent<HandLabelerComponent, ExaminedEvent>(OnExamined);
         // Bound UI subscriptions
         SubscribeLocalEvent<HandLabelerComponent, HandLabelerLabelChangedMessage>(OnHandLabelerLabelChanged);
         SubscribeLocalEvent<HandLabelerComponent, ComponentGetState>(OnGetState);
@@ -127,5 +129,18 @@ public abstract class SharedHandLabelerSystem : EntitySystem
         // Log label change
         _adminLogger.Add(LogType.Action, LogImpact.Low,
             $"{ToPrettyString(args.Actor):user} set {ToPrettyString(uid):labeler} to apply label \"{handLabeler.AssignedLabel}\"");
+    }
+
+    private void OnExamined(EntityUid uid, HandLabelerComponent? handLabeler, ref ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange || !Resolve(uid, ref handLabeler))
+        {
+            return;
+        }
+
+        var text = handLabeler.AssignedLabel == string.Empty
+            ? Loc.GetString("hand-labeler-examine-blank")
+            : Loc.GetString("hand-labeler-examine-label-text", ("label-text", handLabeler.AssignedLabel));
+        args.PushMarkup(text);
     }
 }

--- a/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
@@ -131,16 +131,16 @@ public abstract class SharedHandLabelerSystem : EntitySystem
             $"{ToPrettyString(args.Actor):user} set {ToPrettyString(uid):labeler} to apply label \"{handLabeler.AssignedLabel}\"");
     }
 
-    private void OnExamined(EntityUid uid, HandLabelerComponent? handLabeler, ref ExaminedEvent args)
+    private void OnExamined(Entity<HandLabelerComponent> ent, ref ExaminedEvent args)
     {
-        if (!args.IsInDetailsRange || !Resolve(uid, ref handLabeler))
+        if (!args.IsInDetailsRange)
         {
             return;
         }
 
-        var text = handLabeler.AssignedLabel == string.Empty
+        var text = ent.Comp.AssignedLabel == string.Empty
             ? Loc.GetString("hand-labeler-examine-blank")
-            : Loc.GetString("hand-labeler-examine-label-text", ("label-text", handLabeler.AssignedLabel));
+            : Loc.GetString("hand-labeler-examine-label-text", ("label-text", ent.Comp.AssignedLabel));
         args.PushMarkup(text);
     }
 }

--- a/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
@@ -134,9 +134,7 @@ public abstract class SharedHandLabelerSystem : EntitySystem
     private void OnExamined(Entity<HandLabelerComponent> ent, ref ExaminedEvent args)
     {
         if (!args.IsInDetailsRange)
-        {
             return;
-        }
 
         var text = ent.Comp.AssignedLabel == string.Empty
             ? Loc.GetString("hand-labeler-examine-blank")

--- a/Resources/Locale/en-US/hand-labeler/hand-labeler.ftl
+++ b/Resources/Locale/en-US/hand-labeler/hand-labeler.ftl
@@ -15,3 +15,7 @@ hand-labeler-has-label = This object has a label on it, which reads '{$label}'
 # Verb text
 hand-labeler-remove-label-text = Remove label
 hand-labeler-add-label-text = Apply label
+
+# Shown when the labeler is examined
+hand-labeler-examine-blank = The label text is blank.
+hand-labeler-examine-label-text = The label text is '{$label-text}'.


### PR DESCRIPTION
## About the PR
Examining a hand labeler in details range shows you what its label text is set to.

## Why / Balance
Minor QoL improvement.

## Technical details
Added an `ExamineEvent` handler to `SharedHandLabelerSystem`.

## Media
<img width="359" height="137" alt="image" src="https://github.com/user-attachments/assets/6d724797-5236-42df-ba7c-c02969c8dbb3" />
<img width="409" height="139" alt="image" src="https://github.com/user-attachments/assets/fb7ca5b8-7f5d-4d79-9ee7-510e62bd1387" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Hand labeler's set text now displays on examine.