### PR TITLE
HOTFIX: Reword Wizard objective text to be more hostile

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-wizard.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-wizard.ftl
@@ -42,8 +42,8 @@ roles-antag-wizard-objective = Teach them a lesson they'll never forget.
 
 wizard-role-greeting =
     It's wizard time, fireball!
-    There's been tensions between the Space Wizards Federation and NanoTrasen. You've been selected by the Space Wizards Federation to pay a visit to the station and give them a good "demonstration" of your powers.
-    What you do is up to you, but remember that the Space Wizards want you to make it out alive.
+    There's been tensions between the Space Wizards Federation and NanoTrasen. You've been selected by the Space Wizards Federation to pay a visit to the station and "remind them" why spellcasters are not to be trifled with.
+    Cause mayhem and destruction! What you do is up to you, but remember that the Space Wizards want you to make it out alive.
 
 wizard-round-end-name = wizard
 

--- a/Resources/Prototypes/Objectives/wizard.yml
+++ b/Resources/Prototypes/Objectives/wizard.yml
@@ -25,8 +25,8 @@
 - type: entity
   parent: [BaseWizardObjective, BaseFreeObjective]
   id: WizardDemonstrateObjective
-  name: Show off
-  description: Give the station a good demonstration of your powers!
+  name: Cause chaos
+  description: Teach those station welps to never disrespect a Wizard again!
   components:
   - type: Objective
     icon:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Rewords the Wizard spawn text and renames the "Show off" objective to "Cause chaos".

This PR is set as a hotfix, approved by head admin @Admiral-Obvious-001 .

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Helps convey that the Wizard is meant to be an antagonistic force; no more magic shows, but a show of force.

## Technical details
<!-- Summary of code changes for easier review. -->

FTL change.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Wizard greeting and objective text now more clearly communicates it's intended antagonistic role.