### PR TITLE
Change Energy Shotgun to fit as a Warden weapon

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -839,16 +839,14 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: ProjectileBatteryAmmoProvider
-    proto: BulletLaserSpread
-    fireCost: 150
+    proto: BulletLaserSpreadNarrow
+    fireCost: 100
   - type: BatteryWeaponFireModes
     fireModes:
-    - proto: BulletLaserSpread
-      fireCost: 150
     - proto: BulletLaserSpreadNarrow
-      fireCost: 200
+      fireCost: 100
     - proto: BulletDisablerSmgSpread
-      fireCost: 120
+      fireCost: 60
   - type: Item
     size: Large
     sprite: Objects/Weapons/Guns/Battery/inhands_64x.rsi
@@ -860,13 +858,8 @@
     stealGroup: WeaponEnergyShotgun
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Battery
-    maxCharge: 1200
-    startingCharge: 1200
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 24
-    autoRechargePause: true
-    autoRechargePauseTime: 30
+    maxCharge: 600
+    startingCharge: 600
 
 - type: entity
   name: temperature gun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -840,13 +840,13 @@
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: BulletLaserSpreadNarrow
-    fireCost: 100
+    fireCost: 80
   - type: BatteryWeaponFireModes
     fireModes:
     - proto: BulletLaserSpreadNarrow
-      fireCost: 100
+      fireCost: 80
     - proto: BulletDisablerSmgSpread
-      fireCost: 60
+      fireCost: 48
   - type: Item
     size: Large
     sprite: Objects/Weapons/Guns/Battery/inhands_64x.rsi
@@ -858,8 +858,8 @@
     stealGroup: WeaponEnergyShotgun
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Battery
-    maxCharge: 600
-    startingCharge: 600
+    maxCharge: 480
+    startingCharge: 480
 
 - type: entity
   name: temperature gun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1305,7 +1305,7 @@
     spread: 30
 
 - type: entity
-  name: narrow laser barrage
+  name: lethal laser barrage
   id: BulletLaserSpreadNarrow
   categories: [ HideSpawnMenu ]
   parent: BulletLaser


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR changes the Energy shotgun to be more in line with its intended gameplay in Warden's hands, as #40615 moved it from being HoS equipment to Warden equipment.

1. Self-recharging has been removed.
2. The gun charges at 250% in rechargers compared to previously; a full charge is 24 seconds, or 4.8 seconds with a turbo recharger.
3. The gun no longer has a wide spread; it only toggles between narrow (renamed lethal) and disabling barrage modes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The Energy shotgun being given to Warden means it should get a balance pass to better fit the Warden's playstyle, to discourage handing it off to SecOffs/HoS out in the field. 

The Warden is expected to be in Security for the majority of the shift and therefore the self-recharging is not going to be necessary, as the Warden has easy access to rechargers within the department. With no self-recharging and no further changes the base time for a recharge would be 60 seconds, which would likely make the shotgun unreliable for any continued defense during pressed situations. Lowering it to 24 (or 4 seconds per lethal shot) still makes it a poor choice for constant upkeep but should allow for pushing back an assault and retreating to recharge. 

It might also encourage Wardens to get turbo rechargers for Security, which benefits the whole department.

The removal of the widespread is because its very wide spread largely favors ambush tactics that are more in line with antag gameplay or lethal arrests in maintenance than what one might experience in a Security department fight. You practically need to be inside of the enemy to make the widespread deal more damage than the narrow one. For this reason we've opted to remove it, which should hopefully also reduce the amount of accidental lethal firing caused by the multi toggle.

Please note that these values are for the purposes of playtesting the changes with the playerbase and will be tuned based on player feedback.

## Technical details
<!-- Summary of code changes for easier review. -->

Just yaml!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

It charges faster and doesn't do widespread shooting. It's pretty much the same.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The Energy Shotgun no longer has a self-recharge or wide fire mode, but charges faster in rechargers.
