### PR TITLE
Fix Mothership cannot use their tools and BorgSystem cleanup.

### DIFF
--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.API.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.API.cs
@@ -24,7 +24,7 @@ public abstract partial class SharedBorgSystem
         if (!_mind.TryGetMind(chassis.Owner, out _, out _))
             return false;
 
-        if (!_mobState.IsAlive(chassis.Owner))
+        if (_mobState.IsIncapacitated(chassis.Owner))
             return false;
 
         return true;
@@ -39,13 +39,12 @@ public abstract partial class SharedBorgSystem
         if (chassis.Comp.Active)
             return false; // Already active.
 
-        if (CanActivate(chassis))
-        {
-            SetActive(chassis, true, user);
-            return true;
-        }
+        if (!CanActivate(chassis))
+            return false;
 
-        return false;
+        SetActive(chassis, true, user);
+        return true;
+
     }
 
     /// <summary>

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -197,8 +197,8 @@ public abstract partial class SharedBorgSystem : EntitySystem
         // Unpredicted because the event is raised on the server.
         _popup.PopupEntity(Loc.GetString("borg-mind-added", ("name", Identity.Name(chassis.Owner, EntityManager))), chassis.Owner);
 
-        if (CanActivate(chassis))
-            SetActive(chassis, true);
+        TryActivate(chassis);
+
         _appearance.SetData(chassis.Owner, BorgVisuals.HasPlayer, true);
     }
 
@@ -285,14 +285,9 @@ public abstract partial class SharedBorgSystem : EntitySystem
     private void OnMobStateChanged(Entity<BorgChassisComponent> chassis, ref MobStateChangedEvent args)
     {
         if (args.NewMobState == MobState.Alive)
-        {
-            if (CanActivate(chassis))
-                SetActive(chassis, true, user: args.Origin);
-        }
+            TryActivate(chassis, args.Origin);
         else
-        {
             SetActive(chassis, false, user: args.Origin);
-        }
     }
 
     private void OnBeingGibbed(Entity<BorgChassisComponent> chassis, ref BeingGibbedEvent args)
@@ -357,8 +352,7 @@ public abstract partial class SharedBorgSystem : EntitySystem
     // Raised when a power cell is inserted.
     private void OnPowerCellChanged(Entity<BorgChassisComponent> chassis, ref PowerCellChangedEvent args)
     {
-        if (CanActivate(chassis))
-            SetActive(chassis, true);
+        TryActivate(chassis);
     }
 
     public override void Update(float frameTime)
@@ -374,8 +368,7 @@ public abstract partial class SharedBorgSystem : EntitySystem
             Dirty(uid, borgChassis);
 
             // If we aren't drawing and suddenly get enough power to draw again, reenable.
-            if (CanActivate((uid, borgChassis)))
-                SetActive((uid, borgChassis), true);
+            TryActivate((uid, borgChassis));
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed Mothership being unable to use their tools, caused by predicted borgs PR
Used TryActivate in several places where it should've been used

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix good. Code cleanup good.

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced 
```
(!_mobState.IsAlive())
```
With
```
(_mobState.IsIncapacitated())
```
This is because both of these return false if there is no MobState, this means that if an borg has no MobState, despite being unable to die, it is treated as dead. 

Exchanged a couple instances of
```
if (CanActivate())
     Activate()
```
with
```
TryActivate()
```
Code cleanup

+ Some minor cleanup while I was poking around debugging.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
