### PR TITLE
Make nukie infiltrator shuttle pinpointer universal

### DIFF
--- a/Resources/Maps/Shuttles/infiltrator.yml
+++ b/Resources/Maps/Shuttles/infiltrator.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 266.0.0
+  engineVersion: 270.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/25/2025 16:10:34
+  time: 12/26/2025 13:27:43
   entityCount: 828
 maps: []
 grids:
@@ -161,63 +161,19 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 21.824879
-          - 82.10312
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
         - volume: 2500
           immutable: True
-          moles:
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+          moles: {}
         - volume: 2500
           temperature: 293.15
           moles:
-          - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 6666.982
         - volume: 2500
           temperature: 293.15
           moles:
-          - 0
-          - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Nitrogen: 6666.982
         chunkSize: 4
     - type: DecalGrid
       chunkCollection:
@@ -562,9 +518,10 @@ entities:
     - type: SpreaderGrid
     - type: GridPathfinding
     - type: ImplicitRoof
+    - type: ExplosionAirtightGrid
 - proto: AirlockExternalGlassShuttleSyndicateLocked
   entities:
-  - uid: 8
+  - uid: 2
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -572,12 +529,12 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        13:
+        9:
         - - DoorStatus
           - Close
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 10
+  - uid: 3
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -585,24 +542,24 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        3:
+        5:
         - - DoorStatus
           - Close
     - type: DeviceLinkSink
       invokeCounter: 1
 - proto: AirlockExternalSyndicateLocked
   entities:
-  - uid: 2
+  - uid: 4
     components:
     - type: Transform
       pos: -0.5,-25.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        14:
+        10:
         - - DoorStatus
           - DoorBolt
-  - uid: 3
+  - uid: 5
     components:
     - type: Transform
       pos: -5.5,-16.5
@@ -611,40 +568,40 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        10:
+        3:
         - - DoorStatus
           - Close
-  - uid: 7
+  - uid: 6
     components:
     - type: Transform
       pos: -4.5,-14.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        12:
+        8:
         - - DoorStatus
           - DoorBolt
-  - uid: 9
+  - uid: 7
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        22:
+        11:
         - - DoorStatus
           - DoorBolt
-  - uid: 12
+  - uid: 8
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        7:
+        6:
         - - DoorStatus
           - DoorBolt
-  - uid: 13
+  - uid: 9
     components:
     - type: Transform
       pos: 4.5,-16.5
@@ -653,59 +610,59 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        8:
+        2:
         - - DoorStatus
           - Close
-  - uid: 14
+  - uid: 10
     components:
     - type: Transform
       pos: -0.5,-22.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        2:
+        4:
         - - DoorStatus
           - DoorBolt
-  - uid: 22
+  - uid: 11
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        9:
+        7:
         - - DoorStatus
           - DoorBolt
 - proto: AirlockSyndicateGlassLocked
   entities:
-  - uid: 4
+  - uid: 12
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 5
+  - uid: 13
     components:
     - type: Transform
       pos: 3.5,-22.5
       parent: 1
-  - uid: 6
+  - uid: 14
     components:
     - type: Transform
       pos: -0.5,-18.5
       parent: 1
-  - uid: 17
+  - uid: 15
     components:
     - type: Transform
       pos: -2.5,-20.5
       parent: 1
 - proto: AirlockSyndicateLocked
   entities:
-  - uid: 15
+  - uid: 16
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 16
+  - uid: 17
     components:
     - type: Transform
       pos: 2.5,-5.5
@@ -729,1100 +686,1100 @@ entities:
       fixtures: {}
 - proto: AtmosFixNitrogenMarker
   entities:
-  - uid: 25
+  - uid: 20
     components:
     - type: Transform
       pos: 5.5,-26.5
       parent: 1
-  - uid: 26
+  - uid: 21
     components:
     - type: Transform
       pos: 5.5,-27.5
       parent: 1
 - proto: AtmosFixOxygenMarker
   entities:
-  - uid: 27
+  - uid: 22
     components:
     - type: Transform
       pos: 3.5,-26.5
       parent: 1
-  - uid: 28
+  - uid: 23
     components:
     - type: Transform
       pos: 3.5,-27.5
       parent: 1
 - proto: BannerSyndicate
   entities:
-  - uid: 29
+  - uid: 24
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 1
-  - uid: 30
+  - uid: 25
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 1
 - proto: Bed
   entities:
-  - uid: 31
+  - uid: 26
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
 - proto: BedsheetSyndie
   entities:
-  - uid: 32
+  - uid: 27
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
 - proto: BorgCharger
   entities:
-  - uid: 612
+  - uid: 28
     components:
     - type: Transform
       pos: -4.5,-27.5
       parent: 1
 - proto: BoxEncryptionKeySyndie
   entities:
-  - uid: 34
+  - uid: 30
     components:
     - type: Transform
-      parent: 33
+      parent: 29
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: BoxFlashbang
   entities:
-  - uid: 42
+  - uid: 38
     components:
     - type: Transform
       pos: 0.49331844,-13.366474
       parent: 1
 - proto: BoxFolderNuclearCodes
   entities:
-  - uid: 510
+  - uid: 39
     components:
     - type: Transform
       pos: -2.5286522,-11.44479
       parent: 1
 - proto: BoxHandcuff
   entities:
-  - uid: 43
+  - uid: 40
     components:
     - type: Transform
       pos: 1.4510483,-2.399527
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 51
+  - uid: 41
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 1
-  - uid: 52
+  - uid: 42
     components:
     - type: Transform
       pos: -3.5,-17.5
       parent: 1
-  - uid: 53
+  - uid: 43
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 1
-  - uid: 54
+  - uid: 44
     components:
     - type: Transform
       pos: -4.5,-16.5
       parent: 1
-  - uid: 55
+  - uid: 45
     components:
     - type: Transform
       pos: -5.5,-16.5
       parent: 1
-  - uid: 56
+  - uid: 46
     components:
     - type: Transform
       pos: -6.5,-16.5
       parent: 1
-  - uid: 57
+  - uid: 47
     components:
     - type: Transform
       pos: -7.5,-16.5
       parent: 1
-  - uid: 58
+  - uid: 48
     components:
     - type: Transform
       pos: -8.5,-16.5
       parent: 1
-  - uid: 59
+  - uid: 49
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 1
-  - uid: 60
+  - uid: 50
     components:
     - type: Transform
       pos: -6.5,-17.5
       parent: 1
-  - uid: 61
+  - uid: 51
     components:
     - type: Transform
       pos: -4.5,-15.5
       parent: 1
-  - uid: 62
+  - uid: 52
     components:
     - type: Transform
       pos: -4.5,-14.5
       parent: 1
-  - uid: 63
+  - uid: 53
     components:
     - type: Transform
       pos: -4.5,-13.5
       parent: 1
-  - uid: 64
+  - uid: 54
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 1
-  - uid: 65
+  - uid: 55
     components:
     - type: Transform
       pos: -4.5,-11.5
       parent: 1
-  - uid: 66
+  - uid: 56
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 1
-  - uid: 67
+  - uid: 57
     components:
     - type: Transform
       pos: -5.5,-12.5
       parent: 1
-  - uid: 68
+  - uid: 58
     components:
     - type: Transform
       pos: -6.5,-12.5
       parent: 1
-  - uid: 69
+  - uid: 59
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 1
-  - uid: 70
+  - uid: 60
     components:
     - type: Transform
       pos: -1.5,-16.5
       parent: 1
-  - uid: 71
+  - uid: 61
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 1
-  - uid: 72
+  - uid: 62
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 1
-  - uid: 73
+  - uid: 63
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 1
-  - uid: 74
+  - uid: 64
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 1
-  - uid: 75
+  - uid: 65
     components:
     - type: Transform
       pos: 3.5,-16.5
       parent: 1
-  - uid: 76
+  - uid: 66
     components:
     - type: Transform
       pos: 4.5,-16.5
       parent: 1
-  - uid: 77
+  - uid: 67
     components:
     - type: Transform
       pos: 5.5,-16.5
       parent: 1
-  - uid: 78
+  - uid: 68
     components:
     - type: Transform
       pos: 5.5,-15.5
       parent: 1
-  - uid: 79
+  - uid: 69
     components:
     - type: Transform
       pos: 5.5,-17.5
       parent: 1
-  - uid: 80
+  - uid: 70
     components:
     - type: Transform
       pos: 6.5,-16.5
       parent: 1
-  - uid: 81
+  - uid: 71
     components:
     - type: Transform
       pos: 7.5,-16.5
       parent: 1
-  - uid: 82
+  - uid: 72
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
-  - uid: 83
+  - uid: 73
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 1
-  - uid: 84
+  - uid: 74
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 85
+  - uid: 75
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 86
+  - uid: 76
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
-  - uid: 87
+  - uid: 77
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
-  - uid: 88
+  - uid: 78
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 89
+  - uid: 79
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 90
+  - uid: 80
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 1
-  - uid: 91
+  - uid: 81
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 92
+  - uid: 82
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 93
+  - uid: 83
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 94
+  - uid: 84
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 95
+  - uid: 85
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 96
+  - uid: 86
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 97
+  - uid: 87
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
-  - uid: 98
+  - uid: 88
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 99
+  - uid: 89
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 100
+  - uid: 90
     components:
     - type: Transform
       pos: -1.5,-12.5
       parent: 1
-  - uid: 101
+  - uid: 91
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 102
+  - uid: 92
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-  - uid: 103
+  - uid: 93
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 104
+  - uid: 94
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 105
+  - uid: 95
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 106
+  - uid: 96
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 107
+  - uid: 97
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 108
+  - uid: 98
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 109
+  - uid: 99
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 110
+  - uid: 100
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 111
+  - uid: 101
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 112
+  - uid: 102
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 113
+  - uid: 103
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 114
+  - uid: 104
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 115
+  - uid: 105
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 116
+  - uid: 106
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 117
+  - uid: 107
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 118
+  - uid: 108
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 119
+  - uid: 109
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 120
+  - uid: 110
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 121
+  - uid: 111
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 1
-  - uid: 122
+  - uid: 112
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 123
+  - uid: 113
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 124
+  - uid: 114
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 125
+  - uid: 115
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 126
+  - uid: 116
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 1
-  - uid: 127
+  - uid: 117
     components:
     - type: Transform
       pos: -3.5,-20.5
       parent: 1
-  - uid: 128
+  - uid: 118
     components:
     - type: Transform
       pos: -3.5,-19.5
       parent: 1
-  - uid: 129
+  - uid: 119
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 1
-  - uid: 130
+  - uid: 120
     components:
     - type: Transform
       pos: -4.5,-21.5
       parent: 1
