### PR TITLE
Fix chemical explosion scaling.

### DIFF
--- a/Content.Shared/EntityEffects/Effects/Solution/AreaReactionEntityEffect.cs
+++ b/Content.Shared/EntityEffects/Effects/Solution/AreaReactionEntityEffect.cs
@@ -28,6 +28,8 @@ public sealed partial class AreaReactionEffect : EntityEffectBase<AreaReactionEf
     /// </summary>
     [DataField(required: true)] public SoundSpecifier Sound = default!;
 
+    public override bool Scaling => true;
+
     public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         => Loc.GetString("entity-effect-guidebook-area-reaction",
             ("duration", Duration)

--- a/Content.Shared/EntityEffects/Effects/Transform/EmpEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/Transform/EmpEntityEffectSystem.cs
@@ -49,6 +49,8 @@ public sealed partial class Emp : EntityEffectBase<Emp>
     [DataField]
     public TimeSpan Duration = TimeSpan.FromSeconds(15);
 
+    public override bool Scaling => true;
+
     public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         => Loc.GetString("entity-effect-guidebook-emp-reaction-effect", ("chance", Probability));
 

--- a/Content.Shared/EntityEffects/Effects/Transform/ExplosionEntityEffect.cs
+++ b/Content.Shared/EntityEffects/Effects/Transform/ExplosionEntityEffect.cs
@@ -50,6 +50,8 @@ public sealed partial class Explosion : EntityEffectBase<Explosion>
     [DataField]
     public float TileBreakScale = 1f;
 
+    public override bool Scaling => true;
+
     public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         => Loc.GetString("entity-effect-guidebook-explosion", ("chance", Probability));
 

--- a/Content.Shared/EntityEffects/Effects/Transform/FlashEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/Transform/FlashEntityEffectSystem.cs
@@ -76,6 +76,8 @@ public sealed partial class Flash : EntityEffectBase<Flash>
     [DataField]
     public SoundSpecifier? Sound = new SoundPathSpecifier("/Audio/Weapons/flash.ogg");
 
+    public override bool Scaling => true;
+
     public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         => Loc.GetString("entity-effect-guidebook-flash-reaction-effect", ("chance", Probability));
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed explosion reaction scaling.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Unintended behavior change.

## Technical details
<!-- Summary of code changes for easier review. -->
Explosions by default scaled by reagent quantity, this was disabled with entity effects refactor. This PR sets the default of scaling back to true for all area reactions. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Explosions now scale properly with reagent quantity

