### PR TITLE
Fix Rollerbed sprites

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
@@ -69,13 +69,15 @@
           buckledLayer:
             True: {visible: true}
             False: {visible: false}
+          unfoldedLayer:
+            True: { visible: false }
+            False: { visible: true }
         enum.FoldedVisuals.State: # Copypasta from BaseFoldable b/c collections don't merge when overriding component prototypes.
           foldedLayer:
             True: {visible: true}
             False: {visible: false}
           unfoldedLayer:
             True: {visible: false}
-            False: {visible: true}
     - type: StaticPrice
       price: 120
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed Rollersprites from showing up when an entity is buckled.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug
## Technical details
<!-- Summary of code changes for easier review. -->
YML warrior
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Above are the sprites before the fix, below are the sprites after the fix
<img width="693" height="461" alt="grafik" src="https://github.com/user-attachments/assets/1c603f73-9579-48db-a971-99bd23afeb8b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Rollerbed sprites now don't stack when a patient is buckled to it!