### PR TITLE
Atmospherics Substepping

### DIFF
--- a/Content.Server/Atmos/Commands/AtmosSimulationPauseUnpause.cs
+++ b/Content.Server/Atmos/Commands/AtmosSimulationPauseUnpause.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.Console;
+
+namespace Content.Server.Atmos.Commands;
+
+public sealed class AtmosSimulationPauseUnpause : LocalizedEntityCommands
+{
+    public override string Command => "atmospause";
+    public override string Description => "Pauses or unpauses the atmosphere simulation for the provided grid entity.";
+    public override string Help => $"Usage: {Command}";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+
+    }
+}

--- a/Content.Server/Atmos/Commands/AtmosSimulationPauseUnpause.cs
+++ b/Content.Server/Atmos/Commands/AtmosSimulationPauseUnpause.cs
@@ -1,15 +1,72 @@
+using Content.Server.Administration;
+using Content.Server.Atmos.Components;
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Administration;
 using Robust.Shared.Console;
 
 namespace Content.Server.Atmos.Commands;
 
+[AdminCommand(AdminFlags.Debug)]
 public sealed class AtmosSimulationPauseUnpause : LocalizedEntityCommands
 {
-    public override string Command => "atmospause";
-    public override string Description => "Pauses or unpauses the atmosphere simulation for the provided grid entity.";
-    public override string Help => $"Usage: {Command}";
+    public override string Command => "pauseatmos";
+    public override string Description => Loc.GetString("atmos-pause-description");
+    public override string Help => $"Usage: {Command} <GridUid>";
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
+        var grid = default(EntityUid);
 
+        switch (args.Length)
+        {
+            case 0:
+            {
+                if (shell.Player is null ||
+                    !EntityManager.TryGetComponent<TransformComponent>(shell.Player.AttachedEntity, out var playerxform) ||
+                    playerxform.GridUid == null)
+                {
+                    shell.WriteError(Loc.GetString("error-no-grid-provided-or-invalid-grid"));
+                    return;
+                }
+
+                grid = playerxform.GridUid.Value;
+                break;
+            }
+            case 1:
+            {
+                if (!EntityUid.TryParse(args[0], out var parsedGrid) || !EntityManager.EntityExists(parsedGrid))
+                {
+                    shell.WriteError(Loc.GetString("error-couldnt-parse-entity"));
+                    return;
+                }
+
+                grid = parsedGrid;
+                break;
+            }
+        }
+
+        if (!EntityManager.TryGetComponent<GridAtmosphereComponent>(grid, out var gridAtmos))
+        {
+            shell.WriteError(Loc.GetString("error-no-gridatmosphere"));
+            return;
+        }
+
+        var newEnt = new Entity<GridAtmosphereComponent>(grid, gridAtmos);
+
+        var atmosSys = EntityManager.System<AtmosphereSystem>();
+
+        atmosSys.SetAtmosphereSimulation(newEnt, !newEnt.Comp.Simulated);
+        shell.WriteLine(Loc.GetString("set-atmos-simulation") + " " + EntityManager.ToPrettyString(grid) +
+                        Loc.GetString("to-state") + " " + newEnt.Comp.Simulated);
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            return CompletionResult.FromHint(Loc.GetString("completion-grid-pause"));
+        }
+
+        return CompletionResult.Empty;
     }
 }

--- a/Content.Server/Atmos/Commands/AtmosSimulationSubstep.cs
+++ b/Content.Server/Atmos/Commands/AtmosSimulationSubstep.cs
@@ -1,0 +1,47 @@
+using Robust.Shared.Console;
+
+namespace Content.Server.Atmos.Commands;
+
+public sealed class AtmosSimulationSubstep : LocalizedEntityCommands
+{
+    public override string Command => "atmossubstep";
+    public override string Description => "Substeps the atmosphere simulation by a single atmostick for the provided grid entity. " +
+                                          "Implicitly pauses atmospherics simulation.";
+    public override string Help => $"Usage: {Command} <GridUid>";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length is not 1)
+        {
+            shell.WriteError("Invalid number of arguments.");
+            return;
+        }
+
+        if (!EntityUid.TryParse(args[0], out var grid) || !EntityManager.EntityExists(grid))
+        {
+            shell.WriteError("Entity provided could not be parsed or does not exist.");
+        }
+
+        // blah blah blah
+
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            if (shell.Player is null ||
+                !EntityManager.TryGetComponent<TransformComponent>(shell.Player.AttachedEntity, out var xform))
+            {
+                return CompletionResult.Empty;
+            }
+
+            if (xform.GridUid is { } grid)
+            {
+                return CompletionResult.FromHint(grid.Id.ToString());
+            }
+        }
+
+        return CompletionResult.Empty;
+    }
+}

