### PR TITLE
Localization "and" in description of person

### DIFF
--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -113,12 +113,13 @@ namespace Content.Shared.Localizations
         /// </summary>
         public static string FormatList(List<string> list)
         {
+            var strand = Loc.GetString("items-and");
             return list.Count switch
             {
                 <= 0 => string.Empty,
                 1 => list[0],
-                2 => $"{list[0]} and {list[1]}",
-                _ => $"{string.Join(", ", list.GetRange(0, list.Count - 1))}, and {list[^1]}"
+                2 => $"{list[0]} {strand} {list[1]}",
+                _ => $"{string.Join(", ", list.GetRange(0, list.Count - 1))}, {strand} {list[^1]}"
             };
         }
 

--- a/Resources/Locale/en-US/hands.ftl
+++ b/Resources/Locale/en-US/hands.ftl
@@ -1,0 +1,1 @@
+items-and = and


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Now, "and" in description of person can be localizated. For English people nothing changed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Why not? I'm tired of seeing a word that comes from another language

## Technical details
<!-- Summary of code changes for easier review. -->
Add Loc.GetString for "and" in $"{list[0]} and {list[1]}" and list.GetRange(0, list.Count - 1))}, {strand} {list[^1]}".

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
For English People nothing changed, but for other language people... maybe russian:
Before this PR:
<img width="338" height="37" alt="image" src="https://github.com/user-attachments/assets/b778349e-a6fe-462c-b267-76629d149ee4" />
After this PR:
<img width="364" height="47" alt="image" src="https://github.com/user-attachments/assets/5e7a4706-761f-4182-97ae-245a3b097578" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Add localization for "and" in description of person, what in his hands!
-->
:cl:
- add: Add localization for "and" in description of person, what in his hands!