### PR TITLE
Make Air Alarm displayed values mirror Gas Analyzer

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -99,8 +99,8 @@ public sealed partial class AirAlarmWindow : FancyWindow
     {
         _address.SetMarkup(state.Address);
         _deviceTotal.SetMarkup($"{state.DeviceCount}");
-        _pressure.SetMarkup(Loc.GetString("air-alarm-ui-window-pressure", ("pressure", $"{state.PressureAverage:0.##}")));
-        _temperature.SetMarkup(Loc.GetString("air-alarm-ui-window-temperature", ("tempC", $"{TemperatureHelpers.KelvinToCelsius(state.TemperatureAverage):0.#}"), ("temperature", $"{state.TemperatureAverage:0.##}")));
+        _pressure.SetMarkup(Loc.GetString("air-alarm-ui-window-pressure", ("pressure", $"{state.PressureAverage:0.00}")));
+        _temperature.SetMarkup(Loc.GetString("air-alarm-ui-window-temperature", ("temperature", $"{state.TemperatureAverage:0.0}"), ("tempC", $"{TemperatureHelpers.KelvinToCelsius(state.TemperatureAverage):0.0}")));
         _alarmState.SetMarkup(Loc.GetString("air-alarm-ui-window-alarm-state",
                     ("color", ColorForAlarm(state.AlarmType)),
                     ("state", state.AlarmType)));

--- a/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
@@ -43,11 +43,11 @@ public sealed partial class SensorInfo : BoxContainer
                     ("state", data.AlarmState)));
         PressureLabel.SetMarkup(Loc.GetString("air-alarm-ui-window-pressure-indicator",
                     ("color", AirAlarmWindow.ColorForThreshold(data.Pressure, data.PressureThreshold)),
-                    ("pressure", $"{data.Pressure:0.##}")));
+                    ("pressure", $"{data.Pressure:0.00}")));
         TemperatureLabel.SetMarkup(Loc.GetString("air-alarm-ui-window-temperature-indicator",
                 ("color", AirAlarmWindow.ColorForThreshold(data.Temperature, data.TemperatureThreshold)),
-                ("tempC", $"{TemperatureHelpers.KelvinToCelsius(data.Temperature):0.#}"),
-                ("temperature", $"{data.Temperature:0.##}")));
+                ("tempC", $"{TemperatureHelpers.KelvinToCelsius(data.Temperature):0.0}"),
+                ("temperature", $"{data.Temperature:0.0}")));
 
         foreach (var (gas, amount) in data.Gases)
         {
@@ -61,8 +61,8 @@ public sealed partial class SensorInfo : BoxContainer
             label.SetMarkup(Loc.GetString("air-alarm-ui-gases-indicator",
                 ("gas", Loc.GetString(gasName)),
                 ("color", AirAlarmWindow.ColorForThreshold(fractionGas, data.GasThresholds[gas])),
-                ("amount", $"{amount:0.####}"),
-                ("percentage", $"{(100 * fractionGas):0.##}")));
+                ("amount", $"{amount:0.00}"),
+                ("percentage", $"{(100 * fractionGas):0.0}")));
             GasContainer.AddChild(label);
             _gasLabels.Add(gas, label);
 
@@ -114,11 +114,11 @@ public sealed partial class SensorInfo : BoxContainer
 
         PressureLabel.SetMarkup(Loc.GetString("air-alarm-ui-window-pressure-indicator",
                     ("color", AirAlarmWindow.ColorForThreshold(data.Pressure, data.PressureThreshold)),
-                    ("pressure", $"{data.Pressure:0.##}")));
+                    ("pressure", $"{data.Pressure:0.00}")));
         TemperatureLabel.SetMarkup(Loc.GetString("air-alarm-ui-window-temperature-indicator",
                 ("color", AirAlarmWindow.ColorForThreshold(data.Temperature, data.TemperatureThreshold)),
-                ("tempC", $"{TemperatureHelpers.KelvinToCelsius(data.Temperature):0.#}"),
-                ("temperature", $"{data.Temperature:0.##}")));
+                ("tempC", $"{TemperatureHelpers.KelvinToCelsius(data.Temperature):0.0}"),
+                ("temperature", $"{data.Temperature:0.0}")));
 
         foreach (var (gas, amount) in data.Gases)
         {
@@ -135,8 +135,8 @@ public sealed partial class SensorInfo : BoxContainer
             label.SetMarkup(Loc.GetString("air-alarm-ui-gases-indicator",
                 ("gas", Loc.GetString(gasName)),
                 ("color", AirAlarmWindow.ColorForThreshold(fractionGas, data.GasThresholds[gas])),
-                ("amount", $"{amount:0.####}"),
-                ("percentage", $"{(100 * fractionGas):0.##}")));
+                ("amount", $"{amount:0.00}"),
+                ("percentage", $"{(100 * fractionGas):0.0}")));
         }
 
         _pressureThreshold.UpdateThresholdData(data.PressureThreshold, data.Pressure);

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -29,8 +29,8 @@ air-alarm-ui-window-auto-mode-label = Auto mode
 air-alarm-ui-window-listing-title = {$address} : {-air-alarm-state-name(state:$state)}
 air-alarm-ui-window-pressure = {$pressure} kPa
 air-alarm-ui-window-pressure-indicator = Pressure: [color={$color}]{$pressure} kPa[/color]
-air-alarm-ui-window-temperature = {$tempC} C ({$temperature} K)
-air-alarm-ui-window-temperature-indicator = Temperature: [color={$color}]{$tempC} C ({$temperature} K)[/color]
+air-alarm-ui-window-temperature = {$temperature}K ({$tempC}°C)
+air-alarm-ui-window-temperature-indicator = Temperature: [color={$color}]{$temperature}K ({$tempC}°C)[/color]
 air-alarm-ui-window-alarm-state = [color={$color}]{-air-alarm-state-name(state:$state)}[/color]
 air-alarm-ui-window-alarm-state-indicator = Status: [color={$color}]{-air-alarm-state-name(state:$state)}[/color]
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Displayed decimal places of the air alarm now match those of the gas analyzer. Celsius and Kelvin are swapped to match the gas analyzer.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Kelvin is displayed before Celsius because atmos machines such as the freezer use Kelvin as their unit of measurement while machines used by general station crew such as the space heater use Celsius, and since air alarm menus are typically viewed and used by atmos techs Kelvin seems proper to be displayed first. Also, having the values displayed flipped for the air alarm and gas analyzer is confusing

Values displayed on the air alarm are rounded to the same digits as the gas analyzer for no real reason but to satisfy my brain

## Technical details
<!-- Summary of code changes for easier review. -->
C# changes to the rounding places of values, & flipping the Celsius & Kelvin code in air alarms

FTL change to flip Celsius & Kelvin

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
### Before
<img width="910" height="515" alt="image" src="https://github.com/user-attachments/assets/4c47d184-48c7-44dd-9d83-ec402e87d7a9" />

### After
<img width="884" height="501" alt="image" src="https://github.com/user-attachments/assets/91e9f27e-0d19-4dad-ab66-d03011f98b97" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- tweak: Air alarm display values now match the gas analyzer