### PR TITLE
Xenoartifact: Fix phasing effect

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERemoveCollisionSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERemoveCollisionSystem.cs
@@ -14,12 +14,12 @@ public sealed class XAERemoveCollisionSystem : BaseXAESystem<XAERemoveCollisionC
     /// <inheritdoc />
     protected override void OnActivated(Entity<XAERemoveCollisionComponent> ent, ref XenoArtifactNodeActivatedEvent args)
     {
-        if (!TryComp<FixturesComponent>(ent.Owner, out var fixtures))
+        if (!TryComp<FixturesComponent>(args.Artifact, out var fixtures))
             return;
 
         foreach (var fixture in fixtures.Fixtures.Values)
         {
-            _physics.SetHard(ent.Owner, fixture, false, fixtures);
+            _physics.SetHard(args.Artifact, fixture, false, fixtures);
         }
     }
 }


### PR DESCRIPTION
Fix phasing effect.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed broken phasing effect. Supposed to remove fixtures from artifact, but was attempting to remove fixtures from node.

## Why / Balance
Effect was nonfunctional.

## Technical details
Phase the artifact instead of the node (node had no fixtures anyway)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Artifact phasing fixed.