### PR TITLE
Changes the Salvage directional sign to not say its a department

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
@@ -191,7 +191,7 @@
   parent: BaseSignDirectional
   id: SignDirectionalSalvage
   name: salvage sign
-  description: A direction sign, pointing out which way the Salvage department is.
+  description: A direction sign, pointing out which way Salvage is.
   components:
   - type: Sprite
     state: direction_salvage


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
It's really weird and I haven't seen a dedicated "Salvage department" once. Salvage is under Cargo, and isn't its own department anyway

## Media
<img width="543" height="232" alt="image" src="https://github.com/user-attachments/assets/286319ae-52e7-464a-b00b-01fdb1f79219" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
