### PR TITLE
Remove the remaining CheckButtons

### DIFF
--- a/Content.Client/Administration/UI/BanPanel/BanPanel.xaml.cs
+++ b/Content.Client/Administration/UI/BanPanel/BanPanel.xaml.cs
@@ -294,19 +294,19 @@ public sealed partial class BanPanel : DefaultWindow
     }
 
     /// <summary>
-    /// Adds a check button specifically for one "role" in a "group"
+    /// Adds a toggle button specifically for one "role" in a "group"
     /// E.g. it would add the Chief Medical Officer "role" into the "Medical" group.
     /// </summary>
     private void AddRoleCheckbox(string group, string role, GridContainer roleGroupInnerContainer, Button roleGroupCheckbox)
     {
         var roleCheckboxContainer = new BoxContainer();
-        var roleCheckButton = new Button
+        var roleToggleButton = new Button
         {
             Name = role,
             Text = role,
             ToggleMode = true,
         };
-        roleCheckButton.OnToggled += args =>
+        roleToggleButton.OnToggled += args =>
         {
             // Checks the role group checkbox if all the children are pressed
             if (args.Pressed && _roleCheckboxes[group].All(e => e.Item1.Pressed))
@@ -343,12 +343,12 @@ public sealed partial class BanPanel : DefaultWindow
             roleCheckboxContainer.AddChild(jobIconTexture);
         }
 
-        roleCheckboxContainer.AddChild(roleCheckButton);
+        roleCheckboxContainer.AddChild(roleToggleButton);
 
         roleGroupInnerContainer.AddChild(roleCheckboxContainer);
 
         _roleCheckboxes.TryAdd(group, []);
-        _roleCheckboxes[group].Add((roleCheckButton, rolePrototype));
+        _roleCheckboxes[group].Add((roleToggleButton, rolePrototype));
     }
 
     public void UpdateBanFlag(bool newFlag)

--- a/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
+++ b/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
@@ -47,7 +47,7 @@
                     Access="Public"
                     Text="{Loc 'ui-disposal-unit-button-eject'}"
                     StyleClasses="OpenBoth" />
-            <CheckButton Name="Power"
+            <Button Name="Power"
                          Access="Public"
                          Text="{Loc 'ui-disposal-unit-button-power'}"
                          StyleClasses="OpenLeft" />

--- a/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml
+++ b/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml
@@ -34,7 +34,7 @@
                     Access="Public"
                     Text="{Loc 'ui-disposal-unit-button-eject'}"
                     StyleClasses="OpenBoth" />
-            <CheckButton Name="Power"
+            <Button Name="Power"
                          Access="Public"
                          Text="{Loc 'ui-disposal-unit-button-power'}"
                          StyleClasses="OpenLeft" />

--- a/Content.Client/Instruments/UI/ChannelsMenu.xaml
+++ b/Content.Client/Instruments/UI/ChannelsMenu.xaml
@@ -7,7 +7,7 @@
             <Button Name="AllButton" Text="{Loc 'instruments-component-channels-all-button'}" HorizontalExpand="true" VerticalExpand="true" SizeFlagsStretchRatio="1"/>
             <Button Name="ClearButton" Text="{Loc 'instruments-component-channels-clear-button'}" HorizontalExpand="true" VerticalExpand="true" SizeFlagsStretchRatio="1"/>
         </BoxContainer>
-        <CheckButton Name="DisplayTrackNames"
+        <Button Name="DisplayTrackNames"
                      Text="{Loc 'instruments-component-channels-track-names-toggle'}" />
     </BoxContainer>
 </DefaultWindow>


### PR DESCRIPTION
## About the PR
Change the few remaining CheckButtons into regular toggle buttons, as well as rename a variable that referenced them (and thus, came up in searches for "checkbutton")

## Why / Balance
CheckButton functionality was folded into regular Buttons a while ago, no need to ever use these. They are functionally identical, since CheckButton does not modify anything about it's parent Button. It will probably be marked Obsolete or removed soon

## Technical details
This changes one button element on the disposal unit UI, the mailing unit UI and the MIDI tracks UI. I tested them and they all still work. 
It renames a variable on Banpanel.xaml.cs. Another element in that file still retains the name "CheckboxContainer", as well as the function "AddCheckBox", but I opted to leave these unchanged, to reduce disruption

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
