### PR TITLE
Department specialization console

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -33,8 +33,8 @@
             <BoxContainer Orientation="Horizontal">
                 <Label Text="{Loc 'chem-master-window-buffer-text'}" />
                 <Control HorizontalExpand="True" />
+                <Button MinSize="80 0" Margin="0 0 10 0" Name="BufferSortButton" Access="Public" Text="{Loc 'chem-master-window-sort-type-none'}" />
                 <Button MinSize="80 0" Name="BufferTransferButton" Access="Public" Text="{Loc 'chem-master-window-transfer-button'}" ToggleMode="True" StyleClasses="OpenRight" />
-                <Button MinSize="80 0" Name="BufferSortButton" Access="Public" Text="{Loc 'chem-master-window-sort-type-none'}" StyleClasses="OpenBoth" />
                 <Button MinSize="80 0" Name="BufferDiscardButton" Access="Public" Text="{Loc 'chem-master-window-discard-button'}" ToggleMode="True" StyleClasses="OpenLeft" />
             </BoxContainer>
 

--- a/Content.Client/Drunk/DrunkOverlay.cs
+++ b/Content.Client/Drunk/DrunkOverlay.cs
@@ -27,6 +27,15 @@ public sealed class DrunkOverlay : Overlay
 
     private const float VisualThreshold = 10.0f;
     private const float PowerDivisor = 250.0f;
+    /// <remarks>
+    /// This is a magic number based on my person preference of how quickly the bloodloss effect should kick in.
+    /// It is entirely arbitrary, and you should change it if it sucks.
+    /// Honestly should be refactored to be based on amount of blood lost but that's out of scope for what I'm doing atm.
+    /// Also caps all booze visual effects to a max intensity of 100 seconds or 100 booze power.
+    /// </remarks>
+    private const float MaxBoozePower = 100f;
+
+    private const float BoozePowerScale = 8f;
 
     private float _visualScale = 0;
 
@@ -50,15 +59,9 @@ public sealed class DrunkOverlay : Overlay
 
         var time = status.Item2;
 
-        var power = SharedDrunkSystem.MagicNumber;
+        var power = time == null ? MaxBoozePower : (float) Math.Min((time - _timing.CurTime).Value.TotalSeconds, MaxBoozePower);
 
-        if (time != null)
-        {
-            var curTime = _timing.CurTime;
-            power = (float) (time - curTime).Value.TotalSeconds;
-        }
-
-        CurrentBoozePower += 8f * (power * 0.5f - CurrentBoozePower) * args.DeltaSeconds / (power+1);
+        CurrentBoozePower += BoozePowerScale * (power - CurrentBoozePower) * args.DeltaSeconds / (power+1);
     }
 
     protected override bool BeforeDraw(in OverlayDrawArgs args)

--- a/Content.Client/Fax/UI/FaxWindow.xaml
+++ b/Content.Client/Fax/UI/FaxWindow.xaml
@@ -56,7 +56,7 @@
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Center"
                                 Scale="0.9 0.9"
-                                StyleClasses="Refresh" />
+                                StyleClasses="RefreshButton" />
                          </Button>
                    </BoxContainer>
                 </BoxContainer>

--- a/Content.Client/Paper/UI/PaperSheetlet.cs
+++ b/Content.Client/Paper/UI/PaperSheetlet.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client.Resources;
+using Content.Client.Resources;
 using Content.Client.Stylesheets;
 using Content.Client.Stylesheets.SheetletConfigs;
 using Content.Client.Stylesheets.Stylesheets;
@@ -22,12 +22,22 @@ public sealed class PaperSheetlet : Sheetlet<NanotrasenStylesheet>
             { Texture = sheet.GetTexture(windowCfg.TransparentWindowBackgroundBorderedPath) };
         paperBox.SetPatchMargin(StyleBox.Margin.All, 2);
 
+        var borderedTransparentTex = ResCache.GetTexture("/Textures/Interface/Nano/transparent_window_background_bordered.png");
+        var borderedTransparentBackground = new StyleBoxTexture
+        {
+            Texture = borderedTransparentTex,
+        };
+        borderedTransparentBackground.SetPatchMargin(StyleBox.Margin.All, 2);
+
         return
         [
             E<PanelContainer>().Identifier("PaperContainer").Panel(paperBox),
             E<PanelContainer>()
                 .Identifier("PaperDefaultBorder")
                 .Prop(PanelContainer.StylePropertyPanel, paperBackground),
+            E<PanelContainer>()
+                .Identifier("PaperEditBackground")
+                .Prop(PanelContainer.StylePropertyPanel, borderedTransparentBackground),
         ];
     }
 }

--- a/Content.Client/Paper/UI/PaperWindow.xaml
+++ b/Content.Client/Paper/UI/PaperWindow.xaml
@@ -16,7 +16,7 @@
                         <RichTextLabel Name="BlankPaperIndicator" StyleClasses="LabelWeak" VerticalAlignment="Top" HorizontalAlignment="Center"/>
                         <RichTextLabel StyleClasses="PaperWrittenText" Name="WrittenTextLabel" VerticalAlignment="Top"/>
                         <BoxContainer Name="InputContainer" StyleIdentifier="PaperContainer" Orientation="Vertical" VerticalExpand="True" VerticalAlignment="Stretch">
-                            <PanelContainer StyleClasses="TransparentBorderedWindowPanel" MinHeight="100"
+                            <PanelContainer StyleIdentifier="PaperEditBackground" MinHeight="100"
                                 VerticalAlignment="Stretch" VerticalExpand="True" HorizontalExpand="True">
                                 <TextEdit Name="Input" StyleClasses="PaperLineEdit" Access="Public" />
                             </PanelContainer>

--- a/Content.Client/Stylesheets/CommonStylesheet.cs
+++ b/Content.Client/Stylesheets/CommonStylesheet.cs
@@ -48,6 +48,7 @@ public abstract class CommonStylesheet : PalettedStylesheet, IButtonConfig, IWin
 
     ResPath IIconConfig.HelpIconPath => new("help.png");
     ResPath IIconConfig.CrossIconPath => new("cross.svg.png");
+    ResPath IIconConfig.RefreshIconPath => new("circular_arrow.svg.96dpi.png");
     ResPath IIconConfig.InvertedTriangleIconPath => new("inverted_triangle.svg.png");
 
     ResPath IWindowConfig.WindowHeaderTexturePath => new("window_header.png");

--- a/Content.Client/Stylesheets/SheetletConfigs/IIconConfig.cs
+++ b/Content.Client/Stylesheets/SheetletConfigs/IIconConfig.cs
@@ -6,7 +6,6 @@ public interface IIconConfig : ISheetletConfig
 {
     public ResPath HelpIconPath { get; }
     public ResPath CrossIconPath { get; }
+    public ResPath RefreshIconPath { get; }
     public ResPath InvertedTriangleIconPath { get; }
-
-
 }

--- a/Content.Client/Stylesheets/Sheetlets/ButtonSheetlet.cs
+++ b/Content.Client/Stylesheets/Sheetlets/ButtonSheetlet.cs
@@ -18,6 +18,7 @@ public sealed class ButtonSheetlet<T> : Sheetlet<T> where T : PalettedStylesheet
         IIconConfig iconCfg = sheet;
 
         var crossTex = sheet.GetTextureOr(iconCfg.CrossIconPath, NanotrasenStylesheet.TextureRoot);
