### PR TITLE
Readd CutWireVariationPass

### DIFF
--- a/Content.Server/GameTicking/Rules/VariationPass/CutWireVariationPassSystem.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/CutWireVariationPassSystem.cs
@@ -1,8 +1,6 @@
 using Content.Server.GameTicking.Rules.VariationPass.Components;
 using Content.Server.Wires;
-using Content.Shared.CCVar;
 using Content.Shared.Whitelist;
-using Robust.Shared.Configuration;
 using Robust.Shared.Random;
 
 namespace Content.Server.GameTicking.Rules.VariationPass;
@@ -15,13 +13,9 @@ namespace Content.Server.GameTicking.Rules.VariationPass;
 public sealed class CutWireVariationPassSystem : VariationPassSystem<CutWireVariationPassComponent>
 {
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
-    [Dependency] private readonly IConfigurationManager _cfgManager = default!;
 
     protected override void ApplyVariation(Entity<CutWireVariationPassComponent> ent, ref StationVariationPassEvent args)
     {
-        if (!_cfgManager.GetCVar(CCVars.GameCutWireVariation))
-            return;
-
         var wiresCut = 0;
         var query = AllEntityQuery<WiresComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out _, out var transform))

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -409,10 +409,4 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> GameHostnameInTitlebar =
         CVarDef.Create("game.hostname_in_titlebar", true, CVar.SERVER | CVar.REPLICATED);
-
-    /// <summary>
-    ///     Should CutWireVariationPass be run at round start?
-    /// </summary>
-    public static readonly CVarDef<bool> GameCutWireVariation =
-        CVarDef.Create("game.cut_wire_variation", true, CVar.SERVERONLY);
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
CutWireVariationPass has been re-enabled.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This rule was disabled shortly after introduction in #25786. I believe this was unintentional.

## Technical details
<!-- Summary of code changes for easier review. -->
Variation was readded to roundstart.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Wires will once again break randomly at roundstart.