### PR TITLE
Fix Ninja EMP themselves.

### DIFF
--- a/Content.Shared/Power/EntitySystems/SharedBatterySystem.cs
+++ b/Content.Shared/Power/EntitySystems/SharedBatterySystem.cs
@@ -9,7 +9,6 @@ public abstract class SharedBatterySystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<BatteryComponent, EmpAttemptEvent>(OnEmpAttempt);
         SubscribeLocalEvent<BatteryComponent, EmpPulseEvent>(OnEmpPulse);
     }
 
@@ -19,11 +18,6 @@ public abstract class SharedBatterySystem : EntitySystem
         UseCharge(entity, args.EnergyConsumption, entity.Comp);
         // Apply a cooldown to the entity's self recharge if needed to avoid it immediately self recharging after an EMP.
         TrySetChargeCooldown(entity);
-    }
-
-    private void OnEmpAttempt(Entity<BatteryComponent> entity, ref EmpAttemptEvent args)
-    {
-
     }
 
     public virtual float UseCharge(EntityUid uid, float value, BatteryComponent? battery = null)

--- a/Content.Shared/PowerCell/SharedPowerCellSystem.cs
+++ b/Content.Shared/PowerCell/SharedPowerCellSystem.cs
@@ -74,9 +74,9 @@ public abstract class SharedPowerCellSystem : EntitySystem
         RaiseLocalEvent(uid, new PowerCellChangedEvent(true), false);
     }
 
-    private void OnCellEmpAttempt(EntityUid uid, PowerCellComponent component, EmpAttemptEvent args)
+    private void OnCellEmpAttempt(Entity<PowerCellComponent> entity, ref EmpAttemptEvent args)
     {
-        var parent = Transform(uid).ParentUid;
+        var parent = Transform(entity).ParentUid;
         // relay the attempt event to the slot so it can cancel it
         if (HasComp<PowerCellSlotComponent>(parent))
             RaiseLocalEvent(parent, ref args);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Stopped Ninjas from EMPing their power cells...

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Unintended bug from EMP to shared refactor.

## Technical details
<!-- Summary of code changes for easier review. -->
A by ref event wasn't using ref in SharedPowerCellSystem
Changed two event subscriptions to Entity<T> type so they can properly yell if they're not read/written as a ref.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
