### PR TITLE
Scram bugfixes

### DIFF
--- a/Content.Shared/Trigger/Systems/ScramOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/ScramOnTriggerSystem.cs
@@ -93,6 +93,7 @@ public sealed class ScramOnTriggerSystem : XOnTriggerSystem<ScramOnTriggerCompon
         do
         {
             var valid = false;
+            // Creates the smallest possible bounding square that fits a circle with radius r, which has side length r*2
             var box = Box2.CenteredAround(userCoords.Position, new Vector2(radius*2, radius*2));
             var tilesInRange = _map.GetTilesEnumerator(targetGrid.Value.Owner, targetGrid.Value.Comp, box, false);
             var tileList = new ValueList<Vector2i>();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Scram implant now works when on a grid and 100+ tiles away from the center
Scram implant now properly teleports you within a 100 tile range, up from 5

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
partially fixes bugs addressed in #41785 

This should be superseded by a scram logic rework or a reversion of scram logic to its original state

## Technical details
<!-- Summary of code changes for easier review. -->
Removed arbitrary square rooting of teleportation radius
Shuffled some logic around and added the user's current grid to the pool of target grids, so the implant will always work if you are on a grid

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Scram implant now works when on a grid and 100+ tiles away from the center
- fix: Scram implant now properly teleports you within a 100 tile range, up from 5
