### PR TITLE
Fix species default skin tones

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -205,6 +205,7 @@ namespace Content.Shared.Preferences
             return new()
             {
                 Species = species,
+                Appearance = HumanoidCharacterAppearance.DefaultWithSpecies(species),
             };
         }
 


### PR DESCRIPTION
## About the PR
Correctly apply default colours to all species where applicable, including Urists and the species example images in the guidebook.

With @Quantum-cross' permission, I'm seeing whether I can pull some bits of #36493 out into separate PRs to make that PR easier to review. Actual investigation and fix done by Quantum-cross, as reflected in the git log.

If there are issues that need to be fixed here, I expect I can likely address them.

Fixes #37282.

## Media
Before fix:
<img width="383" height="288" alt="image" src="https://github.com/user-attachments/assets/ca2a0a46-ce49-420a-bde6-dff400ff1bcb" />

After fix:
<img width="367" height="283" alt="image" src="https://github.com/user-attachments/assets/bef201f4-0c05-44b9-b3de-9b24169dd687" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
