### PR TITLE
Consistency fix for soap making

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/soap.yml
+++ b/Resources/Prototypes/Recipes/Reactions/soap.yml
@@ -2,7 +2,8 @@
   id: CreateSoapRegular
   impact: Low
   quantized: true
-  minTemp: 383 # Water boiling point + 10 Kelvin. We are boiling it
+  minTemp: 373 # Water boiling point. We are boiling it
+  priority: -1 # Ensures that the more complicated soaps get made instead
   reactants:
     Oil:
       amount: 10
@@ -18,7 +19,7 @@
   id: CreateSoapNT
   impact: Low
   quantized: true
-  minTemp: 373 # Water boiling point. We are boiling it too, but with higher priority!
+  minTemp: 373
   reactants:
     Oil:
       amount: 15


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed the reaction priority for basic soap so that the fancier soaps are made before it, and so they can all have a consistent reaction temp.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Judging by the comments it appears to have been the intention in #39303 for soap to be made when water boils, but priority was a problem. Malding because I tried to make soap in a microwave and it didn't work.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/c2794c10-5e03-4c99-b1e6-bb067aef994d


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->