### PR TITLE
Derelict Borg Event cleanup

### DIFF
--- a/Content.Server/Antag/AntagMultipleRoleSpawnerSystem.cs
+++ b/Content.Server/Antag/AntagMultipleRoleSpawnerSystem.cs
@@ -46,6 +46,6 @@ public sealed class AntagMultipleRoleSpawnerSystem : EntitySystem
             return;
         }
 
-        args.Entity = Spawn(weightedRandom.Pick(_random));
+        args.Entity = Spawn(ent.Comp.PickAndTake ? weightedRandom.PickAndTake(_random) : weightedRandom.Pick(_random));
     }
 }

--- a/Content.Server/Antag/AntagMultipleRoleSpawnerSystem.cs
+++ b/Content.Server/Antag/AntagMultipleRoleSpawnerSystem.cs
@@ -1,10 +1,15 @@
+using System.Linq;
 using Content.Server.Antag.Components;
+using Content.Shared.Random;
+using Content.Shared.Random.Helpers;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Antag;
 
 public sealed class AntagMultipleRoleSpawnerSystem : EntitySystem
 {
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ILogManager _log = default!;
 
@@ -35,6 +40,14 @@ public sealed class AntagMultipleRoleSpawnerSystem : EntitySystem
         if (entProtos.Count == 0)
             return; // You will just get a normal job
 
-        args.Entity = Spawn(ent.Comp.PickAndTake ? _random.PickAndTake(entProtos) : _random.Pick(entProtos));
+         if (!ent.Comp.PrototypeWeights.TryGetValue(role, out var weightedRandomPrototype) || !_protoMan.TryIndex(weightedRandomPrototype, out WeightedRandomPrototype? weightedRandom))
+         {
+             args.Entity = Spawn(ent.Comp.PickAndTake ? _random.PickAndTake(entProtos) : _random.Pick(entProtos));
+             return;
+         }
+
+        args.Entity = Spawn(weightedRandom.Pick(_random));
+
+        //args.Entity = Spawn(ent.Comp.PickAndTake ? _random.PickAndTake(entProtos) : _random.Pick(entProtos));
     }
 }

--- a/Content.Server/Antag/AntagMultipleRoleSpawnerSystem.cs
+++ b/Content.Server/Antag/AntagMultipleRoleSpawnerSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Antag.Components;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;

--- a/Content.Server/Antag/AntagMultipleRoleSpawnerSystem.cs
+++ b/Content.Server/Antag/AntagMultipleRoleSpawnerSystem.cs
@@ -40,14 +40,12 @@ public sealed class AntagMultipleRoleSpawnerSystem : EntitySystem
         if (entProtos.Count == 0)
             return; // You will just get a normal job
 
-         if (!ent.Comp.PrototypeWeights.TryGetValue(role, out var weightedRandomPrototype) || !_protoMan.TryIndex(weightedRandomPrototype, out WeightedRandomPrototype? weightedRandom))
-         {
-             args.Entity = Spawn(ent.Comp.PickAndTake ? _random.PickAndTake(entProtos) : _random.Pick(entProtos));
-             return;
-         }
+        if (!ent.Comp.PrototypeWeights.TryGetValue(role, out var weightedRandomPrototype) || !_protoMan.TryIndex(weightedRandomPrototype, out WeightedRandomPrototype? weightedRandom))
+        {
+            args.Entity = Spawn(ent.Comp.PickAndTake ? _random.PickAndTake(entProtos) : _random.Pick(entProtos));
+            return;
+        }
 
         args.Entity = Spawn(weightedRandom.Pick(_random));
-
-        //args.Entity = Spawn(ent.Comp.PickAndTake ? _random.PickAndTake(entProtos) : _random.Pick(entProtos));
     }
 }

--- a/Content.Server/Antag/Components/AntagMultipleRoleSpawnerComponent.cs
+++ b/Content.Server/Antag/Components/AntagMultipleRoleSpawnerComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Random;
 using Content.Shared.Roles;
 using Robust.Shared.Prototypes;
 
@@ -20,4 +21,10 @@ public sealed partial class AntagMultipleRoleSpawnerComponent : Component
     /// </summary>
     [DataField]
     public bool PickAndTake;
