### PR TITLE
TriggerOnGameRule

### DIFF
--- a/Content.Server/Trigger/Systems/GameRuleTriggerSystem.cs
+++ b/Content.Server/Trigger/Systems/GameRuleTriggerSystem.cs
@@ -6,10 +6,7 @@ using Content.Shared.Trigger.Components.Effects;
 
 namespace Content.Server.Trigger.Systems;
 
-/// <summary>
-/// Trigger system for game rules.
-/// </summary>
-public sealed class GameRuleTriggerSystem : EntitySystem
+public sealed class AddGameRuleOnTriggerSystem : EntitySystem
 {
     [Dependency] private readonly GameTicker _ticker = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnGameruleComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnGameruleComponent.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Trigger.Components.Triggers;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+
+/// <summary>
+/// Trigger when gamerule actually begins
+/// </summary>
+public sealed partial class TriggerOnGameRuleComponent : BaseTriggerOnXComponent
+{
+    /// <summary>
+    /// Valid gamerules
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityWhitelist? Whitelist;
+
+    /// <summary>
+    /// Invalid gamerules
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityWhitelist? Blacklist;
+}
+

--- a/Content.Shared/Trigger/Systems/TriggerOnGamerule.cs
+++ b/Content.Shared/Trigger/Systems/TriggerOnGamerule.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Trigger.Components.Triggers;
+using Content.Shared.Whitelist;
+using Content.Shared.GameTicking.Components;
+
+namespace Content.Shared.Trigger.Systems;
+
+public sealed class TriggerOnGameRuleSystem : EntitySystem
+{
+    [Dependency] private readonly TriggerSystem _trigger = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GameRuleStartedEvent>(TriggerOnGamerule);
+    }
+    private void TriggerOnGamerule(ref GameRuleStartedEvent args)
+    {
+        var query = EntityQueryEnumerator<TriggerOnGameRuleComponent>();
+
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (_whitelist.IsWhitelistFail(comp.Whitelist, args.RuleEntity))
+                continue;
+            if (_whitelist.IsWhitelistPass(comp.Blacklist, args.RuleEntity))
+                continue;
+
+            _trigger.Trigger(uid, args.RuleEntity, comp.KeyOut);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added TriggerOnGamerule, which is triggered when the GameRule is started and when the white list is passed

## Why / Balance
It can make it easier to create future station events and gives you more freedom for custom events

## Technical details
`GameRuleTriggerSystem` Renamed to `AddGameRuleOnTriggerSystem`, Because AddRuleOnTrigger is on Server, but TriggerOnGameRule is on Shared
add `TriggerOnGameRuleComponent` and `TriggerOnGameRuleSystem`

## Media

https://github.com/user-attachments/assets/4e28e943-be7b-45a0-8221-0c6b622060d8

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`GameRuleTriggerSystem` Renamed to `AddGameRuleOnTriggerSystem`

**Changelog**
The player doesn't care about that