### PR TITLE
Added stamp boxes for all Command roles (and touched up /Fills/Boxes/Heads.yml somewhat)

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -160,6 +160,28 @@
       - state: headset
 
 - type: entity
+  abstract: true # Abstract because this prototype doesn't have a StorageFill set; create a child prototype with the appropriate stamps! (Baking "default" stamps into this parent seems bad for futureproofing.)
+  parent: BoxCardboard
+  id: BoxStamps
+  name: stamp box
+  description: A box containing stamps.
+  components:
+  - type: Item
+    size: Small
+    shape:
+    - 0,0,1,1
+  - type: Storage
+    grid:
+    - 0,0,1,1
+    whitelist:
+      components:
+      - Stamp
+  - type: Sprite
+    layers:
+      - state: box
+      - state: stamp
+
+- type: entity
   name: meson box
   parent: BoxCardboard
   id: BoxMesonScanners

--- a/Resources/Prototypes/Catalog/Fills/Boxes/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/heads.yml
@@ -1,8 +1,149 @@
 - type: entity
-  name: circuit tote [QM]
+  abstract: true
+  parent: BoxCardboard
+  id: BoxStamps
+  name: stamp box
+  description: A box filled with stamps.
+  components:
+  - type: Item
+    size: Small
+    shape:
+    - 0,0,1,1
+  - type: Storage
+    grid:
+    - 0,0,1,1
+    whitelist:
+      components:
+      - Stamp
+  - type: Sprite
+    layers:
+      - state: box
+      - state: stamp
+
+- type: entity
+  name: captain's circuit tote
+  parent: ToteBase
+  id: BoxCaptainCircuitboards
+  description: A tote filled with the captain's circuit boards.
+  components:
+  - type: StorageFill
+    contents:
+      - id: CommsComputerCircuitboard
+      - id: StationRecordsComputerCircuitboard
+
+- type: entity
+  parent: BoxStamps
+  id: BoxCaptainStamps
+  name: captain's stamp box
+  description: A box filled with the captain's stamps.
+  components:
+  - type: StorageFill
+    contents:
+      - id: RubberStampApproved
+      - id: RubberStampDenied
+      - id: RubberStampCaptain
+
+- type: entity
+  name: chief engineer's circuit tote
+  parent: ToteBase
+  id: BoxCECircuitboards
+  description: A tote filled with the chief engineer's circuit boards.
+  components:
+  - type: StorageFill
+    contents:
+      - id: CargoRequestEngineeringComputerCircuitboard
+      - id: AlertsComputerCircuitboard
+      - id: AtmosMonitoringComputerCircuitboard
+      - id: PowerComputerCircuitboard
+      - id: SolarControlComputerCircuitboard
+
+- type: entity
+  parent: BoxStamps
+  id: BoxCEStamps
+  name: chief engineer's stamp box
+  description: A box filled with the chief engineer's stamps.
+  components:
+  - type: StorageFill
+    contents:
+      - id: RubberStampApproved
+      - id: RubberStampDenied
+      - id: RubberStampCE
+
+- type: entity
+  name: chief medical officer's circuit tote
+  parent: ToteBase
+  id: BoxCMOCircuitboards
+  description: A tote filled with the chief medical officer's circuit boards.
+  components:
+  - type: StorageFill
+    contents:
+      - id: MedicalTechFabCircuitboard
+      - id: CargoRequestMedicalComputerCircuitboard
+
+- type: entity
+  parent: BoxStamps
+  id: BoxCMOStamps
+  name: chief medical officer's stamp box
+  description: A box filled with the chief medical officer's stamps.
+  components:
+  - type: StorageFill
+    contents:
+      - id: RubberStampApproved
+      - id: RubberStampDenied
+      - id: RubberStampCMO
+
+- type: entity
+  name: head of personnel's circuit tote
+  parent: ToteBase
+  id: BoxHoPCircuitboards
+  description: A tote filled with the head of personnel's circuit boards.
+  components:
+  - type: StorageFill
+    contents:
+      - id: IDComputerCircuitboard
+      - id: FundingAllocationComputerCircuitboard
+      - id: CargoRequestServiceComputerCircuitboard
+
+- type: entity
+  parent: BoxStamps
+  id: BoxHoPStamps
+  name: head of personnel's stamp box
+  description: A box filled with the head of personnel's stamps.
+  components:
+  - type: StorageFill
+    contents:
+      - id: RubberStampApproved
+      - id: RubberStampDenied
+      - id: RubberStampHop
+
+- type: entity
+  name: head of security's circuit tote
+  parent: ToteBase
+  id: BoxHoSCircuitboards
+  description: A tote filled with the head of security's circuit boards.
+  components:
+  - type: StorageFill
+    contents:
+      - id: SecurityTechFabCircuitboard
+      - id: CargoRequestSecurityComputerCircuitboard
+
+- type: entity
+  parent: BoxStamps
+  id: BoxHoSStamps
+  name: head of security's stamp box
+  description: A box filled with the head of security's stamps.
+  components:
+  - type: StorageFill
+    contents:
+      - id: RubberStampApproved
+      - id: RubberStampDenied
+      - id: RubberStampHos
+
+- type: entity
+  name: quartermaster's circuit tote
   parent: ToteBase
   id: BoxQMCircuitboards
