### PR TITLE
HOTFIX: automatically reset fallback gamemode to default

### DIFF
--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -59,7 +59,7 @@ public sealed partial class GameTicker
             foreach (var preset in fallbackPresets)
             {
                 ClearGameRules();
-                SetGamePreset(preset);
+                SetGamePreset(preset, resetDelay: 1);
                 AddGamePresetRules();
                 StartGamePresetRules();
 
@@ -129,11 +129,11 @@ public sealed partial class GameTicker
         }
     }
 
-    public void SetGamePreset(string preset, bool force = false)
+    public void SetGamePreset(string preset, bool force = false, int? resetDelay = null)
     {
         var proto = FindGamePreset(preset);
         if (proto != null)
-            SetGamePreset(proto, force);
+            SetGamePreset(proto, force, null, resetDelay);
     }
 
     public GamePresetPrototype? FindGamePreset(string preset)


### PR DESCRIPTION
## About the PR
If the round fails to start a gamemode and starts in a fallback, currently the server will be permanently stuck on that gamemode until an admin changes it. Now it reverts to the server default immediately after the fallback round.



## Why / Balance
Shouldn't need admin intervention

## Technical details
GameTicker now uses the same resetDelay parameter as the setgamepreset command, and gives the fallback mode a delay of 1. If the fallback also fails to start, then the next fallback it tries will override the resetDelay, so no harm done if it tries several times. If the round successfully starts, then the delay will tick to 0 on round end, and go back to the server default, same as with a command-applied gamemode

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Errant
- fix: Game mode no longer gets permanently stuck on Extended whenever a round tries to start without enough players.