### PR TITLE
Fix radiation damage being misattributed to radiation receiver (caused artifacts to not be triggered by ambient rads)

### DIFF
--- a/Content.Server/Radiation/Systems/RadiationSystem.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.cs
@@ -49,9 +49,9 @@ public sealed partial class RadiationSystem : EntitySystem
         _accumulator = 0f;
     }
 
-    public void IrradiateEntity(EntityUid uid, float radsPerSecond, float time)
+    public void IrradiateEntity(EntityUid uid, float radsPerSecond, float time, EntityUid? origin = null)
     {
-        var msg = new OnIrradiatedEvent(time, radsPerSecond, uid);
+        var msg = new OnIrradiatedEvent(time, radsPerSecond, origin);
         RaiseLocalEvent(uid, msg);
     }
 

--- a/Content.Shared/Radiation/Events/OnIrradiatedEvent.cs
+++ b/Content.Shared/Radiation/Events/OnIrradiatedEvent.cs
@@ -4,13 +4,13 @@ namespace Content.Shared.Radiation.Events;
 ///     Raised on entity when it was irradiated
 ///     by some radiation source.
 /// </summary>
-public readonly record struct OnIrradiatedEvent(float FrameTime, float RadsPerSecond, EntityUid Origin)
+public readonly record struct OnIrradiatedEvent(float FrameTime, float RadsPerSecond, EntityUid? Origin)
 {
     public readonly float FrameTime = FrameTime;
 
     public readonly float RadsPerSecond = RadsPerSecond;
 
-    public readonly EntityUid Origin = Origin;
+    public readonly EntityUid? Origin = Origin;
 
     public float TotalRads => RadsPerSecond * FrameTime;
 }


### PR DESCRIPTION
Fixes radiation damage being attributed to the victim, fixes #41050 and #37209, as artifact would think all damage was coming from itself and not activate. Alternate approach to #41051

## About the PR
Rad damage no longer blamed on victim (or anything).

## Why / Balance
[Fix mis-attribution.](https://github.com/space-wizards/space-station-14/pull/41051#discussion_r2458154756)

## Technical details
As per #41050, when an entity is being irradiated, incoming rads from all sources are aggregated and the entity is irradiated with the total amount of incoming radiation. Previously, this would then raise an event which attributes the incoming radiation as coming from the entity being irradiated, which is usually not the case.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/ecb29c7f-44fd-43f2-8fb7-bbd41c09b9d7


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Radiation damage from ambient radiation is no longer attributed to anything. This is due to it always being attributed to the victim. `OnIrradiatedEvent(float FrameTime, float RadsPerSecond, EntityUid? Origin)` has its `EntityUid` as nullable, and is always set to null when raised.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fix artifact radiation trigger not being triggered by ambient radiation.