### PR TITLE
Fixed votekick.timeout cvar not configuring behavior as intended.

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -456,7 +456,7 @@ namespace Content.Server.Voting.Managers
                     (Loc.GetString("ui-vote-votekick-abstain"), "abstain")
                 },
                 Duration = TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VotekickTimer)),
-                InitiatorTimeout = TimeSpan.FromMinutes(_cfg.GetCVar(CCVars.VotekickTimeout)),
+                InitiatorTimeout = TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VotekickTimeout)),
                 VoterEligibility = voterEligibility,
                 DisplayVotes = false,
                 TargetEntity = targetNetEntity
@@ -580,7 +580,11 @@ namespace Content.Server.Voting.Managers
 
         private void TimeoutStandardVote(StandardVoteType type)
         {
-            var timeout = TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteSameTypeTimeout));
+            var timeout = TimeSpan.FromSeconds(type switch
+            {
+                StandardVoteType.Votekick => _cfg.GetCVar(CCVars.VotekickTimeout),
+                _ => _cfg.GetCVar(CCVars.VoteSameTypeTimeout)
+            });
             _standardVoteTimeout[type] = _timing.RealTime + timeout;
             DirtyCanCallVoteAll();
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The votekick.timeout cvar is documented to set the minimum time between votekicks, in seconds. None of that worked. The minimum time between votekicks was still controlled by vote.same_type_timeout, as with the other votes. And the only thing it did control was how long of a timeout the _initiator_ of the vote got... which was interpreted as _minutes_ rather than seconds as documented. Thus if someone started a votekick, they were locked out of starting any votes for an hour.

This PR changes the votekick behavior to use the votekick.timeout as it seems to have been intended. Votekicks can be started every 60 seconds now (instead of every 4 minutes as with the other votes), and the initiator of the votekick can start another vote 60 seconds after they started the previous one. Since the vote lasts 45 seconds, that means anyone (including the initiator), can start a second votekick 15 seconds after the previous one has concluded.

## Why / Balance
This is affecting the usefulness of votekick functionality when it is necessary.

## Technical details
Changed FromMinutes to FromSeconds.
TimeoutStandardVote now uses its parameter to determine which cvar it should use for timeout.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Does not affect gameplay.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