--- a/Content.Server/Atmos/Commands/AtmosSimulationSubstep.cs
+++ b/Content.Server/Atmos/Commands/AtmosSimulationSubstep.cs
@@ -1,45 +1,109 @@
+using Content.Server.Administration;
+using Content.Server.Atmos.Components;
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Administration;
+using Content.Shared.Atmos.Components;
 using Robust.Shared.Console;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 
 namespace Content.Server.Atmos.Commands;
 
+[AdminCommand(AdminFlags.Debug)]
 public sealed class AtmosSimulationSubstep : LocalizedEntityCommands
 {
-    public override string Command => "atmossubstep";
-    public override string Description => "Substeps the atmosphere simulation by a single atmostick for the provided grid entity. " +
-                                          "Implicitly pauses atmospherics simulation.";
+    public override string Command => "substepatmos";
+    public override string Description => Loc.GetString("atmos-substep-description");
     public override string Help => $"Usage: {Command} <GridUid>";
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        if (args.Length is not 1)
+        var grid = default(EntityUid);
+
+        switch (args.Length)
         {
-            shell.WriteError("Invalid number of arguments.");
+            case 0:
+            {
+                if (shell.Player is null ||
+                    !EntityManager.TryGetComponent<TransformComponent>(shell.Player.AttachedEntity, out var playerxform) ||
+                    playerxform.GridUid == null)
+                {
+                    shell.WriteError(Loc.GetString("error-no-grid-provided-or-invalid-grid"));
+                    return;
+                }
+
+                grid = playerxform.GridUid.Value;
+                break;
+            }
+            case 1:
+            {
+                if (!EntityUid.TryParse(args[0], out var parsedGrid) || !EntityManager.EntityExists(parsedGrid))
+                {
+                    shell.WriteError(Loc.GetString("error-couldnt-parse-entity"));
+                    return;
+                }
+
+                grid = parsedGrid;
+                break;
+            }
+        }
+
+        // i'm straight piratesoftwaremaxxing
+        if (!EntityManager.TryGetComponent<GridAtmosphereComponent>(grid, out var gridAtmos))
+        {
+            shell.WriteError(Loc.GetString("error-no-gridatmosphere"));
             return;
         }
 
-        if (!EntityUid.TryParse(args[0], out var grid) || !EntityManager.EntityExists(grid))
+        if (!EntityManager.TryGetComponent<GasTileOverlayComponent>(grid, out var gasTile))
         {
-            shell.WriteError("Entity provided could not be parsed or does not exist.");
+            shell.WriteError(Loc.GetString("error-no-gastileoverlay"));
+            return;
         }
 
-        // blah blah blah
+        if (!EntityManager.TryGetComponent<MapGridComponent>(grid, out var mapGrid))
+        {
+            shell.WriteError(Loc.GetString("error-no-mapgrid"));
+            return;
+        }
 
+        if (!EntityManager.TryGetComponent<TransformComponent>(grid, out var xform))
+        {
+            shell.WriteError(Loc.GetString("error-no-xform"));
+            return;
+        }
+
+        if (xform.MapUid == null || xform.MapID == MapId.Nullspace)
+        {
+            shell.WriteError(Loc.GetString("error-no-valid-map"));
+            return;
+        }
+
+        var newEnt =
+            new Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent>(grid,
+                gridAtmos,
+                gasTile,
+                mapGrid,
+                xform);
+
+        var atmosSys = EntityManager.System<AtmosphereSystem>();
+
+        if (gridAtmos.Simulated)
+        {
+            shell.WriteLine(Loc.GetString("info-implicitly-paused-simulation") + " " + EntityManager.ToPrettyString(grid));
+        }
+
+        atmosSys.SetAtmosphereSimulation(newEnt, false);
+        atmosSys.RunProcessingFull(newEnt, xform.MapUid.Value, atmosSys.AtmosTickRate);
+
+        shell.WriteLine(Loc.GetString("info-substepped-grid") + " " + EntityManager.ToPrettyString(grid));
     }
 
     public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
     {
         if (args.Length == 1)
         {
-            if (shell.Player is null ||
-                !EntityManager.TryGetComponent<TransformComponent>(shell.Player.AttachedEntity, out var xform))
-            {
-                return CompletionResult.Empty;
-            }
-
-            if (xform.GridUid is { } grid)
-            {
-                return CompletionResult.FromHint(grid.Id.ToString());
-            }
+            return CompletionResult.FromHint(Loc.GetString("completion-grid-substep"));
         }
 
         return CompletionResult.Empty;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.BenchmarkHelpers.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.BenchmarkHelpers.cs
@@ -48,15 +48,25 @@ public sealed partial class AtmosphereSystem
     }
 
     /// <summary>
