### PR TITLE
Xenoartifact: Fix teleport effect

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERandomTeleportInvokerSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERandomTeleportInvokerSystem.cs
@@ -15,6 +15,7 @@ public sealed class XAERandomTeleportInvokerSystem : BaseXAESystem<XAERandomTele
     [Dependency] private readonly SharedTransformSystem _xform = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedJointSystem _jointSystem = default!;
+
     /// <inheritdoc />
     protected override void OnActivated(Entity<XAERandomTeleportInvokerComponent> ent, ref XenoArtifactNodeActivatedEvent args)
     {
@@ -23,17 +24,13 @@ public sealed class XAERandomTeleportInvokerSystem : BaseXAESystem<XAERandomTele
         // todo: teleport person who activated artifact with artifact itself
         var component = ent.Comp;
 
-        if (!TryComp<XenoArtifactNodeComponent>(ent.Owner, out var nodeComponent) || nodeComponent.Attached is not { } artifact)
-            return;
-
-        var xform = Transform(artifact);
+        var xform = Transform(args.Artifact);
         _popup.PopupPredictedCoordinates(Loc.GetString("blink-artifact-popup"), xform.Coordinates, args.User, PopupType.Medium);
 
         var offsetTo = _random.NextVector2(component.MinRange, component.MaxRange);
 
-        _xform.AttachToGridOrMap(artifact);
-       if (TryComp<JointComponent>(artifact, out var joint))
-            _jointSystem.ClearJoints(artifact, joint);
-        _xform.SetCoordinates(artifact, xform, xform.Coordinates.Offset(offsetTo));
+        _xform.AttachToGridOrMap(args.Artifact);
+        _jointSystem.ClearJoints(args.Artifact);
+        _xform.SetCoordinates(args.Artifact, xform, xform.Coordinates.Offset(offsetTo));
     }
 }


### PR DESCRIPTION
Fix teleport effect, was not teleporting artifact. Also fix the popup happening twice.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed broken random teleport effect. Supposed to teleport artifact but was teleporting the artifact node. 
Additionally fix the teleport popup which was playing twice.

## Why / Balance
Effect was nonfunctional.

## Technical details
Extract attached artifact from artifactnode component and teleport that, instead of previous behavior of teleporting node.
Changed PopupCoordinates into PopupPredictedCoordinates (for popup fix, because non-predicted plays on client and also on server - which then tells clients to popup).

## Media
Before:
https://github.com/user-attachments/assets/407b15d2-4328-4ab1-bab4-779c761197ca
After:
https://github.com/user-attachments/assets/acc5e884-d1ce-4bd6-b7ec-1f6cd90f1b0d




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Artifact instantly teleporting themselves fixed.