### PR TITLE
Fixes some refuling welder typos

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -204,8 +204,8 @@
 - type: entity
   parent: [ Welder, BaseXenoborgContraband ]
   id: RefuelingWelder
-  name: refuling welding tool
-  description: "An slow welder that can refuel itself over time."
+  name: refueling welding tool
+  description: "A slow welder that can refuel itself over time."
   components:
   - type: Tool
     speedModifier: 0.5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Two typos
1. Name: refuling
2. Description: "An slow welder"

## Media
<img width="388" height="122" alt="image" src="https://github.com/user-attachments/assets/c40013eb-8cac-4ea6-ad94-5614ce988fd6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

I don't think this needs a changelog. Worst that'd happen is an admin looking for this specifically for some reason and search for the typo instead. ~~Which I am guilty of because I searched "refuling" when doing this PR~~
