### PR TITLE
Fix hardcoded ftl values by replacing with cvars.

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AutomaticAtmosSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AutomaticAtmosSystem.cs
@@ -28,7 +28,7 @@ public sealed class AutomaticAtmosSystem : EntitySystem
             return;
 
         // We can't actually count how many tiles there are efficiently, so instead estimate with the mass.
-        if (ev.NewMass / _configManager.GetCVar(CCVars.TileDensityMultiplier) >= 7.0f)
+        if (ev.NewMass / ShuttleSystem.TileDensityMultiplier >= 7.0f)
         {
             AddComp<GridAtmosphereComponent>(ent);
             Log.Info($"Giving grid {ent} GridAtmosphereComponent.");

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -7,22 +7,6 @@ namespace Content.Shared.CCVar;
 public sealed partial class CCVars
 {
     /// <summary>
-    ///     Maximum distance a shuttle can FTL.
-    /// </summary>
-    public static readonly CVarDef<float> FTLRange = CVarDef.Create("shuttle.ftl_range", 256f, CVar.REPLICATED);
-
-    /// <summary>
-    ///     Additional buffer distance added when checking if a spot is free for FTL arrival.
-    ///     Used to ensure shuttles don't collide with objects when arriving at their destination.
-    /// </summary>
-    public static readonly CVarDef<float> FTLBufferRange = CVarDef.Create("shuttle.ftl_buffer_range", 8f, CVar.REPLICATED);
-
-    /// <summary>
-    ///     Multiplier applied to tile density for physics calculations.
-    /// </summary>
-    public static readonly CVarDef<float> TileDensityMultiplier = CVarDef.Create("shuttle.tile_density_multiplier", 0.5f, CVar.REPLICATED);
-
-    /// <summary>
     ///     Delay for auto-orientation. Used for people arriving via arrivals.
     /// </summary>
     public static readonly CVarDef<double> AutoOrientDelay =
@@ -122,6 +106,20 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<float> FTLMassLimit =
         CVarDef.Create("shuttle.mass_limit", 300f, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Multiplier applied to the base FTL range for shuttles.
+    ///     Allows game code to define per-shuttle FTL ranges while this CVar provides global balance control.
+    /// </summary>
+    [CVarControl(AdminFlags.Debug, min: 0f, max: 10f)]
+    public static readonly CVarDef<float> ShuttleFTLRangeMultiplier = CVarDef.Create("shuttle.ftl_range_multiplier", 1f, CVar.REPLICATED);
+
+    /// <summary>
+    ///     Multiplier applied to the base FTL buffer range calculation.
+    ///     The base buffer is calculated from the shuttle's grid size, and this multiplier allows global balance control.
+    /// </summary>
+    [CVarControl(AdminFlags.Debug, min: 0f, max: 10f)]
+    public static readonly CVarDef<float> ShuttleFTLBufferRangeMultiplier = CVarDef.Create("shuttle.ftl_buffer_range_multiplier", 1f, CVar.REPLICATED);
 
     /// <summary>
     ///     How long to knock down entities for if they aren't buckled when FTL starts and stops.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Hardcoded magic numbers in Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs are replaced with CVars.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Closes: #42017

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
ADMIN:
- fix: FTL range and buffer are no longer hardcoded and can be modified using *cvar* console command.