-    /// Fully runs one <see cref="GridAtmosphereComponent"/> through the entire Atmos processing loop.
+    /// Fully runs one <see cref="GridAtmosphereComponent"/> entity through the entire Atmos processing loop.
     /// </summary>
-    /// <param name="ent"></param>
-    /// <param name="mapAtmosphere"></param>
-    /// <param name="frameTime"></param>
-    public void RunFullProcessing(Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent> ent,
+    /// <param name="ent">The entity to simulate.</param>
+    /// <param name="mapAtmosphere">The <see cref="MapAtmosphereComponent"/> that belongs to the grid's map.</param>
+    /// <param name="frameTime">Elapsed time to simulate. Recommended value is <see cref="AtmosTickRate"/>.</param>
+    public void RunProcessingFull(Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent> ent,
         Entity<MapAtmosphereComponent?> mapAtmosphere,
         float frameTime)
     {
         while (ProcessAtmosphere(ent, mapAtmosphere, frameTime) != AtmosphereProcessingCompletionState.Finished) { }
+    }
+
+    /// <summary>
+    /// Allows or disallows atmosphere simulation on a <see cref="GridAtmosphereComponent"/>.
+    /// </summary>
+    /// <param name="ent">The atmosphere to pause or unpause processing.</param>
+    /// <param name="simulate">The state to set. True means that the atmosphere is allowed to simulate, false otherwise.</param>
+    public void SetAtmosphereSimulation(Entity<GridAtmosphereComponent> ent, bool simulate)
+    {
+        ent.Comp.Simulated = simulate;
     }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.BenchmarkHelpers.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.BenchmarkHelpers.cs
@@ -46,4 +46,17 @@ public sealed partial class AtmosphereSystem
 
         return processingPaused;
     }
+
+    /// <summary>
+    /// Fully runs one <see cref="GridAtmosphereComponent"/> through the entire Atmos processing loop.
+    /// </summary>
+    /// <param name="ent"></param>
+    /// <param name="mapAtmosphere"></param>
+    /// <param name="frameTime"></param>
+    public void RunFullProcessing(Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent> ent,
+        Entity<MapAtmosphereComponent?> mapAtmosphere,
+        float frameTime)
+    {
+        while (ProcessAtmosphere(ent, mapAtmosphere, frameTime) != AtmosphereProcessingCompletionState.Finished) { }
+    }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -678,10 +678,7 @@ namespace Content.Server.Atmos.EntitySystems
         /// <param name="mapAtmosphere">The <see cref="MapAtmosphereComponent"/> belonging to the
         /// <see cref="GridAtmosphereComponent"/>'s map.</param>
         /// <param name="frameTime">The elapsed time since the last frame.</param>
-        /// <returns>Returns a bool pair that represents the completion state.
-        /// AtmosphereGridAtmosphereCompletionState.Return means the method is returning, ex. due to delegating processing to the next tick.
-        /// AtmosphereGridAtmosphereCompletionState.Continue means the method is continuing, ex. due to finishing a single processing stage.
-        /// (false, true) means the method is completely finished with the GridAtmosphere.</returns>
+        /// <returns>An <see cref="AtmosphereProcessingCompletionState"/> that represents the completion state.</returns>
         private AtmosphereProcessingCompletionState ProcessAtmosphere(Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent> ent,
             Entity<MapAtmosphereComponent?> mapAtmosphere,
             float frameTime)
