### PR TITLE
Fix secret door and turnstile recipe skipping a material requirement

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/secretdoor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/secretdoor.yml
@@ -11,10 +11,9 @@
       steps:
       - material: Steel
         amount: 4
-        doAfter: 4
       - material: MetalRod
         amount: 4
-        doAfter: 4
+        doAfter: 6
 
   - node: assembly
     entity: BaseSecretDoorAssembly

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/turnstile.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/turnstile.yml
@@ -12,10 +12,9 @@
       steps:
       - material: MetalRod
         amount: 4
-        doAfter: 6
       - material: Steel
         amount: 1
-        doAfter: 2
+        doAfter: 6
 
   - node: turnstile
     entity: Turnstile


### PR DESCRIPTION
## Why / Balance
For secret doors and turnstiles, the construction guide currently shows two materials being necessary for the first step, but there's a bug where the second of these materials is skipped and not used in the construction process.

## Technical details
Small YAML change: These recipes have two requirements for the edge out of `start` that both have `doAfter` set. I just removed `doAfter` for the first step. This is also what the shuttle window and mushroom soil recipe do.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
