### PR TITLE
[BUGFIX] Wizard's pondering orb works off station

### DIFF
--- a/Content.Server/DeviceNetwork/Components/WiredNetworkComponent.cs
+++ b/Content.Server/DeviceNetwork/Components/WiredNetworkComponent.cs
@@ -4,5 +4,8 @@ namespace Content.Server.DeviceNetwork.Components
     [ComponentProtoName("WiredNetworkConnection")]
     public sealed partial class WiredNetworkComponent : Component
     {
+        [ViewVariables]
+        [DataField]
+        public bool ConnectsOffGrid;
     }
 }

--- a/Content.Server/DeviceNetwork/Systems/WiredNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/WiredNetworkSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.DeviceNetwork.Components;
 using Content.Shared.DeviceNetwork.Events;
 using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.DeviceNetwork.Systems
 {
@@ -18,8 +19,8 @@ namespace Content.Server.DeviceNetwork.Systems
         /// </summary>
         private void OnBeforePacketSent(EntityUid uid, WiredNetworkComponent component, BeforePacketSentEvent args)
         {
-            // If either of the entities transferring packets are the pondering orb, let it send the packets
-            if (MetaData(uid).EntityName == "pondering orb" || (MetaData(args.Sender)).EntityName == "pondering orb")
+            // If either of the entities transferring packets have the ConnectsOffGrid component, let it send the packets
+            if (component.ConnectsOffGrid || Comp<WiredNetworkComponent>(args.Sender).ConnectsOffGrid)
                 return;
 
             // If they're not on the same grid, cancel the packet transfer 

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -725,6 +725,7 @@
     receiveFrequencyId: SurveillanceCamera
     transmitFrequencyId: SurveillanceCamera
   - type: WiredNetworkConnection
+    connectsOffGrid: true
   - type: SurveillanceCameraMonitor
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed the Wizard's pondering orb, so that it may peer into the station.

## Why / Balance
It was broken, and didn't do what the description said it did.
PLUS John Wizard (@keronshb) told me to!

## Technical details
Adds a new DataField, `connectsOffGrid` to `WiredNetworkComponent`, and a check to allow two devices to connect off station in `WiredNetworkSystem`.

## Media

https://github.com/user-attachments/assets/9f9e6bc7-f887-4f58-b1fc-77b0a97c186b


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
NONE!!!

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the Wizard's Pondering Orb, allowing it to see on station cameras from anywhere.
