### PR TITLE
Fixed several unintended burn groupings with the untrained bible use & clumsy gun explosion

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1471,8 +1471,7 @@
       types:
         Blunt: 5
         Piercing: 4
-      groups:
-        Burn: 3
+        Heat: 3
     catchingFailDamage:
       types:
         Blunt: 1
@@ -1653,8 +1652,7 @@
       types:
         Blunt: 2
         Piercing: 7
-      groups:
-        Burn: 3
+        Heat: 3
     catchingFailDamage:
       types:
         Blunt: 1

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -237,8 +237,7 @@
         types:
           Blunt: 5
           Piercing: 4
-        groups:
-          Burn: 3
+          Heat: 3
       catchingFailDamage:
         types:
           Blunt: 1

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -16,8 +16,8 @@
         Brute: 15
         Airloss: 15
     damageOnUntrainedUse: ## What a non-chaplain takes when attempting to heal someone
-      groups:
-        Burn: 10
+      types:
+        Heat: 10
   - type: MeleeWeapon
     soundHit:
       collection: Punch

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -17,8 +17,7 @@
         types: #literally just picked semi random valus. i tested this once and tweaked it.
           Blunt: 5
           Piercing: 4
-        groups:
-          Burn: 3
+          Heat: 3
       catchingFailDamage:
         types:
           Blunt: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I fixed several unintended burn groupings, with the clumsy condition for clowns, monkeys & kobolds, aswell as untrained use of the bible, which made these evenly deal all burn damages, instead of just heat.

## Why / Balance
it's obviously unintended to get cold, caustic & shock damage from a gun exploding, or a bible searing your hand.

## Technical details

## Media

https://github.com/user-attachments/assets/959bc368-ba8d-4e2d-8d25-6389a380d2e2

<img width="657" height="315" alt="burn-fail-fix" src="https://github.com/user-attachments/assets/8c33f1ce-5a85-4560-bfde-2db5ee793f24" />

<img width="719" height="426" alt="burn-fail-fix2" src="https://github.com/user-attachments/assets/9d57dc26-5427-4891-904b-7fb25d59e343" />



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
:cl:
- fix: Fixed several unintended burn groupings with the clumsy gun explosions & bible misuse.
