### PR TITLE
Don't overwrite values that are mid-edit in air alarm window

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/Widgets/ThresholdBoundControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ThresholdBoundControl.xaml.cs
@@ -30,7 +30,10 @@ public sealed partial class ThresholdBoundControl : BoxContainer
     public void SetValue(float value)
     {
         _value = value;
-        CSpinner.Value = ScaledValue;
+        if (!CSpinner.HasKeyboardFocus())
+        {
+            CSpinner.Value = ScaledValue;
+        }
     }
 
     public void SetEnabled(bool enabled)


### PR DESCRIPTION
## About the PR
When the air alarm is updated, it now will skip overwriting the current value in any threshold control that has keyboard focus.

## Why / Balance
QoL improvement.

## Technical details
I added a check for keyboard focus to the function that updates these controls.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Air alarms will not replace the number you're currently typing