### PR TITLE
Slimes can now pry open doors, to avoid being trapped all-round

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -36,7 +36,7 @@
     tags:
     - FootstepSound
     - DoorBumpOpener
-  - type: Prying # Open door from xeno.yml.
+  - type: Prying # Open door from xeno.yml. # Replace with vent crawling
     pryPowered: true
     force: true
     speedModifier: 1.5


### PR DESCRIPTION
## About the PR
Vent Slimes can now pry open doors, to avoid being trapped in the room they spawn in, or having to click a door 126+ times to break it & get out.

## Why / Balance
It is not fun to have 50% of the (extremely common) slime roles in a round spawn in a locked room that no one has a reason to go into, and be forced to click a door 126+ times just to get out and be immediately killed; this allows vent-slimes to escape the room they are in & actually do antagonistic activities, beyond maybe breaking 1 door.

This only puts them around tarantula strength, which is to say not a lot, so I doubt any large balance concerns will arise from this change.

This is more-or-less designed as a stop-gap until full vent-crawling is supported, so that one of the few common vent antagonists can actually participate in the round until that addition comes.

## Technical details

## Media
<img width="427" height="359" alt="slimepry" src="https://github.com/user-attachments/assets/b098d2e2-980f-493a-a1cb-4eed9929485e" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- add: Vent-Slimes can now pry open powered doors like tarantulas, no longer will they be trapped in a room all-shift!