@@ -824,8 +821,19 @@ namespace Content.Server.Atmos.EntitySystems
 
     public enum AtmosphereProcessingCompletionState : byte
     {
+        /// <summary>
+        /// Method is returning, ex. due to delegating processing to the next tick.
+        /// </summary>
         Return,
+
+        /// <summary>
+        /// Method is continuing, ex. due to finishing a single processing stage.
+        /// </summary>
         Continue,
+
+        /// <summary>
+        /// Method is finished with the GridAtmosphere.
+        /// </summary>
         Finished,
     }
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -649,133 +649,17 @@ namespace Content.Server.Atmos.EntitySystems
                 if (atmosphere.LifeStage >= ComponentLifeStage.Stopping || Paused(owner) || !atmosphere.Simulated)
                     continue;
 
-                atmosphere.Timer += frameTime;
-
-                if (atmosphere.Timer < AtmosTime)
-                    continue;
-
-                // We subtract it so it takes lost time into account.
-                atmosphere.Timer -= AtmosTime;
-
                 var map = new Entity<MapAtmosphereComponent?>(xform.MapUid.Value, _mapAtmosQuery.CompOrNull(xform.MapUid.Value));
 
-                switch (atmosphere.State)
+                var completionState = ProcessAtmosphere(ent, map, frameTime);
+
+                switch (completionState)
                 {
-                    case AtmosphereProcessingState.Revalidate:
-                        if (!ProcessRevalidate(ent))
-                        {
-                            atmosphere.ProcessingPaused = true;
-                            return;
-                        }
-
-                        atmosphere.ProcessingPaused = false;
-
-                        // Next state depends on whether monstermos equalization is enabled or not.
-                        // Note: We do this here instead of on the tile equalization step to prevent ending it early.
-                        //       Therefore, a change to this CVar might only be applied after that step is over.
-                        atmosphere.State = MonstermosEqualization
-                            ? AtmosphereProcessingState.TileEqualize
-                            : AtmosphereProcessingState.ActiveTiles;
+                    case AtmosphereProcessingCompletionState.Return:
+                        return;
+                    case AtmosphereProcessingCompletionState.Continue:
                         continue;
-                    case AtmosphereProcessingState.TileEqualize:
-                        if (!ProcessTileEqualize(ent))
-                        {
-                            atmosphere.ProcessingPaused = true;
-                            return;
-                        }
-
-                        atmosphere.ProcessingPaused = false;
-                        atmosphere.State = AtmosphereProcessingState.ActiveTiles;
-                        continue;
-                    case AtmosphereProcessingState.ActiveTiles:
-                        if (!ProcessActiveTiles(ent))
-                        {
-                            atmosphere.ProcessingPaused = true;
-                            return;
-                        }
-
-                        atmosphere.ProcessingPaused = false;
-                        // Next state depends on whether excited groups are enabled or not.
-                        atmosphere.State = ExcitedGroups ? AtmosphereProcessingState.ExcitedGroups : AtmosphereProcessingState.HighPressureDelta;
-                        continue;
-                    case AtmosphereProcessingState.ExcitedGroups:
-                        if (!ProcessExcitedGroups(ent))
-                        {
-                            atmosphere.ProcessingPaused = true;
-                            return;
-                        }
-
-                        atmosphere.ProcessingPaused = false;
-                        atmosphere.State = AtmosphereProcessingState.HighPressureDelta;
-                        continue;
-                    case AtmosphereProcessingState.HighPressureDelta:
-                        if (!ProcessHighPressureDelta((ent, ent)))
-                        {
-                            atmosphere.ProcessingPaused = true;
-                            return;
-                        }
-
-                        atmosphere.ProcessingPaused = false;
-                        atmosphere.State = DeltaPressureDamage
-                            ? AtmosphereProcessingState.DeltaPressure
-                            : AtmosphereProcessingState.Hotspots;
-                        continue;
-                    case AtmosphereProcessingState.DeltaPressure:
-                        if (!ProcessDeltaPressure(ent))
-                        {
-                            atmosphere.ProcessingPaused = true;
-                            return;
-                        }
-
-                        atmosphere.ProcessingPaused = false;
-                        atmosphere.State = AtmosphereProcessingState.Hotspots;
-                        continue;
-                    case AtmosphereProcessingState.Hotspots:
-                        if (!ProcessHotspots(ent))
-                        {
-                            atmosphere.ProcessingPaused = true;
-                            return;
-                        }
-
-                        atmosphere.ProcessingPaused = false;
-                        // Next state depends on whether superconduction is enabled or not.
-                        // Note: We do this here instead of on the tile equalization step to prevent ending it early.
-                        //       Therefore, a change to this CVar might only be applied after that step is over.
-                        atmosphere.State = Superconduction
-                            ? AtmosphereProcessingState.Superconductivity
-                            : AtmosphereProcessingState.PipeNet;
-                        continue;
-                    case AtmosphereProcessingState.Superconductivity:
-                        if (!ProcessSuperconductivity(atmosphere))
-                        {
-                            atmosphere.ProcessingPaused = true;
-                            return;
-                        }
-
-                        atmosphere.ProcessingPaused = false;
-                        atmosphere.State = AtmosphereProcessingState.PipeNet;
-                        continue;
-                    case AtmosphereProcessingState.PipeNet:
-                        if (!ProcessPipeNets(atmosphere))
-                        {
-                            atmosphere.ProcessingPaused = true;
-                            return;
-                        }
-
-                        atmosphere.ProcessingPaused = false;
-                        atmosphere.State = AtmosphereProcessingState.AtmosDevices;
-                        continue;
-                    case AtmosphereProcessingState.AtmosDevices:
-                        if (!ProcessAtmosDevices(ent, map))
-                        {
-                            atmosphere.ProcessingPaused = true;
-                            return;
-                        }
-
-                        atmosphere.ProcessingPaused = false;
-                        atmosphere.State = AtmosphereProcessingState.Revalidate;
-
-                        // We reached the end of this atmosphere's update tick. Break out of the switch.
+                    case AtmosphereProcessingCompletionState.Finished:
                         break;
                 }
 
