### PR TITLE
All sources of Holy damage halved, but all creatures currently affected have their vulnerability to it doubled

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -187,7 +187,7 @@
     Piercing: 0.8
     Cold: 0.8
     Heat: 0.2
-    Holy: 1.5
+    Holy: 3
   flatReductions:
     Heat: 3
 
@@ -225,7 +225,9 @@
     Poison: 0.0
     Radiation: 0.0
 
-# immune to everything except physical and heat damage; vulnerable to holy damage because they're undead, but not as vulnerable as a ghost or demon would be
+# Immune to everything except brute and heat damage.
+# Also vulnerable to holy damage because they're undead (BiologicalMetaphysical damageContainer), but not as vulnerable as a spirit or demon would be.
+# If we get non-Holy metaphysical damage types in the future, this set might need to be adjusted to provide immunity to them (depends on what exactly the new types are).
 - type: damageModifierSet
   id: Skeleton
   coefficients:
@@ -238,7 +240,6 @@
     Asphyxiation: 0.0
     Bloodloss: 0.0
     Cellular: 0.0
-    Holy: 0.5
   flatReductions:
     Blunt: 5
 
@@ -293,7 +294,7 @@
     Radiation: 0.0
     Shock: 0.8
     Bloodloss: 0.4
-    Holy: 1
+    Holy: 2
 
 - type: damageModifierSet
   id: Cockroach
@@ -331,7 +332,7 @@
 - type: damageModifierSet
   id: ManifestedSpirit
   coefficients:
-    Holy: 2
+    Holy: 4
 
 # Vulps get more heat damage because fur
 - type: damageModifierSet

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -18,7 +18,7 @@
     gibSound: /Audio/Effects/bone_rattle.ogg
   - type: Damageable
     damageContainer: BiologicalMetaphysical # Allows them to take Holy damage
-    damageModifierSet: Skeleton # If we get non-Holy metaphysical damage types in the future, the Skeleton set might need to be adjusted to provide immunity to them (depends on what exactly the new types are)
+    damageModifierSet: Skeleton
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -23,7 +23,7 @@
       collection: Punch
     damage:
       types:
-        Holy: 25
+        Holy: 12.5
         Blunt: 1
   - type: Prayable
     bibleUserOnly: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/gohei.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/gohei.yml
@@ -11,7 +11,7 @@
     wideAnimationRotation: -150
     damage:
       types:
-        Holy: 4
+        Holy: 2
   - type: Item
     size: Small
     sprite: Objects/Weapons/Melee/gohei.rsi

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1178,7 +1178,7 @@
         ignoreResistances: false
         damage:
           types:
-            Holy: 0.5
+            Holy: 0.25
   plantMetabolism:
   - !type:PlantAdjustWater
     amount: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
All sources of Holy damage (space bible, holy water, gohei) have had their damage values halved, but all creatures currently affected by holy damage (skeleton, revenant, animated object, corrupted corgi, cerberus, hellspawn) now take twice as much Holy damage as previously.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As of #41757, skeletons are now affected by holy damage. In that PR I elected to give them a 50% resistance to holy damage (so that the space bible would not just four-shot them, since that would be too strong). But since skeletons can take exactly 100 damage before they go crit (the same as ordinary players), I think it makes sense for them to have no specific modifier to Holy damage so that they can serve as an effective "baseline" for how strong Holy damage should be (e.g, 14 Holy damage should be to a skeleton as 14 Blunt damage is to a human). Thus, halving sources of Holy damage so I can also double how effective it is against every affected creature, resulting in skeletons having no resistance to holy damage without any actual gameplay changes.

In gameplay terms, this PR shouldn't affect actual damage output for any source of Holy damage since the damage reduction and the vulnerability increase were proportionate to each other. The only player-facing change is that the numbers when inspecting these items are halved, but they remain exactly as effective as before in every situation. This PR is exclusively just to make balancing easier to figure out in the future on the backend side of things.

## Technical details
<!-- Summary of code changes for easier review. -->
- Bible, Holywater, Gohei prototypes had their Holy damage values halved
- Hellspawn, Infernal, ManifestedSpirit, Skeleton damageModifierSets had their Holy damage multipliers doubled

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A (small number tweak)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: All sources of Holy damage have been halved. However, all creatures' vulnerability to Holy damage has been doubled, so the actual effectiveness of Holy damage remains exactly the same as previously despite the smaller numbers.