### PR TITLE
Add build configuration selector for vsc

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,6 +9,8 @@
             "type": "shell",
             "args": [
                 "build",
+                "--configuration",
+                "${input:build_configuratiotion}",
                 "/property:GenerateFullPaths=true", // Ask dotnet build to generate full paths for file names.
                 "/consoleloggerparameters:'ForceNoAlign;NoSummary'" // Do not generate summary otherwise it leads to duplicate errors in Problems panel
             ],
@@ -77,5 +79,14 @@
             },
             "problemMatcher": "$msCompile"
         }
-    ]
+    ],
+    "inputs": [
+        {
+            "id": "build_configuratiotion",
+            "description": "Dotnet build configuration",
+            "type": "pickString",
+            "options": ["Debug", "DebugOpt", "Tools", "Release"],
+            "default": "Debug"
+        },
+    ],
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a build configuration selector for vs code.
<!-- What did you change? -->

## Why / Balance
Because unlike rider and vs, it didnt have one
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Mentioning in [robust book](https://docs.spacestation14.com/en/robust-toolbox/build-configurations.html) may be needed. I know that its in the RT section, but its the only page that tells about them.
<!-- Summary of code changes for easier review. -->

## Media
<img width="897" height="223" alt="image" src="https://github.com/user-attachments/assets/db23bccf-4bcf-4bb0-a512-6ee961f2c8fa" />

<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Im not sure if its possible to skip the selector popup, so someone may dislike clicking enter every time if they only build in debug
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
I dont think its required
