### PR TITLE
Engineering roles are now selected before non-Command/non-Security roles

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -86,6 +86,7 @@
   - ChiefEngineer
   - StationEngineer
   - TechnicalAssistant
+  weight: 5
 
 - type: department
   id: Medical


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The Engineering department now has a weight of 5, which means that it will be selected before Cargo, Medical, Science, Service, and Silicon roles.

Command and Security (and the station-specific jobs) have higher weight so they'll still roll beforehand. Also, this doesn't affect antag rolling at all.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Engineering's main responsibility is to ensure that the station remains habitable. This results in obvious problems if the department is absent (mostly during lowpop rounds); typically, the Captain (or some other member of Command) will need to scramble to set up power and atmospherics before the station goes dark. Outside of advanced TEG setups, all power sources on the station also require a degree of upkeep (AME needs to be refueled, singulo needs its plasma tanks refilled, tesla needs its grounding rods repaired, TEG needs various gases to be monitored), which is also difficult with no engineers. Having engineers rolled before other departments helps ensure that at least one engineer is present to maintain power.

One potential downside to this change is that players who have, e.g, Station Engineer set to Low and other roles set to Medium/High will all be funneled into Station Engineer (if they don't get a Command or Security role). In extreme cases this might result in stations with too many engineers and not enough people in other departments. A better alternative to this PR might be to have the _first_ engineer slot have a high weight value, and once that first engineer is found, all other engineering slots have the same weight value as standard crew. But that's the kind of advanced change that would require C# code (and I don't know C#).

## Technical details
<!-- Summary of code changes for easier review. -->
One-line change to Resources/Prototypes/Roles/Jobs/departments.yml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Engineering roles are now selected before most non-Command/non-Security roles, to help ensure that at least one person is present to manage the station's power.