-  - uid: 131
+  - uid: 121
     components:
     - type: Transform
       pos: -4.5,-22.5
       parent: 1
-  - uid: 132
+  - uid: 122
     components:
     - type: Transform
       pos: -4.5,-23.5
       parent: 1
-  - uid: 133
+  - uid: 123
     components:
     - type: Transform
       pos: -4.5,-24.5
       parent: 1
-  - uid: 134
+  - uid: 124
     components:
     - type: Transform
       pos: -4.5,-25.5
       parent: 1
-  - uid: 135
+  - uid: 125
     components:
     - type: Transform
       pos: -4.5,-25.5
       parent: 1
-  - uid: 136
+  - uid: 126
     components:
     - type: Transform
       pos: -4.5,-26.5
       parent: 1
-  - uid: 137
+  - uid: 127
     components:
     - type: Transform
       pos: -4.5,-27.5
       parent: 1
-  - uid: 138
+  - uid: 128
     components:
     - type: Transform
       pos: -5.5,-27.5
       parent: 1
-  - uid: 139
+  - uid: 129
     components:
     - type: Transform
       pos: -6.5,-27.5
       parent: 1
-  - uid: 140
+  - uid: 130
     components:
     - type: Transform
       pos: -6.5,-26.5
       parent: 1
-  - uid: 141
+  - uid: 131
     components:
     - type: Transform
       pos: -6.5,-25.5
       parent: 1
-  - uid: 142
+  - uid: 132
     components:
     - type: Transform
       pos: -6.5,-24.5
       parent: 1
-  - uid: 143
+  - uid: 133
     components:
     - type: Transform
       pos: -6.5,-23.5
       parent: 1
-  - uid: 144
+  - uid: 134
     components:
     - type: Transform
       pos: -6.5,-22.5
       parent: 1
-  - uid: 145
+  - uid: 135
     components:
     - type: Transform
       pos: -2.5,-20.5
       parent: 1
-  - uid: 146
+  - uid: 136
     components:
     - type: Transform
       pos: -1.5,-20.5
       parent: 1
-  - uid: 147
+  - uid: 137
     components:
     - type: Transform
       pos: -0.5,-20.5
       parent: 1
-  - uid: 148
+  - uid: 138
     components:
     - type: Transform
       pos: -0.5,-21.5
       parent: 1
-  - uid: 149
+  - uid: 139
     components:
     - type: Transform
       pos: -0.5,-23.5
       parent: 1
-  - uid: 150
+  - uid: 140
     components:
     - type: Transform
       pos: -0.5,-22.5
       parent: 1
-  - uid: 151
+  - uid: 141
     components:
     - type: Transform
       pos: -0.5,-24.5
       parent: 1
-  - uid: 152
+  - uid: 142
     components:
     - type: Transform
       pos: -0.5,-25.5
       parent: 1
-  - uid: 153
+  - uid: 143
     components:
     - type: Transform
       pos: -0.5,-19.5
       parent: 1
-  - uid: 154
+  - uid: 144
     components:
     - type: Transform
       pos: 0.5,-20.5
       parent: 1
-  - uid: 155
+  - uid: 145
     components:
     - type: Transform
       pos: 1.5,-20.5
       parent: 1
-  - uid: 156
+  - uid: 146
     components:
     - type: Transform
       pos: 2.5,-20.5
       parent: 1
-  - uid: 157
+  - uid: 147
     components:
     - type: Transform
       pos: 3.5,-20.5
       parent: 1
-  - uid: 158
+  - uid: 148
     components:
     - type: Transform
       pos: 4.5,-20.5
       parent: 1
-  - uid: 159
+  - uid: 149
     components:
     - type: Transform
       pos: 3.5,-21.5
       parent: 1
-  - uid: 160
+  - uid: 150
     components:
     - type: Transform
       pos: 3.5,-22.5
       parent: 1
-  - uid: 161
+  - uid: 151
     components:
     - type: Transform
       pos: 3.5,-23.5
       parent: 1
-  - uid: 162
+  - uid: 152
     components:
     - type: Transform
       pos: 3.5,-24.5
       parent: 1
-  - uid: 163
+  - uid: 153
     components:
     - type: Transform
       pos: 3.5,-25.5
       parent: 1
-  - uid: 164
+  - uid: 154
     components:
     - type: Transform
       pos: 3.5,-26.5
       parent: 1
-  - uid: 165
+  - uid: 155
     components:
     - type: Transform
       pos: 3.5,-27.5
       parent: 1
-  - uid: 166
+  - uid: 156
     components:
     - type: Transform
       pos: 4.5,-27.5
       parent: 1
-  - uid: 167
+  - uid: 157
     components:
     - type: Transform
       pos: 5.5,-27.5
       parent: 1
-  - uid: 168
+  - uid: 158
     components:
     - type: Transform
       pos: 5.5,-26.5
       parent: 1
-  - uid: 169
+  - uid: 159
     components:
     - type: Transform
       pos: 5.5,-25.5
       parent: 1
-  - uid: 170
+  - uid: 160
     components:
     - type: Transform
       pos: 5.5,-24.5
       parent: 1
-  - uid: 171
+  - uid: 161
     components:
     - type: Transform
       pos: 5.5,-23.5
       parent: 1
-  - uid: 172
+  - uid: 162
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 173
+  - uid: 163
     components:
     - type: Transform
       pos: 1.5,-26.5
       parent: 1
-  - uid: 174
+  - uid: 164
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 175
+  - uid: 165
     components:
     - type: Transform
       pos: -0.5,-26.5
       parent: 1
-  - uid: 176
+  - uid: 166
     components:
     - type: Transform
       pos: -1.5,-26.5
       parent: 1
-  - uid: 177
+  - uid: 167
     components:
     - type: Transform
       pos: 0.5,-26.5
       parent: 1
-  - uid: 178
+  - uid: 168
     components:
     - type: Transform
       pos: -2.5,-26.5
       parent: 1
-  - uid: 179
+  - uid: 169
     components:
     - type: Transform
       pos: -2.5,-27.5
       parent: 1
-  - uid: 180
+  - uid: 170
     components:
     - type: Transform
       pos: 1.5,-27.5
       parent: 1
-  - uid: 181
+  - uid: 171
     components:
     - type: Transform
       pos: -6.5,-28.5
       parent: 1
-  - uid: 182
+  - uid: 172
     components:
     - type: Transform
       pos: -6.5,-29.5
       parent: 1
-  - uid: 183
+  - uid: 173
     components:
     - type: Transform
       pos: -2.5,-28.5
       parent: 1
-  - uid: 184
+  - uid: 174
     components:
     - type: Transform
       pos: -2.5,-29.5
       parent: 1
-  - uid: 185
+  - uid: 175
     components:
     - type: Transform
       pos: -2.5,-30.5
       parent: 1
-  - uid: 186
+  - uid: 176
     components:
     - type: Transform
       pos: -3.5,-30.5
       parent: 1
-  - uid: 187
+  - uid: 177
     components:
     - type: Transform
       pos: -4.5,-30.5
       parent: 1
-  - uid: 188
+  - uid: 178
     components:
     - type: Transform
       pos: -5.5,-30.5
       parent: 1
-  - uid: 189
+  - uid: 179
     components:
     - type: Transform
       pos: 1.5,-28.5
       parent: 1
-  - uid: 190
+  - uid: 180
     components:
     - type: Transform
       pos: 1.5,-29.5
       parent: 1
-  - uid: 191
+  - uid: 181
     components:
     - type: Transform
       pos: 1.5,-30.5
       parent: 1
-  - uid: 192
+  - uid: 182
     components:
     - type: Transform
       pos: 2.5,-30.5
       parent: 1
-  - uid: 193
+  - uid: 183
     components:
     - type: Transform
       pos: 3.5,-30.5
       parent: 1
-  - uid: 194
+  - uid: 184
     components:
     - type: Transform
       pos: 4.5,-30.5
       parent: 1
-  - uid: 195
+  - uid: 185
     components:
     - type: Transform
       pos: 5.5,-28.5
       parent: 1
-  - uid: 196
+  - uid: 186
     components:
     - type: Transform
       pos: 5.5,-29.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 197
+  - uid: 187
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 1
-  - uid: 198
+  - uid: 188
     components:
     - type: Transform
       pos: -4.5,-26.5
       parent: 1
-  - uid: 199
+  - uid: 189
     components:
     - type: Transform
       pos: -4.5,-27.5
       parent: 1
-  - uid: 200
+  - uid: 190
     components:
     - type: Transform
       pos: -5.5,-27.5
       parent: 1
-  - uid: 201
+  - uid: 191
     components:
     - type: Transform
       pos: -6.5,-27.5
       parent: 1
-  - uid: 202
+  - uid: 192
     components:
     - type: Transform
       pos: -5.5,-23.5
       parent: 1
-  - uid: 203
+  - uid: 193
     components:
     - type: Transform
       pos: -5.5,-22.5
       parent: 1
-  - uid: 204
+  - uid: 194
     components:
     - type: Transform
       pos: -5.5,-20.5
       parent: 1
-  - uid: 205
+  - uid: 195
     components:
     - type: Transform
       pos: -4.5,-20.5
       parent: 1
-  - uid: 206
+  - uid: 196
     components:
     - type: Transform
       pos: -5.5,-19.5
       parent: 1
-  - uid: 207
+  - uid: 197
     components:
     - type: Transform
       pos: -4.5,-19.5
       parent: 1
-  - uid: 208
+  - uid: 198
     components:
     - type: Transform
       pos: -3.5,-19.5
       parent: 1
-  - uid: 209
+  - uid: 199
     components:
     - type: Transform
       pos: -5.5,-21.5
       parent: 1
-  - uid: 210
+  - uid: 200
     components:
     - type: Transform
       pos: -6.5,-26.5
       parent: 1
-  - uid: 211
+  - uid: 201
     components:
     - type: Transform
       pos: -6.5,-25.5
       parent: 1
-  - uid: 212
+  - uid: 202
     components:
     - type: Transform
       pos: -6.5,-24.5
       parent: 1
-  - uid: 213
+  - uid: 203
     components:
     - type: Transform
       pos: -4.5,-23.5
       parent: 1
-  - uid: 214
+  - uid: 204
     components:
     - type: Transform
       pos: -2.5,-20.5
       parent: 1
-  - uid: 215
+  - uid: 205
     components:
     - type: Transform
       pos: -2.5,-19.5
       parent: 1
-  - uid: 216
+  - uid: 206
     components:
     - type: Transform
       pos: -4.5,-25.5
       parent: 1
