### PR TITLE
Fix zombie locked rotation

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -156,7 +156,6 @@ public sealed partial class ZombieSystem
         var combat = EnsureComp<CombatModeComponent>(target);
         RemComp<PacifiedComponent>(target);
         _combat.SetCanDisarm(target, false, combat);
-        _combat.SetInCombatMode(target, true, combat);
 
         //This is the actual damage of the zombie. We assign the visual appearance
         //and range here because of stuff we'll find out later


### PR DESCRIPTION
## About the PR
Fixes #28048

## Technical details
Simply remove one line:
`_combat.SetInCombatMode(target, true, combat)`

`SetInCombatMode` from `SharedCombatModeSystem` does not perform any necessary actions for the zombie to function (specifically in `ZombifyEntity` function). The player can turn on combat mode manually, and for NPCs, the HTN system will do this when attacking. There is simply no need for this line, and it also fixes the previously mentioned issue. 

## Media

https://github.com/user-attachments/assets/a5ff292f-56ea-4813-b8d2-0eb376ef55ca


https://github.com/user-attachments/assets/fe0756d3-9dcc-4946-b3e8-b045d5d56b0a


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: B_Kirill
- fix: Fixed blocked rotation of zombie NPCs.
