### PR TITLE
Improve LagCompensationSystem

### DIFF
--- a/Content.Client/Movement/Systems/LagCompensationSystem.cs
+++ b/Content.Client/Movement/Systems/LagCompensationSystem.cs
@@ -1,0 +1,13 @@
+using Content.Shared.Movement.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+
+namespace Content.Client.Movement.Systems;
+
+public sealed class LagCompensationSystem : SharedLagCompensationSystem
+{
+    public override (EntityCoordinates Coordinates, Angle Angle) GetCoordinatesAngle(Entity<TransformComponent?> ent, GameTick tick)
+    {
+        return Resolve(ent, ref ent.Comp) ? (ent.Comp.Coordinates, ent.Comp.LocalRotation) : default;
+    }
+}

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -152,15 +152,6 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
             ClientLightAttack(entity, mousePos, coordinates, weaponUid, weapon);
     }
 
-    protected override bool InRange(EntityUid user, EntityUid target, float range, ICommonSession? session)
-    {
-        var xform = Transform(target);
-        var targetCoordinates = xform.Coordinates;
-        var targetLocalAngle = xform.LocalRotation;
-
-        return Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false);
-    }
-
     protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform)
     {
         // Server never sends the event to us for predictiveeevent.

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.Helpers.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.Helpers.cs
@@ -85,7 +85,7 @@ public abstract partial class InteractionTest
     }
 
     /// <summary>
-    /// Spawn an entity entity and set it as the target.
+    /// Spawn an entity at the current <see cref="TargetCoords"/> and set it as the target entity.
     /// </summary>
     [MemberNotNull(nameof(Target), nameof(STarget), nameof(CTarget))]
 #pragma warning disable CS8774 // Member must have a non-null value when exiting.

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Timing;
 using Robust.UnitTesting;
 using Content.Shared.Item.ItemToggle;
 using Robust.Client.State;
+using Robust.Client.Timing;
 
 namespace Content.IntegrationTests.Tests.Interaction;
 
@@ -104,13 +105,14 @@ public abstract partial class InteractionTest
     protected ItemToggleSystem ItemToggleSys = default!;
     protected InteractionTestSystem STestSystem = default!;
     protected SharedTransformSystem Transform = default!;
+    protected SharedTransformSystem CTransform = default!;
     protected SharedMapSystem MapSystem = default!;
     protected ISawmill SLogger = default!;
     protected SharedUserInterfaceSystem SUiSys = default!;
 
     // CLIENT dependencies
     protected IEntityManager CEntMan = default!;
-    protected IGameTiming CTiming = default!;
+    protected IClientGameTiming CTiming = default!;
     protected IUserInterfaceManager UiMan = default!;
     protected IInputManager InputManager = default!;
     protected Robust.Client.GameObjects.InputSystem InputSystem = default!;
@@ -179,7 +181,7 @@ public abstract partial class InteractionTest
         // client dependencies
         CEntMan = Client.ResolveDependency<IEntityManager>();
         UiMan = Client.ResolveDependency<IUserInterfaceManager>();
-        CTiming = Client.ResolveDependency<IGameTiming>();
+        CTiming = Client.Resolve<IClientGameTiming>();
         InputManager = Client.ResolveDependency<IInputManager>();
         InputSystem = CEntMan.System<Robust.Client.GameObjects.InputSystem>();
         CTestSystem = CEntMan.System<InteractionTestSystem>();
@@ -187,6 +189,7 @@ public abstract partial class InteractionTest
         ExamineSys = CEntMan.System<ExamineSystem>();
         CLogger = Client.ResolveDependency<ILogManager>().RootSawmill;
         CUiSys = Client.System<SharedUserInterfaceSystem>();
+        CTransform = Client.System<SharedTransformSystem>();
 
         // Setup map.
         await Pair.CreateTestMap();

