### PR TITLE
Update janicart.yml -   id: MopBucket - Added type DrawableSolution -…

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
@@ -26,6 +26,8 @@
     spillWhenThrown: false
   - type: DrainableSolution
     solution: bucket
+  - type: DrawableSolution
+    solution: bucket
   - type: RefillableSolution
     solution: bucket
   - type: ExaminableSolution


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added `DrawableSolution` component to the mop bucket entity.
Resolves #41104

## Why / Balance
Most liquid containers let you draw solutions from them, why not the mop bucket? Especially since it's an open container for liquids.

## Technical details
- Added `DrawableSolution` component with `solution: bucket` to `MopBucket` entity
- The mop bucket already had `DrainableSolution` and `RefillableSolution`, this completes the solution interface

## Media
![Content Client_HBLem2yRXu](https://github.com/user-attachments/assets/cdd87ebc-1adb-404e-be85-d3075fdb2966)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

:cl: **Changelog**

- tweak: Mop buckets can be drawn from properly