### PR TITLE
Adds Self-Recharging Spray Painter to the Basic and Advanced Borg Tool Modules

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -486,6 +486,7 @@
     - item: Wirecutter
     - item: WelderIndustrial
     - item: Multitool
+    - item: SprayPainterRecharging
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: tool-module }
 
@@ -613,6 +614,7 @@
     - item: WelderExperimental
     - item: Multitool
     - item: RemoteSignallerAdvanced
+    - item: SprayPainterRecharging
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: adv-tools-module }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the self-recharging spray painter to the Basic and Advanced Borg Tool Modules
## Why / Balanace
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The overhauled spray painter with it's ability to paint canisters, crates, lockers, decals and more, is a natural addition to the Borg Tool modules. With it, a whole host of new opportunities open up for our helpful Silicons. Ranging from everything from Salvage Borgs being able to paint crates to match their destinations or lay down helpful markers for Salvagers to follow on expeditions. To Engineering Borgs being able to repaint canisters based on their contents or spray painting pipes to visually show what's going on. 

Be it redecorating departments or simply fixing missing detailing after doing repairs. I think it's well past time our Silicon friends were given a chance to use the new spray painter. And do I even have to mention the art lawset? I think it's finally time we gave them a paint brush. 

**Details on the self-recharging spray painter itself:**
15 charges, self-charges 1 charge every second. 

A bug exists within the self-recharging version of the spray painter. If spammed via autoclicker until it has 0 charges, the spray painter will display 'Not enough paint left' and stop functioning even after it's fully recharged, until manually refilled with paint ammo. However, as Borgs cannot presently 'use' the paint ammo to refill their on-board spray painter, this effectively bricks that tool module's spray painter. Replacing the affected module with a new one does resolve the issue, however.

**Final Rambling:**
I see this PR as a 1.0, not the ending point of the spray painter's addition or the balance regarding it. This is as light weight as I can make it, and doesn't address the bug mentioned, or utilize a custom item with configurable charge amounts/timings. Instead relying entirely upon existing systems and tools. There are a great many considerations for it that require actual time in game to work out, such as if the spray painter should be included in the basic tool module at all. If the basic tool version should require spray paint ammo, etc.  

All of that aside? Very few people have seen the potential of the spray painter and giving them to Borgs may open a few more pairs of eyes to what can be done with it. 

## Technical details
<!-- Summary of code changes for easier review. -->
added '- item: SprayPainterRecharging' to lines 489 and 617
## Media
<img width="1325" height="680" alt="Content Client_A6hkENKwlm" src="https://github.com/user-attachments/assets/3f7ae651-5a16-44c0-a94f-51ad6ddabde8"/>
<img width="380" height="157" alt="image" src="https://github.com/user-attachments/assets/9d74d917-f28c-473f-848f-cc042b7d2a6b" />

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added self-recharging spray painter to Basic and Advanced Borg Tool Modules
-->