### PR TITLE
bugfix - correcting poster damage resistances

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -5,6 +5,9 @@
   components:
   - type: Sprite
     sprite: Structures/Wallmounts/posters.rsi
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Card
   - type: Destructible
     thresholds:
     - trigger: # Excess damage, don't spawn entities
@@ -18,7 +21,7 @@
         acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
-        damage: 5
+        damage: 15
       behaviors:
       - !type:PlaySoundBehavior
         sound:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Reduced wall posters durability, allowing them to be destroyed more easily.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In pull request https://github.com/space-wizards/space-station-14/pull/34329 , prototype 'BaseSign' was changed to parent off of 'BaseWallmountMetallic', giving bar signs structure resistance. However, posters also parent off of BaseSign, turning these adverts into durable annoyances. This pull request addresses this issue by overriding the Damagable component on 'PosterBase' to give them Card damage modifiers, bringing them back in line with their paper-like audio and visual references.

## Technical details
<!-- Summary of code changes for easier review. -->
added the following component override to PosterBase:
```
  - type: Damageable
    damageContainer: StructuralInorganic
    damageModifierSet: Card
```
additionally, changed the damage trigger variable from 5 to 15, so you can't simply punch the poster off the wall with a single swing.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="330" height="325" alt="image" src="https://github.com/user-attachments/assets/fc20b53b-5769-47d4-bffd-016dec2d532d" />

_Three posters; the top slashed once with a combat knife, the middle punched by a moth, and the bottom incinerated with a welder._

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- fix: Posters now have proper damage resistances and values, instead of acting like they were made out of metal.