### PR TITLE
Allow item interaction via strip menu

### DIFF
--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -1335,11 +1335,12 @@ namespace Content.Shared.Interaction
         /// <inheritdoc cref="CanAccessViaStorage(Robust.Shared.GameObjects.EntityUid,Robust.Shared.GameObjects.EntityUid)"/>
         public bool CanAccessViaStorage(EntityUid user, EntityUid target, BaseContainer container)
         {
-            if (StorageComponent.ContainerId != container.ID)
-                return false;
-
-            // we don't check if the user can access the storage entity itself. This should be handed by the UI system.
-            return _ui.IsUiOpen(container.Owner, StorageComponent.StorageUiKey.Key, user);
+            if (StorageComponent.ContainerId == container.ID)
+            {
+                // we don't check if the user can access the storage entity itself. This should be handed by the UI system.
+                return _ui.IsUiOpen(container.Owner, StorageComponent.StorageUiKey.Key, user);
+            }
+            return true;
         }
 
         /// <summary>

--- a/Content.Shared/Strip/Components/StrippableComponent.cs
+++ b/Content.Shared/Strip/Components/StrippableComponent.cs
@@ -80,12 +80,14 @@ namespace Content.Shared.Strip.Components
         public readonly bool InsertOrRemove;
         public readonly bool InventoryOrHand;
         public readonly string SlotOrHandName;
+        public readonly bool UseItem;
 
-        public StrippableDoAfterEvent(bool insertOrRemove, bool inventoryOrHand, string slotOrHandName)
+        public StrippableDoAfterEvent(bool insertOrRemove, bool inventoryOrHand, string slotOrHandName, bool useItem = false)
         {
             InsertOrRemove = insertOrRemove;
             InventoryOrHand = inventoryOrHand;
             SlotOrHandName = slotOrHandName;
+            UseItem = useItem;
         }
 
         public override DoAfterEvent Clone() => this;

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -104,10 +104,13 @@ public abstract class SharedStrippableSystem : EntitySystem
 
         var hasEnt = _inventorySystem.TryGetSlotEntity(strippable, args.Slot, out var held, inventory);
 
-        if (_handsSystem.GetActiveItem((user, userHands)) is { } activeItem && !hasEnt)
+        var maybeActiveItem = _handsSystem.GetActiveItem((user, userHands));
+        if (maybeActiveItem is { } activeItem && !hasEnt)
             StartStripInsertInventory((user, userHands), strippable.Owner, activeItem, args.Slot);
-        else if (hasEnt)
+        else if (maybeActiveItem is null && hasEnt)
             StartStripRemoveInventory(user, strippable.Owner, held!.Value, args.Slot);
+        else if (hasEnt)
+            StartStripInteractInventory((user, userHands), strippable.Owner, held!.Value, args.Slot);
     }
 
     private void StripHand(
@@ -135,10 +138,13 @@ public abstract class SharedStrippableSystem : EntitySystem
             return;
         }
 
-        if (_handsSystem.GetActiveItem(user.AsNullable()) is { } activeItem && heldEntity == null)
+        var maybeActiveItem = _handsSystem.GetActiveItem(user.AsNullable());
+        if (maybeActiveItem is { } activeItem && heldEntity == null)
             StartStripInsertHand(user, target, activeItem, handId, targetStrippable);
-        else if (heldEntity != null)
+        else if (maybeActiveItem is null && heldEntity != null)
             StartStripRemoveHand(user, target, heldEntity.Value, handId, targetStrippable);
+        else if (heldEntity != null)
+            StartStripInteractHand(user, target, heldEntity.Value, handId, targetStrippable);
     }
 
     /// <summary>
@@ -570,6 +576,170 @@ public abstract class SharedStrippableSystem : EntitySystem
         // Hand update will trigger strippable update.
     }
 