+
+    /// <summary>
+    ///     antag prototype -> WeightedRandomPrototype to weight different entities to spawn at different rates.
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<AntagPrototype>, ProtoId<WeightedRandomPrototype>> PrototypeWeights = new();
 }

--- a/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
+++ b/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
@@ -44,6 +44,9 @@ namespace Content.Shared.Random.Helpers
             throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
         }
 
+        /// <summary>
+        ///     Picks a random weighted prototype and returns it.
+        /// </summary>
         public static string Pick(this IWeightedRandomPrototype prototype, IRobustRandom? random = null)
         {
             IoCManager.Resolve(ref random);
@@ -65,6 +68,13 @@ namespace Content.Shared.Random.Helpers
 
             // Shouldn't happen
             throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
+        }
+
+        public static string PickAndTake(this IWeightedRandomPrototype prototype, IRobustRandom? random = null)
+        {
+            var key = Pick(prototype, random);
+            prototype.Weights.Remove(key);
+            return key;
         }
 
         public static T Pick<T>(this IRobustRandom random, Dictionary<T, float> weights)

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -247,14 +247,11 @@ ghost-role-information-syndicate-cyborg-assault-name = Syndicate Assault Cyborg
 ghost-role-information-syndicate-cyborg-saboteur-name = Syndicate Saboteur Cyborg
 ghost-role-information-syndicate-cyborg-description = The Syndicate needs reinforcements. You, a cold silicon killing machine, will help them.
 
-ghost-role-information-derelict-cyborg-name = Derelict Cyborg
-ghost-role-information-derelict-cyborg-description = You are a regular cyborg that got lost in space. After years of exposure to ion storms you find yourself near a space station.
-
 ghost-role-information-derelict-engineering-cyborg-name = Derelict Engineer Cyborg
 ghost-role-information-derelict-engineering-cyborg-description = You are an engineer cyborg that got lost in space. After years of exposure to ion storms you find yourself near a space station.
 
-ghost-role-information-derelict-generic-cyborg-name = Derelict Generic Cyborg
-ghost-role-information-derelict-generic-cyborg-description = You are a generic cyborg that got lost in space. After years of exposure to ion storms you find yourself near a space station.
+ghost-role-information-derelict-cyborg-name = Derelict Generic Cyborg
+ghost-role-information-derelict-cyborg-description = You are a regular cyborg that got lost in space. After years of exposure to ion storms you find yourself near a space station.
 
 ghost-role-information-derelict-janitor-cyborg-name = Derelict Janitor Cyborg
 ghost-role-information-derelict-janitor-cyborg-description = You are a janitor cyborg that got lost in space. After years of exposure to ion storms you find yourself near a space station.

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -247,11 +247,14 @@ ghost-role-information-syndicate-cyborg-assault-name = Syndicate Assault Cyborg
 ghost-role-information-syndicate-cyborg-saboteur-name = Syndicate Saboteur Cyborg
 ghost-role-information-syndicate-cyborg-description = The Syndicate needs reinforcements. You, a cold silicon killing machine, will help them.
 
+ghost-role-information-derelict-cyborg-name = Derelict Cyborg
+ghost-role-information-derelict-cyborg-description = You are a regular cyborg that got lost in space. After years of exposure to ion storms you find yourself near a space station.
+
 ghost-role-information-derelict-engineering-cyborg-name = Derelict Engineer Cyborg
 ghost-role-information-derelict-engineering-cyborg-description = You are an engineer cyborg that got lost in space. After years of exposure to ion storms you find yourself near a space station.
 
-ghost-role-information-derelict-cyborg-name = Derelict Generic Cyborg
-ghost-role-information-derelict-cyborg-description = You are a regular cyborg that got lost in space. After years of exposure to ion storms you find yourself near a space station.
+ghost-role-information-derelict-generic-cyborg-name = Derelict Generic Cyborg
+ghost-role-information-derelict-generic-cyborg-description = You are a generic cyborg that got lost in space. After years of exposure to ion storms you find yourself near a space station.
 
 ghost-role-information-derelict-janitor-cyborg-name = Derelict Janitor Cyborg
 ghost-role-information-derelict-janitor-cyborg-description = You are a janitor cyborg that got lost in space. After years of exposure to ion storms you find yourself near a space station.

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -234,7 +234,7 @@
   components:
   - type: GhostRole
     name: ghost-role-information-derelict-generic-cyborg-name
