### PR TITLE
Adds debug wizard's grimoire

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Magic/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/books.yml
@@ -1,8 +1,8 @@
 ﻿- type: entity
+  abstract: true
+  parent: [ BaseItem, BaseMagicalContraband ]
   id: BaseSpellbook
   name: spellbook
-  parent: [ BaseItem, BaseMagicalContraband ]
-  abstract: true
   components:
     - type: Sprite
       sprite: Objects/Misc/books.rsi
@@ -19,13 +19,14 @@
       tags:
       - Spellbook
 
-# For the Wizard Antag
+# For the Wizard antagonist
 # Do not add discounts or price inflation
 - type: entity
-  id: WizardsGrimoire
-  name: wizards grimoire
-  suffix: Wizard
   parent: [ BaseItem, StorePresetSpellbook, BaseMagicalContraband ]
+  id: WizardsGrimoire
+  name: wizard's grimoire
+  suffix: Wizard
+  description: A heavy tome containing complicated arcane formulae for preparing magic spells and conjuring supernatural equipment. Decades of study went into researching this collection of mystical secrets; now go use them to ruin someone's day.
   components:
     - type: Sprite
       sprite: Objects/Misc/books.rsi
@@ -45,36 +46,44 @@
       key: enum.StoreUiKey.Key
     - type: Store
       refundAllowed: true
-      ownerOnly: true # get your own tome!
+      ownerOnly: true # Lesser minds cannot comprehend the arcane secrets within
       balance:
         WizCoin: 10 # prices are balanced around this 10 point maximum and how strong the spells are
 
-# Not meant for wizard antag but meant for spawning, so people can't abuse refund if they were given a tome
+# No-refund version meant for manual spawning, so people can't abuse refund if they were given a tome. Not meant for wizard antag proper!
 - type: entity
+  parent: WizardsGrimoire
   id: WizardsGrimoireNoRefund
-  name: wizards grimoire
-  suffix: Wizard, No Refund
-  parent: [ WizardsGrimoire, StorePresetSpellbook ]
+  suffix: Wizard, no refunding
   components:
     - type: Store
       refundAllowed: false
-      ownerOnly: true # get your own tome!
+
+# For debugging purposes only! Or spawn this for an admeme so a wizard can have every spell at once, I can't stop you.
+- type: entity
+  parent: WizardsGrimoire
+  id: WizardsGrimoireDebug
+  suffix: Wizard, DEBUG
+  description: A heavy tome containing complicated arcane formulae for preparing magic spells and conjuring supernatural equipment. Someone wrote "FOR EXPERIMENTAL USE ONLY" on the inside cover.
+  components:
+    - type: Store
+      ownerOnly: false # For ease of debugging.
       balance:
-        WizCoin: 10 # prices are balanced around this 10 point maximum and how strong the spells are
+        WizCoin: 99999
 
 - type: entity
+  parent: BaseSpellbook
   id: SpawnSpellbook
   name: spawn spellbook
-  parent: BaseSpellbook
   components:
     - type: Spellbook
       spellActions:
         ActionSpawnMagicarpSpell: null
 
 - type: entity
+  parent: BaseSpellbook
   id: ForceWallSpellbook
   name: force wall spellbook
-  parent: BaseSpellbook
   components:
     - type: Sprite
       sprite: Objects/Misc/books.rsi
@@ -95,9 +104,9 @@
         ActionForceWall: null
 
 - type: entity
+  parent: BaseSpellbook
   id: BlinkBook
   name: blink spellbook
-  parent: BaseSpellbook
   components:
     - type: Sprite
       sprite: Objects/Misc/books.rsi
@@ -116,9 +125,9 @@
         ActionBlink: null
 
 - type: entity
+  parent: BaseSpellbook
   id: SmiteBook
   name: smite spellbook
-  parent: BaseSpellbook
   components:
     - type: Sprite
       sprite: Objects/Misc/books.rsi
@@ -139,9 +148,9 @@
         ActionSmiteNoReq: null
 
 - type: entity
+  parent: BaseSpellbook
   id: KnockSpellbook
   name: knock spellbook
-  parent: BaseSpellbook
   components:
     - type: Sprite
       sprite: Objects/Misc/books.rsi
@@ -161,9 +170,9 @@
         ActionKnock: null
 
 - type: entity
+  parent: BaseSpellbook
   id: FireballSpellbook
   name: fireball spellbook
-  parent: BaseSpellbook
   components:
     - type: Sprite
       sprite: Objects/Misc/books.rsi
@@ -185,9 +194,9 @@
         ActionFireball: null
 
 - type: entity
+  parent: BaseSpellbook
   id: ScrollRunes
   name: scroll of runes
-  parent: BaseSpellbook
   components:
   - type: Item
     size: Normal


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a debug version of the wizard's grimoire (contains 99999 WizCoin, ownerOnly set to false). Split off from #41722 by maintainer request.

Since this is a change to \Magic\books.yml anyway, I also added a description to the wizard's grimoire and reordered prototype fields to match code conventions while I was here.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Debug wizard's grimoire makes it easier to do wizard-related dev stuff, since you can just have every spell at once instead of needing to refund spells. (You could also use this for admeme purposes, but keep in mind that ownerOnly is false so if this gets passed around the station EVERYONE can have every spell.)

## Technical details
<!-- Summary of code changes for easier review. -->
Exclusively YAML changes.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A (minor admin/dev-facing change)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The wizard's grimoire now has a proper description.
ADMIN:
- add: Added a debug wizard's grimoire, for debugging purposes. Contains 99999 WizCoin and has ownerOnly set to false. You can use this for admeme purposes but probably shouldn't unless you want to risk everyone on the station having every spell.