### PR TITLE
Add crayon box to Big Bite meals

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -617,8 +617,6 @@
     containers:
       storagebase: !type:AllSelector
         children:
-        - !type:NestedSelector # First since it can spawn a 3x3
-          tableId: HappyHonkToySafeEntityTable
         - id: FoodBurgerCheese
         - !type:GroupSelector
           children:
@@ -626,6 +624,8 @@
           - id: DrinkLemonLimeCan
           - id: DrinkLemonLimeCranberryCan
           - id: DrinkIcedTeaCan
+        - !type:NestedSelector
+          tableId: HappyHonkToySafeEntityTable
 
 - type: entity
   id: FoodMealHappyHonkBigBite
@@ -638,33 +638,11 @@
       storagebase: !type:AllSelector
         children:
         - id: FoodBurgerBig
-        - id: FoodMealFriesCheesy
         - id: DrinkColaBottleFull
+        - !type:NestedSelector
+          tableId: HappyHonkToySafeEntityTable
+        - id: FoodMealFriesCheesy
         - id: FoodPieAppleSlice
-        - !type:GroupSelector # One item is too big, so the HappyHonkToySafeEntityTable can't  be used like the others.
-          children:
-          - id: ToyMouse
-          - id: ToyAi
-          - id: ToyNuke
-          - id: ToyFigurinePassenger
-          - id: ToyFigurineGriffin
-          - id: ToyIan
-          - id: ToyFigurineOwlman
-          - id: ToyFigurineSkeleton
-          - id: FoamBlade
-          - id: ClothingHeadHatBunny
-          - id: PersonalAI
-          #- id: CrayonBox
-          - id: ToySword
-          - id: RevolverCapGun
-          - id: ToyRubberDuck
-          - id: BikeHorn
-            weight: 0.5
-          - id: GoldenBikeHorn
-            weight: 0.1
-          - !type:NestedSelector
-            tableId: AllFigurineMechsTable
-            weight: 6
 
 - type: entity
   parent: BoxCardboard
@@ -691,7 +669,7 @@
       storagebase:
         id: MaterialCloth10
 
-- type: entityTable
+- type: entityTable # size: 2x2
   id: HappyHonkToySafeEntityTable
   table: !type:GroupSelector
     children:
@@ -718,7 +696,7 @@
       tableId: AllFigurineMechsTable
       weight: 6
 
-- type: entityTable
+- type: entityTable # size: 1x2
   id: HappyHonkToyUnsafeEntityTable
   table: !type:GroupSelector
     children:


### PR DESCRIPTION
## About the PR
Add crayon box the Happy Honk Big Bite and shuffle some contents around in it and the Happy Honk Clown meal.

## Why / Balance
Table in FoodMealHappyHonkClown was only moved to avoid bad fills, added to FoodMealHappyHonkBigBite as it didn't use the table because of the size of the crayon box (admittedly a comment I put there, not whoever made it originally).

## Technical details
Moved HappyHonkToySafeEntityTable back to the bottom of FoodMealHappyHonkClown.
Changed the group selector in FoodMealHappyHonkBigBite to a nested selector using HappyHonkToySafeEntityTable, adding the crayon box, and sorted the table by size.
Added comments to the entity tables with their max sizes.

## Media
<img width="157" height="127" alt="Screenshot 2025-12-26 152927" src="https://github.com/user-attachments/assets/aa8497ae-06e5-4226-a056-ca206320afe9" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**

<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Happy Honk Big Bite may now contain crayon boxes.
