### PR TITLE
Mirror contrib guidelines to GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Space Station 14 Contributing Guidelines
+
+Thanks for contributing to Space Station 14.
+When contributing, be sure to follow our [codebase conventions](https://docs.spacestation14.com/en/general-development/codebase-info/codebase-organization.html) and [PR guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
+
+Following these guidelines helps us increase review turnaround time, so be sure to review the linked documents in full.
+
+The last major guidelines update was on **December 6th, 2025**.
+
+### Why is this here?
+We put this here so that GitHub will notify you when submitting a pull request that the PR guidelines have changed, if you haven't read the latest version.


### PR DESCRIPTION
## About the PR
Mirrors links to contrib guidelines/codebase conventions to GitHub under a CONTRIBUTING.md

GitHub will pick this up and notify users in a little pop up that the contributing guidelines/codebase conventions have changed when submitting a PR, if they haven't read the latest version.

## Why / Balance
We recently changed the guidelines a bit to put stress in following the codebase conventions and filling out the PR template in full. Having the PR opening window say "Hey, this has changed, might want to read it!" is better than no warning. Bonus points being that we can change the guidelines and it'll remind people that we changed it.

I did this on accident down at Moffstation and it was nice, as our guidelines went through some iterations, and every time, you got a little reminder that the guidelines have changed since you last PR'd to the repo. Can't really hurt up here, to be honest.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
