### PR TITLE
Removed amber's warden enforcer

### DIFF
--- a/Resources/Maps/amber.yml
+++ b/Resources/Maps/amber.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 266.0.0
+  engineVersion: 267.2.0
   forkId: ""
   forkVersion: ""
-  time: 09/16/2025 02:17:32
-  entityCount: 24842
+  time: 10/08/2025 20:05:50
+  entityCount: 24841
 maps:
 - 1
 grids:
@@ -162602,13 +162602,6 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: WeaponShotgunEnforcer
-  entities:
-  - uid: 20591
-    components:
-    - type: Transform
-      pos: -22.486067,-6.1998725
-      parent: 2
 - proto: WeaponSubMachineGunWt550
   entities:
   - uid: 11313


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
no warben you cant have 2 shotguns

## Technical details
map

## Media
Before
<img width="65" height="72" alt="image" src="https://github.com/user-attachments/assets/fc89d6df-5d45-4a8b-8f5e-356666c0facf" />
After
<img width="93" height="107" alt="image" src="https://github.com/user-attachments/assets/26fd626f-4171-4fb4-8d66-d1fefbe3d4b5" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
no

**Changelog**
:cl:
- remove: On Amber, the wardens enforcer has been removed
