### PR TITLE
Added a guard so we only eject cartridges that still exist.

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
 
 namespace Content.Client.Weapons.Ranged.Systems;
@@ -33,8 +34,17 @@ public sealed partial class GunSystem
             var existing = component.Entities[^1];
             component.Entities.RemoveAt(component.Entities.Count - 1);
 
-            Containers.Remove(existing, component.Container);
-            EnsureShootable(existing);
+            if (EntityManager.EntityExists(existing))
+            {
+                Containers.Remove(existing, component.Container);
+                EnsureShootable(existing);
+            }
+            else
+            {
+                // Prediction can leave a stale uid that the server already deleted.
+                // The list stays trimmed, but we skip resurrection attempts.
+                Log.Debug($"Skipping ballistic cycle for missing cartridge {existing} on {uid}");
+            }
         }
         else if (component.UnspawnedCount > 0)
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I was playing around with guns in the dev environment, when I ran into a client crash. 

```
CLR/System.ArgumentException
An unhandled exception of type 'System.ArgumentException' occurred in Robust.Shared.dll: 'Entity 10304 is not valid.'
at Robust.Shared.GameObjects.EntityManager.AddComponent[T](EntityUid uid, T component, Boolean overwrite, MetaDataComponent metadata) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 305
at Robust.Shared.GameObjects.EntityManager.AddComponent[T](EntityUid uid) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 251
at Robust.Shared.GameObjects.EntityManager.EnsureComponent[T](EntityUid uid) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 835
at Robust.Shared.GameObjects.EntitySystem.EnsureComp[T](EntityUid uid) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntitySystem.Proxy.cs:line 684
at Content.Shared.Weapons.Ranged.Systems.SharedGunSystem.EnsureShootable(EntityUid uid) in C:\Users\d\development\space-station-14\Content.Shared\Weapons\Ranged\Systems\SharedGunSystem.cs:line 558
at Content.Client.Weapons.Ranged.Systems.GunSystem.Cycle(EntityUid uid, BallisticAmmoProviderComponent component, MapCoordinates coordinates) in C:\Users\d\development\space-station-14\Content.Client\Weapons\Ranged\Systems\GunSystem.Ballistic.cs:line 37
at Content.Shared.Weapons.Ranged.Systems.SharedGunSystem.ManualCycle(EntityUid uid, BallisticAmmoProviderComponent component, MapCoordinates coordinates, Nullable1 user, GunComponent gunComp) in C:\Users\d\development\space-station-14\Content.Shared\Weapons\Ranged\Systems\SharedGunSystem.Ballistic.cs:line 230 at Content.Shared.Weapons.Ranged.Systems.SharedGunSystem.OnBallisticUse(EntityUid uid, BallisticAmmoProviderComponent component, UseInHandEvent args) in C:\Users\d\development\space-station-14\Content.Shared\Weapons\Ranged\Systems\SharedGunSystem.Ballistic.cs:line 41 at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass54_02.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 272
at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass67_01.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 460 at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass76_1.<EntCollectOrdered>b__0(Unit& ev) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 664 at Robust.Shared.GameObjects.EntityEventBus.DispatchOrderedEvents(Unit& eventArgs, ValueList1& found) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Ordering.cs:line 52
at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalOrdered(EntityUid uid, Type eventType, EventData subs, Unit& unitRef, Boolean broadcast) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Ordering.cs:line 43
at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEventCore(EntityUid uid, Unit& unitRef, Type type, Boolean broadcast) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 236
at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent args, Boolean broadcast) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 200
at Robust.Shared.GameObjects.EntitySystem.RaiseLocalEvent[TEvent](EntityUid uid, TEvent args, Boolean broadcast) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntitySystem.cs:line 161
at Content.Shared.Interaction.SharedInteractionSystem.UseInHandInteraction(EntityUid user, EntityUid used, Boolean checkCanUse, Boolean checkCanInteract, Boolean checkUseDelay) in C:\Users\d\development\space-station-14\Content.Shared\Interaction\SharedInteractionSystem.cs:line 1222
at Content.Shared.Hands.EntitySystems.SharedHandsSystem.TryUseItemInHand(EntityUid uid, Boolean altInteract, HandsComponent handsComp, String handName) in C:\Users\d\development\space-station-14\Content.Shared\Hands\EntitySystems\SharedHandsSystem.Interactions.cs:line 164
at Content.Shared.Hands.EntitySystems.SharedHandsSystem.HandleUseItem(ICommonSession session) in C:\Users\d\development\space-station-14\Content.Shared\Hands\EntitySystems\SharedHandsSystem.Interactions.cs:line 49
at Robust.Shared.Input.Binding.InputCmdHandler.StateInputCmdHandler.Enabled(ICommonSession session) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\Input\Binding\InputCmdHandler.cs:line 52
at Robust.Shared.Input.Binding.InputCmdHandler.StateInputCmdHandler.HandleCmdMessage(IEntityManager entManager, ICommonSession session, IFullInputCmdMessage message) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\Input\Binding\InputCmdHandler.cs:line 68
at Robust.Client.GameObjects.InputSystem.HandleInputCommand(ICommonSession session, BoundKeyFunction function, IFullInputCmdMessage message, Boolean replay) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\GameObjects\EntitySystems\InputSystem.cs:line 79
at Content.Client.Gameplay.GameplayStateBase.OnKeyBindStateChanged(ViewportBoundKeyEventArgs args) in C:\Users\d\development\space-station-14\Content.Client\Gameplay\GameplayStateBase.cs:line 244
at Content.Client.Gameplay.GameplayState.OnKeyBindStateChanged(ViewportBoundKeyEventArgs args) in C:\Users\d\development\space-station-14\Content.Client\Gameplay\GameplayState.cs:line 140
at Robust.Client.Input.InputManager.ViewportKeyEvent(Control viewport, BoundKeyEventArgs eventArgs) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 456
at Content.Client.Viewport.ScalingViewport.KeyBindDown(GUIBoundKeyEventArgs args) in C:\Users\d\development\space-station-14\Content.Client\Viewport\ScalingViewport.cs:line 134
at Robust.Client.UserInterface.UserInterfaceManager.<>c.<KeyBindDown>b__134_0(Control c, GUIBoundKeyEventArgs ev) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\UserInterface\UserInterfaceManager.Input.cs:line 110
at Robust.Client.UserInterface.UserInterfaceManager._doGuiInput(Control control, GUIBoundKeyEventArgs guiEvent, Action`2 action, Boolean ignoreStop) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\UserInterface\UserInterfaceManager.Input.cs:line 313
at Robust.Client.UserInterface.UserInterfaceManager.KeyBindDown(BoundKeyEventArgs args) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\UserInterface\UserInterfaceManager.Input.cs:line 110
at Robust.Client.UserInterface.UserInterfaceManager.OnUIKeyBindStateChanged(BoundKeyEventArgs args) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\UserInterface\UserInterfaceManager.Input.cs:line 469
at Robust.Client.Input.InputManager.SetBindState(KeyBinding binding, BoundKeyState state, Boolean uiOnly, Boolean isRepeat) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 415
at Robust.Client.Input.InputManager.DownBind(KeyBinding binding, Boolean uiOnly, Boolean isRepeat) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 365
at Robust.Client.Input.InputManager.KeyDown(KeyEventArgs args) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 286
at Robust.Client.GameController.KeyDown(KeyEventArgs keyEvent) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.Input.cs:line 12
at Robust.Client.Graphics.Clyde.Clyde.DispatchSingleEvent(DEventBase ev) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\Graphics\Clyde\Clyde.Events.cs:line 47
at Robust.Client.Graphics.Clyde.Clyde.DispatchEvents() in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\Graphics\Clyde\Clyde.Events.cs:line 31
at Robust.Client.Graphics.Clyde.Clyde.ProcessInput(FrameEventArgs frameEventArgs) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\Graphics\Clyde\Clyde.Windowing.cs:line 393
at Robust.Client.GameController.Input(FrameEventArgs frameEventArgs) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.cs:line 511
at Robust.Client.GameController.<StartupContinue>b__65_2(Object sender, FrameEventArgs args) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.cs:line 264
at Robust.Shared.Timing.GameLoop.Run() in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Shared\Timing\GameLoop.cs:line 187
at Robust.Client.GameController.ContinueStartupAndLoop(DisplayMode mode) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.Standalone.cs:line 163
at Robust.Client.GameController.GameThreadMain(DisplayMode mode) in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.Standalone.cs:line 148
at Robust.Client.GameController.<>c__DisplayClass107_0.<Run>b__0() in C:\Users\d\development\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.Standalone.cs:line 107`
```