-  - uid: 217
+  - uid: 207
     components:
     - type: Transform
       pos: -6.5,-23.5
       parent: 1
-  - uid: 218
+  - uid: 208
     components:
     - type: Transform
       pos: -6.5,-20.5
       parent: 1
-  - uid: 219
+  - uid: 209
     components:
     - type: Transform
       pos: -4.5,-24.5
       parent: 1
-  - uid: 220
+  - uid: 210
     components:
     - type: Transform
       pos: -5.5,-18.5
       parent: 1
-  - uid: 221
+  - uid: 211
     components:
     - type: Transform
       pos: -4.5,-18.5
       parent: 1
-  - uid: 222
+  - uid: 212
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 1
-  - uid: 223
+  - uid: 213
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 1
-  - uid: 224
+  - uid: 214
     components:
     - type: Transform
       pos: -4.5,-21.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 225
+  - uid: 215
     components:
     - type: Transform
       pos: -3.5,-19.5
       parent: 1
-  - uid: 226
+  - uid: 216
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 1
-  - uid: 227
+  - uid: 217
     components:
     - type: Transform
       pos: -3.5,-17.5
       parent: 1
-  - uid: 228
+  - uid: 218
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 1
-  - uid: 229
+  - uid: 219
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 1
-  - uid: 230
+  - uid: 220
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 1
-  - uid: 231
+  - uid: 221
     components:
     - type: Transform
       pos: -1.5,-16.5
       parent: 1
-  - uid: 232
+  - uid: 222
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 1
-  - uid: 233
+  - uid: 223
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 234
+  - uid: 224
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 235
+  - uid: 225
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
-  - uid: 236
+  - uid: 226
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 237
+  - uid: 227
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 238
+  - uid: 228
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 239
+  - uid: 229
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 240
+  - uid: 230
     components:
     - type: Transform
       pos: -3.5,-20.5
       parent: 1
-  - uid: 241
+  - uid: 231
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 1
-  - uid: 242
+  - uid: 232
     components:
     - type: Transform
       pos: -4.5,-21.5
       parent: 1
-  - uid: 243
+  - uid: 233
     components:
     - type: Transform
       pos: -4.5,-22.5
       parent: 1
-  - uid: 244
+  - uid: 234
     components:
     - type: Transform
       pos: -4.5,-23.5
       parent: 1
-  - uid: 245
+  - uid: 235
     components:
     - type: Transform
       pos: -4.5,-24.5
       parent: 1
-  - uid: 246
+  - uid: 236
     components:
     - type: Transform
       pos: -4.5,-25.5
       parent: 1
-  - uid: 247
+  - uid: 237
     components:
     - type: Transform
       pos: -4.5,-26.5
       parent: 1
-  - uid: 248
+  - uid: 238
     components:
     - type: Transform
       pos: -4.5,-27.5
       parent: 1
-  - uid: 249
+  - uid: 239
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 250
+  - uid: 240
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 251
+  - uid: 241
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1832,7 +1789,7 @@ entities:
       canCollide: False
     - type: Fixtures
       fixtures: {}
-  - uid: 252
+  - uid: 242
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1844,13 +1801,13 @@ entities:
       fixtures: {}
 - proto: Carpet
   entities:
-  - uid: 253
+  - uid: 243
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 1
-  - uid: 254
+  - uid: 244
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1858,230 +1815,230 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 255
+  - uid: 245
     components:
     - type: Transform
       pos: -2.5,-26.5
       parent: 1
-  - uid: 256
+  - uid: 246
     components:
     - type: Transform
       pos: -2.5,-28.5
       parent: 1
-  - uid: 257
+  - uid: 247
     components:
     - type: Transform
       pos: -8.5,-16.5
       parent: 1
-  - uid: 258
+  - uid: 248
     components:
     - type: Transform
       pos: -1.5,-16.5
       parent: 1
-  - uid: 259
+  - uid: 249
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 1
-  - uid: 260
+  - uid: 250
     components:
     - type: Transform
       pos: 4.5,-24.5
       parent: 1
-  - uid: 261
+  - uid: 251
     components:
     - type: Transform
       pos: 5.5,-24.5
       parent: 1
-  - uid: 262
+  - uid: 252
     components:
     - type: Transform
       pos: -6.5,-16.5
       parent: 1
-  - uid: 263
+  - uid: 253
     components:
     - type: Transform
       pos: -7.5,-16.5
       parent: 1
-  - uid: 264
+  - uid: 254
     components:
     - type: Transform
       pos: -4.5,-13.5
       parent: 1
-  - uid: 265
+  - uid: 255
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 1
-  - uid: 266
+  - uid: 256
     components:
     - type: Transform
       pos: -4.5,-11.5
       parent: 1
-  - uid: 267
+  - uid: 257
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 268
+  - uid: 258
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 269
+  - uid: 259
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
-  - uid: 270
+  - uid: 260
     components:
     - type: Transform
       pos: 5.5,-16.5
       parent: 1
-  - uid: 271
+  - uid: 261
     components:
     - type: Transform
       pos: 6.5,-16.5
       parent: 1
-  - uid: 272
+  - uid: 262
     components:
     - type: Transform
       pos: -0.5,-24.5
       parent: 1
-  - uid: 273
+  - uid: 263
     components:
     - type: Transform
       pos: -0.5,-23.5
       parent: 1
-  - uid: 274
+  - uid: 264
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 1
-  - uid: 275
+  - uid: 265
     components:
     - type: Transform
       pos: 5.5,-9.5
       parent: 1
-  - uid: 276
+  - uid: 266
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 277
+  - uid: 267
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 1
-  - uid: 278
+  - uid: 268
     components:
     - type: Transform
       pos: 0.5,-26.5
       parent: 1
-  - uid: 279
+  - uid: 269
     components:
     - type: Transform
       pos: 1.5,-27.5
       parent: 1
-  - uid: 280
+  - uid: 270
     components:
     - type: Transform
       pos: -2.5,-27.5
       parent: 1
-  - uid: 281
+  - uid: 271
     components:
     - type: Transform
       pos: -2.5,-29.5
       parent: 1
-  - uid: 282
+  - uid: 272
     components:
     - type: Transform
       pos: 1.5,-26.5
       parent: 1
-  - uid: 283
+  - uid: 273
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 284
+  - uid: 274
     components:
     - type: Transform
       pos: -0.5,-26.5
       parent: 1
-  - uid: 285
+  - uid: 275
     components:
     - type: Transform
       pos: 1.5,-28.5
       parent: 1
-  - uid: 286
+  - uid: 276
     components:
     - type: Transform
       pos: 1.5,-29.5
       parent: 1
-  - uid: 287
+  - uid: 277
     components:
     - type: Transform
       pos: -1.5,-26.5
       parent: 1
-  - uid: 288
+  - uid: 278
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 289
+  - uid: 279
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 1
-  - uid: 290
+  - uid: 280
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 291
+  - uid: 281
     components:
     - type: Transform
       pos: -6.5,-9.5
       parent: 1
-  - uid: 292
+  - uid: 282
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 1
-  - uid: 293
+  - uid: 283
     components:
     - type: Transform
       pos: -4.5,-9.5
       parent: 1
-  - uid: 294
+  - uid: 284
     components:
     - type: Transform
       pos: 7.5,-16.5
       parent: 1
-  - uid: 295
+  - uid: 285
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 296
+  - uid: 286
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
-  - uid: 297
+  - uid: 287
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
 - proto: Chair
   entities:
-  - uid: 298
+  - uid: 288
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-21.5
       parent: 1
-  - uid: 299
+  - uid: 289
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2089,7 +2046,7 @@ entities:
       parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 300
+  - uid: 290
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2097,69 +2054,69 @@ entities:
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 301
+  - uid: 291
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-21.5
       parent: 1
-  - uid: 302
+  - uid: 292
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-8.5
       parent: 1
-  - uid: 303
+  - uid: 293
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-9.5
       parent: 1
-  - uid: 304
+  - uid: 294
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-10.5
       parent: 1
-  - uid: 305
+  - uid: 295
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-8.5
       parent: 1
-  - uid: 306
+  - uid: 296
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 1
-  - uid: 307
+  - uid: 297
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-9.5
       parent: 1
-  - uid: 308
+  - uid: 298
     components:
     - type: Transform
       pos: -2.5,-15.5
       parent: 1
-  - uid: 309
+  - uid: 299
     components:
     - type: Transform
       pos: -1.5,-15.5
       parent: 1
-  - uid: 310
+  - uid: 300
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 1
-  - uid: 311
+  - uid: 301
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 1
-  - uid: 312
+  - uid: 302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2167,108 +2124,127 @@ entities:
       parent: 1
 - proto: ClothingBackpackDuffelSyndicateAmmoFilled
   entities:
-  - uid: 49
+  - uid: 303
     components:
     - type: Transform
       pos: 1.4468282,-11.670399
       parent: 1
+    - type: GroupExamine
+      group:
+      - hoverMessage: ""
+        contextText: verb-examine-group-other
+        icon: /Textures/Interface/examine-star.png
+        components:
+        - Armor
+        - ClothingSpeedModifier
+        entries:
+        - message: >-
+            It provides the following protection:
+
+            - [color=orange]Explosion[/color] damage [color=white]to contents[/color] reduced by [color=lightblue]90%[/color].
+          priority: 0
+          component: Armor
+        - message: This decreases your running speed by [color=yellow]10%[/color].
+          priority: 0
+          component: ClothingSpeedModifier
+        title: null
 - proto: ClothingBackpackDuffelSyndicateFilledMedical
   entities:
-  - uid: 314
+  - uid: 304
     components:
     - type: Transform
       pos: -5.6167116,-4.2485933
       parent: 1
 - proto: ClothingHeadHatSyndie
   entities:
-  - uid: 315
+  - uid: 305
     components:
     - type: Transform
       pos: -3.0420556,-17.469692
       parent: 1
 - proto: ClothingHeadHatSyndieMAA
   entities:
-  - uid: 35
+  - uid: 31
     components:
     - type: Transform
-      parent: 33
+      parent: 29
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingHeadPyjamaSyndicateRed
   entities:
-  - uid: 36
+  - uid: 32
     components:
     - type: Transform
-      parent: 33
+      parent: 29
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingHeadsetAltSyndicate
   entities:
-  - uid: 316
+  - uid: 306
     components:
     - type: Transform
       pos: 1.3157192,-13.513277
       parent: 1
 - proto: ClothingMaskGasSyndicate
   entities:
