### PR TITLE
Fix emergency shuttle round end delay

### DIFF
--- a/Content.IntegrationTests/Tests/Station/EvacShuttleTest.cs
+++ b/Content.IntegrationTests/Tests/Station/EvacShuttleTest.cs
@@ -117,7 +117,7 @@ public sealed class EvacShuttleTest
         Assert.That(shuttleXform.MapUid, Is.EqualTo(centcommMap));
 
         // Round should be ending now
-        await pair.RunSeconds((int)evacSys.RoundEndBufferTime.TotalSeconds);
+        await pair.RunSeconds((int)evacSys.RoundEndBufferTime);
         Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.PostRound));
 
         server.CfgMan.SetCVar(CCVars.EmergencyShuttleDockTime, dockTime);

--- a/Content.IntegrationTests/Tests/Station/EvacShuttleTest.cs
+++ b/Content.IntegrationTests/Tests/Station/EvacShuttleTest.cs
@@ -117,6 +117,7 @@ public sealed class EvacShuttleTest
         Assert.That(shuttleXform.MapUid, Is.EqualTo(centcommMap));
 
         // Round should be ending now
+        await pair.RunSeconds((int)evacSys.RoundEndBufferTime.TotalSeconds);
         Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.PostRound));
 
         server.CfgMan.SetCVar(CCVars.EmergencyShuttleDockTime, dockTime);

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -243,10 +243,9 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
 
         var diskAtCentCom = false;
         var diskQuery = AllEntityQuery<NukeDiskComponent, TransformComponent>();
-        while (diskQuery.MoveNext(out var diskUid, out _, out var transform))
+        while (diskQuery.MoveNext(out var diskUid, out _, out var _))
         {
-            diskAtCentCom = transform.MapUid != null && centcomms.Contains(transform.MapUid.Value);
-            diskAtCentCom |= _emergency.IsTargetEscaping(diskUid);
+            diskAtCentCom = _emergency.IsTargetEscaping(diskUid);
 
             // TODO: The target station should be stored, and the nuke disk should store its original station.
             // This is fine for now, because we can assume a single station in base SS14.

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -242,8 +242,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
             : WinCondition.AllNukiesDead);
 
         var diskAtCentCom = false;
-        var diskQuery = AllEntityQuery<NukeDiskComponent, TransformComponent>();
-        while (diskQuery.MoveNext(out var diskUid, out _, out var _))
+        var diskQuery = AllEntityQuery<NukeDiskComponent>();
+        while (diskQuery.MoveNext(out var diskUid, out var _))
         {
             diskAtCentCom = _emergency.IsTargetEscaping(diskUid);
 

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -42,7 +42,7 @@ public sealed partial class EmergencyShuttleSystem
     /// <summary>
     /// How long after the transit is over to end the round.
     /// </summary>
-    private readonly TimeSpan _bufferTime = TimeSpan.FromSeconds(5);
+    public readonly TimeSpan RoundEndBufferTime = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// <see cref="CCVars.EmergencyShuttleMinTransitTime"/>
@@ -209,7 +209,7 @@ public sealed partial class EmergencyShuttleSystem
             ShuttlesLeft = true;
             _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("emergency-shuttle-left", ("transitTime", $"{TransitTime:0}")));
 
-            Timer.Spawn((int)(TransitTime * 1000) + (int)_bufferTime.TotalMilliseconds, () => _roundEnd.EndRound(), _roundEndCancelToken?.Token ?? default);
+            Timer.Spawn((int)(TransitTime * 1000) + (int)RoundEndBufferTime.TotalMilliseconds, () => _roundEnd.EndRound(), _roundEndCancelToken?.Token ?? default);
         }
 
         // All the others.

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -209,7 +209,7 @@ public sealed partial class EmergencyShuttleSystem
             ShuttlesLeft = true;
             _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("emergency-shuttle-left", ("transitTime", $"{TransitTime:0}")));
 
-            Timer.Spawn((int)(TransitTime * 1000) + _bufferTime.Milliseconds, () => _roundEnd.EndRound(), _roundEndCancelToken?.Token ?? default);
+            Timer.Spawn((int)(TransitTime * 1000) + (int)_bufferTime.TotalMilliseconds, () => _roundEnd.EndRound(), _roundEndCancelToken?.Token ?? default);
         }
 
         // All the others.

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -40,9 +40,9 @@ public sealed partial class EmergencyShuttleSystem
     private float _consoleAccumulator = float.MinValue;
 
     /// <summary>
