### PR TITLE
Flash immunity examine visibility toggle

### DIFF
--- a/Content.Shared/Flash/Components/FlashImmunityComponent.cs
+++ b/Content.Shared/Flash/Components/FlashImmunityComponent.cs
@@ -15,4 +15,10 @@ public sealed partial class FlashImmunityComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool Enabled = true;
+
+    /// <summary>
+    /// Should the flash protection be shown when examining the entity?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool ShowInExamine = true;
 }

--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -268,6 +268,7 @@ public abstract class SharedFlashSystem : EntitySystem
 
     private void OnExamine(Entity<FlashImmunityComponent> ent, ref ExaminedEvent args)
     {
-        args.PushMarkup(Loc.GetString("flash-protection"));
+        if (ent.Comp.ShowInExamine)
+            args.PushMarkup(Loc.GetString("flash-protection"));
     }
 }

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -102,6 +102,7 @@
   - type: FireVisuals
     alternateState: Standing
   - type: FlashImmunity
+    showInExamine: false
   - type: Inventory
     femaleDisplacements:
       jumpsuit:


### PR DESCRIPTION
## About the PR
[#37267](https://github.com/space-wizards/space-station-14/pull/37267) added text to items that protect against flashes in examine, however, that PR did not take into account that `FlashImmunityComponent` can be added to mobs.

## Technical details
Added `ShowInExamine` flag to `FlashImmunityComponent`.

## Media
Before
<img width="426" height="262" alt="1" src="https://github.com/user-attachments/assets/ae221023-e5ab-4e17-a76f-ef28702955a9" />

After
<img width="381" height="239" alt="2" src="https://github.com/user-attachments/assets/9299691a-75dc-47c0-8b7e-640da5de54eb" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
