### PR TITLE
Salvage Specialists now spawn with extended-capacity survival boxes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -44,7 +44,7 @@
 
 - type: entity
   parent: BoxCardboard
-  id: BoxSurvivalEngineering
+  id: BoxSurvivalEngineering # This is no longer exclusively used by engineering so this prototype should probably be renamed at some point
   name: extended-capacity survival box
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
   suffix: Extended
@@ -66,7 +66,7 @@
 
 - type: entity
   parent: BoxSurvivalEngineering
-  id: BoxSurvivalEngineeringNitrogen
+  id: BoxSurvivalEngineeringNitrogen # This is no longer exclusively used by engineering so this prototype should probably be renamed at some point
   suffix: Extended N2
   components:
   - type: EntityTableContainerFill

--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -178,7 +178,7 @@
       name: job-name-salvagespec
     - type: Loadout
       prototypes: [ VisitorSalvageSpecialist, VisitorSalvageSpecialistAlt ]
-      roleLoadout: [ RoleSurvivalStandard ]
+      roleLoadout: [ RoleSurvivalExtended ]
 
 # Engineering
 

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -255,7 +255,7 @@
   - SalvageSpecialistOuterClothing
   - SalvageSpecialistShoes
   - Glasses
-  - Survival
+  - SurvivalExtended
   - Trinkets
   - SalvageSpecialistJobTrinkets
   - GroupSpeciesBreathTool


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Salvage Specialists now spawn with extended-capacity survival boxes, rather than standard survival boxes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mostly the idea just came to me because the extended survival box's prototype name is BoxSurvivalEngineering even though it's also used by the ERT team and doesn't have anything specifically engineer-y to it (compared to the security/medical survival boxes, which have unique masks). I figure that salvage is _the_ role on the station that spends the most time in vacuum (moreso than even engineering) so they have a similar need for a slightly better emergency tank. Practically speaking this provides salvage more time to get back to the station if they run out of air during an excursion.

## Technical details
<!-- Summary of code changes for easier review. -->
- Resources/Prototypes/Loadouts/role_loadouts.yml: JobSalvageSpecialist now uses SurvivalExtended instead of Survival
- Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml: VisitorSalvageSpecialist now uses RoleSurvivalExtended instead of RoleSurvivalStandard

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A (small change)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Salvage Specialists now spawn with extended-capacity survival boxes instead of the standard variety.
