### PR TITLE
chore: made regalrat go the speed he should go

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -61,7 +61,7 @@
         Piercing: 8
   - type: Body
     prototype: Rat
-    requiredLegs: 1 # TODO: More than 1 leg
+    requiredLegs: 0 # TODO: Make more than 1 leg, set to 0 to avoid sprint speed being reset by the body system
   - type: Hunger # probably should be prototyped
     thresholds:
       Overfed: 200
@@ -253,7 +253,7 @@
         Piercing: 3
   - type: Body
     prototype: Rat
-    requiredLegs: 1 # TODO: More than 1 leg
+    requiredLegs: 0 # TODO: Make more than 1 leg, set to 0 to avoid sprint speed being reset by the body system
   - type: Hunger # probably should be prototyped
     thresholds:
       Overfed: 200


### PR DESCRIPTION
## About the PR
Just removed the required legs and set it to 0 for now
Having them to one would default back the following fields from `Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs`:
- `BaseSprintSpeed`
- `BaseAcceleration`
- `BaseAcceleration`

This happens because `Content.Shared/Body/Systems/SharedBodySystem.Parts.cs` is used and `UpdateMovementSpeed` is called with some leg parts that (correct me if I'm wrong I am terribly out of my territory here) have a `legModifier` that is not set anywhere in the `.yml` ?

I'm under the impression that the better move here would maybe to make the rat kings body parts and configure them correctly ? Let me know I'm curious

## Why / Balance
This fixes [#40754](https://github.com/space-wizards/space-station-14/issues/40754)

## Technical details
Just removed the required legs and set it to 0 for now

## Media
Now it `5` for the King
<img width="1432" height="733" alt="image" src="https://github.com/user-attachments/assets/200f6f3b-b40c-4d62-a35c-013e8e4c302b" />
And 3.5 for the followers
<img width="1304" height="467" alt="image" src="https://github.com/user-attachments/assets/ccad147f-8457-4a3d-a618-acba6a49c87f" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Rat king now goes 0.5 faster when sprinting

