### PR TITLE
optimise shuttle collision entity throwing

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -268,7 +268,7 @@ public sealed partial class ShuttleSystem
         ref (List<Entity<PhysicsComponent>> List, HashSet<EntityUid> Processed, EntityQuery<PhysicsComponent> PhysicsQuery) state,
         in EntityUid uid)
     {
-        if (state.PhysicsQuery.TryComp(uid, out var body) && state.Processed.Add(uid))
+        if (state.Processed.Add(uid) && state.PhysicsQuery.TryComp(uid, out var body))
             state.List.Add((uid, body));
 
         return true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
i should've probably done this right away but now it only throws dynamic entities

## Why / Balance
unlag

## Technical details
code reused from ExplosionSystem because i couldn't find a better way to do this since from what i'm seeing RT doesn't let  you just query dynamic entities on a grid
should probably eventually be made better with engine update

## Media
<img width="405" height="552" alt="image" src="https://github.com/user-attachments/assets/2bf1e414-764f-4f61-b61d-59db0ce7cf4b" />

successfully threw things here and in other tests
recreation of The Incident:tm: here seems to have lagged way less than without this tweak

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Large grid shuttle collisions should now be somewhat less laggy.
