### PR TITLE
Fix loadout entity names not being exported/imported

### DIFF
--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -27,6 +27,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
     /// <summary>
     /// Loadout specific name.
     /// </summary>
+    [DataField]
     public string? EntityName;
 
     /*


### PR DESCRIPTION
Just missing a `[DataField]`

Fixes #41876 

:cl:
- fix: Fix loadout names not being exported/imported