### PR TITLE
Toilet cistern stashes spawn containing basic loot

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -233,7 +233,6 @@
     - id: DoubleEmergencyOxygenTankFilled
     - id: DoubleEmergencyNitrogenTankFilled
 
-
 - type: entityTable
   id: ToiletCisternUtilityTable
   table: !type:GroupSelector

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -227,7 +227,3 @@
           Quantity: 20
         - ReagentId: GastroToxin
           Quantity: 20
-  - type: ContainerFill
-    containers:
-      stash:
-      - ToyFigurineCaptain


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
**Edit: this PR now only adds the loot-stash toilet entity as an option and does _not_ map it by default.**

**The cistern stashes of most toilets (accessed via using a crowbar on a toilet) now _have a 50% chance to_ contain a single small item chosen from a table of random, possibly useful items.
~~Additionally, the captain's golden toilet cistern (the thief objective one) will now always contains a captain figurine.~~ Nevermind this test fails because at least 1 map already maps something inside the golden toilet cistern.**

Suggested by ArtisticRoomba.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The secret cistern stash is very rarely used, so this gives it a little something as a treat for those who check them, similar to maints lockers. The loot table is entirely made of small tools, items, and weak improvised weapons, being similar to the maints locker pool except much smaller and without any fluff. It is mostly focused on providing possible minor utility to prisoners, who are usually guaranteed to have 1 or 2 toilets in their cell which they can smash open to access the hidden item.

Currently, the prison break strategy is very formulaic. Make shiv, grow towercap, make baseball bat, go ham on a window and pray. Hopefully this will introduce the opportunity for more interesting prison break strategies, or even just give the prisoner a chance to get some stuff to mess with (and for the warden to be very confused about). It would be neat if prisoners also had a way to get crafted trash crowbars so they can actually use the stash instead of needing to smash the toilet but that's out of scope for this.

## Technical details
<!-- Summary of code changes for easier review. -->
All yaml changes.
Added the ToiletCisternLoot entity table in the misc locker fills (close enough)
Added the ToiletFilled and ToiletDirtyWaterFilled which parent from ToiletEmpty and ToiletDirtyWater respectively and just add an EntityTableContainerFill component which uses the ToiletCisternLoot table. The original entities are still free to be used if you need a toilet to spawn without loot
Added a ContainerFill component to ToiletGoldenDirtyWater which uses the captain toy figurine
~~Replaced ToiletEmpty and ToiletDirtyWater with their new filled versions in migration.yml so all mapped toilets will be the loot-filled versions~~ Edit: Nevermind this causes test fail and also I was told not to do that. Currently this just adds the entities and doesn't map them
Edit: Added entity tables for each of the loot categories for clarity's sake

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/293409a9-de0d-4edb-9e22-dc0e54d3baca

Small showcase of the loot table _**(updated after changes were made)**_
<img width="465" height="478" alt="image" src="https://github.com/user-attachments/assets/ad0900dd-49c2-4797-89de-09ebce52c175" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
I hope not

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Toilet cisterns will now contain a small tool, item or improvised weapon.
-->