### PR TITLE
Vials break as easy as bottles now

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
@@ -87,7 +87,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 15
+        damage: 5
       behaviors:
       - !type:PlaySoundBehavior
         sound:


### PR DESCRIPTION
## About the PR
I found out that vials are more damage resistant than bottles today. Why?

## Why / Balance
Small glass should all break the same

## Technical details
I removed a single digit

## Media
NA

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
NA

**Changelog**
:cl: fix: Vials break as easily as bottles
