### PR TITLE
Localize space villain arcade

### DIFF
--- a/Content.Server/Arcade/SpaceVillainGame/SpaceVillainArcadeComponent.cs
+++ b/Content.Server/Arcade/SpaceVillainGame/SpaceVillainArcadeComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Arcade;
+using Content.Shared.Dataset;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 
@@ -23,85 +24,73 @@ public sealed partial class SpaceVillainArcadeComponent : SharedSpaceVillainArca
     /// <summary>
     /// The sound played when a new session of the SpaceVillain game is begun.
     /// </summary>
-    [DataField("newGameSound")]
+    [DataField]
     public SoundSpecifier NewGameSound = new SoundPathSpecifier("/Audio/Effects/Arcade/newgame.ogg");
 
     /// <summary>
     /// The sound played when the player chooses to attack.
     /// </summary>
-    [DataField("playerAttackSound")]
+    [DataField]
     public SoundSpecifier PlayerAttackSound = new SoundPathSpecifier("/Audio/Effects/Arcade/player_attack.ogg");
 
     /// <summary>
     /// The sound played when the player chooses to heal.
     /// </summary>
-    [DataField("playerHealSound")]
+    [DataField]
     public SoundSpecifier PlayerHealSound = new SoundPathSpecifier("/Audio/Effects/Arcade/player_heal.ogg");
 
     /// <summary>
     /// The sound played when the player chooses to regain mana.
     /// </summary>
-    [DataField("playerChargeSound")]
+    [DataField]
     public SoundSpecifier PlayerChargeSound = new SoundPathSpecifier("/Audio/Effects/Arcade/player_charge.ogg");
 
     /// <summary>
     /// The sound played when the player wins.
     /// </summary>
-    [DataField("winSound")]
+    [DataField]
     public SoundSpecifier WinSound = new SoundPathSpecifier("/Audio/Effects/Arcade/win.ogg");
 
     /// <summary>
     /// The sound played when the player loses.
     /// </summary>
-    [DataField("gameOverSound")]
+    [DataField]
     public SoundSpecifier GameOverSound = new SoundPathSpecifier("/Audio/Effects/Arcade/gameover.ogg");
 
     /// <summary>
     /// The prefixes that can be used to create the game name.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("possibleFightVerbs")]
-    public List<string> PossibleFightVerbs = new()
-        {"Defeat", "Annihilate", "Save", "Strike", "Stop", "Destroy", "Robust", "Romance", "Pwn", "Own"};
+    [DataField]
+    public ProtoId<LocalizedDatasetPrototype> PossibleFightVerbs = "SpaceVillainVerbsFight";
 
     /// <summary>
     /// The first names/titles that can be used to construct the name of the villain.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("possibleFirstEnemyNames")]
-    public List<string> PossibleFirstEnemyNames = new(){
-        "the Automatic", "Farmer", "Lord", "Professor", "the Cuban", "the Evil", "the Dread King",
-        "the Space", "Lord", "the Great", "Duke", "General"
-    };
+    [DataField]
+    public ProtoId<LocalizedDatasetPrototype> PossibleFirstEnemyNames = "SpaceVillainNamesEnemyFirst";
 
     /// <summary>
     /// The last names that can be used to construct the name of the villain.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("possibleLastEnemyNames")]
-    public List<string> PossibleLastEnemyNames = new()
-    {
-        "Melonoid", "Murdertron", "Sorcerer", "Ruin", "Jeff", "Ectoplasm", "Crushulon", "Uhangoid",
-        "Vhakoid", "Peteoid", "slime", "Griefer", "ERPer", "Lizard Man", "Unicorn"
-    };
+    [DataField]
+    public ProtoId<LocalizedDatasetPrototype> PossibleLastEnemyNames = "SpaceVillainNamesEnemyLast";
 
     /// <summary>
     /// The prototypes that can be dispensed as a reward for winning the game.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
     public List<EntProtoId> PossibleRewards = new();
 
     /// <summary>
     /// The minimum number of prizes the arcade machine can have.
     /// </summary>
-    [DataField("rewardMinAmount")]
+    [DataField]
     public int RewardMinAmount;
 
     /// <summary>
     /// The maximum number of prizes the arcade machine can have.
     /// </summary>
-    [DataField("rewardMaxAmount")]
+    [DataField]
     public int RewardMaxAmount;
 
     /// <summary>

--- a/Content.Server/Arcade/SpaceVillainGame/SpaceVillainArcadeSystem.cs
+++ b/Content.Server/Arcade/SpaceVillainGame/SpaceVillainArcadeSystem.cs
@@ -4,15 +4,18 @@ using Content.Server.Advertise.EntitySystems;
 using Content.Shared.Advertise.Components;
 using Content.Shared.Arcade;
 using Content.Shared.Power;
