### PR TITLE
Change guidebook auto-expand depth

### DIFF
--- a/Content.Client/UserInterface/Controls/FancyTree/FancyTree.xaml.cs
+++ b/Content.Client/UserInterface/Controls/FancyTree/FancyTree.xaml.cs
@@ -137,6 +137,7 @@ public sealed partial class FancyTree : Control
         {
             item.Padding.MinWidth = parent.Padding.MinWidth + Indentation;
             parent.Body.AddChild(item);
+            item.ParentItem = parent;
         }
 
         item.UpdateIcon();

--- a/Content.Client/UserInterface/Controls/FancyTree/TreeItem.xaml.cs
+++ b/Content.Client/UserInterface/Controls/FancyTree/TreeItem.xaml.cs
@@ -23,6 +23,7 @@ public sealed partial class TreeItem : PanelContainer
     public event Action<TreeItem>? OnDeselected;
 
     public bool Expanded { get; private set; } = false;
+    public TreeItem? ParentItem;
 
     public TreeItem()
     {

--- a/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
+++ b/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
@@ -208,9 +208,19 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
         }
         _guideWindow.UpdateGuides(guides, rootEntries, forceRoot, selected);
 
-        // Expand up to depth-2.
+        // Expand only the root entries.
         _guideWindow.Tree.SetAllExpanded(false);
-        _guideWindow.Tree.SetAllExpanded(true, 1);
+        _guideWindow.Tree.SetAllExpanded(true, 0);
+
+        // Always expand the currently selected entry & all of its parents
+        if (selected != null && _guideWindow.Tree.Items.TryFirstOrDefault(x => x.Metadata is GuideEntry entry && entry.Id == selected, out var item))
+        {
+            while (item != null)
+            {
+                item.SetExpanded(true);
+                item = item.ParentItem;
+            }
+        }
 
         _guideWindow.OpenCenteredRight();
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reduces the number of guide entries that are expanded when the guidebook is opened.

This also fixes a minor bug, where re-opening the guidebook wouldn't auto-expand the previously selected entry.

## Why / Balance
IMO this probably makes the guidebook a bit less overwhelming for new players.

## Media

Before:
<img width="236" height="926" alt="Content Client_dpkVr2rV1s" src="https://github.com/user-attachments/assets/21c3056b-ff03-4606-a25f-53e0e9b5cf9b" />

After:
<img width="200" height="363" alt="Content Client_Y89oBs7eMf" src="https://github.com/user-attachments/assets/af953067-315c-4938-a484-d322442386a7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
