### PR TITLE
Fix generating migrations with USE_SYSTEM_SQLITE

### DIFF
--- a/Content.Server.Database/ModelSqlite.cs
+++ b/Content.Server.Database/ModelSqlite.cs
@@ -17,6 +17,9 @@ namespace Content.Server.Database
     {
         public SqliteServerDbContext(DbContextOptions<SqliteServerDbContext> options) : base(options)
         {
+#if USE_SYSTEM_SQLITE
+            SQLitePCL.raw.SetProvider(new SQLitePCL.SQLite3Provider_sqlite3());
+#endif
         }
 
         protected override void OnConfiguring(DbContextOptionsBuilder options)


### PR DESCRIPTION
## About the PR
Generating migrations via *Content.Server.Database/add-migration.sh* fails on systems with `USE_SYSTEM_SQLITE` (e.g. FreeBSD) due to a SQLite3 provider not being initialized.