### PR TITLE
Traitors can no longer roll social objectives.

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -5,7 +5,7 @@
     TraitorObjectiveGroupSteal: 1
     TraitorObjectiveGroupKill: 1
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
-    TraitorObjectiveGroupSocial: 1 #Involves helping/harming others without killing them or stealing their stuff
+  # TraitorObjectiveGroupSocial: 1 #Involves helping/harming others without killing them or stealing their stuff. Removed as part of the Traitor design document: "Solo Antagonists"
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSteal


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Traitors can no longer roll social objectives.

## Why / Balance
Traitor design document says traitors should not rely on each other.

## Technical details
Commented out 1 line

## Media
Not entirely sure what to put here?

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- remove: The "help fellow traitor" objective can no longer roll.