### PR TITLE
Add log statement for missing guidebook proto

### DIFF
--- a/Content.Client/Guidebook/DocumentParsingManager.cs
+++ b/Content.Client/Guidebook/DocumentParsingManager.cs
@@ -51,22 +51,25 @@ public sealed partial class DocumentParsingManager
         _sawmill = Logger.GetSawmill("Guidebook");
     }
 
-    public bool TryAddMarkup(Control control, ProtoId<GuideEntryPrototype> entryId, bool log = true)
+    public bool TryAddMarkup(Control control, ProtoId<GuideEntryPrototype> entryId)
     {
         if (!_prototype.Resolve(entryId, out var entry))
+        {
+            _sawmill.Error($"Failed to find guide prototype: `{entryId}`");
             return false;
+        }
 
         using var file = _resourceManager.ContentFileReadText(entry.Text);
-        return TryAddMarkup(control, file.ReadToEnd(), log);
+        return TryAddMarkup(control, file.ReadToEnd());
     }
 
-    public bool TryAddMarkup(Control control, GuideEntry entry, bool log = true)
+    public bool TryAddMarkup(Control control, GuideEntry entry)
     {
         using var file = _resourceManager.ContentFileReadText(entry.Text);
-        return TryAddMarkup(control, file.ReadToEnd(), log);
+        return TryAddMarkup(control, file.ReadToEnd());
     }
 
-    public bool TryAddMarkup(Control control, string text, bool log = true)
+    public bool TryAddMarkup(Control control, string text)
     {
         try
         {

--- a/Content.Client/Guidebook/DocumentParsingManager.cs
+++ b/Content.Client/Guidebook/DocumentParsingManager.cs
@@ -54,10 +54,7 @@ public sealed partial class DocumentParsingManager
     public bool TryAddMarkup(Control control, ProtoId<GuideEntryPrototype> entryId)
     {
         if (!_prototype.Resolve(entryId, out var entry))
-        {
-            _sawmill.Error($"Failed to find guide prototype: `{entryId}`");
             return false;
-        }
 
         using var file = _resourceManager.ContentFileReadText(entry.Text);
         return TryAddMarkup(control, file.ReadToEnd());


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a log statement for if the guidebook fails to find a prototype.
Only slightly a mald PR.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It would have saved 30 minutes of my life: https://github.com/cosmatic-drift-14/cosmatic-drift/pull/749

## Technical details
<!-- Summary of code changes for easier review. -->
I also removed an unused parameter. See Breaking changes.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Removed the `log` parameter in all overloads of `DocumentParsingManager::TryAddMarkup` this parameter had no effect and was not used anywhere.

**Changelog**
no cl no fun
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
