### PR TITLE
Remove rag forensics cleaning

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -362,7 +362,6 @@
     - type: Tag
       tags:
         - Mop
-    - type: CleansForensics
     - type: Fiber
       fiberColor: fibers-white
     - type: DnaSubstanceTrace


### PR DESCRIPTION
## About the PR
Attempt 2 at Title

## Why / Balance
Let me preface this justification by saying I play Detective a lot.

The ability to clean forensics with damp rags is counter intuitive to the forensics system as a whole, and can lead to confusion for newer Detective players.

The most common method of cleaning forensics, soap, leaves a residue that is mostly unique, letting you know that the item in question has been cleaned. This is done by leaving a residue.

When cleaning forensics with the rag, it leaves a fiber, which is much more commonly associated with gloves. This can lead to the scenario in which a newer Detective, one who is used to dealing with residues or implants with DNA, can find an empty implanter with only fibers. How is this player supposed to know you can clean implanters with rags aside from doing a code-dive?

Even if I, an incredibly seasoned Detective player, find an implanter cleaned with a rag, what am I supposed to do? Rags can be crafted for a single cloth and water is abundant on the station. Soap, on the other hand, is relatively rare. Unlike soap, which you might have a reason to keep because slipping is so powerful, rags can be disposed of without a care.

I just see no reason to include such a powerful way to negate the forensics system that more than likely only serves to confuse newer Detective players. (DNA is already SUPER flimsy IMO, considering you can just EAT the soap you use to clean the implanters. DNA is practically worthless against smart antagonists...)

## Technical details
1 liner

## Media
Before PR | Cleaned
<img width="599" height="276" alt="Forensics" src="https://github.com/user-attachments/assets/4cb82f91-5cef-49fd-8462-412d0ee8ca24" />

After PR | Clean't
<img width="403" height="549" alt="Clean't" src="https://github.com/user-attachments/assets/bcfc4887-bcf8-4063-b64d-b2aec84d305b" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
NA

**Changelog**
:cl:
- remove: Rags can no longer be used to remove evidence.