### PR TITLE
Remove static IoC from client & server EntryPoint

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -77,18 +77,21 @@ namespace Content.Client.Entry
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
         [Dependency] private readonly ClientsidePlaytimeTrackingManager _clientsidePlaytimeManager = default!;
 
-        public override void Init()
+        public override void PreInit()
         {
-            ClientContentIoC.Register();
+            ClientContentIoC.Register(Dependencies);
 
             foreach (var callback in TestingCallbacks)
             {
                 var cast = (ClientModuleTestingCallbacks) callback;
                 cast.ClientBeforeIoC?.Invoke();
             }
+        }
 
-            IoCManager.BuildGraph();
-            IoCManager.InjectDependencies(this);
+        public override void Init()
+        {
+            Dependencies.BuildGraph();
+            Dependencies.InjectDependencies(this);
 
             _contentLoc.Initialize();
             _componentFactory.DoAutoRegistrations();

--- a/Content.Client/IoC/ClientContentIoC.cs
+++ b/Content.Client/IoC/ClientContentIoC.cs
@@ -23,6 +23,7 @@ using Content.Client.Lobby;
 using Content.Client.Players.RateLimiting;
 using Content.Shared.Administration.Managers;
 using Content.Shared.Chat;
+using Content.Shared.IoC;
 using Content.Shared.Players.PlayTimeTracking;
 using Content.Shared.Players.RateLimiting;
 
@@ -30,10 +31,9 @@ namespace Content.Client.IoC
 {
     internal static class ClientContentIoC
     {
-        public static void Register()
+        public static void Register(IDependencyCollection collection)
         {
-            var collection = IoCManager.Instance!;
-
+            SharedContentIoC.Register(collection);
             collection.Register<IParallaxManager, ParallaxManager>();
             collection.Register<GeneratedParallaxCache>();
             collection.Register<IChatManager, ChatManager>();

--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -47,7 +47,8 @@ namespace Content.Server.Entry
         [Dependency] private readonly DiscordLink _discordLink = default!;
         [Dependency] private readonly EuiManager _euiManager = default!;
         [Dependency] private readonly GhostKickManager _ghostKick = default!;
-        [Dependency] private readonly IAdminLogManager _admin = default!;
+        [Dependency] private readonly IAdminManager _admin = default!;
+        [Dependency] private readonly IAdminLogManager _adminLog = default!;
         [Dependency] private readonly IAfkManager _afk = default!;
         [Dependency] private readonly IBanManager _ban = default!;
         [Dependency] private readonly IChatManager _chatSan = default!;
@@ -114,7 +115,7 @@ namespace Content.Server.Entry
             _log.GetSawmill("Storage").Level = LogLevel.Info;
             _log.GetSawmill("db.ef").Level = LogLevel.Info;
 
-            _admin.Initialize();
+            _adminLog.Initialize();
             _connection.Initialize();
             _dbManager.Init();
             _preferences.Init();
@@ -152,6 +153,7 @@ namespace Content.Server.Entry
             }
 
             _recipe.Initialize();
+            _admin.Initialize();
             _afk.Initialize();
             _rules.Initialize();
             _discordLink.Initialize();

--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -15,8 +15,6 @@ using Content.Server.Info;
 using Content.Server.IoC;
 using Content.Server.Maps;
 using Content.Server.NodeContainer.NodeGroups;
-using Content.Server.Objectives;
-using Content.Server.Players;
 using Content.Server.Players.JobWhitelist;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Players.RateLimiting;
@@ -42,124 +40,129 @@ namespace Content.Server.Entry
         internal const string ConfigPresetsDir = "/ConfigPresets/";
         private const string ConfigPresetsDirBuild = $"{ConfigPresetsDir}Build/";
 
-        private EuiManager _euiManager = default!;
-        private IVoteManager _voteManager = default!;
-        private ServerUpdateManager _updateManager = default!;
-        private PlayTimeTrackingManager? _playTimeTracking;
-        private IEntitySystemManager? _sysMan;
-        private IServerDbManager? _dbManager;
-        private IWatchlistWebhookManager _watchlistWebhookManager = default!;
-        private IConnectionManager? _connectionManager;
+        [Dependency] private readonly CVarControlManager _cvarCtrl = default!;
+        [Dependency] private readonly ContentLocalizationManager _loc = default!;
+        [Dependency] private readonly ContentNetworkResourceManager _netResMan = default!;
+        [Dependency] private readonly DiscordChatLink _discordChatLink = default!;
+        [Dependency] private readonly DiscordLink _discordLink = default!;
+        [Dependency] private readonly EuiManager _euiManager = default!;
+        [Dependency] private readonly GhostKickManager _ghostKick = default!;
+        [Dependency] private readonly IAdminLogManager _admin = default!;
+        [Dependency] private readonly IAfkManager _afk = default!;
+        [Dependency] private readonly IBanManager _ban = default!;
+        [Dependency] private readonly IChatManager _chatSan = default!;
+        [Dependency] private readonly IChatSanitizationManager _chat = default!;
+        [Dependency] private readonly IComponentFactory _factory = default!;
+        [Dependency] private readonly IConfigurationManager _cfg = default!;
+        [Dependency] private readonly IConnectionManager _connection = default!;
+        [Dependency] private readonly IEntitySystemManager _entSys = default!;
+        [Dependency] private readonly IGameMapManager _gameMap = default!;
+        [Dependency] private readonly ILogManager _log = default!;
+        [Dependency] private readonly INodeGroupFactory _nodeFactory = default!;
+        [Dependency] private readonly IPrototypeManager _proto = default!;
+        [Dependency] private readonly IResourceManager _res = default!;
+        [Dependency] private readonly IServerDbManager _dbManager = default!;
+        [Dependency] private readonly IServerPreferencesManager _preferences = default!;
+        [Dependency] private readonly IStatusHost _host = default!;
+        [Dependency] private readonly IVoteManager _voteManager = default!;
+        [Dependency] private readonly IWatchlistWebhookManager _watchlistWebhookManager = default!;
+        [Dependency] private readonly JobWhitelistManager _job = default!;
+        [Dependency] private readonly MultiServerKickManager _multiServerKick = default!;
+        [Dependency] private readonly PlayTimeTrackingManager _playTimeTracking = default!;
+        [Dependency] private readonly PlayerRateLimitManager _rateLimit = default!;
+        [Dependency] private readonly RecipeManager _recipe = default!;
+        [Dependency] private readonly RulesManager _rules = default!;
+        [Dependency] private readonly ServerApi _serverApi = default!;
+        [Dependency] private readonly ServerInfoManager _serverInfo = default!;
+        [Dependency] private readonly ServerUpdateManager _updateManager = default!;
+
+        public override void PreInit()
+        {
+            ServerContentIoC.Register(Dependencies);
+            foreach (var callback in TestingCallbacks)
+            {
+                var cast = (ServerModuleTestingCallbacks)callback;
+                cast.ServerBeforeIoC?.Invoke();
+            }
+        }
 
         /// <inheritdoc />
         public override void Init()
         {
             base.Init();
+            Dependencies.BuildGraph();
+            Dependencies.InjectDependencies(this);
 
-            var cfg = IoCManager.Resolve<IConfigurationManager>();
-            var res = IoCManager.Resolve<IResourceManager>();
-            var logManager = IoCManager.Resolve<ILogManager>();
+            LoadConfigPresets(_cfg, _res, _log.GetSawmill("configpreset"));
 
-            LoadConfigPresets(cfg, res, logManager.GetSawmill("configpreset"));
+            var aczProvider = new ContentMagicAczProvider(Dependencies);
+            _host.SetMagicAczProvider(aczProvider);
 
-            var aczProvider = new ContentMagicAczProvider(IoCManager.Resolve<IDependencyCollection>());
-            IoCManager.Resolve<IStatusHost>().SetMagicAczProvider(aczProvider);
+            _factory.DoAutoRegistrations();
+            _factory.IgnoreMissingComponents("Visuals");
+            _factory.RegisterIgnore(IgnoredComponents.List);
+            _factory.GenerateNetIds();
 
-            var factory = IoCManager.Resolve<IComponentFactory>();
-            var prototypes = IoCManager.Resolve<IPrototypeManager>();
+            _proto.RegisterIgnore("parallax");
 
-            factory.DoAutoRegistrations();
-            factory.IgnoreMissingComponents("Visuals");
+            _loc.Initialize();
 
-            factory.RegisterIgnore(IgnoredComponents.List);
+            var dest = _cfg.GetCVar(CCVars.DestinationFile);
+            if (!string.IsNullOrEmpty(dest))
+                return; //hacky but it keeps load times for the generator down.
 
-            prototypes.RegisterIgnore("parallax");
+            _log.GetSawmill("Storage").Level = LogLevel.Info;
+            _log.GetSawmill("db.ef").Level = LogLevel.Info;
 
-            ServerContentIoC.Register();
-
-            foreach (var callback in TestingCallbacks)
-            {
-                var cast = (ServerModuleTestingCallbacks) callback;
-                cast.ServerBeforeIoC?.Invoke();
-            }
-
-            IoCManager.BuildGraph();
-            factory.GenerateNetIds();
-            var configManager = IoCManager.Resolve<IConfigurationManager>();
-            var dest = configManager.GetCVar(CCVars.DestinationFile);
-            IoCManager.Resolve<ContentLocalizationManager>().Initialize();
-            if (string.IsNullOrEmpty(dest)) //hacky but it keeps load times for the generator down.
-            {
-                _euiManager = IoCManager.Resolve<EuiManager>();
-                _voteManager = IoCManager.Resolve<IVoteManager>();
-                _updateManager = IoCManager.Resolve<ServerUpdateManager>();
-                _playTimeTracking = IoCManager.Resolve<PlayTimeTrackingManager>();
-                _connectionManager = IoCManager.Resolve<IConnectionManager>();
-                _sysMan = IoCManager.Resolve<IEntitySystemManager>();
-                _dbManager = IoCManager.Resolve<IServerDbManager>();
-                _watchlistWebhookManager = IoCManager.Resolve<IWatchlistWebhookManager>();
-
-                logManager.GetSawmill("Storage").Level = LogLevel.Info;
-                logManager.GetSawmill("db.ef").Level = LogLevel.Info;
-
-                IoCManager.Resolve<IAdminLogManager>().Initialize();
-                IoCManager.Resolve<IConnectionManager>().Initialize();
-                _dbManager.Init();
-                IoCManager.Resolve<IServerPreferencesManager>().Init();
-                IoCManager.Resolve<INodeGroupFactory>().Initialize();
-                IoCManager.Resolve<ContentNetworkResourceManager>().Initialize();
-                IoCManager.Resolve<GhostKickManager>().Initialize();
-                IoCManager.Resolve<ServerInfoManager>().Initialize();
-                IoCManager.Resolve<ServerApi>().Initialize();
-
-                _voteManager.Initialize();
-                _updateManager.Initialize();
-                _playTimeTracking.Initialize();
-                _watchlistWebhookManager.Initialize();
-                IoCManager.Resolve<JobWhitelistManager>().Initialize();
-                IoCManager.Resolve<PlayerRateLimitManager>().Initialize();
-            }
+            _admin.Initialize();
+            _connection.Initialize();
+            _dbManager.Init();
+            _preferences.Init();
+            _nodeFactory.Initialize();
+            _netResMan.Initialize();
+            _ghostKick.Initialize();
+            _serverInfo.Initialize();
+            _serverApi.Initialize();
+            _voteManager.Initialize();
+            _updateManager.Initialize();
+            _playTimeTracking.Initialize();
+            _watchlistWebhookManager.Initialize();
+            _job.Initialize();
+            _rateLimit.Initialize();
         }
 
         public override void PostInit()
         {
             base.PostInit();
 
-            IoCManager.Resolve<IChatSanitizationManager>().Initialize();
-            IoCManager.Resolve<IChatManager>().Initialize();
-            var configManager = IoCManager.Resolve<IConfigurationManager>();
-            var resourceManager = IoCManager.Resolve<IResourceManager>();
-            var dest = configManager.GetCVar(CCVars.DestinationFile);
+            _chatSan.Initialize();
+            _chat.Initialize();
+            var dest = _cfg.GetCVar(CCVars.DestinationFile);
             if (!string.IsNullOrEmpty(dest))
             {
                 var resPath = new ResPath(dest).ToRootedPath();
-                var file = resourceManager.UserData.OpenWriteText(resPath.WithName("chem_" + dest));
+                var file = _res.UserData.OpenWriteText(resPath.WithName("chem_" + dest));
                 ChemistryJsonGenerator.PublishJson(file);
                 file.Flush();
-                file = resourceManager.UserData.OpenWriteText(resPath.WithName("react_" + dest));
+                file = _res.UserData.OpenWriteText(resPath.WithName("react_" + dest));
                 ReactionJsonGenerator.PublishJson(file);
                 file.Flush();
-                IoCManager.Resolve<IBaseServer>().Shutdown("Data generation done");
+                Dependencies.Resolve<IBaseServer>().Shutdown("Data generation done");
+                return;
             }
-            else
-            {
-                IoCManager.Resolve<RecipeManager>().Initialize();
-                IoCManager.Resolve<IAdminManager>().Initialize();
-                IoCManager.Resolve<IAfkManager>().Initialize();
-                IoCManager.Resolve<RulesManager>().Initialize();
 
-                IoCManager.Resolve<DiscordLink>().Initialize();
-                IoCManager.Resolve<DiscordChatLink>().Initialize();
-
-                _euiManager.Initialize();
-
-                IoCManager.Resolve<IGameMapManager>().Initialize();
-                IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<GameTicker>().PostInitialize();
-                IoCManager.Resolve<IBanManager>().Initialize();
-                IoCManager.Resolve<IConnectionManager>().PostInit();
-                IoCManager.Resolve<MultiServerKickManager>().Initialize();
-                IoCManager.Resolve<CVarControlManager>().Initialize();
-            }
+            _recipe.Initialize();
+            _afk.Initialize();
+            _rules.Initialize();
+            _discordLink.Initialize();
+            _discordChatLink.Initialize();
+            _euiManager.Initialize();
+            _gameMap.Initialize();
+            _entSys.GetEntitySystem<GameTicker>().PostInitialize();
+            _ban.Initialize();
+            _connection.PostInit();
+            _multiServerKick.Initialize();
+            _cvarCtrl.Initialize();
         }
 
         public override void Update(ModUpdateLevel level, FrameEventArgs frameEventArgs)
@@ -177,21 +180,27 @@ namespace Content.Server.Entry
 
                 case ModUpdateLevel.FramePostEngine:
                     _updateManager.Update();
-                    _playTimeTracking?.Update();
+                    _playTimeTracking.Update();
                     _watchlistWebhookManager.Update();
-                    _connectionManager?.Update();
+                    _connection.Update();
                     break;
             }
         }
 
         protected override void Dispose(bool disposing)
         {
-            _playTimeTracking?.Shutdown();
-            _dbManager?.Shutdown();
-            IoCManager.Resolve<ServerApi>().Shutdown();
+            var dest = _cfg.GetCVar(CCVars.DestinationFile);
+            if (!string.IsNullOrEmpty(dest))
+            {
+                _playTimeTracking.Shutdown();
+                _dbManager.Shutdown();
+            }
 
-            IoCManager.Resolve<DiscordLink>().Shutdown();
-            IoCManager.Resolve<DiscordChatLink>().Shutdown();
+            _serverApi.Shutdown();
+
+            // TODO Should this be awaited?
+            _discordLink.Shutdown();
+            _discordChatLink.Shutdown();
         }
 
         private static void LoadConfigPresets(IConfigurationManager cfg, IResourceManager res, ISawmill sawmill)

--- a/Content.Server/IoC/ServerContentIoC.cs
+++ b/Content.Server/IoC/ServerContentIoC.cs
@@ -31,56 +31,54 @@ using Content.Shared.Kitchen;
 using Content.Shared.Players.PlayTimeTracking;
 using Content.Shared.Players.RateLimiting;
 
-namespace Content.Server.IoC
-{
-    internal static class ServerContentIoC
-    {
-        public static void Register(IDependencyCollection deps)
-        {
-            SharedContentIoC.Register(deps);
-            deps.Register<IChatManager, ChatManager>();
-            deps.Register<ISharedChatManager, ChatManager>();
-            deps.Register<IChatSanitizationManager, ChatSanitizationManager>();
-            deps.Register<IServerPreferencesManager, ServerPreferencesManager>();
-            deps.Register<IServerDbManager, ServerDbManager>();
-            deps.Register<RecipeManager, RecipeManager>();
-            deps.Register<INodeGroupFactory, NodeGroupFactory>();
-            deps.Register<IConnectionManager, ConnectionManager>();
-            deps.Register<ServerUpdateManager>();
-            deps.Register<IAdminManager, AdminManager>();
-            deps.Register<ISharedAdminManager, AdminManager>();
-            deps.Register<EuiManager, EuiManager>();
-            deps.Register<IVoteManager, VoteManager>();
-            deps.Register<IPlayerLocator, PlayerLocator>();
-            deps.Register<IAfkManager, AfkManager>();
-            deps.Register<IGameMapManager, GameMapManager>();
-            deps.Register<RulesManager, RulesManager>();
-            deps.Register<IBanManager, BanManager>();
-            deps.Register<ContentNetworkResourceManager>();
-            deps.Register<IAdminNotesManager, AdminNotesManager>();
-            deps.Register<GhostKickManager>();
-            deps.Register<ISharedAdminLogManager, AdminLogManager>();
-            deps.Register<IAdminLogManager, AdminLogManager>();
-            deps.Register<PlayTimeTrackingManager>();
-            deps.Register<UserDbDataManager>();
-            deps.Register<ServerInfoManager>();
-            deps.Register<PoissonDiskSampler>();
-            deps.Register<DiscordWebhook>();
-            deps.Register<VoteWebhooks>();
-            deps.Register<ServerDbEntryManager>();
-            deps.Register<ISharedPlaytimeManager, PlayTimeTrackingManager>();
-            deps.Register<ServerApi>();
-            deps.Register<JobWhitelistManager>();
-            deps.Register<PlayerRateLimitManager>();
-            deps.Register<SharedPlayerRateLimitManager, PlayerRateLimitManager>();
-            deps.Register<MappingManager>();
-            deps.Register<IWatchlistWebhookManager, WatchlistWebhookManager>();
-            deps.Register<ConnectionManager>();
-            deps.Register<MultiServerKickManager>();
-            deps.Register<CVarControlManager>();
+namespace Content.Server.IoC;
 
-            deps.Register<DiscordLink>();
-            deps.Register<DiscordChatLink>();
-        }
+internal static class ServerContentIoC
+{
+    public static void Register(IDependencyCollection deps)
+    {
+        SharedContentIoC.Register(deps);
+        deps.Register<IChatManager, ChatManager>();
+        deps.Register<ISharedChatManager, ChatManager>();
+        deps.Register<IChatSanitizationManager, ChatSanitizationManager>();
+        deps.Register<IServerPreferencesManager, ServerPreferencesManager>();
+        deps.Register<IServerDbManager, ServerDbManager>();
+        deps.Register<RecipeManager, RecipeManager>();
+        deps.Register<INodeGroupFactory, NodeGroupFactory>();
+        deps.Register<IConnectionManager, ConnectionManager>();
+        deps.Register<ServerUpdateManager>();
+        deps.Register<IAdminManager, AdminManager>();
+        deps.Register<ISharedAdminManager, AdminManager>();
+        deps.Register<EuiManager, EuiManager>();
+        deps.Register<IVoteManager, VoteManager>();
+        deps.Register<IPlayerLocator, PlayerLocator>();
+        deps.Register<IAfkManager, AfkManager>();
+        deps.Register<IGameMapManager, GameMapManager>();
+        deps.Register<RulesManager, RulesManager>();
+        deps.Register<IBanManager, BanManager>();
+        deps.Register<ContentNetworkResourceManager>();
+        deps.Register<IAdminNotesManager, AdminNotesManager>();
+        deps.Register<GhostKickManager>();
+        deps.Register<ISharedAdminLogManager, AdminLogManager>();
+        deps.Register<IAdminLogManager, AdminLogManager>();
+        deps.Register<PlayTimeTrackingManager>();
+        deps.Register<UserDbDataManager>();
+        deps.Register<ServerInfoManager>();
+        deps.Register<PoissonDiskSampler>();
+        deps.Register<DiscordWebhook>();
+        deps.Register<VoteWebhooks>();
+        deps.Register<ServerDbEntryManager>();
+        deps.Register<ISharedPlaytimeManager, PlayTimeTrackingManager>();
+        deps.Register<ServerApi>();
+        deps.Register<JobWhitelistManager>();
+        deps.Register<PlayerRateLimitManager>();
+        deps.Register<SharedPlayerRateLimitManager, PlayerRateLimitManager>();
+        deps.Register<MappingManager>();
+        deps.Register<IWatchlistWebhookManager, WatchlistWebhookManager>();
+        deps.Register<ConnectionManager>();
+        deps.Register<MultiServerKickManager>();
+        deps.Register<CVarControlManager>();
+        deps.Register<DiscordLink>();
+        deps.Register<DiscordChatLink>();
     }
 }

--- a/Content.Server/IoC/ServerContentIoC.cs
+++ b/Content.Server/IoC/ServerContentIoC.cs
@@ -26,6 +26,7 @@ using Content.Server.Worldgen.Tools;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Administration.Managers;
 using Content.Shared.Chat;
+using Content.Shared.IoC;
 using Content.Shared.Kitchen;
 using Content.Shared.Players.PlayTimeTracking;
 using Content.Shared.Players.RateLimiting;
@@ -34,51 +35,52 @@ namespace Content.Server.IoC
 {
     internal static class ServerContentIoC
     {
-        public static void Register()
+        public static void Register(IDependencyCollection deps)
         {
-            IoCManager.Register<IChatManager, ChatManager>();
-            IoCManager.Register<ISharedChatManager, ChatManager>();
-            IoCManager.Register<IChatSanitizationManager, ChatSanitizationManager>();
-            IoCManager.Register<IServerPreferencesManager, ServerPreferencesManager>();
-            IoCManager.Register<IServerDbManager, ServerDbManager>();
-            IoCManager.Register<RecipeManager, RecipeManager>();
-            IoCManager.Register<INodeGroupFactory, NodeGroupFactory>();
-            IoCManager.Register<IConnectionManager, ConnectionManager>();
-            IoCManager.Register<ServerUpdateManager>();
-            IoCManager.Register<IAdminManager, AdminManager>();
-            IoCManager.Register<ISharedAdminManager, AdminManager>();
-            IoCManager.Register<EuiManager, EuiManager>();
-            IoCManager.Register<IVoteManager, VoteManager>();
-            IoCManager.Register<IPlayerLocator, PlayerLocator>();
-            IoCManager.Register<IAfkManager, AfkManager>();
-            IoCManager.Register<IGameMapManager, GameMapManager>();
-            IoCManager.Register<RulesManager, RulesManager>();
-            IoCManager.Register<IBanManager, BanManager>();
-            IoCManager.Register<ContentNetworkResourceManager>();
-            IoCManager.Register<IAdminNotesManager, AdminNotesManager>();
-            IoCManager.Register<GhostKickManager>();
-            IoCManager.Register<ISharedAdminLogManager, AdminLogManager>();
-            IoCManager.Register<IAdminLogManager, AdminLogManager>();
-            IoCManager.Register<PlayTimeTrackingManager>();
-            IoCManager.Register<UserDbDataManager>();
-            IoCManager.Register<ServerInfoManager>();
-            IoCManager.Register<PoissonDiskSampler>();
-            IoCManager.Register<DiscordWebhook>();
-            IoCManager.Register<VoteWebhooks>();
-            IoCManager.Register<ServerDbEntryManager>();
-            IoCManager.Register<ISharedPlaytimeManager, PlayTimeTrackingManager>();
-            IoCManager.Register<ServerApi>();
-            IoCManager.Register<JobWhitelistManager>();
-            IoCManager.Register<PlayerRateLimitManager>();
-            IoCManager.Register<SharedPlayerRateLimitManager, PlayerRateLimitManager>();
-            IoCManager.Register<MappingManager>();
-            IoCManager.Register<IWatchlistWebhookManager, WatchlistWebhookManager>();
-            IoCManager.Register<ConnectionManager>();
-            IoCManager.Register<MultiServerKickManager>();
-            IoCManager.Register<CVarControlManager>();
+            SharedContentIoC.Register(deps);
+            deps.Register<IChatManager, ChatManager>();
+            deps.Register<ISharedChatManager, ChatManager>();
+            deps.Register<IChatSanitizationManager, ChatSanitizationManager>();
+            deps.Register<IServerPreferencesManager, ServerPreferencesManager>();
+            deps.Register<IServerDbManager, ServerDbManager>();
+            deps.Register<RecipeManager, RecipeManager>();
+            deps.Register<INodeGroupFactory, NodeGroupFactory>();
+            deps.Register<IConnectionManager, ConnectionManager>();
+            deps.Register<ServerUpdateManager>();
+            deps.Register<IAdminManager, AdminManager>();
+            deps.Register<ISharedAdminManager, AdminManager>();
+            deps.Register<EuiManager, EuiManager>();
+            deps.Register<IVoteManager, VoteManager>();
+            deps.Register<IPlayerLocator, PlayerLocator>();
+            deps.Register<IAfkManager, AfkManager>();
+            deps.Register<IGameMapManager, GameMapManager>();
+            deps.Register<RulesManager, RulesManager>();
+            deps.Register<IBanManager, BanManager>();
+            deps.Register<ContentNetworkResourceManager>();
+            deps.Register<IAdminNotesManager, AdminNotesManager>();
+            deps.Register<GhostKickManager>();
+            deps.Register<ISharedAdminLogManager, AdminLogManager>();
+            deps.Register<IAdminLogManager, AdminLogManager>();
+            deps.Register<PlayTimeTrackingManager>();
+            deps.Register<UserDbDataManager>();
+            deps.Register<ServerInfoManager>();
+            deps.Register<PoissonDiskSampler>();
+            deps.Register<DiscordWebhook>();
+            deps.Register<VoteWebhooks>();
+            deps.Register<ServerDbEntryManager>();
+            deps.Register<ISharedPlaytimeManager, PlayTimeTrackingManager>();
+            deps.Register<ServerApi>();
+            deps.Register<JobWhitelistManager>();
+            deps.Register<PlayerRateLimitManager>();
+            deps.Register<SharedPlayerRateLimitManager, PlayerRateLimitManager>();
+            deps.Register<MappingManager>();
+            deps.Register<IWatchlistWebhookManager, WatchlistWebhookManager>();
+            deps.Register<ConnectionManager>();
+            deps.Register<MultiServerKickManager>();
+            deps.Register<CVarControlManager>();
 
-            IoCManager.Register<DiscordLink>();
-            IoCManager.Register<DiscordChatLink>();
+            deps.Register<DiscordLink>();
+            deps.Register<DiscordChatLink>();
         }
     }
 }

--- a/Content.Shared/Entry/EntryPoint.cs
+++ b/Content.Shared/Entry/EntryPoint.cs
@@ -27,7 +27,6 @@ namespace Content.Shared.Entry
         public override void PreInit()
         {
             IoCManager.InjectDependencies(this);
-            SharedContentIoC.Register();
         }
 
         public override void Shutdown()

--- a/Content.Shared/IoC/SharedContentIoC.cs
+++ b/Content.Shared/IoC/SharedContentIoC.cs
@@ -5,10 +5,10 @@ namespace Content.Shared.IoC
 {
     public static class SharedContentIoC
     {
-        public static void Register()
+        public static void Register(IDependencyCollection deps)
         {
-            IoCManager.Register<MarkingManager, MarkingManager>();
-            IoCManager.Register<ContentLocalizationManager, ContentLocalizationManager>();
+            deps.Register<MarkingManager, MarkingManager>();
+            deps.Register<ContentLocalizationManager, ContentLocalizationManager>();
         }
     }
 }

--- a/Content.Tests/ContentUnitTest.cs
+++ b/Content.Tests/ContentUnitTest.cs
@@ -2,8 +2,8 @@ using System.Collections.Generic;
 using System.Reflection;
 using Content.Client.IoC;
 using Content.Server.IoC;
-using Content.Shared.IoC;
 using Robust.Shared.Analyzers;
+using Robust.Shared.IoC;
 using Robust.UnitTesting;
 using EntryPoint = Content.Server.Entry.EntryPoint;
 
@@ -15,16 +15,15 @@ namespace Content.Tests
         protected override void OverrideIoC()
         {
             base.OverrideIoC();
-
-            SharedContentIoC.Register();
+            var dependencies = IoCManager.Instance!;
 
             if (Project == UnitTestProject.Server)
             {
-                ServerContentIoC.Register();
+                ServerContentIoC.Register(dependencies);
             }
             else if (Project == UnitTestProject.Client)
             {
-                ClientContentIoC.Register();
+                ClientContentIoC.Register(dependencies);
             }
         }
 


### PR DESCRIPTION
## About the PR
Removes all the static `IoCManager.Resolve` calls from the client & server setup.

## Why / Balance
They can all be replaced with non-static methods, and I want to mark them as obsolete (see space-wizards/RobustToolbox/pull/6232). This also changes IoC registrations to be consistent with how they are done in engine.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- The server, client, & shared module entrypoints no longer use any static IoC methods. E.g., `SharedContentIoC.Register()` now needs to be given an `IDependencyCollection`.
- The server & client now perform IoC registrations and invoke testing callbacks during `ModRunLevel.PreInit`, instead of near the beginning of `ModRunLevel.Init`
