### PR TITLE
Wall mount destructibles dropping items pass

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Misc/mirror.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Misc/mirror.yml
@@ -33,6 +33,15 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalGlassBreak
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
           SheetGlass1:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Misc/mirror.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Misc/mirror.yml
@@ -33,6 +33,11 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalGlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetGlass1:
+            min: 1
+            max: 2
 
 - type: entity
   parent: Mirror

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -52,6 +52,15 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 25
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Effects/poster_broken.ogg
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 5
       behaviors:
       - !type:PlaySoundBehavior

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -45,6 +45,9 @@
     drawdepth: WallTops
     sprite: Structures/Wallmounts/posters.rsi
     state: poster_broken
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Card
   - type: Destructible
     thresholds:
     - trigger:
@@ -56,6 +59,11 @@
           path: /Audio/Effects/poster_broken.ogg
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          PaperScrap:
+            min: 1
+            max: 1
 
 # Contraband
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/Cabinets/defib_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/Cabinets/defib_cabinet.yml
@@ -40,6 +40,11 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalGlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 2
 
 - type: entity
   parent: DefibrillatorCabinet

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/Cabinets/extinguisher_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/Cabinets/extinguisher_cabinet.yml
@@ -41,6 +41,11 @@
                 collection: MetalGlassBreak
                 params:
                   volume: -4
+            - !type:SpawnEntitiesBehavior
+              spawn:
+                SheetSteel1:
+                  min: 1
+                  max: 2
 
 - type: entity
   parent: ExtinguisherCabinet

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/Cabinets/fireaxe_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/Cabinets/fireaxe_cabinet.yml
@@ -24,6 +24,14 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalGlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 4
+          SheetGlass1:
+            min: 1
+            max: 1
   - type: Sprite
     sprite: Structures/Wallmounts/fireaxe_cabinet.rsi
     layers:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
@@ -50,6 +50,11 @@
           collection: MetalBreak
           params:
             volume: -8
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 1
 
 - type: entity
   parent: BaseWallmountMetallic
@@ -102,6 +107,12 @@
           collection: MetalBreak
           params:
             volume: -8
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 1
+
 
 - type: entity
   parent: BaseWallmountMetallic

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/telescreens.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/telescreens.yml
@@ -23,6 +23,14 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalGlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 1
+          SheetGlass1:
+            min: 1
+            max: 1
   - type: Construction
     graph: WallmountTelescreen
     node: Telescreen

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/telescreens.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/telescreens.yml
@@ -23,6 +23,15 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalGlassBreak
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
           SheetSteel1:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/televisions.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/Monitors/televisions.yml
@@ -56,6 +56,14 @@
               collection: MetalGlassBreak
               params:
                 volume: -4
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              SheetSteel1:
+                min: 1
+                max: 2
+              SheetGlass1:
+                min: 1
+                max: 2
   - type: StationAiWhitelist
 
 - type: entity
@@ -94,3 +102,8 @@
               collection: MetalGlassBreak
               params:
                 volume: -4
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              SheetSteel1:
+                min: 1
+                max: 2

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/air_alarm.yml
@@ -105,6 +105,12 @@
               collection: MetalGlassBreak
               params:
                 volume: -4
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              SheetSteel1:
+                min: 1
+                max: 1
+
   - type: GuideHelp
     guides:
     - AirAlarms
@@ -152,6 +158,11 @@
               collection: MetalGlassBreak
               params:
                 volume: -4
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              SheetSteel1:
+                min: 1
+                max: 2
 
 - type: entity
   id: AirAlarmXeno

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/fire_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/fire_alarm.yml
@@ -106,6 +106,11 @@
               collection: MetalGlassBreak
               params:
                 volume: -4
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              SheetSteel1:
+                min: 1
+                max: 2
   - type: StationAiWhitelist
 
 - type: entity
@@ -148,6 +153,11 @@
               collection: MetalGlassBreak
               params:
                 volume: -4
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              SheetSteel1:
+                min: 1
+                max: 1
 
 - type: entity
   id: FireAlarmXeno

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
@@ -19,6 +19,15 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+    - trigger:
+        !type:DamageTrigger
         damage: 200
       behaviors:
       - !type:DoActsBehavior

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
@@ -26,6 +26,14 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalGlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 2
+          SheetGlass1:
+            min: 1
+            max: 1
   - type: ApcPowerReceiver
     powerLoad: 100
   - type: ExtensionCableReceiver

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/station_map.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/station_map.yml
@@ -14,6 +14,15 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
+            damage: 200
+          behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: GlassBreak
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+        - trigger:
+            !type:DamageTrigger
             damage: 100
           behaviors:
             - !type:PlaySoundBehavior

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/station_map.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/station_map.yml
@@ -21,6 +21,11 @@
                 collection: GlassBreak
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
+            - !type:SpawnEntitiesBehavior
+              spawn:
+                SheetGlass1:
+                  min: 1
+                  max: 1
 
 - type: entity
   parent: BaseWallmountMachine
@@ -79,6 +84,7 @@
             StationMapBroken:
               min: 1
               max: 1
+          offset: 0
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
     - type: UserInterface

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
@@ -23,6 +23,12 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalGlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 1
+
   - type: Rotatable
   - type: SignalTimer
     canEditLabel: false

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
@@ -23,6 +23,15 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalGlassBreak
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
           SheetSteel1:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Made it so the following items from this list drop stuff:

```
AirAlarm | air alarm | 1-2 Steel
AirAlarmAssembly | air alarm assembly | 1 Steel
DefibrillatorCabinet | defibrillator cabinet | 1-2 steel
ExtinguisherCabinet | extinguisher cabinet | 1-2 steel
FireAlarm | fire alarm | 1-2 Steel
FireAlarmAssembly | fire alarm assembly | 1 Steel
FireAxeCabinet | fire axe cabinet | 1-4 steel, 1 glass
Mirror | mirror | 1-2 glass
PosterBroken | broken poster | 1 paper scrap (im iffy on this one)
also made broken poster damagable in the same way the poster was. 
Maybe the poster itself breaking should drop the scrap and the broken poster should stay as nothing. Idk
Screen | screen | 1-2 steel, 1 glass
SignalButton | signal button | 1 steel
SignalSwitch | signal switch | 1 steel
SignalTimer | signal timer | 1 steel
StationMapBroken | station map | 1 glass
WallmountTelescreen | telescreen | 1 steel, 1 glass
WallmountTelevision | television | (this is the big bar sign) 1-2 steel, 1-2 glass
WallmountTelevisionFrame | television frame | 1-2 steel
```

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
part of #42147 
it's not satisfying when something breaks and you don't get anything

## Technical details
<!-- Summary of code changes for easier review. -->
Simple yaml changes, just `!type:SpawnEntitiesBehavior`

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
