### PR TITLE
Vent Slimes now deal twice as much structural damage, aswell as have auto-attack

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -185,13 +185,13 @@
         Dead:
           Base: green_adult_slime_dead
     - type: MeleeWeapon
+      autoAttack: true
       damage:
         types:
           Blunt: 6
           Structural: 8
           Caustic: 1
           Poison: 4
-
 - type: entity
   name: green slime
   parent: MobAdultSlimesGreen


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I raised vent slime structural damage from 4 to 8, and enabled autoAttack on their attacks, allowing them to destroy airlocks in much more reasonable times, without the hand pain.

## Why / Balance
Slimes often spawn locked in rooms, and _unlike_ the tarantulas do not get as easy a method of escape; the player would have to punch an airlock approximately **126** times to destroy it, spending over two boring minutes just to get through one door in a low investment role, only to face yet another airlock, only to just get instantly flashed & knifed to death 10 seconds later. 

They still struggle to actually break anything else, and can't break anything truly important to my knowledge, but with this PR they can now chip away at an airlock just by holding a button for some time, without giving the player carpal tunnel.

Before this PR: **126** hits, approximately 2+ minutes of clicking
After this PR:  **63** hits, approximately 1~ minute of _holding_ LMB

Just enough time to give everyone nearby plenty of warning & opportunity to stop them without wasting the slimes time first.

## Technical details

## Media
<img width="845" height="501" alt="slimedamage" src="https://github.com/user-attachments/assets/35e24ef9-e20c-4f1e-9d84-30111070b644" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Vent-Slimes now have doubled (8) structural damage.