### PR TITLE
Make artifact analyzer power supply sane

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
@@ -48,8 +48,7 @@
   - type: Transform
     anchored: true
   - type: ApcPowerReceiver
-    powerLoad: 12000
-    needsPower: false #only turns on when scanning
+    powerLoad: 5000
   - type: ArtifactAnalyzer
   - type: ItemPlacer
     whitelist:


### PR DESCRIPTION
## About the PR
Follow up to #41377 
Makes the artifact analyzer consume 5kW instead of 12kW, which currently makes it the most power hungry electrical device we have.
According to the code comment it is supposed to only draw this amount of power only when scanning, however
- There is no existing code at all that toggles it when scanning, meaning it currently always draws the full 12kW
- The bool has a completely different purpose - it makes the device powered even without an APC power supply, meaning it currently also works without power

## Why / Balance
Prevents from sci power setups to trip breakers if they have 2 analyzers connected to the same APC.
Helps with #41525

## Technical details
yaml changes

## Media
<img width="417" height="244" alt="grafik" src="https://github.com/user-attachments/assets/68a5f252-313c-4ab6-b621-cdb8d52e40f3" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- tweak: Artifact analyzers are no longer extremely power hungry.