### PR TITLE
Small improvement to suit sensor update loop

### DIFF
--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -27,11 +27,10 @@ public sealed class SuitSensorSystem : SharedSuitSensorSystem
             // check if sensor is ready to update
             if (curTime < sensor.NextUpdate)
                 continue;
+            sensor.NextUpdate += sensor.UpdateRate;
 
             if (!CheckSensorAssignedStation((uid, sensor)))
                 continue;
-
-            sensor.NextUpdate += sensor.UpdateRate;
 
             // get sensor status
             var status = GetSensorState((uid, sensor));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Swapped two lines in the update loop for suit sensors, improving their performance off station.

## Technical details
<!-- Summary of code changes for easier review. -->
Suit sensors use a typical update loop checking a TimeSpan on the component to limit updates. At some point a line snuck in between the bool expression and the assignment of that TimeSpan which causes two problems.

If `CheckSensorAssignedStation()` evaluates false (which it always does off station) the update time will not be increased, causing `CheckSensorAssignedStation()` to be ran every frame until you return to the station.

But secondly the system is using `NextUpdate += UpdateRate`, and because of the above `NextUpdate` could be tens of minutes behind the current time, making the full body of the update loop run every frame until you catch back up to the current time.

Very simple fix. Update the TimeSpan after checking it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->