Manual cycling a ballistic gun can crash the client when the tracked cartridge entity has already been deleted

**Environment:** Windows client, local build at 049549bcb9118f9955954752c4a14ee8aeeb69f0 (RobustToolbox/Content mainline)

**Reproduction:**
- Load into a local session and spawn any ballistic weapon that supports manual cycling (e.g. pump shotgun).
- Fire or otherwise empty the weapon so that the last round is being removed from its BallisticAmmoProviderComponent.
- Immediately spam the manual cycle action (UseInHand) while the server is also removing that round.
- Observe the client crash with System.ArgumentException: Entity <uid> is not valid from EntityManager.AddComponent → SharedGunSystem.EnsureShootable.

**Expected:** Cycling simply ejects a casing or does nothing if no cartridge remains.

**Actual:** The client attempts to attach an AmmoComponent to an entity that has already been deleted, resulting in an unhandled exception and client crash.

**Root Cause:** GunSystem.Cycle blindly called EnsureShootable on the last entry in BallisticAmmoProviderComponent.Entities. When prediction and server state diverge, this UID can already be deleted, so EnsureComp throws because the entity no longer exists.

**Fix:** Added an existence check before removing from the container and ensuring shootable data. If the UID is already gone we skip the operation; the provider list is still trimmed so state converges on the next net update.

## Why / Balance
Cycling a pump-action or similar gun could hard-crash the client with Entity X is not valid if prediction removed the cartridge before the cycle logic ran. This makes manual cycling safe again without altering gameplay balance.

## Technical details
- Guard the ballistic cycle logic on both client and server to ensure the cartridge entity still exists before removing it from the container and calling `EnsureShootable`.
- Emit a debug log explaining when the guard triggers, so future issues are easier to diagnose.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Manually cycling ballistic weapons no longer crashes the client when a cartridge entity has already been deleted.
