### PR TITLE
Change the recipe for licoxide to not require lead

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -55,7 +55,7 @@
 - type: reaction
   id: Licoxide
   reactants:
-    Lead:
+    Lithium:
       amount: 1
     Zinc:
       amount: 1


### PR DESCRIPTION
## About the PR

The recipe for licoxide is now lithium+zinc instead of lead+zinc

## Why / Balance

Licoxide, and by extension, tazinide, cannot consistently be obtained by antagonist chemists. Given the recent nerf to nocturine, tazinide could be an interesting alternative in some situations, so I gave licoxide a more reasonable recipe.

## Technical details

why em el

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: Changed the recipe for licoxide to require lithium instead of lead.
