### PR TITLE
Add Part Assembly and Temprature Construction Validations for Dev builds

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -410,7 +410,7 @@ namespace Content.Server.Construction
                     if ((!temperatureChangeStep.MinTemperature.HasValue || temp >= temperatureChangeStep.MinTemperature.Value) &&
                         (!temperatureChangeStep.MaxTemperature.HasValue || temp <= temperatureChangeStep.MaxTemperature.Value))
                     {
-                        return HandleResult.True;
+                        return validation ? HandleResult.Validated : HandleResult.True;
                     }
 
                     return HandleResult.False;
@@ -422,7 +422,7 @@ namespace Content.Server.Construction
                         break;
 
                     if (partAssemblyStep.Condition(uid, EntityManager))
-                        return HandleResult.True;
+                        return validation ? HandleResult.Validated : HandleResult.True;
                     return HandleResult.False;
                 }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Resolves https://github.com/space-wizards/space-station-14/issues/41394 - This issue currently impacts the stable branch.

## About the PR
I added validation handling for two construction interactions that did not have them.
`return validation ? HandleResult.Validated : HandleResult.True;`

These lines ensure that temperature-based construction and part assembly construction return the correct HandleResult enum value based on whether the system is in validation mode or execution mode, which fixes a couple of debug assert crashes.

See Issue linked above for symptoms and cause, but the short version is that in Sept a PR was made to enforce validation.

This enforcement exposed a bug, where construction events that were not being validated caused a Dev server to crash.

## Why / Balance
Dev was throwing a traceback as the result was being sent without the validation assertion being satisfied.

## Technical details
replaced:
`return HandleResult.True`

with:
`return validation ? HandleResult.Validated : HandleResult.True;`


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed a dev environment crash related to construction event validation.