### PR TITLE
Banana bread now shows up in the guidebook

### DIFF
--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -401,7 +401,7 @@
   name: banana bread recipe
   result: FoodBreadBanana
   time: 15
-  group: LoafCakes
+  group: Breads
   solids:
     FoodDough: 1
     FoodBanana: 1


### PR DESCRIPTION
## About the PR
Banana bread was missing from the cooking section of the guidebook due to being assigned to the wrong group. I fixed it by assigning it to a group that actually exists, and now it appears in the guidebook.

## Media
<img width="659" height="255" alt="image" src="https://github.com/user-attachments/assets/97a9256e-e4af-425e-b174-acc8e61043bf" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed banana bread being missing from the guidebook.