-  - uid: 317
+  - uid: 307
     components:
     - type: Transform
       pos: 0.94071925,-13.482027
       parent: 1
 - proto: ClothingNeckMantleHOS
   entities:
-  - uid: 37
+  - uid: 33
     components:
     - type: MetaData
       desc: Looted from a fallen enemy, the commander earned this in battle.
       name: commander mantle
     - type: Transform
-      parent: 33
+      parent: 29
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingOuterCoatSyndieCap
   entities:
-  - uid: 38
+  - uid: 34
     components:
     - type: Transform
-      parent: 33
+      parent: 29
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtSyndieFormalDress
   entities:
-  - uid: 39
+  - uid: 35
     components:
     - type: Transform
-      parent: 33
+      parent: 29
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpsuitPyjamaSyndicateRed
   entities:
-  - uid: 40
+  - uid: 36
     components:
     - type: Transform
-      parent: 33
+      parent: 29
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpsuitSyndieFormal
   entities:
-  - uid: 41
+  - uid: 37
     components:
     - type: Transform
-      parent: 33
+      parent: 29
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ComfyChair
   entities:
-  - uid: 318
+  - uid: 308
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2276,7 +2252,7 @@ entities:
       parent: 1
 - proto: computerBodyScanner
   entities:
-  - uid: 319
+  - uid: 309
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2284,7 +2260,7 @@ entities:
       parent: 1
 - proto: ComputerIFFSyndicate
   entities:
-  - uid: 320
+  - uid: 310
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2292,7 +2268,7 @@ entities:
       parent: 1
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 321
+  - uid: 311
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2300,28 +2276,28 @@ entities:
       parent: 1
 - proto: ComputerRadar
   entities:
-  - uid: 322
+  - uid: 312
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
 - proto: ComputerShuttleSyndie
   entities:
-  - uid: 323
+  - uid: 313
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
 - proto: CrowbarRed
   entities:
-  - uid: 324
+  - uid: 314
     components:
     - type: Transform
       pos: -3.492848,-22.485775
       parent: 1
 - proto: DisposalBend
   entities:
-  - uid: 325
+  - uid: 315
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2329,7 +2305,7 @@ entities:
       parent: 1
 - proto: DisposalJunction
   entities:
-  - uid: 326
+  - uid: 316
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2337,123 +2313,123 @@ entities:
       parent: 1
 - proto: DisposalPipe
   entities:
-  - uid: 327
+  - uid: 317
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 1
-  - uid: 328
+  - uid: 318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-19.5
       parent: 1
-  - uid: 329
+  - uid: 319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-19.5
       parent: 1
-  - uid: 330
+  - uid: 320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-19.5
       parent: 1
-  - uid: 331
+  - uid: 321
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-19.5
       parent: 1
-  - uid: 332
+  - uid: 322
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-19.5
       parent: 1
-  - uid: 333
+  - uid: 323
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-19.5
       parent: 1
-  - uid: 334
+  - uid: 324
     components:
     - type: Transform
       pos: -0.5,-18.5
       parent: 1
-  - uid: 335
+  - uid: 325
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 1
-  - uid: 336
+  - uid: 326
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 1
-  - uid: 337
+  - uid: 327
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 1
-  - uid: 338
+  - uid: 328
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 339
+  - uid: 329
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 340
+  - uid: 330
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
-  - uid: 341
+  - uid: 331
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 342
+  - uid: 332
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 343
+  - uid: 333
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 344
+  - uid: 334
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 345
+  - uid: 335
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
 - proto: DisposalTrunk
   entities:
-  - uid: 346
+  - uid: 336
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-6.5
       parent: 1
-  - uid: 347
+  - uid: 337
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-19.5
       parent: 1
-  - uid: 348
+  - uid: 338
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2461,133 +2437,133 @@ entities:
       parent: 1
 - proto: DisposalUnit
   entities:
-  - uid: 349
+  - uid: 339
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 350
+  - uid: 340
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 1
 - proto: DoubleEmergencyOxygenTankFilled
   entities:
-  - uid: 351
+  - uid: 341
     components:
     - type: Transform
       pos: -1.6924903,-23.407444
       parent: 1
-  - uid: 352
+  - uid: 342
     components:
     - type: Transform
       pos: -1.4112403,-23.458082
       parent: 1
-  - uid: 353
+  - uid: 343
     components:
     - type: Transform
       pos: 5.390987,-17.346693
       parent: 1
-  - uid: 354
+  - uid: 344
     components:
     - type: Transform
       pos: -6.6334953,-17.346693
       parent: 1
 - proto: DrinkGlass
   entities:
-  - uid: 355
+  - uid: 345
     components:
     - type: Transform
       pos: 2.0779252,-19.21155
       parent: 1
-  - uid: 356
+  - uid: 346
     components:
     - type: Transform
       pos: 2.3123002,-19.21155
       parent: 1
 - proto: DrinkMugDog
   entities:
-  - uid: 357
+  - uid: 347
     components:
     - type: Transform
       pos: 2.2843437,-19.542192
       parent: 1
 - proto: DrinkMugMetal
   entities:
-  - uid: 358
+  - uid: 348
     components:
     - type: Transform
       pos: 2.0968437,-19.526567
       parent: 1
 - proto: DrinkMugRed
   entities:
-  - uid: 359
+  - uid: 349
     components:
     - type: Transform
       pos: 1.9918958,-17.588755
       parent: 1
 - proto: DrinkVacuumFlask
   entities:
-  - uid: 360
+  - uid: 350
     components:
     - type: Transform
       pos: 5.6435027,-21.180143
       parent: 1
-  - uid: 361
+  - uid: 351
     components:
     - type: Transform
       pos: 5.7372527,-21.398893
       parent: 1
 - proto: ExtendedEmergencyOxygenTankFilled
   entities:
-  - uid: 362
+  - uid: 352
     components:
     - type: Transform
       pos: -5.678572,-12.319441
       parent: 1
-  - uid: 363
+  - uid: 353
     components:
     - type: Transform
       pos: 4.305803,-12.272566
       parent: 1
 - proto: FireAxeFlaming
   entities:
-  - uid: 23
+  - uid: 354
     components:
     - type: Transform
       pos: -1.5018963,-3.4569345
       parent: 1
 - proto: FoodBoxDonkpocketPizza
   entities:
-  - uid: 364
+  - uid: 355
     components:
     - type: Transform
       pos: 2.7185502,-19.320925
       parent: 1
 - proto: FoodBoxDonut
   entities:
-  - uid: 365
+  - uid: 356
     components:
     - type: Transform
       pos: 5.5401826,-21.187487
       parent: 1
 - proto: FoodPizzaDonkpocket
   entities:
-  - uid: 366
+  - uid: 357
     components:
     - type: Transform
       pos: 1.4776825,-21.296862
       parent: 1
 - proto: FoodSnackSyndi
   entities:
-  - uid: 367
+  - uid: 358
     components:
     - type: Transform
       pos: 1.5361897,-17.367903
       parent: 1
 - proto: GasMinerNitrogen
   entities:
-  - uid: 368
+  - uid: 359
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2595,7 +2571,7 @@ entities:
       parent: 1
 - proto: GasMinerOxygen
   entities:
-  - uid: 369
+  - uid: 360
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2603,7 +2579,7 @@ entities:
       parent: 1
 - proto: GasMixer
   entities:
-  - uid: 370
+  - uid: 361
     components:
     - type: MetaData
       name: O2+N2 mixer
@@ -2618,19 +2594,19 @@ entities:
       color: '#0335FCFF'
 - proto: GasPassiveVent
   entities:
-  - uid: 371
+  - uid: 362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-26.5
       parent: 1
-  - uid: 372
+  - uid: 363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-26.5
       parent: 1
-  - uid: 373
+  - uid: 364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2638,7 +2614,7 @@ entities:
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 374
+  - uid: 365
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2646,19 +2622,19 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 375
+  - uid: 366
     components:
     - type: Transform
       pos: 5.5,-24.5
       parent: 1
-  - uid: 376
+  - uid: 367
     components:
     - type: Transform
       pos: 3.5,-20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 377
+  - uid: 368
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2666,7 +2642,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 378
+  - uid: 369
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2674,7 +2650,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 379
+  - uid: 370
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2682,14 +2658,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 380
+  - uid: 371
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 381
+  - uid: 372
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2697,7 +2673,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 382
+  - uid: 373
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2705,7 +2681,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 383
+  - uid: 374
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2715,28 +2691,28 @@ entities:
       color: '#FF1212FF'
 - proto: GasPipeFourway
   entities:
-  - uid: 384
+  - uid: 375
     components:
     - type: Transform
       pos: 3.5,-23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 385
+  - uid: 376
     components:
     - type: Transform
       pos: -0.5,-20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 386
+  - uid: 377
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 387
+  - uid: 378
     components:
     - type: Transform
       pos: 0.5,-17.5
@@ -2745,39 +2721,39 @@ entities:
       color: '#FF1212FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 388
+  - uid: 379
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-25.5
       parent: 1
-  - uid: 389
+  - uid: 380
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-25.5
       parent: 1
-  - uid: 390
+  - uid: 381
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-24.5
       parent: 1
-  - uid: 391
+  - uid: 382
     components:
     - type: Transform
       pos: 3.5,-22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 392
+  - uid: 383
     components:
     - type: Transform
       pos: 3.5,-21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 393
+  - uid: 384
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2785,7 +2761,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 394
+  - uid: 385
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2793,7 +2769,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 395
+  - uid: 386
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2801,7 +2777,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 396
+  - uid: 387
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2809,7 +2785,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 397
+  - uid: 388
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2817,7 +2793,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 398
+  - uid: 389
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2825,98 +2801,98 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 399
+  - uid: 390
     components:
     - type: Transform
       pos: -0.5,-19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 400
+  - uid: 391
     components:
     - type: Transform
       pos: -0.5,-18.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 401
+  - uid: 392
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 402
+  - uid: 393
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 403
+  - uid: 394
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 404
+  - uid: 395
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 405
+  - uid: 396
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 406
+  - uid: 397
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 407
+  - uid: 398
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 408
+  - uid: 399
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 409
+  - uid: 400
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 410
+  - uid: 401
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 411
+  - uid: 402
     components:
     - type: Transform
       pos: 0.5,-18.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 412
+  - uid: 403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2924,7 +2900,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 413
+  - uid: 404
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2932,7 +2908,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 414
+  - uid: 405
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2940,7 +2916,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 415
+  - uid: 406
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2948,7 +2924,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 416
+  - uid: 407
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2956,7 +2932,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 417
+  - uid: 408
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2964,13 +2940,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 418
+  - uid: 409
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-19.5
       parent: 1
