### PR TITLE
Replaced incendiary AK ammo with normal AK ammo, bagel.

### DIFF
--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 09/14/2025 23:31:09
+  time: 09/15/2025 00:43:45
   entityCount: 25523
 maps:
 - 943
@@ -113516,17 +113516,17 @@ entities:
     - type: Transform
       pos: -51.5,-4.5
       parent: 60
-- proto: MagazineLightRifleIncendiary
+- proto: MagazineLightRifle
   entities:
   - uid: 1138
     components:
     - type: Transform
-      pos: -26.673944,-6.3476434
+      pos: -26.262257,-6.317416
       parent: 60
   - uid: 1547
     components:
     - type: Transform
-      pos: -26.37181,-6.331765
+      pos: -26.668507,-6.333041
       parent: 60
 - proto: MagazinePistolSubMachineGunTopMounted
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title

## Why / Balance
Combat workgroup and Emisse told me that this was a bad mapping decision. 

## Technical details
map

## Media
<img width="117" height="92" alt="image" src="https://github.com/user-attachments/assets/bc5be52b-9533-4270-9a37-743c04c2f23b" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
**Changelog**
:cl:
MAPS:
- remove: On bagel, replaced the mapped incendiary AK47 ammo for normal AK ammo.
