### PR TITLE
Escape pods count towards making it to CentComm

### DIFF
--- a/Content.Server/Objectives/Components/EscapeConditionComponent.cs
+++ b/Content.Server/Objectives/Components/EscapeConditionComponent.cs
@@ -1,0 +1,11 @@
+using Content.Server.Objectives.Systems;
+
+namespace Content.Server.Objectives.Components;
+
+/// <summary>
+/// Requires that the player is on the emergency shuttle or an escape pod when docking to CentComm.
+/// </summary>
+[RegisterComponent, Access(typeof(EscapeConditionSystem))]
+public sealed partial class EscapeConditionComponent : Component
+{
+}

--- a/Content.Server/Objectives/Systems/EscapeConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/EscapeConditionSystem.cs
@@ -6,7 +6,7 @@ using Content.Shared.Objectives.Components;
 
 namespace Content.Server.Objectives.Systems;
 
-public sealed class EscapeShuttleConditionSystem : EntitySystem
+public sealed class EscapeConditionSystem : EntitySystem
 {
     [Dependency] private readonly EmergencyShuttleSystem _emergencyShuttle = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
@@ -15,10 +15,10 @@ public sealed class EscapeShuttleConditionSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<EscapeShuttleConditionComponent, ObjectiveGetProgressEvent>(OnGetProgress);
+        SubscribeLocalEvent<EscapeConditionComponent, ObjectiveGetProgressEvent>(OnGetProgress);
     }
 
-    private void OnGetProgress(EntityUid uid, EscapeShuttleConditionComponent comp, ref ObjectiveGetProgressEvent args)
+    private void OnGetProgress(EntityUid uid, EscapeConditionComponent comp, ref ObjectiveGetProgressEvent args)
     {
         args.Progress = GetProgress(args.MindId, args.Mind);
     }
@@ -32,9 +32,9 @@ public sealed class EscapeShuttleConditionSystem : EntitySystem
         // You're not escaping if you're restrained!
         // Granting 50% as to allow for partial completion of the objective.
         if (TryComp<CuffableComponent>(mind.OwnedEntity, out var cuffed) && cuffed.CuffedHandCount > 0)
-            return _emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value, false) ? 0.5f : 0f;
+            return _emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value, true) ? 0.5f : 0f;
 
         // Any emergency shuttle counts for this objective, but not pods.
-        return _emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value, false) ? 1f : 0f;
+        return _emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value, true) ? 1f : 0f;
     }
 }

--- a/Content.Server/Shuttles/Components/EscapePodComponent.cs
+++ b/Content.Server/Shuttles/Components/EscapePodComponent.cs
@@ -12,4 +12,9 @@ public sealed partial class EscapePodComponent : Component
     [DataField(customTypeSerializer:typeof(TimeOffsetSerializer))]
     [AutoPausedField]
     public TimeSpan? LaunchTime;
+
+    /// <summary>
+    ///     If the pod has launched yet.
+    /// </summary>
+    public bool Launched = false;
 }

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -193,14 +193,15 @@ public sealed partial class EmergencyShuttleSystem
             if (!TryComp<StationCentcommComponent>(stationUid, out var centcomm) ||
                 Deleted(centcomm.Entity) ||
                 pod.LaunchTime == null ||
-                pod.LaunchTime > _timing.CurTime)
+                pod.LaunchTime > _timing.CurTime ||
+                pod.Launched)
             {
                 continue;
             }
 
             // Don't dock them. If you do end up doing this then stagger launch.
             _shuttle.FTLToDock(uid, shuttle, centcomm.Entity.Value, hyperspaceTime: TransitTime);
-            RemCompDeferred<EscapePodComponent>(uid);
+            pod.Launched = true;
         }
 
         // Departed

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -654,7 +654,7 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
         // check if target is on an emergency shuttle
         var xform = Transform(target);
 
-        if (HasComp<EmergencyShuttleComponent>(xform.GridUid))
+        if (HasComp<EmergencyShuttleComponent>(xform.GridUid) || HasComp<EscapePodComponent>(xform.GridUid))
             return true;
 
         return false;

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -643,9 +643,9 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
     }
 
     /// <summary>
-    /// Returns whether a target is escaping on the emergency shuttle, but only if evac has arrived.
+    ///     Returns whether a target is escaping, but only if evac has arrived.
     /// </summary>
