### PR TITLE
Radiation Storms

### DIFF
--- a/Resources/Locale/en-US/station-events/events/radiation-storm.ftl
+++ b/Resources/Locale/en-US/station-events/events/radiation-storm.ftl
@@ -1,0 +1,2 @@
+station-event-radiation-storm-start-announcement = High radiation levels detected near the station. All personnel are advised to immediately take cover in the maintenance tunnels.
+station-event-radiation-storm-end-announcement = Radiation levels have returned to acceptable levels. Personnel may return to their workstations.

--- a/Resources/Prototypes/Entities/Markers/radiation.yml
+++ b/Resources/Prototypes/Entities/Markers/radiation.yml
@@ -1,0 +1,20 @@
+- type: entity
+  name: temporary radiation
+  id: RadiationTemporary
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: RadiationSource
+    intensity: 1
+    slope: 0.1 #should affect the entire room
+  - type: TimedDespawn
+    lifetime: 180 #3 minutes
+  - type: PointLight
+    color: "#13FF4B" #tritum green
+    energy: 1
+    falloff: 10
+    radius: 10
+    softness: 1
+  - type: EmitSoundOnSpawn
+    sound:
+      collection:
+        RadiationPulse

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -3,6 +3,7 @@
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - id: AnomalySpawn
+  
     - id: BluespaceArtifact
     - id: BluespaceLocker
     - id: BreakerFlip
@@ -24,6 +25,7 @@
     - id: SpiderClownSpawn
     - id: SpiderSpawn
     - id: VentClog
+    - id: RadiationStorm
 
 - type: entityTable
   id: BasicAntagEventsTable
@@ -446,6 +448,24 @@
     weight: 5
     duration: 60
   - type: VentClogRule
+
+- type: entity
+  id: RadiationStorm
+  parent: BaseStationEventShortDelay
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-radiation-storm-start-announcement
+    endAnnouncement: station-event-radiation-storm-end-announcement
+    startAudio:
+      path: /Audio/Announcements/radiation.ogg
+    earliestStart: 20
+    minimumPlayers: 20
+    weight: 5
+    duration: 180
+  - type: VentCrittersRule
+    entries:
+    - id: RadiationTemporary
+      prob: 1.0
 
 - type: entity
   id: SlimesSpawn


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added Radiation storms, a midround event that forces all unprotected crew on the station to take cover in the maintenance tunnels until the radiation dies down.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Radiation storms are a way to force people out of their departments and into maints for a short period of time, giving antagonists the opportunity to attack their target or risk the radiation to break into a department. Radiation storms also provide additional utility to rad suits and Geiger counters.

Currently, the way the radiation storms work is that they create invisible entities that gives off radiation and green light for 3 minutes, after which they depawn. In order to make it so the radiation doesn`t effect maints while still radiating the station, these entities are only spawned on top of air vents. Each of these deal 1 damage per second, with a falloff of 0.1 damage for each tile you are away from the source.

As with all sources of radiation, they do additively stack, but due to the falloff and low power I couldn't get more than 2.5 rads/s just walking around box station.

issues (and reasoning)

1. "What's stopping people from building a gazillion air vents and RRing someone the moment a rad storm happens?"

Nothing, but 1) you can already do this to increase the chances of vent creatures or vent foam happening in a location, and people don't really do that as 2) rad storms aren't guaranteed to happen in a round.

2. "Don't other events also force people out of their departments?"

The issue with other events is that they are pretty random, there isn't really any way to know if it will hit your target's department. Even with station wide events, they don't really encourage people to leave their departments, as the power outage event makes it more difficult to get anywhere and the solar flare event doesn't anything if everyone in the department is close together already, like science or medical.

3. "Won't this just be a noob trap?"

The damage is pretty low and the event doesn't last too long. Additionally, the irradiated areas give off green light and make a sound when they spawn in, making it clear there is SOMETHING there.  We also now have other signs of radiation, just as metallic taste and vomiting. Vent critters are also very capable of killing new players.

4. "Can't I just avoid this event by deconstructing air vents?"

Yes, but not having a air vent is a pretty big downside if there is any spacing at all. Also, once the radioactivity comes, removing the air vent will not remove the radiation. You will also be affected by all air vents within 10 tiles with LOS, so just removing one won't stop all the radiation.

5. "Won't this screw up salvagers/cargo techs on the shuttle/engineers making critical repairs?"

The event is only applied on the station, people in space or on other grids will be fine. Engineers are already radiation resistant with their hardsuits and have the easiest access to radiation proof gear.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/2c567e70-4521-4a48-9ff9-3133f0e8d324

https://github.com/user-attachments/assets/946664ef-e1e9-4c53-8a97-46aad050e97c

<img width="1335" height="1260" alt="image" src="https://github.com/user-attachments/assets/d719400f-6acf-4082-ad84-2ba07c60a5fd" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added radiation storms, a midround event that forces the crew to take shelter in maintenance or risk getting irradiated.