### PR TITLE
Add origin member to class

### DIFF
--- a/Content.Shared/Damage/Systems/DamageableSystem.Events.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.Events.cs
@@ -219,9 +219,7 @@ public record struct BeforeDamageChangedEvent(DamageSpecifier Damage, EntityUid?
 public sealed class DamageModifyEvent(DamageSpecifier damage, EntityUid? origin = null)
     : EntityEventArgs, IInventoryRelayEvent
 {
-    /// <summary>
-    ///     Contains slots that will be affected by relayed damage.
-    /// </summary>
+    /// <inheritdoc/>
     /// <remarks>
     ///     Whenever locational damage is a thing, this should just check only that bit of armor.
     /// </remarks>
@@ -239,7 +237,7 @@ public sealed class DamageModifyEvent(DamageSpecifier damage, EntityUid? origin 
     public DamageSpecifier Damage = damage;
 
     /// <summary>
-    ///     Contains the entity which caused damage event, if any was responsible.
+    ///     Contains the entity which caused the damage, if any was responsible.
     /// </summary>
     public readonly EntityUid? Origin = origin;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added an `Origin` member to `DamageModifyEvent`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This was giving a CS9113 warning as it was never used in the class body.
I assume the intent was to include it in the event.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No player facing changes.
