### PR TITLE
Singularity Hammer and Mjollnir on-cooldown wield fix

### DIFF
--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -495,7 +495,6 @@ namespace Content.Shared.Interaction
                 InteractionActivate(user,
                     target,
                     checkCanInteract: false,
-                    checkUseDelay: true,
                     checkAccess: false,
                     complexInteractions: complexInteractions,
                     checkDeletion: false);
@@ -525,7 +524,6 @@ namespace Content.Shared.Interaction
             InteractionActivate(user,
                 target,
                 checkCanInteract: false,
-                checkUseDelay: true,
                 checkAccess: false,
                 complexInteractions: complexInteractions,
                 checkDeletion: false);
@@ -1137,17 +1135,17 @@ namespace Content.Shared.Interaction
             EntityUid user,
             EntityUid used,
             bool checkCanInteract = true,
-            bool checkUseDelay = true,
             bool checkAccess = true,
             bool? complexInteractions = null,
-            bool checkDeletion = true)
+            bool checkDeletion = true,
+            bool skipDelayCheck = false)
         {
             if (checkDeletion && (IsDeleted(user) || IsDeleted(used)))
                 return false;
 
             DebugTools.Assert(!IsDeleted(user) && !IsDeleted(used));
             _delayQuery.TryComp(used, out var delayComponent);
-            if (checkUseDelay && delayComponent != null && _useDelay.IsDelayed((used, delayComponent)))
+            if (!skipDelayCheck && delayComponent != null && delayComponent.PreventUseInHand && _useDelay.IsDelayed((used, delayComponent)))
                 return false;
 
             if (checkCanInteract && !_actionBlockerSystem.CanInteract(user, used))
@@ -1182,7 +1180,7 @@ namespace Content.Shared.Interaction
                 return false;
 
             DoContactInteraction(user, used);
-            // Still need to call this even without checkUseDelay in case this gets relayed from Activate.
+            // Still need to call this even with the delay component's PreventUseInHand in case this gets relayed from Activate.
             if (delayComponent != null)
                 _useDelay.TryResetDelay(used, component: delayComponent);
 
@@ -1202,14 +1200,13 @@ namespace Content.Shared.Interaction
             EntityUid user,
             EntityUid used,
             bool checkCanUse = true,
-            bool checkCanInteract = true,
-            bool checkUseDelay = true)
+            bool checkCanInteract = true)
         {
             if (IsDeleted(user) || IsDeleted(used))
                 return false;
 
             _delayQuery.TryComp(used, out var delayComponent);
-            if (checkUseDelay && delayComponent != null && _useDelay.IsDelayed((used, delayComponent)))
+            if (delayComponent != null && delayComponent.PreventUseInHand && _useDelay.IsDelayed((used, delayComponent)))
                 return true; // if the item is on cooldown, we consider this handled.
 
             if (checkCanInteract && !_actionBlockerSystem.CanInteract(user, used))
@@ -1230,7 +1227,7 @@ namespace Content.Shared.Interaction
 
             DebugTools.Assert(!IsDeleted(user) && !IsDeleted(used));
             // else, default to activating the item
-            return InteractionActivate(user, used, false, false, false, checkDeletion: false);
+            return InteractionActivate(user, used, false, false, checkDeletion: false, skipDelayCheck: true);
         }
 
         /// <summary>

--- a/Content.Shared/Timing/UseDelayComponent.cs
+++ b/Content.Shared/Timing/UseDelayComponent.cs
@@ -25,6 +25,12 @@ public sealed partial class UseDelayComponent : Component
     /// </remarks>
     [DataField]
     public TimeSpan Delay = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// If false doesn't prevent UseInHand interactions while on cooldown.
+    /// </summary>
+    [DataField]
+    public bool PreventUseInHand = true;
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
@@ -40,6 +40,7 @@
     - state: icon
   - type: UseDelay
     delay: 10
+    preventUseInHand: false
   - type: UseDelayOnMeleeHit
   - type: MeleeThrowOnHit
     stunTime: 3
@@ -89,6 +90,7 @@
       - Item
   - type: UseDelay
     delay: 10
+    preventUseInHand: false
   - type: UseDelayOnMeleeHit
   - type: MeleeWeapon
     wideAnimationRotation: -135


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes not being able to wield (invoke UseInHand events on) the Singularity Hammer or Mjollnir while they are on cooldown

## Why / Balance
The Singularity Hammer and the Mjollnir are the only wieldable weapons with an after attack cooldown and currently you are still able to swing with them when the cooldown activates, and you are even able to wield them through the entity menu but not through using them in your hand. So i don't think this behavior is intended but correct me if iam wrong

## Technical details
See breaking changes

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
There shouldn't be any. Replaced the checkUseDelay variable in the SharedInteractionSystem (which defaults to true and isn't actually overridden anywhere anyways, except when skipping a check after already being passed as true and going through said check) from like 3 different functions with a PreventUseInHand bool in the UseDelayComponent

**Changelog**
:cl: PopGamer46
- fix: Fixed not being able to wield the Singularity Hammer and the Mjollnir while they are on cooldown
