### PR TITLE
adds ConveyorMask colission mask to it's fixture component

### DIFF
--- a/Resources/Prototypes/Entities/Structures/conveyor.yml
+++ b/Resources/Prototypes/Entities/Structures/conveyor.yml
@@ -29,10 +29,7 @@
           - 0.50,0.50
           - -0.50,0.50
         layer:
-        - Impassable
-        - MidImpassable
-        - LowImpassable
-        - DoorPassable
+        - ConveyorMask
         hard: False
   - type: Conveyor
   - type: DeviceNetwork


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Before, in the conveyor prototype, the colision layers were speciefied in a yml list instead of the ConveyorMask declared in the ColisionGroup enum. This commit replaces the colision layers list with the ConveyorMask defined in code.

resolves #39941 

## Why 
Better especifies the actual layer used by the Conveyor Fixture component and it makes it easier to make changes latter since all you have to change is the actual colision mask.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
