### PR TITLE
Skeletons are now affected by Holy damage

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -159,7 +159,7 @@
   id: Card
   coefficients:
     Slash: 2.0
-    Piercing: 0.1 # Holes easily poked through, but do little to structural integrity 
+    Piercing: 0.1 # Holes easily poked through, but do little to structural integrity
     Heat: 3.0
 
 - type: damageModifierSet
@@ -225,7 +225,7 @@
     Poison: 0.0
     Radiation: 0.0
 
-# immune to everything except physical and heat damage
+# immune to everything except physical and heat damage; vulnerable to holy damage because they're undead, but not as vulnerable as a ghost or demon would be
 - type: damageModifierSet
   id: Skeleton
   coefficients:
@@ -238,6 +238,7 @@
     Asphyxiation: 0.0
     Bloodloss: 0.0
     Cellular: 0.0
+    Holy: 0.5
   flatReductions:
     Blunt: 5
 

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -17,8 +17,8 @@
     requiredLegs: 2
     gibSound: /Audio/Effects/bone_rattle.ogg
   - type: Damageable
-    damageContainer: Biological
-    damageModifierSet: Skeleton
+    damageContainer: BiologicalMetaphysical # Allows them to take Holy damage
+    damageModifierSet: Skeleton # If we get non-Holy metaphysical damage types in the future, the Skeleton set might need to be adjusted to provide immunity to them (depends on what exactly the new types are)
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:
@@ -82,9 +82,10 @@
       effects: # TODO: when magic is around - make a milk transformation to a skeleton monster
       - !type:HealthChange
         damage:
-          groups:
-            Burn: -1 # healing obviously up to discussion
-            Brute: -0.75 # these groups are the only 2 possible ways to damage a skeleton
+          groups: # these groups are the only 3 possible ways to damage a skeleton. numerical values obviously up to discussion
+            Burn: -1
+            Brute: -0.75
+            Metaphysical: -2 # Gameplay: skeletons need some way to heal holy damage. Lore: milk is an unholy liquid that shuns the light of god. (/j)
       - !type:PopupMessage
         type: Local
         visualType: Large


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Skeletons are now affected by Holy damage (50% resistance). They can also heal Holy damage with milk (2 damage per 1u).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
"Holy magic kills undead" is a classic fantasy trope. Given that this game has both holy magic and undead in it I think including the trope is fun. In gameplay terms, I think this results in fun potential interactions between the Chaplain and any skeletons (e.g the Chaplain handing out flasks of holy water to the crew to help them defend themselves against a particularly violent skeleton).

This change is **NOT** intended to make the Chaplain a "hard counter" to skeleton, nor a necessity for fighting one. Generally speaking, sources of Holy damage (namely, the Chaplain's holy book, and by extension holy water) are intended to be about as effective against a skeleton as typical decent-but-not-overwhelming improvised weapon. This is the main reason for skeletons having 50% resistance to holy damage; it makes the bible _roughly_ as effective as something like a baseball bat.

Given how rare Holy damage is, and how few things are affected by it, the numbers here (both in regards to skeletons specifically and in regards to Holy damage overall) are subject to change in the future. Given that skeletons have 100 health (same as normal players) I might want to reduce the bible to something like 15 holy (similar to a bat), have skeletons take 1x holy damage (making them a "default standard" for measuring how strong any given source of Holy damage should be), and bump up the multipliers against creatures specifically weak to Holy damage (since something like a revenant should be highly susceptible to it). That kind of fine-tuning should probably be its own PR though.

## Technical details
<!-- Summary of code changes for easier review. -->
- Skeletons now use the BiologicalMetaphysical damageContainer
- The Skeleton damageModifierSet now lists Holy damage with a coefficient of 0.5
- Skeletons' Reactive component now has the milk reaction(s) change Metaphysical damage by -2

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://imgur.com/a/moss-skeletonsmiting-a14p7Lp

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Skeletons are now vulnerable to Holy damage from sources such as the space bible or holy water.