### PR TITLE
Create WieldingRequiresMultipleHandsTest.cs

### DIFF
--- a/Content.IntegrationTests/Tests/Hands/WieldingTests.cs
+++ b/Content.IntegrationTests/Tests/Hands/WieldingTests.cs
@@ -1,6 +1,5 @@
 ﻿using Content.IntegrationTests.Tests.Interaction;
 using Content.Shared.Wieldable.Components;
-using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.Hands;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Requires #40966. Note that until that PR is merged, this test will fail.

Superseded by #41028 (No hard feelings 😢)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
See #40966

## Technical details
<!-- Summary of code changes for easier review. -->
Test first places a mosin in the players hand and fetches the wieldable component from it.
Next it gets the hand count for the player entity. This is done so we can check to ensure the player still only has one hand, otherwise this test is pointless.
Verifies that the mosin was spawned in not wielded.
Interacts with the mosin to wield it and then checks again that it is not wielded.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->