### PR TITLE
close the most recent window when going over the storage window limit

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -113,6 +113,8 @@ public abstract class SharedStorageSystem : EntitySystem
     /// </summary>
     private int _openStorageLimit = -1;
 
+    private readonly List<EntityUid> _openStorageUis = new();
+
     protected readonly List<string> CantFillReasons = [];
 
     // Caching for various checks
@@ -872,7 +874,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
         var uid = args.Target;
         var actor = args.Actor;
-        var count = 0;
+        _openStorageUis.Clear();
 
         if (_userQuery.TryComp(actor, out var userComp))
         {
@@ -886,16 +888,16 @@ public abstract class SharedStorageSystem : EntitySystem
                     if (key is not StorageComponent.StorageUiKey)
                         continue;
 
-                    count++;
-
-                    if (count >= _openStorageLimit)
-                    {
-                        args.Cancel();
-                    }
-
+                    _openStorageUis.Add(ui);
                     break;
                 }
             }
+        }
+
+        // If we're at or over the limit, close the oldest storage UI
+        if (_openStorageUis.Count >= _openStorageLimit)
+        {
+            UI.CloseUi(_openStorageUis[0], StorageComponent.StorageUiKey.Key, actor);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
guess who's back!

when the storage window limit is at or above 2, we don't let users open any more UIs
rather than doing that, this PR makes it so we close the most recently opened storage UI
this makes it consistent with the behavior we see when the storage limit is 1, closing the currently open window and replacing it with the new one

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it was pissing me off!

## Technical details
<!-- Summary of code changes for easier review. -->
modified `OnBoundUIAttempt` to close the oldest open storage UI when the limit is reached instead of just canceling the new UI open
now when you hit the limit, it closes the first storage UI in the list (oldest) to make room for the new one

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

No B/C, doesn't affect gameplay much

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
