### PR TITLE
Fix gas filters

### DIFF
--- a/Content.Client/Atmos/UI/GasFilterBoundUserInterface.cs
+++ b/Content.Client/Atmos/UI/GasFilterBoundUserInterface.cs
@@ -52,14 +52,18 @@ namespace Content.Client.Atmos.UI
 
         private void OnSelectGasPressed()
         {
-            if (_window is null) return;
+            if (_window is null)
+                return;
+
             if (_window.SelectedGas is null)
             {
                 SendMessage(new GasFilterSelectGasMessage(null));
             }
             else
             {
-                if (!int.TryParse(_window.SelectedGas, out var gas)) return;
+                if (!Enum.TryParse<Gas>(_window.SelectedGas, out var gas))
+                    return;
+
                 SendMessage(new GasFilterSelectGasMessage(gas));
             }
         }

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
@@ -156,18 +156,18 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
 
         private void OnSelectGasMessage(EntityUid uid, GasFilterComponent filter, GasFilterSelectGasMessage args)
         {
-            if (args.ID.HasValue)
+            if (args.Gas.HasValue)
             {
-                if (Enum.TryParse<Gas>(args.ID.ToString(), true, out var parsedGas))
+                if (Enum.IsDefined(typeof(Gas), args.Gas))
                 {
-                    filter.FilteredGas = parsedGas;
+                    filter.FilteredGas = args.Gas;
                     _adminLogger.Add(LogType.AtmosFilterChanged, LogImpact.Medium,
-                        $"{ToPrettyString(args.Actor):player} set the filter on {ToPrettyString(uid):device} to {parsedGas.ToString()}");
+                        $"{ToPrettyString(args.Actor):player} set the filter on {ToPrettyString(uid):device} to {args.Gas.ToString()}");
                     DirtyUI(uid, filter);
                 }
                 else
                 {
-                    Log.Warning($"{ToPrettyString(uid)} received GasFilterSelectGasMessage with an invalid ID: {args.ID}");
+                    Log.Warning($"{ToPrettyString(uid)} received GasFilterSelectGasMessage with an invalid ID: {args.Gas}");
                 }
             }
             else

--- a/Content.Shared/Atmos/Piping/Trinary/Components/SharedGasFilterComponent.cs
+++ b/Content.Shared/Atmos/Piping/Trinary/Components/SharedGasFilterComponent.cs
@@ -1,4 +1,6 @@
-﻿using Robust.Shared.Serialization;
+﻿using Content.Shared.Atmos.Prototypes;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Atmos.Piping.Trinary.Components
 {
@@ -48,13 +50,8 @@ namespace Content.Shared.Atmos.Piping.Trinary.Components
     }
 
     [Serializable, NetSerializable]
-    public sealed class GasFilterSelectGasMessage : BoundUserInterfaceMessage
+    public sealed class GasFilterSelectGasMessage(Gas? gas) : BoundUserInterfaceMessage
     {
-        public int? ID { get; }
-
-        public GasFilterSelectGasMessage(int? id)
-        {
-            ID = id;
-        }
+        public readonly Gas? Gas = gas;
     }
 }


### PR DESCRIPTION
## About the PR
Gas filter selection works again

## Why / Balance
Fixes #41563

## Technical details
This was caused by #41563
The UI was converting the gas prototype name into a raw string, networking that to the server and then parsing it into an entry in the `Gas` enum, which only worked because they happened to have the same name.
Now we network a gas enum entry instead. This is still somewhat cursed in the UI itself, but cleaning that up can be done later.

We really need atmos integration tests.

## Media
![ss14](https://github.com/user-attachments/assets/018c7bb2-832a-428b-b8a2-2e57f38ba2f6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`GasFilterSelectGasMessage` now contains a `Gas` enum rather than a raw string.

**Changelog**
:cl:
- fix: Fixed the gas filter gas selection.