-  - uid: 419
+  - uid: 410
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2978,7 +2954,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 420
+  - uid: 411
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2986,7 +2962,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 421
+  - uid: 412
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2994,7 +2970,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 422
+  - uid: 413
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3002,7 +2978,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 423
+  - uid: 414
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3010,7 +2986,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 424
+  - uid: 415
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3018,7 +2994,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 425
+  - uid: 416
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3026,7 +3002,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 426
+  - uid: 417
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3034,7 +3010,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 427
+  - uid: 418
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3042,7 +3018,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 428
+  - uid: 419
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3050,7 +3026,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 429
+  - uid: 420
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3058,7 +3034,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 430
+  - uid: 421
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3066,7 +3042,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 431
+  - uid: 422
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3074,28 +3050,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 432
+  - uid: 423
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 433
+  - uid: 424
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 434
+  - uid: 425
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 435
+  - uid: 426
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3103,7 +3079,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 436
+  - uid: 427
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3111,14 +3087,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 437
+  - uid: 428
     components:
     - type: Transform
       pos: 0.5,-20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 438
+  - uid: 429
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3126,7 +3102,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 439
+  - uid: 430
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3134,7 +3110,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 440
+  - uid: 431
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3142,7 +3118,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 441
+  - uid: 432
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3150,7 +3126,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 442
+  - uid: 433
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3160,7 +3136,7 @@ entities:
       color: '#0335FCFF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 443
+  - uid: 434
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3168,14 +3144,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 444
+  - uid: 435
     components:
     - type: Transform
       pos: 2.5,-19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 445
+  - uid: 436
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3183,7 +3159,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 446
+  - uid: 437
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3193,7 +3169,7 @@ entities:
       color: '#FF1212FF'
 - proto: GasPort
   entities:
-  - uid: 447
+  - uid: 438
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3203,7 +3179,7 @@ entities:
       color: '#0335FCFF'
 - proto: GasPressurePump
   entities:
-  - uid: 448
+  - uid: 439
     components:
     - type: MetaData
       name: waste pump
@@ -3215,7 +3191,7 @@ entities:
       color: '#FF1212FF'
 - proto: GasVentPump
   entities:
-  - uid: 449
+  - uid: 440
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3223,7 +3199,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 450
+  - uid: 441
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3231,7 +3207,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 451
+  - uid: 442
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3239,7 +3215,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 452
+  - uid: 443
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3247,7 +3223,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 453
+  - uid: 444
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3255,7 +3231,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 454
+  - uid: 445
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3263,7 +3239,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 455
+  - uid: 446
     components:
     - type: Transform
       pos: 0.5,-3.5
@@ -3272,7 +3248,7 @@ entities:
       color: '#0335FCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 456
+  - uid: 447
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3280,7 +3256,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 457
+  - uid: 448
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3288,7 +3264,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 458
+  - uid: 449
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3296,7 +3272,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 459
+  - uid: 450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3304,7 +3280,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 460
+  - uid: 451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3312,7 +3288,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 461
+  - uid: 452
     components:
     - type: Transform
       pos: -0.5,-3.5
@@ -3321,247 +3297,247 @@ entities:
       color: '#FF1212FF'
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 462
+  - uid: 453
     components:
     - type: Transform
       pos: -4.5,-26.5
       parent: 1
-  - uid: 463
+  - uid: 454
     components:
     - type: Transform
       pos: -4.5,-25.5
       parent: 1
-  - uid: 464
+  - uid: 455
     components:
     - type: Transform
       pos: -4.5,-24.5
       parent: 1
-  - uid: 465
+  - uid: 456
     components:
     - type: Transform
       pos: -6.5,-24.5
       parent: 1
-  - uid: 466
+  - uid: 457
     components:
     - type: Transform
       pos: -6.5,-25.5
       parent: 1
-  - uid: 467
+  - uid: 458
     components:
     - type: Transform
       pos: -6.5,-26.5
       parent: 1
 - proto: GeneratorWallmountAPU
   entities:
-  - uid: 468
+  - uid: 459
     components:
     - type: Transform
       pos: -6.5,-20.5
       parent: 1
 - proto: GravityGeneratorMini
   entities:
-  - uid: 469
+  - uid: 460
     components:
     - type: Transform
       pos: -5.5,-22.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 470
+  - uid: 461
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 1
-  - uid: 471
+  - uid: 462
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
-  - uid: 472
+  - uid: 463
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-7.5
       parent: 1
-  - uid: 473
+  - uid: 464
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 474
+  - uid: 465
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 475
+  - uid: 466
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 476
+  - uid: 467
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 477
+  - uid: 468
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 478
+  - uid: 469
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 479
+  - uid: 470
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 480
+  - uid: 471
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 481
+  - uid: 472
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 482
+  - uid: 473
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 483
+  - uid: 474
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 484
+  - uid: 475
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 1
-  - uid: 485
+  - uid: 476
     components:
     - type: Transform
       pos: -2.5,-19.5
       parent: 1
-  - uid: 486
+  - uid: 477
     components:
     - type: Transform
       pos: 2.5,-22.5
       parent: 1
-  - uid: 487
+  - uid: 478
     components:
     - type: Transform
       pos: 4.5,-22.5
       parent: 1
-  - uid: 488
+  - uid: 479
     components:
     - type: Transform
       pos: -1.5,-18.5
       parent: 1
-  - uid: 489
+  - uid: 480
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 490
+  - uid: 481
     components:
     - type: Transform
       pos: 3.5,-25.5
       parent: 1
-  - uid: 491
+  - uid: 482
     components:
     - type: Transform
       pos: 5.5,-25.5
       parent: 1
-  - uid: 492
+  - uid: 483
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-19.5
       parent: 1
-  - uid: 493
+  - uid: 484
     components:
     - type: Transform
       pos: 0.5,-18.5
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 494
+  - uid: 485
     components:
     - type: Transform
       pos: -5.5,-13.5
       parent: 1
-  - uid: 495
+  - uid: 486
     components:
     - type: Transform
       pos: 4.5,-13.5
       parent: 1
 - proto: HospitalCurtainsOpen
   entities:
-  - uid: 496
+  - uid: 487
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
 - proto: JetpackBlackFilled
   entities:
-  - uid: 313
+  - uid: 489
     components:
     - type: Transform
-      parent: 45
+      parent: 488
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 501
+  - uid: 490
     components:
     - type: Transform
-      parent: 45
+      parent: 488
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 502
+  - uid: 491
     components:
     - type: Transform
-      parent: 45
+      parent: 488
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 511
+  - uid: 492
     components:
     - type: Transform
-      parent: 45
+      parent: 488
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 512
+  - uid: 493
     components:
     - type: Transform
-      parent: 45
+      parent: 488
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: KnifePlastic
   entities:
-  - uid: 498
+  - uid: 494
     components:
     - type: Transform
       pos: 5.3509636,-21.445768
       parent: 1
 - proto: Lamp
   entities:
-  - uid: 499
+  - uid: 495
     components:
     - type: Transform
       pos: -1.483297,-2.2444057
       parent: 1
 - proto: LockerSyndicatePersonal
   entities:
-  - uid: 33
+  - uid: 29
     components:
     - type: Transform
       pos: 4.5,-5.5
@@ -3572,37 +3548,27 @@ entities:
         immutable: False
         temperature: 293.1496
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 37
-          - 39
-          - 36
-          - 40
-          - 41
-          - 38
+          - 33
           - 35
+          - 32
+          - 36
+          - 37
           - 34
+          - 31
+          - 30
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 45
+  - uid: 488
     components:
     - type: Transform
       pos: -1.5,-17.5
@@ -3613,43 +3579,33 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 313
-          - 501
-          - 502
-          - 511
-          - 512
+          - 489
+          - 490
+          - 491
+          - 492
+          - 493
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: MedicalBed
   entities:
-  - uid: 500
+  - uid: 496
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
 - proto: Mirror
   entities:
-  - uid: 503
+  - uid: 497
     components:
     - type: Transform
       pos: 4.5,-3.5
@@ -3658,131 +3614,133 @@ entities:
       fixtures: {}
 - proto: Multitool
   entities:
-  - uid: 504
+  - uid: 498
     components:
     - type: Transform
       pos: -3.383473,-22.548275
       parent: 1
 - proto: NitrogenTankFilled
   entities:
-  - uid: 505
+  - uid: 499
     components:
     - type: Transform
       pos: 4.633928,-12.616316
       parent: 1
-  - uid: 506
+  - uid: 500
     components:
     - type: Transform
       pos: -5.397322,-12.569441
       parent: 1
-  - uid: 507
+  - uid: 501
     components:
     - type: Transform
       pos: -6.3522453,-17.549818
       parent: 1
-  - uid: 508
+  - uid: 502
     components:
     - type: Transform
       pos: 5.6633797,-17.565443
       parent: 1
 - proto: NuclearBombUnanchored
   entities:
-  - uid: 509
+  - uid: 503
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 1
 - proto: NukeOpsGrenadeSpawner
   entities:
-  - uid: 44
+  - uid: 504
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
 - proto: NukeOpsLootSpawner
   entities:
-  - uid: 46
+  - uid: 505
     components:
     - type: Transform
       pos: -3.5,-17.5
       parent: 1
 - proto: NukeOpsMedkitBruteSpawner
   entities:
-  - uid: 48
+  - uid: 506
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 50
+  - uid: 507
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
 - proto: NukeOpsMedkitSpawner
   entities:
-  - uid: 47
+  - uid: 508
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
 - proto: OperatingTable
   entities:
-  - uid: 513
+  - uid: 509
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
 - proto: OxygenCanister
   entities:
-  - uid: 514
+  - uid: 510
     components:
     - type: Transform
       pos: -1.5,-24.5
       parent: 1
 - proto: OxygenTankFilled
   entities:
-  - uid: 515
+  - uid: 511
     components:
     - type: Transform
       pos: -5.600447,-12.569441
       parent: 1
-  - uid: 516
+  - uid: 512
     components:
     - type: Transform
       pos: 4.399553,-12.522566
       parent: 1
-  - uid: 517
+  - uid: 513
     components:
     - type: Transform
       pos: 5.5227547,-17.440443
       parent: 1
-  - uid: 518
+  - uid: 514
     components:
     - type: Transform
       pos: -6.4928703,-17.440443
       parent: 1
-- proto: PinpointerNuclear
+- proto: PinpointerUniversal
   entities:
-  - uid: 519
+  - uid: 515
     components:
+    - type: MetaData
+      desc: A handheld tracking device. Change targets by clicking on an object while the pinpointer is off. Keep upright to retain accuracy.
     - type: Transform
