### PR TITLE
Snowball: Head of Security's hardsuit is no longer absent

### DIFF
--- a/Resources/Maps/snowball.yml
+++ b/Resources/Maps/snowball.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 268.0.0
   forkId: ""
   forkVersion: ""
-  time: 12/03/2025 06:42:48
+  time: 12/04/2025 03:05:10
   entityCount: 18194
 maps:
 - 1793
@@ -6601,6 +6601,7 @@ entities:
     - type: ImplicitRoof
     - type: RadiationGridResistance
     - type: NavMap
+    - type: ExplosionAirtightGrid
   - uid: 1793
     components:
     - type: MetaData
@@ -84729,7 +84730,7 @@ entities:
     - type: Transform
       pos: 36.5,60.5
       parent: 1
-- proto: LockerHeadOfSecurityFilled
+- proto: LockerHeadOfSecurityFilledHardsuit
   entities:
   - uid: 14603
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The Head of Security was missing their hardsuit. Now they're not.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Consistent gameplay across maps good. Also nobody else was missing their hardsuit.

Put the hardsuit in the HoS's locker since that's how all (non-Captain) command hardsuits on this map are placed.

## Technical details
<!-- Summary of code changes for easier review. -->
Mapping change to replace LockerHeadOfSecurityFilled with LockerHeadOfSecurityFilledHardsuit

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A (small fix)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
MAPS:
- fix: On Snowball, the Head of Security's hardsuit is no longer absent, and now spawns in their locker.