### PR TITLE
ScramOnTrigger teleportation logic rewrite

### DIFF
--- a/Content.Shared/Trigger/Systems/ScramOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/ScramOnTriggerSystem.cs
@@ -20,14 +20,6 @@ public sealed class ScramOnTriggerSystem : XOnTriggerSystem<ScramOnTriggerCompon
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly TurfSystem _turfSystem = default!;
 
-    private EntityQuery<PhysicsComponent> _physicsQuery;
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        _physicsQuery = GetEntityQuery<PhysicsComponent>();
-    }
-
     protected override void OnTrigger(Entity<ScramOnTriggerComponent> ent, EntityUid target, ref TriggerEvent args)
     {
         // We need stop the user from being pulled so they don't just get "attached" with whoever is pulling them.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Rewrote logic in ScramOnTrigger, specifically the SelectRandomTileInRange method.

Supersedes #41786

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #41785
Resolves #31480

This reworks the scram teleportation logic.

This is because the previous logic had multiple fundamental flaws that were not solvable. 
It also introduced several hard-to-pinpoint bugs. 
It also disproportionally weighed small grids compared to larger ones. 
It also did not teleport the user in a circle with a given radius but instead teleported the user in a square which used the rotation of the map and not the current grid. 
It also did not solve the issue of teleporting into space. 
It also did not correctly find non-space tiles. 
It also did not use the correct formula for calculating the side length of the largest square that fits inside a circle. 
It also had a terrible runtime complexity, with a worst-case runtime being at least 20000 operations due enumerating through every tile within range and a combination of the square it used to check for valid teleportation tiles not being lined up with the map and a bug that made it always find the bounding square to be completely filled with tiles. Luckily this never occurred in practice because the error in the formula for calculating the side length of the largest square that fits inside a circle made the volume of the bounding square 1% of the the intended volume.

Given the sheer quantity of issues I opted for a rewrite.

## Technical details
<!-- Summary of code changes for easier review. -->
SelectRandomTileInRange has been mostly rewritten.

The method now makes a series of attempts at finding a random empty non-space tile within a certain radius, and returns null if no tile is found.

On each attempt, a random distance from 0 to radius is calculated(trending towards the upper range), which is then shrunk down based on the current attempt count. This means later attempts will look for areas closer to the player. This is primarily so that the method does not fail more frequently on smaller stations.
A random target coordinate vector is calculated by multiplying the previously attained distance by a random angle.
We check if the tile at the target coordinate vector exists, is not space, and is not blocked. If the check passes, we stop running attempts and return the coordinates.
If every attempt fails, null is returned.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/cc1b2220-2442-4545-a1fb-4b3093b5a637



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The scram implanter now teleports you within a 100 tile radius, as originally intended, and will not teleport you into open space.