### PR TITLE
Moths can no longer eat warning cones (but actually this time).

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -185,6 +185,9 @@
       Plastic: 100
   - type: StaticPrice
     price: 25
+  - type: Tag
+    tags:
+    - WhitelistChameleon
 
 - type: entity
   parent: ClothingHeadBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Moths can no longer eat warning cones by making them not able to eat warning cones.

## Why / Balance
Addresses #40691
I'm not sure if this is the correct way to handle this? This is what I think was the correct way to handle this, this is how I was told as a way to fix it in howtocode, it works at least.

## Technical details
Restates tags for the warning cone, making it not have the clothmade tag.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Moths can no longer eat warning cones.
