### PR TITLE
Add a Cancel property to Effect Validation event args

### DIFF
--- a/Content.Shared/Actions/Events/ActionValidateEvent.cs
+++ b/Content.Shared/Actions/Events/ActionValidateEvent.cs
@@ -1,10 +1,10 @@
 namespace Content.Shared.Actions.Events;
 
 /// <summary>
-/// Raised on an action entity before being used to:
-/// 1. Make sure client is sending the correct kind of target (if any)
-/// 2. Do any validation on the target, if needed
-/// 3. Give the action system an event to raise on the performer, to actually do the action.
+/// Raised on an action entity before it is executed, to:
+/// 1. Verify that the client is providing the correct type of target (if applicable)
+/// 2. Perform any necessary validation on the target
+/// 3. Provide the action system with an event to raise on the performer to carry out the action
 /// </summary>
 [ByRefEvent]
 public struct ActionValidateEvent

--- a/Content.Shared/Actions/Events/ActionValidateEvent.cs
+++ b/Content.Shared/Actions/Events/ActionValidateEvent.cs
@@ -27,6 +27,12 @@ public struct ActionValidateEvent
     /// <summary>
     /// If set to true, the client sent invalid event data and this should be logged as an error.
     /// For functioning input that happens to not be allowed this should not be set, for example a range check.
+    /// Use <see cref="Cancel"/> instead
     /// </summary>
     public bool Invalid;
+
+    /// <summary>
+    /// If set to to true, the Action failed Valdiation and should be Canceld from executing.
+    /// </summary>
+    public bool Cancel;
 }

--- a/Content.Shared/Actions/Events/ActionValidateEvent.cs
+++ b/Content.Shared/Actions/Events/ActionValidateEvent.cs
@@ -2,9 +2,11 @@ namespace Content.Shared.Actions.Events;
 
 /// <summary>
 /// Raised on an action entity before it is executed, to:
-/// 1. Verify that the client is providing the correct type of target (if applicable)
-/// 2. Perform any necessary validation on the target
-/// 3. Provide the action system with an event to raise on the performer to carry out the action
+/// <list type="number">
+/// <item> Verify that the client is providing the correct type of target (if applicable). </item>
+/// <item> Perform any necessary validation on the target. </item>
+/// <item> Provide the action system with an event to raise on the performer to carry out the action. </item>
+/// </list>
 /// </summary>
 [ByRefEvent]
 public struct ActionValidateEvent

--- a/Content.Shared/Actions/Events/ActionValidateEvent.cs
+++ b/Content.Shared/Actions/Events/ActionValidateEvent.cs
@@ -29,12 +29,12 @@ public struct ActionValidateEvent
     /// <summary>
     /// If set to true, the client sent invalid event data and this should be logged as an error.
     /// For functioning input that happens to not be allowed this should not be set, for example a range check.
-    /// Use <see cref="Cancel"/> instead
+    /// Use <see cref="Cancel"/> instead.
     /// </summary>
     public bool Invalid;
 
     /// <summary>
-    /// If set to to true, the Action failed Valdiation and should be Canceld from executing.
+    /// If set to to true, the Action failed Validation  and should be Canceled from executing.
     /// </summary>
     public bool Cancel;
 }

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -372,7 +372,10 @@ public abstract partial class SharedActionsSystem : EntitySystem
             _rotateToFace.TryFaceCoordinates(user, targetWorldPos);
 
         if (!ValidateEntityTarget(user, target, ent))
+        {
+            args.Cancel = true;
             return;
+        }
 
         _adminLogger.Add(LogType.Action,
             $"{ToPrettyString(user):user} is performing the {Name(ent):action} action (provided by {ToPrettyString(args.Provider):provider}) targeted at {ToPrettyString(target):target}.");
@@ -395,7 +398,10 @@ public abstract partial class SharedActionsSystem : EntitySystem
             _rotateToFace.TryFaceCoordinates(user, _transform.ToMapCoordinates(target).Position);
 
         if (!ValidateWorldTarget(user, target, ent))
+        {
+            args.Cancel = true;
             return;
+        }
 
         // if the client specified an entity it needs to be valid
         var targetEntity = GetEntity(args.Input.EntityTarget);

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -321,7 +321,7 @@ public abstract partial class SharedActionsSystem : EntitySystem
             Provider = provider
         };
         RaiseLocalEvent(action, ref validateEv);
-        if (validateEv.Invalid)
+        if (validateEv.Invalid || validateEv.Cancel)
             return false;
 
         if (TryComp<DoAfterArgsComponent>(action, out var actionDoAfterComp) && TryComp<DoAfterComponent>(user, out var performerDoAfterComp) && !skipDoActionRequest)

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -321,7 +321,14 @@ public abstract partial class SharedActionsSystem : EntitySystem
             Provider = provider
         };
         RaiseLocalEvent(action, ref validateEv);
-        if (validateEv.Invalid || validateEv.Cancel)
+        if (validateEv.Invalid)
+        {
+            Log.Warning($"{ToPrettyString(user):user} tried performing a invalid {Name(action):action}.");
+
+            return false;
+        }
+
+        if (validateEv.Cancel)
             return false;
 
         if (TryComp<DoAfterArgsComponent>(action, out var actionDoAfterComp) && TryComp<DoAfterComponent>(user, out var performerDoAfterComp) && !skipDoActionRequest)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Created becouse of: #41200 
I added a new property `Cancel `to `ActionValidateEvent` which indicates that the Valdidation failed and should be canceled.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
at the moment there is only a invalid property which is supposed to be used in case a client is sending invalid data. 
It does not indicate that the action itself is valid. which is why i added this extra property to handle that.
## Technical details
<!-- Summary of code changes for easier review. -->
- added  `public bool Cancel;` to `ActionValidateEvent`
- changed `OnEntityValidate` in `SharedActionSystem` to set Cancel to true when `ValidateEntityTarget` returns `false`
- changed `OnWorldValidate` in `SharedActionSystem` to set Cancel to true when `ValidateWorldTarget` returns `false`
- changed `TryPerformAction` in `SharedActionSystem` to return `false` when the `Cancel` property on the raised `ActionValidateEvent` is `true`
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- `TryPerformAction` may work diffrently as it now checks if the action is allowed or possible, in addtion to the current check if the action is coused by an invalid client event.

If your using `ActionValidateEvent.Invalid` as a check for if an action should execute or not. Change to `ActionValidateEvent.Cancel` instead.

