### PR TITLE
Inventory + Storage toolshed query commands

### DIFF
--- a/Content.Server/Inventory/InventoryCommand.cs
+++ b/Content.Server/Inventory/InventoryCommand.cs
@@ -65,7 +65,6 @@ public sealed class InventoryCommand : ToolshedCommand
         return items;
     }
 
-
     [CommandImplementation("getnamed")]
     public IEnumerable<EntityUid> InventoryGetNamed([PipedArgument] IEnumerable<EntityUid> ents, string slotName)
     {
@@ -102,6 +101,7 @@ public sealed class InventoryCommand : ToolshedCommand
     public EntityUid? InventoryForcePut([PipedArgument] IEnumerable<EntityUid> ents,
         EntityUid itemEnt,
         SlotFlags slotFlag) => InventoryPutEnumerableBase(ents, itemEnt, slotFlag, PutType.ForcePut);
+
     [CommandImplementation("forcespawn")]
     public EntityUid? InventoryForceSpawn([PipedArgument] IEnumerable<EntityUid> ents,
         EntProtoId itemEnt,
@@ -111,6 +111,7 @@ public sealed class InventoryCommand : ToolshedCommand
     public EntityUid? InventoryPut([PipedArgument] IEnumerable<EntityUid> ents,
         EntityUid itemEnt,
         SlotFlags slotFlag) => InventoryPutEnumerableBase(ents, itemEnt, slotFlag, PutType.Put);
+
     [CommandImplementation("spawn")]
     public EntityUid? InventorySpawn([PipedArgument] IEnumerable<EntityUid> ents,
         EntProtoId itemEnt,
@@ -120,6 +121,7 @@ public sealed class InventoryCommand : ToolshedCommand
     public EntityUid? InventoryTryPut([PipedArgument] IEnumerable<EntityUid> ents,
         EntityUid itemEnt,
         SlotFlags slotFlag) => InventoryPutEnumerableBase(ents, itemEnt, slotFlag, PutType.Put);
+
     [CommandImplementation("tryspawn")]
     public EntityUid? InventoryTrySpawn([PipedArgument] IEnumerable<EntityUid> ents,
         EntProtoId itemEnt,
@@ -129,11 +131,11 @@ public sealed class InventoryCommand : ToolshedCommand
     public EntityUid? InventoryEnsure([PipedArgument] IEnumerable<EntityUid> ents,
         EntityUid itemEnt,
         SlotFlags slotFlag) => InventoryPutEnumerableBase(ents, itemEnt, slotFlag, PutType.Ensure);
+
     [CommandImplementation("ensurespawn")]
     public EntityUid? InventoryEnsureSpawn([PipedArgument] IEnumerable<EntityUid> ents,
         EntProtoId itemEnt,
         SlotFlags slotFlag) => InventorySpawnEnumerableBase(ents, itemEnt, slotFlag, PutType.Ensure);
-
 
     private EntityUid? InventorySpawnEnumerableBase(IEnumerable<EntityUid> targetEnts,
         EntProtoId itemToInsert,
@@ -157,6 +159,7 @@ public sealed class InventoryCommand : ToolshedCommand
         Del(spawnedItem);
         return null;
     }
+
     private EntityUid? InventoryPutEnumerableBase(IEnumerable<EntityUid> targetEnts,
         EntityUid itemToInsert,
         SlotFlags slotFlags,

--- a/Content.Server/Storage/StorageCommand.cs
+++ b/Content.Server/Storage/StorageCommand.cs
@@ -32,7 +32,6 @@ public sealed class StorageCommand : ToolshedCommand
             : null;
     }
 
-
     [CommandImplementation("fasttake")]
     public IEnumerable<EntityUid> StorageFastTake([PipedArgument] IEnumerable<EntityUid> storageEnts) =>
         storageEnts.Select(StorageFastTake).OfType<EntityUid>();
@@ -54,11 +53,10 @@ public sealed class StorageCommand : ToolshedCommand
     }
 
     [CommandImplementation("query")]
-    public IEnumerable<EntityUid> StorageQuery([PipedArgument] IEnumerable<EntityUid> storageEnts, bool recurseOnInternalStorage) =>
-        storageEnts.SelectMany(x => StorageQueryRecursibleBase(x, recurseOnInternalStorage));
+    public IEnumerable<EntityUid> StorageQuery([PipedArgument] IEnumerable<EntityUid> storageEnts, bool recursive) =>
+        storageEnts.SelectMany(x => StorageQueryRecursiveBase(x, recursive));
 
-
-    public IEnumerable<EntityUid> StorageQueryRecursibleBase(EntityUid storageEnt, bool recursive)
+    public IEnumerable<EntityUid> StorageQueryRecursiveBase(EntityUid storageEnt, bool recursive)
     {
         _storage ??= GetSys<SharedStorageSystem>();
         _container ??= GetSys<SharedContainerSystem>();
@@ -72,12 +70,11 @@ public sealed class StorageCommand : ToolshedCommand
         {
             foreach (var ent in containedEntities)
             {
-                containedEntities = containedEntities.Concat(StorageQueryRecursibleBase(ent, true));
+                containedEntities = containedEntities.Concat(StorageQueryRecursiveBase(ent, true));
             }
 
         }
 
         return containedEntities;
     }
-
 }

--- a/Resources/Locale/en-US/commands/toolshed/inventory-command.ftl
+++ b/Resources/Locale/en-US/commands/toolshed/inventory-command.ftl
@@ -19,4 +19,4 @@ command-description-inventory-ensure =
 command-description-inventory-ensurespawn =
     Spawns a given prototype on the first piped entity that has a slot matching the given flag if none exists, passing through the UID of whatever is in the slot by the end.
 command-description-inventory-query =
-    Gets all entities in an entity's inventory.
+    Gets the entities in the inventory slots of the piped entities and passes them along.

--- a/Resources/Locale/en-US/commands/toolshed/storage-command.ftl
+++ b/Resources/Locale/en-US/commands/toolshed/storage-command.ftl
@@ -3,4 +3,4 @@ command-description-storage-fasttake =
 command-description-storage-insert =
     Inserts the piped entity into the given storage entity.
 command-description-storage-query =
-    Gets all entities in a given storage entity.
+    Gets the entities in the storagebase of the piped entities and passes them along.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the inventory:query and storage:query toolshed commands.

They respectively get a list of all entities in an inventory or in a storage entity

## Why / Balance
@Kowlin wanted admin abuse tools

## Technical details
Adds the commands

## Media
<img width="1356" height="682" alt="image" src="https://github.com/user-attachments/assets/e4e98334-6350-4553-8692-140bbd5e9783" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: UpAndLeaves
ADMIN
- add: Added storage:query and inventory:query commands