@@ -786,6 +670,163 @@ namespace Content.Server.Atmos.EntitySystems
             // We finished processing all atmospheres successfully, therefore we won't be paused next tick.
             _simulationPaused = false;
         }
+
+        /// <summary>
+        /// Processes a <see cref="GridAtmosphereComponent"/> through its processing stages.
+        /// </summary>
+        /// <param name="ent">The entity to process.</param>
+        /// <param name="mapAtmosphere">The <see cref="MapAtmosphereComponent"/> belonging to the
+        /// <see cref="GridAtmosphereComponent"/>'s map.</param>
+        /// <param name="frameTime">The elapsed time since the last frame.</param>
+        /// <returns>Returns a bool pair that represents the completion state.
+        /// AtmosphereGridAtmosphereCompletionState.Return means the method is returning, ex. due to delegating processing to the next tick.
+        /// AtmosphereGridAtmosphereCompletionState.Continue means the method is continuing, ex. due to finishing a single processing stage.
+        /// (false, true) means the method is completely finished with the GridAtmosphere.</returns>
+        private AtmosphereProcessingCompletionState ProcessAtmosphere(Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent> ent,
+            Entity<MapAtmosphereComponent?> mapAtmosphere,
+            float frameTime)
+        {
+            // They call me the deconstructor the way i be deconstructing it
+            // and by it, i mean... my entity
+            var (owner, atmosphere, visuals, grid, xform) = ent;
+
+            atmosphere.Timer += frameTime;
+
+            if (atmosphere.Timer < AtmosTime)
+                return AtmosphereProcessingCompletionState.Continue; // continue;
+
+            // We subtract it so it takes lost time into account.
+            atmosphere.Timer -= AtmosTime;
+
+            switch (atmosphere.State)
+            {
+                case AtmosphereProcessingState.Revalidate:
+                    if (!ProcessRevalidate(ent))
+                    {
+                        atmosphere.ProcessingPaused = true;
+                        return AtmosphereProcessingCompletionState.Return; // return;
+                    }
+
+                    atmosphere.ProcessingPaused = false;
+
+                    // Next state depends on whether monstermos equalization is enabled or not.
+                    // Note: We do this here instead of on the tile equalization step to prevent ending it early.
+                    //       Therefore, a change to this CVar might only be applied after that step is over.
+                    atmosphere.State = MonstermosEqualization
+                        ? AtmosphereProcessingState.TileEqualize
+                        : AtmosphereProcessingState.ActiveTiles;
+                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                case AtmosphereProcessingState.TileEqualize:
+                    if (!ProcessTileEqualize(ent))
+                    {
+                        atmosphere.ProcessingPaused = true;
+                        return AtmosphereProcessingCompletionState.Return; // return;
+                    }
+
+                    atmosphere.ProcessingPaused = false;
+                    atmosphere.State = AtmosphereProcessingState.ActiveTiles;
+                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                case AtmosphereProcessingState.ActiveTiles:
+                    if (!ProcessActiveTiles(ent))
+                    {
+                        atmosphere.ProcessingPaused = true;
+                        return AtmosphereProcessingCompletionState.Return; // return;
+                    }
+
+                    atmosphere.ProcessingPaused = false;
+                    // Next state depends on whether excited groups are enabled or not.
+                    atmosphere.State = ExcitedGroups ? AtmosphereProcessingState.ExcitedGroups : AtmosphereProcessingState.HighPressureDelta;
+                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                case AtmosphereProcessingState.ExcitedGroups:
+                    if (!ProcessExcitedGroups(ent))
+                    {
+                        atmosphere.ProcessingPaused = true;
+                        return AtmosphereProcessingCompletionState.Return; // return;
+                    }
+
+                    atmosphere.ProcessingPaused = false;
+                    atmosphere.State = AtmosphereProcessingState.HighPressureDelta;
+                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                case AtmosphereProcessingState.HighPressureDelta:
+                    if (!ProcessHighPressureDelta((ent, ent)))
+                    {
+                        atmosphere.ProcessingPaused = true;
+                        return AtmosphereProcessingCompletionState.Return; // return;
+                    }
+
+                    atmosphere.ProcessingPaused = false;
+                    atmosphere.State = DeltaPressureDamage
+                        ? AtmosphereProcessingState.DeltaPressure
+                        : AtmosphereProcessingState.Hotspots;
+                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                case AtmosphereProcessingState.DeltaPressure:
+                    if (!ProcessDeltaPressure(ent))
+                    {
+                        atmosphere.ProcessingPaused = true;
+                        return AtmosphereProcessingCompletionState.Return; // return;
+                    }
+
+                    atmosphere.ProcessingPaused = false;
+                    atmosphere.State = AtmosphereProcessingState.Hotspots;
+                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                case AtmosphereProcessingState.Hotspots:
+                    if (!ProcessHotspots(ent))
+                    {
+                        atmosphere.ProcessingPaused = true;
+                        return AtmosphereProcessingCompletionState.Return; // return;
+                    }
+
+                    atmosphere.ProcessingPaused = false;
+                    // Next state depends on whether superconduction is enabled or not.
+                    // Note: We do this here instead of on the tile equalization step to prevent ending it early.
+                    //       Therefore, a change to this CVar might only be applied after that step is over.
+                    atmosphere.State = Superconduction
+                        ? AtmosphereProcessingState.Superconductivity
+                        : AtmosphereProcessingState.PipeNet;
+                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                case AtmosphereProcessingState.Superconductivity:
+                    if (!ProcessSuperconductivity(atmosphere))
+                    {
+                        atmosphere.ProcessingPaused = true;
+                        return AtmosphereProcessingCompletionState.Return; // return;
+                    }
+
+                    atmosphere.ProcessingPaused = false;
+                    atmosphere.State = AtmosphereProcessingState.PipeNet;
+                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                case AtmosphereProcessingState.PipeNet:
+                    if (!ProcessPipeNets(atmosphere))
+                    {
+                        atmosphere.ProcessingPaused = true;
+                        return AtmosphereProcessingCompletionState.Return; // return;
+                    }
+
+                    atmosphere.ProcessingPaused = false;
+                    atmosphere.State = AtmosphereProcessingState.AtmosDevices;
+                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                case AtmosphereProcessingState.AtmosDevices:
+                    if (!ProcessAtmosDevices(ent, mapAtmosphere))
+                    {
+                        atmosphere.ProcessingPaused = true;
+                        return AtmosphereProcessingCompletionState.Return; // return;
+                    }
+
+                    atmosphere.ProcessingPaused = false;
+                    atmosphere.State = AtmosphereProcessingState.Revalidate;
+
+                    // We reached the end of this atmosphere's update tick. Break out of the switch.
+                    break;
+            }
+
+            return AtmosphereProcessingCompletionState.Finished;
+        }
+    }
+
+    public enum AtmosphereProcessingCompletionState : byte
+    {
+        Return,
+        Continue,
+        Finished,
     }
 
     public enum AtmosphereProcessingState : byte

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -693,7 +693,7 @@ namespace Content.Server.Atmos.EntitySystems
             atmosphere.Timer += frameTime;
 
             if (atmosphere.Timer < AtmosTime)
