### PR TITLE
Fix teleport scroll teleporting into walls

### DIFF
--- a/Content.Server/Tabletop/TabletopSystem.Map.cs
+++ b/Content.Server/Tabletop/TabletopSystem.Map.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Shared.GameTicking;
+using Content.Shared.Maths;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 
@@ -37,7 +38,7 @@ namespace Content.Server.Tabletop
         /// <returns></returns>
         private Vector2 GetNextTabletopPosition()
         {
-            return UlamSpiral(++_tabletops) * TabletopSeparation;
+            return UlamSpiral.Point(++_tabletops) * TabletopSeparation;
         }
 
         /// <summary>
@@ -57,34 +58,6 @@ namespace Content.Server.Tabletop
             // Lighting is always disabled in tabletop world.
             mapComp.LightingEnabled = false;
             Dirty(mapUid, mapComp);
-        }
-
-        /// <summary>
-        ///     Algorithm for mapping scalars to 2D positions in the same pattern as an Ulam Spiral.
-        /// </summary>
-        /// <param name="n">Scalar to map to a 2D position. Must be greater than or equal to 1.</param>
-        /// <returns>The mapped 2D position for the scalar.</returns>
-        private Vector2i UlamSpiral(int n)
-        {
-            var k = (int)MathF.Ceiling((MathF.Sqrt(n) - 1) / 2);
-            var t = 2 * k + 1;
-            var m = (int)MathF.Pow(t, 2);
-            t--;
-
-            if (n >= m - t)
-                return new Vector2i(k - (m - n), -k);
-
-            m -= t;
-
-            if (n >= m - t)
-                return new Vector2i(-k, -k + (m - n));
-
-            m -= t;
-
-            if (n >= m - t)
-                return new Vector2i(-k + (m - n), k);
-
-            return new Vector2i(k, k - (m - n - t));
         }
 
         private void OnRoundRestart(RoundRestartCleanupEvent _)

--- a/Content.Server/Teleportation/TeleportLocationsSystem.cs
+++ b/Content.Server/Teleportation/TeleportLocationsSystem.cs
@@ -37,7 +37,7 @@ public sealed partial class TeleportLocationsSystem : SharedTeleportLocationsSys
 
     protected override void OnTeleportToLocationRequest(Entity<TeleportLocationsComponent> ent, ref TeleportLocationDestinationMessage args)
     {
-        if (Delay.IsDelayed(ent.Owner, TeleportDelay))
+        if (IsDelayed(ent))
             return;
 
         if (!string.IsNullOrWhiteSpace(ent.Comp.Speech))

--- a/Content.Server/Teleportation/TeleportLocationsSystem.cs
+++ b/Content.Server/Teleportation/TeleportLocationsSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Chat.Systems;
 using Content.Shared.Chat;
+using Content.Shared.Popups;
 using Content.Shared.Teleportation;
 using Content.Shared.Teleportation.Components;
 using Content.Shared.Teleportation.Systems;
@@ -15,6 +16,7 @@ namespace Content.Server.Teleportation;
 public sealed partial class TeleportLocationsSystem : SharedTeleportLocationsSystem
 {
     [Dependency] private ChatSystem _chat = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
 
     public override void Initialize()
@@ -47,6 +49,13 @@ public sealed partial class TeleportLocationsSystem : SharedTeleportLocationsSys
         }
 
         base.OnTeleportToLocationRequest(ent, ref args);
+    }
+
+    protected override void HandleTeleportDestinationObstructed(EntityUid userUid)
+    {
+        // Client can't know if the destination is obstructed if it's not loaded.
+        var msg = Loc.GetString("teleportation-menu-destination-obstructed");
+        _popup.PopupEntity(msg, userUid, userUid, PopupType.MediumCaution);
     }
 
     // If it's in shared this doesn't populate the points on the UI

--- a/Content.Shared/Maths/UlamSpiral.cs
+++ b/Content.Shared/Maths/UlamSpiral.cs
@@ -5,10 +5,13 @@ public static class UlamSpiral
     /// <summary>
     ///     Algorithm for mapping scalars to 2D positions in the same pattern as an Ulam Spiral.
     /// </summary>
-    /// <param name="n">Scalar to map to a 2D position. Must be greater than or equal to 1.</param>
+    /// <param name="n">Scalar to map to a 2D position. Returns a zero vector for values smaller than 1.</param>
     /// <returns>The mapped 2D position for the scalar.</returns>
