### PR TITLE
Suppress `SharedMapSystem` info logs in tests

### DIFF
--- a/Content.IntegrationTests/Pair/TestPair.cs
+++ b/Content.IntegrationTests/Pair/TestPair.cs
@@ -30,8 +30,12 @@ public sealed partial class TestPair : RobustIntegrationTest.TestPair
         await base.Initialize();
 
         // Prevent info log spam in some tests (particularly SpawnAndDeleteAllEntitiesOnDifferentMaps)
-        Client.System<SharedMapSystem>().Log.Level = LogLevel.Warning;
         Server.System<SharedMapSystem>().Log.Level = LogLevel.Warning;
+        Client.EntMan.EntitySysManager.SystemLoaded += (_, e) =>
+        {
+            if (e.System is SharedMapSystem map)
+                map.Log.Level = LogLevel.Warning;
+        };
 
         var settings = (PoolSettings)Settings;
         if (!settings.DummyTicker)

--- a/Content.IntegrationTests/Pair/TestPair.cs
+++ b/Content.IntegrationTests/Pair/TestPair.cs
@@ -27,6 +27,12 @@ public sealed partial class TestPair : RobustIntegrationTest.TestPair
 
     protected override async Task Initialize()
     {
+        await base.Initialize();
+
+        // Prevent info log spam in some tests (particularly SpawnAndDeleteAllEntitiesOnDifferentMaps)
+        Client.System<SharedMapSystem>().Log.Level = LogLevel.Warning;
+        Server.System<SharedMapSystem>().Log.Level = LogLevel.Warning;
+
         var settings = (PoolSettings)Settings;
         if (!settings.DummyTicker)
         {


### PR DESCRIPTION
## About the PR
Suppresses `SharedMapSystem` info logs in integration tests.

## Why / Balance
Over half of the test output is just map system logs, mainly due to the `SpawnAndDeleteAllEntitiesOnDifferentMaps` test.
I could just disable the logs for that specific test, but theres some others like `AllDeviceLinkSinksWorkTest`, and I don't think the logs add anything useful for tests.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
