### PR TITLE
Exo: Link engie airlocks

### DIFF
--- a/Resources/Maps/exo.yml
+++ b/Resources/Maps/exo.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.1.0
   forkId: ""
   forkVersion: ""
-  time: 09/25/2025 05:10:49
-  entityCount: 19959
+  time: 09/25/2025 21:06:16
+  entityCount: 19960
 maps:
 - 1
 grids:
@@ -8826,9 +8826,9 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        18305:
+        18143:
         - - DoorStatus
-          - DoorBolt
+          - InputB
 - proto: AirlockExternalGlass
   entities:
   - uid: 543
@@ -9062,9 +9062,9 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        18305:
+        18143:
         - - DoorStatus
-          - DoorBolt
+          - InputA
   - uid: 16699
     components:
     - type: Transform
@@ -10078,7 +10078,7 @@ entities:
       pos: 11.5,-30.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -245251.58
+      secondsUntilStateChange: -245383
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10434,7 +10434,7 @@ entities:
       pos: 34.5,-36.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -20749.275
+      secondsUntilStateChange: -20880.693
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -88133,6 +88133,22 @@ entities:
       parent: 2
 - proto: LogicGateOr
   entities:
+  - uid: 18143
+    components:
+    - type: Transform
+      anchored: True
+      pos: -14.5,-70.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        18305:
+        - - Output
+          - DoorBolt
+    - type: Physics
+      canCollide: False
+      bodyType: Static
   - uid: 18350
     components:
     - type: Transform

--- a/Resources/Maps/exo.yml
+++ b/Resources/Maps/exo.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 266.0.0
+  engineVersion: 267.1.0
   forkId: ""
   forkVersion: ""
-  time: 09/10/2025 20:15:35
+  time: 09/25/2025 05:10:49
   entityCount: 19959
 maps:
 - 1
@@ -8820,6 +8820,15 @@ entities:
     - type: Transform
       pos: -13.5,-69.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal: []
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        18305:
+        - - DoorStatus
+          - DoorBolt
 - proto: AirlockExternalGlass
   entities:
   - uid: 543
@@ -9049,6 +9058,13 @@ entities:
     - type: Transform
       pos: -16.5,-69.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        18305:
+        - - DoorStatus
+          - DoorBolt
   - uid: 16699
     components:
     - type: Transform
@@ -9059,6 +9075,16 @@ entities:
     - type: Transform
       pos: -15.5,-72.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        5745:
+        - - DoorStatus
+          - DoorBolt
+        5774:
+        - - DoorStatus
+          - DoorBolt
 - proto: AirlockExternalGlassLocked
   entities:
   - uid: 201
@@ -9091,6 +9117,11 @@ entities:
     - type: Transform
       pos: -11.5,-81.5
       parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        6303:
+        - - DoorStatus
+          - DoorBolt
   - uid: 1649
     components:
     - type: Transform
@@ -9138,6 +9169,8 @@ entities:
     - type: Transform
       pos: -11.5,-78.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
         1487:
@@ -10045,7 +10078,7 @@ entities:
       pos: 11.5,-30.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -244104.44
+      secondsUntilStateChange: -245251.58
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10401,7 +10434,7 @@ entities:
       pos: 34.5,-36.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -19602.13
+      secondsUntilStateChange: -20749.275
       state: Opening
     - type: DeviceLinkSource
       lastSignals:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Linked engineering's airlocks to space

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's trivially easy to space the entire engineering department on this station and subsequently disrupt the atmosphere in the hall outside since these doors to space aren't bolt linked

## Technical details
<!-- Summary of code changes for easier review. -->
Yaml
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="489" height="910" alt="image" src="https://github.com/user-attachments/assets/0ffc8833-fc65-4516-8e3d-bcae2968074a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
MAPS:
- tweak: On Exo, linked the bolts of engineering's airlocks to space