-                return AtmosphereProcessingCompletionState.Continue; // continue;
+                return AtmosphereProcessingCompletionState.Continue;
 
             // We subtract it so it takes lost time into account.
             atmosphere.Timer -= AtmosTime;
@@ -704,7 +704,7 @@ namespace Content.Server.Atmos.EntitySystems
                     if (!ProcessRevalidate(ent))
                     {
                         atmosphere.ProcessingPaused = true;
-                        return AtmosphereProcessingCompletionState.Return; // return;
+                        return AtmosphereProcessingCompletionState.Return;
                     }
 
                     atmosphere.ProcessingPaused = false;
@@ -715,65 +715,65 @@ namespace Content.Server.Atmos.EntitySystems
                     atmosphere.State = MonstermosEqualization
                         ? AtmosphereProcessingState.TileEqualize
                         : AtmosphereProcessingState.ActiveTiles;
-                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                    return AtmosphereProcessingCompletionState.Continue;
                 case AtmosphereProcessingState.TileEqualize:
                     if (!ProcessTileEqualize(ent))
                     {
                         atmosphere.ProcessingPaused = true;
-                        return AtmosphereProcessingCompletionState.Return; // return;
+                        return AtmosphereProcessingCompletionState.Return;
                     }
 
                     atmosphere.ProcessingPaused = false;
                     atmosphere.State = AtmosphereProcessingState.ActiveTiles;
