### PR TITLE
Remove duce quirk from italian accent

### DIFF
--- a/Resources/Locale/en-US/accent/italian.ftl
+++ b/Resources/Locale/en-US/accent/italian.ftl
@@ -70,13 +70,11 @@ accent-italian-words-21 = nuke
 accent-italian-words-replace-21 = spiciest-a meatball
 
 accent-italian-words-22 = op
-accent-italian-words-replace-22 = greek
-
-accent-italian-words-23 = operative
-accent-italian-words-replace-23 = greek
+accent-italian-words-22-2 = operative
+accent-italian-words-replace-22 = operatore
 
 accent-italian-words-24 = operatives
-accent-italian-words-replace-24 = greeks
+accent-italian-words-replace-24 = operatori
 
 accent-italian-words-25 = sec
 accent-italian-words-replace-25 = polizia

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -48,7 +48,7 @@
     accent-italian-words-20: accent-italian-words-replace-20
     accent-italian-words-21: accent-italian-words-replace-21
     accent-italian-words-22: accent-italian-words-replace-22
-    accent-italian-words-23: accent-italian-words-replace-23
+    accent-italian-words-22-2: accent-italian-words-replace-22
     accent-italian-words-24: accent-italian-words-replace-24
     accent-italian-words-25: accent-italian-words-replace-25
     accent-italian-words-26: accent-italian-words-replace-26


### PR DESCRIPTION
## About the PR
replaced greeks to more neutral "operatore" in italian accent

## Why / Balance
After another audit of locale in my fork I found this gem.
Italian accent was ported from [ss13](https://github.com/SS13-Source-Archive/Pariah-Station/blob/54604c5369c7abb2fb26dd1696815585dc5f8ce0/strings/italian_replacement.json#L45) without any kind of proper review.
Why there is greek. Why greek in english. Why operatives.
I mean, this probably sounds not that bad in english like a "It’s Greek to me". But why this is italian? How forks should translate this? Just funny WW2 reference?

## Technical details
n/a

## Media
https://github.com/user-attachments/assets/8b4bbee7-e38a-4f94-a68e-f45f46717283

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
:cl:
n/a