### PR TITLE
Necrosol (and Romerol) resurrect plants from the dead

### DIFF
--- a/Content.Server/EntityEffects/Effects/Botany/PlantAttributes/PlantResurrectEntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/Effects/Botany/PlantAttributes/PlantResurrectEntityEffectSystem.cs
@@ -18,8 +18,10 @@ public sealed partial class PlantResurrectEntityEffectSystem : EntityEffectSyste
         entity.Comp.Dead = false;
 
         if (entity.Comp.Health <= 0) //so that it doesn't immediately die again
+        {
             entity.Comp.Health = 1;
-
+            entity.Comp.Seed.Seedless = true; // revival makes plant sterile
+        }
         _plantHolder.CheckHealth(entity, entity.Comp);
         entity.Comp.UpdateSpriteAfterUpdate = true;
     }

--- a/Content.Server/EntityEffects/Effects/Botany/PlantAttributes/PlantResurrectEntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/Effects/Botany/PlantAttributes/PlantResurrectEntityEffectSystem.cs
@@ -20,7 +20,8 @@ public sealed partial class PlantResurrectEntityEffectSystem : EntityEffectSyste
         if (entity.Comp.Health <= 0) //so that it doesn't immediately die again
         {
             entity.Comp.Health = 1;
-            entity.Comp.Seed.Seedless = true; // revival makes plant sterile
+            if (args.Effect.ReviveSeedless)
+                entity.Comp.Seed.Seedless = true; // revival makes plant sterile
         }
         _plantHolder.CheckHealth(entity, entity.Comp);
         entity.Comp.UpdateSpriteAfterUpdate = true;

--- a/Content.Server/EntityEffects/Effects/Botany/PlantAttributes/PlantResurrectEntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/Effects/Botany/PlantAttributes/PlantResurrectEntityEffectSystem.cs
@@ -1,0 +1,26 @@
+using Content.Server.Botany.Components;
+using Content.Server.Botany.Systems;
+using Content.Shared.EntityEffects;
+using Content.Shared.EntityEffects.Effects.Botany.PlantAttributes;
+
+namespace Content.Server.EntityEffects.Effects.Botany.PlantAttributes;
+/// <summary>
+/// Plant Entityeffect that revives it from a dead state.
+/// </summary>
+public sealed partial class PlantResurrectEntityEffectSystem : EntityEffectSystem<PlantHolderComponent, PlantResurrect>
+{
+    [Dependency] private readonly PlantHolderSystem _plantHolder = default!;
+    protected override void Effect(Entity<PlantHolderComponent> entity, ref EntityEffectEvent<PlantResurrect> args)
+    {
+        if (entity.Comp.Seed == null)
+            return;
+
+        entity.Comp.Dead = false;
+
+        if (entity.Comp.Health <= 0) //so that it doesn't immediately die again
+            entity.Comp.Health = 1;
+
+        _plantHolder.CheckHealth(entity, entity.Comp);
+        entity.Comp.UpdateSpriteAfterUpdate = true;
+    }
+}

--- a/Content.Shared/EntityEffects/Effects/Botany/PlantAttributes/PlantResurrect.cs
+++ b/Content.Shared/EntityEffects/Effects/Botany/PlantAttributes/PlantResurrect.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.EntityEffects.Effects.Botany.PlantAttributes;
+
+/// <summary>
+///     Resurrects a dead plant
+/// </summary>
+public sealed partial class PlantResurrect : EntityEffectBase<PlantResurrect>
+{
+    public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys) =>
+        Loc.GetString("entity-effect-guidebook-plant-resurrect", ("chance", Probability));
+}

--- a/Content.Shared/EntityEffects/Effects/Botany/PlantAttributes/PlantResurrect.cs
+++ b/Content.Shared/EntityEffects/Effects/Botany/PlantAttributes/PlantResurrect.cs
@@ -7,6 +7,11 @@ namespace Content.Shared.EntityEffects.Effects.Botany.PlantAttributes;
 /// </summary>
 public sealed partial class PlantResurrect : EntityEffectBase<PlantResurrect>
 {
+    /// <summary>
+    /// Whether reviving the plant will remove its seeds, default true
+    /// </summary>
+    [DataField]
+    public bool ReviveSeedless = true;
     public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys) =>
-        Loc.GetString("entity-effect-guidebook-plant-resurrect", ("chance", Probability));
+        Loc.GetString("entity-effect-guidebook-plant-resurrect", ("chance", Probability), ("seedless", ReviveSeedless));
 }

