### PR TITLE
Update Mind Shielding section in Space Law

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
@@ -25,7 +25,10 @@
 
   [color=#a4885c]Tracking Implants:[/color] Trackers can be applied to any suspect that has been convicted of a violent crime (the red linked crimes).
 
-  [color=#a4885c]Mind Shields:[/color] Shields can be administered to any inmate who has been clearly mind controlled, lost control of themselves, or a suspect charged with unlawful control. Unlike standard implantation you may hold a prisoner until you finish issuing Mind Shields, so long as it's done in a timely fashion. If a suspect refuses to cooperate or the implant fails to function they can be charged with Refusal of Mental Shielding.
+  [color=#a4885c]Mind Shields:[/color] Mind Shields can be administered to any suspect charged with a crime if there is reasonable and articulable suspicion to believe they committed the crime while under mind control. If there is undeniable proof of ongoing mind control on the station, such as a successful deconversion, all the following statements apply:
+  - Crew can be required to be shielded and may be forcibly implanted if they refuse.
+  - If a suspect refuses to cooperate or the implant fails to function they can be charged with Refusal of Mental Shielding.
+  - Unlike standard implantation you may indefinitely extend the duration of a prisoner's sentence until you finish issuing Mind Shields, so long as active attempts are made to procure implants and complete the implantation procedure.
 
   Usage of contraband implanters is a detainable offense, but it's not reasonable to detain someone solely for having an unidentified implant inside them.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR updates the Mind Shielding section in Space Law to loosen the restrictions of when Security may forcibly implant someone while also making the requirements clearer. 

Changes

> **Mind Shields:** Shields can be administered to any inmate who has been clearly mind controlled, lost control of themselves, or a suspect charged with unlawful control. Unlike standard implantation you may hold a prisoner until you finish issuing Mind Shields, so long as it's done in a timely fashion. If a suspect refuses to cooperate or the implant fails to function they can be charged with Refusal of Mental Shielding.

to

> **Mind Shields:** Mind Shields can be administered to any suspect charged with a crime if there is reasonable and articulable suspicion to believe they committed the crime while under mind control. If there is undeniable proof of ongoing mind control on the station, such as a successful deconversion, all the following statements apply:
>   - Crew can be required to be shielded and may be forcibly implanted if they refuse.
>   - If a suspect refuses to cooperate or the implant fails to function they can be charged with Refusal of Mental Shielding.
>   - Unlike standard implantation you may indefinitely extend the duration of a prisoner's sentence until you finish issuing Mind Shields, so long as active attempts are made to procure implants and complete the implantation procedure.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The goal here is to make Security's application of mind shields better align with how Revolutionary rounds play out. 

> Mind Shields can be administered to any suspect charged with a crime if there is reasonable and articulable suspicion to believe they committed the crime while under mind control.

This is a lower bar to clear compared to the previous "any inmate who has been clearly mind controlled, lost control of themselves, or a suspect charged with unlawful control." but more closely matches how Security may act during a Revolutionary round - a gibbed Head by multiple crew with no Syndie equipment or someone yelling "X tried flashing me!" are generally situations where Security may arrest and mind shield someone in practice, which the new wording accomodates. While "reasonable suspicion" is a fairly low bar it should keep Security from mind shielding people randomly, and the requirement of "charged with another crime/committed the crime under mind control" means the person must have been arrested for a relevant crime to be mind shielded. 

While "reasonable suspicion" is not defined in Space Law, it is also used for implant checking. What exactly counts as reasonable? Ask your Lawyer.

> If there is undeniable proof of ongoing mind control on the station, such as a successful deconversion, all the following statements apply:

One example of undeniable proof is given but there are others, such as a mind shield implant breaking on a head rev. Since the statements below require this undeniable proof, Security will *have* to initially arrest someone for a crime while under suspicion of mind control and confirm it via an implant before being allowed to randomly grab people for forceful implants.

> - Crew can be required to be shielded and may be forcibly implanted if they refuse.

This is commonstance in situations where a Revolution has been revealed and Security is aiming to protect and deconvert as many crew as possible, but under previous wording issues can arise if a non-Revolutionary refuses mind shielding. This is of course common Revolutionary behavior, but as the crew member has not done any crime, Security would have been unable to demand the implantation (which would open up the crew member for conversion instead). Now, Security has the permission to perform forceful implantation, but requires undeniable proof of a revolution and for the crew member to be offered (so as to not jump immediately to stun+cuff+implant).

>   - If a suspect refuses to cooperate or the implant fails to function they can be charged with Refusal of Mental Shielding.

Parity with previous text.

>   - Unlike standard implantation you may indefinitely extend the duration of a prisoner's sentence until you finish issuing Mind Shields, so long as active attempts are made to procure implants and complete the implantation procedure.

Slight modification from previous text; this line applies to any prisoner (i.e. any person who has been sentenced to a crime, which means you can't apply this to any random crew member you pick up) and "active attempts are made to procure implants and complete the implantation procedure" is more concrete than "in a timely fashion". This could include just getting the implants out of vault, but also holding someone while a raid of Cargo is ongoing. If Security has abandoned the idea of getting new mind shields altogether, the line no longer permits holding the prisoner. Not that it says "extend"; if you have been sentenced for a crime, you may still be held in Security for the duration of that crime.

## Technical details
<!-- Summary of code changes for easier review. -->

Targetting stable because this is a Space Law rules thing.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="819" height="794" alt="image" src="https://github.com/user-attachments/assets/cebc0f39-7bff-4b7f-ab67-ea70505eb19d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
SL gets no CL.