### PR TITLE
Add slowdown to nocturine, buff duration and minor delay reduction

### DIFF
--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -291,10 +291,6 @@
     Narcotic:
       effects: # It would be nice to have speech slurred or mumbly, but accents are a bit iffy atm. Same for distortion effects.
       - !type:MovespeedModifier
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Nocturine
-          min: 2
         walkSpeedModifier: 0.65
         sprintSpeedModifier: 0.65
       - !type:ModifyStatusEffect


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds a movement speed penalty to anyone injected with Nocturine and extends the duration slightly. It also does a minor delay reduction.

35% movement speed penalty
6s -> 5s delay
3s -> 6s duration

| Amount (units) | Old Duration  | New Duration |
| - | - | - |
| 10u | 7s | 10s |
| 20u | 27s | 30s |
| 30u | 47s | 50s |

This PR also fixes a bug where the wrong duration calculation was applied as a result of the bugfix in #39547.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The nocturine nerf in #40231 proved successful in making the chem feel a bit more fair, but it had a too strong counter in just running away. While the ideal use of the drug is on an unsuspecting person alone the 6 second grace period ended up being enough to allow someone to just book it to a public space even if they were distracted.

Adding a slowdown should counteract that; one can make a decent distance if one is aware and ready for the injection, but a surprise injection makes the distance much smaller. The delay has also been reduced slightly to accompany this. The slowdown should also make it more forgiving for new players who may have difficulty getting both injections in at once from a hypopen.

The duration has been extended slightly to make it easier to refill after injecting someone, both since the delay allows for a bit of a scramble and also to account for #40538.

There were attempts to introduce something like yawning or having slurred speech. The yawning didn't really work since it wasn't consistent (it's a probability-based chance) and would really be a bit of a nerf since it makes for an obvious signifier someone has been nocturine'd. Slurred speech didn't work since the current implementation sets the strength of the effect based on the time of the effect, leaving the slurred speech until *after* you've been noct'd. I've left a comment that these functionalities could be added in the future.

## Technical details
<!-- Summary of code changes for easier review. -->

Just yaml!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Had some minor recording difficulties! The yawn in the video below has been removed.

https://github.com/user-attachments/assets/c97bdb36-0fb3-42d7-8a7e-3f4922acee26

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Nocturine now slows the target down, with a longer duration and shorter delay before activating.
