### PR TITLE
Per issue #41143, 'ClusterBang' was changed to 'clusterbang'

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
@@ -49,7 +49,7 @@
 - type: entity
   parent: ClusterBang
   id: ClusterBangFull
-  name: ClusterBang
+  name: clusterbang
   description: Launches three flashbangs after the timer runs out.
   suffix: Full
   components:


### PR DESCRIPTION
## About the PR
Clusterbangs were displayed in-game as _ClusterBang_, and now they are _clusterbang_.

## Why / Balance
Resolves [Issue #41143](https://github.com/space-wizards/space-station-14/issues/41143).

## Technical details
ClusterBangFull's 'name' value changed from ClusterBang to clusterbang.

## Media
<img width="1280" height="750" alt="Screenshot 2025-11-17 at 4 33 41 PM" src="https://github.com/user-attachments/assets/2cd33955-e86d-4bed-a0bf-79829d3a3581" />
<img width="1279" height="746" alt="Screenshot 2025-11-17 at 4 34 00 PM" src="https://github.com/user-attachments/assets/d791a207-5b41-42e9-b299-a017d80d7369" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
N/A

**Changelog**
N/A
