### PR TITLE
fix chasm heisentest

### DIFF
--- a/Content.IntegrationTests/Tests/Chasm/ChasmTest.cs
+++ b/Content.IntegrationTests/Tests/Chasm/ChasmTest.cs
@@ -131,14 +131,5 @@ public sealed class ChasmTest : MovementTest
         // Check that the player no longer hooked.
         Assert.That(grapplingSystem.IsEntityHooked(SPlayer), Is.False, "Player still hooked after dropping the grappling gun.");
         Assert.That(HasComp<JointRelayTargetComponent>(Player), Is.False, "Player still has the JointRelayTargetComponent after dropping the grappling gun.");
-
-        // Attempt (and fail) to walk past the chasm.
-        await Move(DirectionFlag.West, 1f);
-
-        // Wait until we get deleted.
-        await Pair.RunSeconds(5f);
-
-        // Check that the player was deleted
-        AssertDeleted(Player);
     }
 }


### PR DESCRIPTION
## About the PR
Fixes https://github.com/space-wizards/space-station-14/issues/40441

## Technical details
My best guess of what is happening is that walking into the grapple pushes you up or down:
![ss14](https://github.com/user-attachments/assets/02393e72-9d09-4f1b-90e1-5a77b9e2057e)

Printing the coords during the test confirms this.
<img width="854" height="549" alt="fail" src="https://github.com/user-attachments/assets/fa05f4df-eb23-491a-aa0a-7e2c97c42491" />

The step trigger needs a certain overlap of the fixtures to trigger:
![chasm](https://github.com/user-attachments/assets/7173232b-fc95-4852-bfd9-7acf3ccc382e)

Also the check is done in an update loop, meaning your exact position when the trigger is checked is kinda random. With enough vertical offset and lucky timing you then can walk past the chasm without falling into it.

Because random positioning during movement tests is kinda annoying I decided to just remove the last part of the grapple test - falling into the chasm is already tested in the other tests anyways under more controlled conditions and we still have the check if dropping the grapple unhooks you.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none
