### PR TITLE
VoiceOverrideComponent is now usable on clothing/equipment

### DIFF
--- a/Content.Server/Speech/EntitySystems/VoiceOverrideSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VoiceOverrideSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Chat;
 using Content.Server.Speech.Components;
+using Content.Shared.Inventory;
 
 namespace Content.Server.Speech.EntitySystems;
 
@@ -8,7 +9,7 @@ public sealed partial class VoiceOverrideSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<VoiceOverrideComponent, TransformSpeakerNameEvent>(OnTransformSpeakerName);
+        Subs.SubscribeWithRelay<VoiceOverrideComponent, TransformSpeakerNameEvent>(OnTransformSpeakerName, held: false);
     }
 
     private void OnTransformSpeakerName(Entity<VoiceOverrideComponent> entity, ref TransformSpeakerNameEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made the VoiceOverride component listen out for relayed event triggers

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
TransformSpeakerNameEvent is already present in the relayed events list, but VoiceOverride wasn't set up to use that functionality. No reason not to have it available.
Additionally, I have a PR I'm interested in making that this functionality would be required for

## Technical details
<!-- Summary of code changes for easier review. -->
Makes use of SubscribeWithRelay instead of SubscribeLocalEvent

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No player facing changes.
