### PR TITLE
Enable safety on windoors

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -133,8 +133,8 @@
     denyAnimationTime: 0.4
     animatePanel: false
     openUnlitVisible: true
-    # needed so that windoors will close regardless of whether there are people in it; it doesn't crush after all
-    safety: false
+    # needed so that windoors loop between closing and reopening less often even though they don't crush
+    safety: true
   - type: NavMapDoor
   - type: DoorBolt
   - type: Electrified


### PR DESCRIPTION
Cuts back on audio spam when people stand in windoors.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Enables safety on windoors. (Remake of #40518.)

## Why / Balance

Many (dare I say all?) maps use windoors for many departments. People often stand here for a long time talking to one another. When windoors have safety disabled they will shut and push the player(s) adjacent to the door which will cause them to start an annoying close and reopen and close and reopen loop. This can be be very annoying, especially for roles like HoP where people come to your desk for a majority of the shift.

While windoors do not crush players like an airlock, enabling safety would cut back on the audio spam in some situations. If players stand in the windoor then the loop won't happen. A caveat is that players who just stop moving once they bump into the windoor will still make the loop occur, but that's no worse than it is now. In short, this will reduce audio spam in some circumstances and not make it any worse in others.

## Technical details

Enables the safety boolean on the windoor prototype.

## Media

N/A

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Windoors no longer close on their own when someone is standing in them.