-                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                    return AtmosphereProcessingCompletionState.Continue;
                 case AtmosphereProcessingState.ActiveTiles:
                     if (!ProcessActiveTiles(ent))
                     {
                         atmosphere.ProcessingPaused = true;
-                        return AtmosphereProcessingCompletionState.Return; // return;
+                        return AtmosphereProcessingCompletionState.Return;
                     }
 
                     atmosphere.ProcessingPaused = false;
                     // Next state depends on whether excited groups are enabled or not.
                     atmosphere.State = ExcitedGroups ? AtmosphereProcessingState.ExcitedGroups : AtmosphereProcessingState.HighPressureDelta;
-                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                    return AtmosphereProcessingCompletionState.Continue;
                 case AtmosphereProcessingState.ExcitedGroups:
                     if (!ProcessExcitedGroups(ent))
                     {
                         atmosphere.ProcessingPaused = true;
-                        return AtmosphereProcessingCompletionState.Return; // return;
+                        return AtmosphereProcessingCompletionState.Return;
                     }
 
                     atmosphere.ProcessingPaused = false;
                     atmosphere.State = AtmosphereProcessingState.HighPressureDelta;
-                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                    return AtmosphereProcessingCompletionState.Continue;
                 case AtmosphereProcessingState.HighPressureDelta:
                     if (!ProcessHighPressureDelta((ent, ent)))
                     {
                         atmosphere.ProcessingPaused = true;
-                        return AtmosphereProcessingCompletionState.Return; // return;
+                        return AtmosphereProcessingCompletionState.Return;
                     }
 
                     atmosphere.ProcessingPaused = false;
                     atmosphere.State = DeltaPressureDamage
                         ? AtmosphereProcessingState.DeltaPressure
                         : AtmosphereProcessingState.Hotspots;
-                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                    return AtmosphereProcessingCompletionState.Continue;
                 case AtmosphereProcessingState.DeltaPressure:
                     if (!ProcessDeltaPressure(ent))
                     {
                         atmosphere.ProcessingPaused = true;
-                        return AtmosphereProcessingCompletionState.Return; // return;
+                        return AtmosphereProcessingCompletionState.Return;
                     }
 
                     atmosphere.ProcessingPaused = false;
                     atmosphere.State = AtmosphereProcessingState.Hotspots;
-                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                    return AtmosphereProcessingCompletionState.Continue;
                 case AtmosphereProcessingState.Hotspots:
                     if (!ProcessHotspots(ent))
                     {
                         atmosphere.ProcessingPaused = true;
-                        return AtmosphereProcessingCompletionState.Return; // return;
+                        return AtmosphereProcessingCompletionState.Return;
                     }
 
                     atmosphere.ProcessingPaused = false;
@@ -783,32 +783,32 @@ namespace Content.Server.Atmos.EntitySystems
                     atmosphere.State = Superconduction
                         ? AtmosphereProcessingState.Superconductivity
                         : AtmosphereProcessingState.PipeNet;
