### PR TITLE
Fix wielding two-handed items with only one hand

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -449,31 +449,16 @@ public abstract partial class SharedHandsSystem
     }
 
     /// <summary>
-    /// Counts the number of hands that can are empty or can be emptied by dropping an item.
+    /// Counts the number of hands that are empty or can be emptied by dropping an item.
     /// Unremoveable items will cause a hand to not be freeable.
     /// </summary>
-    public int CountFreeableHands(Entity<HandsComponent> hands)
+    /// <param name="except">The hand this entity is in will be ignored when counting.</param>
+    public int CountFreeableHands(Entity<HandsComponent> hands, EntityUid? except = null)
     {
         var freeable = 0;
         foreach (var name in hands.Comp.Hands.Keys)
         {
-            if (HandIsEmpty(hands.AsNullable(), name) || CanDropHeld(hands, name))
-                freeable++;
-        }
-
-        return freeable;
-    }
-
-    /// <summary>
-    /// Counts the number of hands that can are empty or can be emptied by dropping an item, ignoring the hand the <paramref name="except"/> entity is in.
-    /// Unremoveable items will cause a hand to not be freeable.
-    /// </summary>
-    public int CountFreeableHandsExcept(Entity<HandsComponent> hands, EntityUid except)
-    {
-        var freeable = 0;
-        foreach (var name in hands.Comp.Hands.Keys)
-        {
-            if (GetHeldItem(hands.AsNullable(), name) == except)
+            if (except != null && GetHeldItem(hands.AsNullable(), name) == except)
                 continue;
 
             if (HandIsEmpty(hands.AsNullable(), name) || CanDropHeld(hands, name))

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -259,7 +259,7 @@ public abstract class SharedWieldableSystem : EntitySystem
             return false;
         }
 
-        if (_hands.CountFreeableHandsExcept((user, hands), uid) < component.FreeHandsRequired)
+        if (_hands.CountFreeableHands((user, hands), except: uid) < component.FreeHandsRequired)
         {
             if (!quiet)
             {


### PR DESCRIPTION
## About the PR
Title
Thanks to @VerinSenpai for writing an integration test that found this bug.
To reproduce on master:
- Use the `removehand` command so that you only have one hand
- Spawn a baseball bat or mosin
- successfully wield it despite not having a free hand

## Why / Balance
bugfix

## Technical details
`CanWield` was comparing the number of freeable hands. However that included the hand the weapon was held in, which should not count as dropable when trying to wield it.
To fix this we add a new method to count free hands that can ignore a given item when counting.
We cannot just subtract 1 because the weapon itself might be unremoveable.

## Media
![ss14](https://github.com/user-attachments/assets/fdae4956-fc1a-47c7-997d-5b1756fe758c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed being able to wield two-handed weapons when having only one hand.
