### PR TITLE
Fix DeltaPressureTest race condition when using LINDA

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/DeltaPressureTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/DeltaPressureTest.cs
@@ -1,15 +1,11 @@
-using System.Linq;
 using System.Numerics;
 using Content.Server.Atmos;
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
-using Robust.Shared.EntitySerialization;
-using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
 using Robust.Shared.Utility;
 
 namespace Content.IntegrationTests.Tests.Atmos;
@@ -20,7 +16,7 @@ namespace Content.IntegrationTests.Tests.Atmos;
 /// </summary>
 [TestFixture]
 [TestOf(typeof(DeltaPressureSystem))]
-public sealed class DeltaPressureTest
+public sealed class DeltaPressureTest : AtmosTest
 {
     #region Prototypes
 
@@ -92,7 +88,7 @@ public sealed class DeltaPressureTest
 
     #endregion
 
-    private readonly ResPath _testMap = new("Maps/Test/Atmospherics/DeltaPressure/deltapressuretest.yml");
+    protected override ResPath? TestMapPath => new("Maps/Test/Atmospherics/DeltaPressure/deltapressuretest.yml");
 
     // TODO ATMOS TESTS
     // - Check for directional windows (partial airtight ents) properly computing pressure differences
@@ -111,40 +107,15 @@ public sealed class DeltaPressureTest
     [Test]
     public async Task ProcessingListAutoJoinTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
-
-        var entMan = server.EntMan;
-        var mapLoader = entMan.System<MapLoaderSystem>();
-        var atmosphereSystem = entMan.System<AtmosphereSystem>();
-        var deserializationOptions = DeserializationOptions.Default with { InitializeMaps = true };
-
-        Entity<MapGridComponent> grid = default;
-        Entity<DeltaPressureComponent> dpEnt;
-
-        // Load our test map in and assert that it exists.
-        await server.WaitPost(() =>
+        await Server.WaitAssertion(() =>
         {
-#pragma warning disable NUnit2045
-            Assert.That(mapLoader.TryLoadMap(_testMap, out _, out var gridSet, deserializationOptions),
-                $"Failed to load map {_testMap}.");
-            Assert.That(gridSet, Is.Not.Null, "There were no grids loaded from the map!");
-#pragma warning restore NUnit2045
+            var uid = SEntMan.SpawnAtPosition("DeltaPressureSolidTest", new EntityCoordinates(ProcessEnt, Vector2.Zero));
+            var dpEnt = new Entity<DeltaPressureComponent>(uid, SEntMan.GetComponent<DeltaPressureComponent>(uid));
 
-            grid = gridSet.First();
+            Assert.That(SAtmos.IsDeltaPressureEntityInList(RelevantAtmos, dpEnt), "Entity was not in processing list when it should have automatically joined!");
+            SEntMan.DeleteEntity(uid);
+            Assert.That(!SAtmos.IsDeltaPressureEntityInList(RelevantAtmos, dpEnt), "Entity was still in processing list after deletion!");
         });
-
-        await server.WaitAssertion(() =>
-        {
-            var uid = entMan.SpawnAtPosition("DeltaPressureSolidTest", new EntityCoordinates(grid.Owner, Vector2.Zero));
-            dpEnt = new Entity<DeltaPressureComponent>(uid, entMan.GetComponent<DeltaPressureComponent>(uid));
-
-            Assert.That(atmosphereSystem.IsDeltaPressureEntityInList(grid.Owner, dpEnt), "Entity was not in processing list when it should have automatically joined!");
-            entMan.DeleteEntity(uid);
-            Assert.That(!atmosphereSystem.IsDeltaPressureEntityInList(grid.Owner, dpEnt), "Entity was still in processing list after deletion!");
-        });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -154,45 +125,27 @@ public sealed class DeltaPressureTest
     [Test]
     public async Task ProcessingDeltaStandbyTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
-
-        var entMan = server.EntMan;
-        var mapLoader = entMan.System<MapLoaderSystem>();
-        var atmosphereSystem = entMan.System<AtmosphereSystem>();
-        var transformSystem = entMan.System<SharedTransformSystem>();
-        var deserializationOptions = DeserializationOptions.Default with { InitializeMaps = true };
-
-        Entity<MapGridComponent> grid = default;
         Entity<DeltaPressureComponent> dpEnt = default;
         TileAtmosphere tile = null!;
         AtmosDirection direction = default;
 
         // Load our test map in and assert that it exists.
-        await server.WaitPost(() =>
+        await Server.WaitPost(() =>
         {
-#pragma warning disable NUnit2045
-            Assert.That(mapLoader.TryLoadMap(_testMap, out _, out var gridSet, deserializationOptions),
-                $"Failed to load map {_testMap}.");
-            Assert.That(gridSet, Is.Not.Null, "There were no grids loaded from the map!");
-#pragma warning restore NUnit2045
-
-            grid = gridSet.First();
-            var uid = entMan.SpawnAtPosition("DeltaPressureSolidTest", new EntityCoordinates(grid.Owner, Vector2.Zero));
-            dpEnt = new Entity<DeltaPressureComponent>(uid, entMan.GetComponent<DeltaPressureComponent>(uid));
-            Assert.That(atmosphereSystem.IsDeltaPressureEntityInList(grid.Owner, dpEnt), "Entity was not in processing list when it should have been added!");
+            var uid = SEntMan.SpawnAtPosition("DeltaPressureSolidTest", new EntityCoordinates(ProcessEnt, Vector2.Zero));
+            dpEnt = new Entity<DeltaPressureComponent>(uid, SEntMan.GetComponent<DeltaPressureComponent>(uid));
+            Assert.That(SAtmos.IsDeltaPressureEntityInList(ProcessEnt, dpEnt), "Entity was not in processing list when it should have been added!");
         });
 
         for (var i = 0; i < Atmospherics.Directions; i++)
         {
-            await server.WaitPost(() =>
+            await Server.WaitPost(() =>
             {
-                var indices = transformSystem.GetGridOrMapTilePosition(dpEnt);
-                var gridAtmosComp = entMan.GetComponent<GridAtmosphereComponent>(grid);
+                var indices = Transform.GetGridOrMapTilePosition(dpEnt);
 
                 direction = (AtmosDirection)(1 << i);
                 var offsetIndices = indices.Offset(direction);
-                tile = gridAtmosComp.Tiles[offsetIndices];
+                tile = RelevantAtmos.Comp.Tiles[offsetIndices];
 
                 Assert.That(tile.Air, Is.Not.Null, $"Tile at {offsetIndices} should have air!");
 
@@ -202,19 +155,17 @@ public sealed class DeltaPressureTest
                 tile.Air!.AdjustMoles(Gas.Nitrogen, moles);
             });
 
-            await server.WaitRunTicks(30);
+            await Server.WaitRunTicks(30);
 
             // Entity should exist, if it took one tick of damage then it should be instantly destroyed.
-            await server.WaitAssertion(() =>
+            await Server.WaitAssertion(() =>
             {
-                Assert.That(!entMan.Deleted(dpEnt), $"{dpEnt} should still exist after experiencing non-threshold pressure from {direction} side!");
+                Assert.That(!SEntMan.Deleted(dpEnt), $"{dpEnt} should still exist after experiencing non-threshold pressure from {direction} side!");
                 tile.Air!.Clear();
             });
 
-            await server.WaitRunTicks(30);
+            await Server.WaitRunTicks(30);
         }
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -224,39 +175,13 @@ public sealed class DeltaPressureTest
     [Test]
     public async Task ProcessingDeltaDamageTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
-
-        var entMan = server.EntMan;
-        var mapLoader = entMan.System<MapLoaderSystem>();
-        var atmosphereSystem = entMan.System<AtmosphereSystem>();
-        var transformSystem = entMan.System<SharedTransformSystem>();
-        var deserializationOptions = DeserializationOptions.Default with { InitializeMaps = true };
-
-        Entity<MapGridComponent> grid = default;
-        Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent> newGrid = default;
         Entity<DeltaPressureComponent> dpEnt = default;
-        TileAtmosphere tile = null!;
         AtmosDirection direction = default;
 
         // Load our test map in and assert that it exists.
-        await server.WaitPost(() =>
+        await Server.WaitPost(() =>
         {
-#pragma warning disable NUnit2045
-            Assert.That(mapLoader.TryLoadMap(_testMap, out _, out var gridSet, deserializationOptions),
-                $"Failed to load map {_testMap}.");
-            Assert.That(gridSet, Is.Not.Null, "There were no grids loaded from the map!");
-#pragma warning restore NUnit2045
-
-            grid = gridSet.First();
-            newGrid = new Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent>(
-                grid.Owner,
-                entMan.GetComponent<GridAtmosphereComponent>(grid.Owner),
-                entMan.GetComponent<GasTileOverlayComponent>(grid.Owner),
-                entMan.GetComponent<MapGridComponent>(grid.Owner),
-                entMan.GetComponent<TransformComponent>(grid.Owner));
-
-            atmosphereSystem.SetAtmosphereSimulation(newGrid, false);
+            SAtmos.SetAtmosphereSimulation(ProcessEnt, false);
         });
 
         for (var i = 0; i < Atmospherics.Directions; i++)
@@ -270,23 +195,23 @@ public sealed class DeltaPressureTest
              WHICH WILL THROW OFF DELTAS
              */
 
-            await server.WaitPost(() =>
+            await Server.WaitPost(() =>
             {
-                atmosphereSystem.RunProcessingFull(newGrid,newGrid.Owner, atmosphereSystem.AtmosTickRate);
+                SAtmos.RunProcessingFull(ProcessEnt,ProcessEnt.Owner, SAtmos.AtmosTickRate);
             });
 
-            await server.WaitPost(() =>
+            await Server.WaitPost(() =>
             {
                 // Need to spawn an entity each run to ensure it works for all directions.
-                var uid = entMan.SpawnAtPosition("DeltaPressureSolidTest", new EntityCoordinates(grid.Owner, Vector2.Zero));
-                dpEnt = new Entity<DeltaPressureComponent>(uid, entMan.GetComponent<DeltaPressureComponent>(uid));
-                Assert.That(atmosphereSystem.IsDeltaPressureEntityInList(grid.Owner, dpEnt), "Entity was not in processing list when it should have been added!");
+                var uid = SEntMan.SpawnAtPosition("DeltaPressureSolidTest", new EntityCoordinates(ProcessEnt.Owner, Vector2.Zero));
+                dpEnt = new Entity<DeltaPressureComponent>(uid, SEntMan.GetComponent<DeltaPressureComponent>(uid));
+                Assert.That(SAtmos.IsDeltaPressureEntityInList(ProcessEnt.Owner, dpEnt), "Entity was not in processing list when it should have been added!");
 
-                var indices = transformSystem.GetGridOrMapTilePosition(dpEnt);
+                var indices = Transform.GetGridOrMapTilePosition(dpEnt);
 
                 direction = (AtmosDirection)(1 << i);
                 var offsetIndices = indices.Offset(direction);
-                tile = newGrid.Comp1.Tiles[offsetIndices];
+                var tile = ProcessEnt.Comp1.Tiles[offsetIndices];
 
                 Assert.That(tile.Air, Is.Not.Null, $"Tile at {offsetIndices} should have air!");
 
@@ -297,30 +222,28 @@ public sealed class DeltaPressureTest
             });
 
             // get jiggy with it! hit that dance white boy!
-            await server.WaitPost(() =>
+            await Server.WaitPost(() =>
             {
-                atmosphereSystem.RunProcessingFull(newGrid,newGrid.Owner, atmosphereSystem.AtmosTickRate);
+                SAtmos.RunProcessingFull(ProcessEnt,ProcessEnt.Owner, SAtmos.AtmosTickRate);
             });
 
             // need to run some ticks as deleted entities are queued for removal
             // and not removed instantly
-            await server.WaitRunTicks(30);
+            await Server.WaitRunTicks(30);
 
             // Entity shouldn't exist, if it took one tick of damage then it should be instantly destroyed.
-            await server.WaitAssertion(() =>
+            await Server.WaitAssertion(() =>
             {
-                Assert.That(entMan.Deleted(dpEnt), $"{dpEnt} still exists after experiencing threshold pressure from {direction} side!");
+                Assert.That(SEntMan.Deleted(dpEnt), $"{dpEnt} still exists after experiencing threshold pressure from {direction} side!");
 
                 // Double whammy: in case any unintended gas leak occured due to a race condition,
                 // clear out all the tiles.
-                foreach (var mix in atmosphereSystem.GetAllMixtures(newGrid))
+                foreach (var mix in SAtmos.GetAllMixtures(ProcessEnt))
                 {
                     mix.Clear();
                 }
             });
         }
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -330,39 +253,23 @@ public sealed class DeltaPressureTest
     [Test]
     public async Task ProcessingAbsoluteStandbyTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
-
-        var entMan = server.EntMan;
-        var mapLoader = entMan.System<MapLoaderSystem>();
-        var atmosphereSystem = entMan.System<AtmosphereSystem>();
-        var transformSystem = entMan.System<SharedTransformSystem>();
-        var deserializationOptions = DeserializationOptions.Default with { InitializeMaps = true };
-
-        Entity<MapGridComponent> grid = default;
         Entity<DeltaPressureComponent> dpEnt = default;
         TileAtmosphere tile = null!;
         AtmosDirection direction = default;
 
-        await server.WaitPost(() =>
+        await Server.WaitPost(() =>
         {
-#pragma warning disable NUnit2045
-            Assert.That(mapLoader.TryLoadMap(_testMap, out _, out var gridSet, deserializationOptions),
-                $"Failed to load map {_testMap}.");
-            Assert.That(gridSet, Is.Not.Null, "There were no grids loaded from the map!");
-#pragma warning restore NUnit2045
-            grid = gridSet.First();
-            var uid = entMan.SpawnAtPosition("DeltaPressureSolidTestAbsolute", new EntityCoordinates(grid.Owner, Vector2.Zero));
-            dpEnt = new Entity<DeltaPressureComponent>(uid, entMan.GetComponent<DeltaPressureComponent>(uid));
-            Assert.That(atmosphereSystem.IsDeltaPressureEntityInList(grid.Owner, dpEnt), "Entity was not in processing list when it should have been added!");
+            var uid = SEntMan.SpawnAtPosition("DeltaPressureSolidTestAbsolute", new EntityCoordinates(ProcessEnt.Owner, Vector2.Zero));
+            dpEnt = new Entity<DeltaPressureComponent>(uid, SEntMan.GetComponent<DeltaPressureComponent>(uid));
+            Assert.That(SAtmos.IsDeltaPressureEntityInList(ProcessEnt.Owner, dpEnt), "Entity was not in processing list when it should have been added!");
         });
 
         for (var i = 0; i < Atmospherics.Directions; i++)
         {
-            await server.WaitPost(() =>
+            await Server.WaitPost(() =>
             {
-                var indices = transformSystem.GetGridOrMapTilePosition(dpEnt);
-                var gridAtmosComp = entMan.GetComponent<GridAtmosphereComponent>(grid);
+                var indices = Transform.GetGridOrMapTilePosition(dpEnt);
+                var gridAtmosComp = SEntMan.GetComponent<GridAtmosphereComponent>(ProcessEnt);
 
                 direction = (AtmosDirection)(1 << i);
                 var offsetIndices = indices.Offset(direction);
@@ -374,18 +281,16 @@ public sealed class DeltaPressureTest
                 tile.Air!.AdjustMoles(Gas.Nitrogen, moles);
             });
 
-            await server.WaitRunTicks(30);
+            await Server.WaitRunTicks(30);
 
-            await server.WaitAssertion(() =>
+            await Server.WaitAssertion(() =>
             {
-                Assert.That(!entMan.Deleted(dpEnt), $"{dpEnt} should still exist after experiencing non-threshold absolute pressure from {direction} side!");
+                Assert.That(!SEntMan.Deleted(dpEnt), $"{dpEnt} should still exist after experiencing non-threshold absolute pressure from {direction} side!");
                 tile.Air!.Clear();
             });
 
-            await server.WaitRunTicks(30);
+            await Server.WaitRunTicks(30);
         }
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -395,41 +300,21 @@ public sealed class DeltaPressureTest
     [Test]
     public async Task ProcessingAbsoluteDamageTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
-
-        var entMan = server.EntMan;
-        var mapLoader = entMan.System<MapLoaderSystem>();
-        var atmosphereSystem = entMan.System<AtmosphereSystem>();
-        var transformSystem = entMan.System<SharedTransformSystem>();
-        var deserializationOptions = DeserializationOptions.Default with { InitializeMaps = true };
-
-        Entity<MapGridComponent> grid = default;
         Entity<DeltaPressureComponent> dpEnt = default;
         TileAtmosphere tile = null!;
         AtmosDirection direction = default;
 
-        await server.WaitPost(() =>
-        {
-#pragma warning disable NUnit2045
-            Assert.That(mapLoader.TryLoadMap(_testMap, out _, out var gridSet, deserializationOptions),
-                $"Failed to load map {_testMap}.");
-            Assert.That(gridSet, Is.Not.Null, "There were no grids loaded from the map!");
-#pragma warning restore NUnit2045
-            grid = gridSet.First();
-        });
-
         for (var i = 0; i < Atmospherics.Directions; i++)
         {
-            await server.WaitPost(() =>
+            await Server.WaitPost(() =>
             {
                 // Spawn fresh entity each iteration to verify all directions work
-                var uid = entMan.SpawnAtPosition("DeltaPressureSolidTestAbsolute", new EntityCoordinates(grid.Owner, Vector2.Zero));
-                dpEnt = new Entity<DeltaPressureComponent>(uid, entMan.GetComponent<DeltaPressureComponent>(uid));
-                Assert.That(atmosphereSystem.IsDeltaPressureEntityInList(grid.Owner, dpEnt), "Entity was not in processing list when it should have been added!");
+                var uid = SEntMan.SpawnAtPosition("DeltaPressureSolidTestAbsolute", new EntityCoordinates(ProcessEnt.Owner, Vector2.Zero));
+                dpEnt = new Entity<DeltaPressureComponent>(uid, SEntMan.GetComponent<DeltaPressureComponent>(uid));
+                Assert.That(SAtmos.IsDeltaPressureEntityInList(ProcessEnt.Owner, dpEnt), "Entity was not in processing list when it should have been added!");
 
-                var indices = transformSystem.GetGridOrMapTilePosition(dpEnt);
-                var gridAtmosComp = entMan.GetComponent<GridAtmosphereComponent>(grid);
+                var indices = Transform.GetGridOrMapTilePosition(dpEnt);
+                var gridAtmosComp = SEntMan.GetComponent<GridAtmosphereComponent>(ProcessEnt);
 
                 direction = (AtmosDirection)(1 << i);
                 var offsetIndices = indices.Offset(direction);
@@ -442,17 +327,15 @@ public sealed class DeltaPressureTest
                 tile.Air!.AdjustMoles(Gas.Nitrogen, moles);
             });
 
-            await server.WaitRunTicks(30);
+            await Server.WaitRunTicks(30);
 
-            await server.WaitAssertion(() =>
+            await Server.WaitAssertion(() =>
             {
-                Assert.That(entMan.Deleted(dpEnt), $"{dpEnt} still exists after experiencing threshold absolute pressure from {direction} side!");
+                Assert.That(SEntMan.Deleted(dpEnt), $"{dpEnt} still exists after experiencing threshold absolute pressure from {direction} side!");
                 tile.Air!.Clear();
             });
 
-            await server.WaitRunTicks(30);
+            await Server.WaitRunTicks(30);
         }
-
-        await pair.CleanReturnAsync();
     }
 }


### PR DESCRIPTION
## About the PR
Fixes a race condition that would occur when using LINDA for equalization (disabling MonstermosEualization).

## Why / Balance
A race condition can occur when the entity is spawned and compared - if this happens in between a tick and LINDA happens to see a tile with no airtightness than it will equalize and throw off pressure deltas because the air has spread to other parts.

To avoid this we use the new debugging tools to explicitly step where we want and only run the sim when we want.
I also put in a loop that nukes all the mixtures on the grid so we don't have this happen again.

## Technical details
wawawawawawawa

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
n/a
