### PR TITLE
Conditional Meat spike logging severity

### DIFF
--- a/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
+++ b/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
@@ -240,11 +240,7 @@ public sealed class SharedKitchenSpikeSystem : EntitySystem
                 ent);
 
             // normally medium severity, but for humanoids high severity, so new players get relay'd to admin alerts.
-            var logSeverity = LogImpact.Medium;
-            if (HasComp<HumanoidAppearanceComponent>(args.Target))
-            {
-                logSeverity = LogImpact.High;
-            }
+            var logSeverity = HasComp<HumanoidAppearanceComponent>(args.Target) ? LogImpact.High : LogImpact.Medium;
 
             _logger.Add(LogType.Action,
                 logSeverity,


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reducing the meat spike log interaction's severity from Extreme to High, ensuring that only new players will rightfully spam our chat logs

## Why / Balance
These events are *really* spammy with the new meat spike features. And its usually a lot of unneeded noise from regular players that are usually butchering non-sentient creatures.

## Technical details

| Action                           	| Old severity 	| New severity                                                	|
|----------------------------------	|--------------	|-------------------------------------------------------------	|
| Hooking on non-humanoids         	| High         	| Medium                                                      	|
| Hooking on humanoids             	| High         	| High                                                        	|
| Butchering non-humanoids         	| High         	| Medium                                                      	|
| Butchering humanoids             	| High         	| Medium (All damage to and from players is logged as medium) 	|
| Gibbing non-humanoids            	| Extreme      	| High                                                        	|
| Gibbing humanoids                	| Extreme      	| Extreme                                                     	|
| Removing non-humanoids from hook 	| Medium       	| Medium                                                      	|
| Removing humanoids from hook     	| Medium       	| Medium                                                      	|

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
ADMIN:
- tweak: Adjusted meatspike admin log severities.