### PR TITLE
Tile space edges rendering for ZLevels (content part)

### DIFF
--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -33,8 +33,15 @@ namespace Content.Shared.Maps
         [DataField("name")]
         public string Name { get; private set; } = "";
         [DataField("sprite")] public ResPath? Sprite { get; private set; }
-
+        
+        /// <summary>
+        /// Tile edges. Visible when a tile touches another tile that has a lower EdgeSpritePriority than this tile.
+        /// </summary>
         [DataField] public Dictionary<Direction, ResPath> EdgeSprites { get; private set; } = new();
+        
+        /// <summary>
+        /// Tile edges. Visible when a tile touches a space tile.
+        /// </summary>
         [DataField] public Dictionary<Direction, ResPath> EdgeSpaceSprites { get; private set; } = new();
 
         [DataField("edgeSpritePriority")] public int EdgeSpritePriority { get; private set; } = 0;

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -34,7 +34,8 @@ namespace Content.Shared.Maps
         public string Name { get; private set; } = "";
         [DataField("sprite")] public ResPath? Sprite { get; private set; }
 
-        [DataField("edgeSprites")] public Dictionary<Direction, ResPath> EdgeSprites { get; private set; } = new();
+        [DataField] public Dictionary<Direction, ResPath> EdgeSprites { get; private set; } = new();
+        [DataField] public Dictionary<Direction, ResPath> EdgeSpaceSprites { get; private set; } = new();
 
         [DataField("edgeSpritePriority")] public int EdgeSpritePriority { get; private set; } = 0;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
content part
required for: https://github.com/space-wizards/RobustToolbox/pull/6281

If a tile touches space, it will use different edge sprites than when it touches other tiles.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

When developing the z-level system, using regular edgesprites at the boundary with air is not aesthetically pleasing. It would be desirable to have the ability to render a separate view of the tile edges in this situation.

<img width="606" height="703" alt="image" src="https://github.com/user-attachments/assets/093b93c2-590d-43bf-a7b6-d49b6f5f00c4" />
<img width="459" height="461" alt="image" src="https://github.com/user-attachments/assets/e17c75eb-38a3-4849-b5cb-166d262ea1e9" />
