### PR TITLE
Blocking Code Clean-Up & Shield QoL

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -22,34 +22,31 @@ public sealed partial class BlockingSystem
         SubscribeLocalEvent<BlockingUserComponent, EntityTerminatingEvent>(OnEntityTerminating);
     }
 
-    private void OnParentChanged(EntityUid uid, BlockingUserComponent component, ref EntParentChangedMessage args)
+    private void OnParentChanged(Entity<BlockingUserComponent> shieldUser, ref EntParentChangedMessage args)
     {
-        UserStopBlocking(uid, component);
+        UserStopBlocking(shieldUser);
     }
 
-    private void OnInsertAttempt(EntityUid uid, BlockingUserComponent component, ContainerGettingInsertedAttemptEvent args)
+    private void OnInsertAttempt(Entity<BlockingUserComponent> shieldUser, ref ContainerGettingInsertedAttemptEvent args)
     {
-        UserStopBlocking(uid, component);
+        UserStopBlocking(shieldUser);
     }
 
-    private void OnAnchorChanged(EntityUid uid, BlockingUserComponent component, ref AnchorStateChangedEvent args)
+    private void OnAnchorChanged(Entity<BlockingUserComponent> shieldUser, ref AnchorStateChangedEvent args)
     {
         if (args.Anchored)
             return;
 
-        UserStopBlocking(uid, component);
+        UserStopBlocking(shieldUser);
     }
 
     private void OnUserDamageModified(EntityUid uid, BlockingUserComponent component, DamageModifyEvent args)
     {
-        if (component.BlockingItem is not { } item || !TryComp<BlockingComponent>(item, out var blocking))
-            return;
-
-        if (args.Damage.GetTotal() <= 0)
-            return;
-
-        // A shield should only block damage it can itself absorb. To determine that we need the Damageable component on it.
-        if (!TryComp<DamageableComponent>(item, out var dmgComp))
+        if (component.BlockingItem is not { } item
+            || !TryComp<BlockingComponent>(item, out var blocking)
+            || args.Damage.GetTotal() <= 0
+            // A shield should only block damage it can itself absorb. To determine that we need the Damageable component on it.
+            || !TryComp<DamageableComponent>(item, out var dmgComp))
             return;
 
         var blockFraction = blocking.IsBlocking ? blocking.ActiveBlockFraction : blocking.PassiveBlockFraction;
@@ -65,9 +62,8 @@ public sealed partial class BlockingSystem
         args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, modify);
 
         if (blocking.IsBlocking && !args.Damage.Equals(args.OriginalDamage))
-        {
             _audio.PlayPvs(blocking.BlockSound, uid);
-        }
+
     }
 
     private void OnDamageModified(EntityUid uid, BlockingComponent component, DamageModifyEvent args)
@@ -81,12 +77,12 @@ public sealed partial class BlockingSystem
         args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, modifier);
     }
 
-    private void OnEntityTerminating(EntityUid uid, BlockingUserComponent component, ref EntityTerminatingEvent args)
+    private void OnEntityTerminating(Entity<BlockingUserComponent> shieldUser, ref EntityTerminatingEvent args)
     {
-        if (!TryComp<BlockingComponent>(component.BlockingItem, out var blockingComponent))
+        if (!TryComp<BlockingComponent>(shieldUser.Comp.BlockingItem, out var blockingComponent))
             return;
 
-        StopBlockingHelper(component.BlockingItem.Value, blockingComponent, uid);
+        StopBlockingHelper((shieldUser.Comp.BlockingItem.Value, blockingComponent), shieldUser);
 
     }
 
@@ -94,11 +90,11 @@ public sealed partial class BlockingSystem
     /// Check for the shield and has the user stop blocking
     /// Used where you'd like the user to stop blocking, but also don't want to remove the <see cref="BlockingUserComponent"/>
     /// </summary>
-    /// <param name="uid">The user blocking</param>
+    /// <param name="shieldUser">The user entity with the shield</param>
     /// <param name="component">The <see cref="BlockingUserComponent"/></param>
-    private void UserStopBlocking(EntityUid uid, BlockingUserComponent component)
+    private void UserStopBlocking(Entity<BlockingUserComponent> shieldUser)
     {
-        if (TryComp<BlockingComponent>(component.BlockingItem, out var blockComp) && blockComp.IsBlocking)
-            StopBlocking(component.BlockingItem.Value, blockComp, uid);
+        if (TryComp<BlockingComponent>(shieldUser.Comp.BlockingItem, out var blockComp) && blockComp.IsBlocking)
+            StopBlocking((shieldUser.Comp.BlockingItem.Value, blockComp), shieldUser);
     }
 }

