### PR TITLE
Adds a whitelist system for reagents; used for animal cubes, dehydrated carps and welders

### DIFF
--- a/Content.Shared/Chemistry/Components/RefillReagentWhitelistComponent.cs
+++ b/Content.Shared/Chemistry/Components/RefillReagentWhitelistComponent.cs
@@ -1,0 +1,31 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Content.Shared.Chemistry.Reagent;
+
+namespace Content.Shared.Chemistry.Components;
+
+/// <summary>
+/// Restricts which reagents may be refilled into a specific solution.
+/// Enforced by RefillReagentWhitelistSystem during solution transfers.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class RefillReagentWhitelistComponent : Component
+{
+    /// <summary>
+    /// The name of the solution on this entity that is subject to the whitelist (e.g. "cube").
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string Solution = "default";
+
+    /// <summary>
+    /// List of allowed reagent prototype IDs. Incoming transfers containing any reagent not in this list will be blocked.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public List<ProtoId<ReagentPrototype>> Allowed = new();
+
+    /// <summary>
+    /// Optional popup localization id to show when a transfer is blocked.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string? Popup;
+}

--- a/Content.Shared/Chemistry/Components/RefillReagentWhitelistComponent.cs
+++ b/Content.Shared/Chemistry/Components/RefillReagentWhitelistComponent.cs
@@ -8,24 +8,25 @@ namespace Content.Shared.Chemistry.Components;
 /// Restricts which reagents may be refilled into a specific solution.
 /// Enforced by RefillReagentWhitelistSystem during solution transfers.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, Access]
 public sealed partial class RefillReagentWhitelistComponent : Component
 {
     /// <summary>
     /// The name of the solution on this entity that is subject to the whitelist (e.g. "cube").
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public string Solution = "default";
 
     /// <summary>
     /// List of allowed reagent prototype IDs. Incoming transfers containing any reagent not in this list will be blocked.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public List<ProtoId<ReagentPrototype>> Allowed = new();
+    [DataField]
+    public List<ProtoId<ReagentPrototype>> Allowed = [];
 
     /// <summary>
     /// Optional popup localization id to show when a transfer is blocked.
+    /// If null, the default from GetSolutionTransferWhitelistEvent will be used.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public string? Popup;
+    [DataField]
+    public LocId? Popup;
 }

--- a/Content.Shared/Chemistry/Components/RehydratableComponent.cs
+++ b/Content.Shared/Chemistry/Components/RehydratableComponent.cs
@@ -2,7 +2,6 @@ using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Chemistry.Components;
 
@@ -26,10 +25,18 @@ public sealed partial class RehydratableComponent : Component
     public FixedPoint2 CatalystMinimum = FixedPoint2.Zero;
 
     /// <summary>
+    /// If true, transfers into this entity will enforce a whitelist consisting of at least the catalyst reagent.
+    /// If false, the catalyst will still be contributed to the transfer whitelist, but enforcement will only occur
+    /// if another system also sets enforcement.
+    /// </summary>
+    [DataField]
+    public bool EnforceCatalystWhitelist = true;
+
+    /// <summary>
     /// The entity to create when hydrated.
     /// </summary>
     [DataField(required: true)]
-    public List<EntProtoId> PossibleSpawns = new();
+    public List<EntProtoId> PossibleSpawns = [];
 }
 
 /// <summary>

