### PR TITLE
Updated the cyborg weapon module's uplink description to be accurate

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -178,7 +178,7 @@ uplink-radio-jammer-name = Radio Jammer
 uplink-radio-jammer-desc = This device will disrupt any nearby outgoing radio communication as well as suit sensors when activated.
 
 uplink-syndicate-weapon-module-name = Weapon Cyborg Module
-uplink-syndicate-weapon-module-desc = Upgrades a cyborg with both a machete and an advanced laser.
+uplink-syndicate-weapon-module-desc = Upgrades a cyborg with both an energy dagger and an echis pistol.
 
 uplink-syndicate-martyr-module-name = Martyr Cyborg Module
 uplink-syndicate-martyr-module-desc = Turn your emagged borg friend into a walking bomb with just this module. Make sure they're loyal to your cause, results may vary.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I changed the description of the cyborg weapons module to be accurate to what it actually contains today, for obvious reasons;
It now clearly states that it contains an energy dagger and an echis pistol, instead of "a machete and an advanced laser"

## Why / Balance
This makes it easier for new players to not get confused, and is more clear for those who actually need to read the descriptions.

## Technical details

## Media
<img width="495" height="512" alt="weaponmodule" src="https://github.com/user-attachments/assets/d6ef0a50-b1b2-4c15-8c75-bdcc7dc22fef" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- fix: Updated the weapon cyborg model's uplink description to be correct
