### PR TITLE
Small improvement to examinations for access readers

### DIFF
--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -107,9 +107,8 @@ namespace Content.Shared.Localizations
             }
         }
 
-        // TODO: allow fluent to take in lists of strings so this can be a format function like it should be.
         /// <summary>
-        /// Formats a list as per english grammar rules.
+        /// Formats a list as per English grammar rules.
         /// </summary>
         public static string FormatList(List<string> list)
         {
@@ -117,13 +116,16 @@ namespace Content.Shared.Localizations
             {
                 <= 0 => string.Empty,
                 1 => list[0],
-                2 => $"{list[0]} and {list[1]}",
-                _ => $"{string.Join(", ", list.GetRange(0, list.Count - 1))}, and {list[^1]}"
+                2 => Loc.GetString("generic-list", ("item", list[0]), ("itemLast", list[1])),
+                _ => Loc.GetString("generic-long-list",
+                        ("items", string.Join(Loc.GetString("generic-list-separator") + " ", list.GetRange(0, list.Count - 1))),
+                        ("itemLast", list[^1])
+                    ),
             };
         }
 
         /// <summary>
-        /// Formats a list as per english grammar rules, but uses or instead of and.
+        /// Formats a list as per English grammar rules, but uses or instead of and.
         /// </summary>
         public static string FormatListToOr(List<string> list)
         {
@@ -131,8 +133,45 @@ namespace Content.Shared.Localizations
             {
                 <= 0 => string.Empty,
                 1 => list[0],
-                2 => $"{list[0]} or {list[1]}",
-                _ => $"{string.Join(", ", list.GetRange(0, list.Count - 1))}, or {list[^1]}"
+                2 => Loc.GetString("generic-or-list", ("item", list[0]), ("itemLast", list[1])),
+                _ => Loc.GetString("generic-long-or-list",
+                        ("items", string.Join(Loc.GetString("generic-list-separator") + " ", list.GetRange(0, list.Count - 1))),
+                        ("itemLast", list[^1])
+                    ),
+            };
+        }
+
+        /// <summary>
+        /// Formats a complex list as per English grammar rules.
+        /// </summary>
+        public static string FormatComplexList(List<string> list)
+        {
+            return list.Count switch
+            {
+                <= 0 => string.Empty,
+                1 => list[0],
+                2 => Loc.GetString("generic-complex-list", ("item", list[0]), ("itemLast", list[1])),
+                _ => Loc.GetString("generic-long-complex-list",
+                        ("items", string.Join(Loc.GetString("generic-complex-list-separator") + " ", list.GetRange(0, list.Count - 1))),
+                        ("itemLast", list[^1])
+                    ),
+            };
+        }
+
+        /// <summary>
+        /// Formats a complex list as per English grammar rules, but uses or instead of and.
+        /// </summary>
+        public static string FormatComplexListToOr(List<string> list)
+        {
+            return list.Count switch
+            {
+                <= 0 => string.Empty,
+                1 => list[0],
+                2 => Loc.GetString("generic-or-complex-list", ("item", list[0]), ("itemLast", list[1])),
+                _ => Loc.GetString("generic-long-or-complex-list",
+                        ("items", string.Join(Loc.GetString("generic-complex-list-separator") + " ", list.GetRange(0, list.Count - 1))),
+                        ("itemLast", list[^1])
+                    ),
             };
         }
 

--- a/Resources/Locale/en-US/access/systems/access-reader-system.ftl
+++ b/Resources/Locale/en-US/access/systems/access-reader-system.ftl
@@ -1,6 +1,5 @@
 access-reader-unknown-id = Unknown
 access-reader-access-label = [color=yellow]{$access}[/color]
-access-reader-access-list-label = |{$accesses}|
 access-reader-examination = Access is generally restricted to personnel with {$access} access.
 access-reader-examination-functionality-restricted = {$access} access may be required to use certain functions.
 access-reader-access-settings-modified-message = [italic]The access reader has been modified to accept personnel with {$access} access.[/italic]

--- a/Resources/Locale/en-US/access/systems/access-reader-system.ftl
+++ b/Resources/Locale/en-US/access/systems/access-reader-system.ftl
@@ -1,5 +1,6 @@
 access-reader-unknown-id = Unknown
 access-reader-access-label = [color=yellow]{$access}[/color]
+access-reader-access-list-label = |{$accesses}|
 access-reader-examination = Access is generally restricted to personnel with {$access} access.
 access-reader-examination-functionality-restricted = {$access} access may be required to use certain functions.
 access-reader-access-settings-modified-message = [italic]The access reader has been modified to accept personnel with {$access} access.[/italic]

--- a/Resources/Locale/en-US/generic.ftl
+++ b/Resources/Locale/en-US/generic.ftl
@@ -7,6 +7,21 @@ generic-article-an = an
 generic-and = and
 generic-or = or
 
+generic-list-separator = ,
+generic-complex-list-separator = ;
+
+generic-list = {$item} and {$itemLast}
+generic-or-list = {$item} or {$itemLast}
+
+generic-long-list = {$items}, and {$itemLast}
+generic-long-or-list = {$items}, or {$itemLast}
+
+generic-complex-list = {$item}, and {$itemLast}
+generic-or-complex-list = {$item}, or {$itemLast}
+
+generic-long-complex-list = {$items}; and {$itemLast}
+generic-long-or-complex-list = {$items}; or {$itemLast}
+
 generic-unknown = unknown
 generic-unknown-title = Unknown
 generic-error = error


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Improved the display of complex access level lists when examining objects with access readers. This does not change how simple access level lists are displayed in examination messages. So, this change will never actually be seen by players (unless we were to include locks that require multiple access levels to open), but... eh

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
N/A

## Technical details
<!-- Summary of code changes for easier review. -->
Updated ContentLocalizationManager.FormatList and ContentLocalizationManager.FormatListToOr to used localized strings. Also added ContentLocalizationManager.FormatComplexList and ContentLocalizationManager.FormatComplexListToOr to handle complex lists (lists of grouped items)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Some examples of how access reader examinations now handle access levels collections with hashsets that have more than one item in them

Access levels: [Security, Lawyer]

<img width="342" height="180" alt="image" src="https://github.com/user-attachments/assets/cec68bd5-56f5-44f2-aaf5-8695e793914d" />

Access levels: [Research, Medical, Theatre], [Security, Lawyer]

<img width="344" height="203" alt="image" src="https://github.com/user-attachments/assets/a023f08e-a65c-4a82-8b95-605fcd6d920b" />

Access levels: [Research Director], [Research, Medical, Theatre], [Security, Lawyer], [Medical, Detective, Chapel, Captain]

<img width="363" height="222" alt="image" src="https://github.com/user-attachments/assets/f7e6a0ed-3281-4245-8c70-1bec2687fb62" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
N/A