### PR TITLE
Captain and HoP now require Cargo playtime

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -5,6 +5,9 @@
   playTimeTracker: JobCaptain
   requirements:
     - !type:DepartmentTimeRequirement
+      department: Cargo
+      time: 4h
+    - !type:DepartmentTimeRequirement
       department: Engineering
       time: 4h
     - !type:DepartmentTimeRequirement

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -5,6 +5,9 @@
   playTimeTracker: JobHeadOfPersonnel
   requirements:
     - !type:DepartmentTimeRequirement
+      department: Cargo
+      time: 2.5h
+    - !type:DepartmentTimeRequirement
       department: Engineering
       time: 2.5h
     - !type:DepartmentTimeRequirement


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Captain and Head of Personnel now require playtime in the Cargo department to be unlocked; 4 hours for Captain and 2.5 hours for Head of Personnel (the same as their other departmental unlock requirements). Partial remake of #40799, but dropping the Service requirement.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's weird that Cargo is outright excluded from these roles' requirements; the Captain is generally expected to be able to fill in for any critical staffing shortages on the station (and the HoP is expected to be acting captain in the event of the actual Captain's disappearance), so they should have at least reasonable familiarity with all departments. Also, the Head of Personnel has full control over how all station funding is allocated so I'd expect them to be familiar with how that money is spent.

The former PR (#40799) was closed since the maintainers could not reach a consensus (three-way tie on a vote between "merge", "close", and "other"), but two of the "other" votes were to merge without the Service requirement, which is what this PR does. If the total playtime is still concerning we could maybe drop the hours _per department_ to compensate for the addition of new departments (e.g 3hr/department for Captain, 2hr/department for HoP).

## Technical details
<!-- Summary of code changes for easier review. -->
- Changes to the requirements field in captain.yml/head_of_personnel.yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A (YAML-only changes)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Captain and Head of Personnel now require some Cargo playtime to unlock.
