### PR TITLE
Fix helmet lights

### DIFF
--- a/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
@@ -108,7 +108,7 @@ namespace Content.Server.Light.EntitySystems
             // Curently every single flashlight has the same number of levels for status and that's all it uses the charge for
             // Thus we'll just check if the level changes.
 
-            if (!_powerCell.TryGetBatteryFromSlot(ent.Owner, out var battery))
+            if (!_powerCell.TryGetBatteryFromSlotOrEntity(ent.Owner, out var battery))
                 return null;
 
             var currentCharge = _battery.GetCharge(battery.Value.AsNullable());
@@ -203,7 +203,7 @@ namespace Content.Server.Light.EntitySystems
                 return false;
             }
 
-            if (!_powerCell.TryGetBatteryFromSlot(uid.Owner, out var battery))
+            if (!_powerCell.TryGetBatteryFromSlotOrEntity(uid.Owner, out var battery))
             {
                 _audio.PlayPvs(_audio.ResolveSound(component.TurnOnFailSound), uid);
                 _popup.PopupEntity(Loc.GetString("handheld-light-component-cell-missing-message"), uid, user);
@@ -230,7 +230,7 @@ namespace Content.Server.Light.EntitySystems
         public void TryUpdate(Entity<HandheldLightComponent> uid, float frameTime)
         {
             var component = uid.Comp;
-            if (!_powerCell.TryGetBatteryFromSlot(uid.Owner, out var battery))
+            if (!_powerCell.TryGetBatteryFromSlotOrEntity(uid.Owner, out var battery))
             {
                 TurnOff(uid, false);
                 return;

--- a/Content.Shared/Power/EntitySystems/ChargerSystem.cs
+++ b/Content.Shared/Power/EntitySystems/ChargerSystem.cs
@@ -68,7 +68,7 @@ public sealed class ChargerSystem : EntitySystem
                 // add how much each item is charged it
                 foreach (var contained in container.ContainedEntities)
                 {
-                    if (!SearchForBattery(contained, out var battery))
+                    if (!_powerCell.TryGetBatteryFromEntityOrSlot(contained, out var battery))
                         continue;
 
                     var chargePercentage = _battery.GetCharge(battery.Value.AsNullable()) / battery.Value.Comp.MaxCharge * 100;
@@ -93,7 +93,7 @@ public sealed class ChargerSystem : EntitySystem
             return;
 
         AddComp<InsideChargerComponent>(args.Entity);
-        if (SearchForBattery(args.Entity, out var battery))
+        if (_powerCell.TryGetBatteryFromEntityOrSlot(args.Entity, out var battery))
             _battery.RefreshChargeRate(battery.Value.AsNullable());
         UpdateStatus(ent);
     }
@@ -107,7 +107,7 @@ public sealed class ChargerSystem : EntitySystem
             return;
 
         RemComp<InsideChargerComponent>(args.Entity);
-        if (SearchForBattery(args.Entity, out var battery))
+        if (_powerCell.TryGetBatteryFromEntityOrSlot(args.Entity, out var battery))
             _battery.RefreshChargeRate(battery.Value.AsNullable());
         UpdateStatus(ent);
     }
@@ -187,22 +187,6 @@ public sealed class ChargerSystem : EntitySystem
         UpdateStatus((chargerUid, chargerComp));
     }
 
-    private bool SearchForBattery(EntityUid uid, [NotNullWhen(true)] out Entity<PredictedBatteryComponent>? battery)
-    {
-        // try get a battery directly on the inserted entity
-        if (TryComp<PredictedBatteryComponent>(uid, out var batteryComp))
-        {
-            battery = (uid, batteryComp);
-            return true;
-        }
-        // or by checking for a power cell slot on the inserted entity
-        if (_powerCell.TryGetBatteryFromSlot(uid, out battery))
-            return true;
-
-        battery = null;
-        return false;
-    }
-
     private void RefreshAllBatteries(Entity<ChargerComponent> ent)
     {
         // try to get contents of the charger
@@ -211,7 +195,7 @@ public sealed class ChargerSystem : EntitySystem
 
         foreach (var item in container.ContainedEntities)
         {
-            if (SearchForBattery(item, out var battery))
+            if (_powerCell.TryGetBatteryFromEntityOrSlot(item, out var battery))
                 _battery.RefreshChargeRate(battery.Value.AsNullable());
         }
     }
@@ -259,7 +243,7 @@ public sealed class ChargerSystem : EntitySystem
             return CellChargerStatus.Empty;
 
         // Use the first stored battery for visuals. If someone ever makes a multi-slot charger then this will need to be changed.
-        if (!SearchForBattery(container.ContainedEntities[0], out var battery))
+        if (!_powerCell.TryGetBatteryFromEntityOrSlot(container.ContainedEntities[0], out var battery))
             return CellChargerStatus.Off;
 
         if (_battery.IsFull(battery.Value.AsNullable()))

--- a/Content.Shared/PowerCell/PowerCellSystem.API.cs
+++ b/Content.Shared/PowerCell/PowerCellSystem.API.cs
@@ -39,6 +39,45 @@ public sealed partial class PowerCellSystem
     }
 
     /// <summary>
+    /// First tries to get a battery from the entity's power cell slot.
+    /// If that fails check if the entity itself is a battery with <see cref="PredictedBatteryComponent"/>.
+    /// </summary>
+    [PublicAPI]
+    public bool TryGetBatteryFromSlotOrEntity(Entity<PowerCellSlotComponent?> ent, [NotNullWhen(true)] out Entity<PredictedBatteryComponent>? battery)
+    {
+        if (TryGetBatteryFromSlot(ent, out battery))
+            return true;
+
+        if (TryComp<PredictedBatteryComponent>(ent, out var batteryComp))
+        {
+            battery = (ent.Owner, batteryComp);
+            return true;
+        }
+
+        battery = null;
+        return false;
+    }
+
+    /// <summary>
+    /// First checks if the entity itself is a battery with <see cref="PredictedBatteryComponent"/>.
+    /// If that fails it will try to get a battery from the entity's power cell slot instead.
+    /// </summary>
+    [PublicAPI]
+    public bool TryGetBatteryFromEntityOrSlot(Entity<PowerCellSlotComponent?> ent, [NotNullWhen(true)] out Entity<PredictedBatteryComponent>? battery)
+    {
+        if (TryComp<PredictedBatteryComponent>(ent, out var batteryComp))
+        {
+            battery = (ent.Owner, batteryComp);
+            return true;
+        }
+        if (TryGetBatteryFromSlot(ent, out battery))
+            return true;
+
+        battery = null;
+        return false;
+    }
+
+    /// <summary>
     /// Returns whether the entity has a slotted battery and charge for the requested action.
     /// </summary>
     /// <param name="ent">The power cell.</param>


### PR DESCRIPTION
## About the PR
Fixes #41593

## Why / Balance
bugfix

## Technical details
Small oversight made in the power cell prediction PR. I accidentally removed the check for the battery component on the flashlight itself.
<img width="1460" height="63" alt="grafik" src="https://github.com/user-attachments/assets/082121a9-07ab-49a4-ac4a-f802e76df386" />

Added two new API methods for getting a battery from a cell slot or the entity itself if it is a battery.

## Media
![ss14](https://github.com/user-attachments/assets/04961fd6-1afb-49dc-84eb-7ea07916de6c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed helmet lights.
