### PR TITLE
Fix borgs being able to throw items

### DIFF
--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -154,8 +154,9 @@ namespace Content.Server.Hands.Systems
                 !_actionBlockerSystem.CanThrow(player, throwEnt.Value))
                 return false;
 
-            if (_timing.CurTime < hands.NextThrowTime)
+            if (!hands.CanThrow || _timing.CurTime < hands.NextThrowTime)
                 return false;
+
             hands.NextThrowTime = _timing.CurTime + hands.ThrowCooldown;
 
             if (TryComp(throwEnt, out StackComponent? stack) && stack.Count > 1 && stack.ThrowIndividually)

--- a/Content.Shared/Hands/Components/HandsComponent.cs
+++ b/Content.Shared/Hands/Components/HandsComponent.cs
@@ -42,6 +42,12 @@ public sealed partial class HandsComponent : Component
     public bool DisableExplosionRecursion;
 
     /// <summary>
+    ///     Can this mob throw held items?
+    /// </summary>
+    [DataField]
+    public bool CanThrow = true;
+
+    /// <summary>
     ///     Modifies the speed at which items are thrown.
     /// </summary>
     [DataField]

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -87,6 +87,10 @@
     templateId: borg
   - type: Hands
     showInHands: false
+    # Borgs cannot throw items because their robotic arms are not very mobile and are clunky in the way they interact with things.
+    # If they do need to shoot something as a weapon it should use some sort of cannon module instead.
+    # This is important to prevent them from throwing explosive CLF3 beakers or similar.
+    canThrow: false
     disableExplosionRecursion: true
     canBeStripped: false
   - type: ComplexInteraction


### PR DESCRIPTION
## About the PR
Borgs can no longer throw items from whitelisted hands.

## Why / Balance
It was accidentally introduced in #38668 which allowed borgs to have whitelisted hands rather than being a deliberate balance change.

Borgs are currently often using it to throw explosive beakers, being themselves mostly immune to the damage.

Thematically I think them being able to throw items does not fit at all - they have clunky robotic arms and the modules they using to interact with their environment are parts of their bodies rather than agile and, flexible human arms. For cases where they need to throw something specific as a weapon it should instead be a dedicated launcher item.

Additionally borgs are restricted in the way they can interact by design to prevent them from becoming just a humanoid+. A borg with a non-whitelisted hand and the ability to throw would be closer to an IPC.

Most of our borg chassis look somewhat like this, to give a reference for what I mean with "thematically":
![13602608-1054942553482902](https://github.com/user-attachments/assets/5cbfe1ee-3c08-43fe-b403-dbe0d341a54f)

## Technical details
Added a simple bool to `HandsComponent`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed borgs being able to throw items.
