### PR TITLE
Added roundstart toolbelts for cargo technicians (with slightly different items than regular toolbelts)

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -13,6 +13,19 @@
       - id: NetworkConfigurator
 
 - type: entity
+  id: ClothingBeltUtilityCargo
+  parent: ClothingBeltUtility
+  suffix: Cargo
+  components:
+  - type: StorageFill
+    contents:
+      - id: CrowbarGreen
+      - id: Wrench
+      - id: Screwdriver
+      - id: UtilityKnife
+      - id: AppraisalTool
+
+- type: entity
   id: ClothingBeltUtilityEngineering
   parent: ClothingBeltUtility
   suffix: Engineering

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -19,8 +19,8 @@
 - type: startingGear
   id: CargoTechGear
   equipment:
+    belt: ClothingBeltUtilityCargo
     ears: ClothingHeadsetCargo
-    pocket1: AppraisalTool
   #storage:
     #back:
     #- Stuff


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Cargo technicians now spawn with toolbelts containing a crowbar, wrench, screwdriver, appraisal tool, and utility knife.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mostly a quality-of-life feature. These are all items that Cargo can already print from the autolathe (including the belt itself), and the tools in question have consistent utility for the job:
- Crowbar: used to dismantle certain special crates (namely livestock crates).
- Wrench: used to anchor crates.
- Screwdriver: used to dismantle most crates.
- Appraisal tool: used to measure sale prices and verify bounty completion. (Cargo technicians already spawn with one in their pocket, but it fits in the toolbelt so it might as well go in the toolbelt.)
- Utility knife: used to cut up cloth. Makes thematic sense for opening packages and stuff too though in practice most cargo techs *probably* shouldn't be doing that to the mail in actual gameplay because tampering with mail incurs a fine.

As mentioned earlier, these are all items that the autolathe can already print roundstart without much hassle (beyond getting the basic materials, which is not hard for cargo to do). That being said, making these roundstart gear makes them things that all cargo technicians will reliably have (which, notably, includes the knife, though said knife only does 5 damage to be fair), which is a possible balance concern.

## Technical details
<!-- Summary of code changes for easier review. -->
YAML changes to add the toolbelt and make it roundstart cargo tech gear.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1454" height="1080" alt="moss-cargotoolbelts" src="https://github.com/user-attachments/assets/b643bc00-d1b3-4452-9fe7-a1388bbc6be9" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Cargo Technicians now start the round with a toolbelt containing a few tools pertinent to their job.