### PR TITLE
Change default Rat King order from 'Loose' to 'Follow'

### DIFF
--- a/Content.Shared/RatKing/RatKingComponent.cs
+++ b/Content.Shared/RatKing/RatKingComponent.cs
@@ -56,7 +56,7 @@ public sealed partial class RatKingComponent : Component
     /// </summary>
     [DataField("currentOrders"), ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
-    public RatKingOrderType CurrentOrder = RatKingOrderType.Loose;
+    public RatKingOrderType CurrentOrder = RatKingOrderType.Follow;
 
     /// <summary>
     /// The servants that the rat king is currently controlling


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Rat King minion's default orders set to Follow instead of Loose.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Rat King as an antagonist, naturally wants to build up a big horde of rats before fighting the crew since they are quite weak individually. If you don't notice the default stance is 'Loose', the first few rats you spawn may potentially run off and get into random fights before you're ready. So, this changes the default stance to 'Follow'. 
## Technical details
<!-- Summary of code changes for easier review. -->
One line change to CurrentOrder field in RatKingComponent.cs
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: When a Rat King is spawned, the default orders for their army is now set to Follow instead of Loose.