-  description: A Tote filled with QM's Circuit boards.
+  description: A tote filled with the quartermaster's circuit boards.
   components:
   - type: StorageFill
     contents:
@@ -15,110 +156,22 @@
       - id: MailTeleporterMachineCircuitboard
 
 - type: entity
-  name: stamp box [QM]
-  parent: BoxCardboard
+  parent: BoxStamps
   id: BoxQMStamps
-  description: A box filled with QM's Stamps. Stamped of course.
+  name: quartermaster's stamp box
+  description: A box filled with the quartermaster's stamps.
   components:
-  - type: Item
-    size: Small
-    shape:
-    - 0,0,1,1
   - type: StorageFill
     contents:
       - id: RubberStampApproved
       - id: RubberStampDenied
       - id: RubberStampQm
-  - type: Storage
-    grid:
-    - 0,0,1,1
-    whitelist:
-      components:
-      - Stamp
-  - type: Sprite
-    layers:
-      - state: box
-      - state: stamp
 
 - type: entity
-  name: circuit tote [HoP]
-  parent: ToteBase
-  id: BoxHoPCircuitboards
-  description: A Tote filled with HoP's Circuit boards.
-  components:
-  - type: StorageFill
-    contents:
-      - id: IDComputerCircuitboard
-      - id: FundingAllocationComputerCircuitboard
-      - id: CargoRequestServiceComputerCircuitboard
-
-- type: entity
-  name: stamp box [HoP]
-  parent: BoxCardboard
-  id: BoxHoPStamps
-  description: A box filled with HoP's Stamps. Stamped of course.
-  components:
-  - type: Item
-    size: Small
-    shape:
-    - 0,0,1,1
-  - type: StorageFill
-    contents:
-      - id: RubberStampApproved
-      - id: RubberStampDenied
-      - id: RubberStampHop
-  - type: Storage
-    grid:
-    - 0,0,1,1
-    whitelist:
-      components:
-      - Stamp
-  - type: Sprite
-    layers:
-      - state: box
-      - state: stamp
-
-- type: entity
-  name: circuit tote [CE]
-  parent: ToteBase
-  id: BoxCECircuitboards
-  description: A Tote filled with CE's Circuit boards.
-  components:
-  - type: StorageFill
-    contents:
-      - id: CargoRequestEngineeringComputerCircuitboard
-      - id: AlertsComputerCircuitboard
-      - id: AtmosMonitoringComputerCircuitboard
-      - id: PowerComputerCircuitboard
-      - id: SolarControlComputerCircuitboard
-
-- type: entity
-  name: circuit tote [Captain]
-  parent: ToteBase
-  id: BoxCaptainCircuitboards
-  description: A Tote filled with Captain's Circuit boards.
-  components:
-  - type: StorageFill
-    contents:
-      - id: CommsComputerCircuitboard
-      - id: StationRecordsComputerCircuitboard
-
-- type: entity
-  name: circuit tote [CMO]
-  parent: ToteBase
-  id: BoxCMOCircuitboards
-  description: A Tote filled with CMO's Circuit boards.
-  components:
-  - type: StorageFill
-    contents:
-      - id: MedicalTechFabCircuitboard
-      - id: CargoRequestMedicalComputerCircuitboard
-
-- type: entity
-  name: circuit tote [RD]
+  name: research director's circuit tote
   parent: ToteBase
   id: BoxRDCircuitboards
-  description: A Tote filled with RD's Circuit boards.
+  description: A tote filled with the research director's circuit boards.
   components:
   - type: StorageFill
     contents:
@@ -132,12 +185,13 @@
       - id: StationAiFixerCircuitboard
 
 - type: entity
-  name: circuit tote [HoS]
-  parent: ToteBase
-  id: BoxHoSCircuitboards
-  description: A Tote filled with HoS's Circuit boards.
+  parent: BoxStamps
+  id: BoxRDStamps
+  name: research director's stamp box
+  description: A box filled with the research director's stamps.
   components:
   - type: StorageFill
     contents:
-      - id: SecurityTechFabCircuitboard
-      - id: CargoRequestSecurityComputerCircuitboard
+      - id: RubberStampApproved
+      - id: RubberStampDenied
+      - id: RubberStampRd

