### PR TITLE
Guarantee glue and lube in toybox

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -402,6 +402,8 @@
     containers:
       entity_storage: !type:AllSelector
         children:
+        - id: CrazyGlue
+        - id: CrazyLube
         - !type:NestedSelector
           tableId: AllToyWeaponsTable
           rolls: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
A previous PR (https://github.com/space-wizards/space-station-14/pull/41840) randomized toybox contents among other things, and one awkward issue with this is that glue and lube containers are suddenly extremely difficult to get due to sharing their rolls with other toys. This PR fixes that by making them guaranteed in a toy crate in addition to the other randomized contents.

## Why / Balance
This change mainly impacts Science and Clowns.
For Sci, toy boxes were the best source of glue for creating artifact glue. You don't need a lot and it's pretty difficult to make if a chemist isn't a slime / there hasn't been a slime event, so the loss of the guaranteed bottle in a cheap crate hurt this kind of science playstyle. 
For clowns, the issue is twofold; first, is that suddenly getting these materials is a lot harder, and you need chemistry to play along. Second, is that applying glue and lube to objects requires either a crazy glue / crazy lube container or a space glue tube / lube tube. Chemistry can make all the lube and glue they want, but it's completely unusable for say, running around with a Nuclear Authentication Disk (real), getting sec to arrest you, and then getting it stuck to their hands when they try to secure dat disk.

By making these a guarantee in crates, it's restoring how these crates worked previously and how it was more reasonable for science to make artifact glue and for general prankery to occur.

## Technical details
added code above the table rolls for the toy box so that 1 bottle of Crazy Glue and Crazy Lube are guaranteed in each box, in addition to the other rolls introduced with the previous PR.

## Media
(https://github.com/user-attachments/assets/f00d0296-44cb-4960-b990-aba16fc5a2e8)
Just spawning 3 crates to show how it's a guarantee in the crates while still keeping the randomized contents of the previous PR. You can still roll MORE glue / lube in addition to the guaranteed bottle of each, but it's relatively rare to happen. 
## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
**Changelog**
:cl:
- tweak: Guaranteed a bottle of Crazy Glue and Crazy Lube in the toy box.
