### PR TITLE
Just dump your bag into the reagent grinder!

### DIFF
--- a/Content.Shared/Kitchen/Events.cs
+++ b/Content.Shared/Kitchen/Events.cs
@@ -1,0 +1,6 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Kitchen;
+[Serializable, NetSerializable]
+public sealed partial class ContainerDoAfterEvent : SimpleDoAfterEvent { }

--- a/Resources/Locale/en-US/kitchen/components/reagent-grinder-component.ftl
+++ b/Resources/Locale/en-US/kitchen/components/reagent-grinder-component.ftl
@@ -3,6 +3,7 @@
 reagent-grinder-bound-user-interface-instant-button = INSTANT
 reagent-grinder-bound-user-interface-cook-time-label = COOK TIME
 reagent-grinder-component-cannot-put-entity-message = You can't put this in the reagent grinder!
+reagent-grinder-component-storage-full-message = The grinder is full.
 
 grinder-menu-title = All-In-One Grinder 3000
 grinder-menu-grind-button = Grind


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Lets you insert the contents of a held bag directly into a reagent grinder, with a doafter.
Rework/Reimplementation of my work on https://github.com/RonRonstation/ronstation/pull/323, which was heavily inspired by work on https://github.com/space-wizards/space-station-14/pull/32663
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Its a nice convenience feature that makes grinding lots of items much less click-intensive and make botany much easier on my old man hands.
## Technical details
<!-- Summary of code changes for easier review. -->
Adds to the existing OnInteractUsing function in ReagentGrinderSystem. If you are holding something with a storage component, a doafter will start, after which anything inside the storage that has the Extractable component will be added to the storage of the grinder (respecting the maximum capacity of the reagent grinder).
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/4e6262a3-cec0-47ac-81df-eb71e4bdfdb5


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Not that I'm aware of.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: You may now dump extractable items in bags (or other containers) directly into a reagent grinder.