-    description: ghost-role-information-derelict-engineering-generic-description
+    description: ghost-role-information-derelict-generic-cyborg-description
     rules: ghost-role-information-silicon-rules
     raffle:
       settings: default

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -229,6 +229,18 @@
 
 - type: entity
   categories: [ HideSpawnMenu, Spawner ]
+  parent: SpawnPointGhostDerelictCyborg
+  id: SpawnPointGhostDerelictGenericCyborg
+  components:
+  - type: GhostRole
+    name: ghost-role-information-derelict-generic-cyborg-name
+    description: ghost-role-information-derelict-engineering-generic-description
+    rules: ghost-role-information-silicon-rules
+    raffle:
+      settings: default
+
+- type: entity
+  categories: [ HideSpawnMenu, Spawner ]
   parent: BaseAntagSpawner
   id: SpawnPointGhostDerelictCyborg
   components:

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -189,7 +189,7 @@
         path: /Audio/Ambience/Objects/periodic_beep.ogg
 
 - type: entity
-  id: BorgChassisDerelict
+  id: GenericBorgChassisDerelict
   parent: BaseBorgChassisDerelict
   name: derelict cyborg
   description: A man-machine hybrid that assists in station activity. This one is in a state of great disrepair.

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -821,7 +821,7 @@
 
 - type: entity
   parent: PlayerSyndicateAssaultBorgDerelict
-  id: PlayerBorgSyndicateDerelictGhostRole
+  id: PlayerSyndicateAssaultBorgDerelictGhostRole
   suffix: Ghost role
   components:
   - type: GhostRole

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -246,7 +246,7 @@
   - type: ApcPowerReceiverBattery
     idleLoad: 500
     batteryRechargeRate: 1000
-    batteryRechargeEfficiency: 0 # Setting to zero until the light flickering issue associated with dynamic power loads is fixed 
+    batteryRechargeEfficiency: 0 # Setting to zero until the light flickering issue associated with dynamic power loads is fixed
   - type: StationAiCore
   - type: StationAiVision
   - type: InteractionOutline
@@ -315,7 +315,7 @@
       - StationAiCoreElectronics
   - type: StaticPrice
     price: 5000
-      
+
 # The job-ready version of an AI spawn.
 - type: entity
   id: PlayerStationAi
@@ -334,7 +334,7 @@
   description: An unfinished computer core for housing an artifical intelligence.
   components:
   - type: Anchorable
-    flags: 
+    flags:
     - Anchorable
   - type: Rotatable
   - type: Sprite
@@ -677,8 +677,8 @@
   suffix: Ghost role
   components:
     - type: GhostRole
-      name: ghost-role-information-derelict-cyborg-name
-      description: ghost-role-information-derelict-cyborg-description
+      name: ghost-role-information-generic-derelict-cyborg-name
+      description: ghost-role-information-generic-derelict-cyborg-description
       rules: ghost-role-information-silicon-rules
       raffle:
         settings: default

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -672,7 +672,7 @@
     nameSegments: [NamesBorg]
 
 - type: entity
-  parent: PlayerBorgDerelict
+  parent: PlayerGenericBorgDerelict
   id: PlayerGenericBorgDerelictGhostRole
   suffix: Ghost role
   components:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -652,8 +652,8 @@
   - type: GhostTakeoverAvailable
 
 - type: entity
-  parent: BorgChassisDerelict
-  id: PlayerBorgDerelict
+  parent: GenericBorgChassisDerelict
+  id: PlayerGenericBorgDerelict
   suffix: Battery, Module
   components:
   - type: ContainerFill
@@ -673,12 +673,12 @@
 
 - type: entity
   parent: PlayerBorgDerelict
-  id: PlayerBorgDerelictGhostRole
+  id: PlayerGenericBorgDerelictGhostRole
   suffix: Ghost role
   components:
     - type: GhostRole
