### PR TITLE
Minor Estoc DMR balance improvements

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -199,7 +199,7 @@
   name: XL8
   description: |-
     The Experimental Lecter 8
-    An unreasonably expensive military grade assault rifle with integrated optic. 
+    An unreasonably expensive military grade assault rifle with integrated optic.
     Uses .20 rifle ammo.
   components:
   - type: Sprite
@@ -219,7 +219,7 @@
     - Burst
     - SemiAuto
     - FullAuto
-  
+
 - type: entity
   name: Estoc DMR
   parent: [BaseWeaponRifle, BaseSyndicateContraband]
@@ -241,17 +241,12 @@
   - type: Gun
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/estocshot.ogg
-    minAngle: 30
-    maxAngle: 43
     shotsPerBurst: 3
     selectedMode: Burst
     availableModes:
     - Burst
     - SemiAuto
     burstFireRate: 14
-  - type: GunWieldBonus
-    minAngle: -28
-    maxAngle: -25
   - type: ItemSlots
     slots:
       gun_magazine:
@@ -272,12 +267,13 @@
           tags:
           - CartridgeRifle
   - type: SpeedModifiedOnWield
-    walkModifier: 0.75
-    sprintModifier: 0.75
-  - type: CursorOffsetRequiresWield
+    walkModifier: 0.85
+    sprintModifier: 0.85
+  - type: GunRequiresWield
   - type: EyeCursorOffset
     maxOffset: 2
     pvsIncrease: 0.2
+  - type: CursorOffsetRequiresWield
   - type: ContainerContainer
     containers:
       gun_magazine: !type:ContainerSlot


### PR DESCRIPTION
## About the PR
Rebalanced some of the stats around the Estoc DMR, including increasing wielded move speed and improving accuracy. The Estoc also now requires wielding to fire.

Further changes to the Estoc discussed mentioned increased shot speed or a toggleable scope function, but those will be made in different PRs, if implemented.

## Why / Balance
The Estoc at the moment slightly underperforms in comparison to other Syndicate weapons; in addition, the Estoc has some stat modifications that put it out of line with the accuracy of rifles overall.

## Technical details
Removed minimum and maximum spread angles; increased move speed by 10%.

## Media


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes

**Changelog**

:cl:

- tweak: Made improvements to the Estoc DMR's wielded move speed, as well as its accuracy.

