### PR TITLE
Add deep-insert for item slots

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
@@ -131,6 +131,10 @@ namespace Content.Shared.Containers.ItemSlots
         [DataField]
         public bool InsertOnInteract = true;
 
+        [DataField]
+        [Access(typeof(ItemSlotsSystem), Other = AccessPermissions.ReadWriteExecute)]
+        public EntityWhitelist? DeepInsertList;
+
         /// <summary>
         ///     Whether the item slots system will attempt to eject this item to the user's hands when interacted with.
         /// </summary>

--- a/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
@@ -239,6 +239,10 @@
             tags:
               - TrashBag
           priority: 3 # Higher than drinking priority
+          insertOnInteract: true
+          deepInsertList:
+            tags:
+              - Trash
     - type: Fixtures
       fixtures:
         fix1:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds DeepInsertList data field and functionality to ItemSlots
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
When clicking an object that has deepInsertList items configured on the item slots, it will insert that object into the relevant item slots. i.e. If click janicart with a piece of trash, if there is a trashbag attached to janicart, it will insert the trash into the trashbag on janicart.  
## Technical details
<!-- Summary of code changes for easier review. -->
C# changes, Datafield addition on ItemSlots, OnInteractUsing modification in ItemSlotsSystem.cs, YML Change to Janicart 
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/5b449d72-46b6-4fb6-ae04-1098f14fef66

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added ability to insert items into ItemSlots while they're equipped to their respective item.