### PR TITLE
Add Blacklist To Cake Secret Stash

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -28,6 +28,13 @@
   - type: SecretStash
     maxItemSize: "Normal"
     secretStashName: secret-stash-cake
+    blacklist:
+      components:
+      - SecretStash # Prevents being able to insert cakes inside eachother
+      - NukeDisk # Could confuse the Nukies if they don't know that cakes have a stash.
+      tags:
+      - QuantumSpinInverter # It will cause issues with the grinder...
+      - FakeNukeDisk # So you can't tell if the nuke disk is real or fake depending on if it can be inserted or not.
     damageEatenItemInside:
       types:
         Slash: 7.5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Copied the blacklist from plushies to cakes, addresses #40669

## Why / Balance
If nuke disks shouldnt be able to be hidden in cakes they DEFINITELY shouldn't be able to be hidden inside cake slices.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: A blacklist has been added to cakes and cake slices stashes. This prevents the nuclear authentication disk from being hidden inside them.
