### PR TITLE
Make Firespread logical

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -230,7 +230,7 @@ namespace Content.Server.Atmos.EntitySystems
             // An entity with a higher mass will lose some fire and transfer it to the one with lower mass.
             var avg = (flammable.FireStacks * mass1  + otherFlammable.FireStacks * mass2) / 2f;
 
-            // bring each entity to the same firestack mass, firestacks being scaled by the other's mass
+            // bring each entity to the same firestack mass, firestack amount is scaled by the inverse of the entity's mass
             SetFireStacks(uid, avg / mass1, flammable, ignite: true);
             SetFireStacks(otherUid, avg / mass2, otherFlammable, ignite: true);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Fire beforehand would basically extinguish one entity and transfer all stacks to the other. 
The equation didn't make much sense either, it's supposed to weigh by mass but it doesn't really do that properly. 
This PR fixes that by changing the equation.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Seems logical that it should split your firestacks than transfer them all. 

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the equation to average both entity's firestacks modified by mass, then set each entity's firestacks to the average divided by their mass. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/fc973792-368f-40e5-84c3-afd00eca0391

For reference, Real Mouse has less than 1/3rd the weight of a player.

https://github.com/user-attachments/assets/1124f2c6-821e-4317-9dd0-fcfcabc3c236

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Contacting another entity while on fire will transfer less firestacks. 
