### PR TITLE
Added diagnostic huds to the engi-vend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -2,6 +2,7 @@
   id: EngiVendInventory
   startingInventory:
     ClothingEyesGlassesMeson: 4
+    ClothingEyesHudDiagnostic: 4
     ClothingHeadHatWelding: 6
     CrowbarYellow: 8
     Multitool: 4


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I added 4 diagnostic huds to the engi-vend's inventory

## Why / Balance
This lets engineers check up on devices access requirements, as of [37712](https://github.com/space-wizards/space-station-14/pull/37712) being merged.
Doing so will prevent robotics being raided for - _what I understand are_ - the **only** diagnostic huds in the station, and provides engi a unique hud to diagnose device issues, instead of using guesswork.

Balance concerns are a non-issue; this is engineerings job to fix these, and the huds themselves are **not** welding protective, so they have to be mindful about what they have equipped.

## Technical details
Added `ClothingEyesHudDiagnostic: 4` to the EngiVendInventory

## Media
<img width="769" height="522" alt="engivend" src="https://github.com/user-attachments/assets/ac065c44-a4fc-4a1b-9bd1-2f6d93ae8bc6" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added 4 diagnostic huds to the engi-vend