### PR TITLE
Properly document AtmosDeviceEnabled(Disabled)Event

### DIFF
--- a/Content.Shared/Atmos/Piping/Components/AtmosDeviceDisabledEvent.cs
+++ b/Content.Shared/Atmos/Piping/Components/AtmosDeviceDisabledEvent.cs
@@ -1,7 +1,12 @@
 namespace Content.Shared.Atmos.Piping.Components;
 
 /// <summary>
-///     Raised directed on an atmos device when it is enabled.
+/// <para>Raised directed on an AtmosDeviceComponent when it has been removed from
+/// the GridAtmosphereComponent it was attached to.
+/// This can occur when it has been requested manually or when the device has been unanchored.</para>
+///
+/// <para>Any information that you were tracking about the grid should
+/// probably be cleared out here.</para>
 /// </summary>
 [ByRefEvent]
 public readonly record struct AtmosDeviceDisabledEvent;

--- a/Content.Shared/Atmos/Piping/Components/AtmosDeviceEnabledEvent.cs
+++ b/Content.Shared/Atmos/Piping/Components/AtmosDeviceEnabledEvent.cs
@@ -1,7 +1,13 @@
 namespace Content.Shared.Atmos.Piping.Components;
 
 /// <summary>
-///     Raised directed on an atmos device when it is enabled.
+/// <para>Raised directed on an AtmosDeviceComponent when it has been added to
+/// a GridAtmosphereComponent.
+/// This can occur when it has been requested manually or when the device has been anchored.</para>
+///
+/// <para>You can use this to cache specific information about the grid the device is on,
+/// though be careful with caching references to objects that can be removed or changed at any time
+/// (such as <see cref="GasMixture"/>s).</para>
 /// </summary>
 [ByRefEvent]
 public readonly record struct AtmosDeviceEnabledEvent;


### PR DESCRIPTION
## About the PR
Documents `AtmosDeviceEnabledEvent` and `AtmosDeviceDisabledEvent`.

## Why / Balance
The events in question were previously documented pretty badly and IMO lead to a lot of confusion when I was first trying to understand device code.

The documentation also outlines things you can do using the events and things you should look out for (as we've had some issues with people doing certain things).

## Technical details
n/a

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
didnt want to

**Changelog**
n/a
