### PR TITLE
Renames the "Integrated GPS" to "integrated GPS"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/gps.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gps.yml
@@ -21,7 +21,7 @@
     - GPS
 
 - type: entity #why does this exist? Well, "global positioning system" is too long to fit in the cyborg's hand slot.
-  name: Integrated GPS
+  name: integrated GPS
   parent: HandheldGPSBasic
   id: BorgHandheldGPSBasic
   description: A miniaturized Global Positioning System for use in cyborg units.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Renames the "Integrated GPS" to "integrated GPS"

## Why / Balance
It's inconsistent. This is named the "Integrated GPS", while in another module the Salvage cyborg has is named "integrated GPS"

## Media
<img width="395" height="62" alt="image" src="https://github.com/user-attachments/assets/4396fc61-7d9a-4adc-8227-9afb58eac82b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->