### PR TITLE
Disable panic bunker for Leviathan

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/leviathan.toml
+++ b/Resources/ConfigPresets/WizardsDen/leviathan.toml
@@ -4,6 +4,10 @@
 
 [game]
 hostname = "[EN] Wizard's Den Leviathan [US East 1]"
+panic_bunker.enabled = false
+panic_bunker.disable_with_admins = false
+panic_bunker.enable_without_admins = false
+panic_bunker.custom_reason = ""
 
 [hub]
 tags = "lang:en,region:am_n_e,rp:low"

--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -11,7 +11,7 @@ panic_bunker.min_overall_minutes = 120
 panic_bunker.disable_with_admins = true
 panic_bunker.enable_without_admins = true
 panic_bunker.show_reason = true
-panic_bunker.custom_reason = "You have not played on a Wizard's Den server long enough to connect to this server. Please play on Wizard's Den Lizard until you have more playtime."
+panic_bunker.custom_reason = "You have not played on a Wizard's Den server long enough to connect to this server. Please play on Wizard's Den Lizard or Wizard's Den Leviathan until you have more playtime."
 
 # IPIntel stuff
 ipintel_enabled = true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
No more panic bunker on Leviathan.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The admins have voted.
<img width="457" height="257" alt="image" src="https://github.com/user-attachments/assets/839ab49c-2fa9-4c11-8023-a0c8cd76bc14" />


## Technical details
<!-- Summary of code changes for easier review. -->
Removed panic bunker for Leviathan.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
