### PR TITLE
Bugfix: Borg's can't die anymore

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -444,7 +444,7 @@
     thresholds: # slightly tankier than a normal borg
       0: Alive
       125: Critical
-      250: Dead
+      375: Dead # Same as destruction threshold. Borgs act exactly like crit when dead, except for ghosting on move
   - type: EmagSiliconLaw # should xenoborgs be emagable?
     stunTime: 5
   - type: SiliconLawProvider

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/xenoborgs.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/xenoborgs.yml
@@ -92,7 +92,7 @@
     thresholds:
       0: Alive
       250: Critical
-      500: Dead
+      750: Dead # Same as destruction threshold. Borgs act exactly like crit when dead, except for ghosting on move
     stateAlertDict:
       Alive: BorgHealth
       Critical: BorgCrit


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The mobstate threshold for dead has been change to be the same as the explode threshold.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Far as I can tell this only causes problems when borgs die. They can still do everything else they could while crit (talking, viewing laws), but they also ghost with move inputs (which can happen accidently if you didn't expect to die, making you think you're true dead).

## Technical details
<!-- Summary of code changes for easier review. -->
mini yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->