--- a/Content.IntegrationTests/Tests/Movement/LagCompensationTest.cs
+++ b/Content.IntegrationTests/Tests/Movement/LagCompensationTest.cs
@@ -1,0 +1,186 @@
+#nullable enable
+using System.Numerics;
+using Content.Shared.Friction;
+using Content.Shared.Movement.Systems;
+using Robust.Client.Timing;
+using Robust.Shared.Analyzers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+using Robust.Shared.IoC;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Controllers;
+using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
+
+namespace Content.IntegrationTests.Tests.Movement;
+
+/// <summary>
+/// This test attempts to check that lag compensation works.
+/// However, this isn't a thorough test seeing as the test pairs don't actually have simulated latency.
+/// </summary>
+public sealed class LagCompensationTest : MovementTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: roomba
+  components:
+  - type: TestRoomba
+  - type: Physics
+    bodyType: KinematicController
+    linearDamping: 0
+  - type: LagCompensation
+  - type: Fixtures
+    fixtures: { fix1: { } }
+";
+
+    [Test]
+    public async Task RoombaKickTest()
+    {
+        var pos = MapData.GridCoords.Offset(new Vector2(-1.5f, 0.5f));
+        TargetCoords = SEntMan.GetNetCoordinates(Transform.WithEntityId(pos, MapData.MapUid));
+        await SpawnTarget("roomba");
+
+        // Initially roomba spawns adjacent to the player
+        Assert.That(Delta(), Is.EqualTo(-2).Within(0.001));
+        Assert.That(ClientDelta(), Is.EqualTo(-2).Within(0.001));
+
+        // Roomba is stationary
+        await RunTicks(5);
+        Assert.That(Delta(), Is.EqualTo(-2).Within(0.001));
+        Assert.That(ClientDelta(), Is.EqualTo(-2).Within(0.001));
+
+        // Roomba is too far away to be kicked
+        await Client.WaitPost(() => Client.System<RoombaController>().Kick(CTarget));
+        var sComp = Comp<TestRoombaComponent>();
+        var cComp = CEntMan.GetComponent<TestRoombaComponent>(CTarget.Value);
+        Assert.That(cComp.Kicked, Is.Null);
+        Assert.That(sComp.Kicked, Is.Null);
+        await RunTicks(5);
+        Assert.That(cComp.Kicked, Is.Null);
+        Assert.That(sComp.Kicked, Is.Null);
+
+        // Make the roomba start to rooomb
+        sComp.Velocity.X = 1;
+        var start = STiming.CurTick;
+
+        // How far the roomba moves in one tick
+        var tickDelta = sComp.Velocity.X * (float)STiming.TickPeriod.TotalSeconds;
+
+        // The roomba will start to move on the server, but not on the client until it starts applying the relevant
+        // server states
+        var i = 0;
+        while (CTiming.LastRealTick != start)
+        {
+            Assert.That(Delta(), Is.EqualTo(-2 + tickDelta * i).Within(0.001));
+            Assert.That(ClientDelta(), Is.EqualTo(-2).Within(0.001));
+            await RunTicks(1);
+            i++;
+        }
+
+        // Next, we wait until the roomba is just about to go over one tile away on the client.
+        while (ClientDelta() < 1 - tickDelta)
+        {
+            await RunTicks(1);
+        }
+
+        // The roomba is "in range" according to the client, but not according to the server
+        Assert.That(Delta(), Is.GreaterThan(1 + tickDelta));
+        Assert.That(ClientDelta(), Is.LessThan(1));
+
+        // The client will attempt to kick the roomba, and the server should permit the boop, even though it is
+        // technically out of range
+        await Client.WaitPost(() => Client.System<RoombaController>().Kick(CTarget));
+        Assert.That(cComp.Kicked, Is.EqualTo(CPlayer));
+        Assert.That(sComp.Kicked, Is.Null);
+        await RunTicks(4);
+        Assert.That(cComp.Kicked, Is.EqualTo(CPlayer));
+        Assert.That(sComp.Kicked, Is.EqualTo(SPlayer));
+
+        // At this point, the kick will no longer be accepted.
+        sComp.Kicked = null;
+        Assert.That(Delta(), Is.GreaterThan(1 + tickDelta));
+        Assert.That(ClientDelta(), Is.GreaterThan(1 + tickDelta));
+        await Client.WaitPost(() => Client.System<RoombaController>().Kick(CTarget));
+        Assert.That(sComp.Kicked, Is.Null);
+        await RunTicks(5);
+        Assert.That(sComp.Kicked, Is.Null);
+
+    }
+}
+
+/// <summary>
+/// Simple system & component that just makes some entity move around, and allows players to perform a basic lag
+/// compensated interaction.
+/// </summary>
+public sealed partial class RoombaController : VirtualController
+{
+    [Dependency] private readonly SharedLagCompensationSystem _lag = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        UpdatesAfter.Add(typeof(TileFrictionController)); // no friction please
+        base.Initialize();
+        SubscribeAllEvent<KickEvent>(OnKick);
+    }
+
+    public override void UpdateBeforeSolve(bool prediction, float frameTime)
+    {
+        base.UpdateBeforeSolve(prediction, frameTime);
+
+        var query = EntityQueryEnumerator<TestRoombaComponent, PhysicsComponent>();
+        while (query.MoveNext(out var uid, out var roomba, out var physics))
+        {
+            PhysicsSystem.SetLinearVelocity(uid, roomba.Velocity, body: physics);
+            PhysicsSystem.SetLinearDamping(uid, physics, 0);
+        }
+    }
+
+    public void Kick(EntityUid? uid)
+    {
+        if (uid == null)
+            return;
+
+        var t = (IClientGameTiming)_timing;
+        var ev = new KickEvent(GetNetEntity(uid.Value), t.LastRealTick);
+        RaisePredictiveEvent(ev);
+    }
+
+    private void OnKick(KickEvent msg, EntitySessionEventArgs args)
+    {
+        if (args.SenderSession.AttachedEntity is not { } user)
+            return;
+
+        if (GetEntity(msg.Target) is not { Valid:true } target)
+            return;
+
+        var lagCoords = _lag.GetCoordinates(target, args.LastAppliedTick);
+
+        var userPos = TransformSystem.GetWorldPosition(user);
+        var targetPos = TransformSystem.ToWorldPosition(lagCoords);
+        var delta = userPos - targetPos;
+        if (delta.Length() > 1)
+            return;
+
+        var comp = Comp<TestRoombaComponent>(target);
+        comp.Kicked = user;
+        Dirty(target, comp);
+    }
+
+    [Serializable, NetSerializable]
+    public sealed class KickEvent(NetEntity uid, GameTick tick) : EntityEventArgs
+    {
+        public NetEntity Target = uid;
+        public GameTick Tick = tick;
+    }
+}
+
+[RegisterComponent, AutoGenerateComponentState, NetworkedComponent]
+public sealed partial class TestRoombaComponent : Component
+{
+    public Vector2 Velocity = Vector2.Zero;
+
+    [AutoNetworkedField]
+    public EntityUid? Kicked;
+}