--- a/Content.Shared/Chemistry/EntitySystems/RefillReagentWhitelistSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/RefillReagentWhitelistSystem.cs
@@ -1,0 +1,100 @@
+using System;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.FixedPoint;
+using Content.Shared.Popups;
+using Robust.Shared.Localization;
+
+namespace Content.Shared.Chemistry.EntitySystems;
+
+/// <summary>
+/// Cancels solution transfers into a target container,
+/// if at least one of the incoming reagents are not whitelisted.
+/// </summary>
+public sealed class RefillReagentWhitelistSystem : EntitySystem
+{
+    [Dependency] private readonly SharedSolutionContainerSystem _solutions = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RefillReagentWhitelistComponent, SolutionTransferAttemptEvent>(OnTransferAttempt);
+    }
+
+    private void OnTransferAttempt(Entity<RefillReagentWhitelistComponent> ent, ref SolutionTransferAttemptEvent args)
+    {
+        // Only validate when this entity is the transfer target.
+        if (ent.Owner != args.To)
+            return;
+
+        // Ensure the target actually has a relevant solution container.
+        if (!TryComp<SolutionContainerManagerComponent>(ent.Owner, out var _))
+            return;
+
+        // Identify the guarded solution name
+        string? targetSolutionName = null;
+        if (TryComp<RefillableSolutionComponent>(ent.Owner, out var refillable))
+            targetSolutionName = refillable.Solution;
+        else if (TryComp<InjectableSolutionComponent>(ent.Owner, out var injectable))
+            targetSolutionName = injectable.Solution;
+
+        if (targetSolutionName == null)
+            return;
+
+        // Only enforce for the specific named solution.
+        if (!string.Equals(targetSolutionName, ent.Comp.Solution, StringComparison.Ordinal))
+            return;
+
+        // Get the source solution to inspect what would be transferred.
+        // Normal container transfers: source has DrainableSolutionComponent.
+        // Syringes/injectors: don't have DrainableSolutionComponent; resolve via InjectorComponent instead.
+        Solution? sourceSoln = null;
+        if (_solutions.TryGetDrainableSolution(args.From, out var sourceSolnEnt, out var drainable))
+        {
+            sourceSoln = drainable;
+        }
+        else if (TryComp<InjectorComponent>(args.From, out var injector))
+        {
+            if (_solutions.ResolveSolution(args.From, injector.SolutionName, ref injector.Solution, out var sol))
+                sourceSoln = sol;
+        }
+
+        if (sourceSoln == null || sourceSoln.Volume == FixedPoint2.Zero)
+            return;
+
+        // If whitelist is empty, block everything
+        if (ent.Comp.Allowed.Count == 0)
+        {
+            Cancel(ref args, ent);
+            return;
+        }
+
+        // Check each reagent present in the source. If any is not allowed, cancel.
+        foreach (var rq in sourceSoln.Contents)
+        {
+            var proto = rq.Reagent.Prototype;
+            var allowed = false;
+            foreach (var allow in ent.Comp.Allowed)
+            {
+                if (allow == proto)
+                {
+                    allowed = true;
+                    break;
+                }
+            }
+
+            if (!allowed)
+            {
+                Cancel(ref args, ent);
+                return;
+            }
+        }
+    }
+
+    private void Cancel(ref SolutionTransferAttemptEvent args, Entity<RefillReagentWhitelistComponent> ent)
+    {
+        var reason = ent.Comp.Popup ?? "Transfer blocked: reagent not allowed for this container.";
+        args.Cancel(reason);
+    }
+}

--- a/Content.Shared/Chemistry/EntitySystems/RefillReagentWhitelistSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/RefillReagentWhitelistSystem.cs
@@ -1,9 +1,5 @@
-using System;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
-using Content.Shared.FixedPoint;
-using Content.Shared.Popups;
-using Robust.Shared.Localization;
 
 namespace Content.Shared.Chemistry.EntitySystems;
 
@@ -13,18 +9,15 @@ namespace Content.Shared.Chemistry.EntitySystems;
 /// </summary>
 public sealed class RefillReagentWhitelistSystem : EntitySystem
 {
-    [Dependency] private readonly SharedSolutionContainerSystem _solutions = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
-
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<RefillReagentWhitelistComponent, SolutionTransferAttemptEvent>(OnTransferAttempt);
+        SubscribeLocalEvent<RefillReagentWhitelistComponent, GetSolutionTransferWhitelistEvent>(OnGetWhitelist);
     }
 
