### PR TITLE
Space Carp are fireproof now

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -181,7 +181,11 @@
     - type: HTN
       rootTask:
         task: DragonCarpCompound
-
+    - type: Flammable
+      damage:
+       types: {}
+    - type: Temperature
+      heatDamageThreshold: 1200
 - type: entity
   id: MobCarpDungeon
   parent: MobCarp

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -106,7 +106,7 @@
     - RadiationProtection
     - Adrenaline
   - type: Temperature
-    heatDamageThreshold: 800
+    heatDamageThreshold: 2400
   - type: Metabolizer
     solutionOnBody: false
     updateInterval: 0.25


### PR DESCRIPTION
## About the PR
Made Space Dragon and Carp more resistant to higher temperatures, and made Carp immune to fire.

## Why / Balance
Space Dragons can too easily destroy their entire horde of Carp due to the fire spreading between them. This change enables them to not be too concerned with fire spread or high temps, but they can still be damaged by the Space Dragon's fireball itself.

## Technical details
YAML Warrior

## Media

https://github.com/user-attachments/assets/1738ea8c-498b-44a5-928e-28fe76ad8f12

A direct impact fireball.
<img width="403" height="326" alt="Direct_Impact" src="https://github.com/user-attachments/assets/4f5d8059-a402-446b-bb5d-5a066aa9fa33" />

Damage from the outer fireball explosion radius.
<img width="367" height="400" alt="Outer_Explosion" src="https://github.com/user-attachments/assets/4a67d2cb-2eb2-49c1-ba88-5a85beacc1aa" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
NA

**Changelog**
:cl:
- tweak: Space Dragon and Carp are more heat resistant. Carp no longer take fire damage.