### PR TITLE
Fix ChangeComponentsSpellEvent, alter RGB wand and staff of Animation functionality

### DIFF
--- a/Content.Shared/Magic/Events/ChangeComponentSpellEvent.cs
+++ b/Content.Shared/Magic/Events/ChangeComponentSpellEvent.cs
@@ -17,6 +17,6 @@ public sealed partial class ChangeComponentsSpellEvent : EntityTargetActionEvent
 
     [DataField]
     [AlwaysPushInheritance]
-    public HashSet<string> ToRemove = new();
+    public ComponentRegistry ToRemove = new(); // Imp edit, changed to component registry
 
 }

--- a/Content.Shared/Magic/Events/ChangeComponentSpellEvent.cs
+++ b/Content.Shared/Magic/Events/ChangeComponentSpellEvent.cs
@@ -17,6 +17,6 @@ public sealed partial class ChangeComponentsSpellEvent : EntityTargetActionEvent
 
     [DataField]
     [AlwaysPushInheritance]
-    public ComponentRegistry ToRemove = new(); // Imp edit, changed to component registry
+    public ComponentRegistry ToRemove = new();
 
 }

--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -295,8 +295,8 @@ public abstract class SharedMagicSystem : EntitySystem
 
         ev.Handled = true;
 
-        RemoveComponents(ev.Target, ev.ToRemove);
-        AddComponents(ev.Target, ev.ToAdd);
+        EntityManager.RemoveComponents(ev.Target, ev.ToRemove); // imp
+        EntityManager.AddComponents(ev.Target, ev.ToAdd); // imp
     }
     // End Change Component Spells
     #endregion

--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -295,8 +295,8 @@ public abstract class SharedMagicSystem : EntitySystem
 
         ev.Handled = true;
 
-        EntityManager.RemoveComponents(ev.Target, ev.ToRemove); // imp
-        EntityManager.AddComponents(ev.Target, ev.ToAdd); // imp
+        EntityManager.RemoveComponents(ev.Target, ev.ToRemove);
+        EntityManager.AddComponents(ev.Target, ev.ToAdd);
     }
     // End Change Component Spells
     #endregion
@@ -352,28 +352,6 @@ public abstract class SharedMagicSystem : EntitySystem
         }
     }
 
-    private void AddComponents(EntityUid target, ComponentRegistry comps)
-    {
-        foreach (var (name, data) in comps)
-        {
-            if (HasComp(target, data.Component.GetType()))
-                continue;
-
-            var component = (Component)Factory.GetComponent(name);
-            var temp = (object)component;
-            _seriMan.CopyTo(data.Component, ref temp);
-            AddComp(target, (Component)temp!);
-        }
-    }
-
-    private void RemoveComponents(EntityUid target, HashSet<string> comps)
-    {
-        foreach (var toRemove in comps)
-        {
-            if (Factory.TryGetRegistration(toRemove, out var registration))
-                RemComp(target, registration.Type);
-        }
-    }
     // End Spell Helpers
     #endregion
     #region Touch Spells

--- a/Resources/Prototypes/Magic/animate_spell.yml
+++ b/Resources/Prototypes/Magic/animate_spell.yml
@@ -65,11 +65,9 @@
           - !type:PlaySoundBehavior
             sound:
               collection: MetalBreak
-      - type: Hands
       - type: CanEscapeInventory
-      - type: MobCollision
       toRemove:
-      - RequireProjectileTarget
-      - BlockMovement
-      - Item
-      - MeleeRequiresWield
+      - type: RequireProjectileTarget
+      - type: BlockMovement
+      - type: Item
+      - type: MeleeRequiresWield

--- a/Resources/Prototypes/Magic/staves.yml
+++ b/Resources/Prototypes/Magic/staves.yml
@@ -73,6 +73,7 @@
   - type: TargetAction
   - type: EntityTargetAction
     whitelist: { components: [ PointLight ] }
+    blacklist: { components: [ RgbLightController ] }
     event: !type:ChangeComponentsSpellEvent
       toAdd:
       - type: RgbLightController


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes the animate spell to now properly replace values, and makes it so the RGB wand can only apply to one light once (can't waste charges)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently the animate spell is broken. Lockers and other such entities with big resistances or entities with melee attacks were not replaced, causing them to either be nearly invincible (eating 5-6 kammerer shots) or incredibly weak/strong. This balances it so every animated item is roughly the same, minus hitbox size
This is not ideal in my opinion, but I'd rather not make a whole new event just for handling math on animating items at this moment, and it at least makes them less of a bitch to deal with. 
## Technical details
<!-- Summary of code changes for easier review. -->
Previously ChangeComponentsSpellEvent used custom functions to add and remove components, which meant that it couldn't edit components already on an entity. I made it so it uses the functions in entitymanager, which feels like a better solution.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
instances of ChangeComponentsSpellEvent that remove components need to have the components directly referenced instead of the component name as a string, as the type asked for was changed.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The Staff of Animation produces far more consistent results.
- fix: The RGB wand can only be used on a light once, no more eating charges!