### PR TITLE
Fix destructible benchmark OOMing

### DIFF
--- a/Content.Benchmarks/DestructibleBenchmark.cs
+++ b/Content.Benchmarks/DestructibleBenchmark.cs
@@ -89,7 +89,7 @@ public class DestructibleBenchmark
     }
 
     [IterationSetup]
-    public void IterationSetupAsync()
+    public void IterationSetup()
     {
         var plating = _tileDefMan[TileRef].TileId;
         var server = _pair.Server;
@@ -130,7 +130,8 @@ public class DestructibleBenchmark
                 _destructbiles.Add((uid, damageable, destructible));
             }
         })
-            .Wait();
+        .GetAwaiter()
+        .GetResult();
     }
 
     [Benchmark]
@@ -173,7 +174,9 @@ public class DestructibleBenchmark
 
         // Deletion of entities is often queued (QueueDel) which must be processed by running ticks
         // or else it will grow infinitely and leak memory.
-        _pair.Server.WaitRunTicks(2).Wait();
+        _pair.Server.WaitRunTicks(2)
+            .GetAwaiter()
+            .GetResult();
 
         _destructbiles.Clear();
         _damageables.Clear();


### PR DESCRIPTION
## About the PR
Fixes the destructible benchmark consuming like 70 GB of memory.

## Why / Balance
Fixes #41227

## Technical details
As explained in the issue it was consuming massive amounts of memory because we were doing nothing but activating triggers that spawn ents which don't get cleaned up. The change is to thus delete the entire map each iteration and rebuild it.

The test still allocates like crazy as we're creating and leaving garbage objects constantly, though we can generally be smarter about it in the future (reducing allocs during deletion and whatnot).

## Media
<img width="955" height="411" alt="image" src="https://github.com/user-attachments/assets/99de1b5a-6573-4c23-9778-8743c1b472dc" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
n/a