### PR TITLE
[Aseprite Tool] Add Copy Displaced To New Canvas Button

### DIFF
--- a/Tools/SS14 Aseprite Plugins/Displacement Map Visualizer.lua
+++ b/Tools/SS14 Aseprite Plugins/Displacement Map Visualizer.lua
@@ -266,4 +266,42 @@ dialog:color{
     end
 }
 
+dialog:button{
+    id = "save-displaced",
+    text = "Copy Displaced Sprite To New Canvas",
+    onclick = function(ev)
+        local layerDisplacement = findLayer(sprite, dialog.data["displacement-select"])
+        local layerTarget = findLayer(sprite, dialog.data["reference-select"])
+        if not layerDisplacement or not layerTarget then
+            app.alert("Select both displacement and reference layers!")
+            return
+        end
+
+        local celDisplacement = layerDisplacement:cel(1)
+        local celTarget = layerTarget:cel(1)
+        if not celDisplacement or not celTarget then
+            app.alert("Selected layers must have a cel in the first frame!")
+            return
+        end
+
+        local displacedImage = applyDisplacementMap(
+            sprite.width, sprite.height,
+            celDisplacement,
+            celTarget
+        )
+
+        local newSprite = Sprite(sprite.width, sprite.height, sprite.colorMode)
+        if sprite.colorMode == ColorMode.INDEXED then
+            for i=0,sprite.palettes[1].size-1 do
+                newSprite.palettes[1]:setColor(i, sprite.palettes[1]:getColor(i))
+            end
+        end
+
+        local newLayer = newSprite.layers[1]
+        local newCel = newLayer:cel(1)
+        newCel.image:drawImage(displacedImage, 0, 0)
+        app.activeSprite = newSprite
+    end
+}
+
 dialog:show{wait = false}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a button to the Asesprite `Displacement Map Visualizer.lua` script to copy the displaced sprite to a new canvas, this can be helpful when creating custom sprites for certain things.

## Why / Balance
I made this a while ago and improved it for Funky so they had an easier time creating custom hardsuit sprites for Vox, figured it was good to toss here.

## Technical details
Adds a new dialog button `save-displaced` to `Displacement Map Visualizer.lua` which copies the displaced sprite in the visualizer to a new canvas window.

## Media
(Name on the button is different, it's "Copy Displaced Sprite To New Canvas" currently)
![boom](https://github.com/user-attachments/assets/2c9e48b5-14fd-47f9-b4e3-1ce4145f6bb8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
no cl no fun
