### PR TITLE
chore: added a full stop to the tooltip of the accentless speech trait

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -31,7 +31,7 @@ trait-pirate-accent-name = Pirate accent
 trait-pirate-accent-desc = You can't stop speaking like a pirate!
 
 trait-accentless-name = Accentless
-trait-accentless-desc = You don't have the accent that your species would usually have
+trait-accentless-desc = You don't have the accent that your species would usually have.
 
 trait-frontal-lisp-name = Frontal lisp
 trait-frontal-lisp-desc = You thpeak with a lithp.


### PR DESCRIPTION
This makes it consistent with the other tool-tips

## About the PR
Just added a full-stop in some locale to make it consistent with the other tool tip wordings

## Why / Balance
It does not affect balance

## Technical details
Fixes https://github.com/space-wizards/space-station-14/issues/41314
Added a full-stop in a locale wording

## Media
<img width="1187" height="706" alt="image" src="https://github.com/user-attachments/assets/9c080d80-6e5c-4aa6-8590-16115ffde1b6" />


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Tool-tip punctuation for the accentless speech trait
