### PR TITLE
Fix rigged power cells exploding early

### DIFF
--- a/Content.Server/Power/EntitySystems/BatterySystem.API.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.API.cs
@@ -26,7 +26,7 @@ public sealed partial class BatterySystem
 
         TrySetChargeCooldown(ent.Owner);
 
-        var ev = new ChargeChangedEvent(ent.Comp.CurrentCharge, ent.Comp.MaxCharge);
+        var ev = new ChargeChangedEvent(ent.Comp.CurrentCharge, delta, ent.Comp.MaxCharge);
         RaiseLocalEvent(ent, ref ev);
         return delta;
     }
@@ -61,21 +61,23 @@ public sealed partial class BatterySystem
             return;
         }
 
-        var ev = new ChargeChangedEvent(ent.Comp.CurrentCharge, ent.Comp.MaxCharge);
+        var ev = new ChargeChangedEvent(ent.Comp.CurrentCharge, ent.Comp.CurrentCharge - oldCharge, ent.Comp.MaxCharge);
         RaiseLocalEvent(ent, ref ev);
     }
+
     public override void SetMaxCharge(Entity<BatteryComponent?> ent, float value)
     {
         if (!Resolve(ent, ref ent.Comp))
             return;
 
         var old = ent.Comp.MaxCharge;
+        var oldCharge = ent.Comp.CurrentCharge;
         ent.Comp.MaxCharge = Math.Max(value, 0);
         ent.Comp.CurrentCharge = Math.Min(ent.Comp.CurrentCharge, ent.Comp.MaxCharge);
         if (MathHelper.CloseTo(ent.Comp.MaxCharge, old))
             return;
 
-        var ev = new ChargeChangedEvent(ent.Comp.CurrentCharge, ent.Comp.MaxCharge);
+        var ev = new ChargeChangedEvent(ent.Comp.CurrentCharge, ent.Comp.CurrentCharge - oldCharge, ent.Comp.MaxCharge);
         RaiseLocalEvent(ent, ref ev);
     }
 

--- a/Content.Server/Power/EntitySystems/RiggableSystem.cs
+++ b/Content.Server/Power/EntitySystems/RiggableSystem.cs
@@ -101,8 +101,9 @@ public sealed class RiggableSystem : EntitySystem
         if (args.CurrentCharge == 0f)
             return; // No charge to cause an explosion.
 
-        if (args.CurrentChargeRate != 0f)
-            return; // We are not draining or charging the device.
+        // Don't explode if we are not using any charge.
+        if (args.CurrentChargeRate == 0f && args.Delta == 0f)
+            return;
 
         Explode(ent, args.CurrentCharge);
     }

--- a/Content.Shared/Power/ChargeEvents.cs
+++ b/Content.Shared/Power/ChargeEvents.cs
@@ -8,7 +8,23 @@ namespace Content.Shared.Power;
 /// Only raised for entities with <see cref="BatteryComponent"/>.
 /// </summary>
 [ByRefEvent]
-public readonly record struct ChargeChangedEvent(float Charge, float MaxCharge);
+public readonly record struct ChargeChangedEvent(float Charge, float Delta, float MaxCharge)
+{
+    /// <summary>
+    /// The new charge of the battery.
+    /// </summary>
+    public readonly float Charge = Charge;
+
+    /// <summary>
+    /// The amount the charge was changed by.
+    /// </summary>
+    public readonly float Delta = Delta;
+
+    /// <summary>
+    /// The maximum charge of the battery.
+    /// </summary>
+    public readonly float MaxCharge = MaxCharge;
+}
 
 /// <summary>
 /// Raised when a predicted battery's charge or capacity changes (capacity affects relative charge percentage).
@@ -18,7 +34,29 @@ public readonly record struct ChargeChangedEvent(float Charge, float MaxCharge);
 /// Only raised for entities with <see cref="PredictedBatteryComponent"/>.
 /// </summary>
 [ByRefEvent]
