### PR TITLE
Snowball: fix airlocks and windoors in the HoP office

### DIFF
--- a/Resources/Maps/snowball.yml
+++ b/Resources/Maps/snowball.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 268.0.0
   forkId: ""
   forkVersion: ""
-  time: 12/02/2025 06:57:32
+  time: 12/02/2025 14:38:52
   entityCount: 18174
 maps:
 - 1793
@@ -9156,16 +9156,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 28.5,57.5
       parent: 1
-- proto: AirlockEVALocked
-  entities:
-  - uid: 15167
-    components:
-    - type: MetaData
-      name: head of personnel office airlock
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 33.5,59.5
-      parent: 1
 - proto: AirlockExternalAtmosphericsLocked
   entities:
   - uid: 2614
@@ -9850,6 +9840,15 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 25.5,71.5
       parent: 1
+- proto: AirlockHeadOfPersonnelLocked
+  entities:
+  - uid: 13119
+    components:
+    - type: MetaData
+      name: head of personnel office airlock
+    - type: Transform
+      pos: 33.5,59.5
+      parent: 1
 - proto: AirlockHeadOfSecurityGlassLocked
   entities:
   - uid: 176
@@ -10095,6 +10094,8 @@ entities:
     - type: Transform
       pos: 37.5,61.5
       parent: 1
+    - type: AccessReader
+      accessListsOriginal: []
 - proto: AirlockMaintHydroLocked
   entities:
   - uid: 12416
@@ -116713,12 +116714,21 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 53.5,17.5
       parent: 1
-  - uid: 13119
+  - uid: 15167
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,64.5
       parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        13152:
+        - - DoorStatus
+          - Close
+    - type: AccessReader
+      accessListsOriginal: []
   - uid: 17024
     components:
     - type: Transform
@@ -116849,6 +116859,15 @@ entities:
     - type: Transform
       pos: 35.5,64.5
       parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        15167:
+        - - DoorStatus
+          - Close
+    - type: AccessReader
+      accessListsOriginal: []
 - proto: WindoorSecureMedicalLocked
   entities:
   - uid: 4040


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes two problems with the Head of Personnel office on Snowball:
- The airlock between EVA Storage and the Head of Personnel office was a regular EVA Storage airlock, allowing anyone with Externals access to just walk straight into the office.
- The secure windoors at the front of the Head of Personnel office weren't linked via multitool like on other maps, so they could both be opened at the same time.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Prevents random engineers and salvagers and whatnot from just walking straight into the HoP's office
- Prevents random crew from jumping the front desk to break into the HoP's office
- Consistency with other maps
- Resolves #41674

## Technical details
<!-- Summary of code changes for easier review. -->
Mapping changes

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A (small fix without visual changes)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
MAPS:
- fix: On Snowball, the airlock connecting EVA Storage and the Head of Personnel's office now uses Head of Personnel access rather than Externals access.
- fix: On Snowball, the Head of Personnel's office windoors are now linked to each other, like on other maps.