### PR TITLE
Reduced Borg garbled speech chance from low power

### DIFF
--- a/Content.Shared/Speech/Components/DamagedSiliconAccentComponent.cs
+++ b/Content.Shared/Speech/Components/DamagedSiliconAccentComponent.cs
@@ -70,7 +70,7 @@ public sealed partial class DamagedSiliconAccentComponent : Component
     ///     The maximum probability that a character will be dropped due to charge level.
     /// </summary>
     [DataField]
-    public float MaxDropProbFromPower = 0.5f;
+    public float MaxDropProbFromPower = 0.25f;
 
     /// <summary>
     ///     If a character is "dropped", this is the probability that the character will be turned into a period instead


### PR DESCRIPTION
## About the PR
Reduced the probability that Borgs will have garbled speech when at low power.

## Why / Balance
Recent discussion surrounding Borgs and their ability to navigate to a recharger when at 0 power identified that calling for help is one of the only options available. However, speech corruption tends to make it hard to tell what the Borg is saying, so players are tempted to spam the messages in chat in hopes that one variation is understandable enough to make it through.

This PR aims to do two things. First, it lowers the chances that a character will be corrupted in the speech when the borg is on low power. Second, it aims to inform players (through the CL) a detail from the original PR, [here](https://github.com/space-wizards/space-station-14/pull/35318), that only characters after the first 8 are corrupted.

## Technical details
0.5 -> 0.25

## Media
Images taken at 0 power.

Before
<img width="214" height="119" alt="before" src="https://github.com/user-attachments/assets/b69ace30-6a96-49b4-9f2d-1692c659b290" />
```
C: 0.15	'The quick brown fox jumps over the lazy dog'
C: 0.12	'The quick brown fox .umps over the lz. d.g'
C: 0.09	'The quick brown fox jumps ver the laz..dog'
C: 0.06	'The quick brown fox jum.s over.th la.y dog'
C: 0.03	'The quick brown fx jumps .ver tela.y d.g'
C: 0.00	'The quick brown fox jumps ove. t. ay.d.'
```
After
<img width="216" height="132" alt="after" src="https://github.com/user-attachments/assets/146ec441-3933-4402-9f97-4322af57cef0" />
```
C: 0.15	'The quick brown fox jumps over the lazy dog'
C: 0.12	'The quick brown fox jumps overth. laz. dog'
C: 0.09	'The quick brown fox jumps over the azy .og'
C: 0.06	'The quick brown fox jumps over t.e la.y dog'
C: 0.03	'The quick bro.n .ox jumps over the la.y ..g'
C: 0.00	'The quick b.own fox jumps over.e l.zy d.g'
```

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
NA

**Changelog**
:cl:
- tweak: Borgs have less of a chance for speech to be corrupted when low on power. Reminder that the first 8 characters are always safe from speech corruption.

