### PR TITLE
Borg construction materials update

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -261,6 +261,7 @@
     - type: Tag
       tags:
       - Sheet
+      - ConstructionMaterials
     - type: Material
     - type: PhysicalComposition
       materialComposition:

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -261,7 +261,7 @@
     - type: Tag
       tags:
       - Sheet
-      - ConstructionMaterials
+      - ConstructionMaterial
     - type: Material
     - type: PhysicalComposition
       materialComposition:

--- a/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
@@ -60,9 +60,6 @@
         reagents:
         - ReagentId: Gold
           Quantity: 10
-  - type: Tag
-    tags:
-    - ConstructionMaterial
 
 - type: entity
   parent: IngotGold
@@ -108,9 +105,6 @@
         reagents:
         - ReagentId: Silver
           Quantity: 10
-  - type: Tag
-    tags:
-    - ConstructionMaterial
 
 - type: entity
   parent: IngotSilver

--- a/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
@@ -60,6 +60,9 @@
         reagents:
         - ReagentId: Gold
           Quantity: 10
+  - type: Tag
+    tags:
+    - ConstructionMaterial
 
 - type: entity
   parent: IngotGold
@@ -105,6 +108,9 @@
         reagents:
         - ReagentId: Silver
           Quantity: 10
+  - type: Tag
+    tags:
+    - ConstructionMaterial
 
 - type: entity
   parent: IngotSilver

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -571,6 +571,9 @@
   - type: Appearance
   - type: Item
     heldPrefix: bananium
+  - type: Tag
+    tags:
+    - ConstructionMaterial
 
 - type: entity
   parent: MaterialBananium

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -63,6 +63,9 @@
     prototype: CarpetCard
     doAfter: 0.5
     removeOnInteract: true
+  - type: Tag
+    tags:
+    - ConstructionMaterial
 
 - type: entity
   parent: MaterialCardboard


### PR DESCRIPTION
## About the PR
Added tags to additional materials required for the construction of certain structures and allow holding and insertion into lathes by the borg construction module. These include:  Cardboard, Bananium, Meat Sheet.

## Why / Balance
Borg modules with construction materials whitelisted were missing some required for certain constructions. 
They were also unable to place some of these materials in the lathes as well.
This allows borgs to pick up bananium to place in lathes for use by crew or construct structures made of this materials. Cardboard and meat sheets were also neglected when they are required for some construction, which this rectifies.

## Technical details
Addition of the `ConstructionMaterial` tag on the cardboard and meat sheet materials, as well as bananium for use with the relevant borg modules.

## Media
<img width="607" height="862" alt="image" src="https://github.com/user-attachments/assets/44ba2db3-e7d1-4c5c-a469-55fd7db46c88" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Allowed borg construction material module to hold cardboard, meat sheets, bananium, gold and silver ingots.
