### PR TITLE
Renames the radar console computer board to "mass scanner computer board"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -260,7 +260,7 @@
     state: cpu_service
   - type: ComputerBoard
     prototype: ComputerSurveillanceWirelessCameraMonitor
-  
+
 - type: entity
   parent: BaseComputerCircuitboard
   id: XenoborgCameraMonitorCircuitboard
@@ -402,7 +402,7 @@
 - type: entity
   parent: BaseComputerCircuitboard
   id: RadarConsoleCircuitboard
-  name: radar console computer board
+  name: mass scanner computer board
   components:
   - type: Sprite
     state: cpu_supply


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Renames the radar console computer board to "mass scanner computer board"

## Why / Balance
The board probably shouldn't be named completely differently to what it makes. Also, every other board is named after what computer it makes

## Media
<img width="377" height="153" alt="image" src="https://github.com/user-attachments/assets/51d009a1-89bd-46d2-bbe9-511b06be4526" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

This probably doesn't need a changelog