### PR TITLE
`Mapping` no longer runs potencially round ruining commands on live servers.

### DIFF
--- a/Content.Server/Mapping/MappingCommand.cs
+++ b/Content.Server/Mapping/MappingCommand.cs
@@ -2,6 +2,8 @@ using System.Linq;
 using Content.Server.Administration;
 using Content.Server.GameTicking;
 using Content.Shared.Administration;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
 using Robust.Shared.Console;
 using Robust.Shared.ContentPack;
 using Robust.Shared.EntitySerialization;
@@ -15,6 +17,7 @@ namespace Content.Server.Mapping
     [AdminCommand(AdminFlags.Server | AdminFlags.Mapping)]
     public sealed class MappingCommand : LocalizedEntityCommands
     {
+        [Dependency] private readonly IConfigurationManager _cfg = default!;
         [Dependency] private readonly IResourceManager _resourceMgr = default!;
         [Dependency] private readonly SharedMapSystem _mapSystem = default!;
         [Dependency] private readonly MappingSystem _mappingSystem = default!;
@@ -151,9 +154,12 @@ namespace Content.Server.Mapping
                 shell.ExecuteCommand("aghost");
             }
 
-            // don't interrupt mapping with events or auto-shuttle
-            shell.ExecuteCommand("changecvar events.enabled false");
-            shell.ExecuteCommand("changecvar shuttle.auto_call_time 0");
+            if (_cfg.GetCVar(CCVars.GameMappingDisableEventCommands))
+            {
+                // don't interrupt mapping with events or auto-shuttle
+                shell.ExecuteCommand("changecvar events.enabled false");
+                shell.ExecuteCommand("changecvar shuttle.auto_call_time 0");
+            }
 
             if (grid != null)
                 _mappingSystem.ToggleAutosave(grid.Value.Owner, toLoad ?? "NEWGRID");

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -409,4 +409,20 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> GameHostnameInTitlebar =
         CVarDef.Create("game.hostname_in_titlebar", true, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    ///     Should the mapping command disable events/the shuttle?
+    /// </summary>
+    /// <remarks>
+    ///     This is enabled automatically on any server that is not full release.
+    ///     Since you probably don't want admins disabling events and the shuttle on a live server.
+    ///
+    ///     Also, these should probably not run commands like this in the first place.
+    /// </remarks>
+    public static readonly CVarDef<bool> GameMappingDisableEventCommands =
+        # if !FULL_RELEASE
+        CVarDef.Create("game.mapping_event_commands", true, CVar.SERVERONLY);
+        # else
+        CVarDef.Create("game.mapping_event_commands", false, CVar.SERVERONLY);
+        #endif
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes a cvar that is enabled automatically everywhere but full release servers. That prevents the mapping command from running the shuttle and events command.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Small discussion in our admin channel, I have had from past expirience from admining another server that admins use the `mapping` command to create/load a new map (or even just make a map on a live server) and not realise they just nuked events and the auto shuttle in a live server.

"Why a cvar?" I dont wanna ruin mapping servers not running in Tools, their owners can just change it.

Frankly, the whole mapping command should probably be rewritten to not run shell commands and a bunch of other todos. I was tempted to make `mapping` fully unavailable outside dev enviroments.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
