### PR TITLE
minor tweak to changelog files, for contributor sanity

### DIFF
--- a/Resources/Changelog/Admin.yml
+++ b/Resources/Changelog/Admin.yml
@@ -1,4 +1,7 @@
 ﻿AdminOnly: true
+Name: Admin
+Order: 2
+# Do NOT put anything after the Entries section, in order to prevent merge conflict with new CL entries
 Entries:
 - author: DrSmugleaf
   changes:
@@ -1447,5 +1450,3 @@ Entries:
   id: 175
   time: '2025-09-25T21:43:53.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/40246
-Name: Admin
-Order: 2

--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -1,4 +1,5 @@
-﻿Entries:
+﻿# Do NOT put anything after the Entries section, in order to prevent merge conflict with new CL entries
+Entries:
 - author: EmoGarbage404
   changes:
   - message: You can now patch holes in the floors of the evac shuttle and ATS.

--- a/Resources/Changelog/Maps.yml
+++ b/Resources/Changelog/Maps.yml
@@ -1,4 +1,6 @@
-﻿Entries:
+﻿Order: 1
+# Do NOT put anything after the Entries section, in order to prevent merge conflict with new CL entries
+Entries:
 - author: ArtisticRoomba
   changes:
   - message: The mapping changelog has been added! This primarily serves as a way
@@ -731,4 +733,3 @@
   id: 88
   time: '2025-09-25T21:36:16.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/40546
-Order: 1


### PR DESCRIPTION
## About the PR
Move all datafields in the changelog files to before the Entries section, so changes to them never again conflict with new CL entries being added

## Why / Balance
Merge conflicts are annoying

## Technical details

## Media
Changelogs still work
<img width="1758" height="1451" alt="image" src="https://github.com/user-attachments/assets/00df31cc-66fb-4d9e-b28b-636aeee2d21a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
