### PR TITLE
fix elkridge APC powernet

### DIFF
--- a/Resources/Maps/elkridge.yml
+++ b/Resources/Maps/elkridge.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 267.3.0
+  engineVersion: 268.0.0
   forkId: ""
   forkVersion: ""
-  time: 11/04/2025 19:47:26
-  entityCount: 18697
+  time: 12/07/2025 22:51:59
+  entityCount: 18708
 maps:
 - 1
 grids:
@@ -10821,6 +10821,7 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: ImplicitRoof
+    - type: ExplosionAirtightGrid
 - proto: AcousticGuitarInstrument
   entities:
   - uid: 15607
@@ -17080,6 +17081,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: 35.5,-32.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
     - type: Fixtures
       fixtures: {}
   - uid: 9111
@@ -17417,6 +17421,16 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,35.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14562
+    components:
+    - type: MetaData
+      name: APC (Atmospherics Lower)
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 34.5,-41.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -28248,11 +28262,6 @@ entities:
     - type: Transform
       pos: 13.5,-23.5
       parent: 2
-  - uid: 8893
-    components:
-    - type: Transform
-      pos: 26.5,-31.5
-      parent: 2
   - uid: 8894
     components:
     - type: Transform
@@ -31781,7 +31790,7 @@ entities:
   - uid: 12628
     components:
     - type: Transform
-      pos: 33.5,-31.5
+      pos: 34.5,-41.5
       parent: 2
   - uid: 12629
     components:
@@ -31942,6 +31951,11 @@ entities:
     components:
     - type: Transform
       pos: -27.5,25.5
+      parent: 2
+  - uid: 12769
+    components:
+    - type: Transform
+      pos: 27.5,-40.5
       parent: 2
   - uid: 12859
     components:
@@ -32282,11 +32296,6 @@ entities:
     components:
     - type: Transform
       pos: 29.5,-32.5
-      parent: 2
-  - uid: 14562
-    components:
-    - type: Transform
-      pos: 29.5,-31.5
       parent: 2
   - uid: 14563
     components:
@@ -42039,6 +42048,11 @@ entities:
     - type: Transform
       pos: 40.5,-17.5
       parent: 2
+  - uid: 8893
+    components:
+    - type: Transform
+      pos: 33.5,-32.5
+      parent: 2
   - uid: 8974
     components:
     - type: Transform
@@ -45389,6 +45403,16 @@ entities:
     - type: Transform
       pos: -37.5,14.5
       parent: 2
+  - uid: 17542
+    components:
+    - type: Transform
+      pos: 33.5,-31.5
+      parent: 2
+  - uid: 17543
+    components:
+    - type: Transform
+      pos: 33.5,-33.5
+      parent: 2
   - uid: 17594
     components:
     - type: Transform
@@ -45633,6 +45657,51 @@ entities:
     components:
     - type: Transform
       pos: -11.5,-7.5
+      parent: 2
+  - uid: 18700
+    components:
+    - type: Transform
+      pos: 33.5,-34.5
+      parent: 2
+  - uid: 18701
+    components:
+    - type: Transform
+      pos: 33.5,-35.5
+      parent: 2
+  - uid: 18702
+    components:
+    - type: Transform
+      pos: 33.5,-36.5
+      parent: 2
+  - uid: 18703
+    components:
+    - type: Transform
+      pos: 33.5,-37.5
+      parent: 2
+  - uid: 18704
+    components:
+    - type: Transform
+      pos: 33.5,-38.5
+      parent: 2
+  - uid: 18705
+    components:
+    - type: Transform
+      pos: 33.5,-39.5
+      parent: 2
+  - uid: 18706
+    components:
+    - type: Transform
+      pos: 33.5,-40.5
+      parent: 2
+  - uid: 18707
+    components:
+    - type: Transform
+      pos: 33.5,-41.5
+      parent: 2
+  - uid: 18708
+    components:
+    - type: Transform
+      pos: 34.5,-41.5
       parent: 2
 - proto: CableMVStack
   entities:
@@ -102717,13 +102786,6 @@ entities:
       fixtures: {}
 - proto: SignNosmoking
   entities:
-  - uid: 12769
-    components:
-    - type: Transform
-      pos: 34.5,-41.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 12772
     components:
     - type: Transform


### PR DESCRIPTION
## About the PR
atomize elkridge APC atmospherics powernet

## Why / Balance
it was too close to overloading and needed a second apc. most atmospherics departments have two APCs, one for atmos upper and one for atmos lower/proper

## Technical details
n/a

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
MAPS:
- fix: On Elkridge, atomized the LV network for Atmospherics.