### PR TITLE
Add high severity logging to stun prods

### DIFF
--- a/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/makeshiftstunprod.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/makeshiftstunprod.yml
@@ -5,6 +5,10 @@
     - node: start
       edges:
         - to: msstunprod
+          completed:
+          - !type:AdminLog
+            message: "Construction"
+            impact: High
           steps:
             - material: MetalRod
               amount: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Admin logging

## Why / Balance

## Technical details
Just yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
ADMIN:
- tweak: Stun prods are now high severity when crafted.