--- a/Resources/Prototypes/Catalog/Fills/Boxes/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/heads.yml
@@ -1,26 +1,4 @@
 - type: entity
-  abstract: true
-  parent: BoxCardboard
-  id: BoxStamps
-  name: stamp box
-  description: A box filled with stamps.
-  components:
-  - type: Item
-    size: Small
-    shape:
-    - 0,0,1,1
-  - type: Storage
-    grid:
-    - 0,0,1,1
-    whitelist:
-      components:
-      - Stamp
-  - type: Sprite
-    layers:
-      - state: box
-      - state: stamp
-
-- type: entity
   name: captain's circuit tote
   parent: ToteBase
   id: BoxCaptainCircuitboards

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -35,13 +35,13 @@
     - id: ClothingHeadsetAltCommand
     - id: ClothingOuterArmorCaptainCarapace
     - id: BoxCaptainCircuitboards
+    - id: BoxCaptainStamps
     - id: DoorRemoteCustom
     - id: MedalCase
     - id: NukeDisk
     - id: PinpointerNuclear
     - id: PlushieNuke
       prob: 0.1
-    - id: RubberStampCaptain
     - id: SpaceCash1000
     - id: WeaponDisabler
     - id: ClothingEyesGlassesCommand
@@ -156,9 +156,9 @@
     - id: ClothingHeadsetAltEngineering
     - id: DoorRemoteEngineering
     - id: BoxCECircuitboards
+    - id: BoxCEStamps
     - id: RCD
     - id: RCDAmmo
-    - id: RubberStampCE
     - id: MetalFoamGrenade
 
 # Hardsuit table, used for suit storage as well
@@ -215,8 +215,8 @@
     - id: HandheldCrewMonitor
     - id: Hypospray
     - id: BoxCMOCircuitboards
+    - id: BoxCMOStamps
     - id: MedkitFilled
-    - id: RubberStampCMO
     - id: MedTekCartridge
 
 # Hardsuit table, used for suit storage as well
@@ -262,11 +262,11 @@
     - id: Intellicard
     - id: BoxEncryptionKeyScience
     - id: BoxRDCircuitboards
+    - id: BoxRDStamps
     - id: ClothingBeltUtilityFilled
     - id: ClothingHeadsetAltScience
     - id: DoorRemoteResearch
     - id: HandTeleporter
-    - id: RubberStampRd
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable
@@ -321,8 +321,8 @@
     - id: ClothingShoesBootsJack
     - id: DoorRemoteSecurity
     - id: HoloprojectorSecurity
-    - id: RubberStampHos
     - id: BoxHoSCircuitboards
+    - id: BoxHoSStamps
     - id: WeaponDisabler
     - id: WeaponTaser
     - id: WantedListCartridge


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
All Command roles now have stamp boxes in their lockers, containing APPROVED/DENIED rubber stamps and their own unique stamp.

I've also taken the opportunity to clean up Resources/Prototypes/Catalog/Fills/Boxes/heads.yml somewhat:
- Entries are now sorted alphabetically.
- The stamp box now has a specific abstract prototype (rather than needing to re-create it for every new stamp box), in Resources/Prototypes/Catalog/Fills/Boxes/general.yml. This is currently just used for the department heads but in theory it could be used down the line for non-command roles that still have stamps (like Chaplain or Psychologist), or a "generic" stamp box could be added with just APPROVED/DENIED stamps.
- Both stamp boxes and circuit totes had their names/descriptions touched up.

Basically a touchup/slight expansion of #39868.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, the Head of Personnel and the Quartermaster are the only department heads to have APPROVED/DENIED stamps roundstart. These roles also both start with clipboards, so the intent seems to be that they get the stamps for being paper-pusher roles. However, there's a lot of typical forms that other department heads might want to approve/deny:
- Budget adjustments
- Construction permits
- Contraband permits
- Medical evaluations
- Prescriptions
- Research consent forms
- Requests for prototype technologies
- The captain has full authority on the station, so they might have reasons to approve/deny any form just in general

Stamps in general basically function as both roleplay enablers and as ways to prove (or falsify) a department head's explicit approval/denial of a request. Providing more heads with these stamps just gives them more options to interact with paperwork.

## Technical details
<!-- Summary of code changes for easier review. -->
YAML changes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1920" height="1080" alt="Space Station 14 10_2_2025 11_35_09 AM" src="https://github.com/user-attachments/assets/006065ad-e923-489e-b475-d802333cc578" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: ALL department heads now have stamp boxes in their lockers, containing APPROVED/DENIED stamps and their unique stamp.
- tweak: Names and descriptions of stamp boxes and circuit totes have been adjusted.