### PR TITLE
Fix CharacterName/EntityName mismatch for clowns and mimes (#39535)

### DIFF
--- a/Content.IntegrationTests/Tests/Internals/AutoInternalsTests.cs
+++ b/Content.IntegrationTests/Tests/Internals/AutoInternalsTests.cs
@@ -24,7 +24,7 @@ public sealed class AutoInternalsTests
         await server.WaitAssertion(() =>
         {
             var profile = new HumanoidCharacterProfile();
-            var dummy = stationSpawning.SpawnPlayerMob(testMap.GridCoords, "TestInternalsDummy", profile, station: null);
+            var dummy = stationSpawning.SpawnPlayerMob(testMap.GridCoords, profile.Name, "TestInternalsDummy", profile, station: null);
 
             Assert.That(atmos.HasAtmosphere(testMap.Grid), Is.False, "Test map has atmosphere - test needs adjustment!");
             Assert.That(internals.AreInternalsWorking(dummy), "Internals did not automatically connect!");

--- a/Content.IntegrationTests/Tests/Preferences/LoadoutTests.cs
+++ b/Content.IntegrationTests/Tests/Preferences/LoadoutTests.cs
@@ -67,7 +67,7 @@ public sealed class LoadoutTests
 
             profile.SetLoadout(new RoleLoadout("LoadoutTester"));
 
-            var tester = stationSystem.SpawnPlayerMob(testMap.GridCoords, job: "LoadoutTester", profile, station: null);
+            var tester = stationSystem.SpawnPlayerMob(testMap.GridCoords, profile.Name, job: "LoadoutTester", profile, station: null);
 
             var slotQuery = inventorySystem.GetSlotEnumerator(tester);
             var checkedCount = 0;

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -145,7 +145,7 @@ namespace Content.Server.Administration.Systems
                             var stationUid = _stations.GetOwningStation(args.Target);
 
                             var profile = _gameTicker.GetPlayerProfile(targetActor.PlayerSession);
-                            var mobUid = _spawning.SpawnPlayerMob(coords.Value, null, profile, stationUid);
+                            var mobUid = _spawning.SpawnPlayerMob(coords.Value, profile.Name, null, profile, stationUid);
 
                             if (_mindSystem.TryGetMind(args.Target, out var mindId, out var mindComp))
                                 _mindSystem.TransferTo(mindId, mobUid, true, mind: mindComp);
@@ -171,7 +171,7 @@ namespace Content.Server.Administration.Systems
                             var stationUid = _stations.GetOwningStation(args.Target);
 
                             var profile = _gameTicker.GetPlayerProfile(targetActor.PlayerSession);
-                            _spawning.SpawnPlayerMob(coords.Value, null, profile, stationUid);
+                            _spawning.SpawnPlayerMob(coords.Value, profile.Name, null, profile, stationUid);
                         },
                         ConfirmationPopup = true,
                         Impact = LogImpact.High,

--- a/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
@@ -51,7 +51,7 @@ public sealed class DeathMatchRuleSystem : GameRuleSystem<DeathMatchRuleComponen
             var newMind = _mind.CreateMind(ev.Player.UserId, ev.Profile.Name);
             _mind.SetUserId(newMind, ev.Player.UserId);
 
-            var mobMaybe = _stationSpawning.SpawnPlayerCharacterOnStation(ev.Station, null, ev.Profile);
+            var mobMaybe = _stationSpawning.SpawnPlayerCharacterOnStation(ev.Station, ev.Profile.Name, null, ev.Profile);
             DebugTools.AssertNotNull(mobMaybe);
             var mob = mobMaybe!.Value;
 

--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -367,6 +367,7 @@ public sealed class ArrivalsSystem : EntitySystem
         var spawnLoc = _random.Pick(possiblePositions);
         ev.SpawnResult = _stationSpawning.SpawnPlayerMob(
             spawnLoc,
+            ev.Name,
             ev.Job,
             ev.HumanoidCharacterProfile,
             ev.Station);

--- a/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
@@ -73,6 +73,7 @@ public sealed class ContainerSpawnPointSystem : EntitySystem
 
         args.SpawnResult = _stationSpawning.SpawnPlayerMob(
             baseCoords,
+            args.Name,
             args.Job,
             args.HumanoidCharacterProfile,
             args.Station);

--- a/Content.Server/Spawners/EntitySystems/SpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/SpawnPointSystem.cs
@@ -67,6 +67,7 @@ public sealed class SpawnPointSystem : EntitySystem
 
         args.SpawnResult = _stationSpawning.SpawnPlayerMob(
             spawnLoc,
+            args.Name,
             args.Job,
             args.HumanoidCharacterProfile,
             args.Station);

--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -55,7 +55,7 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         if (!TryComp<StationRecordsComponent>(args.Station, out var stationRecords))
             return;
 
-        CreateGeneralRecord(args.Station, args.Mob, args.Profile, args.JobId, stationRecords);
+        CreateGeneralRecord(args.Station, args.Mob, args.Profile, args.Name, args.JobId, stationRecords);
     }
 
     private void OnRename(ref EntityRenamedEvent ev)
@@ -83,8 +83,13 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         }
     }
 
