### PR TITLE
Fix the ethanol guidebook entry

### DIFF
--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -125,7 +125,6 @@
     metabolizerTypes: [ Animal ]
     groups:
     - id: Alcohol
-      rateModifier: 0.1
   - type: Item
     size: Small
     heldPrefix: liver

--- a/Resources/Prototypes/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/slimes.yml
@@ -19,7 +19,7 @@
         - id: Poison
         - id: Narcotic
         - id: Alcohol
-          rateModifier: 0.2
+          rateModifier: 2
     - type: SolutionContainerManager
       solutions:
         stomach:

--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -123,7 +123,6 @@
     metabolizerTypes: [Animal]
     groups:
     - id: Alcohol
-      rateModifier: 0.1 # removes alcohol very slowly along with the stomach removing it as a drink
 
 - type: entity
   id: OrganArachnidKidneys

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -92,7 +92,6 @@
       - id: Poison
       - id: Narcotic
       - id: Alcohol
-        rateModifier: 0.1
   - type: Item
     size: Small
     heldPrefix: stomach

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -225,7 +225,6 @@
     metabolizerTypes: [Human]
     groups:
     - id: Alcohol
-      rateModifier: 0.1 # removes alcohol very slowly along with the stomach removing it as a drink
 
 - type: entity
   id: OrganHumanKidneys

--- a/Resources/Prototypes/Body/Organs/slime.yml
+++ b/Resources/Prototypes/Body/Organs/slime.yml
@@ -19,7 +19,7 @@
         - id: Poison
         - id: Narcotic
         - id: Alcohol
-          rateModifier: 0.25
+          rateModifier: 2.5
     - type: SolutionContainerManager
       solutions:
         stomach:
@@ -37,7 +37,7 @@
       size: Small
       heldPrefix: brain
 
-      
+
 - type: entity
   id: OrganSlimeLungs
   parent: BaseHumanOrgan

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -162,6 +162,7 @@
   meltingPoint: -114.1
   metabolisms:
     Alcohol:
+      metabolismRate: 0.05
       effects:
       - !type:HealthChange
         conditions:
@@ -173,7 +174,7 @@
           inverted: true
         damage:
           types:
-            Poison: 1
+            Poison: 0.1
       # dwarves take less toxin damage and heal a marginal amount of brute
       - !type:HealthChange
         conditions:
@@ -184,7 +185,7 @@
           type: [ Dwarf ]
         damage:
           types:
-            Poison: 0.2
+            Poison: 0.02
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
@@ -194,7 +195,7 @@
           type: [ Dwarf ]
         damage:
           groups:
-            Brute: -1
+            Brute: -0.1
       - !type:Vomit
         probability: 0.04
         conditions:
@@ -206,7 +207,7 @@
           type: [ Dwarf ]
           inverted: true
       - !type:Drunk
-        boozePower: 20
+        boozePower: 2
 
 - type: reagent
   id: Gin
@@ -2520,6 +2521,7 @@
         reagent: Ethanol
         amount: 0.45 # TODO: Figure out why setting this to 0 means this does more damage... WHAT BUG IS THIS?!!
     Alcohol:
+      metabolismRate : 0.05
       effects:
       - !type:Drunk
         boozePower: 10
@@ -2533,7 +2535,7 @@
           inverted: true
         damage:
           types:
-            Poison: 2 # TODO: Figure out poison amount. Ethanol does 1, this does 2 but also metabolises almost 3 to 4 times as fast as ethanol. This would be more Liver damage when that time arrives.
+            Poison: 0.2 # TODO: Figure out poison amount. Ethanol does 0.1, this does 0.2 but also metabolises almost 3 to 4 times as fast as ethanol. This would be more Liver damage when that time arrives.
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
@@ -2543,7 +2545,7 @@
           type: [Dwarf]
         damage:
           types:
-            Poison: 0.4 # TODO: Might increase this, even though it's just double of ethanol from 0.2 to 0.4
+            Poison: 0.04 # TODO: Might increase this, even though it's just double of ethanol from 0.02 to 0.04
       - !type:Vomit
         probability: 0.1 #TODO: Tweak vomit probability, maybe make this more violent and poisonous but the body aggressively purges it...
         conditions:


### PR DESCRIPTION
## About the PR
The metabolism rate modifiers of all livers (and other organs that metabolize `Alcohol`) has been multiplied by 10, meaning that most species metabolize reagents with an `Alcohol` group (currently only ethanol and bacchu's blessing) at a 1x rate.
The metabolism rate and effects of the aforementioned reagents have been divided by 10 to compensate.

## Why / Balance
If I've done this correctly, this shouldn't affect gameplay at all (and from my testing it doesn't), while also fixing the issue of the ethanol guidebook entry being misleading (it says 0.5u/s metabolism rate, when in reality most species metabolize it at 0.05u/s)

## Technical details
YML

## Media
<img width="653" height="378" alt="2025-10-30_04-12-14" src="https://github.com/user-attachments/assets/b2afde90-831c-4312-907c-fcde7d8778aa" />

*please don't ask why the UI on this screenshot looks so scuffed*


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->