### PR TITLE
Reenter Lobby action

### DIFF
--- a/Content.Shared/Respawn/IntrinsicReenterLobbyActionEvent.cs
+++ b/Content.Shared/Respawn/IntrinsicReenterLobbyActionEvent.cs
@@ -1,0 +1,8 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared.Respawn;
+
+/// <summary>
+/// Send the entity's controlling player back to the lobby
+/// </summary>
+public sealed partial class IntrinsicReenterLobbyActionEvent : InstantActionEvent;

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -477,3 +477,14 @@
     icon: Interface/Actions/shop.png
   - type: InstantAction
     event: !type:IntrinsicStoreActionEvent
+
+- type: entity
+  parent: BaseMentalAction
+  id: ActionIntrinsicReenterLobby
+  name: Reenter Lobby
+  description: Leave your current character and return to the server's lobby
+  components:
+  - type: Action
+    icon: Interface/home.png # TODO custom icon?
+  - type: InstantAction
+    event: !type:IntrinsicReenterLobbyActionEvent


### PR DESCRIPTION
## About the PR
Groundwork for the tutorial, but I don't want to pile everything in the same PR. 
This adds an Action entity that allows the mob's controlling player to return to the lobby. Not given or used by anything at this time. Technically it can be added to a mob with the `addaction` command, though admins can just do this to someone directly

## Why / Balance
Will be needed for the Tutorial, to allow players to reset their map entirely or eventually to choose a different tutorial

## Technical details
Just an InstantAction prototype, and the corresponding subscription in RespawnRuleSystem. Technically not _directly_ related to that system, but it's kinda sorta related and there really a more obvious way to put it, and making this its own system feels overkill

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