--- a/Content.IntegrationTests/Tests/Movement/MovementTest.cs
+++ b/Content.IntegrationTests/Tests/Movement/MovementTest.cs
@@ -61,5 +61,22 @@ public abstract class MovementTest : InteractionTest
         var delta = Transform.GetWorldPosition(SEntMan.GetEntity(target.Value)) - Transform.GetWorldPosition(SEntMan.GetEntity(other ?? Player));
         return delta.X;
     }
+
+    /// <summary>
+    /// Variant of <see cref="Delta"/> that runs on the client instead of server.
+    /// </summary>
+    protected float ClientDelta(NetEntity? target = null, NetEntity? other = null)
+    {
+        target ??= Target;
+        if (target == null)
+        {
+            Assert.Fail("No target specified");
+            return 0;
+        }
+
+        var delta = CTransform.GetWorldPosition(ToClient(target.Value))
+                    - CTransform.GetWorldPosition(ToClient(other ?? Player));
+        return delta.X;
+    }
 }
 

--- a/Content.Server/Movement/Components/LagCompensationComponent.cs
+++ b/Content.Server/Movement/Components/LagCompensationComponent.cs
@@ -1,10 +1,15 @@
 using Robust.Shared.Map;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Movement.Components;
 
+/// <summary>
+/// Stores a buffer of previous positions of an entity.
+/// Can be used to check the entity's position at a recent point in time, for use with lag-compensation.
+/// </summary>
 [RegisterComponent]
 public sealed partial class LagCompensationComponent : Component
 {
     [ViewVariables]
-    public readonly Queue<ValueTuple<TimeSpan, EntityCoordinates, Angle>> Positions = new();
+    public readonly Queue<(TimeSpan Time, GameTick Tick, EntityCoordinates Coords, Angle Angle)> Positions = new();
 }

