### PR TITLE
Remove remote detonation/disable from the robotics console.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1514,7 +1514,7 @@
   parent: BaseComputerAiAccess
   id: ComputerRoboticsControl
   name: robotics control console
-  description: Used to remotely monitor, disable and destroy the station's cyborgs.
+  description: Used to remotely monitor the station's cyborgs.
   components:
   - type: Sprite
     layers:
@@ -1529,6 +1529,7 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
   - type: RoboticsConsole
+    allowBorgControl: false
   - type: ActiveRadio
     channels:
     - Science


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. You can no longer remotely detonate or disable borgs with the robotics control console. Description updated as well.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is a mald PR. 
The smallest PRs have the biggest balance reasons.
I had a last straw moment a couple minutes ago where we had another one of over-escalation's classic hits.
> Sci finds out borgs are emagged or have bad laws.
> Sci decides to just start detonating borgs for fun.
> Borgs use law 3 to go out and destroy the robotics console.
> Sci gets made and destroys and wipes borg brains. 

It's hitting a point where we either need to ban all sci and borg players or just remove this feature.
The ability to remotely remove another player's ability to play the game is not fun, and it allows for easy breaches of escalation rules and has become too big of a focal point of silicon gameplay. 

## Technical details
<!-- Summary of code changes for easier review. -->
YAML only changes.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: You can no longer detonate or disable borgs with the robotics console. 