-    private void OnTransferAttempt(Entity<RefillReagentWhitelistComponent> ent, ref SolutionTransferAttemptEvent args)
+    private void OnGetWhitelist(Entity<RefillReagentWhitelistComponent> ent, ref GetSolutionTransferWhitelistEvent args)
     {
-        // Only validate when this entity is the transfer target.
+        // Only contribute when this entity is the transfer target.
         if (ent.Owner != args.To)
             return;
 
@@ -32,69 +25,16 @@ public sealed class RefillReagentWhitelistSystem : EntitySystem
         if (!TryComp<SolutionContainerManagerComponent>(ent.Owner, out var _))
             return;
 
-        // Identify the guarded solution name
-        string? targetSolutionName = null;
-        if (TryComp<RefillableSolutionComponent>(ent.Owner, out var refillable))
-            targetSolutionName = refillable.Solution;
-        else if (TryComp<InjectableSolutionComponent>(ent.Owner, out var injectable))
-            targetSolutionName = injectable.Solution;
-
-        if (targetSolutionName == null)
+        // Only enforce for the specific named solution, provided by the event.
+        if (!string.Equals(args.TargetSolutionName, ent.Comp.Solution, StringComparison.Ordinal))
             return;
 
-        // Only enforce for the specific named solution.
-        if (!string.Equals(targetSolutionName, ent.Comp.Solution, StringComparison.Ordinal))
-            return;
+        // Contribute this component's whitelist and mark enforcement.
+        args.Enforce = true;
+        if (ent.Comp.Popup is { } popup)
+            args.Popup = popup;
 
-        // Get the source solution to inspect what would be transferred.
-        // Normal container transfers: source has DrainableSolutionComponent.
-        // Syringes/injectors: don't have DrainableSolutionComponent; resolve via InjectorComponent instead.
-        Solution? sourceSoln = null;
-        if (_solutions.TryGetDrainableSolution(args.From, out var sourceSolnEnt, out var drainable))
-        {
-            sourceSoln = drainable;
-        }
-        else if (TryComp<InjectorComponent>(args.From, out var injector))
-        {
-            if (_solutions.ResolveSolution(args.From, injector.SolutionName, ref injector.Solution, out var sol))
-                sourceSoln = sol;
-        }
-
-        if (sourceSoln == null || sourceSoln.Volume == FixedPoint2.Zero)
-            return;
-
-        // If whitelist is empty, block everything
-        if (ent.Comp.Allowed.Count == 0)
-        {
-            Cancel(ref args, ent);
-            return;
-        }
-
-        // Check each reagent present in the source. If any is not allowed, cancel.
-        foreach (var rq in sourceSoln.Contents)
-        {
-            var proto = rq.Reagent.Prototype;
-            var allowed = false;
-            foreach (var allow in ent.Comp.Allowed)
-            {
-                if (allow == proto)
-                {
-                    allowed = true;
-                    break;
-                }
-            }
-
-            if (!allowed)
-            {
-                Cancel(ref args, ent);
-                return;
-            }
-        }
-    }
-
-    private void Cancel(ref SolutionTransferAttemptEvent args, Entity<RefillReagentWhitelistComponent> ent)
-    {
-        var reason = ent.Comp.Popup ?? "Transfer blocked: reagent not allowed for this container.";
-        args.Cancel(reason);
+        foreach (var allow in ent.Comp.Allowed)
+            args.Allowed.Add(allow);
     }
 }

--- a/Content.Shared/Chemistry/EntitySystems/RehydratableSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/RehydratableSystem.cs
@@ -22,6 +22,7 @@ public sealed class RehydratableSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<RehydratableComponent, SolutionContainerChangedEvent>(OnSolutionChange);
+        SubscribeLocalEvent<RehydratableComponent, GetSolutionTransferWhitelistEvent>(OnGetWhitelist);
     }
 
     private void OnSolutionChange(Entity<RehydratableComponent> ent, ref SolutionContainerChangedEvent args)
@@ -32,6 +33,17 @@ public sealed class RehydratableSystem : EntitySystem
         {
             Expand(ent);
         }
+    }
+
+    private void OnGetWhitelist(Entity<RehydratableComponent> ent, ref GetSolutionTransferWhitelistEvent args)
+    {
+        if (ent.Owner != args.To)
+            return;
+
+        args.Allowed.Add(ent.Comp.CatalystPrototype);
+
+        if (ent.Comp.EnforceCatalystWhitelist)
+            args.Enforce = true;
     }
 
     // Try not to make this public if you can help it.

--- a/Content.Shared/Chemistry/EntitySystems/SharedInjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedInjectorSystem.cs
@@ -316,7 +316,15 @@ public abstract class SharedInjectorSystem : EntitySystem
         }
 
         // Reusable whitelist enforcement: allow systems to contribute allowed reagents.
-        var whitelist = new GetSolutionTransferWhitelistEvent(injector.Owner, target, targetSolution.Comp.Solution.Name);
+        var targetSolutionName = targetSolution.Comp.Solution.Name;
+        if (targetSolutionName == null)
+        {
+            if (TryComp<RefillableSolutionComponent>(target, out var targetRefillComp))
+                targetSolutionName = targetRefillComp.Solution;
+            else if (TryComp<InjectableSolutionComponent>(target, out var targetInjectComp))
+                targetSolutionName = targetInjectComp.Solution;
+        }
+        var whitelist = new GetSolutionTransferWhitelistEvent(injector.Owner, target, targetSolutionName);
         RaiseLocalEvent(target, ref whitelist);
         RaiseLocalEvent(injector.Owner, ref whitelist);
         if (whitelist.Enforce)

--- a/Content.Shared/Chemistry/EntitySystems/SharedInjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedInjectorSystem.cs
@@ -306,6 +306,15 @@ public abstract class SharedInjectorSystem : EntitySystem
             return false;
         }
 
