### PR TITLE
Wallmounts can now go on Windows

### DIFF
--- a/Content.Shared/Construction/Conditions/WallmountCondition.cs
+++ b/Content.Shared/Construction/Conditions/WallmountCondition.cs
@@ -16,6 +16,7 @@ namespace Content.Shared.Construction.Conditions
     public sealed partial class WallmountCondition : IConstructionCondition
     {
         private static readonly ProtoId<TagPrototype> WallTag = "Wall";
+        private static readonly ProtoId<TagPrototype> WindowTag = "Window";
 
         public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
         {
@@ -45,7 +46,7 @@ namespace Content.Shared.Construction.Conditions
             var tagSystem = entManager.System<TagSystem>();
 
             var userToObjRaycastResults = physics.IntersectRayWithPredicate(entManager.GetComponent<TransformComponent>(user).MapID, rUserToObj, maxLength: length,
-                predicate: (e) => !tagSystem.HasTag(e, WallTag));
+                predicate: (e) => !(tagSystem.HasTag(e, WallTag) || tagSystem.HasTag(e, WindowTag)));
 
             var targetWall = userToObjRaycastResults.FirstOrNull();
 
@@ -56,7 +57,7 @@ namespace Content.Shared.Construction.Conditions
             // check that we didn't try to build wallmount that facing another adjacent wall
             var rAdjWall = new CollisionRay(objWorldPosition, directionWithOffset.Normalized(), (int) CollisionGroup.Impassable);
             var adjWallRaycastResults = physics.IntersectRayWithPredicate(entManager.GetComponent<TransformComponent>(user).MapID, rAdjWall, maxLength: 0.5f,
-               predicate: e => e == targetWall.Value.HitEntity || !tagSystem.HasTag(e, WallTag));
+               predicate: e => e == targetWall.Value.HitEntity || !(tagSystem.HasTag(e, WallTag) || tagSystem.HasTag(e, WindowTag)));
 
             return !adjWallRaycastResults.Any();
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Allows people to build wallmounts (buttons, air alarms, etc) on windows

## Why / Balance
Mappers keep doing it and instead of going on a crusade against them this is less effort (Also it looks better)

## Technical details
Added a check for WindowTag to WallmountSystem

## Media
<img width="164" height="154" alt="image" src="https://github.com/user-attachments/assets/450abe32-ff89-49d7-b7dc-47e572e35967" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Wallmounts can now be built on windows

