### PR TITLE
add 2 empty lines to xenoborg round end text

### DIFF
--- a/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
@@ -122,7 +122,6 @@ public sealed class DeathMatchRuleSystem : GameRuleSystem<DeathMatchRuleComponen
         if (!TryComp<PointManagerComponent>(uid, out var point))
             return;
 
-        args.AddLine("");
         if (component.Victor != null && _player.TryGetPlayerData(component.Victor.Value, out var data))
         {
             args.AddLine(Loc.GetString("point-scoreboard-winner", ("player", data.UserName)));
@@ -130,5 +129,6 @@ public sealed class DeathMatchRuleSystem : GameRuleSystem<DeathMatchRuleComponen
         }
         args.AddLine(Loc.GetString("point-scoreboard-header"));
         args.AddLine(new FormattedMessage(point.Scoreboard).ToMarkup());
+        args.AddLine("");
     }
 }

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -94,8 +94,6 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         GameRuleComponent gameRule,
         ref RoundEndTextAppendEvent args)
     {
-        args.AddLine("");
-
         var winText = Loc.GetString($"nukeops-{component.WinType.ToString().ToLower()}");
         args.AddLine(winText);
 
@@ -113,6 +111,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         {
             args.AddLine(Loc.GetString("nukeops-list-name-user", ("name", name), ("user", sessionData.UserName)));
         }
+        args.AddLine("");
     }
 
     private void OnNukeExploded(NukeExplodedEvent ev)

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -104,8 +104,6 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         var index = (commandLost ? 1 : 0) | (revsLost ? 2 : 0);
         args.AddLine(Loc.GetString(Outcomes[index]));
 
-        args.AddLine("");
-
         var sessionData = _antag.GetAntagIdentifiers(uid);
         args.AddLine(Loc.GetString("rev-headrev-count", ("initialCount", sessionData.Count)));
         foreach (var (mind, data, name) in sessionData)
@@ -120,6 +118,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
             // TODO: someone suggested listing all alive? revs maybe implement at some point
         }
+        args.AddLine("");
     }
 
     private void OnGetBriefing(EntityUid uid, RevolutionaryRoleComponent comp, ref GetBriefingEvent args)

--- a/Content.Server/GameTicking/Rules/SurvivorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SurvivorRuleSystem.cs
@@ -103,10 +103,10 @@ public sealed class SurvivorRuleSystem : GameRuleSystem<SurvivorRuleComponent>
             aliveMarooned++;
         }
 
-        args.AddLine("");
         args.AddLine(Loc.GetString("survivor-round-end-dead-count", ("deadCount", deadSurvivors)));
         args.AddLine(Loc.GetString("survivor-round-end-alive-count", ("aliveCount", aliveMarooned)));
         args.AddLine(Loc.GetString("survivor-round-end-alive-on-shuttle-count", ("aliveCount", aliveOnShuttle)));
+        args.AddLine("");
 
         // Player manifest at EOR shows who's a survivor so no need for extra info here.
     }

--- a/Content.Server/GameTicking/Rules/XenoborgsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/XenoborgsRuleSystem.cs
@@ -55,8 +55,6 @@ public sealed class XenoborgsRuleSystem : GameRuleSystem<XenoborgsRuleComponent>
         var numXenoborgs = GetNumberXenoborgs();
         var numHumans = _mindSystem.GetAliveHumans().Count;
 
-        args.AddLine("");
-
         if (numXenoborgs < 5)
             args.AddLine(Loc.GetString("xenoborgs-crewmajor"));
         else if (4 * numXenoborgs < numHumans)
@@ -87,6 +85,7 @@ public sealed class XenoborgsRuleSystem : GameRuleSystem<XenoborgsRuleComponent>
         {
             args.AddLine(Loc.GetString("xenoborgs-list", ("name", name), ("user", sessionData.UserName)));
         }
+        args.AddLine("");
     }
 
     private void CheckRoundEnd(XenoborgsRuleComponent xenoborgsRuleComponent)

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -65,8 +65,6 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         // This is just the general condition thing used for determining the win/lose text
         var fraction = GetInfectedFraction(true, true);
 
-        args.AddLine("");
-
         if (fraction <= 0)
             args.AddLine(Loc.GetString("zombie-round-end-amount-none"));
         else if (fraction <= 0.25)
@@ -108,6 +106,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
                 ("name", meta.EntityName),
                 ("username", username)));
         }
+        args.AddLine("");
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<title>
<!-- What did you change? -->

## Why / Balance
cause xenoborg round end text was merging with other round end text
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
just 2 empty lines
<!-- Summary of code changes for easier review. -->

## Media
before:
<img width="353" height="281" alt="image" src="https://github.com/user-attachments/assets/9b114ef6-e72e-41c2-9933-f4f49dbf5909" />

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
no fun
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
