### PR TITLE
Cake slice and rubber ducky secret stash fixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -64,6 +64,11 @@
     tags:
     - Cake
     - Slice
+  - type: SecretStash
+    maxItemSize: "Tiny"
+    blacklist:
+      components:
+      - SecretStash # Prevents being able to insert other stashes inside of it. EX: Infinite cake or plushie stacking
 
 # Custom Cake Example
 

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -84,6 +84,8 @@
   - type: Tag
     tags:
     - ToyRubberDuck
+  - type: SecretStash
+    maxItemSize: "Tiny"
 
 - type: entity
   parent: BaseRubberToy


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

I made the secret stash components in both rubber duckies and cake slices reflect their actual object size ("Tiny"). I also restricted cake slices to blacklist secret stashes so you can't infinitely stack em'.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

As of right now, since the cake slice is parented off of the cake with no changes to the stash size, you can fit large items into it. So, if you really wanted to, you could fit CE's magboots all within one slice of cake or even put HOS' energy magnum / the antique laser pistol into a pair of jackboots and shove em in a cake slice, or just put them in directly, then shove them into a storage implanter....... or don't.

Also the blacklist is so that you can't infinitely stack cakes inside of each other or put rubber ducks in cakes to infinitely stack them as well.

Also this probably should have been fixed ages ago :P

## Technical details
<!-- Summary of code changes for easier review. -->

Just YAML

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: The stash sizes of both rubber ducks and cake slices have been reduced to properly reflect their sizes.
- fix: Cake slices can no longer be infinitely stacked inside of each other.