--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
+using Content.Shared.Movement.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 
@@ -20,6 +21,7 @@ public sealed partial class BlockingSystem
         SubscribeLocalEvent<BlockingUserComponent, ContainerGettingInsertedAttemptEvent>(OnInsertAttempt);
         SubscribeLocalEvent<BlockingUserComponent, AnchorStateChangedEvent>(OnAnchorChanged);
         SubscribeLocalEvent<BlockingUserComponent, EntityTerminatingEvent>(OnEntityTerminating);
+        SubscribeLocalEvent<HasRaisedShieldComponent, MoveInputEvent>(OnMoveInput);
     }
 
     private void OnParentChanged(Entity<BlockingUserComponent> shieldUser, ref EntParentChangedMessage args)
@@ -38,6 +40,14 @@ public sealed partial class BlockingSystem
             return;
 
         UserStopBlocking(shieldUser);
+    }
+
+    private void OnMoveInput(Entity<HasRaisedShieldComponent> shieldUser, ref MoveInputEvent args)
+    {
+        if (!TryComp<BlockingUserComponent>(shieldUser, out var shieldUserComp))
+            return;
+
+        UserStopBlocking((shieldUser, shieldUserComp));
     }
 
     private void OnUserDamageModified(EntityUid uid, BlockingUserComponent component, DamageModifyEvent args)

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.Verbs;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Toolshed.Syntax;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Blocking;
@@ -51,81 +52,80 @@ public sealed partial class BlockingSystem : EntitySystem
         SubscribeLocalEvent<BlockingComponent, MapInitEvent>(OnMapInit);
     }
 
-    private void OnMapInit(EntityUid uid, BlockingComponent component, MapInitEvent args)
+    private void OnMapInit(Entity<BlockingComponent> shield, ref MapInitEvent args)
     {
-        _actionContainer.EnsureAction(uid, ref component.BlockingToggleActionEntity, component.BlockingToggleAction);
-        Dirty(uid, component);
+        _actionContainer.EnsureAction(shield, ref shield.Comp.BlockingToggleActionEntity, shield.Comp.BlockingToggleAction);
+        Dirty(shield);
     }
 
-    private void OnEquip(EntityUid uid, BlockingComponent component, GotEquippedHandEvent args)
+    private void OnEquip(Entity<BlockingComponent> shield, ref GotEquippedHandEvent args)
     {
-        component.User = args.User;
-        Dirty(uid, component);
+        shield.Comp.User = args.User;
+        Dirty(shield);
 
         //To make sure that this bodytype doesn't get set as anything but the original
         if (TryComp<PhysicsComponent>(args.User, out var physicsComponent) && physicsComponent.BodyType != BodyType.Static && !HasComp<BlockingUserComponent>(args.User))
         {
             var userComp = EnsureComp<BlockingUserComponent>(args.User);
-            userComp.BlockingItem = uid;
+            userComp.BlockingItem = shield;
             userComp.OriginalBodyType = physicsComponent.BodyType;
         }
     }
 
-    private void OnUnequip(EntityUid uid, BlockingComponent component, GotUnequippedHandEvent args)
+    private void OnUnequip(Entity<BlockingComponent> shield, ref GotUnequippedHandEvent args)
     {
-        StopBlockingHelper(uid, component, args.User);
+        StopBlockingHelper(shield, args.User);
     }
 
-    private void OnDrop(EntityUid uid, BlockingComponent component, DroppedEvent args)
+    private void OnDrop(Entity<BlockingComponent> shield, ref DroppedEvent args)
     {
-        StopBlockingHelper(uid, component, args.User);
+        StopBlockingHelper(shield, args.User);
     }
 
-    private void OnGetActions(EntityUid uid, BlockingComponent component, GetItemActionsEvent args)
+    private void OnGetActions(Entity<BlockingComponent> shield, ref GetItemActionsEvent args)
     {
-        args.AddAction(ref component.BlockingToggleActionEntity, component.BlockingToggleAction);
+        args.AddAction(ref shield.Comp.BlockingToggleActionEntity, shield.Comp.BlockingToggleAction);
     }
 
