### PR TITLE
fixed localization text for vulp shock ear (inner) color

### DIFF
--- a/Resources/Locale/en-US/markings/vulpkanin.ftl
+++ b/Resources/Locale/en-US/markings/vulpkanin.ftl
@@ -38,7 +38,7 @@ marking-VulpEarOtie-otie-inner = Otie ears (Inner)
 marking-VulpEarOtie = Vulpkanin Otie
 
 marking-VulpEarShock-shock = Shock ears (Base)
-marking-VulpEarShock-inner = Shock ears (Inner)
+marking-VulpEarShock-shock-inner = Shock ears (Inner)
 marking-VulpEarShock = Vulpkanin Shock
 
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I changed the localization file, which had the incorrect key for the inner shock ear entry.
In-game, this will change it from saying "marking-VulpEarShock-shock-inner color" to "Shock ears (Inner) color".
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes minor ui issue I guess
## Technical details
<!-- Summary of code changes for easier review. -->
no need
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Nah
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
No
