### PR TITLE
Add KI pills to the radsuit locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -231,7 +231,6 @@
     - id: GeigerCounter
       amount: 2
     - id: PillCanisterPotassiumIodide
-      amount: 1
       prob: 0.75
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added Potassium Iodide pills to the radiation suit locker

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The radiation suit locker is already a bit on the fluffier side as they're mostly mapped in engineering, where engineers in suits are already well equipped for the job.
Adding KI pills gives a reason for even suited engineers to use the locker, as a pill will boost their resilience to radsuit levels. 
KI is also underutilized in the game as it is, and adding more access to it could enable people to interact with high radiation environments more effectively. 

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a KI bottle to the fill table.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Potassium Iodide is now sometimes available in radiation lockers.