### PR TITLE
Fix plasma station comms apc overloaded by default

### DIFF
--- a/Resources/Maps/plasma.yml
+++ b/Resources/Maps/plasma.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 268.0.0
+  engineVersion: 270.0.0
   forkId: ""
   forkVersion: ""
-  time: 11/24/2025 22:34:01
-  entityCount: 26479
+  time: 12/28/2025 21:35:23
+  entityCount: 26487
 maps:
 - 1
 grids:
@@ -10247,6 +10247,7 @@ entities:
       id: Plasma
     - type: ImplicitRoof
     - type: NavMap
+    - type: ExplosionAirtightGrid
 - proto: AccordionInstrument
   entities:
   - uid: 25884
@@ -14967,7 +14968,7 @@ entities:
       pos: -131.5,-45.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -64391.965
+      secondsUntilStateChange: -64586.55
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -16463,11 +16464,14 @@ entities:
   - uid: 4410
     components:
     - type: MetaData
-      name: Telecommunications APC
+      name: Telecommunications East APC
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -84.5,-10.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
     - type: Fixtures
       fixtures: {}
   - uid: 4419
@@ -16823,6 +16827,19 @@ entities:
     - type: Transform
       pos: -99.5,23.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 16798
+    components:
+    - type: MetaData
+      name: Telecommunications West APC
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -88.5,-9.5
+      parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
     - type: Fixtures
       fixtures: {}
   - uid: 16994
@@ -33234,6 +33251,11 @@ entities:
     components:
     - type: Transform
       pos: -15.5,-3.5
+      parent: 2
+  - uid: 16856
+    components:
+    - type: Transform
+      pos: -88.5,-9.5
       parent: 2
   - uid: 16947
     components:
@@ -53073,6 +53095,26 @@ entities:
     - type: Transform
       pos: -45.5,-44.5
       parent: 2
+  - uid: 16861
+    components:
+    - type: Transform
+      pos: -88.5,-9.5
+      parent: 2
+  - uid: 16868
+    components:
+    - type: Transform
+      pos: -88.5,-8.5
+      parent: 2
+  - uid: 16872
+    components:
+    - type: Transform
+      pos: -87.5,-8.5
+      parent: 2
+  - uid: 16907
+    components:
+    - type: Transform
+      pos: -86.5,-8.5
+      parent: 2
   - uid: 16960
     components:
     - type: Transform
@@ -53188,6 +53230,11 @@ entities:
     - type: Transform
       pos: -15.5,-63.5
       parent: 2
+  - uid: 17797
+    components:
+    - type: Transform
+      pos: -85.5,-8.5
+      parent: 2
   - uid: 17835
     components:
     - type: Transform
@@ -53227,6 +53274,11 @@ entities:
     components:
     - type: Transform
       pos: -85.5,-18.5
+      parent: 2
+  - uid: 17990
+    components:
+    - type: Transform
+      pos: -84.5,-8.5
       parent: 2
   - uid: 18106
     components:
@@ -131755,6 +131807,23 @@ entities:
     - type: Transform
       pos: -107.48633,-20.615337
       parent: 2
+- proto: PlushieSpawner50
+  entities:
+  - uid: 14357
+    components:
+    - type: Transform
+      pos: -21.5,11.5
+      parent: 2
+  - uid: 14359
+    components:
+    - type: Transform
+      pos: -20.5,11.5
+      parent: 2
+  - uid: 24648
+    components:
+    - type: Transform
+      pos: -19.5,11.5
+      parent: 2
 - proto: PortableFlasher
   entities:
   - uid: 2394
@@ -146294,7 +146363,7 @@ entities:
     - type: Transform
       pos: -107.5,-2.5
       parent: 2
-- proto: SpacemenFigureSpawner
+- proto: SpacemenFigurineSpawner90
   entities:
   - uid: 26079
     components:
@@ -153020,23 +153089,6 @@ entities:
     components:
     - type: Transform
       pos: -42.5,-1.5
-      parent: 2
-- proto: ToySpawner
-  entities:
-  - uid: 14357
-    components:
-    - type: Transform
-      pos: -21.5,11.5
-      parent: 2
-  - uid: 14359
-    components:
-    - type: Transform
-      pos: -20.5,11.5
-      parent: 2
-  - uid: 24648
-    components:
-    - type: Transform
-      pos: -19.5,11.5
       parent: 2
 - proto: TrainingBomb
   entities:
@@ -171053,7 +171105,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -264498.72
+      secondsUntilStateChange: -264693.3
       state: Opening
     - type: Airlock
       autoClose: False


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed plasma station comms apc being overloaded by adding a second apc.

## Why / Balance
Closes: #41957
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1028" height="578" alt="1" src="https://github.com/user-attachments/assets/a3be6775-35c0-4a9c-ac4f-3c42e88eb8c9" />
<img width="622" height="476" alt="cables" src="https://github.com/user-attachments/assets/1b0f8186-6580-4570-8c2f-d290fa65f78b" />
<img width="785" height="572" alt="east_apc" src="https://github.com/user-attachments/assets/373afd88-7504-4d7d-bdd3-35a761a4b2a6" />
<img width="690" height="563" alt="west_apc" src="https://github.com/user-attachments/assets/9ccbada9-14ea-47f2-bd53-f2ae87130e6e" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
MAPS:
- fix: On Plasma, added a second APC to telecommunications, so the APC is no longer overloaded at the start of the round.