### PR TITLE
Change vulp whine emote name to crying

### DIFF
--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -496,7 +496,7 @@
       collection: VulpkaninSnarls
     Bark:
       collection: VulpkaninBarks
-    Whine:
+    Crying:
       collection: VulpkaninWhines
     Howl:
       collection: VulpkaninHowls
@@ -528,7 +528,7 @@
       collection: VulpkaninSnarls
     Bark:
       collection: VulpkaninBarks
-    Whine:
+    Crying:
       collection: VulpkaninWhines
     Howl:
       collection: VulpkaninHowls

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -236,24 +236,6 @@
   - snarling
 
 - type: emote
-  id: Whine
-  name: chat-emote-name-whine
-  category: Vocal
-  available: false
-  whitelist:
-    components:
-    - Vocal
-  blacklist:
-    components:
-    - BorgChassis
-  chatMessages: ["chat-emote-msg-whine"]
-  chatTriggers:
-  - whine
-  - whines
-  - whined
-  - whining
-
-- type: emote
   id: Howl
   name: chat-emote-name-howl
   category: Vocal


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Change the name of the emote vulpkanins use to whine to be crying, to be more universal. Includes removal of whine emote recognition (@whine/*whine won't play audio)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This makes typing the emote identical to other species. This was brought up in #40178.

## Technical details
<!-- Summary of code changes for easier review. -->
 - Remove Whine emote
 - Rename Whine->Crying

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/22230d4f-122e-494d-aced-598f139eb7ec



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: buunie099
- tweak: Changed Vulpkanin whine emote to cry