### PR TITLE
Skeleton spawns as an invisible ghost role instead of as an entity

### DIFF
--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -35,6 +35,7 @@ using Content.Shared.Verbs;
 using Robust.Shared.Collections;
 using Content.Shared.Ghost.Roles.Components;
 using Content.Shared.Roles.Components;
+using Robust.Shared.Containers;
 
 namespace Content.Server.Ghost.Roles;
 
@@ -50,6 +51,7 @@ public sealed class GhostRoleSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly FollowerSystem _followerSystem = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
     [Dependency] private readonly SharedMindSystem _mindSystem = default!;
     [Dependency] private readonly SharedRoleSystem _roleSystem = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -785,6 +787,9 @@ public sealed class GhostRoleSystem : EntitySystem
 
         var mob = Spawn(component.Prototype, Transform(uid).Coordinates);
         _transform.AttachToGridOrMap(mob);
+
+        if (_containers.TryGetContainingContainer((component.Owner, null, null), out var container))
+            _containers.Insert(mob, container);
 
         var spawnedEvent = new GhostRoleSpawnerUsedEvent(uid, mob);
         RaiseLocalEvent(mob, spawnedEvent);

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -788,6 +788,7 @@ public sealed class GhostRoleSystem : EntitySystem
         var mob = Spawn(component.Prototype, Transform(uid).Coordinates);
         _transform.AttachToGridOrMap(mob);
 
+        // If our spawner is in a container, make sure the spawned entity ends up in there too
         if (_containers.TryGetContainingContainer((component.Owner, null, null), out var container))
             _containers.Insert(mob, container);
 

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -359,3 +359,19 @@
     - state: green
     - sprite: Clothing/Head/Hats/wizardhat.rsi
       state: icon
+
+- type: entity
+  categories: [ HideSpawnMenu, Spawner ]
+  parent: BaseAntagSpawner
+  id: SpawnPointGhostSkeleton
+  components:
+  - type: GhostRoleMobSpawner
+    prototype: MobSkeletonCloset
+  - type: GhostRole
+    name: ghost-role-information-closet-skeleton-name
+    description: ghost-role-information-closet-skeleton-description
+    rules: ghost-role-information-freeagent-rules
+    mindRoles:
+    - MindRoleGhostRoleFreeAgent
+    raffle:
+      settings: default

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -45,6 +45,11 @@
         layer:
         - MachineLayer
   - type: EntityStorage
+    whitelist:
+      components:
+        - MobState
+        - Item
+        - GhostRoleAntagSpawner
   - type: ContainerContainer
     containers:
       entity_storage: !type:Container

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -181,8 +181,14 @@
     weight: 5
     duration: 1
     minimumPlayers: 10
-  - type: RandomEntityStorageSpawnRule
-    prototype: MobSkeletonCloset
+  - type: AntagRandomSpawn
+  - type: AntagSelection
+    definitions:
+    - spawnerPrototype: SpawnPointGhostSkeleton
+      min: 1
+      max: 1
+      pickPlayer: false
+
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -181,13 +181,8 @@
     weight: 5
     duration: 1
     minimumPlayers: 10
-  - type: AntagRandomSpawn
-  - type: AntagSelection
-    definitions:
-    - spawnerPrototype: SpawnPointGhostSkeleton
-      min: 1
-      max: 1
-      pickPlayer: false
+  - type: RandomEntityStorageSpawnRule
+    prototype: SpawnPointGhostSkeleton
 
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
## About the PR
<!-- What did you change? -->
Made in response to https://github.com/space-wizards/space-station-14/issues/41992. Changes skeleton spawn event to use an antag spawner as opposed to just spawning an SSD skeleton in a locker, and makes modifications to GhostRoleSystem and ClosetBase whitelist to allow for us to spawn entities from spawners in containers properly.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Skeleton's spawning in closets is cool and unique but them spawning as they currently do often leads to them being killed or just dragged to the bar while waiting for a player. Now the game rule uses a spawn point that doesn't create the skeleton until the role is actually picked.
## Technical details
<!-- Summary of code changes for easier review. -->
Added a new spawn point prototype for skeletons, modifications to GhostRoleSystem.cs and various yml prototypes.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Skeletons spawns now behave the same as Paradox Clone spawns.