-    private void OnToggleAction(EntityUid uid, BlockingComponent component, ToggleActionEvent args)
+    private void OnToggleAction(Entity<BlockingComponent> shield, ref ToggleActionEvent args)
     {
         if (args.Handled)
             return;
 
-        var blockQuery = GetEntityQuery<BlockingComponent>();
         var handQuery = GetEntityQuery<HandsComponent>();
-
         if (!handQuery.TryGetComponent(args.Performer, out var hands))
             return;
 
+        var blockQuery = GetEntityQuery<BlockingComponent>();
+
         var shields = _handsSystem.EnumerateHeld((args.Performer, hands)).ToArray();
 
-        foreach (var shield in shields)
+        foreach (var heldShield in shields)
         {
-            if (shield == uid)
+            if (heldShield == shield.Owner
+                || !blockQuery.TryGetComponent(heldShield, out var otherBlockComp)
+                || !otherBlockComp.IsBlocking)
                 continue;
 
-            if (blockQuery.TryGetComponent(shield, out var otherBlockComp) && otherBlockComp.IsBlocking)
-            {
-                CantBlockError(args.Performer);
-                return;
-            }
+            CantBlockError(args.Performer, Loc.GetString("action-popup-blocking-user-already-blocking"));
+            return;
         }
 
-        if (component.IsBlocking)
-            StopBlocking(uid, component, args.Performer);
+        if (shield.Comp.IsBlocking)
+            StopBlocking(shield, args.Performer);
         else
-            StartBlocking(uid, component, args.Performer);
+            StartBlocking(shield, args.Performer);
 
         args.Handled = true;
     }
 
-    private void OnShutdown(EntityUid uid, BlockingComponent component, ComponentShutdown args)
+    private void OnShutdown(Entity<BlockingComponent> shield, ref ComponentShutdown args)
     {
         //In theory the user should not be null when this fires off
-        if (component.User != null)
+        if (shield.Comp.User != null)
         {
-            _actionsSystem.RemoveProvidedActions(component.User.Value, uid);
-            StopBlockingHelper(uid, component, component.User.Value);
+            _actionsSystem.RemoveProvidedActions(shield.Comp.User.Value, shield);
+            StopBlockingHelper(shield, shield.Comp.User.Value);
         }
     }
 
@@ -134,18 +134,17 @@ public sealed partial class BlockingSystem : EntitySystem
     /// Creates a new hard fixture to bodyblock
     /// Also makes the user static to prevent prediction issues
     /// </summary>
-    /// <param name="item"> The entity with the blocking component</param>
-    /// <param name="component"> The <see cref="BlockingComponent"/></param>
+    /// <param name="shield"> The shield entity with the blocking component</param>
     /// <param name="user"> The entity who's using the item to block</param>
     /// <returns></returns>
-    public bool StartBlocking(EntityUid item, BlockingComponent component, EntityUid user)
+    public bool StartBlocking(Entity<BlockingComponent> shield, EntityUid user)
     {
-        if (component.IsBlocking)
+        if (shield.Comp.IsBlocking)
             return false;
 
         var xform = Transform(user);
 
-        var shieldName = Name(item);
+        var shieldName = Name(shield);
 
         var blockerName = Identity.Entity(user, EntityManager);
         var msgUser = Loc.GetString("action-popup-blocking-user", ("shield", shieldName));
@@ -154,14 +153,14 @@ public sealed partial class BlockingSystem : EntitySystem
         //Don't allow someone to block if they're not parented to a grid
         if (xform.GridUid != xform.ParentUid)
         {
-            CantBlockError(user);
+            CantBlockError(user, Loc.GetString("action-popup-blocking-user-cant-block"));
             return false;
         }
 
         // Don't allow someone to block if they're not holding the shield
-        if (!_handsSystem.IsHolding(user, item, out _))
+        if (!_handsSystem.IsHolding(user, shield, out _))
         {
-            CantBlockError(user);
+            CantBlockError(user, Loc.GetString("action-popup-blocking-user-not-holding"));
             return false;
         }
 
@@ -175,7 +174,7 @@ public sealed partial class BlockingSystem : EntitySystem
             {
                 if (uid != user && mobQuery.HasComponent(uid))
                 {
-                    TooCloseError(user);
+                    CantBlockError(user, Loc.GetString("action-popup-blocking-user-too-close"));
                     return false;
                 }
             }
@@ -185,55 +184,47 @@ public sealed partial class BlockingSystem : EntitySystem
         _transformSystem.AnchorEntity(user, xform);
         if (!xform.Anchored)
         {
-            CantBlockError(user);
+            CantBlockError(user, Loc.GetString("action-popup-blocking-user-cant-block"));
             return false;
         }
-        _actionsSystem.SetToggled(component.BlockingToggleActionEntity, true);
+        _actionsSystem.SetToggled(shield.Comp.BlockingToggleActionEntity, true);
         _popupSystem.PopupPredicted(msgUser, msgOther, user, user);
 
         if (TryComp<PhysicsComponent>(user, out var physicsComponent))
         {
             _fixtureSystem.TryCreateFixture(user,
-                component.Shape,
+                shield.Comp.Shape,
                 BlockingComponent.BlockFixtureID,
                 hard: true,
                 collisionLayer: (int)CollisionGroup.WallLayer,
                 body: physicsComponent);
         }
 
-        component.IsBlocking = true;
-        Dirty(item, component);
+        shield.Comp.IsBlocking = true;
+        Dirty(shield);
 
         return true;
     }
 
