### PR TITLE
Fixed Mime Lizard Plush going "weh" when colliding with something or being eaten

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/plushielizard_jobs.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/plushielizard_jobs.yml
@@ -214,6 +214,8 @@
     sound: null
   - type: EmitSoundOnCollide
     sound: null
+  - type: Edible
+    useSound: null
   - type: MeleeWeapon
     wideAnimationRotation: 180
     soundHit: null


### PR DESCRIPTION
## About the PR
The Mime Lizard Plushie no longer breaks its vow when under high stress (hitting a wall or being eaten).

## Why / Balance
Every other sound was muted, but these one weren't.

## Technical details
Minor change to plushielizard_jobs.yml only.

## Media
Before:
https://github.com/user-attachments/assets/fbfc8c9e-ff97-41d5-812c-a1c5d5950c00

After:
https://github.com/user-attachments/assets/60d24941-d25d-489d-b926-15af6837aba1
https://github.com/user-attachments/assets/7de0cf45-d126-4dcd-bfd5-f9e26858157e





## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
Purely .yml change.

**Changelog**
:cl:
- fix: The Mime Job Lizard plushie no longer breaks its vow when being thrown against something or eaten.
