### PR TITLE
Fix powered lights reacting to signals going low

### DIFF
--- a/Content.Shared/Light/EntitySystems/SharedPoweredLightSystem.cs
+++ b/Content.Shared/Light/EntitySystems/SharedPoweredLightSystem.cs
@@ -116,6 +116,11 @@ public abstract class SharedPoweredLightSystem : EntitySystem
 
     private void OnSignalReceived(Entity<PoweredLightComponent> ent, ref SignalReceivedEvent args)
     {
+        var state = SignalState.Momentary;
+        args.Data?.TryGetValue(DeviceNetworkConstants.LogicState, out state);
+        if (state == SignalState.Low)
+            return;
+
         if (args.Port == ent.Comp.OffPort)
             SetState(ent, false, ent.Comp);
         else if (args.Port == ent.Comp.OnPort)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Fix powered lights reacting to signals going Low.

E.g.: If some input signal is connected to the "ON" port of a light, then when this signal becomes Low (from a previously High state), the light also got turned on.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Caused buggy behavior (see demos with sound ON)


## Technical details
<!-- Summary of code changes for easier review. -->

Added check that signal explicitly wasn't Low.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

About these demos, power sensors have a Charging and Discharging output that update **in the same tick**. Since lights also react to signals becoming Low instead of just High, this causes the light to behave erratically (and to the player: incorrectly).

And yes I've also tested more normal use-cases like directional and momentary switches, those are not affected by this change and remain behaving correctly.

### Before fix

Watch with sound, you can hear the light react:

https://github.com/user-attachments/assets/2494d178-bfa9-4649-a58a-7270ceef24f8

### After fix

https://github.com/user-attachments/assets/c50c6cca-d1e7-4ff8-bf5a-cec5879d1d62


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

Nah
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
