### PR TITLE
Non-moths can no longer eat towels

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
@@ -139,6 +139,12 @@ public sealed partial class IngestionSystem
     /// </remarks>
     private void OnDrainableIsDigestible(Entity<DrainableSolutionComponent> ent, ref IsDigestibleEvent args)
     {
+        // Check for EdibleComponent or FoodComponent. Do not make universally digestible if special digestion is required.
+        if (TryComp<EdibleComponent>(ent.Owner, out var edibleComp) && edibleComp.RequiresSpecialDigestion)
+            return;
+        if (TryComp<FoodComponent>(ent.Owner, out var foodComp) && foodComp.RequiresSpecialDigestion)
+            return;
+
         args.UniversalDigestion();
     }
 

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
@@ -139,12 +139,6 @@ public sealed partial class IngestionSystem
     /// </remarks>
     private void OnDrainableIsDigestible(Entity<DrainableSolutionComponent> ent, ref IsDigestibleEvent args)
     {
-        // Check for EdibleComponent or FoodComponent. Do not make universally digestible if special digestion is required.
-        if (TryComp<EdibleComponent>(ent.Owner, out var edibleComp) && edibleComp.RequiresSpecialDigestion)
-            return;
-        if (TryComp<FoodComponent>(ent.Owner, out var foodComp) && foodComp.RequiresSpecialDigestion)
-            return;
-
         args.UniversalDigestion();
     }
 

--- a/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
@@ -9,18 +9,16 @@
     sprite: Clothing/Multiple/towel.rsi
   - type: Clothing
     sprite: Clothing/Multiple/towel.rsi
-    slots: 
+    slots:
     - BELT
     - INNERCLOTHING
     - HEAD
     femaleMask: UniformTop
-    equipSound: 
-    unequipSound: 
+    equipSound:
+    unequipSound:
   - type: Spillable
     solution: absorbed
     spillWhenThrown: false
-  - type: DrainableSolution
-    solution: absorbed
   - type: Absorbent
     pickupAmount: 15
   - type: SolutionContainerManager
@@ -163,7 +161,7 @@
         color: "#0089EF"
   - type: Fiber
     fiberColor: fibers-blue
-    
+
 - type: entity
   id: TowelColorDarkBlue
   name: dark blue towel
@@ -766,4 +764,3 @@
         color: "#535353"
   - type: Fiber
     fiberColor: fibers-black
-    


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed a bug that allowed everyone to eat towels.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #40165

## Technical details
<!-- Summary of code changes for easier review. -->
The towels presented an edge case. Because they had both the `Food` component and the `DrainableSolution` component, `RequiresSpecialDigestion` was completely ignored due to this:
```cs
private void OnDrainableIsDigestible(Entity<DrainableSolutionComponent> ent, ref IsDigestibleEvent 
{
    args.UniversalDigestion();
}
```
This made it so anyone could eat it. To fix this, the `DrainableSolutionComponent` has been removed from the towel.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Unneeded. 
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Non-moths can no longer eat towels.