-      pos: -2.4942985,-13.37949
+      pos: -2.5,-13.5
       parent: 1
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 520
+  - uid: 516
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 1
-  - uid: 521
+  - uid: 517
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-6.5
       parent: 1
-  - uid: 522
+  - uid: 518
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3790,14 +3748,14 @@ entities:
       parent: 1
 - proto: PlushieNuke
   entities:
-  - uid: 523
+  - uid: 519
     components:
     - type: Transform
       pos: -2.4227936,-2.3320491
       parent: 1
 - proto: PosterContrabandC20r
   entities:
-  - uid: 524
+  - uid: 520
     components:
     - type: Transform
       pos: 1.5,-14.5
@@ -3806,7 +3764,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandCC64KAd
   entities:
-  - uid: 525
+  - uid: 521
     components:
     - type: Transform
       pos: -5.5,-18.5
@@ -3815,7 +3773,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandCybersun600
   entities:
-  - uid: 526
+  - uid: 522
     components:
     - type: Transform
       pos: 2.5,-6.5
@@ -3824,7 +3782,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandDonk
   entities:
-  - uid: 527
+  - uid: 523
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3834,7 +3792,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandDonutCorp
   entities:
-  - uid: 528
+  - uid: 524
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3844,7 +3802,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandEnergySwords
   entities:
-  - uid: 529
+  - uid: 525
     components:
     - type: Transform
       pos: 2.5,-18.5
@@ -3853,7 +3811,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandEnlistGorlex
   entities:
-  - uid: 530
+  - uid: 526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3863,7 +3821,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandFreeSyndicateEncryptionKey
   entities:
-  - uid: 531
+  - uid: 527
     components:
     - type: Transform
       pos: -2.5,-8.5
@@ -3872,7 +3830,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandInterdyne
   entities:
-  - uid: 532
+  - uid: 528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3882,7 +3840,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandKosmicheskayaStantsiya
   entities:
-  - uid: 533
+  - uid: 529
     components:
     - type: Transform
       pos: -2.5,-22.5
@@ -3891,14 +3849,14 @@ entities:
       fixtures: {}
 - proto: PosterContrabandMoth
   entities:
-  - uid: 534
+  - uid: 530
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 535
+  - uid: 531
     components:
     - type: Transform
       pos: 2.5,-3.5
@@ -3907,7 +3865,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandNuclearDeviceInformational
   entities:
-  - uid: 536
+  - uid: 532
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3915,7 +3873,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 537
+  - uid: 533
     components:
     - type: Transform
       pos: 0.5,-14.5
@@ -3924,7 +3882,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandSyndicatePistol
   entities:
-  - uid: 538
+  - uid: 534
     components:
     - type: Transform
       pos: 1.5,-10.5
@@ -3933,7 +3891,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandSyndicateRecruitment
   entities:
-  - uid: 539
+  - uid: 535
     components:
     - type: Transform
       pos: -1.5,-14.5
@@ -3942,7 +3900,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandWaffleCorp
   entities:
-  - uid: 540
+  - uid: 536
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3952,7 +3910,7 @@ entities:
       fixtures: {}
 - proto: Poweredlight
   entities:
-  - uid: 541
+  - uid: 537
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3960,7 +3918,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 542
+  - uid: 538
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3968,7 +3926,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 543
+  - uid: 539
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3976,7 +3934,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 544
+  - uid: 540
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3984,14 +3942,14 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 545
+  - uid: 541
     components:
     - type: Transform
       pos: -4.5,-19.5
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 546
+  - uid: 542
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3999,7 +3957,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 547
+  - uid: 543
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4007,7 +3965,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 548
+  - uid: 544
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4015,21 +3973,21 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 549
+  - uid: 545
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 550
+  - uid: 546
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 551
+  - uid: 547
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4037,7 +3995,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 552
+  - uid: 548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4045,7 +4003,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 553
+  - uid: 549
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4055,7 +4013,7 @@ entities:
       powerLoad: 0
 - proto: PoweredSmallLight
   entities:
-  - uid: 554
+  - uid: 550
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4063,7 +4021,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 555
+  - uid: 551
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4071,7 +4029,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 556
+  - uid: 552
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4079,7 +4037,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 557
+  - uid: 553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4087,7 +4045,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 558
+  - uid: 554
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4095,7 +4053,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 559
+  - uid: 555
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4103,31 +4061,31 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 560
+  - uid: 556
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 1
-  - uid: 561
+  - uid: 557
     components:
     - type: Transform
       pos: 5.5,-15.5
       parent: 1
-  - uid: 562
+  - uid: 558
     components:
     - type: Transform
       pos: 2.5,-19.5
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 563
+  - uid: 559
     components:
     - type: Transform
       pos: -1.5,-26.5
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 564
+  - uid: 560
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4135,7 +4093,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 565
+  - uid: 561
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4145,260 +4103,260 @@ entities:
       powerLoad: 0
 - proto: Rack
   entities:
-  - uid: 566
+  - uid: 562
     components:
     - type: Transform
       pos: -3.5,-22.5
       parent: 1
-  - uid: 567
+  - uid: 563
     components:
     - type: Transform
       pos: 5.5,-23.5
       parent: 1
-  - uid: 568
+  - uid: 564
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-12.5
       parent: 1
-  - uid: 569
+  - uid: 565
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-12.5
       parent: 1
-  - uid: 570
+  - uid: 566
     components:
     - type: Transform
       pos: -1.5,-23.5
       parent: 1
-  - uid: 571
+  - uid: 567
     components:
     - type: Transform
       pos: -6.5,-17.5
       parent: 1
-  - uid: 572
+  - uid: 568
     components:
     - type: Transform
       pos: 5.5,-17.5
       parent: 1
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 573
+  - uid: 569
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 574
+  - uid: 570
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-19.5
       parent: 1
-  - uid: 575
+  - uid: 571
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 576
+  - uid: 572
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 577
+  - uid: 573
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 578
+  - uid: 574
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 579
+  - uid: 575
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 580
+  - uid: 576
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 581
+  - uid: 577
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 582
+  - uid: 578
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 583
+  - uid: 579
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1
-  - uid: 584
+  - uid: 580
     components:
     - type: Transform
       pos: 4.5,-22.5
       parent: 1
-  - uid: 585
+  - uid: 581
     components:
     - type: Transform
       pos: 2.5,-22.5
       parent: 1
-  - uid: 586
+  - uid: 582
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 1
-  - uid: 587
+  - uid: 583
     components:
     - type: Transform
       pos: -2.5,-19.5
       parent: 1
-  - uid: 588
+  - uid: 584
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 589
+  - uid: 585
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 590
+  - uid: 586
     components:
     - type: Transform
       pos: 0.5,-18.5
       parent: 1
-  - uid: 591
+  - uid: 587
     components:
     - type: Transform
       pos: 3.5,-25.5
       parent: 1
-  - uid: 592
+  - uid: 588
     components:
     - type: Transform
       pos: 5.5,-25.5
       parent: 1
-  - uid: 593
+  - uid: 589
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 1
-  - uid: 594
+  - uid: 590
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
-  - uid: 595
+  - uid: 591
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 596
+  - uid: 592
     components:
     - type: Transform
       pos: -1.5,-18.5
       parent: 1
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 597
+  - uid: 593
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 598
+  - uid: 594
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 599
+  - uid: 595
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 600
+  - uid: 596
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 601
+  - uid: 597
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 602
+  - uid: 598
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 603
+  - uid: 599
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 604
+  - uid: 600
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 605
+  - uid: 601
     components:
     - type: Transform
       pos: 5.5,-19.5
       parent: 1
-  - uid: 606
+  - uid: 602
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 607
+  - uid: 603
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 608
+  - uid: 604
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 609
+  - uid: 605
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        600:
+        596:
         - - Pressed
           - Toggle
-        599:
+        595:
         - - Pressed
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 611
+  - uid: 606
     components:
     - type: Transform
       pos: 5.5,-20.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        605:
+        601:
         - - Pressed
           - Toggle
     - type: Fixtures
       fixtures: {}
 - proto: SignalButtonDirectional
   entities:
-  - uid: 20
+  - uid: 607
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4406,15 +4364,15 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        602:
+        598:
         - - Pressed
           - Toggle
-        598:
+        594:
         - - Pressed
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 21
+  - uid: 608
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4422,39 +4380,39 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
+        593:
+        - - Pressed
+          - Toggle
         597:
-        - - Pressed
-          - Toggle
-        601:
-        - - Pressed
-          - Toggle
-        608:
-        - - Pressed
-          - Toggle
-        606:
         - - Pressed
           - Toggle
         604:
         - - Pressed
           - Toggle
-        607:
+        602:
+        - - Pressed
+          - Toggle
+        600:
         - - Pressed
           - Toggle
         603:
+        - - Pressed
+          - Toggle
+        599:
         - - Pressed
           - Toggle
     - type: Fixtures
       fixtures: {}
 - proto: SignDirectionalEvac
   entities:
-  - uid: 613
+  - uid: 609
     components:
     - type: Transform
       pos: 0.5,-22.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 614
+  - uid: 610
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4462,7 +4420,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 615
+  - uid: 611
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4470,7 +4428,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 616
+  - uid: 612
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4478,7 +4436,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 617
+  - uid: 613
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4488,7 +4446,7 @@ entities:
       fixtures: {}
 - proto: SignElectricalMed
   entities:
-  - uid: 618
+  - uid: 614
     components:
     - type: Transform
       pos: -2.5,-18.5
@@ -4497,7 +4455,7 @@ entities:
       fixtures: {}
 - proto: SignNosmoking
   entities:
-  - uid: 619
+  - uid: 615
     components:
     - type: Transform
       pos: 5.5,-22.5
@@ -4506,21 +4464,21 @@ entities:
       fixtures: {}
 - proto: SignSecureSmallRed
   entities:
-  - uid: 620
+  - uid: 616
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 621
+  - uid: 617
     components:
     - type: Transform
       pos: 4.5,-17.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 622
+  - uid: 618
     components:
     - type: Transform
       pos: 2.5,-11.5
@@ -4529,187 +4487,187 @@ entities:
       fixtures: {}
 - proto: SMESBasic
   entities:
-  - uid: 623
+  - uid: 619
     components:
     - type: Transform
       pos: -5.5,-19.5
       parent: 1
-  - uid: 624
+  - uid: 620
     components:
     - type: Transform
       pos: -4.5,-19.5
       parent: 1
 - proto: SoapSyndie
   entities:
