### PR TITLE
Intellicards rename to AI stored on them

### DIFF
--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -323,11 +323,17 @@ public abstract partial class SharedStationAiSystem : EntitySystem
     private void OnHolderConInsert(Entity<StationAiHolderComponent> ent, ref EntInsertedIntoContainerMessage args)
     {
         UpdateAppearance((ent.Owner, ent.Comp));
+
+        if (ent.Comp.RenameOnInsert && args.Container.ID == ent.Comp.Slot.ID)
+            _metadata.SetEntityName(ent.Owner, MetaData(args.Entity).EntityName);
     }
 
     private void OnHolderConRemove(Entity<StationAiHolderComponent> ent, ref EntRemovedFromContainerMessage args)
     {
         UpdateAppearance((ent.Owner, ent.Comp));
+
+        if (ent.Comp.RenameOnInsert && args.Container.ID == ent.Comp.Slot.ID)
+            _metadata.SetEntityName(ent.Owner, Prototype(ent.Owner)?.Name ?? string.Empty);
     }
 
     private void OnHolderMapInit(Entity<StationAiHolderComponent> ent, ref MapInitEvent args)
@@ -498,9 +504,6 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         ClearEye(ent);
         ent.Comp.Remote = true;
 
-        // Just so text and the likes works properly
-        _metadata.SetEntityName(ent.Owner, MetaData(args.Entity).EntityName);
-
         if (SetupEye(ent))
             AttachEye(ent);
     }
@@ -514,9 +517,6 @@ public abstract partial class SharedStationAiSystem : EntitySystem
             return;
 
         ent.Comp.Remote = true;
-
-        // Reset name to whatever
-        _metadata.SetEntityName(ent.Owner, Prototype(ent.Owner)?.Name ?? string.Empty);
 
         // Remove eye relay
         RemCompDeferred<RelayInputMoverComponent>(args.Entity);

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -322,17 +322,29 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
     private void OnHolderConInsert(Entity<StationAiHolderComponent> ent, ref EntInsertedIntoContainerMessage args)
     {
+        if (_timing.ApplyingState)
+            return;
+
+        if (args.Container.ID != ent.Comp.Slot.ID)
+            return;
+
         UpdateAppearance((ent.Owner, ent.Comp));
 
-        if (ent.Comp.RenameOnInsert && args.Container.ID == ent.Comp.Slot.ID)
+        if (ent.Comp.RenameOnInsert)
             _metadata.SetEntityName(ent.Owner, MetaData(args.Entity).EntityName);
     }
 
     private void OnHolderConRemove(Entity<StationAiHolderComponent> ent, ref EntRemovedFromContainerMessage args)
     {
+        if (_timing.ApplyingState)
+            return;
+
+        if (args.Container.ID != ent.Comp.Slot.ID)
+            return;
+
         UpdateAppearance((ent.Owner, ent.Comp));
 
-        if (ent.Comp.RenameOnInsert && args.Container.ID == ent.Comp.Slot.ID)
+        if (ent.Comp.RenameOnInsert)
             _metadata.SetEntityName(ent.Owner, Prototype(ent.Owner)?.Name ?? string.Empty);
     }
 

--- a/Content.Shared/Silicons/StationAi/StationAiHolderComponent.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiHolderComponent.cs
@@ -11,6 +11,12 @@ public sealed partial class StationAiHolderComponent : Component
 {
     public const string Container = StationAiCoreComponent.Container;
 
+    /// <summary>
+    /// Whether the holder should be renamed to the name of the inserted object.
+    /// </summary>
+    [DataField]
+    public bool RenameOnInsert = true;
+
     [DataField]
     public ItemSlot Slot = new();
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Intellicards (and any AI holders) now get renamed to the AI stored on them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Always felt like a missing feature. Now that we have several AIs, this seems like a good thing to have.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the subscription to be in AIHolder instead of AiCore, added a new datafield so you can exclude holders from being renamed.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="279" height="106" alt="image" src="https://github.com/user-attachments/assets/275ce44f-85e1-4894-bef9-7a097d14c743" />
<img width="305" height="166" alt="image" src="https://github.com/user-attachments/assets/08e935c3-2e9e-4e5d-a9c2-cdc731c20ffd" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Intellicards now get renamed to the name of the AI stored on them.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