-      name: ghost-role-information-generic-derelict-cyborg-name
-      description: ghost-role-information-generic-derelict-cyborg-description
+      name: ghost-role-information-derelict-generic-cyborg-name
+      description: ghost-role-information-derelict-generic-cyborg-description
       rules: ghost-role-information-silicon-rules
       raffle:
         settings: default

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -32,8 +32,7 @@
     - id: ClosetSkeleton
     - id: KingRatMigration
     - id: RevenantSpawn
-    - !type:NestedSelector
-      tableId: DerelictBorgEventTable
+    - id: DerelictCyborgSpawn
 
 - type: entityTable
   id: ModerateAntagEventsTable
@@ -46,17 +45,7 @@
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
     - id: WizardSpawn
-    - !type:NestedSelector
-      tableId: DerelictBorgEventTable
-
-- type: entityTable
-  id: DerelictBorgEventTable #For Derelict Borg spawns
-  table: !type:GroupSelector
-    children:
-    - !type:GroupSelector # Standard NT Borgs
-      weight: 85
-      children:
-        - id: DerelictCyborgSpawn
+    - id: DerelictCyborgSpawn
 
 - type: entity
   id: BaseStationEvent

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -689,6 +689,29 @@
 
 - type: entity
   parent: BaseGameRule
+  id: DerelictCyborgSpawn
+  components:
+  - type: StationEvent
+    weight: 15
+    earliestStart: 15
+    reoccurrenceDelay: 20
+    minimumPlayers: 4
+    duration: null
+  - type: SpaceSpawnRule
+    spawnDistance: 0
+  - type: AntagMultipleRoleSpawner
+    antagRoleToPrototypes:
+      SubvertedSilicon: [ PlayerGenericBorgDerelictGhostRole, PlayerJanitorBorgDerelictGhostRole, PlayerMedicalBorgDerelictGhostRole, PlayerMiningBorgDerelictGhostRole, PlayerBorgSyndicateDerelictGhostRole, PlayerEngineeringBorgDerelictGhostRole ]
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ SubvertedSilicon ]
+      spawnerPrototype: SpawnPointGhostDerelictCyborg
+      min: 1
+      max: 1
+      pickPlayer: false
+
+- type: entity
+  parent: BaseGameRule
   id: DerelictEngineerCyborgSpawn
   components:
   - type: StationEvent

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -700,6 +700,8 @@
   - type: SpaceSpawnRule
     spawnDistance: 0
   - type: AntagMultipleRoleSpawner
+    prototypeWeights:
+      SubvertedSilicon: DerelictCyborgWeights
     antagRoleToPrototypes:
       SubvertedSilicon: [ PlayerGenericBorgDerelictGhostRole, PlayerJanitorBorgDerelictGhostRole, PlayerMedicalBorgDerelictGhostRole, PlayerMiningBorgDerelictGhostRole, PlayerBorgSyndicateDerelictGhostRole, PlayerEngineeringBorgDerelictGhostRole ]
   - type: AntagSelection
@@ -709,6 +711,16 @@
       min: 1
       max: 1
       pickPlayer: false
+
+- type: weightedRandom
+  id: DerelictCyborgWeights
+  weights:
+    PlayerGenericBorgDerelictGhostRole: 5
+    PlayerJanitorBorgDerelictGhostRole: 5
+    PlayerMedicalBorgDerelictGhostRole: 5
+    PlayerMiningBorgDerelictGhostRole: 5
+    PlayerBorgSyndicateDerelictGhostRole: 5
+    PlayerEngineeringBorgDerelictGhostRole: 5
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -689,23 +689,126 @@
 
 - type: entity
   parent: BaseGameRule
-  id: DerelictCyborgSpawn
+  id: DerelictEngineerCyborgSpawn
   components:
   - type: StationEvent
-    weight: 9
+    weight: 2.5
     earliestStart: 15
     reoccurrenceDelay: 20
     minimumPlayers: 4
     duration: null
   - type: SpaceSpawnRule
     spawnDistance: 0
-  - type: AntagMultipleRoleSpawner
-    antagRoleToPrototypes:
-      SubvertedSilicon: [ PlayerBorgDerelictGhostRole, PlayerJanitorBorgDerelictGhostRole, PlayerMedicalBorgDerelictGhostRole, PlayerMiningBorgDerelictGhostRole, PlayerBorgSyndicateDerelictGhostRole, PlayerEngineeringBorgDerelictGhostRole ]
+  - type: AntagSpawner
+    prototype: PlayerEngineeringBorgDerelictGhostRole
   - type: AntagSelection
     definitions:
-    - prefRoles: [ SubvertedSilicon ]
-      spawnerPrototype: SpawnPointGhostDerelictCyborg
+    - spawnerPrototype: SpawnPointGhostDerelictEngineeringCyborg
+      min: 1
+      max: 1
+      pickPlayer: false
+
+- type: entity
+  parent: BaseGameRule
+  id: DerelictGenericCyborgSpawn
+  components:
+  - type: StationEvent
+    weight: 2.5
+    earliestStart: 15
+    reoccurrenceDelay: 20
+    minimumPlayers: 4
+    duration: null
+  - type: SpaceSpawnRule
+    spawnDistance: 0
+  - type: AntagSpawner
+    prototype: PlayerBorgDerelictGhostRole
+  - type: AntagSelection
+    definitions:
+    - spawnerPrototype: SpawnPointGhostDerelictCyborg
+      min: 1
+      max: 1
+      pickPlayer: false
+
+- type: entity
+  parent: BaseGameRule
+  id: DerelictJanitorCyborgSpawn
+  components:
+  - type: StationEvent
+    weight: 2.5
+    earliestStart: 15
+    reoccurrenceDelay: 20
+    minimumPlayers: 4
+    duration: null
+  - type: SpaceSpawnRule
+    spawnDistance: 0
+  - type: AntagSpawner
+    prototype: PlayerJanitorBorgDerelictGhostRole
+  - type: AntagSelection
+    definitions:
+    - spawnerPrototype: SpawnPointGhostDerelictJanitorCyborg
+      min: 1
+      max: 1
+      pickPlayer: false
+
+- type: entity
+  parent: BaseGameRule
+  id: DerelictMedicalCyborgSpawn
+  components:
+  - type: StationEvent
+    weight: 2.5
+    earliestStart: 15
+    reoccurrenceDelay: 20
+    minimumPlayers: 4
+    duration: null
+  - type: SpaceSpawnRule
+    spawnDistance: 0
+  - type: AntagSpawner
+    prototype: PlayerMedicalBorgDerelictGhostRole
+  - type: AntagSelection
+    definitions:
+    - spawnerPrototype: SpawnPointGhostDerelictMedicalCyborg
+      min: 1
+      max: 1
+      pickPlayer: false
+
+- type: entity
+  parent: BaseGameRule
+  id: DerelictMiningCyborgSpawn
+  components:
+  - type: StationEvent
+    weight: 2.5
+    earliestStart: 15
+    reoccurrenceDelay: 20
+    minimumPlayers: 4
+    duration: null
+  - type: SpaceSpawnRule
+    spawnDistance: 0
+  - type: AntagSpawner
+    prototype: PlayerMiningBorgDerelictGhostRole
+  - type: AntagSelection
+    definitions:
+    - spawnerPrototype: SpawnPointGhostDerelictMiningCyborg
+      min: 1
+      max: 1
+      pickPlayer: false
+
+- type: entity
+  parent: BaseGameRule
+  id: DerelictSyndicateAssaultCyborgSpawn
+  components:
+  - type: StationEvent
+    weight: 2.5
+    earliestStart: 25
+    reoccurrenceDelay: 20
+    minimumPlayers: 15
+    duration: null
+  - type: SpaceSpawnRule
+    spawnDistance: 0
+  - type: AntagSpawner
+    prototype: PlayerBorgSyndicateDerelictGhostRole
+  - type: AntagSelection
+    definitions:
+    - spawnerPrototype: SpawnPointGhostDerelictSyndicateAssaultCyborg
       min: 1
       max: 1
       pickPlayer: false

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -56,15 +56,7 @@
     - !type:GroupSelector # Standard NT Borgs
       weight: 85
       children:
-        - id: DerelictEngineerCyborgSpawn
-        - id: DerelictGenericCyborgSpawn
-        - id: DerelictJanitorCyborgSpawn
-        - id: DerelictMedicalCyborgSpawn
-        - id: DerelictMiningCyborgSpawn
-    - !type:GroupSelector # Other Borgs
-      weight: 15
-      children:
-        - id: DerelictSyndicateAssaultCyborgSpawn
+        - id: DerelictCyborgSpawn
 
 - type: entity
   id: BaseStationEvent

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -703,7 +703,7 @@
     prototypeWeights:
       SubvertedSilicon: DerelictCyborgWeights
     antagRoleToPrototypes:
-      SubvertedSilicon: [ PlayerGenericBorgDerelictGhostRole, PlayerJanitorBorgDerelictGhostRole, PlayerMedicalBorgDerelictGhostRole, PlayerMiningBorgDerelictGhostRole, PlayerBorgSyndicateDerelictGhostRole, PlayerEngineeringBorgDerelictGhostRole ]
+      SubvertedSilicon: [ PlayerGenericBorgDerelictGhostRole, PlayerJanitorBorgDerelictGhostRole, PlayerMedicalBorgDerelictGhostRole, PlayerMiningBorgDerelictGhostRole, PlayerSyndicateAssaultBorgDerelict, PlayerEngineeringBorgDerelictGhostRole ]
   - type: AntagSelection
     definitions:
     - prefRoles: [ SubvertedSilicon ]
@@ -719,7 +719,7 @@
     PlayerJanitorBorgDerelictGhostRole: 5
     PlayerMedicalBorgDerelictGhostRole: 5
     PlayerMiningBorgDerelictGhostRole: 5
-    PlayerBorgSyndicateDerelictGhostRole: 5
+    PlayerSyndicateAssaultBorgDerelict: 5
     PlayerEngineeringBorgDerelictGhostRole: 5
 
 - type: entity
@@ -840,7 +840,7 @@
   - type: SpaceSpawnRule
     spawnDistance: 0
   - type: AntagSpawner
-    prototype: PlayerBorgSyndicateDerelictGhostRole
+    prototype: PlayerSyndicateAssaultBorgDerelict
   - type: AntagSelection
     definitions:
     - spawnerPrototype: SpawnPointGhostDerelictSyndicateAssaultCyborg

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -697,126 +697,23 @@
 
 - type: entity
   parent: BaseGameRule
-  id: DerelictEngineerCyborgSpawn
+  id: DerelictCyborgSpawn
   components:
   - type: StationEvent
-    weight: 2.5
+    weight: 9
     earliestStart: 15
     reoccurrenceDelay: 20
     minimumPlayers: 4
     duration: null
   - type: SpaceSpawnRule
     spawnDistance: 0
-  - type: AntagSpawner
-    prototype: PlayerEngineeringBorgDerelictGhostRole
+  - type: AntagMultipleRoleSpawner
+    antagRoleToPrototypes:
+      SubvertedSilicon: [ PlayerBorgDerelictGhostRole, PlayerJanitorBorgDerelictGhostRole, PlayerMedicalBorgDerelictGhostRole, PlayerMiningBorgDerelictGhostRole, PlayerBorgSyndicateDerelictGhostRole, PlayerEngineeringBorgDerelictGhostRole ]
   - type: AntagSelection
     definitions:
