### PR TITLE
prioritize borg UI over stripping UI

### DIFF
--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CombatMode;
 using Content.Shared.Cuffs;
-using Content.Shared.Cuffs.Components;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
@@ -16,6 +15,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Popups;
 using Content.Shared.Strip.Components;
+using Content.Shared.UserInterface;
 using Content.Shared.Verbs;
 using Robust.Shared.Utility;
 
@@ -53,7 +53,9 @@ public abstract class SharedStrippableSystem : EntitySystem
         SubscribeLocalEvent<StrippingComponent, CanDropTargetEvent>(OnCanDropOn);
         SubscribeLocalEvent<StrippableComponent, CanDropDraggedEvent>(OnCanDrop);
         SubscribeLocalEvent<StrippableComponent, DragDropDraggedEvent>(OnDragDrop);
-        SubscribeLocalEvent<StrippableComponent, ActivateInWorldEvent>(OnActivateInWorld);
+        // Prioritize other UIs unless they are verb only.
+        // The stripping UI can always be opened via drag drop.
+        SubscribeLocalEvent<StrippableComponent, ActivateInWorldEvent>(OnActivateInWorld, after: new[] { typeof(ActivatableUISystem) });
     }
 
     private void AddStripVerb(EntityUid uid, StrippableComponent component, GetVerbsEvent<Verb> args)


### PR DESCRIPTION
## About the PR
Prioritizes the borg UI over the stripping UI when pressing E on a borg.
If the borg is locked or has a closed wire panel and the borg UI cannot be opened then it will open the stripping UI instead.
The stripping UI is always available via drag drop.

## Why / Balance
It's annoying that you always have to use the verb menu.
This is a QOL improvement for roboticists and the xenoborg mothership.

## Technical details
Both `StrippableSystem` and `ActivatableUISystem` subscribe to `ActivateInWorldEvent`, but the order in which these subscriptions are handled is pretty much random. So we enforce the order to prioritize the latter.

At the moment trying to open the UI for a locked borg will also play a denied sound and show a popup, same for when looking at the UI verb, but that is an existing problem and is the fault of `LockSystem` doing stuff in an attempt event that it should not do. I'll fix that in a separate PR.

## Media
![ss14](https://github.com/user-attachments/assets/57317910-9877-4f9d-936d-1dbae5cd1bdc)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- tweak: Pressing E on unlocked borgs with an open wire panel will now open the borg UI instead of the stripping UI.
