### PR TITLE
Remove reverted shuttle event change from the changelog

### DIFF
--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -3634,13 +3634,6 @@
   id: 9294
   time: '2025-12-15T01:50:21.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/41823
-- author: PJB3005
-  changes:
-  - message: Removed friendly & freelancer "unknown shuttle" events.
-    type: Remove
-  id: 9295
-  time: '2025-12-15T03:42:56.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41860
 - author: Meara1179
   changes:
   - message: Added crowbar to the Medical Borg's Rescue module.


### PR DESCRIPTION
## About the PR
Removes #41860 's changelog entry

## Why / Balance
#41862 reverted that PR, but did not remove it from the changelog

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
