### PR TITLE
Use RT list formatting

### DIFF
--- a/Content.Client/Guidebook/Controls/GuideReagentReaction.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideReagentReaction.xaml.cs
@@ -191,13 +191,10 @@ public sealed partial class GuideReagentReaction : BoxContainer, ISearchableCont
             MixTexture.Texture = sysMan.GetEntitySystem<SpriteSystem>().Frame0(primaryCategory.Icon);
         }
 
-        var mixingVerb = ContentLocalizationManager.FormatList(mixingCategories
-            .Select(p => Loc.GetString(p.VerbText)).ToList());
-
         var minTemp = prototype?.MinimumTemperature ?? 0;
         var maxTemp = prototype?.MaximumTemperature ?? float.PositiveInfinity;
         var text = Loc.GetString("guidebook-reagent-recipes-mix-info",
-            ("verb", mixingVerb),
+            ("verb", mixingCategories.Select(p => p.VerbText)),
             ("minTemp", minTemp),
             ("maxTemp", maxTemp),
             ("hasMax", !float.IsPositiveInfinity(maxTemp)));

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -403,15 +403,8 @@ namespace Content.Server.Lathe
 
             var message =
                 recipeNames.Count > ent.Comp.MaximumItems ?
-                    Loc.GetString(
-                        "lathe-unlock-recipe-radio-broadcast-overflow",
-                        ("items", ContentLocalizationManager.FormatList(recipeNames.GetRange(0, ent.Comp.MaximumItems))),
-                        ("count", recipeNames.Count)
-                    ) :
-                    Loc.GetString(
-                        "lathe-unlock-recipe-radio-broadcast",
-                        ("items", ContentLocalizationManager.FormatList(recipeNames))
-                    );
+                    Loc.GetString("lathe-unlock-recipe-radio-broadcast-overflow", ("items", recipeNames)) :
+                    Loc.GetString("lathe-unlock-recipe-radio-broadcast", ("items", recipeNames));
 
             foreach (var channel in ent.Comp.Channels)
             {

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -77,9 +77,8 @@ public sealed class AccessReaderSystem : EntitySystem
         if (canSeeAccessModification)
         {
             var localizedCurrentNames = GetLocalizedAccessNames(mainAccessReader.Value.Comp.AccessLists);
-            var accessesFormatted = ContentLocalizationManager.FormatListToOr(localizedCurrentNames);
             var currentSettingsMessage = localizedCurrentNames.Count > 0
-                ? Loc.GetString("access-reader-access-settings-modified-message", ("access", accessesFormatted))
+                ? Loc.GetString("access-reader-access-settings-modified-message", ("access", localizedCurrentNames))
                 : Loc.GetString("access-reader-access-settings-removed-message");
 
             args.PushMarkup(currentSettingsMessage);
@@ -93,8 +92,7 @@ public sealed class AccessReaderSystem : EntitySystem
         if (localizedOriginalNames.Count == 0)
             return;
 
-        var originalAccessesFormatted = ContentLocalizationManager.FormatListToOr(localizedOriginalNames);
-        var originalSettingsMessage = Loc.GetString(mainAccessReader.Value.Comp.ExaminationText, ("access", originalAccessesFormatted));
+        var originalSettingsMessage = Loc.GetString(mainAccessReader.Value.Comp.ExaminationText, ("access", localizedOriginalNames));
         args.PushMarkup(originalSettingsMessage);
     }
 

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -860,11 +860,9 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
             if (recognized.Count == 0)
                 return;
 
-            var msg = ContentLocalizationManager.FormatList(recognized);
-
             // Finally push the full message
             args.PushMarkup(Loc.GetString(entity.Comp.LocRecognizableReagents,
-                ("recognizedString", msg)));
+                ("recognizedString", recognized)));
         }
     }
 

--- a/Content.Shared/Contraband/ContrabandSystem.cs
+++ b/Content.Shared/Contraband/ContrabandSystem.cs
@@ -115,11 +115,8 @@ public sealed class ContrabandSystem : EntitySystem
         var jobs = allowedJobs.Select(p => _proto.Index(p).LocalizedName).ToArray();
         var localizedJobs = jobs.Select(p => Loc.GetString("contraband-job-plural", ("job", p)));
 
-        //creating a combined list of jobs and departments for the restricted text
-        var list = ContentLocalizationManager.FormatList(localizedDepartments.Concat(localizedJobs).ToList());
-
         // department restricted text
-        return Loc.GetString("contraband-examine-text-Restricted-department", ("departments", list), ("type", itemType));
+        return Loc.GetString("contraband-examine-text-Restricted-department", ("departments", localizedDepartments.Concat(localizedJobs)), ("type", itemType));
     }
 
     private FormattedMessage GetContrabandExamine(String deptMessage, String carryMessage)

