### PR TITLE
Smuggler Satchel Heisen

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
@@ -242,13 +242,13 @@
   table: !type:AllSelector
     children:
     - !type:NestedSelector
+      tableId: RandomSatchelBurgerTable #2x medium
+    - !type:NestedSelector
       tableId: RandomSatchelPresentsOrToysTable #3x small
     - !type:NestedSelector
       tableId: RandomSatchelCashTable #1x small
     - !type:NestedSelector
       tableId: RandomSatchelWeaponTable #5x small
-    - !type:NestedSelector
-      tableId: RandomSatchelBurgerTable #5x small
     - !type:NestedSelector
       tableId: RandomSatchelGenericTableSmall #1x small
     - !type:NestedSelector
@@ -309,24 +309,18 @@
       amount: !type:RangeNumberSelector
         range: 1, 5
 
-- type: entityTable #5x small
+- type: entityTable #2x medium
   id: RandomSatchelBurgerTable
   table: !type:GroupSelector
+    amount: !type:RangeNumberSelector
+      range: 1, 2
     children:
     - id: SpaceCash100
       weight: 10
     - id: FoodBurgerAppendix
-      amount: !type:RangeNumberSelector
-        range: 1, 5
     - id: FoodBurgerEmpowered
-      amount: !type:RangeNumberSelector
-        range: 1, 5
     - id: FoodBurgerClown
-      amount: !type:RangeNumberSelector
-        range: 1, 5
     - id: FoodBurgerGhost
-      amount: !type:RangeNumberSelector
-        range: 1, 5
 
 - type: entityTable #1x small
   id: RandomSatchelGenericTableSmall

--- a/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/smuggler_tables.yml
@@ -312,7 +312,7 @@
 - type: entityTable #2x medium
   id: RandomSatchelBurgerTable
   table: !type:GroupSelector
-    amount: !type:RangeNumberSelector
+    rolls: !type:RangeNumberSelector
       range: 1, 2
     children:
     - id: SpaceCash100


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes the heisenburger test fail.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
```
  ----> NUnit.Framework.AssertionException : SERVER: 5.130s [ERRO] system.container_fill: Entity smuggler's satchel (38057/n38057, ClothingBackpackSatchelSmugglerFilled) with a EntityTableContainerFillComponent failed to insert an entity: spesos (38074/n38074, SpaceCash100).
Current contents:
	 - spesos (38058/n38058, SpaceCash100)
	 - spesos (38059/n38059, SpaceCash100)
	 - spesos (38060/n38060, SpaceCash100)
	 - spesos (38061/n38061, SpaceCash100)
	 - spesos (38062/n38062, SpaceCash100)
	 - ghost burger (38063/n38063, FoodBurgerGhost)
	 - ghost burger (38065/n38065, FoodBurgerGhost)
	 - ghost burger (38067/n38067, FoodBurgerGhost)
	 - ghost burger (38069/n38069, FoodBurgerGhost)
	 - ghost burger (38071/n38071, FoodBurgerGhost)
	 - spesos (38073/n38073, SpaceCash100)
```
## Technical details
<!-- Summary of code changes for easier review. -->
Moved the table to be the first spawn, just in case.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->