+        var refreshTex = sheet.GetTextureOr(iconCfg.RefreshIconPath, NanotrasenStylesheet.TextureRoot);
 
         var rules = new List<StyleRule>
         {
@@ -49,6 +50,11 @@ public sealed class ButtonSheetlet<T> : Sheetlet<T> where T : PalettedStylesheet
             E<TextureButton>()
                 .Class(StyleClass.CrossButtonRed)
                 .Prop(TextureButton.StylePropertyTexture, crossTex),
+
+            // Refresh Button
+            E<TextureButton>()
+                .Class(StyleClass.RefreshButton)
+                .Prop(TextureButton.StylePropertyTexture, refreshTex),
 
             // Ensure labels in buttons are aligned.
             E<Label>()

--- a/Content.Client/Stylesheets/Sheetlets/ConfirmButtonSheetlet.cs
+++ b/Content.Client/Stylesheets/Sheetlets/ConfirmButtonSheetlet.cs
@@ -1,0 +1,32 @@
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Content.Client.Stylesheets;
+using Content.Client.Stylesheets.Stylesheets;
+using static Content.Client.Stylesheets.StylesheetHelpers;
+
+namespace Content.Client.UserInterface.Controls;
+
+[CommonSheetlet]
+public sealed class ConfirmButtonSheetlet : Sheetlet<NanotrasenStylesheet>
+{
+    public override StyleRule[] GetRules(NanotrasenStylesheet sheet, object config)
+    {
+        return [
+            E<ConfirmButton>()
+                .Pseudo(ConfirmButton.ConfirmPrefix + ContainerButton.StylePseudoClassNormal)
+                .Prop(Control.StylePropertyModulateSelf, sheet.NegativePalette.Element),
+
+            E<ConfirmButton>()
+                .Pseudo(ConfirmButton.ConfirmPrefix + ContainerButton.StylePseudoClassHover)
+                .Prop(Control.StylePropertyModulateSelf, sheet.NegativePalette.HoveredElement),
+
+            E<ConfirmButton>()
+                .Pseudo(ConfirmButton.ConfirmPrefix + ContainerButton.StylePseudoClassPressed)
+                .Prop(Control.StylePropertyModulateSelf, sheet.NegativePalette.PressedElement),
+
+            E<ConfirmButton>()
+                .Pseudo(ConfirmButton.ConfirmPrefix + ContainerButton.StylePseudoClassDisabled)
+                .Prop(Control.StylePropertyModulateSelf, sheet.NegativePalette.DisabledElement),
+        ];
+    }
+}

--- a/Content.Client/Stylesheets/StyleClass.cs
+++ b/Content.Client/Stylesheets/StyleClass.cs
@@ -1,4 +1,4 @@
-﻿namespace Content.Client.Stylesheets;
+namespace Content.Client.Stylesheets;
 
 ///
 /// <summary>
@@ -57,6 +57,7 @@ public static class StyleClass
     public const string ButtonIdCard = "ButtonIdCard";
 
     public const string CrossButtonRed = "CrossButtonRed";
+    public const string RefreshButton = "RefreshButton";
 
     public const string ItemStatus = "ItemStatus";
     public const string ItemStatusNotHeld = "ItemStatusNotHeld";

--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -50,7 +50,6 @@ namespace Content.Client.Stylesheets
         public const string StyleClassHandSlotHighlight = "HandSlotHighlight";
         public const string StyleClassChatPanel = "ChatPanel";
         public const string StyleClassChatSubPanel = "ChatSubPanel";
-        public const string StyleClassTransparentBorderedWindowPanel = "TransparentBorderedWindowPanel";
         public const string StyleClassHotbarPanel = "HotbarPanel";
         public const string StyleClassTooltipPanel = "tooltipBox";
         public const string StyleClassTooltipAlertTitle = "tooltipAlertTitle";
@@ -254,13 +253,6 @@ namespace Content.Client.Stylesheets
                 Texture = handSlotHighlightTex,
             };
             handSlotHighlight.SetPatchMargin(StyleBox.Margin.All, 2);
-
-            var borderedTransparentWindowBackgroundTex = resCache.GetTexture("/Textures/Interface/Nano/transparent_window_background_bordered.png");
-            var borderedTransparentWindowBackground = new StyleBoxTexture
-            {
-                Texture = borderedTransparentWindowBackgroundTex,
-            };
-            borderedTransparentWindowBackground.SetPatchMargin(StyleBox.Margin.All, 2);
 
             var hotbarBackground = new StyleBoxTexture
             {
@@ -654,12 +646,6 @@ namespace Content.Client.Stylesheets
                     {
                         new StyleProperty(PanelContainer.StylePropertyPanel, borderedWindowBackground),
                     }),
