### PR TITLE
Fix Vox Only Having 1 Head Marking Point

### DIFF
--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -45,9 +45,6 @@
     FacialHair:
       points: 1
       required: false
-    Head:
-      points: 1
-      required: true
     Snout:
       points: 1
       required: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Vox for some reason had only one head marking 

## Why / Balance
This seemed like an oversight since every other species doesn't have a limit this restrictive.

## Technical details
Removed point limit from Vox.yml

## Media
befrore
<img width="703" height="348" alt="image" src="https://github.com/user-attachments/assets/529bee8b-1f1b-4cf6-8a56-74bbd82c6a1b" />
after
<img width="914" height="391" alt="image" src="https://github.com/user-attachments/assets/d989105a-7b77-49ae-a64d-e77e7d2d4653" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Vox can now have more than 1 head marking.
