### PR TITLE
Fixes parcels and parcel wrapped humanoids being invulnerable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/parcel_wrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/parcel_wrap.yml
@@ -80,6 +80,17 @@
   - type: Destructible
     thresholds:
     - trigger:
+        !type:DamageTrigger
+        damage: 8
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Effects/poster_broken.ogg
+          params:
+            volume: -4
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
         !type:DamageTypeTrigger
         damageType: Slash
         damage: 5
@@ -130,7 +141,6 @@
       sprite: Objects/Misc/ParcelWrap/paper_labels.rsi
       map: ["enum.PaperLabelVisuals.Layer"]
 
-
 - type: entity
   parent: BaseWrappedParcel
   id: WrappedParcelHumanoid
@@ -155,21 +165,6 @@
         - MobMask
         layer:
         - MobLayer
-  - type: Damageable
-    damageContainer: Inorganic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 5
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          path: /Audio/Effects/poster_broken.ogg
-          params:
-            volume: -4
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
 
 - type: entity
   parent: BaseItem


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This is a bugfix for: https://github.com/space-wizards/space-station-14/pull/40911

Courtesy of Bald Man/Devin Foster -  (Discord: b.a.l.d_m.a.n), it was discovered that wrapping a humanoid in parcel wrap renders them nigh invulnerable to various types of damage such as nuclear detonations and gunfire. 

Through testing I found that the issue was related to a lack of any additional damagetypes/DamageTriggers being added to WrappedParcelHumanoid. Meaning that it was only able to be damaged by slashing. This PR resolves that issue by adding a DamageTrigger which enables the parcel wrap to be properly destroyed by any Inorganic-applicable damage, such as nuclear detonations, or gunfire. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The ability to survive nuclear detonations, admeme-levels of gunfire, or being hurled into a sun was not intended.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a generic DamageTrigger to the BaseWrappedParcel which resolves the issue with both the humanoid and standard parcel wrap applications being invulnerable.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1003" height="857" alt="ShareX_govdAvRUJC" src="https://github.com/user-attachments/assets/99e4a889-8ab4-4c98-8dbb-e57cd1c3494a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

#### Changelog

:cl:
- fix: Fixed parcels being indestructible for all damage types except Slash damage.