### PR TITLE
Species Restrictions and How to save Vox population.

### DIFF
--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -72,6 +72,7 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
         });
 
         _configurationManager.OnValueChanged(CCVars.GameRoleTimers, _ => RefreshProfileEditor());
+        _configurationManager.OnValueChanged(CCVars.RoundstartSpeciesTimers, _ => RefreshProfileEditor());
         _configurationManager.OnValueChanged(CCVars.GameRoleLoadoutTimers, _ => RefreshProfileEditor());
 
         _configurationManager.OnValueChanged(CCVars.GameRoleWhitelist, _ => RefreshProfileEditor());

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -26,6 +26,7 @@ using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Client.Utility;
 using Robust.Shared.Configuration;
@@ -613,6 +614,26 @@ namespace Content.Client.Lobby.UI
             {
                 var name = Loc.GetString(_species[i].Name);
                 SpeciesButton.AddItem(name, i);
+
+                if (!_requirements.IsAllowed(
+                        _species[i],
+                        (HumanoidCharacterProfile?)_preferencesManager.Preferences?.SelectedCharacter,
+                        out var reason))
+                {
+                    SpeciesButton.SetItemDisabled(SpeciesButton.GetIdx(i), true);
+
+                    var button = SpeciesButton.OptionsScroll
+                        .Children
+                        .OfType<BoxContainer>()
+                        .Single()
+                        .Children
+                        .OfType<Button>()
+                        .Single(button => button.Text == name);
+
+                    var tooltip = new Tooltip();
+                    tooltip.SetMessage(reason);
+                    button.TooltipSupplier = _ => tooltip;
+                }
 
                 if (Profile?.Species.Equals(_species[i].ID) == true)
                 {

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -110,6 +110,12 @@ public sealed partial class CCVars
         GameRoleTimers = CVarDef.Create("game.role_timers", true, CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
+    ///     If roundstart species should be restricted based on time.
+    /// </summary>
+    public static readonly CVarDef<bool>
+        RoundstartSpeciesTimers = CVarDef.Create("game.species_timers", true, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
     /// If role loadout items should be restricted based on time.
     /// </summary>
     public static readonly CVarDef<bool>

--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -1,7 +1,7 @@
 using Content.Shared.Dataset;
 using Content.Shared.Humanoid.Markings;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Content.Shared.Species;
 
 namespace Content.Shared.Humanoid.Prototypes;
 
@@ -33,6 +33,12 @@ public sealed partial class SpeciesPrototype : IPrototype
     /// </summary>
     [DataField(required: true)]
     public bool RoundStart { get; private set; } = false;
+
+    /// <summary>
+    ///     Requirements for the species in the character editor.
+    /// </summary>
+    [DataField]
+    public HashSet<SpeciesRestriction>? Restrictions;
 
     // The below two are to avoid fetching information about the species from the entity
     // prototype.

--- a/Content.Shared/Species/Restrictions/OverallPlaytimeRestriction.cs
+++ b/Content.Shared/Species/Restrictions/OverallPlaytimeRestriction.cs
@@ -1,0 +1,53 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Localizations;
+using Content.Shared.Players.PlayTimeTracking;
+using Content.Shared.Preferences;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Species.Restrictions;
+
+[UsedImplicitly]
+[Serializable, NetSerializable]
+public sealed partial class OverallPlaytimeRestriction : SpeciesRestriction
+{
+    /// <inheritdoc cref="OverallPlaytimeRestriction.Time"/>
+    [DataField(required: true)]
+    public TimeSpan Time;
+
+    public override bool Check(IEntityManager entManager,
+        IPrototypeManager protoManager,
+        HumanoidCharacterProfile? profile,
+        IReadOnlyDictionary<string, TimeSpan> playTimes,
+        [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        reason = new FormattedMessage();
+
+        var overallTime = playTimes.GetValueOrDefault(PlayTimeTrackingShared.TrackerOverall);
+        var overallDiffSpan = Time - overallTime;
+        var overallDiff = overallDiffSpan.TotalMinutes;
+        var formattedOverallDiff = ContentLocalizationManager.FormatPlaytime(overallDiffSpan);
+
+        if (!Inverted)
+        {
+            if (overallDiff <= 0 || overallTime >= Time)
+                return true;
+
+            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
+                "species-timer-overall-insufficient",
+                ("time", formattedOverallDiff)));
+            return false;
+        }
+
+        if (overallDiff <= 0 || overallTime >= Time)
+        {
+            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString("species-timer-overall-too-high",
+                ("time", formattedOverallDiff)));
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/Species/SpeciesRestrictions.cs
+++ b/Content.Shared/Species/SpeciesRestrictions.cs
@@ -1,0 +1,26 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Preferences;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Species;
+
+/// <summary>
+/// Abstract class for playtime and other requirements for roundstart species.
+/// </summary>
+[ImplicitDataDefinitionForInheritors]
+[Serializable, NetSerializable]
+public abstract partial class SpeciesRestriction
+{
+    [DataField]
+    public bool Inverted;
+
+    public abstract bool Check(
+        IEntityManager entManager,
+        IPrototypeManager protoManager,
+        HumanoidCharacterProfile? profile,
+        IReadOnlyDictionary<string, TimeSpan> playTimes,
+        [NotNullWhen(false)] out FormattedMessage? reason);
+}
+

--- a/Content.Shared/Species/Systems/SharedSpeciesSystem.cs
+++ b/Content.Shared/Species/Systems/SharedSpeciesSystem.cs
@@ -1,0 +1,23 @@
+﻿using Content.Shared.Humanoid.Prototypes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Species.Systems;
+
+public sealed class SharedSpeciesSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
+
+    /// <summary>
+    /// Returns the list of requirements for a role, or null. May be altered by requirement overrides.
+    /// </summary>
+    public HashSet<SpeciesRestriction>? GetSpeciesRestrictions(SpeciesPrototype species)
+    {
+        return species.Restrictions;
+    }
+
+    /// <inheritdoc cref="GetSpeciesRestrictions(SpeciesPrototype)"/>
+    public HashSet<SpeciesRestriction>? GetSpeciesRestrictions(ProtoId<SpeciesPrototype> speciesId)
+    {
+        return _prototypes.TryIndex(speciesId, out var job) ? GetSpeciesRestrictions(job) : null;
+    }
+}

--- a/Resources/Locale/en-US/species/species-requirements.ftl
+++ b/Resources/Locale/en-US/species/species-requirements.ftl
@@ -1,0 +1,2 @@
+﻿species-timer-overall-insufficient = You require [color=yellow]{$time}[/color] more overall playtime to unlock this.
+species-timer-overall-too-high = You require [color=yellow]{$time}[/color] less overall playtime to select this. (Are you trying to play a trainee species?)

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -2,6 +2,9 @@
   id: Vox
   name: species-name-vox
   roundStart: true
+  restrictions:
+    - !type:OverallPlaytimeRestriction
+      time: 14400 # 4 hrs
   prototype: MobVox
   sprites: MobVoxSprites
   markingLimits: MobVoxMarkingLimits


### PR DESCRIPTION

## About the PR
This PR adds a playtime restriction for the Vox race, preventing players with less than 4 hours of total playtime from selecting it during character setup. The goal is to shield new players from the initial complexity of the race and allow them to first learn the game's core mechanics on more straightforward species.

## Why / Balance
The Vox race has unique breathing requirements, that can be hard for a new player. This often leads to a frustrating first experience where the player dies quickly without understanding why.

This PR doesn't change Balance.

## Technical details
- Added `SpeciesRestriction` absctract class to inherit restrictions from it.
- Inherited first `OverallPlaytimeRestriction` very similar to job's `OverallPlaytimeRequirement`
- Added `OverallPlaytimeRestriction` to Vox species prototype with 4 hours time.
- Added  `game.species_timers` CVar. Set false if roundstart species shouldn't be restricted based on time.
- Very ashamed of way i got needed `Button` in [HumanoidProfileEditor.xaml.cs](https://github.com/space-wizards/space-station-14/compare/master...Deatherd:species-requirements?expand=1#diff-f82295fc04d81250749022acc9392c61f82fb1b4a09dae6a953125b3082ac6a2). If you have idea how to make it proper please tell.
## Media

https://github.com/user-attachments/assets/4ba84529-9857-4761-b506-531bf2ca9ed3

<img width="821" height="461" alt="demo" src="https://github.com/user-attachments/assets/9ef12e28-2225-4886-bb10-2023fe56db40" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Now you need 4 hours playtime for Vox unlock!