-    private void CantBlockError(EntityUid user)
+    private void CantBlockError(EntityUid user, string errorMessage)
     {
-        var msgError = Loc.GetString("action-popup-blocking-user-cant-block");
-        _popupSystem.PopupClient(msgError, user, user);
-    }
-
-    private void TooCloseError(EntityUid user)
-    {
-        var msgError = Loc.GetString("action-popup-blocking-user-too-close");
-        _popupSystem.PopupClient(msgError, user, user);
+        _popupSystem.PopupClient(errorMessage, user, user);
     }
 
     /// <summary>
     /// Called where you want the user to stop blocking.
     /// </summary>
-    /// <param name="item"> The entity with the blocking component</param>
-    /// <param name="component"> The <see cref="BlockingComponent"/></param>
+    /// <param name="shield"> The shield entity with the blocking component</param>
     /// <param name="user"> The entity who's using the item to block</param>
     /// <returns></returns>
-    public bool StopBlocking(EntityUid item, BlockingComponent component, EntityUid user)
+    public bool StopBlocking(Entity<BlockingComponent> shield, EntityUid user)
     {
-        if (!component.IsBlocking)
+        if (!shield.Comp.IsBlocking)
             return false;
 
         var xform = Transform(user);
 
-        var shieldName = Name(item);
+        var shieldName = Name(shield);
 
         var blockerName = Identity.Entity(user, EntityManager);
         var msgUser = Loc.GetString("action-popup-blocking-disabling-user", ("shield", shieldName));
@@ -247,14 +238,14 @@ public sealed partial class BlockingSystem : EntitySystem
             if (xform.Anchored)
                 _transformSystem.Unanchor(user, xform);
 
-            _actionsSystem.SetToggled(component.BlockingToggleActionEntity, false);
+            _actionsSystem.SetToggled(shield.Comp.BlockingToggleActionEntity, false);
             _fixtureSystem.DestroyFixture(user, BlockingComponent.BlockFixtureID, body: physicsComponent);
             _physics.SetBodyType(user, blockingUserComponent.OriginalBodyType, body: physicsComponent);
             _popupSystem.PopupPredicted(msgUser, msgOther, user, user);
         }
 
-        component.IsBlocking = false;
-        Dirty(item, component);
+        shield.Comp.IsBlocking = false;
+        Dirty(shield);
 
         return true;
     }
@@ -263,13 +254,12 @@ public sealed partial class BlockingSystem : EntitySystem
     /// Called where you want someone to stop blocking and to remove the <see cref="BlockingUserComponent"/> from them
     /// Won't remove the <see cref="BlockingUserComponent"/> if they're holding another blocking item
     /// </summary>
-    /// <param name="uid"> The item the component is attached to</param>
-    /// <param name="component"> The <see cref="BlockingComponent"/> </param>
+    /// <param name="shield"> The shield entity with the blocking component</param>
     /// <param name="user"> The person holding the blocking item </param>
-    private void StopBlockingHelper(EntityUid uid, BlockingComponent component, EntityUid user)
+    private void StopBlockingHelper(Entity<BlockingComponent> shield, EntityUid user)
     {
-        if (component.IsBlocking)
-            StopBlocking(uid, component, user);
+        if (shield.Comp.IsBlocking)
+            StopBlocking(shield, user);
 
         var userQuery = GetEntityQuery<BlockingUserComponent>();
         var handQuery = GetEntityQuery<HandsComponent>();
@@ -279,33 +269,33 @@ public sealed partial class BlockingSystem : EntitySystem
 
         var shields = _handsSystem.EnumerateHeld((user, hands)).ToArray();
 
-        foreach (var shield in shields)
+        foreach (var heldShield in shields)
         {
-            if (HasComp<BlockingComponent>(shield) && userQuery.TryGetComponent(user, out var blockingUserComponent))
+            if (HasComp<BlockingComponent>(heldShield) && userQuery.TryGetComponent(user, out var blockingUserComponent))
             {
-                blockingUserComponent.BlockingItem = shield;
+                blockingUserComponent.BlockingItem = heldShield;
                 return;
             }
         }
 
         RemComp<BlockingUserComponent>(user);
-        component.User = null;
+        shield.Comp.User = null;
     }
 