-  - uid: 625
+  - uid: 621
     components:
     - type: Transform
       pos: 2.4424396,-17.430403
       parent: 1
 - proto: SodaDispenser
   entities:
-  - uid: 626
+  - uid: 622
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 1
 - proto: StorageCanister
   entities:
-  - uid: 627
+  - uid: 623
     components:
     - type: Transform
       pos: 2.5,-23.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 628
+  - uid: 624
     components:
     - type: Transform
       pos: -3.5,-19.5
       parent: 1
 - proto: SuitStorageEVASyndicate
   entities:
-  - uid: 629
+  - uid: 625
     components:
     - type: Transform
       pos: 0.5,-24.5
       parent: 1
-  - uid: 630
+  - uid: 626
     components:
     - type: Transform
       pos: 0.5,-23.5
       parent: 1
-  - uid: 631
+  - uid: 627
     components:
     - type: Transform
       pos: 3.5,-17.5
       parent: 1
-  - uid: 632
+  - uid: 628
     components:
     - type: Transform
       pos: -4.5,-17.5
       parent: 1
 - proto: SyndicateMicrowave
   entities:
-  - uid: 497
+  - uid: 629
     components:
     - type: Transform
       pos: 3.5,-19.5
       parent: 1
 - proto: Table
   entities:
-  - uid: 637
+  - uid: 630
     components:
     - type: Transform
       pos: 5.5,-21.5
       parent: 1
-  - uid: 638
+  - uid: 631
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-21.5
       parent: 1
-  - uid: 639
+  - uid: 632
     components:
     - type: Transform
       pos: 3.5,-19.5
       parent: 1
-  - uid: 640
+  - uid: 633
     components:
     - type: Transform
       pos: 2.5,-19.5
       parent: 1
-  - uid: 641
+  - uid: 634
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 1
 - proto: TablePlasmaGlass
   entities:
-  - uid: 642
+  - uid: 635
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 643
+  - uid: 636
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
-  - uid: 644
+  - uid: 637
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 645
+  - uid: 638
     components:
     - type: Transform
       pos: -2.5,-11.5
       parent: 1
-  - uid: 646
+  - uid: 639
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
-  - uid: 647
+  - uid: 640
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 648
+  - uid: 641
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 649
+  - uid: 642
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
-  - uid: 650
+  - uid: 643
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
-  - uid: 651
+  - uid: 644
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
-  - uid: 652
+  - uid: 645
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 653
+  - uid: 646
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 1
-  - uid: 654
+  - uid: 647
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 1
-  - uid: 655
+  - uid: 648
     components:
     - type: Transform
       pos: -2.5,-17.5
       parent: 1
-  - uid: 656
+  - uid: 649
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-2.5
       parent: 1
-  - uid: 657
+  - uid: 650
     components:
     - type: Transform
       pos: -3.5,-17.5
       parent: 1
-  - uid: 658
+  - uid: 651
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4717,59 +4675,59 @@ entities:
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 659
+  - uid: 652
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-  - uid: 660
+  - uid: 653
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 661
+  - uid: 654
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-7.5
       parent: 1
-  - uid: 662
+  - uid: 655
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-7.5
       parent: 1
-  - uid: 663
+  - uid: 656
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-13.5
       parent: 1
-  - uid: 664
+  - uid: 657
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-13.5
       parent: 1
-  - uid: 665
+  - uid: 658
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-30.5
       parent: 1
-  - uid: 666
+  - uid: 659
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-30.5
       parent: 1
-  - uid: 667
+  - uid: 660
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-30.5
       parent: 1
-  - uid: 668
+  - uid: 661
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4777,825 +4735,825 @@ entities:
       parent: 1
 - proto: ToolboxSyndicate
   entities:
-  - uid: 669
+  - uid: 662
     components:
     - type: Transform
       pos: -2.468854,-17.396727
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 671
+  - uid: 663
     components:
     - type: Transform
       pos: 5.5,-15.5
       parent: 1
-  - uid: 672
+  - uid: 664
     components:
     - type: MetaData
       name: tank dispenser
     - type: Transform
       pos: 2.5,-24.5
       parent: 1
-  - uid: 673
+  - uid: 665
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 1
 - proto: VendingMachineYouTool
   entities:
-  - uid: 674
+  - uid: 666
     components:
     - type: Transform
       pos: -3.5,-24.5
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 11
+  - uid: 667
     components:
     - type: Transform
       pos: -1.5,-25.5
       parent: 1
-  - uid: 675
+  - uid: 668
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 676
+  - uid: 669
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 677
+  - uid: 670
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
-  - uid: 678
+  - uid: 671
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 1
-  - uid: 679
+  - uid: 672
     components:
     - type: Transform
       pos: 4.5,-14.5
       parent: 1
-  - uid: 680
+  - uid: 673
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 1
-  - uid: 681
+  - uid: 674
     components:
     - type: Transform
       pos: 2.5,-18.5
       parent: 1
-  - uid: 682
+  - uid: 675
     components:
     - type: Transform
       pos: 1.5,-25.5
       parent: 1
-  - uid: 683
+  - uid: 676
     components:
     - type: Transform
       pos: 1.5,-18.5
       parent: 1
-  - uid: 684
+  - uid: 677
     components:
     - type: Transform
       pos: 7.5,-17.5
       parent: 1
-  - uid: 685
+  - uid: 678
     components:
     - type: Transform
       pos: -3.5,-26.5
       parent: 1
-  - uid: 686
+  - uid: 679
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-7.5
       parent: 1
-  - uid: 687
+  - uid: 680
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
-  - uid: 688
+  - uid: 681
     components:
     - type: Transform
       pos: -3.5,-28.5
       parent: 1
-  - uid: 689
+  - uid: 682
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 690
+  - uid: 683
     components:
     - type: Transform
       pos: 4.5,-18.5
       parent: 1
-  - uid: 691
+  - uid: 684
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 1
-  - uid: 692
+  - uid: 685
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 693
+  - uid: 686
     components:
     - type: Transform
       pos: -6.5,-11.5
       parent: 1
-  - uid: 694
+  - uid: 687
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
-  - uid: 695
+  - uid: 688
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 696
+  - uid: 689
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 1
-  - uid: 697
+  - uid: 690
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 1
-  - uid: 698
+  - uid: 691
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 1
-  - uid: 699
+  - uid: 692
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 700
+  - uid: 693
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 1
-  - uid: 701
+  - uid: 694
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-8.5
       parent: 1
-  - uid: 702
+  - uid: 695
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-7.5
       parent: 1
-  - uid: 703
+  - uid: 696
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-8.5
       parent: 1
-  - uid: 704
+  - uid: 697
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 705
+  - uid: 698
     components:
     - type: Transform
       pos: 5.5,-18.5
       parent: 1
-  - uid: 706
+  - uid: 699
     components:
     - type: Transform
       pos: -8.5,-15.5
       parent: 1
-  - uid: 707
+  - uid: 700
     components:
     - type: Transform
       pos: -8.5,-17.5
       parent: 1
-  - uid: 708
+  - uid: 701
     components:
     - type: Transform
       pos: -7.5,-17.5
       parent: 1
-  - uid: 709
+  - uid: 702
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 1
-  - uid: 710
+  - uid: 703
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 1
-  - uid: 711
+  - uid: 704
     components:
     - type: Transform
       pos: 3.5,-18.5
       parent: 1
-  - uid: 712
+  - uid: 705
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-6.5
       parent: 1
-  - uid: 713
+  - uid: 706
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 1
-  - uid: 714
+  - uid: 707
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-8.5
       parent: 1
-  - uid: 715
+  - uid: 708
     components:
     - type: Transform
       pos: 5.5,-14.5
       parent: 1
-  - uid: 716
+  - uid: 709
     components:
     - type: Transform
       pos: 7.5,-15.5
       parent: 1
-  - uid: 717
+  - uid: 710
     components:
     - type: Transform
       pos: -6.5,-19.5
       parent: 1
-  - uid: 718
+  - uid: 711
     components:
     - type: Transform
       pos: -6.5,-18.5
       parent: 1
-  - uid: 719
+  - uid: 712
     components:
     - type: Transform
       pos: -3.5,-25.5
       parent: 1
-  - uid: 720
+  - uid: 713
     components:
     - type: Transform
       pos: 2.5,-25.5
       parent: 1
-  - uid: 721
+  - uid: 714
     components:
     - type: Transform
       pos: 2.5,-27.5
       parent: 1
-  - uid: 722
+  - uid: 715
     components:
     - type: Transform
       pos: 4.5,-17.5
       parent: 1
-  - uid: 723
+  - uid: 716
     components:
     - type: Transform
       pos: -7.5,-21.5
       parent: 1
-  - uid: 724
+  - uid: 717
     components:
     - type: Transform
       pos: -7.5,-27.5
       parent: 1
-  - uid: 725
+  - uid: 718
     components:
     - type: Transform
       pos: -7.5,-24.5
       parent: 1
-  - uid: 726
+  - uid: 719
     components:
     - type: Transform
       pos: 6.5,-21.5
       parent: 1
-  - uid: 727
+  - uid: 720
     components:
     - type: Transform
       pos: 6.5,-24.5
       parent: 1
-  - uid: 728
+  - uid: 721
     components:
     - type: Transform
       pos: 6.5,-26.5
       parent: 1
-  - uid: 729
+  - uid: 722
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 730
+  - uid: 723
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 731
+  - uid: 724
     components:
     - type: Transform
       pos: -3.5,-27.5
       parent: 1
-  - uid: 732
+  - uid: 725
     components:
     - type: Transform
       pos: -6.5,-12.5
       parent: 1
-  - uid: 733
+  - uid: 726
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 1
-  - uid: 734
+  - uid: 727
     components:
     - type: Transform
       pos: 5.5,-11.5
       parent: 1
-  - uid: 735
+  - uid: 728
     components:
     - type: Transform
       pos: -5.5,-11.5
       parent: 1
-  - uid: 736
+  - uid: 729
     components:
     - type: Transform
       pos: -6.5,-20.5
       parent: 1
-  - uid: 737
+  - uid: 730
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 1
-  - uid: 738
+  - uid: 731
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 1
-  - uid: 739
+  - uid: 732
     components:
     - type: Transform
       pos: 5.5,-20.5
       parent: 1
-  - uid: 740
+  - uid: 733
     components:
     - type: Transform
       pos: -5.5,-14.5
       parent: 1
-  - uid: 741
+  - uid: 734
     components:
     - type: Transform
       pos: 6.5,-17.5
       parent: 1
-  - uid: 742
+  - uid: 735
     components:
     - type: Transform
       pos: -3.5,-14.5
       parent: 1
