### PR TITLE
Move ChemMaster buffer sort button out of transfer/discard button group

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -33,8 +33,7 @@
             <BoxContainer Orientation="Horizontal">
                 <Label Text="{Loc 'chem-master-window-buffer-text'}" />
                 <Control HorizontalExpand="True" />
-                <Button MinSize="80 0" Name="BufferSortButton" Access="Public" Text="{Loc 'chem-master-window-sort-type-none'}" />
-                <Control MinSize="10 0" /> <!-- Padding -->
+                <Button MinSize="80 0" Margin="0 0 10 0" Name="BufferSortButton" Access="Public" Text="{Loc 'chem-master-window-sort-type-none'}" />
                 <Button MinSize="80 0" Name="BufferTransferButton" Access="Public" Text="{Loc 'chem-master-window-transfer-button'}" ToggleMode="True" StyleClasses="OpenRight" />
                 <Button MinSize="80 0" Name="BufferDiscardButton" Access="Public" Text="{Loc 'chem-master-window-discard-button'}" ToggleMode="True" StyleClasses="OpenLeft" />
             </BoxContainer>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I moved the ChemMaster buffer sort button to the left one button, and made it not a part of the transfer/discard visual grouping.

## Why / Balance
The visual grouping of buttons used here is usually used in places where the grouped buttons affect the same thing, especially when they are mutually exclusive. Grouping the transfer and discard buttons helps communicate to players that they are mutually exclusive settings that affect the same thing, i.e. what the ChemMaster does when you use the buttons for specific reagents.

Having the sort button in the same grouping, in between the transfer and discard buttons makes the relationship between the transfer and discard buttons much less clear.

I am aware that there are many other issues with the ChemMaster UI, and that there are active discussions about what to do about it, which may result in changes that make this irrelevant. But this is by far the most confusing part of the current UI in my opinion, and making it less confusing doesn't require much in the way of change, so I decided to PR it while it was on my mind in hopes the ChemMaster could be a touch less confusing while the big decision making is still in progress.

## Technical details
Moved the sort button, changed the sort button to use the default button shape, and added a control for padding. All in xaml.

## Media
Before: 
<img width="626" height="67" alt="image" src="https://github.com/user-attachments/assets/dd7d9c8f-5a52-48bd-8cd1-0f1d379185d2" />

After:
<img width="636" height="69" alt="image" src="https://github.com/user-attachments/assets/b4bf2b7f-f719-4a58-b08f-5e7267faed45" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
