### PR TITLE
Fix flash examine text on skeletons

### DIFF
--- a/Content.Shared/Flash/Components/FlashImmunityComponent.cs
+++ b/Content.Shared/Flash/Components/FlashImmunityComponent.cs
@@ -21,4 +21,10 @@ public sealed partial class FlashImmunityComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool ShowInExamine = true;
+
+    /// <summary>
+    /// Should the examine verb itself be shown?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool ShowExamine = false;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Skeletons no longer have "This provides immunity to bright flashes"

## Why / Balance
It really makes no sense for this to be on the examine text

## Technical details
d-1 super hard C#

no it was just adding this code to `FlashImmunityComponent.cs`
`[DataField, AutoNetworkedField]
    public bool ShowExamine = false;`
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="577" height="349" alt="image" src="https://github.com/user-attachments/assets/aefd414d-4048-4fc5-84fd-bb445a791557" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
no

**Changelog**
:cl:
- tweak: Skeletons no longer have the flash immunity examine text
