### PR TITLE
Don't show NaN/infinity if AME has no cores

### DIFF
--- a/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
+++ b/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
@@ -150,7 +150,7 @@ public sealed class AmeControllerSystem : EntitySystem
         // how much power can be produced at the current settings, in kW
         // we don't use max. here since this is what is set in the Controller, not what the AME is actually producing
         float targetedPowerSupply = 0;
-        if (TryGetAMENodeGroup(uid, out var group))
+        if (TryGetAMENodeGroup(uid, out var group) && group.CoreCount > 0)
         {
             coreCount = group.CoreCount;
             targetedPowerSupply = group.CalculatePower(controller.InjectionAmount, group.CoreCount) / 1000;


### PR DESCRIPTION
Fixes #41025