-  - uid: 743
+  - uid: 736
     components:
     - type: Transform
       pos: -2.5,-18.5
       parent: 1
-  - uid: 744
+  - uid: 737
     components:
     - type: Transform
       pos: 2.5,-26.5
       parent: 1
-  - uid: 745
+  - uid: 738
     components:
     - type: Transform
       pos: 2.5,-28.5
       parent: 1
-  - uid: 746
+  - uid: 739
     components:
     - type: Transform
       pos: 6.5,-25.5
       parent: 1
-  - uid: 747
+  - uid: 740
     components:
     - type: Transform
       pos: 6.5,-22.5
       parent: 1
-  - uid: 748
+  - uid: 741
     components:
     - type: Transform
       pos: -7.5,-23.5
       parent: 1
-  - uid: 749
+  - uid: 742
     components:
     - type: Transform
       pos: -7.5,-26.5
       parent: 1
-  - uid: 750
+  - uid: 743
     components:
     - type: Transform
       pos: -7.5,-22.5
       parent: 1
-  - uid: 751
+  - uid: 744
     components:
     - type: Transform
       pos: -7.5,-20.5
       parent: 1
-  - uid: 752
+  - uid: 745
     components:
     - type: Transform
       pos: 4.5,-15.5
       parent: 1
-  - uid: 753
+  - uid: 746
     components:
     - type: Transform
       pos: 6.5,-28.5
       parent: 1
-  - uid: 754
+  - uid: 747
     components:
     - type: Transform
       pos: 6.5,-27.5
       parent: 1
-  - uid: 755
+  - uid: 748
     components:
     - type: Transform
       pos: 6.5,-23.5
       parent: 1
-  - uid: 756
+  - uid: 749
     components:
     - type: Transform
       pos: 6.5,-20.5
       parent: 1
-  - uid: 757
+  - uid: 750
     components:
     - type: Transform
       pos: -7.5,-25.5
       parent: 1
-  - uid: 758
+  - uid: 751
     components:
     - type: Transform
       pos: -7.5,-28.5
       parent: 1
-  - uid: 759
+  - uid: 752
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-15.5
       parent: 1
-  - uid: 760
+  - uid: 753
     components:
     - type: Transform
       pos: -5.5,-18.5
       parent: 1
-  - uid: 761
+  - uid: 754
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 762
+  - uid: 755
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 763
+  - uid: 756
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 764
+  - uid: 757
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-  - uid: 765
+  - uid: 758
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-7.5
       parent: 1
-  - uid: 766
+  - uid: 759
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 1
-  - uid: 767
+  - uid: 760
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 768
+  - uid: 761
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 769
+  - uid: 762
     components:
     - type: Transform
       pos: -6.5,-14.5
       parent: 1
-  - uid: 770
+  - uid: 763
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-  - uid: 771
+  - uid: 764
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 772
+  - uid: 765
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-7.5
       parent: 1
-  - uid: 773
+  - uid: 766
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-8.5
       parent: 1
-  - uid: 774
+  - uid: 767
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
-  - uid: 775
+  - uid: 768
     components:
     - type: Transform
       pos: -6.5,-13.5
       parent: 1
-  - uid: 776
+  - uid: 769
     components:
     - type: Transform
       pos: -3.5,-30.5
       parent: 1
-  - uid: 777
+  - uid: 770
     components:
     - type: Transform
       pos: 6.5,-15.5
       parent: 1
-  - uid: 778
+  - uid: 771
     components:
     - type: Transform
       pos: 5.5,-13.5
       parent: 1
-  - uid: 779
+  - uid: 772
     components:
     - type: Transform
       pos: -7.5,-15.5
       parent: 1
-  - uid: 780
+  - uid: 773
     components:
     - type: Transform
       pos: 1.5,-14.5
       parent: 1
-  - uid: 781
+  - uid: 774
     components:
     - type: Transform
       pos: -4.5,-18.5
       parent: 1
-  - uid: 782
+  - uid: 775
     components:
     - type: Transform
       pos: -2.5,-25.5
       parent: 1
-  - uid: 783
+  - uid: 776
     components:
     - type: Transform
       pos: 0.5,-25.5
       parent: 1
-  - uid: 785
+  - uid: 777
     components:
     - type: Transform
       pos: -1.5,-22.5
       parent: 1
-  - uid: 786
+  - uid: 778
     components:
     - type: Transform
       pos: 0.5,-22.5
       parent: 1
-  - uid: 787
+  - uid: 779
     components:
     - type: Transform
       pos: 1.5,-24.5
       parent: 1
-  - uid: 788
+  - uid: 780
     components:
     - type: Transform
       pos: 1.5,-23.5
       parent: 1
-  - uid: 789
+  - uid: 781
     components:
     - type: Transform
       pos: 1.5,-22.5
       parent: 1
-  - uid: 790
+  - uid: 782
     components:
     - type: Transform
       pos: -2.5,-24.5
       parent: 1
-  - uid: 791
+  - uid: 783
     components:
     - type: Transform
       pos: -2.5,-23.5
       parent: 1
-  - uid: 792
+  - uid: 784
     components:
     - type: Transform
       pos: -2.5,-22.5
       parent: 1
-  - uid: 793
+  - uid: 785
     components:
     - type: Transform
       pos: 5.5,-22.5
       parent: 1
-  - uid: 794
+  - uid: 786
     components:
     - type: Transform
       pos: -7.5,-14.5
       parent: 1
-  - uid: 795
+  - uid: 787
     components:
     - type: Transform
       pos: -7.5,-18.5
       parent: 1
-  - uid: 796
+  - uid: 788
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-28.5
       parent: 1
-  - uid: 797
+  - uid: 789
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-28.5
       parent: 1
-  - uid: 798
+  - uid: 790
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-28.5
       parent: 1
-  - uid: 799
+  - uid: 791
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-28.5
       parent: 1
-  - uid: 800
+  - uid: 792
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-28.5
       parent: 1
-  - uid: 801
+  - uid: 793
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-28.5
       parent: 1
-  - uid: 802
+  - uid: 794
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-6.5
       parent: 1
-  - uid: 803
+  - uid: 795
     components:
     - type: Transform
       pos: 4.5,-27.5
       parent: 1
-  - uid: 804
+  - uid: 796
     components:
     - type: Transform
       pos: 4.5,-26.5
       parent: 1
-  - uid: 805
+  - uid: 797
     components:
     - type: Transform
       pos: 4.5,-25.5
       parent: 1
-  - uid: 806
+  - uid: 798
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 807
+  - uid: 799
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 808
+  - uid: 800
     components:
     - type: Transform
       pos: 2.5,-30.5
       parent: 1
-  - uid: 809
+  - uid: 801
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-17.5
       parent: 1
-  - uid: 810
+  - uid: 802
     components:
     - type: Transform
       pos: 3.5,-29.5
       parent: 1
-  - uid: 811
+  - uid: 803
     components:
     - type: Transform
       pos: -5.5,-29.5
       parent: 1
-  - uid: 812
+  - uid: 804
     components:
     - type: Transform
       pos: 4.5,-29.5
       parent: 1
-  - uid: 813
+  - uid: 805
     components:
     - type: Transform
       pos: -4.5,-29.5
       parent: 1
-  - uid: 814
+  - uid: 806
     components:
     - type: Transform
       pos: 5.5,-29.5
       parent: 1
-  - uid: 815
+  - uid: 807
     components:
     - type: Transform
       pos: -3.5,-29.5
       parent: 1
-  - uid: 816
+  - uid: 808
     components:
     - type: Transform
       pos: 2.5,-29.5
       parent: 1
-  - uid: 817
+  - uid: 809
     components:
     - type: Transform
       pos: 6.5,-14.5
       parent: 1
-  - uid: 818
+  - uid: 810
     components:
     - type: Transform
       pos: 6.5,-18.5
       parent: 1
-  - uid: 819
+  - uid: 811
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 820
+  - uid: 812
     components:
     - type: Transform
       pos: -6.5,-29.5
       parent: 1
-  - uid: 821
+  - uid: 813
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-30.5
       parent: 1
-  - uid: 822
+  - uid: 814
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-30.5
       parent: 1
-  - uid: 823
+  - uid: 815
     components:
     - type: Transform
       pos: 8.5,-15.5
       parent: 1
-  - uid: 824
+  - uid: 816
     components:
     - type: Transform
       pos: 8.5,-17.5
       parent: 1
-  - uid: 825
+  - uid: 817
     components:
     - type: Transform
       pos: -9.5,-17.5
       parent: 1
-  - uid: 826
+  - uid: 818
     components:
     - type: Transform
       pos: -9.5,-15.5
       parent: 1
 - proto: WarningN2
   entities:
-  - uid: 827
+  - uid: 819
     components:
     - type: Transform
       pos: 4.5,-25.5
@@ -5604,7 +5562,7 @@ entities:
       fixtures: {}
 - proto: WarningO2
   entities:
-  - uid: 828
+  - uid: 820
     components:
     - type: Transform
       pos: 2.5,-25.5
@@ -5613,7 +5571,7 @@ entities:
       fixtures: {}
 - proto: WarningWaste
   entities:
-  - uid: 829
+  - uid: 821
     components:
     - type: Transform
       pos: 4.5,-18.5
@@ -5622,26 +5580,26 @@ entities:
       fixtures: {}
 - proto: WaterCooler
   entities:
-  - uid: 830
+  - uid: 822
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 1
 - proto: WeaponTurretSyndicate
   entities:
-  - uid: 24
+  - uid: 823
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 610
+  - uid: 824
     components:
     - type: Transform
       pos: -1.5,-19.5
       parent: 1
 - proto: WindoorSecure
   entities:
-  - uid: 831
+  - uid: 825
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5649,17 +5607,17 @@ entities:
       parent: 1
 - proto: Wrench
   entities:
-  - uid: 832
+  - uid: 826
     components:
     - type: Transform
       pos: 5.4749,-23.512577
       parent: 1
-  - uid: 833
+  - uid: 827
     components:
     - type: Transform
       pos: 5.63115,-23.481327
       parent: 1
-  - uid: 834
+  - uid: 828
     components:
     - type: Transform
       pos: 1.6061028,-13.284962


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Replaces the pinpointer on the nukie shuttle with a universal pinpointer
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes issue #41979
in the case of nukies needing to carry their nuke, they wont have to spend 5TC on an emag so that they dont roundstalll when they lose it or it gets stolen.
## Technical details
<!-- Summary of code changes for easier review. -->
mapping
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The nukie infiltrator ship now starts with a universal pinpointer.
