### PR TITLE
Predict LungSystem

### DIFF
--- a/Content.IntegrationTests/Tests/Body/LungTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LungTest.cs
@@ -1,7 +1,7 @@
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Components;
-using Content.Server.Body.Systems;
+using Content.Shared.Body.Systems;
 using Content.Shared.Body.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared;

--- a/Content.Server/Body/Components/LungComponent.cs
+++ b/Content.Server/Body/Components/LungComponent.cs
@@ -1,10 +1,10 @@
-using Content.Server.Body.Systems;
+using Content.Shared.Body.Systems;
 using Content.Shared.Alert;
 using Content.Shared.Atmos;
 using Content.Shared.Chemistry.Components;
 using Robust.Shared.Prototypes;
 
-namespace Content.Server.Body.Components;
+namespace Content.Shared.Body.Components;
 
 [RegisterComponent, Access(typeof(LungSystem))]
 public sealed partial class LungComponent : Component

--- a/Content.Server/Body/Systems/LungSystem.cs
+++ b/Content.Server/Body/Systems/LungSystem.cs
@@ -4,11 +4,13 @@ using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Atmos;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Clothing;
+using Content.Shared.Body.Components;
+using Content.Server.Body.Systems;
 using Content.Shared.Inventory.Events;
 using BreathToolComponent = Content.Shared.Atmos.Components.BreathToolComponent;
 using InternalsComponent = Content.Shared.Body.Components.InternalsComponent;
 
-namespace Content.Server.Body.Systems;
+namespace Content.Shared.Body.Systems;
 
 public sealed class LungSystem : EntitySystem
 {

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.EntityEffects;
 using Content.Shared.Alert;
 using Content.Shared.Atmos;
 using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
 using Content.Shared.Body.Events;
 using Content.Shared.Body.Prototypes;
 using Content.Shared.Chemistry.Components;


### PR DESCRIPTION
Untested yet. I would like to make sure all is accounted for before moving the files. Everything here is subject to change, and I would love more help or advice on this!

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Wanting to help #39550 efforts, I've moved the LungComponent to from Server to Shared, then LungSystem and RespiratiorSystem. Also adjusted LungTest, but only so it would use the correct using and let me build.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Prediction good!
Besides that, on a forked repo I wanted to work with the LungComponent in a SharedSystem for something combat related, but it turned into a whole mess from not being able to just get the Server Component into the system.
Lastly, when the above mentioned PR is merged, LungComponent will be the only organ-y component left in the body\component folder, which would be sad!

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`LungComponent ` has been moved to `Content.Shared.Body.Components`
`LungSystem ` has been moved to `Content.Shared.Body.Systems`

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