+using Content.Shared.Random.Helpers;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Arcade.SpaceVillain;
 
 public sealed partial class SpaceVillainArcadeSystem : EntitySystem
 {
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
@@ -52,7 +55,7 @@ public sealed partial class SpaceVillainArcadeSystem : EntitySystem
     /// <returns>A fight-verb.</returns>
     public string GenerateFightVerb(SpaceVillainArcadeComponent arcade)
     {
-        return _random.Pick(arcade.PossibleFightVerbs);
+        return _random.Pick(_prototypeManager.Index(arcade.PossibleFightVerbs));
     }
 
     /// <summary>
@@ -61,7 +64,10 @@ public sealed partial class SpaceVillainArcadeSystem : EntitySystem
     /// <returns>An enemy-name.</returns>
     public string GenerateEnemyName(SpaceVillainArcadeComponent arcade)
     {
-        return $"{_random.Pick(arcade.PossibleFirstEnemyNames)} {_random.Pick(arcade.PossibleLastEnemyNames)}";
+        var possibleFirstEnemyNames = _prototypeManager.Index(arcade.PossibleFirstEnemyNames);
+        var possibleLastEnemyNames = _prototypeManager.Index(arcade.PossibleLastEnemyNames);
+
+        return $"{_random.Pick(possibleFirstEnemyNames)} {_random.Pick(possibleLastEnemyNames)}";
     }
 
     private void OnComponentInit(EntityUid uid, SpaceVillainArcadeComponent component, ComponentInit args)

--- a/Resources/Locale/en-US/datasets/arcade_villain.ftl
+++ b/Resources/Locale/en-US/datasets/arcade_villain.ftl
@@ -1,0 +1,40 @@
+# Verbs
+arcade-villain-verbs-fight-1 = Annihilate
+arcade-villain-verbs-fight-2 = Defeat
+arcade-villain-verbs-fight-3 = Destroy
+arcade-villain-verbs-fight-4 = Own
+arcade-villain-verbs-fight-5 = Pwn
+arcade-villain-verbs-fight-6 = Robust
+arcade-villain-verbs-fight-7 = Romance
+arcade-villain-verbs-fight-8 = Save
+arcade-villain-verbs-fight-9 = Stop
+arcade-villain-verbs-fight-10 = Strike
+
+# Enemy names
+arcade-villain-names-enemy-first-1 = Duke
+arcade-villain-names-enemy-first-2 = Farmer
+arcade-villain-names-enemy-first-3 = General
+arcade-villain-names-enemy-first-4 = Lord
+arcade-villain-names-enemy-first-5 = Professor
+arcade-villain-names-enemy-first-6 = the Automatic
+arcade-villain-names-enemy-first-7 = the Cuban
+arcade-villain-names-enemy-first-8 = the Dread King
+arcade-villain-names-enemy-first-9 = the Evil
+arcade-villain-names-enemy-first-10 = the Great
+arcade-villain-names-enemy-first-11 = the Space
+
+arcade-villain-names-enemy-last-1 = Crushulon
+arcade-villain-names-enemy-last-2 = ERPer
+arcade-villain-names-enemy-last-3 = Ectoplasm
+arcade-villain-names-enemy-last-4 = Griefer
+arcade-villain-names-enemy-last-5 = Jeff
+arcade-villain-names-enemy-last-6 = Lizard Man
+arcade-villain-names-enemy-last-7 = Melonoid
+arcade-villain-names-enemy-last-8 = Murdertron
+arcade-villain-names-enemy-last-9 = Peteoid
+arcade-villain-names-enemy-last-10 = Ruin
+arcade-villain-names-enemy-last-11 = Sorcerer
+arcade-villain-names-enemy-last-12 = Uhangoid
+arcade-villain-names-enemy-last-13 = Unicorn
+arcade-villain-names-enemy-last-14 = Vhakoid
+arcade-villain-names-enemy-last-15 = slime

--- a/Resources/Prototypes/Datasets/arcade_villain.yml
+++ b/Resources/Prototypes/Datasets/arcade_villain.yml
@@ -1,0 +1,17 @@
+- type: localizedDataset
+  id: SpaceVillainVerbsFight
+  values:
+    prefix: arcade-villain-verbs-fight-
+    count: 10
+
+- type: localizedDataset
+  id: SpaceVillainNamesEnemyFirst
+  values:
+    prefix: arcade-villain-names-enemy-first-
+    count: 11
+
+- type: localizedDataset
+  id: SpaceVillainNamesEnemyLast
+  values:
+    prefix: arcade-villain-names-enemy-last-
+    count: 15


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Moves hardcoded verbs and names in `SpaceVillainArcadeComponent` into LocalizedDatasetPrototype so now they are localizable.

Also removed duplicated enemy first name `Lord`

## Why / Balance
Localization is good

## Media
https://github.com/user-attachments/assets/867fcd4e-d8b5-49d6-b935-1a4f9ade97cb

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Type of fields `PossibleFightVerbs`, `PossibleFirstEnemyNames` and `PossibleLastEnemyNames` have been changed from `List<string>` to `ProtoId<LocalizedDatasetPrototype>`.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