-                new StyleRule(
-                    new SelectorElement(null, new[] {StyleClassTransparentBorderedWindowPanel}, null, null),
-                    new[]
-                    {
-                        new StyleProperty(PanelContainer.StylePropertyPanel, borderedTransparentWindowBackground),
-                    }),
                 // inventory slot background
                 new StyleRule(
                     new SelectorElement(null, new[] {StyleClassInventorySlotBackground}, null, null),
@@ -752,23 +738,6 @@ namespace Content.Client.Stylesheets
 
                 Element<ContainerButton>().Class(ContainerButton.StyleClassButton).Class(ButtonCaution)
                     .Pseudo(ContainerButton.StylePseudoClassDisabled)
-                    .Prop(Control.StylePropertyModulateSelf, ButtonColorCautionDisabled),
-
-                // Colors for confirm buttons confirm states.
-                Element<ConfirmButton>()
-                    .Pseudo(ConfirmButton.ConfirmPrefix + ContainerButton.StylePseudoClassNormal)
-                    .Prop(Control.StylePropertyModulateSelf, ButtonColorCautionDefault),
-
-                Element<ConfirmButton>()
-                    .Pseudo(ConfirmButton.ConfirmPrefix + ContainerButton.StylePseudoClassHover)
-                    .Prop(Control.StylePropertyModulateSelf, ButtonColorCautionHovered),
-
-                Element<ConfirmButton>()
-                    .Pseudo(ConfirmButton.ConfirmPrefix + ContainerButton.StylePseudoClassPressed)
-                    .Prop(Control.StylePropertyModulateSelf, ButtonColorCautionPressed),
-
-                Element<ConfirmButton>()
-                    .Pseudo(ConfirmButton.ConfirmPrefix + ContainerButton.StylePseudoClassDisabled)
                     .Prop(Control.StylePropertyModulateSelf, ButtonColorCautionDisabled),
 
                 new StyleRule(new SelectorChild(
@@ -1610,9 +1579,6 @@ namespace Content.Client.Stylesheets
                 Element<TextureButton>().Class("CrossButtonRed").Pseudo(TextureButton.StylePseudoClassHover)
                     .Prop(Control.StylePropertyModulateSelf, Color.FromHex("#753131")),
 
-                //
-                Element<TextureButton>().Class("Refresh")
-                    .Prop(TextureButton.StylePropertyTexture, resCache.GetTexture("/Textures/Interface/Nano/circular_arrow.svg.96dpi.png")),
                 // ---
 
                 // Profile Editor

--- a/Content.IntegrationTests/Tests/Weapons/WeaponTests.cs
+++ b/Content.IntegrationTests/Tests/Weapons/WeaponTests.cs
@@ -1,0 +1,63 @@
+﻿using Content.IntegrationTests.Tests.Interaction;
+using Content.Shared.Damage;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+using Content.Shared.Wieldable.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Weapons;
+
+public sealed class WeaponTests : InteractionTest
+{
+    protected override string PlayerPrototype => "MobHuman"; // The default test mob only has one hand
+    private static readonly EntProtoId MobHuman = "MobHuman";
+    private static readonly EntProtoId SniperMosin = "WeaponSniperMosin";
+
+    [Test]
+    public async Task GunRequiresWieldTest()
+    {
+        var gunSystem = SEntMan.System<SharedGunSystem>();
+
+        await AddAtmosphere(); // prevent the Urist from suffocating
+
+        var urist = await SpawnTarget(MobHuman);
+        var damageComp = Comp<DamageableComponent>(urist);
+
+        var mosinNet = await PlaceInHands(SniperMosin);
+        var mosinEnt = ToServer(mosinNet);
+
+        await Pair.RunSeconds(2f); // Guns have a cooldown when picking them up.
+
+        Assert.That(HasComp<GunRequiresWieldComponent>(mosinNet),
+            "Looks like you've removed the 'GunRequiresWield' component from the mosin sniper." +
+            "If this was intentional, please update WeaponTests.cs to reflect this change!");
+
+        var startAmmo = gunSystem.GetAmmoCount(mosinEnt);
+        var wieldComp = Comp<WieldableComponent>(mosinNet);
+
+        Assert.That(startAmmo, Is.GreaterThan(0), "Mosin was spawned with no ammo!");
+        Assert.That(wieldComp.Wielded, Is.False, "Mosin was spawned wielded!");
+
+        await AttemptShoot(urist, false); // should fail due to not being wielded
+        var updatedAmmo = gunSystem.GetAmmoCount(mosinEnt);
+
+        Assert.That(updatedAmmo,
+            Is.EqualTo(startAmmo),
+            "Mosin discharged ammo when the weapon should not have fired!");
+        Assert.That(damageComp.TotalDamage.Value,
+            Is.EqualTo(0),
+            "Urist took damage when the weapon should not have fired!");
+
+        await UseInHand();
+
+        Assert.That(wieldComp.Wielded, Is.True, "Mosin failed to wield when interacted with!");
+
+        await AttemptShoot(urist);
+        updatedAmmo = gunSystem.GetAmmoCount(mosinEnt);
+
+        Assert.That(updatedAmmo, Is.EqualTo(startAmmo - 1), "Mosin failed to discharge appropriate amount of ammo!");
+        Assert.That(damageComp.TotalDamage.Value,
+            Is.GreaterThan(0),
+            "Mosin was fired but urist sustained no damage!");
+    }
+}

--- a/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
+++ b/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
@@ -150,7 +150,7 @@ public sealed class AmeControllerSystem : EntitySystem
         // how much power can be produced at the current settings, in kW
         // we don't use max. here since this is what is set in the Controller, not what the AME is actually producing
         float targetedPowerSupply = 0;
-        if (TryGetAMENodeGroup(uid, out var group))
+        if (TryGetAMENodeGroup(uid, out var group) && group.CoreCount > 0)
         {
             coreCount = group.CoreCount;
             targetedPowerSupply = group.CalculatePower(controller.InjectionAmount, group.CoreCount) / 1000;

--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.EntityEffects.Effects.Solution;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Random.Helpers;
 using Robust.Shared.Collections;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -197,6 +198,9 @@ public sealed class MetabolizerSystem : SharedMetabolizerSystem
                 foreach (var effect in entry.Effects)
                 {
                     if (scale < effect.MinScale)
+                        continue;
+
+                    if (effect.Probability < 1.0f && !_random.Prob(effect.Probability))
                         continue;
 
                     // See if conditions apply

--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -146,10 +146,10 @@ namespace Content.Server.Chemistry.EntitySystems
             {
                 // force open container, if applicable, to avoid confusing people on why it doesn't dispense
                 _openable.SetOpen(storedContainer, true);
-                _solutionTransferSystem.Transfer(reagentDispenser,
+                _solutionTransferSystem.Transfer(new SolutionTransferData(reagentDispenser,
                         storedContainer, src.Value,
                         outputContainer.Value, dst.Value,
-                        (int)reagentDispenser.Comp.DispenseAmount);
+                        (int)reagentDispenser.Comp.DispenseAmount));
             }
 
             UpdateUiState(reagentDispenser);

--- a/Content.Server/Speech/EntitySystems/SlurredSystem.cs
+++ b/Content.Server/Speech/EntitySystems/SlurredSystem.cs
@@ -15,6 +15,16 @@ public sealed class SlurredSystem : SharedSlurredSystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
+    /// <summary>
+    /// Divisor applied to total seconds used to get the odds of slurred speech occuring.
+    /// </summary>
+    private const float SlurredModifier = 1100f;
+
+    /// <summary>
+    /// Minimum amount of time on the slurred accent for it to start taking effect.
+    /// </summary>
+    private const float SlurredThreshold = 80f;
+
     public override void Initialize()
     {
         SubscribeLocalEvent<SlurredAccentComponent, AccentGetEvent>(OnAccent);
@@ -32,15 +42,9 @@ public sealed class SlurredSystem : SharedSlurredSystem
             return 0;
 
         // This is a magic number. Why this value? No clue it was made 3 years before I refactored this.
-        var magic = SharedDrunkSystem.MagicNumber;
+        var magic = time.Item2 == null ? SlurredModifier : (float) (time.Item2 - _timing.CurTime).Value.TotalSeconds - SlurredThreshold;
 
-        if (time.Item2 != null)
-        {
-            var curTime = _timing.CurTime;
-            magic = (float) (time.Item2 - curTime).Value.TotalSeconds - 80f;
-        }
-
-        return Math.Clamp(magic / SharedDrunkSystem.MagicNumber, 0f, 1f);
+        return Math.Clamp(magic / SlurredModifier, 0f, 1f);
     }
 
     private void OnAccent(Entity<SlurredAccentComponent> entity, ref AccentGetEvent args)

--- a/Content.Shared/Chemistry/Components/DrainableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/DrainableSolutionComponent.cs
@@ -15,4 +15,10 @@ public sealed partial class DrainableSolutionComponent : Component
     /// </summary>
     [DataField]
     public string Solution = "default";
+
+    /// <summary>
+    /// The drain doafter time required to transfer reagents from the solution.
+    /// </summary>
+    [DataField]
+    public TimeSpan DrainTime = TimeSpan.Zero;
 }

--- a/Content.Shared/Chemistry/Components/DumpableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/DumpableSolutionComponent.cs
@@ -5,7 +5,9 @@ namespace Content.Shared.Chemistry.Components;
 /// <summary>
 /// Denotes that there is a solution contained in this entity that can be
 /// easily dumped into (that is, completely removed from the dumping container
-/// into this one). Think pouring a container fully into this.
+/// into this one). Think pouring a container fully into this. The action for this is represented via drag & drop.
+///
+/// To represent it being possible to controllably pour volumes into the entity, see <see cref="RefillableSolutionComponent"/>.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class DumpableSolutionComponent : Component

--- a/Content.Shared/Chemistry/Components/HyposprayComponent.cs
+++ b/Content.Shared/Chemistry/Components/HyposprayComponent.cs
@@ -25,6 +25,13 @@ public sealed partial class HyposprayComponent : Component
     public FixedPoint2 TransferAmount = FixedPoint2.New(5);
 
     /// <summary>
+    /// The delay to draw reagents using the hypospray.
+    /// If set, <see cref="RefillableSolutionComponent"/> RefillTime should probably have the same value.
+    /// </summary>
+    [DataField]
+    public float DrawTime = 0f;
+
+    /// <summary>
     ///     Sound that will be played when injecting.
     /// </summary>
     [DataField]

--- a/Content.Shared/Chemistry/Components/RefillableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/RefillableSolutionComponent.cs
@@ -5,9 +5,10 @@ namespace Content.Shared.Chemistry.Components;
 
 /// <summary>
 /// Denotes that the entity has a solution contained which can be easily added
-/// to. This should go on things that are meant to be refilled, including
-/// pouring things into a beaker. If you run it under a sink tap, it's probably
-/// refillable.
+/// to in controlled volumes. This should go on things that are meant to be refilled, including
+/// pouring things into a beaker. The action for this is represented via clicking.
+///
+/// To represent it being possible to just dump entire volumes at once into an entity, see <see cref="DumpableSolutionComponent"/>.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class RefillableSolutionComponent : Component
@@ -23,4 +24,10 @@ public sealed partial class RefillableSolutionComponent : Component
     /// </summary>
     [DataField]
     public FixedPoint2? MaxRefill = null;
+
+    /// <summary>
+    /// The refill doafter time required to transfer reagents into the solution.
+    /// </summary>
+    [DataField]
+    public TimeSpan RefillTime = TimeSpan.Zero;
 }

--- a/Content.Shared/Chemistry/EntitySystems/ScoopableSolutionSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/ScoopableSolutionSystem.cs
@@ -36,7 +36,7 @@ public sealed class ScoopableSolutionSystem : EntitySystem
             !_solution.TryGetRefillableSolution(beaker, out var target, out _))
             return false;
 
-        var scooped = _solutionTransfer.Transfer(user, ent, src.Value, beaker, target.Value, srcSolution.Volume);
+        var scooped = _solutionTransfer.Transfer(new SolutionTransferData(user, ent, src.Value, beaker, target.Value, srcSolution.Volume));
         if (scooped == 0)
             return false;
 

--- a/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
@@ -1,19 +1,19 @@
+using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Administration.Logs;
-using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Database;
+using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
-using Robust.Shared.Network;
-using Robust.Shared.Player;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Chemistry.EntitySystems;
 
 /// <summary>
-/// Allows an entity to transfer solutions with a customizable amount per click.
-/// Also provides <see cref="Transfer"/> API for other systems.
+/// Allows an entity to transfer solutions with a customizable amount -per click-.
+/// Also provides <see cref="Transfer"/>, <see cref="RefillTransfer"/> and <see cref="DrainTransfer"/> API for other systems.
 /// </summary>
 public sealed class SolutionTransferSystem : EntitySystem
 {
@@ -21,6 +21,10 @@ public sealed class SolutionTransferSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+
+    private EntityQuery<RefillableSolutionComponent> _refillableQuery;
+    private EntityQuery<DrainableSolutionComponent> _drainableQuery;
 
     /// <summary>
     ///     Default transfer amounts for the set-transfer verb.
@@ -32,28 +36,18 @@ public sealed class SolutionTransferSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<SolutionTransferComponent, GetVerbsEvent<AlternativeVerb>>(AddSetTransferVerbs);
-        SubscribeLocalEvent<SolutionTransferComponent, AfterInteractEvent>(OnAfterInteract);
         SubscribeLocalEvent<SolutionTransferComponent, TransferAmountSetValueMessage>(OnTransferAmountSetValueMessage);
-    }
+        SubscribeLocalEvent<SolutionTransferComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<SolutionTransferComponent, SolutionDrainTransferDoAfterEvent>(OnSolutionDrainTransferDoAfter);
+        SubscribeLocalEvent<SolutionTransferComponent, SolutionRefillTransferDoAfterEvent>(OnSolutionFillTransferDoAfter);
 
-    private void OnTransferAmountSetValueMessage(Entity<SolutionTransferComponent> ent, ref TransferAmountSetValueMessage message)
-    {
-        var (uid, comp) = ent;
-
-        var newTransferAmount = FixedPoint2.Clamp(message.Value, comp.MinimumTransferAmount, comp.MaximumTransferAmount);
-        comp.TransferAmount = newTransferAmount;
-
-        if (message.Actor is { Valid: true } user)
-            _popup.PopupEntity(Loc.GetString("comp-solution-transfer-set-amount", ("amount", newTransferAmount)), uid, user);
-
-        Dirty(uid, comp);
+        _refillableQuery = GetEntityQuery<RefillableSolutionComponent>();
+        _drainableQuery = GetEntityQuery<DrainableSolutionComponent>();
     }
 
     private void AddSetTransferVerbs(Entity<SolutionTransferComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
-        var (uid, comp) = ent;
-
-        if (!args.CanAccess || !args.CanInteract || !comp.CanChangeTransferAmount || args.Hands == null)
+        if (!args.CanAccess || !args.CanInteract || !ent.Comp.CanChangeTransferAmount || args.Hands == null)
             return;
 
         // Custom transfer verb
@@ -66,7 +60,7 @@ public sealed class SolutionTransferSystem : EntitySystem
             // TODO: remove server check when bui prediction is a thing
             Act = () =>
             {
-                _ui.OpenUi(uid, TransferAmountUiKey.Key, @event.User);
+                _ui.OpenUi(ent.Owner, TransferAmountUiKey.Key, @event.User);
             },
             Priority = 1
         });
@@ -76,7 +70,7 @@ public sealed class SolutionTransferSystem : EntitySystem
         var user = args.User;
         foreach (var amount in DefaultTransferAmounts)
         {
-          if (amount < comp.MinimumTransferAmount || amount > comp.MaximumTransferAmount)
+            if (amount < ent.Comp.MinimumTransferAmount || amount > ent.Comp.MaximumTransferAmount)
                 continue;
 
             AlternativeVerb verb = new();
@@ -84,11 +78,11 @@ public sealed class SolutionTransferSystem : EntitySystem
             verb.Category = VerbCategory.SetTransferAmount;
             verb.Act = () =>
             {
-                comp.TransferAmount = amount;
+                ent.Comp.TransferAmount = amount;
 
-                _popup.PopupClient(Loc.GetString("comp-solution-transfer-set-amount", ("amount", amount)), uid, user);
+                _popup.PopupClient(Loc.GetString("comp-solution-transfer-set-amount", ("amount", amount)), ent.Owner, user);
 
-                Dirty(uid, comp);
+                Dirty(ent.Owner, ent.Comp);
             };
 
             // we want to sort by size, not alphabetically by the verb text.
@@ -99,117 +93,301 @@ public sealed class SolutionTransferSystem : EntitySystem
         }
     }
 