-                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                    return AtmosphereProcessingCompletionState.Continue;
                 case AtmosphereProcessingState.Superconductivity:
                     if (!ProcessSuperconductivity(atmosphere))
                     {
                         atmosphere.ProcessingPaused = true;
-                        return AtmosphereProcessingCompletionState.Return; // return;
+                        return AtmosphereProcessingCompletionState.Return;
                     }
 
                     atmosphere.ProcessingPaused = false;
                     atmosphere.State = AtmosphereProcessingState.PipeNet;
-                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                    return AtmosphereProcessingCompletionState.Continue;
                 case AtmosphereProcessingState.PipeNet:
                     if (!ProcessPipeNets(atmosphere))
                     {
                         atmosphere.ProcessingPaused = true;
-                        return AtmosphereProcessingCompletionState.Return; // return;
+                        return AtmosphereProcessingCompletionState.Return;
                     }
 
                     atmosphere.ProcessingPaused = false;
                     atmosphere.State = AtmosphereProcessingState.AtmosDevices;
-                    return AtmosphereProcessingCompletionState.Continue; // continue;
+                    return AtmosphereProcessingCompletionState.Continue;
                 case AtmosphereProcessingState.AtmosDevices:
                     if (!ProcessAtmosDevices(ent, mapAtmosphere))
                     {
                         atmosphere.ProcessingPaused = true;
-                        return AtmosphereProcessingCompletionState.Return; // return;
+                        return AtmosphereProcessingCompletionState.Return;
                     }
 
                     atmosphere.ProcessingPaused = false;

--- a/Resources/Locale/en-US/commands/atmos-simulation-pause.ftl
+++ b/Resources/Locale/en-US/commands/atmos-simulation-pause.ftl
@@ -1,0 +1,6 @@
+atmos-pause-description = Pauses or unpauses the atmosphere simulation for the provided grid entity.
+
+set-atmos-simulation = Set atmospherics simulation on
+to-state = to state
+
+completion-grid-pause = GridUid of the grid you want to pause/unpause. Automatically uses the grid you're standing on if empty.

--- a/Resources/Locale/en-US/commands/atmos-simulation-substep.ftl
+++ b/Resources/Locale/en-US/commands/atmos-simulation-substep.ftl
@@ -1,0 +1,14 @@
+atmos-substep-description = Substeps the atmosphere simulation by a single atmostick for the provided grid entity. Implicitly pauses atmospherics simulation.
+
+error-no-grid-provided-or-invalid-grid = You must either provide a grid entity or be standing on a grid to substep.
+error-couldnt-parse-entity = Entity provided could not be parsed or does not exist. Try standing on a grid you want to substep.
+error-no-gridatmosphere = Entity provided doesn't have a GridAtmosphereComponent.
+error-no-gastileoverlay = Entity provided doesn't have a GasTileOverlayComponent.
+error-no-mapgrid = Entity provided doesn't have a MapGridComponent.
+error-no-xform = Entity provided doesn't have a TransformComponent?
+error-no-valid-map = The grid provided is not on a valid map?
+
+info-implicitly-paused-simulation = Implicitly paused atmospherics simulation on
+info-substepped-grid = Substepped atmospherics simulation by one atmostick on
+
+completion-grid-substep = GridUid of the grid you want to substep. Automatically uses the grid you're standing on if empty.


### PR DESCRIPTION
## About the PR
Adds atmospherics substepping, a debugging tool that allows you to easily pause grids and progress the atmospherics simulation on them by one atmostick.

## Why / Balance
More Atmos debugging tools yay, but more importantly it'll be very useful for tests. We can simply pause processing on a grid and then execute a system run on that grid, instead of having to guess as to if we've ran a processing tick or not.

## Technical details
Most of the code that runs the switch that progresses a `GridAtmosphereComponent` through the various processing stages of Atmospherics has been extracted to a method `ProcessAtmosphere`.

The contents of this method had multiple exits. Sometimes a grid finished processing and we'd like to move onto the next one, sometimes we need to delegate to the next tick to keep on our time budget, etc. An enum `AtmosphereProcessingCompletionState` was made to convey this information.

## Media
https://github.com/user-attachments/assets/eb43ce15-ac9c-463b-abb5-7e4e0ae18808

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The code that handles processing Atmospherics states has been extracted into a new `ProcessAtmosphere` method. If you've implemented custom processing states, you might need to migrate them over.

**Changelog**
n/a
