### PR TITLE
fix: scan for ShowAccessReaderSettingsComponent on examiner and not on airlock

### DIFF
--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -70,9 +70,10 @@ public sealed class AccessReaderSystem : EntitySystem
             }
         }
 
+        var examiner = args.Examiner;
         var canSeeAccessModification = accessHasBeenModified &&
-            (HasComp<ShowAccessReaderSettingsComponent>(ent) ||
-            _inventorySystem.TryGetInventoryEntity<ShowAccessReaderSettingsComponent>(args.Examiner, out _));
+                                       (HasComp<ShowAccessReaderSettingsComponent>(examiner) ||
+                                        _inventorySystem.TryGetInventoryEntity<ShowAccessReaderSettingsComponent>(examiner, out _));
 
         if (canSeeAccessModification)
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes check for showing actual access reader settings

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Small fix - access reader settings are now shown if ShowAccessReaderSettingsComponent is on the airlock, but ShowAccessReaderSettingsComponent was supposed to be component for examiner or his inventory.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
