### PR TITLE
Xenoartifact: Fixed ambient radiation damage not triggering artifact.

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/XAT/XATDamageThresholdReachedSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAT/XATDamageThresholdReachedSystem.cs
@@ -22,7 +22,11 @@ public sealed class XATDamageThresholdReachedSystem : BaseXATSystem<XATDamageThr
 
     private void OnDamageChanged(Entity<XenoArtifactComponent> artifact, Entity<XATDamageThresholdReachedComponent, XenoArtifactNodeComponent> node, ref DamageChangedEvent args)
     {
-        if (!args.DamageIncreased || args.DamageDelta == null || args.Origin == artifact.Owner)
+        if (!args.DamageIncreased || args.DamageDelta == null)
+            return;
+
+        // Allow radiation to pass through because radiation damage is ALWAYS attributed to the receiver instead of the source.
+        if (args.Origin == artifact.Owner && !args.DamageDelta.DamageDict.ContainsKey("Radiation"))
             return;
 
         var damageTriggerComponent = node.Comp1;


### PR DESCRIPTION
Fixed ambient radiation damage not triggering artifact. Fixes #37209 

## About the PR
Artifact damage trigger is now lenient on radiation. This is a workaround to an underlying source issue: #41050

## Why / Balance
Fixes broken trigger. This will mean that radioactive artifacts can trigger themselves, but this cannot be resolved without changing underlying radiation systems.

## Technical details
The artifact damage system did not add damage sourced from the artifact. This was probably to protect the artifact from triggering itself from radiation, but because all radiation damage counts as being from the thing that received it, it would never trigger from any ambient radiation source.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/ecb29c7f-44fd-43f2-8fb7-bbd41c09b9d7


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fix artifact radiation trigger not being triggered by ambient radiation.