### PR TITLE
Preserve Fire Alarm State

### DIFF
--- a/Content.Server/Atmos/Monitor/Components/FireAlarmComponent.cs
+++ b/Content.Server/Atmos/Monitor/Components/FireAlarmComponent.cs
@@ -3,4 +3,6 @@ namespace Content.Server.Atmos.Monitor.Components;
 [RegisterComponent]
 public sealed partial class FireAlarmComponent : Component
 {
+    [DataField("alarmTriggered")]
+    public bool AlarmTriggered = false;
 }


### PR DESCRIPTION
Fix for #12841

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Changes fire alarms so they have internal state to check whether they've been manually triggered.

Also changes fire alarms so they asserts a "Normal" state when not triggered, so it can work with other fire alarms and air alarms without stomping on them. That is, any "Danger" signal a firelock sees will trigger it - so you can hook multiple fire alarms and air alarms to a firelock and they should work together.

## Why / Balance
To fix #12841.

## Technical details
- Adds internal state to fire alarms.
- Stops fire alarms from clearing all alarm state from attached firelocks.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Preserve fire alarm state between power outages.