### PR TITLE
Fixed game crash on mech construction

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/mechs/hamtr_construction.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/mechs/hamtr_construction.yml
@@ -121,6 +121,9 @@
 
       - tool: Welding
         doAfter: 1
+        completed:
+        - !type:SnapToNode
+          node: hamtr
 
   - node: hamtr
     actions:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/mechs/honker_construction.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/mechs/honker_construction.yml
@@ -112,6 +112,9 @@
 
       - tool: Honking
         doAfter: 1
+        completed:
+        - !type:SnapToNode
+          node: hamtr
 
   - node: honker
     actions:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/mechs/ripley_construction.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/mechs/ripley_construction.yml
@@ -121,6 +121,9 @@
 
       - tool: Welding
         doAfter: 1
+        completed:
+        - !type:SnapToNode
+          node: ripley
 
   - node: ripley
     actions:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/mechs/vim_construction.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/mechs/vim_construction.yml
@@ -30,3 +30,6 @@
     actions:
     - !type:BuildMech
       mechPrototype: MechVim
+      completed:
+      - !type:SnapToNode
+        node: vim


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Mechs no longer crash the client upon building their 

## Why / Balance
fixes: https://github.com/space-wizards/space-station-14/issues/40975

## Technical details
yml

## Media

https://github.com/user-attachments/assets/d7d5f5a3-27f8-4df1-a9c4-e83a75a8f2bd



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
no
