### PR TITLE
Large machines like the anomaly generator no longer collide with holopads

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -64,6 +64,10 @@ public enum CollisionGroup
     // Tabletop machines
     TabletopMachineLayer = Opaque | BulletImpassable,
 
+    // Large machines: anomaly generator, gravity generator, station anchor, etc.
+    LargeMachineMask = Impassable | HighImpassable | MidImpassable | LowImpassable,
+    LargeMachineLayer = Opaque | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,
+
     // Airlocks, windoors, firelocks
     GlassAirlockLayer = HighImpassable | MidImpassable | BulletImpassable | InteractImpassable,
     AirlockLayer = Opaque | GlassAirlockLayer,

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -279,9 +279,9 @@
           bounds: "-1.5,-0.5,1.5,0.6"
         density: 50
         mask:
-        - LargeMobMask
+        - LargeMachineMask
         layer:
-        - WallLayer
+        - LargeMachineLayer
   - type: Repairable
     fuelCost: 10
     doAfterDelay: 5

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -37,9 +37,9 @@
           bounds: "-1.5,-1.5,1.5,1.5"
         density: 50
         mask:
-        - LargeMobMask
+        - LargeMachineMask
         layer:
-        - WallLayer
+        - LargeMachineLayer
   - type: Repairable
     fuelCost: 10
     doAfterDelay: 5
@@ -107,9 +107,9 @@
           bounds: "-0.4,-0.4,0.4,0.4"
         density: 3125
         mask:
-        - LargeMobMask
+        - LargeMachineMask
         layer:
-        - WallLayer
+        - LargeMachineLayer
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
@@ -42,9 +42,9 @@
           bounds: "-0.7,-0.7,0.7,0.7"
         density: 190
         mask:
-        - LargeMobMask
+        - LargeMachineMask
         layer:
-        - WallLayer
+        - LargeMachineLayer
 
 - type: entity
   id: StationAnchorIndestructible


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Closes #41428

Removes the impassable flag from the collision groups of large machines such as the anomaly generator, station anchor, and gravity generator. This lets them be dragged over holopads.

## Why / Balance
It seems counter-intuitive that large machines currently collide with holopads when dragged.

## Technical details
I created a new collision mask `LargeMachineMask` and layer `LargeMachineLayer` for large machines. I did this because I felt that using `LargeMobMask` for them was somewhat confusing, as they are not mobs.

- `LargeMachineMask` is identical to `LargeMobMask`.
- `LargeMachineLayer` is equal to `WallLayer` with `Impassable` removed. Holopads currently collide with these machines because their mask is `Impassable`, and `WallLayer` contains `Impassable`.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

### Before
https://github.com/user-attachments/assets/341574d6-fe75-46cb-b463-4719cf7dfdeb

### After
https://github.com/user-attachments/assets/8ecd1a9a-bbc1-48ea-97d1-bc51d212f9f0

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Large machines like the anomaly generator no longer collide with holopads when dragged.
