### PR TITLE
Add StatusIcon component to MobBaseAncestor

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1441,6 +1441,7 @@
       effects:
       - !type:WashCreamPie
   - type: Crawler
+  - type: StatusIcon
 
 
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the StatusIcon component to MobBaseAncestor, which will show the ID on HUDs for anything based off of it.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Pun Pun, as well as other monkies, kobolds, and scurrets, can wear an ID, be hired on to jobs, but before this silicons would not consider them crew due to rules as written. Also based on an admin vote where they *should* be considered crew.
## Technical details
<!-- Summary of code changes for easier review. -->
One line of yaml.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="824" height="692" alt="image" src="https://github.com/user-attachments/assets/21aea711-7f63-4752-9ea7-426a918601e3" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Minemoder
- fix: Monkies, Kobolds, and Scurrets will now show their ID on HUDs.