+    private void OnTransferAmountSetValueMessage(Entity<SolutionTransferComponent> ent, ref TransferAmountSetValueMessage message)
+    {
+        var newTransferAmount = FixedPoint2.Clamp(message.Value, ent.Comp.MinimumTransferAmount, ent.Comp.MaximumTransferAmount);
+        ent.Comp.TransferAmount = newTransferAmount;
+
+        if (message.Actor is { Valid: true } user)
+            _popup.PopupEntity(Loc.GetString("comp-solution-transfer-set-amount", ("amount", newTransferAmount)), ent.Owner, user);
+
+        Dirty(ent.Owner, ent.Comp);
+    }
+
     private void OnAfterInteract(Entity<SolutionTransferComponent> ent, ref AfterInteractEvent args)
     {
         if (!args.CanReach || args.Target is not {} target)
             return;
 
-        var (uid, comp) = ent;
+        // We have two cases for interaction:
+        // Held Drainable --> Target Refillable
+        // Held Refillable <-- Target Drainable
 
-        //Special case for reagent tanks, because normally clicking another container will give solution, not take it.
-        if (comp.CanReceive
-            && !HasComp<RefillableSolutionComponent>(target) // target must not be refillable (e.g. Reagent Tanks)
-            && _solution.TryGetDrainableSolution(target, out var targetSoln, out _) // target must be drainable
-            && TryComp<RefillableSolutionComponent>(uid, out var refill)
-            && _solution.TryGetRefillableSolution((uid, refill, null), out var ownerSoln, out var ownerRefill))
+        // In the case where the target has both Refillable and Drainable, Held --> Target takes priority.
+
+        if (ent.Comp.CanSend
+            && _drainableQuery.TryComp(ent.Owner, out var heldDrainable)
+            && _refillableQuery.TryComp(target, out var targetRefillable)
+            && TryGetTransferrableSolutions((ent.Owner, heldDrainable),
+                (target, targetRefillable),
+                out var ownerSoln,
+                out var targetSoln,
+                out _))
         {
-            var transferAmount = comp.TransferAmount; // This is the player-configurable transfer amount of "uid," not the target reagent tank.
+            args.Handled = true; //If we reach this point, the interaction counts as handled.
 
-            // if the receiver has a smaller transfer limit, use that instead
-            if (refill?.MaxRefill is {} maxRefill)
+            var transferAmount = ent.Comp.TransferAmount;
+            if (targetRefillable.MaxRefill is {} maxRefill)
                 transferAmount = FixedPoint2.Min(transferAmount, maxRefill);
 
-            var transferred = Transfer(args.User, target, targetSoln.Value, uid, ownerSoln.Value, transferAmount);
-            args.Handled = true;
-            if (transferred > 0)
-            {
-                var toTheBrim = ownerRefill.AvailableVolume == 0;
-                var msg = toTheBrim
-                    ? "comp-solution-transfer-fill-fully"
-                    : "comp-solution-transfer-fill-normal";
+            var transferData = new SolutionTransferData(args.User, ent.Owner, ownerSoln.Value, target, targetSoln.Value, transferAmount);
+            var transferTime = targetRefillable.RefillTime + heldDrainable.DrainTime;
 
-                _popup.PopupClient(Loc.GetString(msg, ("owner", args.Target), ("amount", transferred), ("target", uid)), uid, args.User);
-                return;
+            if (transferTime > TimeSpan.Zero)
+            {
+                if (!CanTransfer(transferData))
+                    return;
+
+                var doAfterArgs = new DoAfterArgs(EntityManager, args.User, transferTime, new SolutionDrainTransferDoAfterEvent(transferAmount), ent.Owner, target)
+                {
+                    BreakOnDamage = true,
+                    BreakOnMove = true,
+                    NeedHand = true,
+                    Hidden = true,
+                };
+                _doAfter.TryStartDoAfter(doAfterArgs);
             }
+            else
+            {
+                DrainTransfer(transferData);
+            }
+
+            return;
         }
 
-        // if target is refillable, and owner is drainable
-        if (comp.CanSend
-            && TryComp<RefillableSolutionComponent>(target, out var targetRefill)
-            && _solution.TryGetRefillableSolution((target, targetRefill, null), out targetSoln, out _)
-            && _solution.TryGetDrainableSolution(uid, out ownerSoln, out _))
+        if (ent.Comp.CanReceive
+            && _refillableQuery.TryComp(ent.Owner, out var heldRefillable)
+            && _drainableQuery.TryComp(target, out var targetDrainable)
+            && TryGetTransferrableSolutions((target, targetDrainable),
+                (ent.Owner, heldRefillable),
+                out targetSoln,
+                out ownerSoln,
+                out var solution))
         {
-            var transferAmount = comp.TransferAmount;
+            args.Handled = true; //If we reach this point, the interaction counts as handled.
 
-            if (targetRefill?.MaxRefill is {} maxRefill)
+            var transferAmount = ent.Comp.TransferAmount; // This is the player-configurable transfer amount of "uid," not the target drainable.
+            if (heldRefillable.MaxRefill is {} maxRefill) // if the receiver has a smaller transfer limit, use that instead
                 transferAmount = FixedPoint2.Min(transferAmount, maxRefill);
 
-            var transferred = Transfer(args.User, uid, ownerSoln.Value, target, targetSoln.Value, transferAmount);
-            args.Handled = true;
-            if (transferred > 0)
+            var transferData = new SolutionTransferData(args.User, target, targetSoln.Value, ent.Owner, ownerSoln.Value, transferAmount);
+            var transferTime = heldRefillable.RefillTime + targetDrainable.DrainTime;
+
+            if (transferTime > TimeSpan.Zero)
             {
-                var message = Loc.GetString("comp-solution-transfer-transfer-solution", ("amount", transferred), ("target", target));
-                _popup.PopupClient(message, uid, args.User);
+                if (!CanTransfer(transferData))
+                    return;
+
+                var doAfterArgs = new DoAfterArgs(EntityManager, args.User, transferTime, new SolutionRefillTransferDoAfterEvent(transferAmount), ent.Owner, target)
+                {
+                    BreakOnDamage = true,
+                    BreakOnMove = true,
+                    NeedHand = true,
+                    Hidden = true,
+                };
+                _doAfter.TryStartDoAfter(doAfterArgs);
+            }
+            else
+            {
+                RefillTransfer(transferData, solution);
             }
         }
+    }
+
+    private void OnSolutionDrainTransferDoAfter(Entity<SolutionTransferComponent> ent, ref SolutionDrainTransferDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Target is not { } target)
+            return;
+
+        // Have to check again, in case something has changed.
+        if (CanSend(ent, target, out var ownerSoln, out var targetSoln))
+        {
+            DrainTransfer(new SolutionTransferData(args.User, ent.Owner, ownerSoln.Value, args.Target.Value, targetSoln.Value, args.Amount));
+        }
+    }
+
+    private void OnSolutionFillTransferDoAfter(Entity<SolutionTransferComponent> ent, ref SolutionRefillTransferDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Target is not { } target)
+            return;
+
+        // Have to check again, in case something has changed.
+        if (!CanRecieve(ent, target, out var ownerSoln, out var targetSoln, out var solution))
+            return;
+
+        RefillTransfer(new SolutionTransferData(args.User, target, targetSoln.Value, ent.Owner, ownerSoln.Value, args.Amount), solution);
+    }
+
+    private bool CanSend(Entity<SolutionTransferComponent, DrainableSolutionComponent?> ent,
+        Entity<RefillableSolutionComponent?> target,
+        [NotNullWhen(true)] out Entity<SolutionComponent>? drainable,
+        [NotNullWhen(true)] out Entity<SolutionComponent>? refillable)
+    {
+        drainable = null;
+        refillable = null;
+
+        return ent.Comp1.CanReceive && TryGetTransferrableSolutions(ent.Owner, target, out drainable, out refillable, out _);
+    }
+
+    private bool CanRecieve(Entity<SolutionTransferComponent> ent,
+        EntityUid source,
+        [NotNullWhen(true)] out Entity<SolutionComponent>? drainable,
+        [NotNullWhen(true)] out Entity<SolutionComponent>? refillable,
+        [NotNullWhen(true)] out Solution? solution)
+    {
+        drainable = null;
+        refillable = null;
+        solution = null;
+
+        return ent.Comp.CanReceive && TryGetTransferrableSolutions(source, ent.Owner, out drainable, out refillable, out solution);
+    }
+
+    private bool TryGetTransferrableSolutions(Entity<DrainableSolutionComponent?> source,
+        Entity<RefillableSolutionComponent?> target,
+        [NotNullWhen(true)] out Entity<SolutionComponent>? drainable,
+        [NotNullWhen(true)] out Entity<SolutionComponent>? refillable,
+        [NotNullWhen(true)] out Solution? solution)
+    {
+        drainable = null;
+        refillable = null;
+        solution = null;
+
+        if (!_drainableQuery.Resolve(source, ref source.Comp) || !_refillableQuery.Resolve(target, ref target.Comp))
+            return false;
+
+        if (!_solution.TryGetDrainableSolution(source, out drainable, out _))
+            return false;
+
+        if (!_solution.TryGetRefillableSolution(target, out refillable, out solution))
+            return false;
+
+        return true;
     }
 
     /// <summary>
