### PR TITLE
changes the min and max variables in the TargetTemperature clamp to t…

### DIFF
--- a/Content.Server/Atmos/Portable/SpaceHeaterSystem.cs
+++ b/Content.Server/Atmos/Portable/SpaceHeaterSystem.cs
@@ -112,7 +112,9 @@ public sealed class SpaceHeaterSystem : EntitySystem
         if (!TryComp<GasThermoMachineComponent>(uid, out var thermoMachine))
             return;
 
-        thermoMachine.TargetTemperature = float.Clamp(thermoMachine.TargetTemperature + args.Temperature, thermoMachine.MinTemperature, thermoMachine.MaxTemperature);
+        thermoMachine.TargetTemperature = float.Clamp(thermoMachine.TargetTemperature + args.Temperature,
+                                                      spaceHeater.MinTemperature,
+                                                      spaceHeater.MaxTemperature);
 
         UpdateAppearance(uid);
         DirtyUI(uid, spaceHeater);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed the bug where you were able to set the space heater temperature to a value higher than the minimum or lower than the maximum.

resolves #40357

## Why / Balance
It was a bug and wasn't allowed to function like that.

## Technical details
The Clamp function in the Temperature changing part of the space heater system wasn't clamping to the correct min and max temps.

## Media
before:
https://github.com/user-attachments/assets/2919e86d-62f3-488b-85a1-4b6b45d7c67b

After:
https://github.com/user-attachments/assets/fb9d421d-f82d-409a-a5de-008e178f3b03

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed issue allowing space heater temperature to be set above the allowed limit.