--- a/Content.Shared/EntityEffects/EffectConditions/JobCondition.cs
+++ b/Content.Shared/EntityEffects/EffectConditions/JobCondition.cs
@@ -47,6 +47,6 @@ public sealed partial class JobCondition : EntityEffectCondition
     public override string GuidebookExplanation(IPrototypeManager prototype)
     {
         var localizedNames = Job.Select(jobId => prototype.Index(jobId).LocalizedName).ToList();
-        return Loc.GetString("reagent-effect-condition-guidebook-job-condition", ("job", ContentLocalizationManager.FormatListToOr(localizedNames)));
+        return Loc.GetString("reagent-effect-condition-guidebook-job-condition", ("job", localizedNames));
     }
 }

--- a/Content.Shared/EntityEffects/Effects/EvenHealthChange.cs
+++ b/Content.Shared/EntityEffects/Effects/EvenHealthChange.cs
@@ -72,7 +72,7 @@ public sealed partial class EvenHealthChange : EntityEffect
         var healsordeals = heals ? (deals ? "both" : "heals") : (deals ? "deals" : "none");
         return Loc.GetString("reagent-effect-guidebook-even-health-change",
             ("chance", Probability),
-            ("changes", ContentLocalizationManager.FormatList(damages)),
+            ("changes", damages),
             ("healsordeals", healsordeals));
     }
 

--- a/Content.Shared/EntityEffects/Effects/HealthChange.cs
+++ b/Content.Shared/EntityEffects/Effects/HealthChange.cs
@@ -83,7 +83,7 @@ namespace Content.Shared.EntityEffects.Effects
 
             return Loc.GetString("reagent-effect-guidebook-health-change",
                 ("chance", Probability),
-                ("changes", ContentLocalizationManager.FormatList(damages)),
+                ("changes", damages),
                 ("healsordeals", healsordeals));
         }
 

--- a/Content.Shared/EntityEffects/EntityEffect.cs
+++ b/Content.Shared/EntityEffects/EntityEffect.cs
@@ -58,10 +58,7 @@ public abstract partial class EntityEffect
             return null;
 
         return Loc.GetString(ReagentEffectFormat, ("effect", effect), ("chance", Probability),
-            ("conditionCount", Conditions?.Length ?? 0),
-            ("conditions",
-                ContentLocalizationManager.FormatList(Conditions?.Select(x => x.GuidebookExplanation(prototype)).ToList() ??
-                                                        new List<string>())));
+            ("conditions", Conditions?.Select(x => x.GuidebookExplanation(prototype)) ?? Enumerable.Empty<string>()));
     }
 }
 

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
@@ -209,12 +209,11 @@ public abstract partial class SharedHandsSystem : EntitySystem
         var heldItemNames = EnumerateHeld((examinedUid, handsComp))
             .Where(entity => !HasComp<VirtualItemComponent>(entity))
             .Select(item => FormattedMessage.EscapeText(Identity.Name(item, EntityManager)))
-            .Select(itemName => Loc.GetString("comp-hands-examine-wrapper", ("item", itemName)))
             .ToList();
 
         var locKey = heldItemNames.Count != 0 ? "comp-hands-examine" : "comp-hands-examine-empty";
         var locUser = ("user", Identity.Entity(examinedUid, EntityManager));
-        var locItems = ("items", ContentLocalizationManager.FormatList(heldItemNames));
+        var locItems = ("items", heldItemNames);
 
         using (args.PushGroup(nameof(HandsComponent)))
         {

--- a/Content.Shared/Lathe/SharedLatheSystem.cs
+++ b/Content.Shared/Lathe/SharedLatheSystem.cs
@@ -18,6 +18,7 @@ namespace Content.Shared.Lathe;
 public abstract class SharedLatheSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly ILocalizationManager _localization = default!;
     [Dependency] private readonly SharedMaterialStorageSystem _materialStorage = default!;
     [Dependency] private readonly EmagSystem _emag = default!;
 
@@ -160,7 +161,7 @@ public abstract class SharedLatheSystem : EntitySystem
 
         if (proto.ResultReagents is { } resultReagents)
         {
-            return ContentLocalizationManager.FormatList(resultReagents
+            return _localization.FormatList(resultReagents
                 .Select(p => Loc.GetString("lathe-menu-result-reagent-display", ("reagent", _proto.Index(p.Key).LocalizedName), ("amount", p.Value)))
                 .ToList());
         }

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -107,35 +107,6 @@ namespace Content.Shared.Localizations
             }
         }
 
