### PR TITLE
Use PredictedQueueDel in SharedDestructibleSystem.DestroyEntity

### DIFF
--- a/Content.Shared/Destructible/SharedDestructibleSystem.cs
+++ b/Content.Shared/Destructible/SharedDestructibleSystem.cs
@@ -1,9 +1,9 @@
-﻿namespace Content.Shared.Destructible;
+namespace Content.Shared.Destructible;
 
 public abstract class SharedDestructibleSystem : EntitySystem
 {
     /// <summary>
-    ///     Force entity to be destroyed and deleted.
+    /// Force entity to be destroyed and deleted.
     /// </summary>
     public bool DestroyEntity(EntityUid owner)
     {
@@ -15,12 +15,12 @@ public abstract class SharedDestructibleSystem : EntitySystem
         var eventArgs = new DestructionEventArgs();
         RaiseLocalEvent(owner, eventArgs);
 
-        QueueDel(owner);
+        PredictedQueueDel(owner);
         return true;
     }
 
     /// <summary>
-    ///     Force entity to break.
+    /// Force entity to break.
     /// </summary>
     public void BreakEntity(EntityUid owner)
     {
@@ -30,7 +30,7 @@ public abstract class SharedDestructibleSystem : EntitySystem
 }
 
 /// <summary>
-///     Raised before an entity is about to be destroyed and deleted
+/// Raised before an entity is about to be destroyed and deleted
 /// </summary>
 public sealed class DestructionAttemptEvent : CancellableEntityEventArgs
 {
@@ -38,7 +38,7 @@ public sealed class DestructionAttemptEvent : CancellableEntityEventArgs
 }
 
 /// <summary>
-///     Raised when entity is destroyed and about to be deleted.
+/// Raised when entity is destroyed and about to be deleted.
 /// </summary>
 public sealed class DestructionEventArgs : EntityEventArgs
 {
@@ -46,7 +46,7 @@ public sealed class DestructionEventArgs : EntityEventArgs
 }
 
 /// <summary>
-///     Raised when entity was heavy damage and about to break.
+/// Raised when entity was heavy damage and about to break.
 /// </summary>
 public sealed class BreakageEventArgs : EntityEventArgs
 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Minor refactor. Currently SharedDestructibleSystem.DestroyEntity is used only in server-side, but should be okay to be used in shared now. DamageChangedEvent still awaits moving to shared tho.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
