### PR TITLE
predict name identifiers

### DIFF
--- a/Content.Client/NameIdentifier/NameIdentifierSystem.cs
+++ b/Content.Client/NameIdentifier/NameIdentifierSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared.NameIdentifier;
+
+namespace Content.Client.NameIdentifier;
+
+public sealed class NameIdentifierSystem : SharedNameIdentifierSystem;

--- a/Content.Server/NameIdentifier/NameIdentifierSystem.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierSystem.cs
@@ -7,10 +7,7 @@ using Robust.Shared.Random;
 
 namespace Content.Server.NameIdentifier;
 
-/// <summary>
-///     Handles unique name identifiers for entities e.g. `monkey (MK-912)`
-/// </summary>
-public sealed class NameIdentifierSystem : EntitySystem
+public sealed class NameIdentifierSystem : SharedNameIdentifierSystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
@@ -28,7 +25,6 @@ public sealed class NameIdentifierSystem : EntitySystem
 
         SubscribeLocalEvent<NameIdentifierComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<NameIdentifierComponent, ComponentShutdown>(OnComponentShutdown);
-        SubscribeLocalEvent<NameIdentifierComponent, RefreshNameModifiersEvent>(OnRefreshNameModifiers);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(CleanupIds);
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnReloadPrototypes);
 
@@ -120,24 +116,6 @@ public sealed class NameIdentifierSystem : EntitySystem
 
         Dirty(ent);
         _nameModifier.RefreshNameModifiers(ent.Owner);
-    }
-
-    private void OnRefreshNameModifiers(Entity<NameIdentifierComponent> ent, ref RefreshNameModifiersEvent args)
-    {
-        if (ent.Comp.Group is null)
-            return;
-
-        // Don't apply the modifier if the component is being removed
-        if (ent.Comp.LifeStage > ComponentLifeStage.Running)
-            return;
-
-        if (!_prototypeManager.Resolve(ent.Comp.Group, out var group))
-            return;
-
-        var format = group.FullName ? "name-identifier-format-full" : "name-identifier-format-append";
-        // We apply the modifier with a low priority to keep it near the base name
-        // "Beep (Si-4562) the zombie" instead of "Beep the zombie (Si-4562)"
-        args.AddModifier(format, -10, ("identifier", ent.Comp.FullIdentifier));
     }
 
     private void InitialSetupPrototypes()

--- a/Content.Shared/NameIdentifier/SharedNameIdentifierSystem.cs
+++ b/Content.Shared/NameIdentifier/SharedNameIdentifierSystem.cs
@@ -1,0 +1,37 @@
+using Content.Shared.NameModifier.EntitySystems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.NameIdentifier;
+
+/// <summary>
+///     Handles unique name identifiers for entities e.g. `monkey (MK-912)`
+/// </summary>
+public abstract class SharedNameIdentifierSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<NameIdentifierComponent, RefreshNameModifiersEvent>(OnRefreshNameModifiers);
+    }
+
+    private void OnRefreshNameModifiers(Entity<NameIdentifierComponent> ent, ref RefreshNameModifiersEvent args)
+    {
+        if (ent.Comp.Group is null)
+            return;
+
+        // Don't apply the modifier if the component is being removed
+        if (ent.Comp.LifeStage > ComponentLifeStage.Running)
+            return;
+
+        if (!_prototypeManager.Resolve(ent.Comp.Group, out var group))
+            return;
+
+        var format = group.FullName ? "name-identifier-format-full" : "name-identifier-format-append";
+        // We apply the modifier with a low priority to keep it near the base name
+        // "Beep (Si-4562) the zombie" instead of "Beep the zombie (Si-4562)"
+        args.AddModifier(format, -10, ("identifier", ent.Comp.FullIdentifier));
+    }
+}


### PR DESCRIPTION
## About the PR
I noticed this wasn't predicted yet when working on the borg prediction PR.
This is only really noticeable after that PR is merged and you rename a borg using the borg UI.

## Why / Balance
prediction good

## Technical details
Just moves a single subscription to shared. The datafields are already networked and dirtied.

## Media
still works
<img width="297" height="112" alt="grafik" src="https://github.com/user-attachments/assets/b7cb757d-322c-4aa6-81ca-8b0020dd12d4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
no one will notice
