### PR TITLE
Increased Nukie Playtime Requirements Slightly

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -7,6 +7,9 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 18000 # 5h
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 18000 # 5h
   guides: [ NuclearOperatives ]
 
 - type: antag
@@ -18,9 +21,12 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 18000 # 5h
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 18000 # 5h
   - !type:RoleTimeRequirement
     role: JobChemist
-    time: 10800 # 3h
+    time: 18000 # 5h
   guides: [ NuclearOperatives ]
 
 - type: antag
@@ -34,6 +40,9 @@
     time: 18000 # 5h
   - !type:DepartmentTimeRequirement
     department: Security
+    time: 18000 # 5h
+  - !type:DepartmentTimeRequirement
+    department: Command
     time: 18000 # 5h
   # should be changed to nukie playtime when thats tracked (wyci)
   guides: [ NuclearOperatives ]


### PR DESCRIPTION
## About the PR
Increased playtime requirements for all Nukie roles.

## Why / Balance
I've witnessed and participated in Nukie rounds where Operators don't know how to use their uplinks, guns, _or even suit internals._ I've seen rounds where the Corpsman doesn't know the advanced brute meds. I've been an Operator under Commanders that can't fly the Infiltrator.

Personally I think these requirements are still too low but I leave that up to maints to decide. I just want to draw attention to the fact that you can roll Nukie way earlier than you might know about several of the mechanics necessary to be competent enough to make it to the station, much less make the round interesting.

I know the intent of maints behind #36666 was to lower playtime requirements, but what I feel like with this PR is I am bringing Nukie requirements _up to the same standard HoS/Sec is held to._

It takes 12.5hrs minimum to roll SecOff, a role comparable to Operator.
It takes 20hrs minimum to roll HoS, a role comparable to Commander.
It only takes 5hrs minimum to roll Chemist, but I would argue that Corpsman is even more demanding than Commander in terms of game knowledge, so I felt comfortable upping the requirements there.

## Technical details
Operative playtime requirement increased by 5hrs for **Security** for 10hrs total.
Corpsman playtime requirement increased by 5hrs for **Security** and 2hrs for **Chemist** for 15hrs total.
Commander playtime requirement increased by 5hrs for **Command** for 15hrs total.

## Media
Operator
<img width="669" height="54" alt="Operator" src="https://github.com/user-attachments/assets/f84cb5a4-1618-4950-bbe3-0eeaee751da6" />
Corpsman
<img width="664" height="68" alt="Corpsman" src="https://github.com/user-attachments/assets/0e992240-1e87-4a08-9003-34fa02bac332" />
Commander
<img width="674" height="68" alt="Commander" src="https://github.com/user-attachments/assets/7e275172-cc52-4cd3-9163-823ca51f87df" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
NA

**Changelog**
:cl:
- tweak: Increased Nukie playtime requirements
