### PR TITLE
Remove wizards healing wand for the random magic item spell

### DIFF
--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -204,8 +204,6 @@
         orGroup: Magics
       - id: WeaponWandPolymorphBread
         orGroup: Magics
-      - id: WeaponStaffHealing
-        orGroup: Magics
       - id: WeaponStaffPolymorphDoor
         orGroup: Magics
       - id: AnimationStaff


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The healing wand is not a very destructive item and if anything helps crew. It can be especillly bad when the crew starts healing the wizard! Wizard is supposed to be a station threat, not a benefit.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The Summon Magic spell no longer will give out healing wands. When there are more wands added it will be brought back

