### PR TITLE
Admin log now shows APC power toggle interactions

### DIFF
--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -2,7 +2,9 @@ using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Power.Pow3r;
 using Content.Shared.Access.Systems;
+using Content.Shared.Administration.Logs;
 using Content.Shared.APC;
+using Content.Shared.Database;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Emp;
 using Content.Shared.Popups;
@@ -18,6 +20,7 @@ namespace Content.Server.Power.EntitySystems;
 public sealed class ApcSystem : EntitySystem
 {
     [Dependency] private readonly AccessReaderSystem _accessReader = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly EmagSystem _emag = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
@@ -112,7 +115,7 @@ public sealed class ApcSystem : EntitySystem
 
         if (_accessReader.IsAllowed(args.Actor, uid))
         {
-            ApcToggleBreaker(uid, component);
+            ApcToggleBreaker(uid, component, user: args.Actor);
         }
         else
         {
@@ -121,7 +124,12 @@ public sealed class ApcSystem : EntitySystem
         }
     }
 
-    public void ApcToggleBreaker(EntityUid uid, ApcComponent? apc = null, PowerNetworkBatteryComponent? battery = null)
+    /// <summary>Toggles the enabled state of the APC's main breaker.</summary>
+    public void ApcToggleBreaker(
+        EntityUid uid,
+        ApcComponent? apc = null,
+        PowerNetworkBatteryComponent? battery = null,
+        EntityUid? user = null)
     {
         if (!Resolve(uid, ref apc, ref battery))
             return;
@@ -134,6 +142,13 @@ public sealed class ApcSystem : EntitySystem
 
         UpdateUIState(uid, apc);
         _audio.PlayPvs(apc.OnReceiveMessageSound, uid, AudioParams.Default.WithVolume(-2f));
+
+        if (user != null)
+        {
+            var humanReadableState = apc.MainBreakerEnabled ? "Enabled" : "Disabled";
+            _adminLogger.Add(LogType.ItemConfigure, LogImpact.Medium,
+                $"{ToPrettyString(user):user} set the main breaker state of {ToPrettyString(uid):entity} to {humanReadableState:state}.");
+        }
     }
 
     private void OnEmagged(EntityUid uid, ApcComponent comp, ref GotEmaggedEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
First PR!

Closes #41800.
Adds admin logging to the toggle main breaker interaction on APCs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Logging, see issue #41800.

## Technical details
<!-- Summary of code changes for easier review. -->
The method `ApcToggleBreaker` was modified to take an additional optional parameter corresponding to the user that toggled the breaker. If this parameter is provided, it will generate an admin log tracking the APC toggle state, the APC that was modified, and the user who toggled the APC.
The call to `ApcToggleBreaker` in `OnToggleMainBreaker` was updated to include the user that performed the interaction.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="664" height="93" alt="admin logs showing breaker state being toggled" src="https://github.com/user-attachments/assets/f352a4c0-a73f-4115-a0c1-1e76d24d4d7a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
The public method ApcToggleBreaker now takes one additional optional parameter corresponding to the user that toggled the breaker.
Update calls to use named parameters.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
ADMIN:
- add: The admin log now shows APC power toggle interactions.
