### PR TITLE
Fix changeling blindness

### DIFF
--- a/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
+++ b/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
@@ -2,7 +2,6 @@
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.IdentityManagement;
-using Robust.Shared.Network;
 
 namespace Content.Shared.Traits.Assorted;
 
@@ -38,18 +37,23 @@ public sealed class PermanentBlindnessSystem : EntitySystem
         {
             _blinding.SetMinDamage((blindness.Owner, blindable), 0);
         }
+
+        // Heal all eye damage when the component is removed.
+        // Otherwise you would still be blind, but not *permanently* blind, meaning you have to heal the eye damage with oculine.
+        // This is needed for changelings that transform from a blind player to a non-blind one.
+        _blinding.AdjustEyeDamage((blindness.Owner, blindable), -blindable.EyeDamage);
     }
 
     private void OnMapInit(Entity<PermanentBlindnessComponent> blindness, ref MapInitEvent args)
     {
-        if(!TryComp<BlindableComponent>(blindness.Owner, out var blindable))
+        if (!TryComp<BlindableComponent>(blindness.Owner, out var blindable))
             return;
 
         if (blindness.Comp.Blindness != 0)
             _blinding.SetMinDamage((blindness.Owner, blindable), blindness.Comp.Blindness);
         else
         {
-            var maxMagnitudeInt = (int) BlurryVisionComponent.MaxMagnitude;
+            var maxMagnitudeInt = (int)BlurryVisionComponent.MaxMagnitude;
             _blinding.SetMinDamage((blindness.Owner, blindable), maxMagnitudeInt);
         }
     }


### PR DESCRIPTION
## About the PR
They did not heal eye damage when transforming from a permanently blind identity to a non-blind one.

## Why / Balance
Resolves #40476

## Technical details
Just heal eye damage on component removal

## Media
Transforming between a blind identity, one with bad eyesight and a healthy one.
![ss14](https://github.com/user-attachments/assets/ad7335ed-94a4-454c-ac0d-83259d5c0916)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
nope

**Changelog**
nope