--- a/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
@@ -518,3 +518,9 @@ entity-effect-guidebook-plant-mutate-chemicals =
         [1] Mutates
         *[other] mutate
     } a plant to produce {$name}
+
+entity-effect-guidebook-plant-resurrect = 
+    { $chance ->
+        [1] Revives
+        *[other] revives 
+    } a plant from a dead state

--- a/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
@@ -523,4 +523,4 @@ entity-effect-guidebook-plant-resurrect =
     { $chance ->
         [1] Revives
         *[other] revive
-    } a plant from a dead state
+    } a plant from a dead state at the cost of becoming seedless

--- a/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
@@ -519,8 +519,8 @@ entity-effect-guidebook-plant-mutate-chemicals =
         *[other] mutate
     } a plant to produce {$name}
 
-entity-effect-guidebook-plant-resurrect = 
+entity-effect-guidebook-plant-resurrect =
     { $chance ->
         [1] Revives
-        *[other] revives 
+        *[other] revive
     } a plant from a dead state

--- a/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
@@ -523,4 +523,7 @@ entity-effect-guidebook-plant-resurrect =
     { $chance ->
         [1] Revives
         *[other] revive
-    } a plant from a dead state at the cost of becoming seedless
+    } a plant from a dead state {$seedless ->
+        [true] at the cost of becoming seedless
+        *[false] to as it was in life
+    }

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1304,14 +1304,14 @@
   color: "#86a5bd"
   worksOnTheDead: true
   plantMetabolism:
+  - !type:PlantResurrect
+    minScale: 4
   - !type:PlantAdjustToxins
     amount: -5
   - !type:PlantAdjustHealth
     amount: 5
   - !type:PlantCryoxadone
     probability: 0.5
-  - !type:PlantResurrect
-    minScale: 4
   metabolisms:
     Medicine:
       effects:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1309,7 +1309,7 @@
   - !type:PlantAdjustHealth
     amount: 5
   - !type:PlantResurrect
-    minScale: 9
+    minScale: 4
   metabolisms:
     Medicine:
       effects:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1308,7 +1308,8 @@
     amount: -5
   - !type:PlantAdjustHealth
     amount: 5
-  - !type:PlantCryoxadone {}
+  - !type:PlantResurrect
+    minScale: 9
   metabolisms:
     Medicine:
       effects:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1308,6 +1308,8 @@
     amount: -5
   - !type:PlantAdjustHealth
     amount: 5
+  - !type:PlantCryoxadone
+    probability: 0.5
   - !type:PlantResurrect
     minScale: 4
   metabolisms:

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -473,6 +473,10 @@
             - !type:ReagentCondition
               reagent: Romerol
               min: 5
+  plantMetabolism:
+  - !type:PlantAdjustMutationLevel
+    amount: 5
+  - !type:PlantResurrect
 
 - type: reagent
   id: UncookedAnimalProteins


### PR DESCRIPTION
Adds the ability for Necrosol (and romerol) to resurrect plants from the dead.

## About the PR
Currently, Necrosol does exactly the same thing cryoxodone does when you put it in a plant, that being de-age it. Which is pretty dissapointing. This PR makes it so adding 4u of Necrosol (or any amount of romerol) will resurrect a plant.

Why also Romerol? Well it's also a chemical that revives people, and much like with people it will horribly mutate the plant in the reviving process.

## Why / Balance
Most botany chemicals can be made pretty early into the shift, this one gives a reward for those thousands of units of omnizine they send to chemistry.

Not particularly overpowered because generally plants only die in botany due to negligence or lack of knowledge/resources and getting seeds for new plants is easy.

Necrosol will also de-age the plant similarly to cryoxadone although weaker, if the plant was young it may de-age right back into a seed.

## Technical details
Adds a new plant-related entityeffect "PlantResurrect", applies it to necrosol and romerol.

Also somewhat related I noticed that presumably since the entity effect moveabout botany chems no longer display how much they need to perform an effect on a plant. IE: In addition to this effect, Phalanxamine also doesn't say it needs 4u to remove unviability.

## Media
https://github.com/user-attachments/assets/5c5c24f8-0c12-4a22-888a-55f77d1aa8a2

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
Slightly changes the existing Necrosol and Romerol yamls.

**Changelog**

- add: 4u of Necrosol or any amount of Romerol will now resurrect a plant from the dead at the cost of their seeds.