-    private Vector2i UlamSpiral(int n)
+    public static Vector2i Point(int n)
     {
+        if (n <= 0)
+            return new Vector2i(0, 0);
+
         var k = (int)MathF.Ceiling((MathF.Sqrt(n) - 1) / 2);
         var t = 2 * k + 1;
         var m = (int)MathF.Pow(t, 2);

--- a/Content.Shared/Maths/UlamSpiral.cs
+++ b/Content.Shared/Maths/UlamSpiral.cs
@@ -32,4 +32,13 @@ public static class UlamSpiral
 
         return new Vector2i(k, k - (m - n - t));
     }
+
+    /// <summary>
+    ///     Returns the largest value for which <see cref="Point"> will generate a point within a <paramref name="maxDistance"> Chebyshev distance from origin.
+    /// </summary>
+    public static int PointsForMaxDistance(int maxDistance)
+    {
+        var x = maxDistance * 2 + 1;
+        return x * x;
+    }
 }

--- a/Content.Shared/Maths/UlamSpiral.cs
+++ b/Content.Shared/Maths/UlamSpiral.cs
@@ -1,0 +1,32 @@
+namespace Content.Shared.Maths;
+
+public static class UlamSpiral
+{
+    /// <summary>
+    ///     Algorithm for mapping scalars to 2D positions in the same pattern as an Ulam Spiral.
+    /// </summary>
+    /// <param name="n">Scalar to map to a 2D position. Must be greater than or equal to 1.</param>
+    /// <returns>The mapped 2D position for the scalar.</returns>
+    private Vector2i UlamSpiral(int n)
+    {
+        var k = (int)MathF.Ceiling((MathF.Sqrt(n) - 1) / 2);
+        var t = 2 * k + 1;
+        var m = (int)MathF.Pow(t, 2);
+        t--;
+
+        if (n >= m - t)
+            return new Vector2i(k - (m - n), -k);
+
+        m -= t;
+
+        if (n >= m - t)
+            return new Vector2i(-k, -k + (m - n));
+
+        m -= t;
+
+        if (n >= m - t)
+            return new Vector2i(-k + (m - n), k);
+
+        return new Vector2i(k, k - (m - n - t));
+    }
+}

