### PR TITLE
Reverts Mop + Glowstick Storage Rotation

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -37,7 +37,6 @@
   - type: Item
     size: Large
     sprite: Objects/Specific/Janitorial/mop.rsi
-    storedRotation: 45
   - type: Absorbent
     useAbsorberSolution: true
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
@@ -30,7 +30,6 @@
   - type: Item
     sprite: Objects/Misc/glowstick.rsi
     heldPrefix: unlit
-    storedRotation: -45
   - type: Appearance
   - type: PointLight
     enabled: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reverts part of [#41149] - Specifically the rotation on the Mops and Glowsticks

## Why / Balance
When items are rotated at awkward non-right angles for inventory storage it creates frequent visual glitches (Seen in the preview for #41149 with the ointment) and also just looks quite frankly: bad.

Currently storage sprites don't support multiple layers which breaks both the fill levels on the mops and the main function of the glowstick when both are stored. I tried making new storage sprites for these items but was unable to fix this issue since that requires coding. I'd rather have these rotations reverted since currently the awkward rotations cause visual glitches when stored.

If anyone can code these functions into the storage sprites for the Mops + Glowsticks I'd be happy to pass the new sprites to you.

## Technical details
Two lines of Yaml.

## Media
Not Necessary

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
N/A