### PR TITLE
Janitor Golden Plunger loadout category tweak

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -485,18 +485,12 @@
   - JanitorWintercoat
 
 - type: loadoutGroup
-  id: JanitorPlunger
-  name: loadout-group-janitor-plunger
-  minLimit: 0
-  loadouts:
-  - JanitorGoldenPlunger
-
-- type: loadoutGroup
   id: JanitorJobTrinkets
   name: loadout-group-jobtrinkets
   minLimit: 0
   loadouts:
   - LizardPlushieJanitor
+  - JanitorGoldenPlunger
 
 - type: loadoutGroup
   id: BotanistHead

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -152,7 +152,6 @@
   - Survival
   - Trinkets
   - JanitorJobTrinkets
-  - JanitorPlunger
   - GroupSpeciesBreathTool
 
 - type: roleLoadout


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Moved the golden plunger Janitor loadout item into the Job Trinket loadout category, and removed the Golden Plunger category, as outlined in https://github.com/space-wizards/space-station-14/issues/41315.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed JanitorPlunger loadoutGroup from loadout_groups.yml
Added JanitorGoldenPlunger to JanitorJobTrinkets loadoutGroup in loadout_groups.yml
Removed JanitorPlunger from the JobJanitor roleLoadout in role_loadouts.yml

## Media
<img width="798" height="308" alt="Content Client_8GJaliiNn4" src="https://github.com/user-attachments/assets/6f74afc3-a9a2-4742-a43b-6700d12be876" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- remove: Removed the Janitor plunger section from the Janitor loadout.
- tweak: Moved the Golden Plunger into the Job trinkets section of the Janitor loadout.
