### PR TITLE
Captain and HoP now require Cargo/Service playtime

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -8,6 +8,9 @@
       department: Cargo
       time: 4h
     - !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 4h
+    - !type:DepartmentTimeRequirement
       department: Engineering
       time: 4h
     - !type:DepartmentTimeRequirement
@@ -18,9 +21,6 @@
       time: 4h
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 4h
-    - !type:DepartmentTimeRequirement
-      department: Service
       time: 4h
     - !type:DepartmentTimeRequirement
       department: Command

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -8,6 +8,9 @@
       department: Cargo
       time: 2.5h
     - !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 2.5h
+    - !type:DepartmentTimeRequirement
       department: Engineering
       time: 2.5h
     - !type:DepartmentTimeRequirement
@@ -18,9 +21,6 @@
       time: 2.5h
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 2.5h
-    - !type:DepartmentTimeRequirement
-      department: Service
       time: 2.5h
     - !type:DepartmentTimeRequirement
       department: Command


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Captain and Head of Personnel now require playtime in the Cargo and Service departments to be unlocked; 4 hours for Captain and 2.5 hours for Head of Personnel (the same as their other departmental unlock requirements).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's weird that these departments are outright excluded from these roles' requirements; the Captain is generally expected to fill in any staffing shortages on the station (and the HoP is expected to be acting captain in the event of the actual Captain's disappearance), so they should have at least reasonable familiarity with all departments. Also, the Head of Personnel is _the head of the Service department_ so not requiring _any_ Service playtime is baffling.

## Technical details
<!-- Summary of code changes for easier review. -->
Additional DepartmentTimeRequirements added to the files in Resources/Prototypes/Roles/Jobs/Command/

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="964" height="377" alt="moss-cargocaptainplaytime" src="https://github.com/user-attachments/assets/a5dc372d-082d-4411-8773-1309902459cc" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Captain and Head of Personnel now require some Cargo/Service playtime to be unlocked.
