### PR TITLE
Port FTL arrival effect fix from https://github.com/new-frontiers-14/frontier-station-14/pull/3495

### DIFF
--- a/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
@@ -203,7 +203,8 @@ public sealed partial class DockingSystem
                     var spawnPosition = new EntityCoordinates(targetGridXform.MapUid!.Value, _transform.ToMapCoordinates(gridPosition).Position);
 
                     // TODO: use tight bounds
-                    var dockedBounds = new Box2Rotated(shuttleAABB.Translated(spawnPosition.Position), targetAngle, spawnPosition.Position);
+                    var targetWorldAngle = (targetGridAngle + targetAngle).Reduced();
+                    var dockedBounds = new Box2Rotated(shuttleAABB.Translated(spawnPosition.Position), targetWorldAngle, spawnPosition.Position);
 
                     // Check if there's no intersecting grids (AKA oh god it's docking at cargo).
                     grids.Clear();

--- a/Resources/Prototypes/Entities/Effects/shuttle.yml
+++ b/Resources/Prototypes/Entities/Effects/shuttle.yml
@@ -4,7 +4,7 @@
   description: Visualizer for shuttles arriving. You shouldn't see this!
   components:
   - type: Transform
-    noRot: true
+    noRot: false
     gridTraversal: false
   - type: FtlVisualizer
     sprite:


### PR DESCRIPTION
Ports the FTL arrival fix from frontier https://github.com/new-frontiers-14/frontier-station-14/pull/3495

AGPL but author said it's OK for sloth to port it.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes the FTL visualization rotation.

I tested this by enabling arrivals in dev and changing the map to reach. Delete all the docking airlocks except the top one and you should see the arrivals FTL thing clip into the station.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
From what I can tell this just adds the rotation of the FTL dock target to the visualization. I don't know the specifics I just tested it and it seems to work fine.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Broken:

<img width="1337" height="619" alt="image" src="https://github.com/user-attachments/assets/5575f16d-72fe-49ad-b08f-65256587e135" />



Fixed:

<img width="1337" height="619" alt="image" src="https://github.com/user-attachments/assets/2c6761b0-2902-4275-9d92-1caf3b437b7c" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: whatston3, Crude Oil
- fix: FTL Arrival visualization displays properly again when arriving at a dock