+        // Give the target a chance to cancel (e.g., whitelist).
+        var transferAttempt = new SolutionTransferAttemptEvent(injector.Owner, target);
+        RaiseLocalEvent(target, ref transferAttempt);
+        if (transferAttempt.CancelReason is { } reason)
+        {
+            _popup.PopupClient(reason, target, user);
+            return false;
+        }
+
         // Move units from attackSolution to targetSolution
         Solution removedSolution;
         if (TryComp<StackComponent>(target, out var stack))

--- a/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
@@ -182,7 +182,12 @@ public sealed class SolutionTransferSystem : EntitySystem
         }
 
         // Collect and enforce any whitelist from interested systems before proceeding.
-        var whitelist = new GetSolutionTransferWhitelistEvent(sourceEntity, targetEntity, target.Comp.Solution.Name);
+        // Ensure we pass a sensible solution name even if the Solution.Name field is unset.
+        var targetSolutionName = target.Comp.Solution.Name;
+        if (targetSolutionName == null && TryComp<RefillableSolutionComponent>(targetEntity, out var targetRefillComp))
+            targetSolutionName = targetRefillComp.Solution;
+        var whitelist = new GetSolutionTransferWhitelistEvent(sourceEntity, targetEntity, targetSolutionName);
+
         // Allow both source and target to contribute to the whitelist.
         RaiseLocalEvent(targetEntity, ref whitelist);
         RaiseLocalEvent(sourceEntity, ref whitelist);

--- a/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
@@ -1,13 +1,12 @@
 using Content.Shared.Administration.Logs;
-using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Database;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
-using Robust.Shared.Network;
-using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Chemistry.EntitySystems;
 
@@ -182,6 +181,30 @@ public sealed class SolutionTransferSystem : EntitySystem
             return FixedPoint2.Zero;
         }
 
+        // Collect and enforce any whitelist from interested systems before proceeding.
+        var whitelist = new GetSolutionTransferWhitelistEvent(sourceEntity, targetEntity, target.Comp.Solution.Name);
+        // Allow both source and target to contribute to the whitelist.
+        RaiseLocalEvent(targetEntity, ref whitelist);
+        RaiseLocalEvent(sourceEntity, ref whitelist);
+
+        if (whitelist.Enforce)
+        {
+            // If whitelist is enforced and empty, block everything.
+            if (whitelist.Allowed.Count == 0)
+            {
+                _popup.PopupClient(Loc.GetString(whitelist.Popup), targetEntity, user);
+                return FixedPoint2.Zero;
+            }
+            foreach (var rq in sourceSolution.Contents)
+            {
+                if (!whitelist.Allowed.Contains(rq.Reagent.Prototype))
+                {
+                    _popup.PopupClient(Loc.GetString(whitelist.Popup), targetEntity, user);
+                    return FixedPoint2.Zero;
+                }
+            }
+        }
+
         // Check if the target is cancelling the transfer
         RaiseLocalEvent(targetEntity, ref transferAttempt);
         if (transferAttempt.CancelReason is {} targetReason)
