### PR TITLE
Update Cognizine'd entities rules popup to match their actual alignment

### DIFF
--- a/Content.Server/EntityEffects/Effects/MakeSentientEntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/Effects/MakeSentientEntityEffectSystem.cs
@@ -38,5 +38,6 @@ public sealed partial class MakeSentientEntityEffectSystem : EntityEffectSystem<
 
         ghostRole.RoleName = entity.Comp.EntityName;
         ghostRole.RoleDescription = Loc.GetString("ghost-role-information-cognizine-description");
+        ghostRole.RoleRules = Loc.GetString("ghost-role-information-nonantagonist-rules");
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When raffling for a ghost role created by cognizine, ghost-role-information-nonantagonist-rules are shown instead of the default.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This just makes the rules popup match the actual role in the cognizined entity's character panel and resolves https://github.com/space-wizards/space-station-14/issues/41651.
## Technical details
<!-- Summary of code changes for easier review. -->
One line change in MakeSentientEntityEffectSystem updating the RoleRules of the added ghost role to ghost-role-information-nonantagonist-rules.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Previously:
<img width="675" height="535" alt="image" src="https://github.com/user-attachments/assets/6450a548-89bb-4d80-98e7-e96fe52ac858" />
Now:
<img width="489" height="476" alt="image" src="https://github.com/user-attachments/assets/cf86087f-c3f7-444e-8e25-c29716da81cc" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: The rules popup for ghost roles created by cognizine now correctly tells you the role is crew aligned when you enter the raffle for it.

