### PR TITLE
Remove static IoC from Replay and Shared EntryPoint

### DIFF
--- a/Content.Replay/EntryPoint.cs
+++ b/Content.Replay/EntryPoint.cs
@@ -19,8 +19,8 @@ public sealed class EntryPoint : GameClient
     public override void Init()
     {
         base.Init();
-        IoCManager.BuildGraph();
-        IoCManager.InjectDependencies(this);
+        Dependencies.BuildGraph();
+        Dependencies.InjectDependencies(this);
     }
 
     public override void PostInit()

--- a/Content.Shared/Entry/EntryPoint.cs
+++ b/Content.Shared/Entry/EntryPoint.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Content.Shared.Humanoid.Markings;
-using Content.Shared.IoC;
 using Content.Shared.Maps;
 using Robust.Shared;
 using Robust.Shared.Configuration;
@@ -21,12 +20,15 @@ namespace Content.Shared.Entry
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly ITileDefinitionManager _tileDefinitionManager = default!;
         [Dependency] private readonly IResourceManager _resMan = default!;
+#if DEBUG
+        [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+#endif
 
         private readonly ResPath _ignoreFileDirectory = new("/IgnoredPrototypes/");
 
         public override void PreInit()
         {
-            IoCManager.InjectDependencies(this);
+            Dependencies.InjectDependencies(this);
         }
 
         public override void Shutdown()
@@ -44,13 +46,12 @@ namespace Content.Shared.Entry
             base.PostInit();
 
             InitTileDefinitions();
-            IoCManager.Resolve<MarkingManager>().Initialize();
+            Dependencies.Resolve<MarkingManager>().Initialize();
 
 #if DEBUG
-            var configMan = IoCManager.Resolve<IConfigurationManager>();
-            configMan.OverrideDefault(CVars.NetFakeLagMin, 0.075f);
-            configMan.OverrideDefault(CVars.NetFakeLoss, 0.005f);
-            configMan.OverrideDefault(CVars.NetFakeDuplicates, 0.005f);
+            _configurationManager.OverrideDefault(CVars.NetFakeLagMin, 0.075f);
+            _configurationManager.OverrideDefault(CVars.NetFakeLoss, 0.005f);
+            _configurationManager.OverrideDefault(CVars.NetFakeDuplicates, 0.005f);
 #endif
         }
 


### PR DESCRIPTION
## About the PR
This PR removes all static `IoCManager` calls in `Replay.EntryPoint` and `Shared.EntryPoint`.

## Why / Balance
Non-static methods are better

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

