### PR TITLE
fix whitelist applying for rejoining a round

### DIFF
--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -327,7 +327,7 @@ namespace Content.Server.Connection
                     }
 
                     var whitelistStatus = await IsWhitelisted(whitelist, e.UserData, _sawmill);
-                    if (!whitelistStatus.isWhitelisted)
+                    if (!whitelistStatus.isWhitelisted && !wasInGame)
                     {
                         // Not whitelisted.
                         return (ConnectionDenyReason.Whitelist, Loc.GetString("whitelist-fail-prefix", ("msg", whitelistStatus.denyMessage!)), null);


### PR DESCRIPTION
## About the PR
All i did was add 14 characters in `Content.Server/Connection/ConnectionManager.cs` to make rejoining a round bypass the whitelist.

## Why / Balance
The whitelist applying when rejoining was a bug, [as said on the SS14 discord server](https://discord.com/channels/310555209753690112/790656972801572905/1422613046823489700).

## Technical details
It’s literally just ` && !wasInGame` added to the `if` at line 330 of `Content.Server/Connection/ConnectionManager.cs`.

## Media
Not relevant.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl:
- fix: The whitelist no longer prevents players from rejoining a round they already participated in.