### PR TITLE
Fix power sensor looking at wrong electrical network

### DIFF
--- a/Content.Server/DeviceLinking/Systems/PowerSensorSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/PowerSensorSystem.cs
@@ -98,28 +98,19 @@ public sealed class PowerSensorSystem : EntitySystem
         var nodeContainer = Comp<NodeContainerComponent>(uid);
         var deviceNode = (CableDeviceNode) nodeContainer.Nodes[cable.Node];
 
-        var charge = 0f;
-        var chargingState = false;
-        var dischargingState = false;
-
         // update state based on the power stats retrieved from the selected power network
         var xform = _xformQuery.GetComponent(uid);
         if (!TryComp(xform.GridUid, out MapGridComponent? grid))
             return;
 
-        var cables = deviceNode.GetReachableNodes(xform, _nodeQuery, _xformQuery, grid, EntityManager);
-        foreach (var node in cables)
-        {
-            if (node.NodeGroup == null || node.NodeGroupID != deviceNode.NodeGroupID)
-                continue;
+        if (deviceNode.NodeGroup == null)
+            return;
 
-            var group = (IBasePowerNet) node.NodeGroup;
-            var stats = _powerNet.GetNetworkStatistics(group.NetworkNode);
-            charge = comp.Output ? stats.OutStorageCurrent : stats.InStorageCurrent;
-            chargingState = charge > comp.LastCharge;
-            dischargingState = charge < comp.LastCharge;
-            break;
-        }
+        var group = (IBasePowerNet) deviceNode.NodeGroup;
+        var stats = _powerNet.GetNetworkStatistics(group.NetworkNode);
+        var charge = comp.Output ? stats.OutStorageCurrent : stats.InStorageCurrent;
+        var chargingState = charge > comp.LastCharge;
+        var dischargingState = charge < comp.LastCharge;
 
         comp.LastCharge = charge;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Fixed power sensor looking at a random (the first connected) electrical network if it happened to be the first cable in the list of connected cables.

If you had an LV wire connected that was added first, then the power sensor looked at the LV network state, even if it was configured to look at HV network state.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Because it didn't work reliably

## Technical details
<!-- Summary of code changes for easier review. -->

Added missing check in loop that iterated through connected cables. It never compared against the configured network.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

### Before fix

https://github.com/user-attachments/assets/b4eee246-4cbe-4c90-ae5d-705acbaf8006

In this particular case I determined it was looking at the MV network to determine charging/discharging state.


### After fix

https://github.com/user-attachments/assets/e71de6a5-dc9e-4b42-b696-0c52b89dba68


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: redmushie
- fix: Fixed power sensors not respecting their configured network setting