--- a/Content.Server/Movement/Systems/LagCompensationSystem.cs
+++ b/Content.Server/Movement/Systems/LagCompensationSystem.cs
@@ -1,22 +1,17 @@
 using Content.Server.Movement.Components;
-using Robust.Server.Player;
+using Content.Shared.Movement.Systems;
 using Robust.Shared.Map;
-using Robust.Shared.Player;
 using Robust.Shared.Timing;
 
 namespace Content.Server.Movement.Systems;
 
-/// <summary>
-/// Stores a buffer of previous positions of the relevant entity.
-/// Can be used to check the entity's position at a recent point in time.
-/// </summary>
-public sealed class LagCompensationSystem : EntitySystem
+public sealed class LagCompensationSystem : SharedLagCompensationSystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
 
-    // I figured 500 ping is max, so 1.5 is 750.
+    // I figured 500 ping is max
     // Max ping I've had is 350ms from aus to spain.
-    public static readonly TimeSpan BufferTime = TimeSpan.FromMilliseconds(750);
+    public static readonly TimeSpan BufferTime = TimeSpan.FromMilliseconds(500);
 
     public override void Initialize()
     {
@@ -40,13 +35,10 @@ public sealed class LagCompensationSystem : EntitySystem
         {
             while (comp.Positions.TryPeek(out var pos))
             {
-                if (pos.Item1 < earliestTime)
-                {
-                    comp.Positions.Dequeue();
-                    continue;
-                }
+                if (pos.Time >= earliestTime)
+                    break;
 
-                break;
+                comp.Positions.Dequeue();
             }
         }
     }
@@ -56,56 +48,37 @@ public sealed class LagCompensationSystem : EntitySystem
         if (!args.NewPosition.EntityId.IsValid())
             return; // probably being sent to nullspace for deletion.
 
-        component.Positions.Enqueue((_timing.CurTime, args.NewPosition, args.NewRotation));
+        component.Positions.Enqueue((_timing.CurTime, _timing.CurTick, args.NewPosition, args.NewRotation));
     }
 
-    public (EntityCoordinates Coordinates, Angle Angle) GetCoordinatesAngle(EntityUid uid, ICommonSession? pSession,
-        TransformComponent? xform = null)
+    public override (EntityCoordinates Coordinates, Angle Angle) GetCoordinatesAngle(
+        Entity<TransformComponent?> ent,
+        GameTick tick)
     {
-        if (!Resolve(uid, ref xform))
+        if (!Resolve(ent, ref ent.Comp))
             return (EntityCoordinates.Invalid, Angle.Zero);
 
-        if (pSession == null || !TryComp<LagCompensationComponent>(uid, out var lag) || lag.Positions.Count == 0)
-            return (xform.Coordinates, xform.LocalRotation);
+        if (!TryComp<LagCompensationComponent>(ent, out var lag) || lag.Positions.Count == 0)
+            return (ent.Comp.Coordinates, ent.Comp.LocalRotation);
 
         var angle = Angle.Zero;
         var coordinates = EntityCoordinates.Invalid;
-        var ping = pSession.Ping;
-        // Use 1.5 due to the trip buffer.
-        var sentTime = _timing.CurTime - TimeSpan.FromMilliseconds(ping * 1.5);
 
+        // Replay the position history, starting with the oldest known position, up until we find an entry that was
+        // inserted after the requested tick.
         foreach (var pos in lag.Positions)
         {
-            coordinates = pos.Item2;
-            angle = pos.Item3;
-
-            if (pos.Item1 >= sentTime)
+            if (pos.Tick > tick)
                 break;
+
+            coordinates = pos.Coords;
+            angle = pos.Angle;
         }
 
-        if (coordinates == default)
-        {
-            Log.Debug($"No long comp coords found, using {xform.Coordinates}");
-            coordinates = xform.Coordinates;
-            angle = xform.LocalRotation;
-        }
-        else
-        {
-            Log.Debug($"Actual coords is {xform.Coordinates} and got {coordinates}");
-        }
+        if (coordinates != default)
+            return (coordinates, angle);
 
-        return (coordinates, angle);
-    }
-
-    public Angle GetAngle(EntityUid uid, ICommonSession? session, TransformComponent? xform = null)
-    {
-        var (_, angle) = GetCoordinatesAngle(uid, session, xform);
-        return angle;
-    }
-
-    public EntityCoordinates GetCoordinates(EntityUid uid, ICommonSession? session, TransformComponent? xform = null)
-    {
-        var (coordinates, _) = GetCoordinatesAngle(uid, session, xform);
-        return coordinates;
+        var oldest = lag.Positions.Peek();
+        return (oldest.Coords, oldest.Angle);
     }
 }

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -47,7 +47,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         float range,
         MapId mapId,
         EntityUid ignore,
