### PR TITLE
Make chemicals not react inside pills

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry.yml
@@ -648,6 +648,7 @@
     solutions:
       food:
         maxVol: 20
+        canReact: false
   - type: ExplosionResistance
     damageCoefficient: 0.025 # survives conventional explosives but not minibombs and nukes
   - type: Damageable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

*The information and videos below are slightly outdated, chemicals react in pills, but not in stomachs, meaning that reactions occur immediately upon swallowing the pill*

## About the PR
Reagents no longer react inside pills and inside stomachs (which means they only reacting when they start metabolizing)

## Why / Balance
This allows for some funny antag strategies, allowing to turn people into ticking bombs by giving them specific pills (see videos below)

## Technical details
Simply added `canReact: false` to a bunch of places

## Media

https://github.com/user-attachments/assets/f2f16d8f-70f2-47c3-9b10-720c63ca0781

https://github.com/user-attachments/assets/5add41ae-af1c-4d60-8a2c-c37baff2c817

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Chemical reactions no longer occur inside pills 