-        // TODO: allow fluent to take in lists of strings so this can be a format function like it should be.
-        /// <summary>
-        /// Formats a list as per english grammar rules.
-        /// </summary>
-        public static string FormatList(List<string> list)
-        {
-            return list.Count switch
-            {
-                <= 0 => string.Empty,
-                1 => list[0],
-                2 => $"{list[0]} and {list[1]}",
-                _ => $"{string.Join(", ", list.GetRange(0, list.Count - 1))}, and {list[^1]}"
-            };
-        }
-
-        /// <summary>
-        /// Formats a list as per english grammar rules, but uses or instead of and.
-        /// </summary>
-        public static string FormatListToOr(List<string> list)
-        {
-            return list.Count switch
-            {
-                <= 0 => string.Empty,
-                1 => list[0],
-                2 => $"{list[0]} or {list[1]}",
-                _ => $"{string.Join(", ", list.GetRange(0, list.Count - 1))}, or {list[^1]}"
-            };
-        }
-
         /// <summary>
         /// Formats a direction struct as a human-readable string.
         /// </summary>
@@ -157,7 +128,11 @@ namespace Content.Shared.Localizations
 
         private static ILocValue FormatLoc(LocArgs args)
         {
-            var id = ((LocValueString) args.Args[0]).Value;
+            LocId id = args.Args[0] switch
+            {
+                LocValueLocId locId => locId.Value,
+                LocValueString str => str.Value,
+            };
 
             return new LocValueString(Loc.GetString(id, args.Options.Select(x => (x.Key, x.Value.Value!)).ToArray()));
         }

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -224,9 +224,7 @@ public sealed class ReflectSystem : EntitySystem
             typeList.Add(type);
         }
 
-        var msg = ContentLocalizationManager.FormatList(typeList);
-
-        args.PushMarkup(Loc.GetString("reflect-component-examine", ("value", value), ("type", msg)));
+        args.PushMarkup(Loc.GetString("reflect-component-examine", ("value", value), ("type", typeList)));
     }
     #endregion
 }

--- a/Resources/Locale/en-US/access/systems/access-reader-system.ftl
+++ b/Resources/Locale/en-US/access/systems/access-reader-system.ftl
@@ -1,6 +1,6 @@
 access-reader-unknown-id = Unknown
 access-reader-access-label = [color=yellow]{$access}[/color]
-access-reader-examination = Access is generally restricted to personnel with {$access} access.
+access-reader-examination = Access is generally restricted to personnel with {LIST($access, type: "or")} access.
 access-reader-examination-functionality-restricted = {$access} access may be required to use certain functions.
-access-reader-access-settings-modified-message = [italic]The access reader has been modified to accept personnel with {$access} access.[/italic]
+access-reader-access-settings-modified-message = [italic]The access reader has been modified to accept personnel with {LIST($access, type: "or")} access.[/italic]
 access-reader-access-settings-removed-message = [italic]The settings on the access reader have been deleted.[/italic]

--- a/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
+++ b/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
@@ -3,7 +3,7 @@ shared-solution-container-component-on-examine-main-text = It contains {INDEFINI
    *[other] mixture of chemicals.
     }
 
