### PR TITLE
Add climbing component to borgs

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -248,6 +248,7 @@
     damageProtection:
       flatReductions:
         Heat: 10 # capable of touching light bulbs and stoves without feeling pain!
+  - type: Climbing
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Adds climbing component to borgs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

1) https://www.youtube.com/watch?v=MK9liYPm7eE

2) Borgs get countered by tableops (see media)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:
![dotnet_eSVSu6mJdb](https://github.com/user-attachments/assets/f022d1e0-d7d9-4ef3-a478-510b3215a417)
![dotnet_d7QHWhSgAD](https://github.com/user-attachments/assets/0dd2d10c-3bc2-427e-a2ac-861bcd952e79)
![dotnet_TNxJBgBW6Z](https://github.com/user-attachments/assets/9e71292a-0aab-4431-b1df-ff6e0f5d1e12)

After:
https://github.com/space-wizards/space-station-14/commit/8fb93ed5f18732489ef72dedd4ca8aebbcb1b162
![dotnet_gOz5WUkDSE](https://github.com/user-attachments/assets/fbec4564-64c5-4965-b69f-638c537d6fba)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Borgs may now climb tables.