### PR TITLE
Fix test compile errors when updating dependencies

### DIFF
--- a/Content.Benchmarks/Content.Benchmarks.csproj
+++ b/Content.Benchmarks/Content.Benchmarks.csproj
@@ -9,6 +9,7 @@
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>12</LangVersion>
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />

--- a/Content.MapRenderer/Content.MapRenderer.csproj
+++ b/Content.MapRenderer/Content.MapRenderer.csproj
@@ -5,6 +5,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>enable</Nullable>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Content.YAMLLinter/Content.YAMLLinter.csproj
+++ b/Content.YAMLLinter/Content.YAMLLinter.csproj
@@ -5,6 +5,7 @@
         <OutputPath>..\bin\Content.YAMLLinter\</OutputPath>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <ServerGarbageCollection>true</ServerGarbageCollection>
+        <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
     </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Ran across this while updating dependencies on the RT .NET 10 update. Should be fine to merge immediately.
