### PR TITLE
Add "Reset Volume" features to the hypopen

### DIFF
--- a/Content.Client/Chemistry/UI/HyposprayStatusControl.cs
+++ b/Content.Client/Chemistry/UI/HyposprayStatusControl.cs
@@ -15,8 +15,8 @@ public sealed class HyposprayStatusControl : Control
     private readonly RichTextLabel _label;
     private readonly SharedSolutionContainerSystem _solutionContainers;
 
-    private FixedPoint2 PrevVolume;
-    private FixedPoint2 PrevMaxVolume;
+    private FixedPoint2? PrevVolume;
+    private FixedPoint2? PrevMaxVolume;
     private bool PrevOnlyAffectsMobs;
 
     public HyposprayStatusControl(Entity<HyposprayComponent> parent, SharedSolutionContainerSystem solutionContainers)

--- a/Content.Shared/Chemistry/Components/HyposprayComponent.cs
+++ b/Content.Shared/Chemistry/Components/HyposprayComponent.cs
@@ -20,8 +20,7 @@ public sealed partial class HyposprayComponent : Component
     /// <summary>
     ///     Amount of the units that will be transfered.
     /// </summary>
-    [AutoNetworkedField]
-    [DataField]
+    [DataField, AutoNetworkedField]
     public FixedPoint2 TransferAmount = FixedPoint2.New(5);
 
     /// <summary>
@@ -33,15 +32,13 @@ public sealed partial class HyposprayComponent : Component
     /// <summary>
     /// Decides whether you can inject everything or just mobs.
     /// </summary>
-    [AutoNetworkedField]
-    [DataField(required: true)]
+    [DataField(required: true), AutoNetworkedField]
     public bool OnlyAffectsMobs = false;
 
     /// <summary>
     /// If this can draw from containers in mob-only mode.
     /// </summary>
-    [AutoNetworkedField]
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool CanContainerDraw = true;
 
     /// <summary>
@@ -50,4 +47,34 @@ public sealed partial class HyposprayComponent : Component
     /// </summary>
     [DataField]
     public bool InjectOnly = false;
+
+    /// <summary>
+    /// If this container requires a doafter to reset its injection volume.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool RequireReset = false;
+
+    /// <summary>
+    /// The amount the hypospray will reset to; set by SolutionContainerManager's hypospray solution when initialized.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2? ResetAmount = null;
+
+    /// <summary>
+    /// The reset doafter duration.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float ResetTime = 3f;
+
+    /// <summary>
+    /// The sound that will play when the hypospray is reset.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier? ResetSoundStart;
+
+    /// <summary>
+    /// The sound that will play when the hypospray is reset.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier? ResetSoundEnd;
 }

--- a/Resources/Locale/en-US/chemistry/components/hypospray-component.ftl
+++ b/Resources/Locale/en-US/chemistry/components/hypospray-component.ftl
@@ -14,7 +14,10 @@ hypospray-component-empty-message = Nothing to inject.
 hypospray-component-feel-prick-message = You feel a tiny prick!
 hypospray-component-transfer-already-full-message = {$owner} is already full!
 hypospray-cant-inject = Can't inject into {$target}!
+hypospray-component-reset-volume = You start pulling back the storage spring.
 
 hypospray-verb-mode-label = Toggle Container Draw
 hypospray-verb-mode-inject-all = You cannot draw from containers anymore.
 hypospray-verb-mode-inject-mobs-only = You can now draw from containers.
+
+hypospray-verb-reset-label = Reset Storage

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -166,7 +166,7 @@ uplink-binary-translator-key-name = Binary Translator Key
 uplink-binary-translator-key-desc = Lets you tap into the silicons' binary channel. Don't talk on it though, at least not without a voice mask.
 
 uplink-hypopen-name = Hypopen
