### PR TITLE
Fix some crystals

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/crystal_shard.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/crystal_shard.yml
@@ -178,6 +178,8 @@
     prototypes:
       - ShardCrystalGreen
       - ShardCrystalPink
+      - ShardCrystalYellow
+      - ShardCrystalBlack
       - ShardCrystalOrange
       - ShardCrystalBlue
       - ShardCrystalCyan


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed ShardCrystalRandom to include black and yellow crystals. This means that random crystals (from chemical reactions) can now create yellow and black crystals.

## Why / Balance
presumably this is an oversight

## Technical details
Copy and pasted ShardCrystalPink twice. Then changed "Pink" to "Yellow" on one line and "black" to the other.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Creating crystal chemical reaction now can produce yellow and black crystals!