-    private void CreateGeneralRecord(EntityUid station, EntityUid player, HumanoidCharacterProfile profile,
-        string? jobId, StationRecordsComponent records)
+    private void CreateGeneralRecord(
+        EntityUid station,
+        EntityUid player,
+        HumanoidCharacterProfile profile,
+        string name,
+        string? jobId,
+        StationRecordsComponent records)
     {
         // TODO make PlayerSpawnCompleteEvent.JobId a ProtoId
         if (string.IsNullOrEmpty(jobId)
@@ -97,7 +102,7 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         TryComp<FingerprintComponent>(player, out var fingerprintComponent);
         TryComp<DnaComponent>(player, out var dnaComponent);
 
-        CreateGeneralRecord(station, idUid.Value, profile.Name, profile.Age, profile.Species, profile.Gender, jobId, fingerprintComponent?.Fingerprint, dnaComponent?.DNA, profile, records);
+        CreateGeneralRecord(station, idUid.Value, name, profile.Age, profile.Species, profile.Gender, jobId, fingerprintComponent?.Fingerprint, dnaComponent?.DNA, profile, records);
     }
 
 

--- a/Content.Shared/GameTicking/PlayerSpawnCompleteEvent.cs
+++ b/Content.Shared/GameTicking/PlayerSpawnCompleteEvent.cs
@@ -14,6 +14,7 @@ public sealed class PlayerSpawnCompleteEvent : EntityEventArgs
 {
     public EntityUid Mob { get; }
     public ICommonSession Player { get; }
+    public string Name { get; }
     public string? JobId { get; }
     public bool LateJoin { get; }
     public bool Silent { get; }
@@ -25,6 +26,7 @@ public sealed class PlayerSpawnCompleteEvent : EntityEventArgs
 
     public PlayerSpawnCompleteEvent(EntityUid mob,
         ICommonSession player,
+        string name,
         string? jobId,
         bool lateJoin,
         bool silent,
@@ -34,6 +36,7 @@ public sealed class PlayerSpawnCompleteEvent : EntityEventArgs
     {
         Mob = mob;
         Player = player;
+        Name = name;
         JobId = jobId;
         LateJoin = lateJoin;
         Silent = silent;

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -59,6 +59,12 @@ namespace Content.Shared.Preferences
         [DataField]
         private Dictionary<string, RoleLoadout> _loadouts = new();
 
+        /// <summary>
+        /// The character's default name. A character's name can be overriden by some special roles (e.g. clown, mime,
+        /// AI) which is not reflected here. Therefore, generally speaking, DO NOT USE THIS VALUE FOR GAMEPLAY SYSTEMS
+        /// BECAUSE SPECIAL ROLES WILL GET THE WRONG NAME!!!
+        /// Instead use: Mind's CharacterName (preferred), player's mob's EntityName.
+        /// </summary>
         [DataField]
         public string Name { get; set; } = "John Doe";
 

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -2,25 +2,19 @@ using System.Linq;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Inventory;
-using Content.Shared.Item;
 using Content.Shared.Preferences.Loadouts;
 using Content.Shared.Roles;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
-using Robust.Shared.Collections;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
-using Robust.Shared.Utility;
 
 namespace Content.Shared.Station;
 
 public abstract class SharedStationSpawningSystem : EntitySystem
 {
     [Dependency] protected readonly IPrototypeManager PrototypeManager = default!;
-    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] protected readonly InventorySystem InventorySystem = default!;
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
-    [Dependency] private readonly MetaDataSystem _metadata = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
 
@@ -56,31 +50,6 @@ public abstract class SharedStationSpawningSystem : EntitySystem
 
                 EquipStartingGear(entity, loadoutProto, raiseEvent: false);
             }
-        }
-
-        EquipRoleName(entity, loadout, roleProto);
-    }
-
-    /// <summary>
-    /// Applies the role's name as applicable to the entity.
-    /// </summary>
-    public void EquipRoleName(EntityUid entity, RoleLoadout loadout, RoleLoadoutPrototype roleProto)
-    {
-        string? name = null;
-
-        if (roleProto.CanCustomizeName)
-        {
-            name = loadout.EntityName;
-        }
-
-        if (string.IsNullOrEmpty(name) && PrototypeManager.Resolve(roleProto.NameDataset, out var nameData))
-        {
-            name = Loc.GetString(_random.Pick(nameData.Values));
-        }
-
-        if (!string.IsNullOrEmpty(name))
-        {
-            _metadata.SetEntityName(entity, name);
         }
     }
 


### PR DESCRIPTION
## About the PR
This fixes #39535.

## Technical details
The problem was that the mob's EntityName of a clown/mime gets changed by OutfitSystem, but the mind's CharacterName does not. It's a somewhat subtle bug because you can explain the mismatch away as "stage names", which makes it look intentional, but I'm confident it wasn't intentional. I've made a fairly simple fix, which sets the mind's name to the mob's name after spawning a new mind.

## Media
<img width="513" height="375" alt="bugfix_charactername_targetobjective" src="https://github.com/user-attachments/assets/da3dc0fa-be86-4d54-93f3-5bd97d931b73" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.