### PR TITLE
Logging for turret controller

### DIFF
--- a/Content.Server/TurretController/DeployableTurretControllerSystem.cs
+++ b/Content.Server/TurretController/DeployableTurretControllerSystem.cs
@@ -112,7 +112,7 @@ public sealed partial class DeployableTurretControllerSystem : SharedDeployableT
             [CmdSetArmamemtState] = armamentState,
         };
 
-        _adminLogger.Add(LogType.Chat, LogImpact.Medium, $"{ToPrettyString(user)} set {ToPrettyString(ent)} to {armamentState}");
+        _adminLogger.Add(LogType.ItemConfigure, LogImpact.Medium, $"{ToPrettyString(user)} set {ToPrettyString(ent)} to {armamentState}");
 
         _deviceNetwork.QueuePacket(ent, null, payload, device: device);
     }
@@ -139,7 +139,7 @@ public sealed partial class DeployableTurretControllerSystem : SharedDeployableT
 
         foreach (var exemption in exemptions)
         {
-            _adminLogger.Add(LogType.Chat, LogImpact.Medium, $"{ToPrettyString(user)} set {ToPrettyString(ent)} authorization of {exemption} to {enabled}");
+            _adminLogger.Add(LogType.ItemConfigure, LogImpact.Medium, $"{ToPrettyString(user)} set {ToPrettyString(ent)} authorization of {exemption} to {enabled}");
         }
 
         _deviceNetwork.QueuePacket(ent, null, payload, device: device);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds admin logging for armament setting, and authorized personnel for the turret controller. Related to issue #40846

## Why / Balance
Admin Logging is good

## Technical details
Added admin logging to DeployableTurretControllerSystems

## Media
<img width="1400" height="930" alt="image" src="https://github.com/user-attachments/assets/a73805bf-4b99-40b3-b1b7-ed1a8ee3663a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**

Admin logging, no cl
