### PR TITLE
Packed: minor HoP windoor improvements

### DIFF
--- a/Resources/Maps/packed.yml
+++ b/Resources/Maps/packed.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 268.0.0
   forkId: ""
   forkVersion: ""
-  time: 12/01/2025 20:40:27
-  entityCount: 16060
+  time: 12/07/2025 02:12:06
+  entityCount: 16058
 maps:
 - 126
 grids:
@@ -7123,6 +7123,7 @@ entities:
     - type: RadiationGridResistance
     - type: SpreaderGrid
     - type: ImplicitRoof
+    - type: ExplosionAirtightGrid
   - uid: 126
     components:
     - type: MetaData
@@ -43989,7 +43990,7 @@ entities:
       pos: 59.5,39.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -19835.2
+      secondsUntilStateChange: -19911.514
       state: Closing
 - proto: CurtainsWhiteOpen
   entities:
@@ -49845,7 +49846,7 @@ entities:
       pos: 26.5,37.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -67128.984
+      secondsUntilStateChange: -67205.3
       state: Closing
   - uid: 9362
     components:
@@ -72826,7 +72827,7 @@ entities:
       pos: 12.5,12.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -5300.9326
+      secondsUntilStateChange: -5377.2476
       state: Closing
   - uid: 5750
     components:
@@ -103229,6 +103230,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: 16.5,-2.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        10272:
+        - - DoorStatus
+          - Close
   - uid: 758
     components:
     - type: Transform
@@ -103264,18 +103272,6 @@ entities:
       parent: 2
     - type: AccessReader
       accessListsOriginal: []
-  - uid: 7775
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,-1.5
-      parent: 2
-  - uid: 7778
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-1.5
-      parent: 2
   - uid: 14990
     components:
     - type: Transform
@@ -103592,6 +103588,15 @@ entities:
     - type: Transform
       pos: 16.5,-2.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        563:
+        - - DoorStatus
+          - Close
+    - type: AccessReader
+      accessListsOriginal: []
 - proto: WindoorSecureMedicalLocked
   entities:
   - uid: 9615


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Two mapping changes to Packed:
- The windoors at the HoP office's window are now linked to each other, and won't both stay open at the same time (like on most other maps).
- The windoors in the HoP line itself have been removed, since they don't really add anything other than making an already-cramped waiting area even more cramped.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Consistent mapping good
- I'm mostly sure that the HoP windoors on Packed used to work like this anyway so I think it's possible a recent mapping PR broke them? I could be wrong though
- I'm sick of waiting at the HoP desk and having the useless all-access windoor behind me constantly open and close because there's no space for me to stand without bumping into either it or the windoor in front of me

## Technical details
<!-- Summary of code changes for easier review. -->
Mapping changes

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Animation](https://github.com/user-attachments/assets/9184b0c5-6170-46b6-99a3-b2dcbc159633)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
MAPS:
- tweak: On Packed, the line in front of the Head of Personnel office no longer has windoors. (The windoors in the office itself remain.)
- fix: On Packed, the Head of Personnel office's windoors are now linked to each other, as on most other maps.