-    /// How long after the transit is over to end the round.
+    /// <see cref="CCVars.RoundEndBufferTime"/>
     /// </summary>
-    public readonly TimeSpan RoundEndBufferTime = TimeSpan.FromSeconds(5);
+    public float RoundEndBufferTime { get; private set; }
 
     /// <summary>
     /// <see cref="CCVars.EmergencyShuttleMinTransitTime"/>
@@ -89,6 +89,7 @@ public sealed partial class EmergencyShuttleSystem
         Subs.CVar(ConfigManager, CCVars.EmergencyShuttleMinTransitTime, SetMinTransitTime, true);
         Subs.CVar(ConfigManager, CCVars.EmergencyShuttleMaxTransitTime, SetMaxTransitTime, true);
         Subs.CVar(ConfigManager, CCVars.EmergencyShuttleAuthorizeTime, SetAuthorizeTime, true);
+        Subs.CVar(ConfigManager, CCVars.RoundEndBufferTime, SetRoundEndBufferTime, true);
         SubscribeLocalEvent<EmergencyShuttleConsoleComponent, ComponentStartup>(OnEmergencyStartup);
         SubscribeLocalEvent<EmergencyShuttleConsoleComponent, EmergencyShuttleAuthorizeMessage>(OnEmergencyAuthorize);
         SubscribeLocalEvent<EmergencyShuttleConsoleComponent, EmergencyShuttleRepealMessage>(OnEmergencyRepeal);
@@ -109,6 +110,11 @@ public sealed partial class EmergencyShuttleSystem
     private void SetMaxTransitTime(float obj)
     {
         MaximumTransitTime = Math.Max(MinimumTransitTime, obj);
+    }
+
+    private void SetRoundEndBufferTime(float obj)
+    {
+        RoundEndBufferTime = obj;
     }
 
     private void OnEmergencyStartup(EntityUid uid, EmergencyShuttleConsoleComponent component, ComponentStartup args)
@@ -209,7 +215,7 @@ public sealed partial class EmergencyShuttleSystem
             ShuttlesLeft = true;
             _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("emergency-shuttle-left", ("transitTime", $"{TransitTime:0}")));
 
-            Timer.Spawn((int)(TransitTime * 1000) + (int)RoundEndBufferTime.TotalMilliseconds, () => _roundEnd.EndRound(), _roundEndCancelToken?.Token ?? default);
+            Timer.Spawn((int)((TransitTime + RoundEndBufferTime) * 1000), () => _roundEnd.EndRound(), _roundEndCancelToken?.Token ?? default);
         }
 
         // All the others.

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -56,7 +56,6 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
     [Dependency] private readonly CommunicationsConsoleSystem _commsConsole = default!;
     [Dependency] private readonly DeviceNetworkSystem _deviceNetworkSystem = default!;
     [Dependency] private readonly DockingSystem _dock = default!;
-    [Dependency] private readonly EmergencyShuttleSystem _evac = default!;
     [Dependency] private readonly GameTicker _ticker = default!;
     [Dependency] private readonly IdCardSystem _idSystem = default!;
     [Dependency] private readonly NavMapSystem _navMap = default!;
