### PR TITLE
fix rcd overlay getting stuck for borg modules

### DIFF
--- a/Content.Client/RCD/RCDConstructionGhostSystem.cs
+++ b/Content.Client/RCD/RCDConstructionGhostSystem.cs
@@ -20,7 +20,7 @@ public sealed class RCDConstructionGhostSystem : EntitySystem
     [Dependency] private readonly IPlacementManager _placementManager = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
     [Dependency] private readonly HandsSystem _hands = default!;
-    
+
     private Direction _placementDirection = default;
 
     public override void Update(float frameTime)
@@ -41,6 +41,11 @@ public sealed class RCDConstructionGhostSystem : EntitySystem
             return;
 
         var heldEntity = _hands.GetActiveItem(player);
+
+        // Don't open the placement overlay for client-side RCDs.
+        // This may happen when predictively spawning one in your hands.
+        if (heldEntity != null && IsClientSide(heldEntity.Value))
+            return;
 
         if (!TryComp<RCDComponent>(heldEntity, out var rcd))
         {
@@ -69,7 +74,7 @@ public sealed class RCDConstructionGhostSystem : EntitySystem
             MobUid = heldEntity.Value,
             PlacementOption = PlacementMode,
             EntityType = prototype.Prototype,
-            Range = (int) Math.Ceiling(SharedInteractionSystem.InteractionRange),
+            Range = (int)Math.Ceiling(SharedInteractionSystem.InteractionRange),
             IsTile = (prototype.Mode == RcdMode.ConstructTile),
             UseEditorContext = false,
         };


### PR DESCRIPTION
## About the PR
Title

Reproduction:
- spawn a `cyborg [Battery]`
- take control of it
- switch the borg type to engi borg
- select the RCD module
- select a different module
- the ghost preview will be stuck

## Why / Balance
bugfix

## Technical details
Now that we have borg prediction the items borg modules give you will predictively spawn in your hands.
Predictive spawning will spawn a client-side entity and delete that once the server state comes in.
The update loop that is checking if the player is holding an RCD each tick opened the placement preview for the RCD when it was spawned on the client, but did not close it when it is deleted and replaced by the server entity. We prevent this by adding an `IsClientSide` guard since the placement manager would not allow you to use an client-side entity for construction anyways.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed the RCD placement ghost getting stuck for engi borgs.
