### PR TITLE
Fix the wizard teleport scroll teleporting people into the wall

### DIFF
--- a/Content.Shared/Teleportation/Components/TeleportLocationsComponent.cs
+++ b/Content.Shared/Teleportation/Components/TeleportLocationsComponent.cs
@@ -49,8 +49,14 @@ public sealed partial class TeleportLocationsComponent : Component
     /// <summary>
     /// Maximum radius around the beacon the user could teleport to.
     /// </summary>
-    [DataField("maxRandomRadius"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float MaxRandomRadius = 4.0f;
+
+    /// <summary>
+    /// Maximum attempts to find a teleport location that isn't inside of a wall
+    /// </summary>
+    [DataField]
+    public int MaxTeleportAttempts = 20;
 }
 
 /// <summary>

--- a/Content.Shared/Teleportation/Systems/SharedTeleportLocationsSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportLocationsSystem.cs
@@ -18,7 +18,7 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _xform = default!;
 
     protected const string TeleportDelay = "TeleportDelay";
-    private const int MaxRandomTeleportAttempts = 20;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -40,7 +40,6 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
         if (!TryGetEntity(args.NetEnt, out var telePointEnt) || TerminatingOrDeleted(telePointEnt) || !HasComp<WarpPointComponent>(telePointEnt) || Delay.IsDelayed(ent.Owner, TeleportDelay))
             return;
 
-
         var comp = ent.Comp;
         var originEnt = args.Actor;
         var telePointXForm = Transform(telePointEnt.Value);
@@ -49,7 +48,7 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
         var newCoords = coords.Offset(_random.NextVector2(ent.Comp.MaxRandomRadius));
 
         // TODO: Turn this into a generic method for xform.
-        for (var i = 0; i < MaxRandomTeleportAttempts; i++)
+        for (var i = 0; i < ent.Comp.MaxTeleportAttempts; i++)
         {
             var randVector = _random.NextVector2(ent.Comp.MaxRandomRadius);
             newCoords = coords.Offset(randVector);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
quick fix to make the teleport scroll no longer teleport people inside of walls

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Some station anchors are in the wall, and if you teleport onto them you'll just get stuck in the wall and die.

## Technical details
<!-- Summary of code changes for easier review. -->
Just copy pasted the code from the hand teleporter which works well enough until theres a better solution for teleporting

Radius is low cause there shouldn't be any beacons buried that deep in the wall and also to prevent people from ending up too far away, idk.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/55bc5b71-a02f-44b7-a625-4483809aed6b

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
