### PR TITLE
hugbox tag fix

### DIFF
--- a/Resources/Locale/en-US/_Moffstation/recipes/tags.ftl
+++ b/Resources/Locale/en-US/_Moffstation/recipes/tags.ftl
@@ -1,1 +1,0 @@
-﻿construction-graph-tag-boxhug = a box of hugs

--- a/Resources/Locale/en-US/recipes/tags.ftl
+++ b/Resources/Locale/en-US/recipes/tags.ftl
@@ -8,6 +8,7 @@ construction-graph-tag-clown-bike-horn = bike horn
 construction-graph-tag-clowne-horn = broken bike horn
 construction-graph-tag-happy-honk-meal = happy honk meal
 construction-graph-tag-woeful-cluwne-meal = woeful cluwne meal
+construction-graph-tag-boxhug = a box of hugs
 
 # mime
 construction-graph-tag-suspenders = suspenders


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
construction tag was in moffstation namespace because it was ported

## Why / Balance
pro

## Technical details
just moves it and nukes the folder

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
n/a
