### PR TITLE
(Fix) Make paper extinguishable with fire extinguisher

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -8,9 +8,15 @@
     - Document
     - Paper
   - type: Appearance
+  - type: Reactive
+    groups:
+      Flammable: [ Touch ]
+      Extinguish: [ Touch ]
+  - type: ExtinguishableSetCollisionWake
   - type: Flammable
     fireSpread: true
     alwaysCombustible: true
+    canExtinguish: true
     damage:
       types:
         Heat: 1


### PR DESCRIPTION
## About the PR
Paper can now be extinguished with fire extinguishers.

## Why / Balance
Fixes #42066 
Paper should be extinguishable like other flammable items (candles, etc) for consistency and realism.

## Technical details
Added ExtinguishableSetCollisionWake and Reactive Behaviour to BasePaper so paper reacts to fire extinguishers like for example a candle.

## Media
I doubt this needs media because this is really small. But if really neccesary i can add it.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
I dont think it breaks anything. 

**Changelog**
:cl:
- fix: Paper can now be extinguished (e.g. fire extinguisher)
