### PR TITLE
Widen Ammo UI

### DIFF
--- a/Content.Client/Weapons/Ranged/ItemStatus/BulletRender.cs
+++ b/Content.Client/Weapons/Ranged/ItemStatus/BulletRender.cs
@@ -149,6 +149,15 @@ public sealed class BulletRender : BaseBulletRenderer
     public const int BulletHeight = 12;
     public const int VerticalSeparation = 2;
 
+    private static readonly LayoutParameters LayoutLarge = new LayoutParameters
+    {
+        ItemHeight = BulletHeight,
+        ItemSeparation = 6,
+        ItemWidth = 5,
+        VerticalSeparation = VerticalSeparation,
+        MinCountPerRow = MinCountPerRow
+    };
+
     private static readonly LayoutParameters LayoutNormal = new LayoutParameters
     {
         ItemHeight = BulletHeight,
@@ -185,8 +194,9 @@ public sealed class BulletRender : BaseBulletRenderer
             if (_type == value)
                 return;
 
-            Parameters = _type switch
+            Parameters = value switch
             {
+                BulletType.Large => LayoutLarge,
                 BulletType.Normal => LayoutNormal,
                 BulletType.Tiny => LayoutTiny,
                 _ => throw new ArgumentOutOfRangeException()
@@ -218,6 +228,7 @@ public sealed class BulletRender : BaseBulletRenderer
 
     public enum BulletType
     {
+        Large,
         Normal,
         Tiny
     }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.AmmoCounter.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.AmmoCounter.cs
@@ -110,7 +110,12 @@ public sealed partial class GunSystem
             _bulletRender.Count = count;
             _bulletRender.Capacity = capacity;
 
-            _bulletRender.Type = capacity > 50 ? BulletRender.BulletType.Tiny : BulletRender.BulletType.Normal;
+            _bulletRender.Type = capacity switch
+            {
+                > 50 => BulletRender.BulletType.Tiny,
+                > 15 => BulletRender.BulletType.Normal,
+                _ => BulletRender.BulletType.Large
+            };
         }
     }
 
@@ -236,7 +241,12 @@ public sealed partial class GunSystem
             _bulletRender.Count = count;
             _bulletRender.Capacity = capacity;
 
-            _bulletRender.Type = capacity > 50 ? BulletRender.BulletType.Tiny : BulletRender.BulletType.Normal;
+            _bulletRender.Type = capacity switch
+            {
+                > 50 => BulletRender.BulletType.Tiny,
+                > 15 => BulletRender.BulletType.Normal,
+                _ => BulletRender.BulletType.Large
+            };
 
             _ammoCount.Text = $"x{count:00}";
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Widened the distance between rendered bullets on the ammo counter UI if the magazine capacity isn't larger than 15.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
When ammo is that squished together, it's hard to see how many bullets you have left. For magazin fed guns, this isn't an issue, because they have an ammo counter number - Shotguns however don't.
All this space left in the UI and we don't use it. I changed that.
## Technical details
<!-- Summary of code changes for easier review. -->
Introduced a `LayOutParameters` called `LayoutLarge`.
Transformed the If check for the parameters into a switch to account for the new `LayOutParameters`
Added a third enum to `BulletType`
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="375" height="68" alt="grafik" src="https://github.com/user-attachments/assets/05d8d491-0618-4ede-becb-ea79f0d2def8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Certain low-capacity weapons, like Mosin, Shotguns and Handguns will have their ammo counter UI enlargened to have an easier time gauging your ammo.