### PR TITLE
Fix: LockSystem - HasUserAccess - Set DenyReason Localization Text Properly

### DIFF
--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -351,7 +351,7 @@ public sealed class LockSystem : EntitySystem
 
         if (!quiet)
         {
-            var denyReason = accessEv.DenyReason = Loc.GetString(_defaultDenyReason);
+            var denyReason = accessEv.DenyReason ?? Loc.GetString(_defaultDenyReason);
             _sharedPopupSystem.PopupClient(denyReason, ent, user);
         }
 


### PR DESCRIPTION
**Fixes** #40987  
**Related to** #40883  

Ensures the correct `"Access denied."` text is displayed when interacting with locked entities without proper access.  
The popup was still triggered, but the localized denial message was never set.  

---

### About the PR
- Sets `args.DenyReason ?? Loc.GetString("lock-comp-has-user-access-fail") properly in the LockSystem

### Why
- After the lock system refactor to event-based checks, `DenyReason` was never assigned a localized string.  
This caused the access denial popup to appear without proper text.  

### Technical
- Sets `args.DenyReason ??= Loc.GetString("lock-comp-has-user-access-fail") properly in the LockSystem

---

:cl: **Changelog**  
- fix: Fixed missing `"Access denied."` text when attempting to interact with locked entities without proper access  
