### PR TITLE
Brought skeleton & borg gibbing in-line with regular gibbing methods

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -185,7 +185,8 @@
           params:
             volume: 5
     - trigger:
-        !type:DamageTrigger
+        !type:DamageTypeTrigger
+        damageType: Blunt
         damage: 300
       behaviors:
       - !type:PlaySoundBehavior

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -36,7 +36,8 @@
   - type: Destructible
     thresholds:
     - trigger:
-        !type:DamageTrigger
+        !type:DamageTypeTrigger
+        damageType: Blunt
         damage: 150
       behaviors:
       - !type:GibBehavior { }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I made borgs & skeletons gib only via blunt damage, as is standard for most everything else in-game.

## Why / Balance
This is to bring skeleton & borg gibbing methods in-line with every other gibbing method, and to make it more intuitive to newer players; this PR aims to achieve gibbing parity, and to remove the possibility of accidental gibbing for the following reasons;

1. "Accidental gibbing" It is mechanically unfun to be able to be gibbed instantly at range, without warning or any thought put into it; often, a player doesn't even _intend_ to gib the skeleton/borg, but accidentally does so as it doesn't take much, leaving both the player and the borg/skeleton feeling bad about what happened. (Clake, Laser pistol, Energy shotgun, Stinger grenade etc)

2. "Intentional gibbing" You can still gib skeletons & borgs relatively easily, it just requires intention now, as you can no longer just mindlessly shoot at the until they pop, you have to sit there for some time hitting them, which gives people time to consider whether or not they _should_ actually gib them or not, or engage in RP, etc.

3. "Intentional, unintended gibbing" Small scale antagonists like tarantulas, space carp, or rat kings can currently gib both borgs and skeletons, which can ruin the round for some players, all because they went crit near a carp/tarantula, and someone took a carp/tarantula role and decided to bite them a few dozen times.

I believe that unintentional gibbing should not be a thing, and that this will improve the QoL of these two roles considerably, to not have to stress about being instantly destroyed and removed from the round.

**Considerations to note:** The Syndicate Assault borgs, and the Xeno borgs may have to have special considerations on whether they should be able to be destroyed at a range for balance reasons; if these are a blocking issue, I can address that with coding help from another contributor/maint, hopefully.

## Technical details
I changed `!type:DamageTrigger` to
```
 !type:DamageTypeTrigger
 damageType: Blunt

```
## Media
<img width="326" height="305" alt="pierceborg" src="https://github.com/user-attachments/assets/2df2bd79-2ffb-4d72-821a-c55d1b99b7b2" />

<img width="302" height="302" alt="pierceskele" src="https://github.com/user-attachments/assets/1dc8eae1-71ea-4874-ba4d-48c63a988e67" />

https://github.com/user-attachments/assets/a3220fdb-527d-4746-b375-ef93cadcacd4


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Borgs & Skeletons only gib via blunt damage now