-        ICommonSession? session)
+        EntitySessionEventArgs? args)
     {
         // Originally the client didn't predict damage effects so you'd intuit some level of how far
         // in the future you'd need to predict, but then there was a lot of complaining like "why would you add artifical delay" as if ping is a choice.
@@ -62,25 +62,13 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         // Could also check the arc though future effort + if they're aimbotting it's not really going to make a difference.
 
         // (This runs lagcomp internally and is what clickattacks use)
+        // TODO MELEE FIX
+        // I'm 99% it doesn't, or at least not anymore.
         if (!Interaction.InRangeUnobstructed(ignore, targetUid, range + 0.1f, overlapCheck: false))
             return false;
 
         // TODO: Check arc though due to the aforementioned aimbot + damage split comments it's less important.
         return true;
-    }
-
-    protected override bool InRange(EntityUid user, EntityUid target, float range, ICommonSession? session)
-    {
-        EntityCoordinates targetCoordinates;
-        Angle targetLocalAngle;
-
-        if (session is { } pSession)
-        {
-            (targetCoordinates, targetLocalAngle) = _lag.GetCoordinatesAngle(target, pSession);
-            return Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false);
-        }
-
-        return Interaction.InRangeUnobstructed(user, target, range);
     }
 
     protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform)

--- a/Content.Shared/Movement/Systems/SharedLagCompensationSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedLagCompensationSystem.cs
@@ -1,0 +1,31 @@
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.Movement.Systems;
+
+/// <summary>
+/// This system can be used to get an entity's position some time into the past.
+/// This can be used to check the apparent position that a client would have seen at the time that they were attempting
+/// to interact with an entity.
+/// </summary>
+/// <remarks>
+/// This assumes that the client was not actively predicting the position of the entity. E.g., you shouldn't use this
+/// to get the position of the player's own entity.
+/// </remarks>
+public abstract class SharedLagCompensationSystem : EntitySystem
+{
+    /// <summary>
+    /// Fetch the position of an entity at some specific tick.
+    /// </summary>
+    /// <remarks>
+    /// To get the position as it would have been seen by a client, the given tick should correspond to the client's
+    /// IClientGameTiming.LastRealTick
+    /// </remarks>
+    public abstract (EntityCoordinates Coordinates, Angle Angle) GetCoordinatesAngle(Entity<TransformComponent?> ent, GameTick tick);
+
+    public Angle GetAngle(Entity<TransformComponent?> ent, GameTick tick)
+        => GetCoordinatesAngle(ent, tick).Angle;
+
+    public EntityCoordinates GetCoordinates(Entity<TransformComponent?> ent, GameTick tick)
+        => GetCoordinatesAngle(ent, tick).Coordinates;
+}


### PR DESCRIPTION
## About the PR

This PR attempts to improve the accuracy of the lag compensation system, which is used by melee combat to try infer the  position where a player would have seen an entity when they tried to attack it.

## Technical details
Requires https://github.com/space-wizards/RobustToolbox/pull/6200

The current implementation is based on the player's ping, and is pretty inaccurate. In particular it just arbitrarily multiplies the ping by 1.5 to try an account the the clients buffered sever states, which should really just be some kind of offset instead of multiplier.

Instead of trying to figure out how to fix the ping based approach, this instead just switches to allowing the client to report the tick of the last applied server state, and using that to figure out the compensated positions. 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
- LagCompensationSystem's methods now need to be given a `GameTick` corresponding to a client's last applied game state instead of their `ICommonSession`.
- The signature of several melee system methods have changed, with `ICommonSession?` being replaced with `EntitySessionEventArgs?`

:cl:
- tweak: Melee combat lag compensation should be more accurate.
