### PR TITLE
Fix DeltaPressure serialization spam

### DIFF
--- a/Content.Server/Atmos/Components/DeltaPressureComponent.cs
+++ b/Content.Server/Atmos/Components/DeltaPressureComponent.cs
@@ -40,7 +40,10 @@ public sealed partial class DeltaPressureComponent : Component
     /// for removal while the entity is being deleted.
     /// </summary>
     /// <remarks>Note that while <see cref="AirtightComponent"/> already stores the grid,
-    /// we cannot trust it to be available on init or when the entity is being deleted. Tragic.</remarks>
+    /// we cannot trust it to be available on init or when the entity is being deleted. Tragic.
+    /// Double note: this is set during ComponentInit and thus does not need to be a datafield
+    /// or else it will spam serialization.</remarks>
+    /// TODO ATMOS: Simply use AirtightComponent's GridUID caching and handle entity removal from the processing list on an invalidation system similar to InvalidTiles.
     [ViewVariables(VVAccess.ReadOnly)]
     public EntityUid? GridUid;
 


### PR DESCRIPTION
## About the PR
Fix DeltaPressure spamming serialization
Fixes #41117 
## Why / Balance
The cached GridUid does not need to be saved and is overwritten anyways during initialization so the performance gain is net zero.

## Technical details
Changes a DataField to ViewVariables (readonly)

## Media
tests passed locally

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A.

**Changelog**
N/A.
