### PR TITLE
Unclamp Vox Hue

### DIFF
--- a/Resources/Prototypes/Species/skin_colorations.yml
+++ b/Resources/Prototypes/Species/skin_colorations.yml
@@ -11,8 +11,7 @@
 
 - type: skinColoration
   id: VoxFeathers
-  strategy: !type:ClampedHsvColoration
-    hue: [0.081, 0.48]
+  strategy: !type:ClampedHslColoration
     saturation: [0.2, 0.8]
     value: [0.36, 0.55]
 

--- a/Resources/Prototypes/Species/skin_colorations.yml
+++ b/Resources/Prototypes/Species/skin_colorations.yml
@@ -11,7 +11,7 @@
 
 - type: skinColoration
   id: VoxFeathers
-  strategy: !type:ClampedHslColoration
+  strategy: !type:ClampedHsvColoration
     saturation: [0.2, 0.8]
     value: [0.36, 0.55]
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Unclamped Vox hue, **this does not change value or saturation clamps.**

_**I am turning off notifications for this PR because this will be horrifically controversial cause god forbid we have a purple raptor, [good luck everybody else!](https://www.youtube.com/watch?v=yCdGeElhCK4)**_

## Why / Balance
One Must Imagine Vox Happy
<img width="418" height="290" alt="image" src="https://github.com/user-attachments/assets/f885ea7e-259a-4690-9e7b-296f1da63030" />

If this gets merged I'll also make Vox baby hair.

## Technical details
Removed hue clamp from Vox in skin_colorations.yml

## Media
https://youtu.be/Mr8qUUUnfek

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Removed hue restriction on Vox skin.