### PR TITLE
Fixed stunned holoparasites

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -111,6 +111,13 @@
     - type: Tag
       tags:
         - CannotSuicide
+    - type: StatusEffect
+      whitelist:
+        components:
+        - Mobstate
+      blacklist:
+        tags:
+        - StunImmune
 
 # From the uplink injector
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Holoparasites can no longer be shot with tasers and stuff

## Why / Balance
Fixes https://github.com/space-wizards/space-station-14/issues/40836


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/254f854e-1beb-4ec2-95c6-b2728ad692bb


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Holoparasites can no longer be stunned
