### PR TITLE
Revert "Trip APCs when they exceed a power limit (#41377)"

### DIFF
--- a/Content.Client/Power/APC/UI/ApcMenu.xaml
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml
@@ -19,7 +19,7 @@
                         <!-- Power On/Off -->
                         <Label Text="{Loc 'apc-menu-breaker-label'}" HorizontalExpand="True"
                                 StyleClasses="highlight" MinWidth="120"/>
-                        <BoxContainer Orientation="Horizontal" MinWidth="150">
+                        <BoxContainer Orientation="Horizontal" MinWidth="90">
                             <Button Name="BreakerButton" Text="{Loc 'apc-menu-breaker-button'}" HorizontalExpand="True" ToggleMode="True"/>
                         </BoxContainer>
                         <!--Charging Status-->

--- a/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
@@ -40,14 +40,7 @@ namespace Content.Client.Power.APC.UI
 
             if (PowerLabel != null)
             {
-                if (castState.Tripped)
-                {
-                    PowerLabel.Text = Loc.GetString("apc-menu-power-state-label-tripped");
-                }
-                else
-                {
-                    PowerLabel.Text = Loc.GetString("apc-menu-power-state-label-text", ("power", castState.Power), ("maxLoad", castState.MaxLoad));
-                }
+                PowerLabel.Text = Loc.GetString("apc-menu-power-state-label-text", ("power", castState.Power));
             }
 
             if (ExternalPowerStateLabel != null)

--- a/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
+++ b/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
@@ -7,11 +7,11 @@ using Content.Server.Power.NodeGroups;
 using Content.Server.Power.Pow3r;
 using Content.Shared.Power.Components;
 using Content.Shared.NodeContainer;
-using Robust.Server.GameObjects;
 using Robust.Shared.EntitySerialization;
 
 namespace Content.IntegrationTests.Tests.Power;
 
+[Explicit]
 public sealed class StationPowerTests
 {
     /// <summary>
@@ -21,21 +21,27 @@ public sealed class StationPowerTests
 
     private static readonly string[] GameMaps =
     [
+        "Fland",
+        "Meta",
+        "Packed",
+        "Omega",
         "Bagel",
         "Box",
-        "Elkridge",
-        "Fland",
+        "Core",
         "Marathon",
-        "Oasis",
-        "Packed",
-        "Plasma",
-        "Relic",
-        "Snowball",
+        "Saltern",
         "Reach",
-        "Exo",
+        "Train",
+        "Oasis",
+        "Gate",
+        "Amber",
+        "Loop",
+        "Plasma",
+        "Elkridge",
+        "Convex",
+        "Relic",
     ];
 
-    [Explicit]
     [Test, TestCaseSource(nameof(GameMaps))]
     public async Task TestStationStartingPowerWindow(string mapProtoId)
     {
@@ -94,54 +100,6 @@ public sealed class StationPowerTests
                 $"Needs at least {requiredStoredPower - totalStartingCharge} more stored power!");
         });
 
-        await pair.CleanReturnAsync();
-    }
-
-    [Test, TestCaseSource(nameof(GameMaps))]
-    public async Task TestApcLoad(string mapProtoId)
-    {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Dirty = true,
-        });
-        var server = pair.Server;
-
-        var entMan = server.EntMan;
-        var protoMan = server.ProtoMan;
-        var ticker = entMan.System<GameTicker>();
-        var xform = entMan.System<TransformSystem>();
-
-        // Load the map
-        await server.WaitAssertion(() =>
-        {
-            Assert.That(protoMan.TryIndex<GameMapPrototype>(mapProtoId, out var mapProto));
-            var opts = DeserializationOptions.Default with { InitializeMaps = true };
-            ticker.LoadGameMap(mapProto, out var mapId, opts);
-        });
-
-        // Wait long enough for power to ramp up, but before anything can trip
-        await pair.RunSeconds(2);
-
-        // Check that no APCs start overloaded
-        var apcQuery = entMan.EntityQueryEnumerator<ApcComponent, PowerNetworkBatteryComponent>();
-        Assert.Multiple(() =>
-        {
-            while (apcQuery.MoveNext(out var uid, out var apc, out var battery))
-            {
-                // Uncomment the following line to log starting APC load to the console
-                //Console.WriteLine($"ApcLoad:{mapProtoId}:{uid}:{battery.CurrentSupply}");
-                if (xform.TryGetMapOrGridCoordinates(uid, out var coord))
-                {
-                    Assert.That(apc.MaxLoad, Is.GreaterThanOrEqualTo(battery.CurrentSupply),
-                            $"APC {uid} on {mapProtoId} ({coord.Value.X}, {coord.Value.Y}) is overloaded {battery.CurrentSupply} / {apc.MaxLoad}");
-                }
-                else
-                {
-                    Assert.That(apc.MaxLoad, Is.GreaterThanOrEqualTo(battery.CurrentSupply),
-                            $"APC {uid} on {mapProtoId} is overloaded {battery.CurrentSupply} / {apc.MaxLoad}");
-                }
-            }
-        });
 
         await pair.CleanReturnAsync();
     }

