### PR TITLE
Zombies can't hurt II.

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -238,10 +238,7 @@ namespace Content.Server.Zombies
 
         private void OnMeleeHit(Entity<ZombieComponent> entity, ref MeleeHitEvent args)
         {
-            if (args.User != entity.Owner)
-                return;
-
-            if (!args.HitEntities.Any())
+            if (!args.IsHit)
                 return;
 
             var cannotSpread = HasComp<NonSpreaderZombieComponent>(args.User);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Zombies can no longer hurt II. Also cleaned up Zombie system a smidge.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
NPC zombies don't attack II, and this is a frequent source of confusion and ahelps. It makes sense to just disallow zeds from attacking II instead of politely asking them not to.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a check for IncurableZombieComponent.
Big code cleanup for OnMeleeHit listener in ZombieSystem.
This is not predicted but it wasn't before so :P

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Zombies can no longer hurt Initial Infected

