### PR TITLE
Add date formatting to admin-notes-unbanned

### DIFF
--- a/Content.Client/Administration/UI/Notes/AdminNotesLine.xaml.cs
+++ b/Content.Client/Administration/UI/Notes/AdminNotesLine.xaml.cs
@@ -82,7 +82,11 @@ public sealed partial class AdminNotesLine : BoxContainer
 
         if (Note.UnbannedTime is not null)
         {
-            ExtraLabel.Text = Loc.GetString("admin-notes-unbanned", ("admin", Note.UnbannedByName ?? "[error]"), ("date", Note.UnbannedTime));
+            ExtraLabel.Text = Loc.GetString(
+                "admin-notes-unbanned",
+                ("admin", Note.UnbannedByName ?? "[error]"),
+                ("date", Note.UnbannedTime.Value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss"))
+            );
             ExtraLabel.Visible = true;
         }
         else if (Note.ExpiryTime is not null)
@@ -139,7 +143,7 @@ public sealed partial class AdminNotesLine : BoxContainer
 
     private string FormatRoleBanMessage()
     {
-        var banMessage = new StringBuilder($"{Loc.GetString("admin-notes-banned-from")} {string.Join(", ", Note.BannedRoles ?? new []{"unknown"})} ");
+        var banMessage = new StringBuilder($"{Loc.GetString("admin-notes-banned-from")} {string.Join(", ", Note.BannedRoles ?? new[] { "unknown" })} ");
         return FormatBanMessageCommon(banMessage);
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fix the lack of admin timestamp formatting on the ``admin-notes-unbanned`` timestamp.

## Why / Balance
Clarity.

## Technical details
Some formatting was added, not much more then that

## Media
<img width="548" height="107" alt="image" src="https://github.com/user-attachments/assets/a0463266-bc66-4ff7-bda2-a1a1c031e7a4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
ADMIN:
- tweak: The "unbanned by" message in the admin notes now formats its date properly.