### PR TITLE
Fix text links in the guidebook being clickable if the cursor is anywhere to the right of the link, outside it's bounds

### DIFF
--- a/Content.Client/Guidebook/Richtext/TextLinkTag.cs
+++ b/Content.Client/Guidebook/Richtext/TextLinkTag.cs
@@ -33,6 +33,7 @@ public sealed class TextLinkTag : IMarkupTagHandler
         label.MouseFilter = Control.MouseFilterMode.Stop;
         label.FontColorOverride = LinkColor;
         label.DefaultCursorShape = Control.CursorShape.Hand;
+        label.HorizontalAlignment = Control.HAlignment.Left;
 
         label.OnMouseEntered += _ => label.FontColorOverride = Color.LightSkyBlue;
         label.OnMouseExited += _ => label.FontColorOverride = Color.CornflowerBlue;


### PR DESCRIPTION
## About the PR
Text links in the guidebook had a bug where they were were clickable/hoverable when the mouse wasn't anywhere close to them (anywhere to the right of the link).

## Technical details
TextLinkTags in the guidebook were set to the default "stretch" horizontal layout, so during layout they were all being stretched to the right side of the panel they're in. Despite not causing any visual changes, this made their clickbox huge.

## Media
![bad_links](https://github.com/user-attachments/assets/1f8534b2-e61a-4b02-8b60-be893e60bf2b)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
