### PR TITLE
Prioritize spoon mixing over drinking

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ReactionMixerSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReactionMixerSystem.cs
@@ -19,10 +19,7 @@ public sealed partial class ReactionMixerSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<ReactionMixerComponent, AfterInteractEvent>(
-            OnAfterInteract,
-            before: [typeof(IngestionSystem)]
-        );
+        SubscribeLocalEvent<ReactionMixerComponent, AfterInteractEvent>(OnAfterInteract, before: [typeof(IngestionSystem)]);
         SubscribeLocalEvent<ReactionMixerComponent, ShakeEvent>(OnShake);
         SubscribeLocalEvent<ReactionMixerComponent, ReactionMixDoAfterEvent>(OnDoAfter);
     }

--- a/Content.Server/Chemistry/EntitySystems/ReactionMixerSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReactionMixerSystem.cs
@@ -19,7 +19,10 @@ public sealed partial class ReactionMixerSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<ReactionMixerComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<ReactionMixerComponent, AfterInteractEvent>(
+            OnAfterInteract,
+            before: [typeof(IngestionSystem)]
+        );
         SubscribeLocalEvent<ReactionMixerComponent, ShakeEvent>(OnShake);
         SubscribeLocalEvent<ReactionMixerComponent, ReactionMixDoAfterEvent>(OnDoAfter);
     }
@@ -29,12 +32,13 @@ public sealed partial class ReactionMixerSystem : EntitySystem
         if (!args.Target.HasValue || !args.CanReach || !entity.Comp.MixOnInteract)
             return;
 
-        if (!MixAttempt(entity, args.Target.Value, out var solution))
+        if (!MixAttempt(entity, args.Target.Value, out _))
             return;
 
         var doAfterArgs = new DoAfterArgs(EntityManager, args.User, entity.Comp.TimeToMix, new ReactionMixDoAfterEvent(), entity, args.Target.Value, entity);
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
+        args.Handled = true;
     }
 
     private void OnDoAfter(Entity<ReactionMixerComponent> entity, ref ReactionMixDoAfterEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR & Why / Balance
<!-- What did you change? -->
Pick up spoon
Left click drink with spoon
Both drinking and stirring doafter happen
Sadness.

This fixes that.

## Technical details
<!-- Summary of code changes for easier review. -->

Fix is to just make it so that stirring handles the interaction event and is definitely run before attempting to drink.
I can only assume there's some other interaction that might have a similar issue or get messed up by this, but eh. If you are using a mixing spoon on a drink you _probably_ wanna mix it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Much small change.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Stirring is once again prioritized over drinking. No longer will your bartender be very tempted to taste test your drink as they stir it.