-    private void OnVerbExamine(EntityUid uid, BlockingComponent component, GetVerbsEvent<ExamineVerb> args)
+    private void OnVerbExamine(Entity<BlockingComponent> shield, ref GetVerbsEvent<ExamineVerb> args)
     {
         if (!args.CanInteract || !args.CanAccess)
             return;
-
-        var fraction = component.IsBlocking ? component.ActiveBlockFraction : component.PassiveBlockFraction;
-        var modifier = component.IsBlocking ? component.ActiveBlockDamageModifier : component.PassiveBlockDamageModifer;
+        var shieldComp = shield.Comp;
+        var fraction = shieldComp.IsBlocking ? shieldComp.ActiveBlockFraction : shieldComp.PassiveBlockFraction;
+        var modifier = shieldComp.IsBlocking ? shieldComp.ActiveBlockDamageModifier : shieldComp.PassiveBlockDamageModifer;
 
         var msg = new FormattedMessage();
         msg.AddMarkupOrThrow(Loc.GetString("blocking-fraction", ("value", MathF.Round(fraction * 100, 1))));
 
         AppendCoefficients(modifier, msg);
 
-        _examine.AddDetailedExamineVerb(args, component, msg,
+        _examine.AddDetailedExamineVerb(args, shieldComp, msg,
             Loc.GetString("blocking-examinable-verb-text"),
             "/Textures/Interface/VerbIcons/dot.svg.192dpi.png",
             Loc.GetString("blocking-examinable-verb-message")

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -201,6 +201,7 @@ public sealed partial class BlockingSystem : EntitySystem
         }
 
         shield.Comp.IsBlocking = true;
+        EnsureComp<HasRaisedShieldComponent>(user);
         Dirty(shield);
 
         return true;
@@ -245,6 +246,7 @@ public sealed partial class BlockingSystem : EntitySystem
         }
 
         shield.Comp.IsBlocking = false;
+        RemComp<HasRaisedShieldComponent>(user);
         Dirty(shield);
 
         return true;

--- a/Content.Shared/Blocking/Components/BlockingUserComponent.cs
+++ b/Content.Shared/Blocking/Components/BlockingUserComponent.cs
@@ -11,13 +11,13 @@ public sealed partial class BlockingUserComponent : Component
     /// <summary>
     /// The entity that's being used to block
     /// </summary>
-    [DataField("blockingItem")]
+    [DataField]
     public EntityUid? BlockingItem;
 
     /// <summary>
     /// Stores the entities original bodytype
     /// Used so that it can be put back to what it was after anchoring
     /// </summary>
-    [DataField("originalBodyType")]
+    [DataField]
     public BodyType OriginalBodyType;
 }

--- a/Content.Shared/Blocking/Components/HasRaisedShieldComponent.cs
+++ b/Content.Shared/Blocking/Components/HasRaisedShieldComponent.cs
@@ -1,0 +1,9 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Blocking;
+
+/// <summary>
+/// This component gets dynamically added to an Entity when they raise a shield via <see cref="BlockingSystem"/>
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class HasRaisedShieldComponent : Component;

--- a/Resources/Locale/en-US/actions/actions/blocking.ftl
+++ b/Resources/Locale/en-US/actions/actions/blocking.ftl
@@ -4,6 +4,8 @@ action-popup-blocking-disabling-user = You lower your {$shield}!
 action-popup-blocking-other = {CAPITALIZE(THE($blockerName))} raises {POSS-ADJ($blockerName)} {$shield}!
 action-popup-blocking-disabling-other = {CAPITALIZE(THE($blockerName))} lowers {POSS-ADJ($blockerName)} {$shield}!
 
+action-popup-blocking-user-already-blocking = You already raised another shield!
+action-popup-blocking-user-not-holding = You aren't holding the shield you're trying to raise.
 action-popup-blocking-user-cant-block = You tried to raise your shield, but it was no use.
 action-popup-blocking-user-too-close = There's no room here to block. Try moving a bit!
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I cleaned up the blocking code. Mostly just making the parameters use Entities instead of uid + comps.
I also added two new FTL lines.
I also added the ability to lower your shield with a movement input.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fumbling for the action button to lower your shield feels bad, especially if you have a few actions already lined up, and the button for it going increasingly further away from your finger.
## Technical details
<!-- Summary of code changes for easier review. -->
Added `HasShieldRaisedComponent` to track when someone has a shield raised.
Then I subscribed to `MoveInputEvent` to lower the shield when someone does it.
Then that component gets removed to be efficient.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/3820b34c-ed5e-4b6e-8dc3-072088d78e24


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Shields can now be lowered via a movement input if they're raised!