### PR TITLE
Remove `IsFirstTimePredicted` from SharedAnomalySystem.cs

### DIFF
--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -72,9 +72,6 @@ public abstract class SharedAnomalySystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
-        if (!Timing.IsFirstTimePredicted)
-            return;
-
         DebugTools.Assert(component.MinPulseLength > TimeSpan.FromSeconds(3)); // this is just to prevent lagspikes mispredicting pulses
         RefreshPulseTimer(uid, component);
 
@@ -155,9 +152,6 @@ public abstract class SharedAnomalySystem : EntitySystem
     public void DoAnomalySupercriticalEvent(EntityUid uid, AnomalyComponent? component = null)
     {
         if (!Resolve(uid, ref component))
-            return;
-
-        if (!Timing.IsFirstTimePredicted)
             return;
 
         if (_net.IsServer)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title

## Why / Balance
works fine without it
also fixes part of https://github.com/space-wizards/space-station-14/issues/41116
## Technical details

## Media
<img width="500" height="560" alt="image" src="https://github.com/user-attachments/assets/4a6cd251-6667-487e-95b6-a23d94dfd46e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
no

**Changelog**
no cl no fub