### PR TITLE
Make dice rolling use the normal rng to increase performance

### DIFF
--- a/Content.Shared/Dice/SharedDiceSystem.cs
+++ b/Content.Shared/Dice/SharedDiceSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.Dice;
@@ -12,6 +13,7 @@ public abstract class SharedDiceSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()
     {
@@ -72,9 +74,7 @@ public abstract class SharedDiceSystem : EntitySystem
 
     private void Roll(Entity<DiceComponent> entity, EntityUid? user = null)
     {
-        var rand = new System.Random((int)_timing.CurTick.Value);
-
-        var roll = rand.Next(1, entity.Comp.Sides + 1);
+        var roll = _random.Next(1, entity.Comp.Sides + 1);
         SetCurrentSide(entity, roll);
 
         var popupString = Loc.GetString("dice-component-on-roll-land",


### PR DESCRIPTION
## About the PR
Make dice rolling use the normal rng to increase performance

## Why / Balance
If enough dice are rolled fast enough, this could put strain on the server, see [leviathan round #99264](https://moon.spacestation14.com/replays/leviathan/2025/12/24/leviathan-2025_12_24-17_01-round_99264.zip), from 1:04 to 1:08 at chapel (you might want to turn volume down)

## Technical details
Previously, a new rng was created and seeded with the tick number whenever a dice was rolled. This is less efficient than using the normal rng for two reasons: the normal rng doesn't require reseeding every time its used and uses an algorithm that is much faster.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

**Changelog**
None