### PR TITLE
Add a new gas React() benchmark

### DIFF
--- a/Content.Benchmarks/GasReactionBenchmark.cs
+++ b/Content.Benchmarks/GasReactionBenchmark.cs
@@ -22,7 +22,7 @@ namespace Content.Benchmarks;
 [MemoryDiagnoser]
 public class GasReactionBenchmark
 {
-    private const int Iterations = 100;
+    private const int Iterations = 1000;
     private TestPair _pair = default!;
     private AtmosphereSystem _atmosphereSystem = default!;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Add a new atmos benchmark that test the gases reaction on tiles

## Why / Balance
Benchmark can be useful; I need one for #38934 

## Technical details
N/A

## Media
<img width="816" height="528" alt="image" src="https://github.com/user-attachments/assets/147d2f36-216d-400f-a522-358bb6d8b5d9" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
