### PR TITLE
Remove IsFirstTimePredicted from Ninja systems

### DIFF
--- a/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
+++ b/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
@@ -56,9 +56,6 @@ public sealed class DashAbilitySystem : EntitySystem
     /// </summary>
     private void OnDash(Entity<DashAbilityComponent> ent, ref DashEvent args)
     {
-        if (!_timing.IsFirstTimePredicted)
-            return;
-
         var (uid, comp) = ent;
         var user = args.Performer;
         if (!CheckDash(uid, user))

--- a/Content.Shared/Ninja/Systems/SharedNinjaGlovesSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedNinjaGlovesSystem.cs
@@ -128,8 +128,7 @@ public abstract class SharedNinjaGlovesSystem : EntitySystem
     public bool AbilityCheck(EntityUid uid, BeforeInteractHandEvent args, out EntityUid target)
     {
         target = args.Target;
-        return _timing.IsFirstTimePredicted
-            && !_combatMode.IsInCombatMode(uid)
+        return !_combatMode.IsInCombatMode(uid)
             && _hands.GetActiveItem(uid) == null
             && _interaction.InRangeUnobstructed(uid, target);
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed IsFirstTimePredicted usages in the ninja systems.

## Why / Balance
Per #41116, this check is being misused and in these particular instances makes no sense.

I tested these changes and observed no difference in behavior, prediction or otherwise. The UI mispredict occurs whether this check is here or not.

## Technical details
Removed the mentioned check and verified changes. Not really anything technical here.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->