### PR TITLE
Allow upgraded solars to take structural damage

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
@@ -13,6 +13,9 @@
   - type: InteractionOutline
   - type: Transform
     anchored: true
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Metallic
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -68,9 +71,6 @@
   - type: Sprite
     sprite: Structures/Power/Generation/solar_panel.rsi
     state: solar_panel_plasma
-  - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger: # Excess damage, don't spawn entities
@@ -111,9 +111,6 @@
   - type: Sprite
     sprite: Structures/Power/Generation/solar_panel.rsi
     state: solar_panel_uranium
-  - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger: # Excess damage, don't spawn entities
@@ -150,9 +147,6 @@
     supplyRampTolerance: 500
     supplyRampRate: 500
   - type: SolarPanel
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger: # Excess damage, don't spawn entities
@@ -189,9 +183,6 @@
   components:
   - type: Sprite
     state: solar_panel_glass_broken
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger: # Excess damage, don't spawn entities
@@ -230,9 +221,6 @@
   components:
   - type: Sprite
     state: solar_panel_plasma_broken
-  - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger: # Excess damage, don't spawn entities
@@ -271,9 +259,6 @@
   components:
   - type: Sprite
     state: solar_panel_uranium_broken
-  - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger: # Excess damage, don't spawn entities


### PR DESCRIPTION
## About the PR
Allow plasma and uranium solar panels, as well as they're broken variants, to take structural damage.

## Why / Balance
Bugfix and yml cleanup.

## Technical details
Moved damageable to SolarPanelBasePhysSprite as it's only parented by solar panels anyway, and they should be inheriting the same damage container and modifier set.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Upgraded solar panels can now take structural damage.