-    /// Transfer from a solution to another, allowing either entity to cancel it and show a popup.
+    /// Attempt to drain a solution into another, such as pouring a bottle into a glass.
+    /// Includes a pop-up if the transfer failed or succeeded
+    /// </summary>
+    /// <param name="data">The transfer data making up the transfer.</param>
+    /// <returns>The actual amount transferred.</returns>
+    private void DrainTransfer(SolutionTransferData data)
+    {
+        var transferred = Transfer(data);
+        if (transferred <= 0)
+            return;
+
+        var message = Loc.GetString("comp-solution-transfer-transfer-solution", ("amount", transferred), ("target", data.TargetEntity));
+        _popup.PopupClient(message, data.SourceEntity, data.User);
+    }
+
+    /// <summary>
+    /// Attempt to fill a solution from another container, such as tapping from a water tank.
+    /// Includes a pop-up if the transfer failed or succeeded.
+    /// </summary>
+    /// <param name="data">The transfer data making up the transfer.</param>
+    /// <param name="targetSolution">The target solution,included for LoC pop-up purposes.</param>
+    /// <returns>The actual amount transferred.</returns>
+    private void RefillTransfer(SolutionTransferData data, Solution targetSolution)
+    {
+        var transferred = Transfer(data);
+        if (transferred <= 0)
+            return;
+
+        var toTheBrim = targetSolution.AvailableVolume == 0;
+        var msg = toTheBrim
+            ? "comp-solution-transfer-fill-fully"
+            : "comp-solution-transfer-fill-normal";
+
+        _popup.PopupClient(Loc.GetString(msg, ("owner", data.SourceEntity), ("amount", transferred), ("target", data.TargetEntity)), data.TargetEntity, data.User);
+    }
+
+    /// <summary>
+    /// Transfer from a solution to another, allowing either entity to cancel.
+    /// Includes a pop-up if the transfer failed.
     /// </summary>
     /// <returns>The actual amount transferred.</returns>
-    public FixedPoint2 Transfer(EntityUid user,
-        EntityUid sourceEntity,
-        Entity<SolutionComponent> source,
-        EntityUid targetEntity,
-        Entity<SolutionComponent> target,
-        FixedPoint2 amount)
+    public FixedPoint2 Transfer(SolutionTransferData data)
     {
-        var transferAttempt = new SolutionTransferAttemptEvent(sourceEntity, targetEntity);
+        var sourceSolution = data.Source.Comp.Solution;
+        var targetSolution = data.Target.Comp.Solution;
 
-        // Check if the source is cancelling the transfer
-        RaiseLocalEvent(sourceEntity, ref transferAttempt);
-        if (transferAttempt.CancelReason is {} reason)
-        {
-            _popup.PopupClient(reason, sourceEntity, user);
+        if (!CanTransfer(data))
             return FixedPoint2.Zero;
-        }
 
-        var sourceSolution = source.Comp.Solution;
-        if (sourceSolution.Volume == 0)
-        {
-            _popup.PopupClient(Loc.GetString("comp-solution-transfer-is-empty", ("target", sourceEntity)), sourceEntity, user);
-            return FixedPoint2.Zero;
-        }
+        var actualAmount = FixedPoint2.Min(data.Amount, FixedPoint2.Min(sourceSolution.Volume, targetSolution.AvailableVolume));
 
-        // Check if the target is cancelling the transfer
-        RaiseLocalEvent(targetEntity, ref transferAttempt);
-        if (transferAttempt.CancelReason is {} targetReason)
-        {
-            _popup.PopupClient(targetReason, targetEntity, user);
-            return FixedPoint2.Zero;
-        }
+        var solution = _solution.SplitSolution(data.Source, actualAmount);
+        _solution.AddSolution(data.Target, solution);
 
-        var targetSolution = target.Comp.Solution;
-        if (targetSolution.AvailableVolume == 0)
-        {
-            _popup.PopupClient(Loc.GetString("comp-solution-transfer-is-full", ("target", targetEntity)), targetEntity, user);
-            return FixedPoint2.Zero;
-        }
+        var ev = new SolutionTransferredEvent(data.SourceEntity, data.TargetEntity, data.User, actualAmount);
+        RaiseLocalEvent(data.TargetEntity, ref ev);
 
-        var actualAmount = FixedPoint2.Min(amount, FixedPoint2.Min(sourceSolution.Volume, targetSolution.AvailableVolume));
-
-        var solution = _solution.SplitSolution(source, actualAmount);
-        _solution.AddSolution(target, solution);
-
-        var ev = new SolutionTransferredEvent(sourceEntity, targetEntity, user, actualAmount);
-        RaiseLocalEvent(targetEntity, ref ev);
-
-        _adminLogger.Add(LogType.Action, LogImpact.Medium,
-            $"{ToPrettyString(user):player} transferred {SharedSolutionContainerSystem.ToPrettyString(solution)} to {ToPrettyString(targetEntity):target}, which now contains {SharedSolutionContainerSystem.ToPrettyString(targetSolution)}");
+        _adminLogger.Add(LogType.Action,
+            LogImpact.Medium,
+            $"{ToPrettyString(data.User):player} transferred {SharedSolutionContainerSystem.ToPrettyString(solution)} to {ToPrettyString(data.TargetEntity):target}, which now contains {SharedSolutionContainerSystem.ToPrettyString(targetSolution)}");
 
         return actualAmount;
     }
