### PR TITLE
Changes Slippery Slope to not require a robe and hat for casting.

### DIFF
--- a/Resources/Locale/en-US/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/store/spellbook-catalog.ftl
@@ -45,7 +45,7 @@ spellbook-cluwne-name = Cluwne's Curse
 spellbook-cluwne-desc = For when you really hate someone and Smite isn't enough. Requires Wizard Robe & Hat.
 
 spellbook-slip-name = Slippery Slope
-spellbook-slip-desc = Learn the ancient ways of the Janitor and curse your target to be slippery. Requires Wizard Robe & Hat.
+spellbook-slip-desc = Learn the ancient ways of the Janitor and curse your target to be slippery.
 
 spellbook-item-recall-name = Item Recall
 spellbook-item-recall-description = Mark a held item and summon it back at any time with just a snap of your fingers!

--- a/Resources/Prototypes/Magic/touch_spells.yml
+++ b/Resources/Prototypes/Magic/touch_spells.yml
@@ -94,4 +94,4 @@
   - type: SpeakOnAction
     sentence: action-speech-spell-slip
   - type: Magic
-    requiresClothes: true
+    requiresClothes: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Slippery Slope no longer requires a robe and hat for casting.

## Why / Balance
The spell is not nearly as extreme as smite or cluwn curse for touch spells, and almost never gets used in rounds. This would allow it to be more of a viable option for wizards, as well as allowing for more experimentation.

## Technical details
Changed RequiresClothes to false on slippery slope, removed the clause about requiring a robe and hat from the description in the wizards grimoire.

## Media
<img width="325" height="118" alt="image" src="https://github.com/user-attachments/assets/e087e1b2-b09d-467f-953b-ba0c3fa79bfd" />


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**

:cl:
- tweak: Wizards Slippery Slope spell no longer requires a robe and hat to be cast.
