### PR TITLE
Remove x86 targets from Content Packaging

### DIFF
--- a/Content.Packaging/ServerPackaging.cs
+++ b/Content.Packaging/ServerPackaging.cs
@@ -19,9 +19,6 @@ public static class ServerPackaging
         new PlatformReg("osx-x64", "MacOS", true),
         new PlatformReg("osx-arm64", "MacOS", true),
         // Non-default platforms (i.e. for Watchdog Git)
-        new PlatformReg("win-x86", "Windows", false),
-        new PlatformReg("linux-x86", "Linux", false),
-        new PlatformReg("linux-arm", "Linux", false),
         new PlatformReg("freebsd-x64", "FreeBSD", false),
     };
 


### PR DESCRIPTION
They don't compile and even if they did, I doubt they would work.

linux-x86 result
<img width="1253" height="879" alt="image" src="https://github.com/user-attachments/assets/99e04b8b-5cf3-415d-9b3f-639f29ba4280" />

win-x86 compiles and runs until a zstd error, providing your own zstd surprisingly runs! Sadly, ACZ throws OutOfMemory because 32 bits. If you provide a build.json and try to start the round, that will also throw OutOfMemory because 32 bits... but you can join the server, which is actually kinda impressive.

eventually, the server also crashes