### PR TITLE
fixed post checkout hook on vscode sourcecode manager

### DIFF
--- a/BuildChecker/git_helper.py
+++ b/BuildChecker/git_helper.py
@@ -13,7 +13,7 @@ from typing import List
 
 SOLUTION_PATH = Path("..") / "SpaceStation14.sln"
 # If this doesn't match the saved version we overwrite them all.
-CURRENT_HOOKS_VERSION = "3"
+CURRENT_HOOKS_VERSION = "4"
 QUIET = len(sys.argv) == 2 and sys.argv[1] == "--quiet"
 
 
@@ -79,7 +79,7 @@ def install_hooks():
     print("Hooks need updating.")
 
     hooks_target_dir = Path(run_command(["git", "rev-parse", "--git-path", "hooks"], True).stdout.strip())
-    hooks_source_dir = Path("hooks")
+    hooks_source_dir = Path("./hooks")
 
     # Clear entire tree since we need to kill deleted files too.
     for filename in os.listdir(hooks_target_dir):

--- a/BuildChecker/hooks/post-checkout
+++ b/BuildChecker/hooks/post-checkout
@@ -2,12 +2,12 @@
 
 gitroot=$(git rev-parse --show-toplevel)
 
-cd "$gitroot/BuildChecker" || exit
 
 if [[ $(uname) == MINGW* || $(uname) == CYGWIN* ]]; then
     # Windows
-    py -3 git_helper.py --quiet
+    py -3 "$gitroot/BuildChecker/git_helper.py" --quiet
 else
     # Not Windows, so probably some other Unix thing.
-    python3 git_helper.py --quiet
+    python3 "$gitroot/BuildChecker/git_helper.py" --quiet
 fi
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixed bug post checkout hook on vscode sourcecode manager which coused a error window to apper clamint drectory is not a git repository

## Technical details
Removed cd command in post checkout hook and writen the path from toplevel to the file directly

also changed path in git_helper.py hooks_source_dir to be relative to the file as it coused errors when the current directory wasnt in BuildChecker

moved hooks version to 4

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
requires to update git hooks by either by launching RUN_THIS.py or git_helper.py in BuildChecker directly