-public readonly record struct PredictedBatteryChargeChangedEvent(float CurrentCharge, float CurrentChargeRate, TimeSpan CurrentTime, float MaxCharge);
+public readonly record struct PredictedBatteryChargeChangedEvent(float CurrentCharge, float Delta, float CurrentChargeRate, float MaxCharge)
+{
+    /// <summary>
+    /// The new charge of the battery.
+    /// </summary>
+    public readonly float CurrentCharge = CurrentCharge;
+
+    /// <summary>
+    /// The amount the charge was changed by.
+    /// This might be 0 if only the charge rate was modified.
+    /// </summary>
+    public readonly float Delta = Delta;
+
+    /// <summary>
+    /// The new charge rate of the battery.
+    /// </summary>
+    public readonly float CurrentChargeRate = CurrentChargeRate;
+
+    /// <summary>
+    /// The maximum charge of the battery.
+    /// </summary>
+    public readonly float MaxCharge = MaxCharge;
+}
 
 /// <summary>
 /// Raised when a battery changes its state between full, empty, or neither.

--- a/Content.Shared/Power/EntitySystems/PredictedBatterySystem.API.cs
+++ b/Content.Shared/Power/EntitySystems/PredictedBatterySystem.API.cs
@@ -36,7 +36,7 @@ public sealed partial class PredictedBatterySystem
 
         TrySetChargeCooldown(ent.Owner);
 
-        var changedEv = new PredictedBatteryChargeChangedEvent(newValue, ent.Comp.ChargeRate, curTime, ent.Comp.MaxCharge);
+        var changedEv = new PredictedBatteryChargeChangedEvent(newValue, delta, ent.Comp.ChargeRate, ent.Comp.MaxCharge);
         RaiseLocalEvent(ent, ref changedEv);
 
         // Raise events if the battery status changed between full, empty, or neither.
@@ -95,7 +95,7 @@ public sealed partial class PredictedBatterySystem
         ent.Comp.LastUpdate = curTime;
         Dirty(ent);
 
-        var ev = new PredictedBatteryChargeChangedEvent(newValue, ent.Comp.ChargeRate, curTime, ent.Comp.MaxCharge);
+        var ev = new PredictedBatteryChargeChangedEvent(newValue, delta, ent.Comp.ChargeRate, ent.Comp.MaxCharge);
         RaiseLocalEvent(ent, ref ev);
 
         // Raise events if the battery status changed between full, empty, or neither.
@@ -115,13 +115,14 @@ public sealed partial class PredictedBatterySystem
         if (value == ent.Comp.MaxCharge)
             return;
 
+        var oldCharge = GetCharge(ent);
         ent.Comp.MaxCharge = Math.Max(value, 0);
         ent.Comp.LastCharge = GetCharge(ent); // This clamps it using the new max.
         var curTime = _timing.CurTime;
         ent.Comp.LastUpdate = curTime;
         Dirty(ent);
 
-        var ev = new PredictedBatteryChargeChangedEvent(ent.Comp.LastCharge, ent.Comp.ChargeRate, curTime, ent.Comp.MaxCharge);
+        var ev = new PredictedBatteryChargeChangedEvent(ent.Comp.LastCharge, ent.Comp.LastCharge - oldCharge, ent.Comp.ChargeRate, ent.Comp.MaxCharge);
         RaiseLocalEvent(ent, ref ev);
 
         // Raise events if the battery status changed between full, empty, or neither.
@@ -240,7 +241,7 @@ public sealed partial class PredictedBatterySystem
         Dirty(ent);
 
         // Inform other systems about the new rate;
-        var changedEv = new PredictedBatteryChargeChangedEvent(ent.Comp.LastCharge, ent.Comp.ChargeRate, curTime, ent.Comp.MaxCharge);
+        var changedEv = new PredictedBatteryChargeChangedEvent(ent.Comp.LastCharge, 0f, ent.Comp.ChargeRate, ent.Comp.MaxCharge);
         RaiseLocalEvent(ent, ref changedEv);
 
         return refreshEv.NewChargeRate;


### PR DESCRIPTION
## About the PR
Power cells where exploding instantly when inserted into a device, not only when the device was toggled on.
Thanks to Bald Man reporting this.

## Why / Balance
bugfix

## Technical details
Added a check if the predicted battery is actually draining or charging when the event is raised (it might just be refreshing the charge rate, but the result can be 0).
Removed redundant TryComps since the needed information was already available in the event.
Removed `CurrentTime` from the event, I'm not even sure why it was in there, probably left over from an earlier version.

## Media
![ss14-ezgif com-optimize(1)](https://github.com/user-attachments/assets/03c6e448-f9e6-4830-9125-d813c7baa007)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Removed `PredictedBatteryChargeChangedEvent.CurrentTime`. Use `IGameTiming.CurTime` instead.

**Changelog**
:cl:
- fix: Fixed rigged power cells immediately exploding when inserted into a device even if it's toggled off.
