### PR TITLE
Fix missing access denial popup for AccessReaderComponent

### DIFF
--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -186,6 +186,8 @@ public sealed class AccessReaderSystem : EntitySystem
         // If the user has access to this lock, we pass it into the event.
         if (IsAllowed(args.User, ent))
             args.HasAccess |= LockTypes.Access;
+        else
+            args.DenyReason ??= Loc.GetString("lock-comp-has-user-access-fail");
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #40987
Related to PR #40883

Set DenyReason in CheckUserHasLockAccessEvent when access is denied to display "Access denied." popup to users. Uses ??= to avoid overriding reasons from other lock systems.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added an `else` clause to `AccessReaderSystem.OnCheckLockAccess` that sets the `DenyReason` field when a user is denied access to a locked entity.

## Why / Balance
After PR #40883 refactored the lock system to use an event-based architecture, users stopped receiving feedback when attempting to interact with locked entities (lockers, doors, etc.) without proper access. The interaction would simply fail silently or show an error, which is poor UX. This restores the "Access denied." popup that users expect.

## Technical details
- Modified `AccessReaderSystem.OnCheckLockAccess` to set `args.DenyReason` using the existing `"lock-comp-has-user-access-fail"` localization key when `IsAllowed` returns false
- Uses `??=` (null-coalescing assignment) to ensure we don't override deny reasons that may have been set by other lock type systems (e.g., fingerprint readers)
- Follows the same pattern already used by `FingerprintReaderSystem`

## Media
![Content Client_lMj4LdkduG](https://github.com/user-attachments/assets/b125a8e0-829d-4e34-bd1a-4a35ef5fcc56)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Fixed missing "Access denied." popup when attempting to interact with locked entities without proper access
:cl:
