### PR TITLE
Change PoolSettings "Connected" default to False

### DIFF
--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
@@ -167,7 +167,7 @@ public abstract partial class InteractionTest
   - type: CombatMode
 ";
 
-    protected static PoolSettings Default => new() { Connected = true, Dirty = true };
+    protected static PoolSettings Default => new() { Connected = false, Dirty = true };
     protected virtual PoolSettings Settings => Default;
 
     [SetUp]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed default behavior for interaction tests.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
#18732 calls out that Connected is default false.

The PairSettings class also claims this:
```
    /// <summary>
    /// Set to true if the given server/client pair should be connected from each other.
    /// Defaults to disconnected as it makes dirty recycling slightly faster.
    /// </summary>
    public virtual bool Connected { get; init; }
```

but the InteractionTest base class default settings are `protected static PoolSettings Default => new() { Connected = true, Dirty = true };` which means that any test using the "defaults" will be running connected. Since almost every test creates a new  PoolSettings if they intend to run connected, this is counterintuitive behavior. 

On my local machine I saw a 7.5% speedup with this change, with all tests still passing.
<img width="1288" height="255" alt="image" src="https://github.com/user-attachments/assets/675aee7d-ed39-4090-8f68-6b531e555688" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
InteractionTest default PoolSettings are now to run unconnected. Any tests that need server/client connectivity must define a PoolSettings with Connected set to True.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No player facing changes.