@@ -234,3 +257,20 @@ public record struct SolutionTransferAttemptEvent(EntityUid From, EntityUid To, 
 /// </summary>
 [ByRefEvent]
 public record struct SolutionTransferredEvent(EntityUid From, EntityUid To, EntityUid User, FixedPoint2 Amount);
+
+/// <summary>
+/// Raised on both the source and target to collect a whitelist of reagents that are allowed for this transfer.
+/// Systems can add to <see cref="Allowed"/> and set <see cref="Enforce"/> to true to require that only whitelisted
+/// reagents may be transferred.
+/// <para>If <see cref="Enforce"/> is true and the whitelist is empty, the transfer is blocked.</para>
+/// </summary>
+[ByRefEvent]
+public struct GetSolutionTransferWhitelistEvent(EntityUid from, EntityUid to, string? targetSolutionName)
+{
+    public EntityUid From = from;
+    public EntityUid To = to;
+    public string? TargetSolutionName = targetSolutionName;
+    public HashSet<ProtoId<ReagentPrototype>> Allowed = [];
+    public bool Enforce = false;
+    public LocId Popup = "comp-solution-transfer-blocked-default";
+}

--- a/Resources/Locale/en-US/chemistry/components/solution-transfer-component.ftl
+++ b/Resources/Locale/en-US/chemistry/components/solution-transfer-component.ftl
@@ -10,6 +10,7 @@ comp-solution-transfer-is-full = {CAPITALIZE(THE($target))} is full!
 
 ## Displayed when a transfer is blocked by a whitelist
 comp-solution-transfer-blocked-default = This won't go in here!
+comp-solution-transfer-blocked-welder-only = I need welding fuel!
 
 ## Displayed in change transfer amount verb's name
 comp-solution-transfer-verb-custom-amount = Custom

--- a/Resources/Locale/en-US/chemistry/components/solution-transfer-component.ftl
+++ b/Resources/Locale/en-US/chemistry/components/solution-transfer-component.ftl
@@ -8,6 +8,9 @@ comp-solution-transfer-transfer-solution = You transfer {$amount}u to {THE($targ
 comp-solution-transfer-is-empty = {CAPITALIZE(THE($target))} is empty!
 comp-solution-transfer-is-full = {CAPITALIZE(THE($target))} is full!
 
+## Displayed when a transfer is blocked by a whitelist
+comp-solution-transfer-blocked-default = This won't go in here!
+
 ## Displayed in change transfer amount verb's name
 comp-solution-transfer-verb-custom-amount = Custom
 comp-solution-transfer-verb-amount = {$amount}u

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -19,6 +19,7 @@
       - !type:AddToSolutionReaction
         solution: cube
   - type: Rehydratable
+    EnforceCatalystWhitelist: true
   - type: CollisionWake
     enabled: false
   - type: Fixtures
@@ -66,10 +67,6 @@
   - type: Tag
     tags:
     - Meat
-  - type: RefillReagentWhitelist
-    solution: cube
-    allowed:
-    - Water
 
 - type: entity
   parent: RehydratableAnimalCube
@@ -196,10 +193,6 @@
     catalyst: Blood # blood is fuel
     possibleSpawns:
     - MobAbomination
-  - type: RefillReagentWhitelist
-    solution: cube
-    allowed:
-    - Blood
 
 # It inherits FoodComponent from PlushieCarp, but is de-facto inedible
 # PlushieCarp has requiresSpecialDigestion:true, and this one is not whitelisted anywhere, so it behaves like it's not edible

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -66,6 +66,10 @@
   - type: Tag
     tags:
     - Meat
+  - type: RefillReagentWhitelist
+    solution: cube
+    allowed:
+    - Water
 
 - type: entity
   parent: RehydratableAnimalCube
@@ -192,6 +196,10 @@
     catalyst: Blood # blood is fuel
     possibleSpawns:
     - MobAbomination
+  - type: RefillReagentWhitelist
+    solution: cube
+    allowed:
+    - Blood
 
 # It inherits FoodComponent from PlushieCarp, but is de-facto inedible
 # PlushieCarp has requiresSpecialDigestion:true, and this one is not whitelisted anywhere, so it behaves like it's not edible

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -85,6 +85,11 @@
         - ReagentId: WeldingFuel
           Quantity: 100
         maxVol: 100
+  - type: RefillReagentWhitelist
+    solution: Welder
+    allowed:
+    - WeldingFuel
+    popup: comp-solution-transfer-blocked-welder-only
   - type: Tool
     useSound:
       collection: Welder


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a component and system to restrict which reagents can be transferred into specific solution containers.
With initial application to:
- Rehydratable cubes ensuring they only accept water/blood.
- Dehydrated Space Carps ensuring they only accept water.
- Welders ensuring they only accept welding fuel.

## Why / Balance
Closes #25378 
Closes #30234 

The rehydratable animal cubes are intended to be activated with water only, but previously any reagent could be added to their cube solution, clogging the cube and preventing water to activate them. Same goes for dehydrated carps and welders.

This ensures that only whitelisted reagents can activate these entities, regardless of transfer method (beaker pour or syringe injection).

## Technical details
- Adds RefillReagentWhitelistComponent that defines allowed reagents for a solution
- Adds RefillReagentWhitelistSystem that intercepts SolutionTransferAttemptEvent to validate incoming transfers
- Modified SharedInjectorSystem to raise a transfer attempt events for syringe injectionsSystem properly handles both:
  - Direct pour (beakers and such via RefillableSolutionComponent)
  - Syringe (via InjectableSolutionComponent) transfers
- Whitelist component configured for the abstract RehydratableAnimalCube with only water allowed
  - AbominationCube explicitly configured to accept blood instead of water
- Whitelist welders to only accept welding fuel

## Media
### Animal Cubes
https://github.com/user-attachments/assets/d25bdb4b-b974-402c-a45a-061f98a9d7f5
### Welders
https://github.com/user-attachments/assets/aade21be-a19e-4b56-884e-4d541136be33

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
- fix: Animal cubes, dehydrated carps and welders can no longer be clogged with useless reagents!
