### PR TITLE
Add doafter to filling the hypopen

### DIFF
--- a/Content.Shared/Chemistry/Components/DrainableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/DrainableSolutionComponent.cs
@@ -14,4 +14,10 @@ public sealed partial class DrainableSolutionComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public string Solution = "default";
+
+    /// <summary>
+    /// The drain doafter time required to transfer reagents from the solution.
+    /// </summary>
+    [DataField]
+    public float DrainTime = 0f;
 }

--- a/Content.Shared/Chemistry/Components/HyposprayComponent.cs
+++ b/Content.Shared/Chemistry/Components/HyposprayComponent.cs
@@ -25,6 +25,13 @@ public sealed partial class HyposprayComponent : Component
     public FixedPoint2 TransferAmount = FixedPoint2.New(5);
 
     /// <summary>
+    /// Whether or not the hypospray is able to draw from containers or if it's a single use
+    /// device that can only inject.
+    /// </summary>
+    [DataField]
+    public float DrawDelay = 0f;
+
+    /// <summary>
     ///     Sound that will be played when injecting.
     /// </summary>
     [DataField]

--- a/Content.Shared/Chemistry/Components/RefillableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/RefillableSolutionComponent.cs
@@ -14,12 +14,18 @@ public sealed partial class RefillableSolutionComponent : Component
     /// <summary>
     /// Solution name that can added to easily.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public string Solution = "default";
 
     /// <summary>
     /// The maximum amount that can be transferred to the solution at once
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public FixedPoint2? MaxRefill = null;
+
+    /// <summary>
+    /// The refill doafter time required to transfer reagents into the solution.
+    /// </summary>
+    [DataField]
+    public float RefillTime = 0f;
 }

--- a/Content.Shared/Chemistry/EntitySystems/HypospraySystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/HypospraySystem.cs
@@ -1,10 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Administration.Logs;
-using Content.Shared.Body.Components;
-using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.Hypospray.Events;
 using Content.Shared.Database;
+using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Forensics;
 using Content.Shared.IdentityManagement;
@@ -16,6 +16,7 @@ using Content.Shared.Timing;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Chemistry.EntitySystems;
 
@@ -27,6 +28,7 @@ public sealed class HypospraySystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainers = default!;
     [Dependency] private readonly UseDelaySystem _useDelay = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
 
     public override void Initialize()
     {
@@ -36,6 +38,7 @@ public sealed class HypospraySystem : EntitySystem
         SubscribeLocalEvent<HyposprayComponent, MeleeHitEvent>(OnAttack);
         SubscribeLocalEvent<HyposprayComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<HyposprayComponent, GetVerbsEvent<AlternativeVerb>>(AddToggleModeVerb);
+        SubscribeLocalEvent<HyposprayComponent, HyposprayDrawDoAfterEvent>(OnDrawDoAfter);
     }
 
     #region Ref events
@@ -63,6 +66,20 @@ public sealed class HypospraySystem : EntitySystem
         TryDoInject(entity, args.HitEntities[0], args.User);
     }
 
+    private void OnDrawDoAfter(Entity<HyposprayComponent> entity, ref HyposprayDrawDoAfterEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (entity.Comp.CanContainerDraw
+            && args.Target.HasValue
+            && !EligibleEntity(args.Target.Value, entity)
+            && _solutionContainers.TryGetDrawableSolution(args.Target.Value, out var drawableSolution, out _))
+        {
+            TryDraw(entity, args.Target.Value, drawableSolution.Value, args.User);
+        }
+    }
+
     #endregion
 
     #region Draw/Inject
@@ -73,7 +90,7 @@ public sealed class HypospraySystem : EntitySystem
             && !EligibleEntity(target, entity)
             && _solutionContainers.TryGetDrawableSolution(target, out var drawableSolution, out _))
         {
-            return TryDraw(entity, target, drawableSolution.Value, user);
+            return TryStartDraw(entity, target, drawableSolution.Value, user);
         }
 
         return TryDoInject(entity, target, user);
@@ -186,17 +203,37 @@ public sealed class HypospraySystem : EntitySystem
         return true;
     }
 
-    private bool TryDraw(Entity<HyposprayComponent> entity, EntityUid target, Entity<SolutionComponent> targetSolution, EntityUid user)
+    public bool TryStartDraw(Entity<HyposprayComponent> entity, EntityUid target, Entity<SolutionComponent> targetSolution, EntityUid user)
     {
-        if (!_solutionContainers.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out var soln,
-                out var solution) || solution.AvailableVolume == 0)
+        if (!_solutionContainers.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out var soln))
+            return false;
+
+        if (!TryGetDrawAmount(entity, target, targetSolution, user,  soln.Value, out _))
+            return false;
+
+        var doAfterArgs = new DoAfterArgs(EntityManager, user, entity.Comp.DrawDelay, new HyposprayDrawDoAfterEvent(), entity, target, null)
+        {
+            BreakOnDamage = true,
+            BreakOnMove = true,
+            NeedHand = true,
+            Hidden = true,
+        };
+
+        return _doAfter.TryStartDoAfter(doAfterArgs, out _);
+    }
+
+    private bool TryGetDrawAmount(Entity<HyposprayComponent> entity, EntityUid target, Entity<SolutionComponent> targetSolution, EntityUid user, Entity<SolutionComponent> solutionEntity, [NotNullWhen(true)] out FixedPoint2? amount)
+    {
+        amount = null;
+
+        if (solutionEntity.Comp.Solution.AvailableVolume == 0)
         {
             return false;
         }
 
         // Get transfer amount. May be smaller than _transferAmount if not enough room, also make sure there's room in the injector
         var realTransferAmount = FixedPoint2.Min(entity.Comp.TransferAmount, targetSolution.Comp.Solution.Volume,
-            solution.AvailableVolume);
+            solutionEntity.Comp.Solution.AvailableVolume);
 
         if (realTransferAmount <= 0)
         {
@@ -207,7 +244,19 @@ public sealed class HypospraySystem : EntitySystem
             return false;
         }
 
