### PR TITLE
Change Botany Minimum Quantity For Random Chems

### DIFF
--- a/Content.Server/EntityEffects/Effects/Botany/PlantMutateChemicalsEntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/Effects/Botany/PlantMutateChemicalsEntityEffectSystem.cs
@@ -34,7 +34,7 @@ public sealed partial class PlantMutateChemicalsEntityEffectSystem : EntityEffec
         else
         {
             //Set the minimum to a fifth of the quantity to give some level of bad luck protection
-            seedChemQuantity.Min = FixedPoint2.Min(pick.Quantity / 5f, 1f);
+            seedChemQuantity.Min = FixedPoint2.Clamp(pick.Quantity / 5f, FixedPoint2.Epsilon, 1f);
             seedChemQuantity.Max = seedChemQuantity.Min + amount;
             seedChemQuantity.Inherent = false;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the minimum quantity on random botany to be the min of quantity/5 or 1.  For any non-vestine chems, this will just be 1.  However, this allows vestine chems to continue to be in very small quantities.

## Why / Balance
 #41731 made a change in the botany random chemical logic to allow for significantly lower minimum chemicals to allow vestine to produce less than 1 vestine per harvest - and almost none at 0 potency.

This was good for vestine chems, but bad for general random chemicals.  With random chems, we can now see things like 0.09u chorine on a plant with 86 potency.  That quantity of a chem isn't useful and it feels bad.  Prior to  #41731 that would have been 1.86 chlorine. With this change, that would instead give 1.09 chlorine - still a relatively small amount but can potentially be useful if mass produces.

The reason it feels bad is that it's low enough that there is no way to functionally use it.  With a minimum quantity of 1u, you can practically farm enough of the chem to use for various purposes if you scale up production.

The impact on vestine chems will be minimal because of the nature of how the vestine chems work.  Since they roll on a much smaller table, the dominant factor in how much people receive comes from the increasing max when rerolling the same chemical.  So while having a slightly higher min will add a bit more vestine on very low potency plants, it doesn't have a major impact on higher potency plants who've had more vestine put in.

## Technical details
Change ChemQuantity.Min to be min(quantity/5,1)
Change ChemQuantity.Max to be min + amount.


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Tested ingame, no longer get chems with 0.09 or otherwise very low quantities.
Checked Vestine chems before and after change - small sample size but shows no massive difference (variance was more significant than the changes)
<img width="762" height="873" alt="BotanyPR" src="https://github.com/user-attachments/assets/45c33784-78b8-4510-abde-a7fbb802938c" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Changed botany chem minimums to closer match behavior prior to vestine chem addition
-->