+
+    /// <summary>
+    /// Check if the source solution can transfer the amount to the target solution, and display a pop-up if it fails.
+    /// </summary>
+    private bool CanTransfer(SolutionTransferData data)
+    {
+        var transferAttempt = new SolutionTransferAttemptEvent(data.SourceEntity, data.TargetEntity);
+
+        // Check if the source is cancelling the transfer
+        RaiseLocalEvent(data.SourceEntity, ref transferAttempt);
+        if (transferAttempt.CancelReason is {} reason)
+        {
+            _popup.PopupClient(reason, data.SourceEntity, data.User);
+            return false;
+        }
+
+        var sourceSolution = data.Source.Comp.Solution;
+        if (sourceSolution.Volume == 0)
+        {
+            _popup.PopupClient(Loc.GetString("comp-solution-transfer-is-empty", ("target", data.SourceEntity)), data.SourceEntity, data.User);
+            return false;
+        }
+
+        // Check if the target is cancelling the transfer
+        RaiseLocalEvent(data.TargetEntity, ref transferAttempt);
+        if (transferAttempt.CancelReason is {} targetReason)
+        {
+            _popup.PopupClient(targetReason, data.TargetEntity, data.User);
+            return false;
+        }
+
+        var targetSolution = data.Target.Comp.Solution;
+        if (targetSolution.AvailableVolume == 0)
+        {
+            _popup.PopupClient(Loc.GetString("comp-solution-transfer-is-full", ("target", data.TargetEntity)), data.TargetEntity, data.User);
+            return false;
+        }
+
+        return true;
+    }
+}
+
+
+/// <summary>
+/// A collection of data containing relevant entities and values for transferring reagents.
+/// </summary>
+/// <param name="user">The user performing the transfer.</param>
+/// <param name="sourceEntity">The entity holding the solution container which reagents are being moved from.</param>
+/// <param name="source">The entity holding the solution from which reagents are being moved away from.</param>
+/// <param name="targetEntity">The entity holding the solution container which reagents are being moved to.</param>
+/// <param name="target">The entity holding the solution which reagents are being moved to</param>
+/// <param name="amount">The amount being moved.</param>
+public struct SolutionTransferData(EntityUid user, EntityUid sourceEntity, Entity<SolutionComponent> source, EntityUid targetEntity, Entity<SolutionComponent> target, FixedPoint2 amount)
+{
+    public EntityUid User = user;
+    public EntityUid SourceEntity = sourceEntity;
+    public Entity<SolutionComponent> Source = source;
+    public EntityUid TargetEntity = targetEntity;
+    public Entity<SolutionComponent> Target = target;
+    public FixedPoint2 Amount = amount;
 }
 
 /// <summary>
