### PR TITLE
Make DAGD more likely but restrict it to 1 traitor per round

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -34,7 +34,7 @@
   id: TraitorObjectiveGroupState
   weights:
     EscapeShuttleObjective: 1
-    DieObjective: 0.05
+    DieObjective: 0.2
     #HijackShuttleObjective: 0.02
 
 - type: weightedRandom

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -64,6 +64,8 @@
       - EscapeShuttleCondition
       - StealCondition
   - type: DieCondition
+  - type: ObjectiveLimit
+    limit: 1
 
 #- type: entity
 #  parent: [BaseTraitorObjective, BaseLivingObjective]


### PR DESCRIPTION
## About the PR
Title

## Why / Balance

- DAGD being freeform allows more player freedom on how it's carried out, enabling cool scenarios and gimmicks.
- DAGD makes players exempt from the dreaded rule 2.9 bwoink, allowing them to do what they want with minimal fears of disciplinary repercussions. (See the [Discourse](https://forum.spacestation14.com/t/rule-2-9s-vagueness-pushes-traitors-to-be-passive/25117/8))
- DAGD leads to more interesting rounds. Chaos makes the game fun, and DAGD tots normally cause a ton more chaos than stupid help X objectives or steal objectives.
- DAGD is just too rare as is. How often do you roll tot? Ok now how often do you roll DAGD? In my days of hours I think I have rolled it once, maybe twice.

## Technical details
Weight is 4 times higher. In my limited testing respawning myself and making myself a tot, I always got it once within 8-10 or so tots. The ObjectiveSystem code reads pretty jank, but I've been told that 5x would essentially guarantee a DAGD every round which I don't want, so I went with 4x instead.

## Media
NA

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
NA

**Changelog**
:cl: 
- tweak: Make DAGD more likely but restrict it to 1 traitor per round