-examinable-solution-has-recognizable-chemicals = You can recognize {$recognizedString} in the solution.
+examinable-solution-has-recognizable-chemicals = You can recognize {LIST($recognizedString)} in the solution.
 examinable-solution-recognized = [color={$color}]{$chemical}[/color]
 
 examinable-solution-on-examine-volume = The contained solution is { $fillLevel ->

--- a/Resources/Locale/en-US/contraband/contraband-severity.ftl
+++ b/Resources/Locale/en-US/contraband/contraband-severity.ftl
@@ -12,8 +12,8 @@ contraband-examine-text-Restricted =
 
 contraband-examine-text-Restricted-department =
     { $type ->
-        *[item] [color=yellow]This item is restricted to {$departments}, and may be considered contraband.[/color]
-        [reagent] [color=yellow]This reagent is restricted to {$departments}, and may be considered contraband.[/color]
+        *[item] [color=yellow]This item is restricted to {LIST($departments)}, and may be considered contraband.[/color]
+        [reagent] [color=yellow]This reagent is restricted to {LIST($departments)}, and may be considered contraband.[/color]
     }
 
 contraband-examine-text-Major =

--- a/Resources/Locale/en-US/guidebook/chemistry/conditions.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/conditions.ftl
@@ -29,7 +29,7 @@ reagent-effect-condition-guidebook-mob-state-condition =
     the mob is { $state }
 
 reagent-effect-condition-guidebook-job-condition =
-    the target's job is { $job }
+    the target's job is { LIST($job, type: "or") }
 
 reagent-effect-condition-guidebook-solution-temperature =
     the solution's temperature is { $max ->

--- a/Resources/Locale/en-US/guidebook/chemistry/core.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/core.ftl
@@ -2,9 +2,9 @@
     {$chance ->
         [1] { $effect }
         *[other] Has a { NATURALPERCENT($chance, 2) } chance to { $effect }
-    }{ $conditionCount ->
+    }{ COUNT($conditions) ->
         [0] .
-        *[other] {" "}when { $conditions }.
+        *[other] {" "}when { LIST($conditions) }.
     }
 
 guidebook-reagent-name = [bold][color={$color}]{CAPITALIZE($name)}[/color][/bold]
@@ -20,10 +20,10 @@ guidebook-reagent-plant-metabolisms-rate = [bold]Plant Metabolism[/bold] [color=
 guidebook-reagent-physical-description = [italic]Seems to be {$description}.[/italic]
 guidebook-reagent-recipes-mix-info = {$minTemp ->
     [0] {$hasMax ->
-            [true] {CAPITALIZE($verb)} below {NATURALFIXED($maxTemp, 2)}K
-            *[false] {CAPITALIZE($verb)}
+            [true] {CAPITALIZE(LIST($verb))} below {NATURALFIXED($maxTemp, 2)}K
+            *[false] {CAPITALIZE(LIST($verb))}
         }
-    *[other] {CAPITALIZE($verb)} {$hasMax ->
+    *[other] {CAPITALIZE(LIST($verb))} {$hasMax ->
             [true] between {NATURALFIXED($minTemp, 2)}K and {NATURALFIXED($maxTemp, 2)}K
             *[false] above {NATURALFIXED($minTemp, 2)}K
         }

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -85,7 +85,7 @@ reagent-effect-guidebook-health-change =
                     [deals] deal
                     *[both] modify health by
                  }
-    } { $changes }
+    } { LIST($changes) }
 
 reagent-effect-guidebook-even-health-change =
     { $chance ->
@@ -99,7 +99,7 @@ reagent-effect-guidebook-even-health-change =
             [deals] evenly deal
             *[both] evenly modify health by
         }
-    } { $changes }
+    } { LIST($changes) }
 
 
 reagent-effect-guidebook-status-effect =

--- a/Resources/Locale/en-US/hands/hands-system.ftl
+++ b/Resources/Locale/en-US/hands/hands-system.ftl
@@ -1,5 +1,5 @@
 # Examine text after when they're holding something (in-hand)
-comp-hands-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } holding { $items }.
+comp-hands-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } holding { LIST($items, wrapper: "comp-hands-examine-wrapper") }.
 comp-hands-examine-empty = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } not holding anything.
 comp-hands-examine-wrapper = { INDEFINITE($item) } [color=paleturquoise]{$item}[/color]
 

--- a/Resources/Locale/en-US/lathe/lathesystem.ftl
+++ b/Resources/Locale/en-US/lathe/lathesystem.ftl
@@ -1,4 +1,4 @@
 lathe-popup-material-not-used = This material is not used in this machine.
-lathe-unlock-recipe-radio-broadcast = This lathe is now capable of producing the following recipes: {$items}
-lathe-unlock-recipe-radio-broadcast-overflow = This lathe is now capable of producing {$count} new recipes, including: {$items}
+lathe-unlock-recipe-radio-broadcast = This lathe is now capable of producing the following recipes: {LIST($items)}
+lathe-unlock-recipe-radio-broadcast-overflow = This lathe is now capable of producing {COUNT($items)} new recipes, including: {LIST($items)}
 lathe-unlock-recipe-radio-broadcast-item = [bold]{$item}[/bold]

--- a/Resources/Locale/en-US/reflect/reflect-component.ftl
+++ b/Resources/Locale/en-US/reflect/reflect-component.ftl
@@ -1,3 +1,3 @@
-reflect-component-examine = It has a [color=lightblue]{$value}%[/color] chance to [color=cyan]reflect[/color] {$type}.
+reflect-component-examine = It has a [color=lightblue]{$value}%[/color] chance to [color=cyan]reflect[/color] {LIST($type)}.
 reflect-component-nonenergy = bullets
 reflect-component-energy = energy bolts


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Requires https://github.com/space-wizards/RobustToolbox/pull/6219.

## About the PR
Uses RT list formatting functions.

## Why / Balance
Better localizability.

## Technical details
- kill ContentLocalizationManager.FormatList
- pass lists directly into Loc.GetString

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
SS14 now uses Robust Toolbox's list formatting functions which are properly locale-aware and can be controlled in Fluent. ContentLocalizationManager.FormatList is removed. Consider passing lists into Fluent and using `LIST()` or `COUNT()`, or using `ILocalizationManager.FormatList` if you must get the format in C#.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
