### PR TITLE
Hitscans now have names

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -18,6 +18,7 @@
 
 - type: entity
   id: BasicHitscan
+  name: basic laser ray
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanAmmo
@@ -38,6 +39,7 @@
 - type: entity
   parent: BasicHitscan
   id: RedLightLaser
+  name: red light laser ray
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
@@ -48,6 +50,7 @@
 - type: entity
   parent: BasicHitscan
   id: RedLaser
+  name: red laser ray
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
@@ -58,6 +61,7 @@
 - type: entity
   parent: BasicHitscan
   id: RedMediumLaser
+  name: red amplified laser ray
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
@@ -68,6 +72,7 @@
 - type: entity
   parent: BasicHitscan
   id: RedHeavyLaser
+  name: red high-energy laser ray
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
@@ -88,6 +93,7 @@
 - type: entity
   parent: BasicHitscan
   id: RedLaserPractice
+  name: red practice laser ray
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
@@ -98,6 +104,7 @@
 - type: entity
   parent: BasicHitscan
   id: XrayLaser
+  name: X-ray pulse beam
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
@@ -119,6 +126,7 @@
 - type: entity
   parent: BasicHitscan
   id: Pulse
+  name: blue high-energy laser ray
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
@@ -139,6 +147,7 @@
 - type: entity
   parent: BasicHitscan
   id: RedShuttleLaser
+  name: shuttle class red laser ray
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicRaycast
@@ -162,6 +171,7 @@
 - type: entity
   parent: BasicHitscan
   id: DebugLaser
+  name: debug laser ray
   suffix: DEBUG
   categories: [ HideSpawnMenu ]
   components:
@@ -183,6 +193,7 @@
 - type: entity
   parent: DebugLaser
   id: DebugLaserGib
+  name: debug gibbing ray
   suffix: DEBUG
   categories: [ HideSpawnMenu ]
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The hitscans have been given names. That's all.

## Why / Balance
When I was working with my PR #41744 I encountered the problem that the hitscans don't have a name, which is not critical in general, but it forces me to get the ID of its prototype instead of the hitscan's name. Even the projectiles have their own names.
In general, this can be useful not only for my PR, if someone needs to get the name of the hitscan in their code.

## Technical details
<!-- Summary of code changes for easier review. -->
Only YAML changes in `hitscan.yml`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**