-        var removedSolution = _solutionContainers.Draw(target, targetSolution, realTransferAmount);
+        amount = realTransferAmount;
+        return true;
+    }
+
+    private bool TryDraw(Entity<HyposprayComponent> entity, EntityUid target, Entity<SolutionComponent> targetSolution, EntityUid user)
+    {
+        if (!_solutionContainers.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out var soln))
+            return false;
+
+        if (!TryGetDrawAmount(entity, target, targetSolution, user, soln.Value, out var amount))
+            return false;
+
+        var removedSolution = _solutionContainers.Draw(target, targetSolution, amount.Value);
 
         if (!_solutionContainers.TryAddSolution(soln.Value, removedSolution))
         {
@@ -275,3 +324,6 @@ public sealed class HypospraySystem : EntitySystem
 
     #endregion
 }
+
+[Serializable, NetSerializable]
+public sealed partial class HyposprayDrawDoAfterEvent : SimpleDoAfterEvent {}

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -661,14 +661,14 @@
         maxVol: 10
   - type: RefillableSolution
     solution: hypospray
-    refillTime: 1.5
+    refillTime: 1.25
   - type: ExaminableSolution
     solution: hypospray
     heldOnly: true # Allow examination only when held in hand.
     exactVolume: true
   - type: Hypospray
     onlyAffectsMobs: false
-    drawDelay: 1.5
+    drawDelay: 1.25
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice # A new shitcurity meta

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -661,12 +661,14 @@
         maxVol: 10
   - type: RefillableSolution
     solution: hypospray
+    refillTime: 1.5
   - type: ExaminableSolution
     solution: hypospray
     heldOnly: true # Allow examination only when held in hand.
     exactVolume: true
   - type: Hypospray
     onlyAffectsMobs: false
+    drawDelay: 1.5
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice # A new shitcurity meta


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds the ability to define a doafter for transferring reagents with `RefillableComponent`, and for drawing reagents with `HyposprayComponent`. This is applied to the hypopen item (*only* the hypopen, and not any derivatives like the borg hypo).

The doafter value is set to 1.25 seconds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This PR superseedes #40497, as this implementation essentially does the same but in a way that is easier for players to learn and grasp; filling the hypopen is something the player has to do regardless, so putting in the delay here instead of as its own unique action makes it part of the flow. It is also a bit "nicer" since the refill it split in two doafters, allowing one to stop halfway through if needed. It isn't as "fun" as resetting a spring but much better flow overall.

Since it does the same, the description below is more or less copied wholesale from #40497

---

The hypopen is known to be an extremely powerful antagonist item, both because of the effects of the chems it can provide but also its versatility as a stealthy disabling/killing tool, a refillable instant-injection medipen, and a powerful non-valid weapon. Not only can it perform all of those things but it can switch between them seamlessly and with high sustain.

The changes introduced in this PR are intended to reduce the "sustain" of it, making it less ideal in active combat scenarios. By introducing what is effectively a stand-still reload, it is no longer viable to use it to inject more than 10u into a target before needing to retreat or (more likely) have the target succumb.

For self-injections, it becomes a fine way to top up with some healing during combat, or to use meth at the start of combat, but you can not sustain yourself with healing/meth while moving at the same time.

For hostile injections, it can be used as a one-time poison injection when the target is in a crowd. If the target is alone however (i.e. a stealth kill) the impact is much less noticeable; since you're under no pressure to move around and can stand still, refilling the hypopen is easy and therefore you can continue injecting the single target (e.g. to top up nocturine).

> Why reduce its combat sustain?

There are several poisons, heals and combat enhancement drugs that allow antagonists to reach high power peaks if they utilize them, and the hypopen makes that peak even sharper due to the ease of which it can allow users to bypass the time it takes to administer the chems. This has raised certain roles (Chemist, Botanist) to have potential to be at a much stronger power level than the average antagonist to the point where there is little counterplay from the opposing side.

While a future medical rework will likely change this dynamic, this PR is intended to address the state of the game as it is currently.

> Isn't Nocturine/Meth the problem?

Nocturine stealth kills are effectively unchanged with this PR, and that is intended. #40231 intends to address Nocturine's strength, and there will be further looks into Meth in the future.

> What about CMO's hypospray?

I do not see this PR as being the endgame for ensuring a more balanced chem antag experience, and with the hypospray being unchanged I expect chem antags to simply kill CMO for it and go about as they did before. Expect a PR down the road to deal with that.

## Technical details
<!-- Summary of code changes for easier review. -->

This PR touches on some stuff in the core `SolutionTransferSystem` by adding the `RefillTime` and `DrainTime` properties. This is because previously we assumed any "basic" transfer of liquid would always be instant, and any other system that uses a doafter does that as part of a bespoke system.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/a081a303-1f2b-43de-adcd-3980078ec5d9

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The hypopen now requires a short delay before being filled.
