### PR TITLE
Fix the round end trigger for xenoborgs

### DIFF
--- a/Content.Server/GameTicking/Rules/XenoborgsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/XenoborgsRuleSystem.cs
@@ -92,7 +92,7 @@ public sealed class XenoborgsRuleSystem : GameRuleSystem<XenoborgsRuleComponent>
         var numXenoborgs = GetNumberXenoborgs();
         var numHumans = _mindSystem.GetAliveHumans().Count;
 
-        if ((float)numXenoborgs / numHumans > xenoborgsRuleComponent.XenoborgShuttleCallPercentage)
+        if ((float)numXenoborgs / (numHumans + numXenoborgs) > xenoborgsRuleComponent.XenoborgShuttleCallPercentage)
         {
             foreach (var station in _station.GetStations())
             {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title ^
<!-- What did you change? -->

## Why / Balance
the idea was to call the shuttle after 70% of the crew were turned into xenoborgs, but the code was calculating the ratio between xenoborgs and crew. which means the shuttle would be called when the number of xenoborgs were 70% of the number of crew. which is bellow the winning condition for xenoborgs (have more xenoborgs than alive crew, which corresponds to roughly 50% of the crew being converted)
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
replaced the denominator from the number of alive crew to the sum of the num of alive crew and number of xenoborgs
<!-- Summary of code changes for easier review. -->

## Media
no need
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
I don't think it's needed?
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
