### PR TITLE
Improve CreateDeleteCreateTest failure messages

### DIFF
--- a/Content.IntegrationTests/Tests/Lobby/CharacterCreationTest.cs
+++ b/Content.IntegrationTests/Tests/Lobby/CharacterCreationTest.cs
@@ -82,7 +82,7 @@ public sealed class CharacterCreationTest
 
         if (clientCharacter is not HumanoidCharacterProfile a)
         {
-            Assert.Fail($"Not a nameof(HumanoidCharacterProfile)");
+            Assert.Fail($"Not a {nameof(HumanoidCharacterProfile)}");
             return;
         }
 


### PR DESCRIPTION
## About the PR
There is a heisentest where `CreateDeleteCreateTest` randomly fails the `clientCharacters[1].MemberwiseEquals(profile)` assert (see #40457). This PR reworks the test to try make the actual failure a bit clearer, so that it should return information about the actual part of the character profile that is not equal.

Even if the source of the bug is fixed, IMO this is still worth merging.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