-    public bool IsTargetEscaping(EntityUid target)
+    public bool IsTargetEscaping(EntityUid target, bool CountEscapePods = true)
     {
         // if evac isn't here then sitting in a pod doesn't return true
         if (!EmergencyShuttleArrived)
@@ -654,7 +654,7 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
         // check if target is on an emergency shuttle
         var xform = Transform(target);
 
-        if (HasComp<EmergencyShuttleComponent>(xform.GridUid) || HasComp<EscapePodComponent>(xform.GridUid))
+        if (HasComp<EmergencyShuttleComponent>(xform.GridUid) || (CountEscapePods && HasComp<EscapePodComponent>(xform.GridUid)))
             return true;
 
         return false;

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -284,7 +284,7 @@
   - type: AntagObjectives
     objectives:
     - ParadoxCloneKillObjective
-    - ParadoxCloneLivingObjective
+    - ParadoxCloneEscapeObjective
   - type: AntagRandomSpawn # TODO: improve spawning so they only start in maints
   - type: AntagSelection
     agentName: paradox-clone-round-end-agent-name

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -5,7 +5,7 @@
   - type: ThiefRule
   - type: AntagObjectives
     objectives:
-    - EscapeThiefShuttleObjective
+    - EscapeThiefObjective
   - type: AntagRandomObjectives
     sets:
     - groups: ThiefBigObjectiveGroups

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -33,7 +33,7 @@
 - type: weightedRandom
   id: TraitorObjectiveGroupState
   weights:
-    EscapeShuttleObjective: 1
+    EscapeObjective: 1
     DieObjective: 0.2
     #HijackShuttleObjective: 0.02
 
@@ -119,5 +119,5 @@
 - type: weightedRandom
   id: ThiefObjectiveGroupEscape
   weights:
-    EscapeThiefShuttleObjective: 1
+    EscapeThiefObjective: 1
 #Changeling, crew, wizard, when you code it...

--- a/Resources/Prototypes/Objectives/paradoxClone.yml
+++ b/Resources/Prototypes/Objectives/paradoxClone.yml
@@ -17,7 +17,7 @@
 - type: entity
   parent: [BaseParadoxCloneObjective, BaseLivingObjective]
   id: ParadoxCloneLivingObjective
-  name: Escape to CentComm alive and unrestrained via the escape shuttle.
+  name: Escape to CentComm alive and unrestrained.
   description: Return to your old life.
   components:
   - type: Objective

--- a/Resources/Prototypes/Objectives/paradoxClone.yml
+++ b/Resources/Prototypes/Objectives/paradoxClone.yml
@@ -16,8 +16,8 @@
 
 - type: entity
   parent: [BaseParadoxCloneObjective, BaseLivingObjective]
-  id: ParadoxCloneLivingObjective
-  name: Escape to CentComm alive and unrestrained.
+  id: ParadoxCloneEscapeShuttleObjective
+  name: Escape to CentComm alive and unrestrained via the escape shuttle.
   description: Return to your old life.
   components:
   - type: Objective
@@ -25,6 +25,18 @@
       sprite: Structures/Furniture/chairs.rsi
       state: shuttle
   - type: EscapeShuttleCondition
+
+- type: entity
+  parent: [BaseParadoxCloneObjective, BaseLivingObjective]
+  id: ParadoxCloneEscapeObjective
+  name: Escape to CentComm alive and unrestrained.
+  description: Return to your old life.
+  components:
+  - type: Objective
+    icon:
+      sprite: Structures/Furniture/chairs.rsi
+      state: shuttle
+  - type: EscapeCondition
 
 - type: entity
   parent: [BaseParadoxCloneObjective, BaseKillObjective]

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -555,7 +555,7 @@
 - type: entity
   parent: [BaseThiefObjective, BaseLivingObjective]
   id: EscapeThiefShuttleObjective
-  name: Escape to CentComm alive and unrestrained via the escape shuttle.
+  name: Escape to CentComm alive and unrestrained.
   description: You don't want your illegal activities to be discovered by anyone, do you?
   components:
   - type: Objective

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -555,7 +555,7 @@
 - type: entity
   parent: [BaseThiefObjective, BaseLivingObjective]
   id: EscapeThiefShuttleObjective
-  name: Escape to CentComm alive and unrestrained.
+  name: Escape to CentComm alive and unrestrained via the escape shuttle.
   description: You don't want your illegal activities to be discovered by anyone, do you?
   components:
   - type: Objective
@@ -564,3 +564,16 @@
       sprite: Structures/Furniture/chairs.rsi
       state: shuttle
   - type: EscapeShuttleCondition
+
+- type: entity
+  parent: [BaseThiefObjective, BaseLivingObjective]
+  id: EscapeThiefObjective
+  name: Escape to CentComm alive and unrestrained.
+  description: You don't want your illegal activities to be discovered by anyone, do you?
+  components:
+  - type: Objective
+    difficulty: 1.3
+    icon:
+      sprite: Structures/Furniture/chairs.rsi
+      state: shuttle
+  - type: EscapeCondition

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -37,7 +37,7 @@
 - type: entity
   parent: [BaseTraitorObjective, BaseLivingObjective]
   id: EscapeShuttleObjective
-  name: Escape to CentComm alive and unrestrained.
+  name: Escape to CentComm alive and unrestrained via the escape shuttle.
   description: One of our undercover agents will debrief you when you arrive. Don't show up in cuffs.
   components:
   - type: Objective
@@ -46,6 +46,19 @@
       sprite: Structures/Furniture/chairs.rsi
       state: shuttle
   - type: EscapeShuttleCondition
+
+- type: entity
+  parent: [BaseTraitorObjective, BaseLivingObjective]
+  id: EscapeObjective
+  name: Escape to CentComm alive and unrestrained.
+  description: One of our undercover agents will debrief you when you arrive. Don't show up in cuffs.
+  components:
+  - type: Objective
+    difficulty: 1.3
+    icon:
+      sprite: Structures/Furniture/chairs.rsi
+      state: shuttle
+  - type: EscapeCondition
 
 - type: entity
   parent: BaseTraitorObjective
@@ -62,6 +75,7 @@
     blacklist:
       components:
       - EscapeShuttleCondition
+      - EscapeCondition
       - StealCondition
   - type: DieCondition
   - type: ObjectiveLimit

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -37,7 +37,7 @@
 - type: entity
   parent: [BaseTraitorObjective, BaseLivingObjective]
   id: EscapeShuttleObjective
-  name: Escape to CentComm alive and unrestrained via the escape shuttle.
+  name: Escape to CentComm alive and unrestrained.
   description: One of our undercover agents will debrief you when you arrive. Don't show up in cuffs.
   components:
   - type: Objective


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Escape pods now count towards making it to CentComm. This affects the Escape objectives of paradox clones, thieves, and traitors. It also affects kill/maroon objectives.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
There are two reasons for this change: Escape objectives, and kill objectives.

**Escape Objectives**

We've had Escape to CentComm as an objective for a while now and it leads to a few primary outcomes for people who succeed in this objective.
1. You hide on the outside of the evac shuttle in a crate, wall closet, or chair.
2. You disguise yourself and linger in the inside of the evac shuttle and hope security doesn't realize who you are.
3. You don't engage in impactful antagonistic behavior during the round with the intention of never drawing enough heat from security for you to be a person of interest on the evac shuttle, and leave undisguised on the inside of the evac shuttle.

The escape objective forces confrontation between antagonists and security on the evac shuttle by forcing them together. For the solo antagonists who have this objective, it is extremely unlikely you are able to evade an entire security team who is aware of your presence and may or may not be armed with lethal weaponry. In addition, it is difficult to properly hide your identity as most species have identifying features(dwarf height, lizard/vulp tail, vox everything, etc.) which are apparent to any experienced security officer. The likelihood of getting recognized while disguised only increases with the amount of confrontations you have had with security. This funnels a lot of players into option 3, which is not engaging in meaningful, round-impacting antagonist behavior because it greatly hurts your chances of escaping unrestrained. Indeed, your best chances of completing the Escape objective is to not engage in antagonistic behavior at all so security has no reason to arrest you or deny you entry to the evac shuttle. 

Needless to say, this is not engaging.

Allowing solo antagonists to complete this objective by leaving on an escape pod transforms escape objectives to function closer to a "Survive to the end of the round while remaining on station" as opposed to the current "Don't get noticed by security on evac".
This is a much-preferred change as it does not provide anywhere near as much of a clamp on the antagonist's ability to influence the round and create conflict.


**Kill/Maroon Objectives**

The evac-shuttle centric nature of kill/maroon objectives often results in a lot of traitors waiting until the evac shuttle arrives and their target boards the shuttle to attempt their objective. In many cases this is ideal; your target either doesn't make it into the evac shuttle, in which case you complete your objective, or your target makes it into the evac shuttle(where you are waiting) where you minibomb/northstar/etc to gib them and complete your objective.

This is not ideal - waiting until the end of the round to engage in antagonistic behavior means that less happens during the round itself.

Now that your kill/maroon target can make it to CentComm via an escape pod, this hurts the strategy of waiting on evac for your target to come to you. It is now more optimal to seek out your target during the round and kill them, which is more engaging for everyone.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a check for EscapePodComponent in IsTargetEscaped, and replaced a deletion of EscapePodComponent with a check for a Launched datafield in EscapePodComponent.
Created EscapeConditionSystem & Objective.
Modified IsTargetEscaped to specify if the escape pods should not be included in the check.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="779" height="621" alt="image" src="https://github.com/user-attachments/assets/4b755ef2-f716-4322-9105-bf5c49cbfd6a" />

<img width="1366" height="624" alt="image" src="https://github.com/user-attachments/assets/906e8012-adb0-49b3-ae20-d18c4f0a0794" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Escape pods now count towards making it to CentComm.
