### PR TITLE
Minor Knock spell refactor + fix its obstruction check

### DIFF
--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -401,22 +401,30 @@ public abstract class SharedMagicSystem : EntitySystem
     #endregion
     #region Knock Spells
     /// <summary>
-    /// Opens all doors and locks within range
+    /// Opens all doors and locks within range.
     /// </summary>
-    /// <param name="args"></param>
     private void OnKnockSpell(KnockSpellEvent args)
     {
         if (args.Handled || !PassesSpellPrerequisites(args.Action, args.Performer))
             return;
 
         args.Handled = true;
+        Knock(args.Performer, args.Range);
+    }
 
-        var transform = Transform(args.Performer);
+    /// <summary>
+    /// Opens all doors and locks within range.
+    /// </summary>
+    /// <param name="performer">Performer of spell. </param>
+    /// <param name="range">Radius around <see cref="performer"/> in which all doors and locks should be opened.</param>
+    public void Knock(EntityUid performer, float range)
+    {
+        var transform = Transform(performer);
 
         // Look for doors and lockers, and don't open/unlock them if they're already opened/unlocked.
-        foreach (var target in _lookup.GetEntitiesInRange(_transform.GetMapCoordinates(args.Performer, transform), args.Range, flags: LookupFlags.Dynamic | LookupFlags.Static))
+        foreach (var target in _lookup.GetEntitiesInRange(_transform.GetMapCoordinates(performer, transform), range, flags: LookupFlags.Dynamic | LookupFlags.Static))
         {
-            if (!_examine.InRangeUnOccluded(args.Performer, target, range: 0))
+            if (!_examine.InRangeUnOccluded(performer, target, range: 0))
                 continue;
 
             if (TryComp<DoorBoltComponent>(target, out var doorBoltComp) && doorBoltComp.BoltsDown)
@@ -426,7 +434,7 @@ public abstract class SharedMagicSystem : EntitySystem
                 _door.StartOpening(target);
 
             if (TryComp<LockComponent>(target, out var lockComp) && lockComp.Locked)
-                _lock.Unlock(target, args.Performer, lockComp);
+                _lock.Unlock(target, performer, lockComp);
         }
     }
     // End Knock Spells

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEKnockSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEKnockSystem.cs
@@ -1,4 +1,4 @@
-using Content.Shared.Magic.Events;
+using Content.Shared.Magic;
 using Content.Shared.Xenoarchaeology.Artifact.XAE.Components;
 
 namespace Content.Shared.Xenoarchaeology.Artifact.XAE;
@@ -8,14 +8,10 @@ namespace Content.Shared.Xenoarchaeology.Artifact.XAE;
 /// </summary>
 public sealed class XAEKnockSystem : BaseXAESystem<XAEKnockComponent>
 {
+    [Dependency] private readonly SharedMagicSystem _magic = default!;
     /// <inheritdoc />
     protected override void OnActivated(Entity<XAEKnockComponent> ent, ref XenoArtifactNodeActivatedEvent args)
     {
-        var ev = new KnockSpellEvent
-        {
-            Performer = args.Artifact,
-            Range = ent.Comp.KnockRange
-        };
-        RaiseLocalEvent(ev);
+        _magic.Knock(args.Artifact, ent.Comp.KnockRange);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Cleanups related to Knock effect of xeno-artifact:
1. KNOCK spell now will not be obstructed by any mob, consoles, etc - only walls and other stuff that blocks line of sight
2. Artifact effect of knock now casts spell by itself, not by the node inside.
3. Removed IsFirstTimePredicted check that was not needed in XAEKnockSystem

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Knock spell being obstructed by mob prevented it from working in a lot of scenarios with artifacts. Solution to change check for InRangeUnOccluded was conceptually approved by Keron - by design it should work through windows, mobs, consoles, etc, only being blocked, basically, by other doors or walls.

Artifact casting spell from node is just inconvenient and puzzling behaviour - all effects should be made by either artifact, or the one who activates it.

## Technical details
<!-- Summary of code changes for easier review. -->
IsFirstTimePredicted originally was added without fully understanding its core functionality, so now its removed from this system.
Changed call of Knock code to system method call to bring it in accordance with https://docs.spacestation14.com/en/general-development/codebase-info/conventions.html#method-events-vs-entity-system-methods

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

[knock-artifact.webm](https://github.com/user-attachments/assets/c4d7981f-55e8-45fd-b387-ee8c85059c2b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: KNOCK spell and 'Mild electromagnetic interference' xeno artifact effects now will be blocked only by obstructed line of sight (range is still applied)