### PR TITLE
Add `AtmosTest` test assertion for a valid grid

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/AtmosTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/AtmosTest.cs
@@ -20,7 +20,7 @@ public abstract class AtmosTest : InteractionTest
     protected AtmosphereSystem SAtmos = default!;
     protected EntityLookupSystem LookupSystem = default!;
 
-    protected Entity<GridAtmosphereComponent> RelevantAtmos = default!;
+    protected Entity<GridAtmosphereComponent> RelevantAtmos;
 
     /// <summary>
     /// Used in <see cref="AtmosphereSystem.RunProcessingFull"/>. Resolved during test setup.
@@ -40,14 +40,35 @@ public abstract class AtmosTest : InteractionTest
         SAtmos = SEntMan.System<AtmosphereSystem>();
         LookupSystem = SEntMan.System<EntityLookupSystem>();
 
-        RelevantAtmos = (MapData.Grid, SEntMan.GetComponent<GridAtmosphereComponent>(MapData.Grid));
+        SEntMan.TryGetComponent<GridAtmosphereComponent>(MapData.Grid, out var gridAtmosComp);
+        SEntMan.TryGetComponent<GasTileOverlayComponent>(MapData.Grid, out var overlayComp);
+        SEntMan.TryGetComponent<MapGridComponent>(MapData.Grid, out var mapGridComp);
+        var xform = SEntMan.GetComponent<TransformComponent>(MapData.Grid);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(gridAtmosComp,
+                    Is.Not.Null,
+                    "Loaded map doesn't have a GridAtmosphereComponent on its grid. " +
+                    "Did you forget to override TestMapPath with a proper atmospherics testing map?");
+            Assert.That(overlayComp,
+                Is.Not.Null,
+                "Loaded map doesn't have a GasTileOverlayComponent on its grid. " +
+                "Did you forget to override TestMapPath with a proper atmospherics testing map?");
+            Assert.That(mapGridComp,
+                Is.Not.Null,
+                "Loaded map doesn't have a MapGridComponent on its grid. " +
+                "Did you forget to override TestMapPath with a proper atmospherics testing map?");
+        }
+
+        RelevantAtmos = (MapData.Grid, gridAtmosComp);
 
         ProcessEnt = new Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent>(
             MapData.Grid.Owner,
-            SEntMan.GetComponent<GridAtmosphereComponent>(MapData.Grid.Owner),
-            SEntMan.GetComponent<GasTileOverlayComponent>(MapData.Grid.Owner),
-            SEntMan.GetComponent<MapGridComponent>(MapData.Grid.Owner),
-            SEntMan.GetComponent<TransformComponent>(MapData.Grid.Owner));
+            gridAtmosComp,
+            overlayComp,
+            mapGridComp,
+            xform);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes `AtmosTest` assert that the grid has all needed components in the setup phase.

Fixes #42125

## Why / Balance
If you forgot to override the `TestMapPath` it'll populate the map with a 1x1 tile that doesn't have any atmospherics components on it. When `GetComponent` fails the failure message is kinda annoying to figure out and I'd rather just have an easy point-out for testwriters.

Why this doesn't override the test map by default:
Map-based atmos tests usually require a specific setup in order to test (see the `TileAtmosphere` tests). Any test that needs a test server for testing a client/server instance can just spin up a test and choose a different generic map to override (some tests use the basic DeltaPressure test map because it's literally a 5x5 grid with a star cut out in the middle).

Why this doesn't check if the test map path is null:
Sometimes due to mapping sillyness there aren't any comps so this is a good check to tell people to check their map.

Why this doesn't modify setup behavior to choose whether or not to load a test map and TryComp for components:
In that instance we would have to modify `InteractionTest` behavior and make the `Setup` call a virtual or something. In any sense it's a much more complicated solution that requires me to modify previous tests, and ultimately its not something I'm comfortable doing in a PR intended for selfmerging.

## Technical details
simple debug assert for null

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
n/a
