### PR TITLE
Packed: Replace duplicate security camera router with sci router

### DIFF
--- a/Resources/Maps/packed.yml
+++ b/Resources/Maps/packed.yml
@@ -85872,13 +85872,15 @@ entities:
     - type: Transform
       pos: 14.5,-17.5
       parent: 2
-- proto: SurveillanceCameraRouterSecurity
+- proto: SurveillanceCameraRouterScience
   entities:
   - uid: 4644
     components:
     - type: Transform
       pos: 15.5,-19.5
       parent: 2
+- proto: SurveillanceCameraRouterSecurity
+  entities:
   - uid: 6899
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Replaced duplicate camera router for security, which was next to the science telecom server, with a camera router for science.

Fixes #40780

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Science was missing a camera router, sec had two.

<!-- ## Media
Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- ## Breaking changes
List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

<!-- **Changelog**
Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
