### PR TITLE
Borg UI verb now gives feedback [Mald pr]

### DIFF
--- a/Content.Shared/Wires/ActivatableUIRequiresPanelComponent.cs
+++ b/Content.Shared/Wires/ActivatableUIRequiresPanelComponent.cs
@@ -14,4 +14,7 @@ public sealed partial class ActivatableUIRequiresPanelComponent : Component
     /// </summary>
     [DataField]
     public bool RequireOpen = true;
+
+    [DataField]
+    public LocId? PanelClosedPopup = "activatable-ui-requires-panel-panel-closed-popup";
 }

--- a/Content.Shared/Wires/SharedWiresSystem.cs
+++ b/Content.Shared/Wires/SharedWiresSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
+using Content.Shared.Popups;
 using Content.Shared.Tools.Systems;
 using Content.Shared.UserInterface;
 using Robust.Shared.Audio.Systems;
@@ -15,6 +16,7 @@ public abstract class SharedWiresSystem : EntitySystem
     [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
     [Dependency] protected readonly SharedAudioSystem Audio = default!;
     [Dependency] protected readonly SharedToolSystem Tool = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
@@ -159,7 +161,11 @@ public abstract class SharedWiresSystem : EntitySystem
             return;
 
         if (component.RequireOpen != wires.Open)
+        {
             args.Cancel();
+
+            _popup.PopupClient(component.PanelClosedPopup, args.User, uid);
+        }
     }
 
     private void OnActivatableUIPanelChanged(EntityUid uid, ActivatableUIRequiresPanelComponent component, ref PanelChangedEvent args)

--- a/Resources/Locale/en-US/wires/components/activatable-ui-panel.ftl
+++ b/Resources/Locale/en-US/wires/components/activatable-ui-panel.ftl
@@ -1,0 +1,1 @@
+activatable-ui-requires-panel-panel-closed-popup = The panel is closed!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
requires #39844 to make sense

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I was so confused why the UI button was there but didn't say why it wasn't opening. Now it just gives you a popup when you can't open it

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