@@ -234,3 +412,35 @@ public record struct SolutionTransferAttemptEvent(EntityUid From, EntityUid To, 
 /// </summary>
 [ByRefEvent]
 public record struct SolutionTransferredEvent(EntityUid From, EntityUid To, EntityUid User, FixedPoint2 Amount);
+
+/// <summary>
+/// Doafter event for solution transfers where the held item is drained into the target. Checks for validity both when initiating and when finishing the event.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class SolutionDrainTransferDoAfterEvent : DoAfterEvent
+{
+    public FixedPoint2 Amount;
+
+    public SolutionDrainTransferDoAfterEvent(FixedPoint2 amount)
+    {
+        Amount = amount;
+    }
+
+    public override DoAfterEvent Clone() => this;
+}
+
+/// <summary>
+/// Doafter event for solution transfers where the held item is filled from the target. Checks for validity both when initiating and when finishing the event.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class SolutionRefillTransferDoAfterEvent : DoAfterEvent
+{
+    public FixedPoint2 Amount;
+
+    public SolutionRefillTransferDoAfterEvent(FixedPoint2 amount)
+    {
+        Amount = amount;
+    }
+
+    public override DoAfterEvent Clone() => this;
+}

--- a/Content.Shared/Drunk/SharedDrunkSystem.cs
+++ b/Content.Shared/Drunk/SharedDrunkSystem.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Speech.EntitySystems;
 using Content.Shared.StatusEffectNew;
 using Content.Shared.Traits.Assorted;
 using Robust.Shared.Prototypes;
@@ -8,12 +7,6 @@ namespace Content.Shared.Drunk;
 public abstract class SharedDrunkSystem : EntitySystem
 {
     public static EntProtoId Drunk = "StatusEffectDrunk";
-    public static EntProtoId Woozy = "StatusEffectWoozy";
-
-    /* I have no clue why this magic number was chosen, I copied it from slur system and needed it for the overlay
-    If you have a more intelligent magic number be my guest to completely explode this value.
-    There were no comments as to why this value was chosen three years ago. */
-    public static float MagicNumber = 1100f;
 
     [Dependency] protected readonly StatusEffectsSystem Status = default!;
 

--- a/Content.Shared/EntityEffects/Effects/StatusEffects/ModifyParalysisEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/StatusEffects/ModifyParalysisEntityEffectSystem.cs
@@ -1,5 +1,4 @@
 ﻿using Content.Shared.StatusEffectNew;
-using Content.Shared.StatusEffectNew.Components;
 using Content.Shared.Stunnable;
 using Robust.Shared.Prototypes;
 
@@ -10,12 +9,12 @@ namespace Content.Shared.EntityEffects.Effects.StatusEffects;
 /// Duration is modified by scale.
 /// </summary>
 /// <inheritdoc cref="EntityEffectSystem{T,TEffect}"/>
-public sealed partial class ModifyParalysisEntityEffectSystem : EntityEffectSystem<StatusEffectContainerComponent, ModifyParalysis>
+public sealed partial class ModifyParalysisEntityEffectSystem : EntityEffectSystem<MetaDataComponent, ModifyParalysis>
 {
     [Dependency] private readonly StatusEffectsSystem _status = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
 
-    protected override void Effect(Entity<StatusEffectContainerComponent> entity, ref EntityEffectEvent<ModifyParalysis> args)
+    protected override void Effect(Entity<MetaDataComponent> entity, ref EntityEffectEvent<ModifyParalysis> args)
     {
         var time = args.Effect.Time * args.Scale;
 

--- a/Content.Shared/EntityEffects/Effects/StatusEffects/ModifyStatusEffectEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/StatusEffects/ModifyStatusEffectEntityEffectSystem.cs
@@ -1,5 +1,4 @@
 ﻿using Content.Shared.StatusEffectNew;
-using Content.Shared.StatusEffectNew.Components;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.EntityEffects.Effects.StatusEffects;
@@ -9,11 +8,11 @@ namespace Content.Shared.EntityEffects.Effects.StatusEffects;
 /// Duration is modified by scale.
 /// </summary>
 /// <inheritdoc cref="EntityEffectSystem{T,TEffect}"/>
-public sealed partial class ModifyStatusEffectEntityEffectSystem : EntityEffectSystem<StatusEffectContainerComponent, ModifyStatusEffect>
+public sealed partial class ModifyStatusEffectEntityEffectSystem : EntityEffectSystem<MetaDataComponent, ModifyStatusEffect>
 {
     [Dependency] private readonly StatusEffectsSystem _status = default!;
 
-    protected override void Effect(Entity<StatusEffectContainerComponent> entity, ref EntityEffectEvent<ModifyStatusEffect> args)
+    protected override void Effect(Entity<MetaDataComponent> entity, ref EntityEffectEvent<ModifyStatusEffect> args)
     {
         var time = args.Effect.Time * args.Scale;
         var delay = args.Effect.Delay;

--- a/Content.Shared/Fluids/EntitySystems/SolutionDumpingSystem.cs
+++ b/Content.Shared/Fluids/EntitySystems/SolutionDumpingSystem.cs
@@ -44,7 +44,6 @@ public sealed class SolutionDumpingSystem : EntitySystem
         //SubscribeLocalEvent<RefillableSolutionComponent, DragDropDraggedEvent>(OnRefillableDragged); For if you want to refill a container by dragging it into another one. Can't find a use for that currently.
         SubscribeLocalEvent<DrainableSolutionComponent, DragDropDraggedEvent>(OnDrainableDragged);
 
-        SubscribeLocalEvent<RefillableSolutionComponent, DrainedTargetEvent>(OnDrainedToRefillableDragged);
         SubscribeLocalEvent<DumpableSolutionComponent, DrainedTargetEvent>(OnDrainedToDumpableDragged);
 
         // We use queries for these since CanDropDraggedEvent gets called pretty rapidly
@@ -62,7 +61,7 @@ public sealed class SolutionDumpingSystem : EntitySystem
     private void OnDrainableCanDragDropped(Entity<DrainableSolutionComponent> ent, ref CanDropDraggedEvent args)
     {
         // Easily drawn-from thing can be dragged onto easily refillable thing.
-        if (!_refillableQuery.HasComp(args.Target) && !_dumpQuery.HasComp(args.Target))
+        if (!_dumpQuery.HasComp(args.Target))
             return;
 
         args.CanDrop = true;
@@ -117,28 +116,6 @@ public sealed class SolutionDumpingSystem : EntitySystem
             _solContainer.TryAddSolution(targetSolEnt.Value,
                 _solContainer.SplitSolution(sourceEnt.Value, targetSol.AvailableVolume));
         }
-
-        _audio.PlayPredicted(AbsorbentComponent.DefaultTransferSound, ent, args.User);
-    }
-
-    private void OnDrainedToRefillableDragged(Entity<RefillableSolutionComponent> ent, ref DrainedTargetEvent args)
-    {
-        if (!_solContainer.TryGetRefillableSolution((ent, ent.Comp),
-                out var targetSolEnt,
-                out var targetSol))
-            return;
-
-        // Check openness, hands, source being empty, and target being full.
-        if (!DragInteractionChecks(args.User,
-                args.Source,
-                ent.Owner,
-                args.SourceSolution,
-                targetSol,
-                out var sourceEnt))
-            return;
-
-        _solContainer.TryAddSolution(targetSolEnt.Value,
-            _solContainer.SplitSolution(sourceEnt.Value, targetSol.AvailableVolume));
 
         _audio.PlayPredicted(AbsorbentComponent.DefaultTransferSound, ent, args.User);
     }

--- a/Content.Shared/IdentityManagement/Components/IdentityComponent.cs
+++ b/Content.Shared/IdentityManagement/Components/IdentityComponent.cs
@@ -14,8 +14,12 @@ namespace Content.Shared.IdentityManagement.Components;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class IdentityComponent : Component
 {
+    /// <summary>
+    /// The slot which carries around the entity representing the carrier's
+    /// perceived identity. May be null if the component is not initialized.
+    /// </summary>
     [ViewVariables]
-    public ContainerSlot IdentityEntitySlot = default!;
+    public ContainerSlot? IdentityEntitySlot;
 }
 
 /// <summary>
@@ -32,7 +36,7 @@ public sealed class IdentityRepresentation
     public string? PresumedName;
     public string? PresumedJob;
 
-    public IdentityRepresentation(string trueName, Gender trueGender, string ageString, string? presumedName=null, string? presumedJob=null)
+    public IdentityRepresentation(string trueName, Gender trueGender, string ageString, string? presumedName = null, string? presumedJob = null)
     {
         TrueName = trueName;
         TrueGender = trueGender;

--- a/Content.Shared/IdentityManagement/Identity.cs
+++ b/Content.Shared/IdentityManagement/Identity.cs
@@ -13,7 +13,13 @@ public static class Identity
     /// <summary>
     ///     Returns the name that should be used for this entity for identity purposes.
     /// </summary>
-    public static string Name(EntityUid uid, IEntityManager ent, EntityUid? viewer=null)
+    /// <remarks>
+    /// This will return the true identity of the entity if called before the
+    /// identity component has been initialized — this may occur for example if
+    /// the client raises an event in response to an entity entering PVS for
+    /// the first time.
+    /// </remarks>
+    public static string Name(EntityUid uid, IEntityManager ent, EntityUid? viewer = null)
     {
         if (!uid.IsValid())
             return string.Empty;
@@ -27,7 +33,7 @@ public static class Identity
         if (!ent.TryGetComponent<IdentityComponent>(uid, out var identity))
             return uidName;
 
-        var ident = identity.IdentityEntitySlot.ContainedEntity;
+        var ident = identity.IdentityEntitySlot?.ContainedEntity;
         if (ident is null)
             return uidName;
 
@@ -52,6 +58,7 @@ public static class Identity
     /// <param name="viewer">
     ///     If this entity can see through identities, this method will always return the actual target entity.
     /// </param>
+    /// <inheritdoc cref="Name" path="remarks" />
     public static EntityUid Entity(EntityUid uid, IEntityManager ent, EntityUid? viewer = null)
     {
         if (!ent.TryGetComponent<IdentityComponent>(uid, out var identity))
@@ -60,7 +67,7 @@ public static class Identity
         if (viewer != null && CanSeeThroughIdentity(uid, viewer.Value, ent))
             return uid;
 
-        return identity.IdentityEntitySlot.ContainedEntity ?? uid;
+        return identity.IdentityEntitySlot?.ContainedEntity ?? uid;
     }
 
     public static bool CanSeeThroughIdentity(EntityUid uid, EntityUid viewer, IEntityManager ent)

--- a/Content.Shared/IdentityManagement/IdentitySystem.cs
+++ b/Content.Shared/IdentityManagement/IdentitySystem.cs
@@ -78,11 +78,17 @@ public sealed class IdentitySystem : EntitySystem
     // Creates an identity entity, and store it in the identity container
     private void OnMapInit(Entity<IdentityComponent> ent, ref MapInitEvent args)
     {
+        if (ent.Comp.IdentityEntitySlot is not { } slot)
+        {
+            Log.Error($"Uninitialized IdentityEntitySlot for {ToPrettyString(ent.Owner)}.");
+            return;
+        }
+
         var ident = Spawn(null, Transform(ent).Coordinates);
 
         _metaData.SetEntityName(ident, "identity");
         QueueIdentityUpdate(ent);
-        _container.Insert(ident, ent.Comp.IdentityEntitySlot);
+        _container.Insert(ident, slot);
     }
 
     private void OnComponentInit(Entity<IdentityComponent> ent, ref ComponentInit args)
@@ -132,7 +138,7 @@ public sealed class IdentitySystem : EntitySystem
     /// </summary>
     private void UpdateIdentityInfo(Entity<IdentityComponent> ent)
     {
-        if (ent.Comp.IdentityEntitySlot.ContainedEntity is not { } ident)
+        if (ent.Comp.IdentityEntitySlot?.ContainedEntity is not { } ident)
             return;
 
         var representation = GetIdentityRepresentation(ent.Owner);

--- a/Content.Shared/StatusEffectNew/Components/StatusEffectComponent.cs
+++ b/Content.Shared/StatusEffectNew/Components/StatusEffectComponent.cs
@@ -35,7 +35,8 @@ public sealed partial class StatusEffectComponent : Component
     /// <summary>
     /// If true, this status effect has been applied. Used to ensure that <see cref="StatusEffectAppliedEvent"/> only fires once.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    /// We actually don't want to network this, that way client can apply an effect it's receiving properly!
+    [DataField]
     public bool Applied;
 
     /// <summary>

--- a/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
@@ -51,7 +51,7 @@ public sealed partial class StatusEffectsSystem : EntitySystem
             if (effect.EndEffectTime is null)
                 continue;
 
-            if (!(_timing.CurTime >= effect.EndEffectTime))
+            if (_timing.CurTime < effect.EndEffectTime)
                 continue;
 
             if (effect.AppliedTo is null)
@@ -81,14 +81,14 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         if (args.Container.ID != StatusEffectContainerComponent.ContainerId)
             return;
 
-        if (!TryComp<StatusEffectComponent>(args.Entity, out var statusComp))
+        if (!_effectQuery.TryComp(args.Entity, out var statusComp))
             return;
 
         // Make sure AppliedTo is set correctly so events can rely on it
         if (statusComp.AppliedTo != ent)
         {
             statusComp.AppliedTo = ent;
-            Dirty(args.Entity, statusComp);
+            DirtyField(args.Entity, statusComp, nameof(StatusEffectComponent.AppliedTo));
         }
     }
 
@@ -97,7 +97,7 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         if (args.Container.ID != StatusEffectContainerComponent.ContainerId)
             return;
 
-        if (!TryComp<StatusEffectComponent>(args.Entity, out var statusComp))
+        if (!_effectQuery.TryComp(args.Entity, out var statusComp))
             return;
 
         var ev = new StatusEffectRemovedEvent(ent);
@@ -127,20 +127,17 @@ public sealed partial class StatusEffectsSystem : EntitySystem
     /// <returns>Returns true if the effect is applied.</returns>
     private bool TryApplyStatusEffect(Entity<StatusEffectComponent> statusEffectEnt)
     {
-        if (!statusEffectEnt.Comp.Applied &&
-            statusEffectEnt.Comp.AppliedTo != null &&
-            _timing.CurTime >= statusEffectEnt.Comp.StartEffectTime)
-        {
-            var ev = new StatusEffectAppliedEvent(statusEffectEnt.Comp.AppliedTo.Value);
-            RaiseLocalEvent(statusEffectEnt, ref ev);
+        if (statusEffectEnt.Comp.Applied ||
+            statusEffectEnt.Comp.AppliedTo == null ||
+            _timing.CurTime < statusEffectEnt.Comp.StartEffectTime)
+            return false;
 
-            statusEffectEnt.Comp.Applied = true;
+        var ev = new StatusEffectAppliedEvent(statusEffectEnt.Comp.AppliedTo.Value);
+        RaiseLocalEvent(statusEffectEnt, ref ev);
 
-            DirtyField(statusEffectEnt, statusEffectEnt.Comp, nameof(StatusEffectComponent.StartEffectTime));
-            return true;
-        }
+        statusEffectEnt.Comp.Applied = true;
 
-        return false;
+        return true;
     }
 
     public bool CanAddStatusEffect(EntityUid uid, EntProtoId effectProto)
@@ -207,7 +204,7 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         var startTime = delay == null ? TimeSpan.Zero : _timing.CurTime + delay.Value;
         SetStatusEffectStartTime(effect.Value, startTime);
 
-        TryApplyStatusEffect((effect.Value, effectComp));
+        TryApplyStatusEffect((statusEffect.Value, effectComp));
 
         return true;
     }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -628,6 +628,26 @@ public abstract partial class SharedGunSystem : EntitySystem
     {
         public List<(NetCoordinates coordinates, Angle angle, SpriteSpecifier Sprite, float Distance)> Sprites = new();
     }
+
+    /// <summary>
+    /// Get the ammo count for a given EntityUid. Can be a firearm or magazine.
+    /// </summary>
+    public int GetAmmoCount(EntityUid uid)
+    {
+        var ammoEv = new GetAmmoCountEvent();
+        RaiseLocalEvent(uid, ref ammoEv);
+        return ammoEv.Count;
+    }
+
+    /// <summary>
+    /// Get the ammo capacity for a given EntityUid. Can be a firearm or magazine.
+    /// </summary>
+    public int GetAmmoCapacity(EntityUid uid)
+    {
+        var ammoEv = new GetAmmoCountEvent();
+        RaiseLocalEvent(uid, ref ammoEv);
+        return ammoEv.Capacity;
+    }
 }
 
 /// <summary>

--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -1,34 +1,4 @@
 ﻿Entries:
-- author: TiniestShark
-  changes:
-  - message: Mecha parts now require two hands to pick up.
-    type: Tweak
-  id: 8641
-  time: '2025-06-09T07:40:14.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/38162
-- author: DrSmugleaf
-  changes:
-  - message: Fixed eating and drinking verbs showing up after a short delay and their
-      effect being delayed.
-    type: Fix
-  id: 8642
-  time: '2025-06-09T14:36:05.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/38164
-- author: sowelipililimute
-  changes:
-  - message: Departmental request computers now send their orders directly to Cargo,
-      instead of requiring paper slips be brought to Cargo for insertion
-    type: Tweak
-  id: 8643
-  time: '2025-06-09T15:11:19.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37943
-- author: Disp-Dev
-  changes:
-  - message: Two new recipes have been added, Full English and Full American breakfast.
-    type: Add
-  id: 8644
-  time: '2025-06-09T22:33:02.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37279
 - author: cnv41
   changes:
   - message: Fixed a minor typo in coffin description.
@@ -3929,3 +3899,31 @@
   id: 9142
   time: '2025-10-21T14:16:02.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/40542
+- author: Princess-Cheeseballs
+  changes:
+  - message: You can now get drunk again.
+    type: Fix
+  id: 9143
+  time: '2025-10-21T20:24:06.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/41002
+- author: SlamBamActionman
+  changes:
+  - message: The hypopen now requires a short delay before being filled.
+    type: Tweak
+  id: 9144
+  time: '2025-10-21T22:17:15.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/40538
+- author: SolidSyn
+  changes:
+  - message: Changed the cooldown on wizards mind swap spell from 5 minutes to 3 minutes.
+    type: Tweak
+  id: 9145
+  time: '2025-10-21T22:47:48.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/41027
+- author: ToastEnjoyer
+  changes:
+  - message: A security flashlight now spawns in the HoS's locker roundstart.
+    type: Add
+  id: 9146
+  time: '2025-10-22T13:32:43.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/41031

--- a/Resources/Locale/en-US/specialization/specialization.ftl
+++ b/Resources/Locale/en-US/specialization/specialization.ftl
@@ -32,4 +32,3 @@ placeholders-specialization-12 = Perma Dweller
 placeholders-specialization-13 = Redshield officer
 placeholders-specialization-14 = Maxcap technician
 placeholders-specialization-15 = Drug cook
-placeholders-specialization-16 = Inclusion Officer

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -319,6 +319,7 @@
     - id: ClothingMaskNeckGaiter
     - id: ClothingOuterCoatHoSTrench
     - id: ClothingShoesBootsJack
+    - id: FlashlightSeclite
     - id: DoorRemoteSecurity
     - id: HoloprojectorSecurity
     - id: RubberStampHos

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -174,7 +174,7 @@
   parent: ClothingNeckBase
   id: ClothingNeckCloakMoth
   name: moth cloak
-  description: A cloak in the form of moth wings is an unusual and original element of the wardrobe that can attract the attention of others. It is made of a thin fabric imitating moth wings, with soft and fluffy edges. The raincoat is fastened around the neck with Velcro, and has a hood in the shape of a moths head.
+  description: A cloak in the form of moth wings is an unusual and original element of the wardrobe that can attract the attention of others. It is made of a thin fabric imitating moth wings, with soft and fluffy edges. The raincoat is fastened around the neck with straps, and has a hood in the shape of a moths head.
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/moth.rsi

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -661,12 +661,15 @@
         maxVol: 10
   - type: RefillableSolution
     solution: hypospray
+    refillTime: 1.25
+    maxRefill: 5
   - type: ExaminableSolution
     solution: hypospray
     heldOnly: true # Allow examination only when held in hand.
     exactVolume: true
   - type: Hypospray
     onlyAffectsMobs: false
+    drawTime: 1.25
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice # A new shitcurity meta

--- a/Resources/Prototypes/Magic/mindswap_spell.yml
+++ b/Resources/Prototypes/Magic/mindswap_spell.yml
@@ -5,7 +5,7 @@
   description: Exchange bodies with another person!
   components:
   - type: Action
-    useDelay: 300
+    useDelay: 180
     sound: !type:SoundPathSpecifier
       path: /Audio/Magic/staff_animation.ogg
     icon:

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -206,7 +206,7 @@
           type: [ Dwarf ]
           inverted: true
       - !type:Drunk
-        boozePower: 2
+        boozePower: 20
 
 - type: reagent
   id: Gin


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Requires:
❌https://github.com/space-wizards/space-station-14/pull/40267

## About the PR
Added new department specialization console, who adds the ability to visually display specialized department roles (like xenoarch) alongside the main role. It shows up on ID cards and the manifest.
AgentIdCards have new field "Specialization"

## Why / Balance
Provides an in-game method for crew members to have more specific job titles that reflect their role specialization (e.g., "Pathologist" instead of just "Doctor"). My plan is to have the console in heads offices, on the bridge, and maybe in HoP/Captain rooms. That way you could assign specializations right after the briefing. New crew members could check the manifest to see who does what, and there'd be less confusion.

## Technical details
UI works through sheetlets (i think)
New UI Button with Id Card texture through styleclass 
Specialization console UI, prototype etc.


## Media

https://github.com/user-attachments/assets/8a6b8ee2-97a7-4208-8c3e-eb5f4bad9850

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
:cl: bebright
- add: Added department specialization console.
