### PR TITLE
You can now link signaler and grenade

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -15,6 +15,12 @@
     slots:
     - Belt
   - type: TriggerOnUse
+  - type: DeviceLinkSink
+    ports:
+    - Trigger
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: TriggerOnSignal
   - type: TimerTrigger
     delay: 3
   - type: Damageable


### PR DESCRIPTION
## About the PR
Now we can link grenade to signaler.

## Why / Balance
Can be dangerous as... "lag machine", making some grenades explode in one moment.
But as good side, you can make... mines and... keeping as hostages whole station or crucial systems of station

## Technical details
Just changing base prototype of grenades, adding signals for them.

**Changelog**
:cl:
- tweak: Now you can connect grenade to signaler with multitool.
