### PR TITLE
Allow reading when handcuffed

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Item;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Events;
+using Content.Shared.Paper;
 using Content.Shared.Popups;
 using Content.Shared.Pulling.Events;
 using Content.Shared.Rejuvenate;
@@ -95,7 +96,12 @@ namespace Content.Shared.Cuffs
         private void CheckInteract(Entity<CuffableComponent> ent, ref InteractionAttemptEvent args)
         {
             if (!ent.Comp.CanStillInteract)
-                args.Cancelled = true;
+            {
+                if (!HasComp<PaperComponent>(args.Target))
+                {
+                    args.Cancelled = true;
+                }
+            }
         }
 
         private void OnUncuffAttempt(ref UncuffAttemptEvent args)


### PR DESCRIPTION
## About the PR
Players can now read paper when handcuffed.

### Also allows eating paper when handcuffed.
I think eating your arrest warrant off the table behind HOS's back is hilarious and should be left in the game.
But since it's not clearly conveyed when it's happening, it's up for debate.

## Why / Balance
You should be able to eat/read your warrant and detective's printouts in the interrogation room.

## Technical details
Added an exemption for `PaperComponent` in `SharedCuffableSystem`.

## Media
https://github.com/user-attachments/assets/840a38fa-87b4-46fa-a12a-7318af0218d8

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- add: You can now read when handcuffed