### PR TITLE
Fix to properly randomize Pun Pun's suit sensors

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -41,7 +41,6 @@
     sprite: Clothing/Uniforms/Jumpsuit/punpun.rsi
   - type: SuitSensor
     controlsLocked: false
-    randomMode: false
     mode: SensorCords
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed one line in jumpsuits.yml to properly randomize Pun Pun's suit sensors.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I don't see any particular reason why Pun's sensors *shouldn't* be randomize, as the rest of crew are.
## Technical details
<!-- Summary of code changes for easier review. -->
Removes "randomMode: false" from "ClothingUniformJumpsuitJacketMonkey" in jumpsuits.yml
## Media
N/A, not needed particularly 
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: jckspjf
- tweak: Pun Pun's jumpsuit now properly randomizes his suit sensors.