+    /// <summary>
+    ///     Begins a DoAfter to use the item in the user's active hand on the item in the target's inventory.
+    /// </summary>
+    private void StartStripInteractInventory(
+        Entity<HandsComponent?> user,
+        EntityUid target,
+        EntityUid targetItem,
+        string slot)
+    {
+        if (!_handsSystem.TryGetActiveItem(user, out var userItem))
+            return;
+
+        if (!_inventorySystem.TryGetSlot(target, slot, out var slotDef))
+        {
+            Log.Error($"{ToPrettyString(user)} attempted to use item {ToPrettyString(userItem)} in a non-existent inventory slot ({slot}) on {ToPrettyString(target)}");
+            return;
+        }
+
+        // TODO: time modifiers should be affected by activeItem somehow
+        var (time, stealth) = GetStripTimeModifiers(user, target, targetItem, slotDef.StripTime);
+
+        if (!stealth)
+        {
+            if (IsStripHidden(slotDef, user))
+                _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner-hidden",
+                    ("slot", slot)),
+                    target,
+                    target,
+                    PopupType.Large);
+            else
+            {
+                _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner-interact-item",
+                    ("user", Identity.Entity(user, EntityManager)),
+                    ("userItem", userItem),
+                    ("targetItem", targetItem)),
+                    target,
+                    target);
+            }
+        }
+
+        var prefix = stealth ? "stealthily " : "";
+        _adminLogger.Add(LogType.Stripping,
+            LogImpact.Low,
+            $"{ToPrettyString(user):actor} is trying to {prefix}use item {ToPrettyString(userItem):userItem} on {ToPrettyString(targetItem):targetItem} in {ToPrettyString(target):target}'s {slot} slot");
+
+        _interactionSystem.DoContactInteraction(user, targetItem);
+
+        var doAfterArgs = new DoAfterArgs(EntityManager, user, time, new StrippableDoAfterEvent(false, true, slot, true), user, target, userItem)
+        {
+            Hidden = stealth,
+            AttemptFrequency = AttemptFrequency.EveryTick,
+            BreakOnDamage = true,
+            BreakOnMove = true,
+            NeedHand = true,
+            DuplicateCondition = DuplicateConditions.SameTool
+        };
+
+        _doAfterSystem.TryStartDoAfter(doAfterArgs);
+    }
+
+    /// <summary>
+    ///     Uses the item in the user's active hand on the item in the target's inventory.
+    /// </summary>
+    private void StripInteractInventory(
+        Entity<HandsComponent?> user,
+        EntityUid userItem,
+        EntityUid target,
+        string slot)
+    {
+        if (!Resolve(user, ref user.Comp))
+            return;
+
+        if (!_inventorySystem.TryGetSlotEntity(target, slot, out var maybeTargetItem) ||
+            maybeTargetItem is not { } targetItem)
+            return;
+
+        if (!_interactionSystem.InteractUsing(
+            user,
+            userItem,
+            targetItem,
+            Transform(target).Coordinates))
+            return;
+
+        _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):actor} has used the item {ToPrettyString(userItem):userItem} on {ToPrettyString(targetItem):targetItem} in {ToPrettyString(target):target}'s {slot} slot");
+    }
+
+    /// <summary>
+    ///     Begins a DoAfter to use the item in the user's active hand on the item in the target's hand.
+    /// </summary>
+    private void StartStripInteractHand(
+        Entity<HandsComponent?> user,
+        Entity<HandsComponent?> target,
+        EntityUid targetItem,
+        string handName,
+        StrippableComponent? targetStrippable = null)
+    {
+        if (!Resolve(user, ref user.Comp) ||
+            !Resolve(target, ref target.Comp) ||
+            !Resolve(target, ref targetStrippable))
+            return;
+
+        if (!_handsSystem.TryGetActiveItem(user, out var userItem))
+            return;
+
+        // TODO: time modifiers should be affected by activeItem somehow, instead of needing strippablecomponent
+        var (time, stealth) = GetStripTimeModifiers(user, target, targetItem, targetStrippable.HandStripDelay);
+
+        if (!stealth)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner-interact-item",
+                ("user", Identity.Entity(user, EntityManager)),
+                ("userItem", userItem),
+                ("targetItem", targetItem)),
+                target,
+                target);
+        }
+
+        var prefix = stealth ? "stealthily " : "";
+        _adminLogger.Add(LogType.Stripping,
+            LogImpact.Low,
+            $"{ToPrettyString(user):actor} is trying to {prefix}use item {ToPrettyString(userItem):userItem} on {ToPrettyString(targetItem):targetItem} in {ToPrettyString(target):target}'s hands");
+
+        _interactionSystem.DoContactInteraction(user, targetItem);
+
+        var doAfterArgs = new DoAfterArgs(EntityManager, user, time, new StrippableDoAfterEvent(false, false, handName, true), user, target, userItem)
+        {
+            Hidden = stealth,
+            AttemptFrequency = AttemptFrequency.EveryTick,
+            BreakOnDamage = true,
+            BreakOnMove = true,
+            NeedHand = true,
+            DuplicateCondition = DuplicateConditions.SameTool
+        };
+
+        _doAfterSystem.TryStartDoAfter(doAfterArgs);
+    }
+
+    /// <summary>
+    ///     Uses the item in the user's active hand on the item in the target's inventory.
+    /// </summary>
+    private void StripInteractHand(
+        Entity<HandsComponent?> user,
+        EntityUid userItem,
+        Entity<HandsComponent?> target,
+        string handId)
+    {
+        if (!Resolve(user, ref user.Comp) ||
+            !Resolve(target, ref target.Comp))
+            return;
+
+        if (!_handsSystem.TryGetHeldItem(target, handId, out var maybeTargetItem) ||
+            maybeTargetItem is not { } targetItem)
+            return;
+
+        if (!_interactionSystem.InteractUsing(
+            user,
+            userItem,
+            targetItem,
+            Transform(target).Coordinates))
+            return;
+
+        _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):actor} has used the item {ToPrettyString(userItem):userItem} on {ToPrettyString(targetItem):targetItem} in {ToPrettyString(target):target}'s hands");
+    }
+
     private void OnStrippableDoAfterRunning(Entity<HandsComponent> entity, ref DoAfterAttemptEvent<StrippableDoAfterEvent> ev)
     {
         var args = ev.DoAfter.Args;
@@ -581,16 +751,18 @@ public abstract class SharedStrippableSystem : EntitySystem
 
         if (ev.Event.InventoryOrHand)
         {
-            if ( ev.Event.InsertOrRemove && !CanStripInsertInventory((entity.Owner, entity.Comp), args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName) ||
-                !ev.Event.InsertOrRemove && !CanStripRemoveInventory(entity.Owner, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName))
+            if ((ev.Event.InsertOrRemove && !CanStripInsertInventory((entity.Owner, entity.Comp), args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName) ||
+                !ev.Event.InsertOrRemove && !CanStripRemoveInventory(entity.Owner, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName)) &&
+                !ev.Event.UseItem)
             {
                 ev.Cancel();
             }
         }
         else
         {
-            if ( ev.Event.InsertOrRemove && !CanStripInsertHand((entity.Owner, entity.Comp), args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName) ||
-                !ev.Event.InsertOrRemove && !CanStripRemoveHand(entity.Owner, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName))
+            if ((ev.Event.InsertOrRemove && !CanStripInsertHand((entity.Owner, entity.Comp), args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName) ||
+                !ev.Event.InsertOrRemove && !CanStripRemoveHand(entity.Owner, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName)) &&
+                !ev.Event.UseItem)
             {
                 ev.Cancel();
             }
@@ -607,7 +779,14 @@ public abstract class SharedStrippableSystem : EntitySystem
         DebugTools.Assert(ev.Used != null);
         DebugTools.Assert(ev.SlotOrHandName != null);
 
-        if (ev.InventoryOrHand)
+        if (ev.UseItem)
+        {
+            if (ev.InventoryOrHand)
+                StripInteractInventory((entity.Owner, entity.Comp), ev.Used.Value, ev.Target.Value, ev.SlotOrHandName);
+            else
+                StripInteractHand((entity.Owner, entity.Comp), ev.Used.Value, ev.Target.Value, ev.SlotOrHandName);
+        }
+        else if (ev.InventoryOrHand)
         {
             if (ev.InsertOrRemove)
                 StripInsertInventory((entity.Owner, entity.Comp), ev.Target.Value, ev.Used.Value, ev.SlotOrHandName);

--- a/Resources/Locale/en-US/strip/strippable-component.ftl
+++ b/Resources/Locale/en-US/strip/strippable-component.ftl
@@ -13,6 +13,7 @@ strippable-component-alert-owner-insert-hand = {CAPITALIZE(THE($user))} is putti
 
 # generic warning for when a user interacts with your equipped items.
 strippable-component-alert-owner-interact = {CAPITALIZE(THE($user))} is fumbling around with your {$item}!
+strippable-component-alert-owner-interact-item = {CAPITALIZE(THE($user))} is fumbling around with your {$targetItem} using {INDEFINITE($userItem)} {$userItem}!
 
 # StripVerb
 strip-verb-get-data-text = Strip


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Users can now perform item interactions on other users' clothes or held items!
There's a doafter to allow the interaction. The person being interacted with will see what item is being used, and on what.
After this doafter, the interaction is performed. This may include a 2nd doafter. See video.

## Why / Balance
I scope crept an item ive been planning to add to a downstream and this happened.

As far as i know this is an ancient TODO. The doafter length means interactions still feel fair imo, and this can probably lead to some more intuitive interaction. (i'm imagining a future system where you can 'offer' an item to cancel doafters on it, so patrons can offer bartenders an empty glass to pour into...)

~~Only real loss is that you can no longer strip items from people unless you have an empty hand, but thats pretty minor tbh.~~ EDIT: as long as you're in harm mode, you will always prioritize stripping someone over using an item interaction!

## Technical details
Moves some logic around in `SharedInteractionSystem` to only perform a UI open check if we are interacting with an item in a basecontainer. Anything in an alternatively-named container (such as a hand or inventory slot) can be interacted with.
**Note:** I'm genuinely not sure if this will cause issues, and would appreciate if someone could check my work here.

Adds a bool `UseItem` to `StrippableDoAfterEvent`. This bool triggers logic for item interactions.
I kept in the bool `InsertOrRemove` even though it doesnt matter for interactions in order to minimize breaking changes.

4 new methods in `SharedStrippableSystem` for interactions in inv slots, interactions in hands, and handling DoAfters for both.

## Media

https://github.com/user-attachments/assets/af107927-ad8d-49b6-a4d8-e6f39dd8cc25

video here is from a downstream fork, but all of the logic is the same. i just didnt want to rerecord it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: You can now use items on things people are wearing or holding.