### PR TITLE
Admin improvements for Looc and Deadchat

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -271,8 +271,8 @@ public sealed partial class ChatSystem : SharedChatSystem
             return;
 
         // Systems can differentiate Looc and DeadChat by type, and cancel the speak attempt if necessary.
-        var ev = new LoocSpeakAttemptEvent(sendType);
-        RaiseLocalEvent(source, ref ev);
+        var ev = new InGameOocMessageAttemptEvent(player, sendType);
+        RaiseLocalEvent(source, ref ev, true);
         if (ev.Cancelled)
             return;
 

--- a/Content.Shared/Administration/AdminFrozenSystem.cs
+++ b/Content.Shared/Administration/AdminFrozenSystem.cs
@@ -32,7 +32,8 @@ public sealed class AdminFrozenSystem : EntitySystem
         SubscribeLocalEvent<AdminFrozenComponent, ChangeDirectionAttemptEvent>(OnAttempt);
         SubscribeLocalEvent<AdminFrozenComponent, EmoteAttemptEvent>(OnEmoteAttempt);
         SubscribeLocalEvent<AdminFrozenComponent, SpeakAttemptEvent>(OnSpeakAttempt);
-        SubscribeLocalEvent<AdminFrozenComponent, LoocSpeakAttemptEvent>(OnLoocSpeakAttempt);
+        SubscribeLocalEvent<AdminFrozenComponent, InGameOocMessageAttemptEvent>(OnInGameOocMessageAttempt);
+        SubscribeLocalEvent<InGameOocMessageAttemptEvent>(OnInGameOocMessageAttemptBroadcast);
     }
 
     /// <summary>
@@ -58,13 +59,18 @@ public sealed class AdminFrozenSystem : EntitySystem
         args.Cancel();
     }
 
-    private void OnLoocSpeakAttempt(Entity<AdminFrozenComponent> ent, ref LoocSpeakAttemptEvent args)
+    private void OnInGameOocMessageAttempt(Entity<AdminFrozenComponent> ent, ref InGameOocMessageAttemptEvent args)
     {
         if (!ent.Comp.Muted)
             return;
 
         // Despite Type being available, Admin Mute does not care to differentiate. If you are out, you are out.
         args.Cancelled = true;
+    }
+
+    private void OnInGameOocMessageAttemptBroadcast(ref InGameOocMessageAttemptEvent args)
+    {
+        //TODO Player LOOC mute/ban. Session is in the  args, but where to store/check the muted state?
     }
 
     private void OnAttempt(EntityUid uid, AdminFrozenComponent component, CancellableEntityEventArgs args)

--- a/Content.Shared/Chat/InGameOocMessageAttemptEvent.cs
+++ b/Content.Shared/Chat/InGameOocMessageAttemptEvent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Player;
+
+namespace Content.Shared.Chat;
+
+/// <summary>
+/// Event fired before a player's entity speaks on LOOC or Deadchat.
+/// </summary>
+[ByRefEvent]
+public record struct InGameOocMessageAttemptEvent(ICommonSession Session, InGameOOCChatType Type, bool Cancelled = false);

--- a/Content.Shared/Chat/SpeakAttemptEvents.cs
+++ b/Content.Shared/Chat/SpeakAttemptEvents.cs
@@ -1,7 +1,0 @@
-namespace Content.Shared.Chat;
-
-/// <summary>
-/// Event fired before a player's entity speaks on LOOC or Deadchat.
-/// </summary>
-[ByRefEvent]
-public record struct LoocSpeakAttemptEvent(InGameOOCChatType Type, bool Cancelled = false);


### PR DESCRIPTION
## About the PR
Mobs who have been "Freeze and Muted" can no longer send on LOOC or Deadchat
These two channels will now also show the speaking mob in admin logs, not just the player's username
An admin sending to deadchat will now also appear in the log as their mob info

Chat stuff is under freeze, but these changes are required by the admin team, and should not meaningfully clash with any refactor work

## Why / Balance
Muted players being able to LOOC (or deadchat) was a simple oversight.
Admins asked for the log part, and it makes sense for looc/deachat logs to be consistent with the logs for regular chat messages.

## Technical details
ChatSystem.TrySendInGameOOCMessage raises an event just before calling SendDeadChat or SendLOOC. Different event for the two cases, in case we might want to deal with them differently in the future. For now, both of them are subscribed-to by AdminFrozenSystem as a simple cancellable event

## Media
Logs, live
<img width="1575" height="277" alt="Screenshot_2025-11-03_222814_before" src="https://github.com/user-attachments/assets/f00d414b-3912-4d77-8909-d9a7a12970f8" />

Logs, after
<img width="1781" height="322" alt="Screenshot_2025-11-03_222059_after" src="https://github.com/user-attachments/assets/3289d2f5-82bf-4b80-a81d-e30322e3df15" />

Freeze-Muted player, live:
<img width="556" height="588" alt="Screenshot_2025-11-03_223713" src="https://github.com/user-attachments/assets/554f7a2a-22df-491f-a2de-ba49db17983d" />

Freeze-Muted player, after:
<img width="556" height="588" alt="Screenshot_2025-11-03_223828" src="https://github.com/user-attachments/assets/e055bcd2-9002-43c1-a659-585102c7661c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl: Errant
ADMIN:
- tweak: Looc and Deadchat logs now show mob information, similar to the logs of the IC chat channels.
- fix: Mobs who have been "Freeze and Muted" can no longer send on LOOC or Deadchat.
