### PR TITLE
Allow pacifists to use disabling modes of energy magnum and energy shotgun

### DIFF
--- a/Content.Shared/CombatMode/Pacification/PacificationSystem.cs
+++ b/Content.Shared/CombatMode/Pacification/PacificationSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Content.Shared.Throwing;
+using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Timing;
 
@@ -64,6 +65,10 @@ public sealed class PacificationSystem : EntitySystem
     {
         if (HasComp<PacifismAllowedGunComponent>(args.Used))
             return;
+
+        if (TryComp<BatteryWeaponFireModesComponent>(args.Used, out var component))
+            if (component.FireModes[component.CurrentFireMode].PacifismAllowedMode)
+                return;
 
         // Disallow firing guns in all cases.
         ShowPopup(ent, args.Used, "pacified-cannot-fire-gun");

--- a/Content.Shared/Weapons/Ranged/Components/BatteryWeaponFireModesComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BatteryWeaponFireModesComponent.cs
@@ -42,6 +42,12 @@ public sealed partial class BatteryWeaponFireMode
     /// </summary>
     [DataField]
     public float FireCost = 100;
+
+    /// <summary>
+    /// Wether or not this fire mode can be used by pacifists
+    /// </summary>
+    [DataField]
+    public bool PacifismAllowedMode = false;
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -847,6 +847,7 @@
       fireCost: 80
     - proto: BulletDisablerSmgSpread
       fireCost: 48
+      pacifismAllowedMode: true
   - type: Item
     size: Large
     sprite: Objects/Weapons/Guns/Battery/inhands_64x.rsi
@@ -898,6 +899,7 @@
       fireCost: 150
     - proto: BulletDisabler
       fireCost: 62.5
+      pacifismAllowedMode: true
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 48


### PR DESCRIPTION
## About the PR
Allowed the energy magnum and energy shotgun disabler modes to be used by pacifists.

## Why / Balance
Solves #40951.

## Technical details
Added bool PacifismAllowedMode to BatteryWeaponsFireModes, default to false and set to true on allowed modes. Added to pacifism logic to make the bool work.

## Media

https://github.com/user-attachments/assets/ef41c27f-73e1-45ce-a431-1071a152016e


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Energy shotgun and energy magnum can now be used by pacifists in their disabling modes.
