### PR TITLE
Change Traitor steal objective rolls to be unique

### DIFF
--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -30,7 +30,7 @@
   - type: Objective
     difficulty: 2.75
   - type: ObjectiveLimit
-    limit: 1 # there is usually only 1 of each steal objective, have 2 max for drama
+    limit: 1 # there is usually only 1 of each steal objective and there is no current way for a traitor to find where an object has ended up, so setting this to 1 to prevent traitors / sleeper agents being unable to interact with objectives due to another traitor previously taking it.
 
 # state
 
@@ -299,7 +299,7 @@
   - type: NotJobRequirement
     jobs: [ HeadOfPersonnel ]
   - type: ObjectiveLimit
-    limit: 3 # ian only has 2 slices, 3 obj for drama
+    limit: 2 # ian has 2 slices, so putting this at 2 so traitors can potentially cooperate to get ian away from hop
   - type: StealCondition
     stealGroup: FoodMeatCorgi
     owner: objective-condition-steal-Ian
@@ -321,6 +321,8 @@
   parent: BaseCaptainObjective
   id: CaptainIDStealObjective
   components:
+  - type: ObjectiveLimit
+    limit: 2 # captain's spare ID works for this objective, and putting this at 2 allows for there to be either cooperation from traitors to secure both IDs or conflict if one ID is taken and one of them tries to bail / betray
   - type: StealCondition
     stealGroup: CaptainIDCard
 


### PR DESCRIPTION
This is my first PR so hopefully I haven't messed anything up. Any feedback is appreciated.

## About the PR
The PR is a yam change to prevent the same traitor steal objective to be rolled twice for unique items to forcing them to be unique (whereas for captain's ID and corgi meat this was bumped down from 3 to 2 as only 2 are available for each)

## Why / Balance
To make a complex issue not have a huge description, this is to fix the issue that steal objectives have where unique items are notoriously difficult to actually find once they're out of the hands of their respective heads, and how the round rarely gets driven by overlap once that happens. Unless both traitors with the same objective roll find themselves trying to loot the same item at the same time, there is zero chance of drama happening because of the overlap, and instead the one who gets there second has to just accept that there is no way to find the item and they must give up. This is especially frustrating for sleepers.

Until a way to track objective items is available, removing overlap should help to make rounds have a bit more action and steal objectives a bit less frustrating.

## Technical details
Yaml only. Lowered the general steal objective limit from 2 to 1, making most steal objectives unique in a round. Lowered the corgi meat limit from 3 to 2 as 2 are available, and introduced a limit to cap's ID set at 2 (no functional change versus how it is currently, keeps how traitors can potentially cooperative / snake each other over securing them).

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes
**Changelog**
:cl:
- tweak: Traitor steal objectives cannot be generated beyond the number of those items available on the station.
