### PR TITLE
Zookeepers now spawn with the correct shoes

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -1551,7 +1551,7 @@
   id: VisitorZookeeper
   equipment:
     jumpsuit: ClothingUniformJumpsuitSafari
-    shoes: ClothingShoesBootsSalvage
+    shoes: ClothingShoesBootsWork
     head: ClothingHeadSafari
     id: VisitorPDA
     belt: ClothingBeltUtility

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
@@ -19,7 +19,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitSafari
     head: ClothingHeadSafari
-    shoes: ClothingShoesColorWhite
+    shoes: ClothingShoesBootsWork
     id: ZookeeperPDA
     ears: ClothingHeadsetService
   #storage:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Zookeepers originally had white shoes which look weird on them. Visitor versions also had salvage boots for some reason.
## Technical details
<!-- Summary of code changes for easier review. -->
Changed zookeeper shoes to workboots.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="288" height="427" alt="image" src="https://github.com/user-attachments/assets/09402862-7f8b-4cbb-8a6e-0bd0e11a9be4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: MrBarbados
- tweak: Zookeepers now start with workboots.