--- a/Content.Server/Power/Components/ApcComponent.cs
+++ b/Content.Server/Power/Components/ApcComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Power.Components;
 
-[RegisterComponent, AutoGenerateComponentPause]
+[RegisterComponent]
 public sealed partial class ApcComponent : BaseApcNetComponent
 {
     [DataField("onReceiveMessageSound")]
@@ -33,32 +33,6 @@ public sealed partial class ApcComponent : BaseApcNetComponent
 
     public const float HighPowerThreshold = 0.9f;
     public static TimeSpan VisualsChangeDelay = TimeSpan.FromSeconds(1);
-
-    /// <summary>
-    /// Maximum continuous load in Watts that this APC can supply to loads. Exceeding this starts a
-    /// timer, which after enough overloading causes the APC to "trip" off.
-    /// </summary>
-    [DataField]
-    public float MaxLoad = 20e3f;
-
-    /// <summary>
-    /// Time that the APC can be continuously overloaded before tripping off.
-    /// </summary>
-    [DataField]
-    public TimeSpan TripTime = TimeSpan.FromSeconds(3);
-
-    /// <summary>
-    /// Time that overloading began.
-    /// </summary>
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
-    public TimeSpan? TripStartTime;
-
-    /// <summary>
-    /// Set to true if the APC tripped off. Used to indicate problems in the UI. Reset by switching
-    /// APC on.
-    /// </summary>
-    [DataField]
-    public bool TripFlag;
 
     // TODO ECS power a little better!
     // End the suffering

--- a/Content.Shared/APC/SharedApc.cs
+++ b/Content.Shared/APC/SharedApc.cs
@@ -181,17 +181,13 @@ namespace Content.Shared.APC
         public readonly int Power;
         public readonly ApcExternalPowerState ApcExternalPower;
         public readonly float Charge;
-        public readonly float MaxLoad;
-        public readonly bool Tripped;
 
-        public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge, float maxLoad, bool tripped)
+        public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge)
         {
             MainBreaker = mainBreaker;
             Power = power;
             ApcExternalPower = apcExternalPower;
             Charge = charge;
-            MaxLoad = maxLoad;
-            Tripped = tripped;
         }
 
         public bool Equals(ApcBoundInterfaceState? other)
@@ -201,9 +197,7 @@ namespace Content.Shared.APC
             return MainBreaker == other.MainBreaker &&
                    Power == other.Power &&
                    ApcExternalPower == other.ApcExternalPower &&
-                   MathHelper.CloseTo(Charge, other.Charge) &&
-                   MathHelper.CloseTo(MaxLoad, other.MaxLoad) &&
-                   Tripped == other.Tripped;
+                   MathHelper.CloseTo(Charge, other.Charge);
         }
 
         public override bool Equals(object? obj)
@@ -213,7 +207,7 @@ namespace Content.Shared.APC
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(MainBreaker, Power, (int) ApcExternalPower, Charge, MaxLoad, Tripped);
+            return HashCode.Combine(MainBreaker, Power, (int) ApcExternalPower, Charge);
         }
     }
 

--- a/Resources/Locale/en-US/ui/power-apc.ftl
+++ b/Resources/Locale/en-US/ui/power-apc.ftl
@@ -10,8 +10,7 @@ apc-menu-charge-label = {$percent} Charged
 apc-menu-power-state-good = Good
 apc-menu-power-state-low = Low
 apc-menu-power-state-none = None
-apc-menu-power-state-label-text = { POWERWATTS($power) } / { POWERWATTS($maxLoad) }
-apc-menu-power-state-label-tripped = OVERLOAD
+apc-menu-power-state-label-text = { POWERWATTS($power) }
 
 # For the flavor text on the footer
 

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
@@ -38,6 +38,6 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: ApcPowerReceiver
-    powerLoad: 5000
+    powerLoad: 15000
   - type: StaticPrice
     price: 7500


### PR DESCRIPTION
## About the PR
Reverts the APC power tripping change for Stable.

## Why / Balance
Unfortunately we've received a lot of information after we've done the release that Vulture didn't really report anything and that there are some really bad problems - for example almost all medbays are not designed correctly (one APC for all of medbay instead of per-room) so they will trip very easily.

Hotfixing all maps to `stable` is just a really bad idea, I would much rather just fix them progressively on `master` and then do a proper release in 2 weeks time.

## Technical details
n/a

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
stable CL nonexistant
