### PR TITLE
DeltaPressure better ent handling

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -481,6 +481,7 @@ namespace Content.Server.Atmos.EntitySystems
             {
                 atmosphere.DeltaPressureCursor = 0;
                 atmosphere.DeltaPressureDamageResults.Clear();
+                _deltaPressureInvalidEntityQueue.Clear();
             }
 
             var remaining = count - atmosphere.DeltaPressureCursor;
@@ -522,6 +523,13 @@ namespace Content.Server.Atmos.EntitySystems
                 {
                     return false;
                 }
+            }
+
+            // Ents may have been invalidated (missing AirtightComp) during parallel processing.
+            // Since we can't touch the ent list during parallel processing, we queue them up here to be removed.
+            while (_deltaPressureInvalidEntityQueue.TryDequeue(out var invalidEnt))
+            {
+                TryRemoveDeltaPressureEntity(ent.AsNullable(), invalidEnt);
             }
 
             return true;


### PR DESCRIPTION
## About the PR
Improves internal dP processing a little by TryComping for AirtightComponent when we use it.

## Why / Balance
For whatever reason some goober could delete AirtightComponent on a DeltaPressure entity which will cause an exception when the component is retrieved. This just makes it so that we make sure it's there before we perform dP operations.

## Technical details
We just TryComp. Gotta keep the branch predictor on its toes.

Since we're checking for invalid entities in a critical section, we can't just remove them right now. If we went to remove them, the substitution that dP does during removal would change data potentially belonging to another threadpool worker.

As such we just defer removal to the end of the critical section when we're finalizing processing.

Oh, and I also moved an unnecessary over-retrieval of a tile's pressure out of the loop because we just need to retrieve it once.

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
n/a