@@ -229,7 +228,7 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
     /// </summary>
     private void OnEmergencyFTLComplete(EntityUid uid, EmergencyShuttleComponent component, ref FTLCompletedEvent args)
     {
-        var countdownTime = TimeSpan.FromSeconds(ConfigManager.GetCVar(CCVars.RoundRestartTime)) + _evac.RoundEndBufferTime;
+        var countdownTime = TimeSpan.FromSeconds(ConfigManager.GetCVar(CCVars.RoundRestartTime)) + RoundEndBufferTime;
         var shuttle = args.Entity;
         if (TryComp<DeviceNetworkComponent>(shuttle, out var net))
         {

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -56,6 +56,7 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
     [Dependency] private readonly CommunicationsConsoleSystem _commsConsole = default!;
     [Dependency] private readonly DeviceNetworkSystem _deviceNetworkSystem = default!;
     [Dependency] private readonly DockingSystem _dock = default!;
+    [Dependency] private readonly EmergencyShuttleSystem _evac = default!;
     [Dependency] private readonly GameTicker _ticker = default!;
     [Dependency] private readonly IdCardSystem _idSystem = default!;
     [Dependency] private readonly NavMapSystem _navMap = default!;
@@ -228,7 +229,7 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
     /// </summary>
     private void OnEmergencyFTLComplete(EntityUid uid, EmergencyShuttleComponent component, ref FTLCompletedEvent args)
     {
-        var countdownTime = TimeSpan.FromSeconds(ConfigManager.GetCVar(CCVars.RoundRestartTime));
+        var countdownTime = TimeSpan.FromSeconds(ConfigManager.GetCVar(CCVars.RoundRestartTime)) + _evac.RoundEndBufferTime;
         var shuttle = args.Entity;
         if (TryComp<DeviceNetworkComponent>(shuttle, out var net))
         {

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -643,7 +643,7 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
     }
 
     /// <summary>
-    /// Returns whether a target is escaping on the emergency shuttle, but only if evac has arrived.
+    /// Returns whether a target is escaping on the emergency shuttle, or has already reached centcomm, but only if evac has arrived.
     /// </summary>
     public bool IsTargetEscaping(EntityUid target)
     {
@@ -655,6 +655,9 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
         var xform = Transform(target);
 
         if (HasComp<EmergencyShuttleComponent>(xform.GridUid))
+            return true;
+
+        if (xform.MapUid != null && GetCentcommMaps().Contains(xform.MapUid.Value))
             return true;
 
         return false;

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -228,7 +228,7 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
     /// </summary>
     private void OnEmergencyFTLComplete(EntityUid uid, EmergencyShuttleComponent component, ref FTLCompletedEvent args)
     {
-        var countdownTime = TimeSpan.FromSeconds(ConfigManager.GetCVar(CCVars.RoundRestartTime)) + RoundEndBufferTime;
+        var countdownTime = TimeSpan.FromSeconds(ConfigManager.GetCVar(CCVars.RoundRestartTime) + RoundEndBufferTime);
         var shuttle = args.Entity;
         if (TryComp<DeviceNetworkComponent>(shuttle, out var net))
         {

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -201,7 +201,7 @@ public sealed partial class CCVars
     ///     That can break Nukeops win conditions (disk/bomb delivery on Centcomm).
     /// </summary>
     public static readonly CVarDef<float> RoundEndBufferTime =
-        CVarDef.Create("shuttle.round_end_buffer_time", 0.5f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.round_end_buffer_time", 1.0f, CVar.SERVERONLY);
 
     #region impacts
 

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Administration;
+using Content.Shared.Administration;
 using Content.Shared.CCVar.CVarAccess;
 using Robust.Shared.Configuration;
 
@@ -194,6 +194,14 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<float> GridImpulseMultiplier =
         CVarDef.Create("shuttle.grid_impulse_multiplier", 0.01f, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Time in seconds how much to wait before ending the round, AFTER the emergency shuttle docks to Centcomm.
+    ///     Setting this to zero is undesirable - evac might not finish it's FTL.
+    ///     That can break Nukeops win conditions (disk/bomb delivery on Centcomm).
+    /// </summary>
+    public static readonly CVarDef<float> RoundEndBufferTime =
+        CVarDef.Create("shuttle.round_end_buffer_time", 0.5f, CVar.SERVERONLY);
 
     #region impacts
 


### PR DESCRIPTION
## About the PR
Round end is supposed to be delayed by a few seconds after emergency shuttle lands, but it doesn't due to a bug/regression.

## Why / Balance
Fixes #41066.
Also should reduce client stutter spike on evac shuttle landing, now that round end summary display is delayed.

## Technical details
Fixed the following delay never actually applying:
https://github.com/space-wizards/space-station-14/blob/891f5a8f6ba76701dd447d6f33e27cc9029a673d/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs#L42-L45

## Media
<img width="952" height="549" alt="{5ED3D5A9-9CAC-4549-A3B2-7716E231CCCC}" src="https://github.com/user-attachments/assets/05ae6324-a17d-4dc2-accc-6b7697da060b" />


## Requirements
- [х] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [х] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
EmergencyShuttleSystem.IsTargetEscaping now also checks if target is on Centcomm map.

**Changelog**
:cl:
- fix: Fixed nukeops centcomm bombing not awarding major victory.