### PR TITLE
Fix batteries not counting towards the battery bounty

### DIFF
--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -519,6 +519,7 @@
     whitelist:
       components:
       - Battery
+      - PredictedBattery
 
 - type: cargoBounty
   id: BountyLaserGun


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
HOPEFULLY fixed the battery bounty not working

## Technical details
<!-- Summary of code changes for easier review. -->
Added "PredictedBattery" to the components whitelist of the bounty

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
