### PR TITLE
Gas analyzer fix for gas pipe manifolds

### DIFF
--- a/Content.Server/Atmos/Piping/EntitySystems/GasPipeManifoldSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/GasPipeManifoldSystem.cs
@@ -51,6 +51,7 @@ public sealed partial class GasPipeManifoldSystem : EntitySystem
             return;
 
         var pipeNames = ent.Comp.InletNames.Union(ent.Comp.OutletNames);
+        var pipeCount = pipeNames.Count();
 
         foreach (var pipeName in pipeNames)
         {
@@ -58,8 +59,8 @@ public sealed partial class GasPipeManifoldSystem : EntitySystem
                 continue;
 
             var pipeLocal = pipe.Air.Clone();
-            pipeLocal.Multiply(pipe.Volume / pipe.Air.Volume);
-            pipeLocal.Volume = pipe.Volume;
+            pipeLocal.Multiply(pipe.Volume * pipeCount / pipe.Air.Volume);
+            pipeLocal.Volume = pipe.Volume * pipeCount;
 
             args.GasMixtures.Add((Name(ent), pipeLocal));
             break;

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -366,31 +366,37 @@
         nodeGroupID: Pipe
         pipeDirection: South
         pipeLayer: 0
+        volume: 50
       south1:
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: South
         pipeLayer: 1
+        volume: 50
       south2:
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: South
         pipeLayer: 2
+        volume: 50
       north0:
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: North
         pipeLayer: 0
+        volume: 50
       north1:
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: North
         pipeLayer: 1
+        volume: 50
       north2:
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: North
         pipeLayer: 2
+        volume: 50
   - type: GasPipeManifold
   - type: AtmosMonitoringConsoleDevice
     navMapBlip: GasPipeManifold


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Reduced the volume of each pipe node of gas manifolds from the default value of 200L to 50L (reducing their total volume from 1200L to 300L).

Gas analyzers now correctly report the total volume and the number of moles of gas contained in gas pipe manifolds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Closes #40703, closes #40705.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Comparison of a straight pipe and a gas pipe manifold after the changes.
<img width="363" height="415" alt="pipe_analysis" src="https://github.com/user-attachments/assets/af16bae9-df3b-49ca-b596-2fb6c3e77dc9" /> <img width="365" height="413" alt="manifold_analysis" src="https://github.com/user-attachments/assets/9d967e0b-4dc6-44b3-8cc1-cb96d2f702a3" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Gas analyzers now correctly report the total volume and the number of moles of gas contained in gas pipe manifolds.
- tweak: The total volume of gas that gas pipe manifolds can contain has been reduced from 1200L to 300L.