-uplink-hypopen-desc = A chemical hypospray disguised as a pen, capable of instantly injecting up to 10u of reagents. Starts empty.
+uplink-hypopen-desc = A chemical hypospray disguised as a pen, capable of instantly injecting up to 10u of reagents. It starts empty and must be reset between uses.
 
 uplink-voice-mask-name = Voice Mask
 uplink-voice-mask-desc = A gas mask that lets you adjust your voice to whoever you can think of. Also utilizes cutting-edge chameleon technology.

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -667,6 +667,18 @@
     exactVolume: true
   - type: Hypospray
     onlyAffectsMobs: false
+    requireReset: true
+    resetTime: 2.5
+    resetSoundStart:
+      path: /Audio/Items/Handcuffs/cuff_end.ogg
+      params:
+        volume: -4
+        maxDistance: 2
+    resetSoundEnd:
+      path: /Audio/Items/pen_click.ogg
+      params:
+        volume: -4
+        maxDistance: 2
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice # A new shitcurity meta


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds a new "reset" feature to `HyposprayComponent` and applies it to the hypopen item (only the hypo*pen*, and not any derivatives like the borg hypo). 

This causes the hypopen to reduce its max volume by 5 units every time you inject (10u -> 5u -> 0u). To restore the max volume to its original value, the user must spend 2.5 seconds performing a (hidden) doafter to reset the spring. This can be done by activating the pen while it is empty, or via a rightclick verb. 

Full credit to Kayla Solace on Discord for the idea!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The hypopen is known to be an extremely powerful antagonist item, both because of the effects of the chems it can provide but also its versatility as a stealthy disabling/killing tool, a refillable instant-injection medipen, and a powerful non-valid weapon. Not only can it perform all of those things but it can switch between them seamlessly and with high sustain.

The changes introduced in this PR are intended to reduce the "sustain" of it, making it less ideal in active combat scenarios. By introducing what is effectively a stand-still reload, it is no longer viable to use it to inject more than 10u into a target before needing to retreat or (more likely) have the target succumb. 

For self-injections, it becomes a fine way to top up with some healing during combat, or to use meth at the start of combat, but you can not sustain yourself with healing/meth while moving at the same time. 

For hostile injections, it can be used as a one-time poison injection when the target is in a crowd. If the target is alone however (i.e. a stealth kill) the impact is much less noticeable; since you're under no pressure to move around and can stand still, reseting the hypopen is easy and therefore you can continue injecting the single target (e.g. to top up nocturine). 

> Why reduce its combat sustain?

There are several poisons, heals and combat enhancement drugs that allow antagonists to reach high power peaks if they utilize them, and the hypopen makes that peak even sharper due to the ease of which it can allow users to bypass the time it takes to administer the chems. This has raised certain roles (Chemist, Botanist) to have potential to be at a much stronger power level than the average antagonist to the point where there is little counterplay from the opposing side.

While a future medical rework will likely change this dynamic, this PR is intended to address the state of the game as it is currently.

> Isn't Nocturine/Meth the problem? 

Nocturine stealth kills are effectively unchanged with this PR, and that is intended. #40231 intends to address Nocturine's strength, and there will be further looks into Meth in the future. 

> What about CMO's hypospray?

I do not see this PR as being the endgame for ensuring a more balanced chem antag experience, and with the hypospray being unchanged I expect chem antags to simply kill CMO for it and go about as they did before. Expect a PR down the road to deal with that. 

## Technical details
<!-- Summary of code changes for easier review. -->

Adds some new behavior to `HypospraySystem`; the main thing I am a bit iffy on is using `OnMapInit` to set the base `ResetAmount` since it needs to occur after the solution's `MaxVolume` is set, but it should be fine I hope.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Video shows the use of the pen; the slime injections show that there's time to inject more nocturine after sleeping someone. 
https://youtu.be/wXkTOYl2xYM

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: SlamBamActionman, Kayla Solace
- tweak: The hypopen now requires being reset between uses, which can be done via activating the pen or rightclicking after use.
