### PR TITLE
Added the cosmetic carp suit to the autodrobe inventory

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -62,6 +62,7 @@
     ClothingShoesBling: 1
     ClothingShoesBootsCowboyFancy: 1
     ClothingOuterDogi: 1
+    ClothingOuterSuitCarp: 1
     ClothingMaskBlushingClown: 1
     ClothingMaskBlushingMime: 1
     ClothingHeadHatCowboyBountyHunter: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I added one (1) cosmetic carp suit to the autodrobe/costume vendor's contraband inventory.

## Why / Balance
The carp suit is a non-contraband, cute cosmetic item that is currently unobtainable elsewhere other than from a syndicates uplink; this makes them highly sus and pointless, as "why not just buy the carp hardsuit for the same price instead?" and leads to illegal security stops & searches, because they *know* it's not obtainable outside of syndi purchases or rare salvage pulls (iirc?)

This PR muddies the water over whether or not that carp suit you see is a carp hardsuit or not, whilst adding a cute cosmetic for players to use and have fun with.

This has no balance concerns other than making it more unclear as to when a carp suit is actually a carp hardsuit; the carp suit does _not_ make carp friendly towards you, unlike the carp hardsuit.

EDIT by @SlamBamActionman; This PR is allowed to bypass the clothing freeze primarily due to the balance relevance to the carp softsuit, as it helps ensure the suit is less immediately obvious as a valid equipment, unlike how it is currently.

## Technical details

## Media
<img width="970" height="451" alt="carpsuit" src="https://github.com/user-attachments/assets/52e231c5-ffe0-473c-8317-73a978b42770" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added a cosmetic carp suit to the AutoDrobe's contraband inventory!