### PR TITLE
Fix prototypes so they pass analyzer checks (again) (AGAIN)

### DIFF
--- a/Content.Server/Worldgen/Prototypes/BiomePrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/BiomePrototype.cs
@@ -13,7 +13,7 @@ namespace Content.Server.Worldgen.Prototypes;
 public sealed partial class BiomePrototype : IPrototype, IInheritingPrototype
 {
     /// <inheritdoc />
-    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<EntityPrototype>))]
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<BiomePrototype>))]
     public string[]? Parents { get; private set; }
 
     /// <inheritdoc />

--- a/Content.Server/Worldgen/Prototypes/NoiseChannelPrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/NoiseChannelPrototype.cs
@@ -83,7 +83,7 @@ public class NoiseChannelConfig
 public sealed partial class NoiseChannelPrototype : NoiseChannelConfig, IPrototype, IInheritingPrototype
 {
     /// <inheritdoc />
-    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<EntityPrototype>))]
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<NoiseChannelPrototype>))]
     public string[]? Parents { get; private set; }
 
     /// <inheritdoc />

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -19,7 +19,7 @@ namespace Content.Shared.Maps
 
         public const string SpaceID = "Space";
 
-        [ParentDataFieldAttribute(typeof(AbstractPrototypeIdArraySerializer<ContentTileDefinition>))]
+        [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<ContentTileDefinition>))]
         public string[]? Parents { get; private set; }
 
         [NeverPushInheritance]

--- a/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
@@ -13,8 +13,8 @@ public sealed partial class LoadoutGroupPrototype : IPrototype, IInheritingProto
     public string ID { get; private set; } = string.Empty;
 
     /// <inheritdoc />
-    [ParentDataFieldAttribute(typeof(AbstractPrototypeIdArraySerializer<LoadoutGroupPrototype>))]
-    public string[]? Parents { get; }
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<LoadoutGroupPrototype>))]
+    public string[]? Parents { get; private set; }
 
     /// <inheritdoc />
     [NeverPushInheritance]
@@ -32,7 +32,7 @@ public sealed partial class LoadoutGroupPrototype : IPrototype, IInheritingProto
     /// </summary>
     [DataField]
     public int MinLimit = 1;
-    
+
     /// <summary>
     /// Number of loadouts that are selected by default.
     /// </summary>

--- a/Content.Shared/Silicons/StationAi/StationAiCustomizationPrototype.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiCustomizationPrototype.cs
@@ -41,7 +41,7 @@ public sealed partial class StationAiCustomizationPrototype : IPrototype, IInher
     /// The prototype we inherit from.
     /// </summary>
     [ViewVariables]
-    [ParentDataFieldAttribute(typeof(AbstractPrototypeIdArraySerializer<StationAiCustomizationPrototype>))]
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<StationAiCustomizationPrototype>))]
     public string[]? Parents { get; private set; }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
See #37485 #35435 and https://github.com/space-wizards/RobustToolbox/pull/5699
Someone please merge the analyzer already.

## Why / Balance
cleanup

## Technical details
Some prototypes were linting for the wrong prototype name, which did not cause any errors because inheritance was never used for them.
Added missing setter.
Removed some redundant naming.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
not player facing
