### PR TITLE
[Staging] Fix certain projectiles moving faster than intended

### DIFF
--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -284,7 +284,7 @@ public abstract class SharedMagicSystem : EntitySystem
         var ent = Spawn(ev.Prototype, fromMap);
         var direction = _transform.ToMapCoordinates(toCoords).Position -
                          fromMap.Position;
-        _gunSystem.ShootProjectile(ent, direction, userVelocity, ev.Performer, ev.Performer);
+        _gunSystem.ShootProjectile(ent, direction, userVelocity, ev.Performer, ev.Performer, 25f);
     }
     // End Projectile Spells
     #endregion

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -24,6 +24,7 @@
     - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/kinetic_accel.ogg
+    projectileSpeed: 25
   - type: AmmoCounter
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/staves.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/staves.yml
@@ -14,6 +14,7 @@
   - type: Gun
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/Magic/staff_healing.ogg
+    projectileSpeed: 25
   - type: BasicEntityAmmoProvider
     proto: ProjectileHealingBolt
     capacity: 10
@@ -34,6 +35,7 @@
   - type: Gun
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/Magic/staff_door.ogg
+    projectileSpeed: 25
   - type: BasicEntityAmmoProvider
     proto: ProjectilePolyboltDoor
     capacity: 10

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/wands.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/wands.yml
@@ -11,6 +11,7 @@
   - type: Gun
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/Magic/staff_animation.ogg
+    projectileSpeed: 25
   - type: BasicEntityAmmoProvider
     proto: ProjectilePolyboltCarp
     capacity: 5
@@ -52,6 +53,7 @@
     fireRate: 0.25
     soundGunshot:
       path: /Audio/Magic/fireball.ogg
+    projectileSpeed: 25
   - type: BasicEntityAmmoProvider
     proto: ProjectileFireball
     capacity: 5
@@ -72,6 +74,7 @@
   - type: Gun
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/Magic/staff_animation.ogg
+    projectileSpeed: 25
   - type: BasicEntityAmmoProvider
     proto: ProjectileLocker
     capacity: 5
@@ -107,6 +110,7 @@
   - type: Gun
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/mateba.ogg # PUNCH
+    projectileSpeed: 25
   - type: BasicEntityAmmoProvider
     proto: BulletInstakillMagic
     capacity: 3
@@ -126,6 +130,7 @@
   - type: Gun
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/Magic/staff_door.ogg
+    projectileSpeed: 25
   - type: BasicEntityAmmoProvider
     proto: ProjectilePolyboltDoor
     capacity: 10

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -633,6 +633,7 @@
     fireRate: 0.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser.ogg
+    projectileSpeed: 25
   - type: BatteryAmmoProvider
     proto: BulletTaser
     fireCost: 200
@@ -985,7 +986,7 @@
   components:
   - type: BatterySelfRecharger
     autoRechargeRate: 30
-  # "remove" wield bonus and penalty so borgs can use it 
+  # "remove" wield bonus and penalty so borgs can use it
   - type: GunWieldBonus
     minAngle: 0
     maxAngle: 0


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Gun projectile speed was recently changed from 25 to 40. Turns out, a lot of things are guns!

Tasers and PKA use a timer for despawning, so the higher speed meant they travelled further than intended.
Spells, wands and staves are also guns; 25 speed is not reactable by any means, but a fireball travelling at that speed is a lot more visible than at 40 where it kinda just whizzes by.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

In terms of tasers and PKA, their distance is an intended limitation. While the despawn time could be changed instead of the speed, I feel it's safer for a hotfix to just go back to the old speed.

Some of the spells could probably work at 40 speed, but again, it's a hotfix so I'd rather play it safe now and they can be changed further in the future.

## Technical details
<!-- Summary of code changes for easier review. -->

Mostly yaml, except for action spells which are hardcoded to use default value via `_gunSystem.ShootProjectile`. Want it to not be hardcoded? That's for a non-hotfix PR to solve.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Reverted taser, PKA and magic spell speeds back to old projectile speeds.
