### PR TITLE
Update `ConstructionSystem` to support invisible layers that are between visible ones

### DIFF
--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -306,22 +306,7 @@ namespace Content.Client.Construction
                 var targetSprite = EnsureComp<SpriteComponent>(dummy);
                 EntityManager.System<AppearanceSystem>().OnChangeData(dummy, targetSprite);
 
-                for (var i = 0; i < targetSprite.AllLayers.Count(); i++)
-                {
-                    if (!targetSprite[i].Visible || !targetSprite[i].RsiState.IsValid)
-                        continue;
-
-                    var rsi = targetSprite[i].Rsi ?? targetSprite.BaseRSI;
-                    if (rsi is null || !rsi.TryGetState(targetSprite[i].RsiState, out var state) ||
-                        state.StateId.Name is null)
-                        continue;
-
-                    _sprite.AddBlankLayer((ghost.Value, sprite), i);
-                    _sprite.LayerSetSprite((ghost.Value, sprite), i, new SpriteSpecifier.Rsi(rsi.Path, state.StateId.Name));
-                    sprite.LayerSetShader(i, "unshaded");
-                    _sprite.LayerSetVisible((ghost.Value, sprite), i, true);
-                }
-
+                CopyVisibleSpriteLayersToGhost((ghost.Value, sprite), targetSprite);
                 Del(dummy);
             }
             else
@@ -331,6 +316,28 @@ namespace Content.Client.Construction
                 EnsureComp<WallMountComponent>(ghost.Value).Arc = new(Math.Tau);
 
             return true;
+        }
+
+        private void CopyVisibleSpriteLayersToGhost(Entity<SpriteComponent> ghost, SpriteComponent source)
+        {
+            // Uses sequential indexing for ghost layers to handle cases where
+            // invisible layers are between visible ones in the source sprite
+            var visibleLayers = 0;
+            foreach (var layer in source.AllLayers)
+            {
+                if (!layer.Visible || !layer.RsiState.IsValid)
+                    continue;
+
+                var rsi = layer.Rsi ?? source.BaseRSI;
+                if (rsi is null || !rsi.TryGetState(layer.RsiState, out var state) || state.StateId.Name is null)
+                    continue;
+
+                _sprite.AddBlankLayer(ghost, visibleLayers);
+                _sprite.LayerSetSprite(ghost.Owner, visibleLayers, new SpriteSpecifier.Rsi(rsi.Path, state.StateId.Name));
+                ghost.Comp.LayerSetShader(visibleLayers, "unshaded");
+                _sprite.LayerSetVisible(ghost.Owner, visibleLayers, true);
+                visibleLayers++;
+            }
         }
 
         private bool CheckConstructionConditions(ConstructionPrototype prototype, EntityCoordinates loc, Direction dir,


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This change was made for constructable struct cases when we need not visible layer between visible ones like `GlassBox` with `caplaser` state

## Why / Balance
It will allow to avoid exceptions in the future.
Current problem is that if we have this in prototype for example (GlassBox):
```yaml
  - type: Sprite
    noRot: true
    sprite: Structures/Storage/glassbox.rsi
    layers:
    - state: base
    - state: caplaser
      map: ["enum.ItemCabinetVisuals.Layer"]
      visible: false
    - state: glass
      map: ["enum.OpenableVisuals.Layer"]
```
The attempt to place ghost construction of it will throw exception because original code was using iteration counter as index for layers while skipping invisible ones for some iterations.
By presented example it was creating this layer index:
```yaml
`0, 2` -> Exception! Because we skipped the `1` wich is `caplaser` and is not visible
```
## Technical details
Adds new index value `visibleLayers` that increments when a system method executes successfully without returning. This index value is used here:
```C#
                _sprite.AddBlankLayer(ghost, visibleLayers);
                _sprite.LayerSetSprite(ghost.Owner, visibleLayers, new SpriteSpecifier.Rsi(rsi.Path, state.StateId.Name));
                ghost.Comp.LayerSetShader(visibleLayers, "unshaded");
                _sprite.LayerSetVisible(ghost.Owner, visibleLayers, true);
                visibleLayers++;
```
So it fixes the layer indexing.
Also some code was moved to a new method `CopyVisibleSpriteLayersToGhost` for a better readability.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
None