### PR TITLE
Fix missing scrollbars in Admin Player List window

### DIFF
--- a/Content.Client/UserInterface/Controls/ListContainer.cs
+++ b/Content.Client/UserInterface/Controls/ListContainer.cs
@@ -27,7 +27,16 @@ public class ListContainer : Control
     /// Called when creating a button on the UI.
     /// The provided <see cref="ListContainerButton"/> is the generated button that Controls should be parented to.
     /// </summary>
-    public Action<ListData, ListContainerButton>? GenerateItem;
+    public Action<ListData, ListContainerButton>? GenerateItem
+    {
+        get => _generateItem;
+        set {
+            _generateItem = value;
+            // Invalidate _itemHeight so we recalculate the size of children the next
+            // time PopulateList() is called
+            _itemHeight = 0;
+        }
+    }
 
     /// <inheritdoc cref="BaseButton.OnPressed"/>
     public Action<BaseButton.ButtonEventArgs, ListData>? ItemPressed;
@@ -58,6 +67,7 @@ public class ListContainer : Control
     private bool _updateChildren = false;
     private bool _suppressScrollValueChanged;
     private ButtonGroup? _buttonGroup;
+    public Action<ListData, ListContainerButton>? _generateItem;
 
     public int ScrollSpeedY { get; set; } = 50;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

At low numbers of players (<15 with the default window size), the Admin Player List window was missing scrollbars. This fixes that problem.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Unintended bug.

## Technical details
<!-- Summary of code changes for easier review. -->

The admin player list uses a `ListContainer` to display it's items. The first time items are added (`ListContainer.PopulateList`), the container calls it's `GenerateItem` action for the first item and measures the size of the resulting control in order to determine the `_itemHeight` - this value is used to determine if scrollbars are necessary.

The `Content.Client.Administration.UI.Tabs.PlayerTab.PlayerTab`, however, does a few things:

1. Hooks up the `AdminSystem.PlayerListChanged` to it's own `RefreshPlayerList` (which in turn, adds items to the `ListContainer`)
2. Modifies some cvars
3. Hooks up the `ListContainer.GenerateItem` to the function which populates the items in the player list
4. Manually calls `RefreshPlayerList` to populate the player list

The problem is that at stage 2, changing those cvars triggers the AdminSystem.PlayerListChanged, which causes the ListContainer to calculate and cache the _itemHeight; but _ohno_, the GenerateItem hasn't been hooked up, so a bunch of empty items are added to the list and the cached _itemHeight is wrong. At step 4, the items are re-added, this time with the correct contents, as GenerateItem _is_ hooked up, but _itemHeight isn't re-evaluated.

~~This change just moves step 2 down until after step 3 and puts in a big warning comment explaining why.~~

Strike that, better idea; this change modifies the ListContainer, and invalidates the cached _itemHeight when GenerateItem changes, removing this particular footgun from code.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:
<img width="721" height="299" alt="2025-09-23_22-09" src="https://github.com/user-attachments/assets/41f99c94-27bb-4f0d-b670-40d60e2dce56" />
After:
<img width="681" height="278" alt="2025-09-23_22-06" src="https://github.com/user-attachments/assets/ac111314-1b6c-4bd6-9063-2f78fc4ba5fd" />

In both of these, I made some local hacks to fake some additional players, but you get the idea.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
ADMIN:
- fix: Fix bug where scrollbars were missing from player list