### PR TITLE
Made all tarantulas able to drag entities

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2500,6 +2500,8 @@
     interactSuccessSpawn: EffectHearts
     interactSuccessSound:
       path: /Audio/Animals/snake_hiss.ogg
+  - type: Puller
+    needsHands: false
   - type: NoSlip
   - type: Spider
   - type: IgnoreSpiderWeb


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I gave tarantulas stronger legs; they can now drag entities (prey) back to their lair for later consumption.
This includes Shiva, Tarantulas, and Clown Tarantulas.

## Why / Balance
It always feels bad when you make a kill as a tarantula, but because your opponent fled during the fight, the corpse is now in the middle of the busy station, far from your lair; it'd be much more thematic and interesting if the tarantula could drag the corpses, as this establishes more of a 'lair' feel, and slightly increases the skill ceiling for their playstyle.
Reindeer & kangaroos can both drag, I don't see why man sized *_tarantulas_* shouldn't be able to pull things aswell :godo:

## Technical details
I just added;
```
- type: Puller
    needsHands: false
```
to the spiderBase

## Media

https://github.com/user-attachments/assets/db42beb7-e405-49ca-836a-01529919d3c1



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: All tarantulas can now pull
