### PR TITLE
Fix changelog button always indicating new changes.

### DIFF
--- a/Content.Client/Changelog/ChangelogManager.cs
+++ b/Content.Client/Changelog/ChangelogManager.cs
@@ -52,7 +52,7 @@ namespace Content.Client.Changelog
             // Open changelog purely to compare to the last viewed date.
             var changelogs = await LoadChangelog();
             UpdateChangelogs(changelogs);
-            _configManager.OnCVarValueChanged += OnCVarValueChanged;
+            _configManager.OnValueChanged(CCVars.ServerId, OnServerIdCVarChanged);
         }
 
         private void UpdateChangelogs(List<Changelog> changelogs)
@@ -98,12 +98,9 @@ namespace Content.Client.Changelog
             NewChangelogEntriesChanged?.Invoke();
         }
 
-        private void OnCVarValueChanged(CVarChangeInfo changedVar)
+        private void OnServerIdCVarChanged(string newValue)
         {
-            if (changedVar.Name == CCVars.ServerId.Name)
-            {
-                CheckLastSeenEntry();
-            }
+            CheckLastSeenEntry();
         }
 
         public Task<List<Changelog>> LoadChangelog()


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes a bug in the "ChangelogButton" -  these buttons are supposed to have a red highlight when there are new, unread entries in the changelog, with the highlight being removed when you click the button to read the changelog.

This didn't work correctly and connecting to a remote server would always show the button as if there were new changes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

UI bug.

## Technical details
<!-- Summary of code changes for easier review. -->

ChangelogManager would read the changelogs, determine the most recent entry and compare to a value stored on disk, in a filename derived from CCVars.ServerId.

However, the changelogs are loaded before the server CVars are set, so if you've connected to a server with a non-default ServerId, ChangelogManager would end up reading your "last seen changelog id" from an "unknown_server_id" file.

If you want to repro locally, you'll need to add this to your server config file:

```
[server]
id = "blablabla"
```


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
