### PR TITLE
Typo fix

### DIFF
--- a/Content.Shared/Roles/SharedRoleSystem.cs
+++ b/Content.Shared/Roles/SharedRoleSystem.cs
@@ -684,7 +684,7 @@ public abstract class SharedRoleSystem : EntitySystem
     /// <inheritdoc cref="GetRoleRequirements(JobPrototype)"/>
     public HashSet<JobRequirement>? GetRoleRequirements(AntagPrototype antag)
     {
-        if (_requirementOverride != null && _requirementOverride.Jobs.TryGetValue(antag.ID, out var req))
+        if (_requirementOverride != null && _requirementOverride.Antags.TryGetValue(antag.ID, out var req))
             return req;
 
         return antag.Requirements;


### PR DESCRIPTION
## About the PR
Fixed antag role requirements checking for job requirements instead.

## Why / Balance
Seems like an unintended copypaste mistake that wasn't caught because Prototype-Ids are not strongly typed

## Technical details
Change one reference of JobRequirementOverridePrototype.Jobs to .Antags where it is indexed by (effectively) a `ProtoId<AntagPrototype>`
Stumbled on this while toying with replacing IPrototype.ID with ProtoId

## Media
Setup:
```yaml
- type: jobRequirementOverride
  id: Test2
  jobs:
    Captain:
    - !type:DepartmentTimeRequirement
      department: Engineering
      time: 7m
  antags:
    Thief:
    - !type:DepartmentTimeRequirement
      department: Engineering
      time: 2m
```
With `cvar game.role_timer_override Test2` ran on the server, and client restarted to ensure the requirements are up-to-date.

Before:
(Tooltip is on Thief, just to be clear :⁾ )
<img width="1216" height="679" alt="image" src="https://github.com/user-attachments/assets/714d36ed-a91d-4100-973a-a8b875e256d7" />

After:
<img width="1727" height="671" alt="image" src="https://github.com/user-attachments/assets/57b22ca1-6d85-4ad9-b43a-0c2884d5886c" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
Unneeded I believe