### PR TITLE
Give Rust Removal a shorter Doafter (#770)

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -509,7 +509,7 @@
         - to: wall
           steps:
             - tool: Welding
-              doAfter: 1
+              doAfter: 2
         - to: wall
           steps:
             - tool: Brushing
@@ -521,7 +521,7 @@
         - to: reinforcedWall
           steps:
             - tool: Welding
-              doAfter: 1
+              doAfter: 2
         - to: reinforcedWall
           steps:
             - tool: Brushing


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Cut down the time it takes to brush rust off both solid and reinforced walls by 1/3, or down to 4 seconds. Used to be twelve seconds, which made brushing kind of unviable. Welding rust off walls also got reduced down to taking just two seconds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Some stations, like Elkridge, make it completely inviable for de-rusting with anything other than the experimental welder. Not to mention that janitors shouldn't _have_ to seek out a pair of meson goggles or a welding mask and torch in order to do part of their job effectively. Welding walls is now, frankly, overkill, taking only half the time. I envision it more as a late-round upgrade, with the experimental welder and maybe a pair of engineering goggles after having proven themselves, so the janitor can finally finish up the cleaning of the station... or at least, try to do so before the nukies blow it to hell.

While the interaction between Service and Engineering or Sci _could_ be more valuable, it's mostly just redundant. Janitors already have interactions with other departments, it's being let in to clean.

## Technical details

`girder.yml` 
`reinforcedWallRust` `doAfter` for `tool: Welding` decreased to `2`. `doAfter` for `tool: Brushing` decreased to `4`.
`wallRust` `doAfter` for `tool: Welding` decreased to `2`. `doAfter` for `tool: Brushing` decreased to `4`.
 
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Exempt. I think. Likely. You brush faster.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

None!

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Nilsy
- tweak: Both rusted variants of Solid and Reinforced walls now take only 4 seconds to brush clean, and just two seconds to weld clean.
