### PR TITLE
Fix label markup escapeing

### DIFF
--- a/Content.Shared/Labels/EntitySystems/LabelSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/LabelSystem.cs
@@ -54,7 +54,7 @@ public sealed partial class LabelSystem : EntitySystem
     {
         label ??= EnsureComp<LabelComponent>(uid);
 
-        label.CurrentLabel = text;
+        label.CurrentLabel = text == null ? null : FormattedMessage.EscapeText(text);
         _nameModifier.RefreshNameModifiers(uid);
 
         Dirty(uid, label);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Labels could add any markup you wanted (bad and dangerous), this just escapes all labels.

## Technical details
<!-- Summary of code changes for easier review. -->

I just escaped the label themselves, I'm unsure if this is the correct approach though. You could also escape the right click menu itself or even in the identify function.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="706" height="583" alt="image" src="https://github.com/user-attachments/assets/fed165f5-6b4e-4bd1-9e9c-a7cef285d853" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Labelers can no longer add markup tags to items
