### PR TITLE
Preventing external airlocks from turning into regular airlocks

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -310,9 +310,9 @@ namespace Content.Server.Construction
             if (GetCurrentNode(uid, construction)?.DoNotReplaceInheritingEntities == true &&
                 metaData.EntityPrototype?.ID != null)
             {
-                var parents = ProtoMan.EnumerateParents<EntityPrototype>(metaData.EntityPrototype.ID)?.ToList();
+                var parents = ProtoMan.EnumerateAllParents<EntityPrototype>(metaData.EntityPrototype.ID)?.ToList();
 
-                if (parents != null && parents.Any(x => x.ID == newEntity))
+                if (parents != null && parents.Any(x => x.id == newEntity))
                     return null;
             }
 

--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -312,12 +312,9 @@ namespace Content.Server.Construction
             if (GetCurrentNode(uid, construction)?.DoNotReplaceInheritingEntities == true &&
                 metaData.EntityPrototype?.ID != null)
             {
-                var parents = PrototypeManager
-                    .EnumerateAllParents<EntityPrototype>(metaData.EntityPrototype.ID)?
-                    .Select(parent => parent.id)
-                    .ToList();
+                var parents = PrototypeManager.EnumerateAllParents<EntityPrototype>(metaData.EntityPrototype.ID)?.ToList();
 
-                if (parents != null && parents.Any(entity => entity == newEntity))
+                if (parents != null && parents.Any(x => x.id == newEntity))
                     return null;
             }
 

--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -314,7 +314,7 @@ namespace Content.Server.Construction
             {
                 var parents = PrototypeManager.EnumerateAllParents<EntityPrototype>(metaData.EntityPrototype.ID)?.ToList();
 
-                if (parents != null && parents.Any(x => x.id == newEntity))
+                if (parents != null && parents.Any(parent => parent.id == newEntity))
                     return null;
             }
 

--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -312,9 +312,12 @@ namespace Content.Server.Construction
             if (GetCurrentNode(uid, construction)?.DoNotReplaceInheritingEntities == true &&
                 metaData.EntityPrototype?.ID != null)
             {
-                var parents = PrototypeManager.EnumerateParents<EntityPrototype>(metaData.EntityPrototype.ID)?.ToList();
+                var parents = PrototypeManager
+                    .EnumerateAllParents<EntityPrototype>(metaData.EntityPrototype.ID)?
+                    .Select(parent => parent.id)
+                    .ToList();
 
-                if (parents != null && parents.Any(x => x.ID == newEntity))
+                if (parents != null && parents.Any(entity => entity == newEntity))
                     return null;
             }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR prevents external airlocks from turning into basic airlocks when steel or plasteel is removed from their maintenance panels.

## Why / Balance
External airlocks can't be deconstructed with RCDs. However, there's an easy way to mitigate that. Open the airlock's maintenance panel, place steel or plasteel inside and remove it with a crowbar. The external airlock turns into a basic airlock which can be deconstructed with an RCD and the change is irreversible.

https://github.com/user-attachments/assets/d16c345e-58f7-497c-9382-c6c72768d6e7

## Technical details
In the `constructionGraph` defined in `structures/airlock.yml`, `airlock` and `glassAirlock` nodes have their `DoNotReplaceInheritingEntities` fields set to true. This flag prevents airlocks from being downgraded into basic airlocks when steel or plasteel is removed from their maintenance panel.

This behavior is implemented in the `ConstructionSystem.ChangeEntity()` method. It uses `PrototypeManager.EnumerateParents()` to retrieve parent prototypes. However, `EnumerateParents()` stops traversing the hierarchy when it encounters an abstract parent. External airlocks inherit from `AirlockRCDResistant` which is an abstract entity.

I replaced `EnumerateParents()` with `EnumerateAllParents()` which includes abstract parents.

## Media


https://github.com/user-attachments/assets/cdf3004e-7e22-4336-8039-b5e058f41168



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
ConstructionSystem.ChangeEntity() updated

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Steel
- fix: Removing steel or plasteel from external airlock maintenance panels no longer turns the external airlock into a regular airlock.