-    - spawnerPrototype: SpawnPointGhostDerelictEngineeringCyborg
-      min: 1
-      max: 1
-      pickPlayer: false
-
-- type: entity
-  parent: BaseGameRule
-  id: DerelictGenericCyborgSpawn
-  components:
-  - type: StationEvent
-    weight: 2.5
-    earliestStart: 15
-    reoccurrenceDelay: 20
-    minimumPlayers: 4
-    duration: null
-  - type: SpaceSpawnRule
-    spawnDistance: 0
-  - type: AntagSpawner
-    prototype: PlayerBorgDerelictGhostRole
-  - type: AntagSelection
-    definitions:
-    - spawnerPrototype: SpawnPointGhostDerelictCyborg
-      min: 1
-      max: 1
-      pickPlayer: false
-
-- type: entity
-  parent: BaseGameRule
-  id: DerelictJanitorCyborgSpawn
-  components:
-  - type: StationEvent
-    weight: 2.5
-    earliestStart: 15
-    reoccurrenceDelay: 20
-    minimumPlayers: 4
-    duration: null
-  - type: SpaceSpawnRule
-    spawnDistance: 0
-  - type: AntagSpawner
-    prototype: PlayerJanitorBorgDerelictGhostRole
-  - type: AntagSelection
-    definitions:
-    - spawnerPrototype: SpawnPointGhostDerelictJanitorCyborg
-      min: 1
-      max: 1
-      pickPlayer: false
-
-- type: entity
-  parent: BaseGameRule
-  id: DerelictMedicalCyborgSpawn
-  components:
-  - type: StationEvent
-    weight: 2.5
-    earliestStart: 15
-    reoccurrenceDelay: 20
-    minimumPlayers: 4
-    duration: null
-  - type: SpaceSpawnRule
-    spawnDistance: 0
-  - type: AntagSpawner
-    prototype: PlayerMedicalBorgDerelictGhostRole
-  - type: AntagSelection
-    definitions:
-    - spawnerPrototype: SpawnPointGhostDerelictMedicalCyborg
-      min: 1
-      max: 1
-      pickPlayer: false
-
-- type: entity
-  parent: BaseGameRule
-  id: DerelictMiningCyborgSpawn
-  components:
-  - type: StationEvent
-    weight: 2.5
-    earliestStart: 15
-    reoccurrenceDelay: 20
-    minimumPlayers: 4
-    duration: null
-  - type: SpaceSpawnRule
-    spawnDistance: 0
-  - type: AntagSpawner
-    prototype: PlayerMiningBorgDerelictGhostRole
-  - type: AntagSelection
-    definitions:
-    - spawnerPrototype: SpawnPointGhostDerelictMiningCyborg
-      min: 1
-      max: 1
-      pickPlayer: false
-
-- type: entity
-  parent: BaseGameRule
-  id: DerelictSyndicateAssaultCyborgSpawn
-  components:
-  - type: StationEvent
-    weight: 2.5
-    earliestStart: 25
-    reoccurrenceDelay: 20
-    minimumPlayers: 15
-    duration: null
-  - type: SpaceSpawnRule
-    spawnDistance: 0
-  - type: AntagSpawner
-    prototype: PlayerBorgSyndicateDerelictGhostRole
-  - type: AntagSelection
-    definitions:
-    - spawnerPrototype: SpawnPointGhostDerelictSyndicateAssaultCyborg
+    - prefRoles: [ SubvertedSilicon ]
+      spawnerPrototype: SpawnPointGhostDerelictCyborg
       min: 1
       max: 1
       pickPlayer: false

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -744,10 +744,10 @@
   - type: SpaceSpawnRule
     spawnDistance: 0
   - type: AntagSpawner
-    prototype: PlayerBorgDerelictGhostRole
+    prototype: PlayerGenericBorgDerelictGhostRole
   - type: AntagSelection
     definitions:
-    - spawnerPrototype: SpawnPointGhostDerelictCyborg
+    - spawnerPrototype: SpawnPointGhostDerelictGenericCyborg
       min: 1
       max: 1
       pickPlayer: false

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
@@ -36,4 +36,4 @@
     entity: BorgChassisSelectable
 
   - node: derelictcyborg
-    entity: BorgChassisDerelict
+    entity: GenericBorgChassisDerelict


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Rolled every derelict borg midround event into a single event that picks a random derelict borg.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Previous implementation was iffy: old derelict borg events were nearly identical and copy-pasted. Each derelict borg event had its own identical weight so it was dominating the ghost role pool, and made adding additional derelict borgs increase this weight further or required you to adjust the weight of all other derelict borg roles so as to not increase the overall weight.

Also cleanup good

Resolves #40195

## Technical details
<!-- Summary of code changes for easier review. -->
Added in a new derelict borg event which uses AntagMultipleRoleSpawner. The other derelict borg gamerules still exist but should not appear naturally.
Added PrototypeWeights field to AntagMultipleRoleSpawnerComponent, and modified AntagMultipleRoleSpawnerComponent to accommodate.
Added new static helper method to SharedRandomExtensions, PickAndTake(this IWeightedRandomPrototype prototype, IRobustRandom? random = null).

Minor locale changes and cleanup.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="743" height="575" alt="image" src="https://github.com/user-attachments/assets/4990d302-aa81-479f-a64d-65206e73b392" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Derelict cyborg events no longer reveal the chassis beforehand.