### PR TITLE
Fix spreaders not re-spreading on deletion

### DIFF
--- a/Content.Server/Spreader/SpreaderSystem.cs
+++ b/Content.Server/Spreader/SpreaderSystem.cs
@@ -295,7 +295,7 @@ public sealed class SpreaderSystem : EntitySystem
     /// This function activates all spreaders that are adjacent to a given entity. This also activates other spreaders
     /// on the same tile as the current entity (for thin airtight entities like windoors).
     /// </summary>
-    public void ActivateSpreadableNeighbors(EntityUid uid, (EntityUid Grid, Vector2i Tile)? position = null)
+    public void ActivateSpreadableNeighbors(EntityUid origin, (EntityUid Grid, Vector2i Tile)? position = null)
     {
         Vector2i tile;
         EntityUid gridUid;
@@ -303,7 +303,7 @@ public sealed class SpreaderSystem : EntitySystem
 
         if (position == null)
         {
-            var transform = Transform(uid);
+            var transform = Transform(origin);
             if (!TryComp(transform.GridUid, out gridComp) || TerminatingOrDeleted(transform.GridUid.Value))
                 return;
 
@@ -321,7 +321,7 @@ public sealed class SpreaderSystem : EntitySystem
         while (anchored.MoveNext(out var entity))
         {
             // Don't re-activate the terminating entity
-            if (entity == uid)
+            if (entity == origin)
                 continue;
             DebugTools.Assert(Transform(entity.Value).Anchored);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a bug where spreaders would not reactivate their neighbors after being deleted. This meant that, when the outer entity of a spreader was deleted, it'd essentially "kill off" the spreader and prevent it from spreading any further. This causes spreaders to essentially just decay the minute they start getting taken care of, which was a strange issue we noticed when testing tile fires downstream.

@Princess-Cheeseballs upstreaming merge token due and merge token owed.

Closes #37610
Supersedes and closes #39356

## Technical details
<!-- Summary of code changes for easier review. -->
As far as I can tell, some functions got changed during a refactor a while ago that caused the `ActiveEdgeSpreaderComponent` to get added to the station's grid rather than the edge spreader itself. It also meant that basically all the code in this function was doing nothing, which is pretty funny. I don't know how the grid having ActiveEdgeSpreader but no EdgeSpreader doesn't error in general but there you go, I suppose.

The real fix was just changing the two HasComp checks before the EnsureComp calls but I opted to also rename some variables and add comments to clarify it, since using generic names like `uid` and `ent` when there are multiple entities being juggled is generally pretty hard to follow.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed kudzu, puddles, etc. not spreading after their edges were destroyed or cleaned up.