--- a/Content.Shared/Teleportation/Systems/SharedTeleportLocationsSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportLocationsSystem.cs
@@ -13,13 +13,14 @@ namespace Content.Shared.Teleportation.Systems;
 /// </summary>
 public abstract partial class SharedTeleportLocationsSystem : EntitySystem
 {
-    [Dependency] protected UseDelaySystem Delay = default!;
+    [Dependency] private UseDelaySystem Delay = default!;
 
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private SharedUserInterfaceSystem _ui = default!;
     [Dependency] private SharedTransformSystem _xform = default!;
 
     protected const string TeleportDelay = "TeleportDelay";
+    protected const string TeleportFailedDelay = "TeleportFailedDelay";
 
     public override void Initialize()
     {
@@ -29,9 +30,14 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
         SubscribeLocalEvent<TeleportLocationsComponent, TeleportLocationDestinationMessage>(OnTeleportToLocationRequest);
     }
 
+    protected bool IsDelayed(EntityUid entityUid)
+    {
+        return Delay.IsDelayed(entityUid, TeleportDelay) || Delay.IsDelayed(entityUid, TeleportFailedDelay);
+    }
+
     private void OnUiOpenAttempt(Entity<TeleportLocationsComponent> ent, ref ActivatableUIOpenAttemptEvent args)
     {
-        if (!Delay.IsDelayed(ent.Owner, TeleportDelay))
+        if (!IsDelayed(ent))
             return;
 
         args.Cancel();
@@ -39,19 +45,24 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
 
     protected virtual void OnTeleportToLocationRequest(Entity<TeleportLocationsComponent> ent, ref TeleportLocationDestinationMessage args)
     {
-        if (!TryGetEntity(args.NetEnt, out var telePointEnt) || TerminatingOrDeleted(telePointEnt) || !HasComp<WarpPointComponent>(telePointEnt) || Delay.IsDelayed(ent.Owner, TeleportDelay))
+        if (!TryGetEntity(args.NetEnt, out var telePointEnt) || TerminatingOrDeleted(telePointEnt) || !HasComp<WarpPointComponent>(telePointEnt) || IsDelayed(ent))
             return;
 
         var comp = ent.Comp;
         var originEnt = args.Actor;
         var telePointXForm = Transform(telePointEnt.Value);
 
-        if (ChooseSafeLocation((telePointEnt.Value, telePointXForm), maxDistance: 3) is not { } safeTargetMapCoords)
-            return;
-
+        // Spawn effect even if the target is unsafe - the failure is funny.
         var originEntXForm = Transform(originEnt);
-
         SpawnAtPosition(comp.TeleportEffect, originEntXForm.Coordinates);
+
+        if (ChooseSafeLocation((telePointEnt.Value, telePointXForm), maxDistance: 3) is not { } safeTargetMapCoords)
+        {
+            // Prevent spamming effects if the target is obstructed.
+            Delay.TryResetDelay(ent.Owner, true, id: TeleportFailedDelay);
+
+            return;
+        }
 
         _xform.SetMapCoordinates(originEnt, safeTargetMapCoords);
         SpawnAtPosition(comp.TeleportEffect, originEntXForm.Coordinates);

--- a/Content.Shared/Teleportation/Systems/SharedTeleportLocationsSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportLocationsSystem.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Teleportation.Systems;
 /// </summary>
 public abstract partial class SharedTeleportLocationsSystem : EntitySystem
 {
-    [Dependency] private UseDelaySystem Delay = default!;
+    [Dependency] private UseDelaySystem _delay = default!;
 
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private SharedUserInterfaceSystem _ui = default!;
@@ -32,7 +32,7 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
 
     protected bool IsDelayed(EntityUid entityUid)
     {
-        return Delay.IsDelayed(entityUid, TeleportDelay) || Delay.IsDelayed(entityUid, TeleportFailedDelay);
+        return _delay.IsDelayed(entityUid, TeleportDelay) || _delay.IsDelayed(entityUid, TeleportFailedDelay);
     }
 
     private void OnUiOpenAttempt(Entity<TeleportLocationsComponent> ent, ref ActivatableUIOpenAttemptEvent args)
@@ -59,7 +59,7 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
         if (ChooseSafeLocation((telePointEnt.Value, telePointXForm), maxDistance: 3) is not { } safeTargetMapCoords)
         {
             // Prevent spamming effects if the target is obstructed.
-            Delay.TryResetDelay(ent.Owner, true, id: TeleportFailedDelay);
+            _delay.TryResetDelay(ent.Owner, true, id: TeleportFailedDelay);
 
             return;
         }
@@ -67,7 +67,7 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
         _xform.SetMapCoordinates(originEnt, safeTargetMapCoords);
         SpawnAtPosition(comp.TeleportEffect, originEntXForm.Coordinates);
 
-        Delay.TryResetDelay(ent.Owner, true, id: TeleportDelay);
+        _delay.TryResetDelay(ent.Owner, true, id: TeleportDelay);
 
         if (!ent.Comp.CloseAfterTeleport)
             return;

--- a/Content.Shared/Teleportation/Systems/SharedTeleportLocationsSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportLocationsSystem.cs
@@ -1,7 +1,10 @@
-﻿using Content.Shared.Teleportation.Components;
+﻿using Content.Shared.Maths;
+using Content.Shared.Teleportation.Components;
 using Content.Shared.Timing;
 using Content.Shared.UserInterface;
 using Content.Shared.Warps;
+using Robust.Shared.Map;
+using System.Numerics;
 
 namespace Content.Shared.Teleportation.Systems;
 
@@ -12,6 +15,7 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
 {
     [Dependency] protected UseDelaySystem Delay = default!;
 
+    [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private SharedUserInterfaceSystem _ui = default!;
     [Dependency] private SharedTransformSystem _xform = default!;
 
@@ -42,11 +46,15 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
         var originEnt = args.Actor;
         var telePointXForm = Transform(telePointEnt.Value);
 
-        SpawnAtPosition(comp.TeleportEffect, Transform(originEnt).Coordinates);
+        if (ChooseSafeLocation((telePointEnt.Value, telePointXForm), maxDistance: 3) is not { } safeTargetMapCoords)
+            return;
 
-        _xform.SetMapCoordinates(originEnt, _xform.GetMapCoordinates(telePointEnt.Value, telePointXForm));
+        var originEntXForm = Transform(originEnt);
 
-        SpawnAtPosition(comp.TeleportEffect, telePointXForm.Coordinates);
+        SpawnAtPosition(comp.TeleportEffect, originEntXForm.Coordinates);
+
+        _xform.SetMapCoordinates(originEnt, safeTargetMapCoords);
+        SpawnAtPosition(comp.TeleportEffect, originEntXForm.Coordinates);
 
         Delay.TryResetDelay(ent.Owner, true, id: TeleportDelay);
 
@@ -55,5 +63,36 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
 
         // Teleport's done, now tell the BUI to close if needed.
         _ui.CloseUi(ent.Owner, TeleportLocationUiKey.Key);
+    }
+
+    private MapCoordinates? ChooseSafeLocation(Entity<TransformComponent> targetEntity, int maxDistance)
+    {
+        // If the target point is on a grid, use that grid's rotation.
+        var gridTransform = targetEntity.Comp.GridUid is { } grid
+            ? Matrix3Helpers.CreateTransform(Vector2.Zero, _xform.GetWorldRotation(Transform(grid)))
+            : Matrix3x2.Identity;
+        return ChooseSafeLocation(_xform.GetMapCoordinates(targetEntity), maxDistance, gridTransform);
+    }
+
+    private MapCoordinates? ChooseSafeLocation(MapCoordinates targetCoords, int maxDistance, Matrix3x2 gridTransform)
+    {
+        var maxAttempts = UlamSpiral.PointsForMaxDistance(maxDistance);
+        // Transforms an offset from the target entity into the final world space position.
+        var worldToGridSpacePlusTargetPos = gridTransform * Matrix3x2.CreateTranslation(targetCoords.Position);
+
+        for (var attempt = 0; attempt <= maxAttempts; attempt++)
+        {
+            var offset = UlamSpiral.Point(attempt);
+            var offsetWorldPos = Vector2.Transform(new Vector2(offset.X, offset.Y), worldToGridSpacePlusTargetPos);
+            var offsetCoords = new MapCoordinates(offsetWorldPos, targetCoords.MapId);
+
+            if (!_lookup.AnyEntitiesIntersecting(offsetCoords, LookupFlags.Static))
+            {
+                // Selected location is not inside a wall.
+                return offsetCoords;
+            }
+        }
+
+        return null;
     }
 }

--- a/Content.Shared/Teleportation/Systems/SharedTeleportLocationsSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportLocationsSystem.cs
@@ -61,6 +61,8 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
             // Prevent spamming effects if the target is obstructed.
             _delay.TryResetDelay(ent.Owner, true, id: TeleportFailedDelay);
 
+            HandleTeleportDestinationObstructed(originEnt);
+
             return;
         }
 
@@ -74,6 +76,13 @@ public abstract partial class SharedTeleportLocationsSystem : EntitySystem
 
         // Teleport's done, now tell the BUI to close if needed.
         _ui.CloseUi(ent.Owner, TeleportLocationUiKey.Key);
+    }
+
+    /// <summary>
+    /// Called when the destination was obstructed and the user wasn't teleported.
+    /// </summary>
+    protected virtual void HandleTeleportDestinationObstructed(EntityUid userUid)
+    {
     }
 
     /// <remarks>

--- a/Resources/Locale/en-US/teleportation/teleportation-menu-gui.ftl
+++ b/Resources/Locale/en-US/teleportation/teleportation-menu-gui.ftl
@@ -1,5 +1,6 @@
 ﻿## Default
 teleportation-menu-default-window-title = Teleportation Menu
+teleportation-menu-destination-obstructed = You don't feel like you went anywhere...
 
 ## Wizard
 teleportation-scroll-window-title = Teleportation Scroll

--- a/Resources/Prototypes/Magic/teleport_scroll.yml
+++ b/Resources/Prototypes/Magic/teleport_scroll.yml
@@ -24,3 +24,5 @@
     delays:
       TeleportDelay: !type:UseDelayInfo
         length: 300
+      TeleportFailedDelay: !type:UseDelayInfo
+        length: 10

--- a/Resources/Prototypes/Magic/teleport_scroll.yml
+++ b/Resources/Prototypes/Magic/teleport_scroll.yml
@@ -30,3 +30,5 @@
     delays:
       TeleportDelay: !type:UseDelayInfo
         length: 300
+      TeleportFailedDelay: !type:UseDelayInfo
+        length: 10


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

The teleport scroll now checks for tiles without obstructions around the target in an Ulam spiral pattern.

## Why / Balance

Prevents wizards from getting stuck in walls after teleporting, because it's not very fun.

If a teleport fails due to this check, the user still sends the teleportation message, and an effect is still spawned at their current (unchanged) position, but the cooldown is reduced to 10 seconds - coincidentally, about as long as the smoke takes to clear.

This prevents the wizard from having to wait for 5 minutes if they made a poor choice while not on the station, allows the crew to hurt the wizard through smoke if on the station and being used as a means of escape, and is just funny because it makes the wizard look incompetent.

## Technical details

Split into multiple commits for review convenience.

Closes #40695 (does the same thing but using random checks)
Allows revert of #40755

<!-- ## Media
Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- ## Breaking changes
List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: opl
- fix: Wizard's teleport scroll can no longer teleport its user into a wall.
