### PR TITLE
Remove flammability mass

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -221,8 +221,8 @@ namespace Content.Server.Atmos.EntitySystems
             var mass2 = 1f;
             if (_physicsQuery.TryComp(uid, out var physics) && _physicsQuery.TryComp(otherUid, out var otherPhys))
             {
-                mass1 = physics.Mass + 0.1f;   // Plus 0.1 to avoid possible div/0
-                mass2 = otherPhys.Mass + 0.1f;
+                mass1 = physics.Mass;
+                mass2 = otherPhys.Mass;
             }
 
             // Get the average of both entity's firestacks * mass


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Flammable objects do not gain mass.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This seems like an oversight in the original code.

## Technical details
<!-- Summary of code changes for easier review. -->
FlammableComponent adds a fixture for flammable detection. This fixture is given a density of one, as the default value.
However, this adds to the overall mass of the object despite not actually applying a physical characteristic. I have changed the fixture to have a density of zero.

I also add 0.1 to the detected mass in the flamestack transfer portion of the system to avoid a potential divide by zero or flamestack deletion if an already massless item collides. This should make the behavior of flammable items nearly the same, other than being slightly lighter. 

The mass of the previous fixture was 0.38. I reduced this to 0.1 to also reduce the impact of very light items and provide a nice simple number.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Flammable items no longer have bonus mass.