### PR TITLE
Changed mindswaps cooldown from 5 minutes to 3 minutes

### DIFF
--- a/Resources/Prototypes/Magic/mindswap_spell.yml
+++ b/Resources/Prototypes/Magic/mindswap_spell.yml
@@ -5,7 +5,7 @@
   description: Exchange bodies with another person!
   components:
   - type: Action
-    useDelay: 300
+    useDelay: 180
     sound: !type:SoundPathSpecifier
       path: /Audio/Magic/staff_animation.ogg
     icon:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed wizards mindswap spell cooldown from 300 seconds to 180 seconds.

## Why / Balance
To allow the spell to cause more disruption for the round, as wizards will soon not be a roundstart antagonist. 
TGs cooldown was only a minute, and could even be upgraded down to 10 seconds, so this would allow for more experimentation with the spell itself

## Technical details
Changed useDelay: on ActionMindSwap from 300 seconds to 180 seconds.

## Media
N/A

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Changed the cooldown on wizards mind swap spell from 5 minutes to 3 minutes.

