### PR TITLE
[Hotfix] Remove pull-escape trick

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -242,13 +242,18 @@ namespace Content.Shared.Cuffs
             args.Cancel();
         }
 
-        private void HandleStopPull(EntityUid uid, CuffableComponent component, AttemptStopPullingEvent args)
+        private void HandleStopPull(EntityUid uid, CuffableComponent component, ref AttemptStopPullingEvent args)
         {
             if (args.User == null || !Exists(args.User.Value))
                 return;
 
             if (args.User.Value == uid && !component.CanStillInteract)
+            {
+                //TODO: UX feedback. Simply blocking the normal interaction feels like an interface bug
+
                 args.Cancelled = true;
+            }
+
         }
 
         private void OnRemoveCuffsAlert(Entity<CuffableComponent> ent, ref RemoveCuffsAlertEvent args)

--- a/Content.Shared/Movement/Pulling/Events/AttemptStopPullingEvent.cs
+++ b/Content.Shared/Movement/Pulling/Events/AttemptStopPullingEvent.cs
@@ -3,6 +3,8 @@ namespace Content.Shared.Pulling.Events;
 /// <summary>
 /// Raised when a request is made to stop pulling an entity.
 /// </summary>
+
+[ByRefEvent]
 public record struct AttemptStopPullingEvent(EntityUid? User = null)
 {
     public readonly EntityUid? User = User;

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -599,7 +599,7 @@ public sealed class PullingSystem : EntitySystem
             return true;
 
         var msg = new AttemptStopPullingEvent(user);
-        RaiseLocalEvent(pullableUid, msg, true);
+        RaiseLocalEvent(pullableUid, ref msg);
 
         if (msg.Cancelled)
             return false;

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -599,7 +599,7 @@ public sealed class PullingSystem : EntitySystem
             return true;
 
         var msg = new AttemptStopPullingEvent(user);
-        RaiseLocalEvent(pullableUid, ref msg);
+        RaiseLocalEvent(pullableUid, ref msg, true);
 
         if (msg.Cancelled)
             return false;


### PR DESCRIPTION
## About the PR
AttemptStopPullingEvent did not properly return it's altered variables, because it wasn't by reference. This meant that on one specific codepath the handcuffs on a mob were ignored when trying to escape a pull

## Why / Balance
https://discord.com/channels/310555209753690112/1413536061174583296/1417089600467501067

## Technical details

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl: Errant
- fix: Players can no longer ignore handcuffs and escape being pulled.
