### PR TITLE
ReagentColorVisualizerSystem for coloring an entity based on reagents in a solution

### DIFF
--- a/Content.Client/Chemistry/Visualizers/ReagentColorVisualizerSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/ReagentColorVisualizerSystem.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Chemistry.Components;
+using Robust.Client.GameObjects;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+
+namespace Content.Client.Chemistry.Visualizers;
+
+public sealed class ReagentColorVisualizerSystem : VisualizerSystem<ReagentColorComponent>
+{
+    protected override void OnAppearanceChange(EntityUid uid, ReagentColorComponent component, ref AppearanceChangeEvent args)
+    {
+        if (AppearanceSystem.TryGetData(uid, ReagentColorVisuals.Color, out Color color, args.Component) &&
+            TryComp<SpriteComponent>(uid, out var sprite))
+        {
+            sprite.Color = color;
+        }
+    }
+}

--- a/Content.Server/Anomaly/Components/ReagentProducerAnomalyComponent.cs
+++ b/Content.Server/Anomaly/Components/ReagentProducerAnomalyComponent.cs
@@ -60,14 +60,6 @@ public sealed partial class ReagentProducerAnomalyComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public SoundSpecifier ChangeSound = new SoundPathSpecifier("/Audio/Effects/waterswirl.ogg");
-    /// <summary>
-    /// The component will repaint the sprites of the object to match the current color of the solution,
-    /// if the RandomSprite component is hung correctly.
-    /// Ideally, this should be put into a separate component, but I suffered for 4 hours,
-    /// and nothing worked out for me. So for now it will be like this.
-    /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadOnly)]
-    public bool NeedRecolor = false;
 
     /// <summary>
     /// the maximum amount of reagent produced per second

--- a/Content.Server/Anomaly/Effects/ReagentProducerAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/ReagentProducerAnomalySystem.cs
@@ -2,10 +2,7 @@ using Content.Server.Anomaly.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Anomaly.Components;
 using Content.Shared.Chemistry.Components;
-using Content.Shared.Sprite;
-using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Anomaly.Effects;
@@ -30,8 +27,6 @@ public sealed class ReagentProducerAnomalySystem : EntitySystem
 
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly PointLightSystem _light = default!;
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
 
     public const string FallbackReagent = "Water";
@@ -79,27 +74,6 @@ public sealed class ReagentProducerAnomalySystem : EntitySystem
             _solutionContainer.TryAddSolution(component.Solution.Value, newSol); // TODO - the container is not fully filled.
 
             component.AccumulatedFrametime = 0;
-
-            // The component will repaint the sprites of the object to match the current color of the solution,
-            // if the RandomSprite component is hung correctly.
-
-            // Ideally, this should be put into a separate component, but I suffered for 4 hours,
-            // and nothing worked out for me. So for now it will be like this.
-            if (component.NeedRecolor)
-            {
-                var color = producerSolution.GetColor(_prototypeManager);
-                _light.SetColor(uid, color);
-                if (TryComp<RandomSpriteComponent>(uid, out var randomSprite))
-                {
-                    foreach (var ent in randomSprite.Selected)
-                    {
-                        var state = randomSprite.Selected[ent.Key];
-                        state.Color = color;
-                        randomSprite.Selected[ent.Key] = state;
-                    }
-                    Dirty(uid, randomSprite);
-                }
-            }
         }
     }
 

--- a/Content.Server/Anomaly/Effects/ReagentProducerAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/ReagentProducerAnomalySystem.cs
@@ -2,8 +2,6 @@ using Content.Server.Anomaly.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Anomaly.Components;
 using Content.Shared.Chemistry.Components;
-using Content.Shared.Sprite;
-using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Random;
 
@@ -29,7 +27,6 @@ public sealed partial class ReagentProducerAnomalySystem : EntitySystem
 
     [Dependency] private SharedSolutionContainerSystem _solutionContainer = default!;
     [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private PointLightSystem _light = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
 
     public const string FallbackReagent = "Water";
@@ -77,27 +74,6 @@ public sealed partial class ReagentProducerAnomalySystem : EntitySystem
             _solutionContainer.TryAddSolution(component.Solution.Value, newSol); // TODO - the container is not fully filled.
 
             component.AccumulatedFrametime = 0;
-
-            // The component will repaint the sprites of the object to match the current color of the solution,
-            // if the RandomSprite component is hung correctly.
-
-            // Ideally, this should be put into a separate component, but I suffered for 4 hours,
-            // and nothing worked out for me. So for now it will be like this.
-            if (component.NeedRecolor)
-            {
-                var color = producerSolution.GetColor(ProtoMan);
-                _light.SetColor(uid, color);
-                if (TryComp<RandomSpriteComponent>(uid, out var randomSprite))
-                {
-                    foreach (var ent in randomSprite.Selected)
-                    {
-                        var state = randomSprite.Selected[ent.Key];
-                        state.Color = color;
-                        randomSprite.Selected[ent.Key] = state;
-                    }
-                    Dirty(uid, randomSprite);
-                }
-            }
         }
     }
 

--- a/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
@@ -77,9 +77,9 @@ public sealed class ReagentColorSystem : EntitySystem
         }
 
         // Update appearance for sprite coloring (for slimes)
-        if (HasComp<AppearanceComponent>(uid))
+        if (TryComp<AppearanceComponent>(uid, out var appComp))
         {
-            _appearance.SetData(uid, ReagentColorVisuals.Color, color);
+            _appearance.SetData(uid, ReagentColorVisuals.Color, color, appComp);
         }
     }
 }

--- a/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
@@ -1,0 +1,89 @@
+using Content.Server.Light.EntitySystems;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Sprite;
+using Robust.Server.GameObjects;
+using Robust.Shared.Prototypes;
+using System.Linq;
+
+namespace Content.Server.Chemistry.EntitySystems;
+
+/// <summary>
+/// This system handles updating the sprite and light color of entities
+/// with a <see cref="ReagentColorComponent"/> to match their solution's color.
+/// </summary>
+public sealed class ReagentColorSystem : EntitySystem
+{
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly PointLightSystem _light = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ReagentColorComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(Entity<ReagentColorComponent> entity, ref ComponentStartup args)
+    {
+        UpdateColor(entity);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<ReagentColorComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (_solutionContainer.ResolveSolution(uid, comp.SolutionName, ref comp.Solution))
+            {
+                UpdateColor((uid, comp));
+            }
+        }
+    }
+
+    private void UpdateColor(Entity<ReagentColorComponent> entity)
+    {
+        var (uid, comp) = entity;
+        if (!_solutionContainer.TryGetSolution(uid, comp.SolutionName, out _, out var solution))
+            return;
+
+        var color = solution.GetColor(_prototypeManager);
+        if (color.A <= 0f)
+            return;
+
+        // Update point light color
+        if (TryComp<PointLightComponent>(uid, out var light) && light.Color != color)
+        {
+            _light.SetColor(uid, color, light);
+        }
+
+        // Update random sprite colors (for anomalies)
+        if (TryComp<RandomSpriteComponent>(uid, out var randomSprite))
+        {
+            var changed = false;
+            // Create a copy of the keys to iterate over, as the dictionary might be modified.
+            var keys = randomSprite.Selected.Keys.ToList();
+            foreach (var key in keys)
+            {
+                var state = randomSprite.Selected[key];
+                if (state.Color != color)
+                {
+                    state.Color = color;
+                    randomSprite.Selected[key] = state;
+                    changed = true;
+                }
+            }
+            if (changed)
+                Dirty(uid, randomSprite);
+        }
+
+        // Update appearance for sprite coloring (for slimes)
+        if (HasComp<AppearanceComponent>(uid))
+        {
+            _appearance.SetData(uid, ReagentColorVisuals.Color, color);
+        }
+    }
+}

--- a/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
@@ -33,7 +33,7 @@ public sealed class ReagentColorSystem : EntitySystem
 
     private void OnSolutionChanged(Entity<ReagentColorComponent> entity, ref SolutionContainerChangedEvent args)
     {
-        if (args.SolutionId == entity.Comp.SolutionName)
+        if (args.SolutionId == entity.Comp.Solution)
         {
             UpdateColor(entity, args.Solution);
         }
@@ -43,7 +43,7 @@ public sealed class ReagentColorSystem : EntitySystem
     {
         var (uid, comp) = entity;
 
-        if (solution == null && !_solutionContainer.TryGetSolution(uid, comp.SolutionName, out _, out solution))
+        if (solution == null && !_solutionContainer.TryGetSolution(uid, comp.Solution, out _, out solution))
             return;
 
         var color = solution.GetColor(_prototypeManager);

--- a/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
@@ -1,0 +1,89 @@
+using Content.Server.Light.EntitySystems;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Sprite;
+using Robust.Server.GameObjects;
+using Robust.Shared.Prototypes;
+using System.Linq;
+
+namespace Content.Server.Chemistry.EntitySystems;
+
+/// <summary>
+/// This system handles updating the sprite and light color of entities
+/// with a <see cref="ReagentColorComponent"/> to match their solution's color.
+/// </summary>
+public sealed partial class ReagentColorSystem : EntitySystem
+{
+    [Dependency] private SharedSolutionContainerSystem _solutionContainer = default!;
+    [Dependency] private IPrototypeManager _prototypeManager = default!;
+    [Dependency] private PointLightSystem _light = default!;
+    [Dependency] private SharedAppearanceSystem _appearance = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ReagentColorComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(Entity<ReagentColorComponent> entity, ref ComponentStartup args)
+    {
+        UpdateColor(entity);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<ReagentColorComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (_solutionContainer.ResolveSolution(uid, comp.SolutionName, ref comp.Solution))
+            {
+                UpdateColor((uid, comp));
+            }
+        }
+    }
+
+    private void UpdateColor(Entity<ReagentColorComponent> entity)
+    {
+        var (uid, comp) = entity;
+        if (!_solutionContainer.TryGetSolution(uid, comp.SolutionName, out _, out var solution))
+            return;
+
+        var color = solution.GetColor(_prototypeManager);
+        if (color.A <= 0f)
+            return;
+
+        // Update point light color
+        if (TryComp<PointLightComponent>(uid, out var light) && light.Color != color)
+        {
+            _light.SetColor(uid, color, light);
+        }
+
+        // Update random sprite colors (for anomalies)
+        if (TryComp<RandomSpriteComponent>(uid, out var randomSprite))
+        {
+            var changed = false;
+            // Create a copy of the keys to iterate over, as the dictionary might be modified.
+            var keys = randomSprite.Selected.Keys.ToList();
+            foreach (var key in keys)
+            {
+                var state = randomSprite.Selected[key];
+                if (state.Color != color)
+                {
+                    state.Color = color;
+                    randomSprite.Selected[key] = state;
+                    changed = true;
+                }
+            }
+            if (changed)
+                Dirty(uid, randomSprite);
+        }
+
+        // Update appearance for sprite coloring (for slimes)
+        if (HasComp<AppearanceComponent>(uid))
+        {
+            _appearance.SetData(uid, ReagentColorVisuals.Color, color);
+        }
+    }
+}

--- a/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
@@ -23,6 +23,7 @@ public sealed partial class ReagentColorSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<ReagentColorComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<ReagentColorComponent, SolutionChangedEvent>(OnSolutionChanged);
     }
 
     private void OnStartup(Entity<ReagentColorComponent> entity, ref ComponentStartup args)
@@ -30,24 +31,19 @@ public sealed partial class ReagentColorSystem : EntitySystem
         UpdateColor(entity);
     }
 
-    public override void Update(float frameTime)
+    private void OnSolutionChanged(Entity<ReagentColorComponent> entity, ref SolutionChangedEvent args)
     {
-        base.Update(frameTime);
-
-        var query = EntityQueryEnumerator<ReagentColorComponent>();
-        while (query.MoveNext(out var uid, out var comp))
+        if (args.Solution.Comp.Id == entity.Comp.SolutionName)
         {
-            if (_solutionContainer.ResolveSolution(uid, comp.SolutionName, ref comp.Solution))
-            {
-                UpdateColor((uid, comp));
-            }
+            UpdateColor(entity, args.Solution.Comp.Solution);
         }
     }
 
-    private void UpdateColor(Entity<ReagentColorComponent> entity)
+    private void UpdateColor(Entity<ReagentColorComponent> entity, Solution? solution = null)
     {
         var (uid, comp) = entity;
-        if (!_solutionContainer.TryGetSolution(uid, comp.SolutionName, out _, out var solution))
+
+        if (solution == null && !_solutionContainer.TryGetSolution(uid, comp.SolutionName, out _, out solution))
             return;
 
         var color = solution.GetColor(_prototypeManager);

--- a/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
@@ -77,9 +77,9 @@ public sealed partial class ReagentColorSystem : EntitySystem
         }
 
         // Update appearance for sprite coloring (for slimes)
-        if (HasComp<AppearanceComponent>(uid))
+        if (TryComp<AppearanceComponent>(uid, out var appComp))
         {
-            _appearance.SetData(uid, ReagentColorVisuals.Color, color);
+            _appearance.SetData(uid, ReagentColorVisuals.Color, color, appComp);
         }
     }
 }

--- a/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
@@ -33,7 +33,7 @@ public sealed partial class ReagentColorSystem : EntitySystem
 
     private void OnSolutionChanged(Entity<ReagentColorComponent> entity, ref SolutionChangedEvent args)
     {
-        if (args.Solution.Comp.Id == entity.Comp.SolutionName)
+        if (args.Solution.Comp.Id == entity.Comp.Solution)
         {
             UpdateColor(entity, args.Solution.Comp.Solution);
         }
@@ -43,7 +43,7 @@ public sealed partial class ReagentColorSystem : EntitySystem
     {
         var (uid, comp) = entity;
 
-        if (solution == null && !_solutionContainer.TryGetSolution(uid, comp.SolutionName, out _, out solution))
+        if (solution == null && !_solutionContainer.TryGetSolution(uid, comp.Solution, out _, out solution))
             return;
 
         var color = solution.GetColor(_prototypeManager);

--- a/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentColorSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Light.EntitySystems;
+using Content.Shared.Body.Systems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Sprite;
@@ -22,11 +23,11 @@ public sealed partial class ReagentColorSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<ReagentColorComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<ReagentColorComponent, MapInitEvent>(OnMapInit, after: [typeof(BloodstreamSystem)]);
         SubscribeLocalEvent<ReagentColorComponent, SolutionChangedEvent>(OnSolutionChanged);
     }
 
-    private void OnStartup(Entity<ReagentColorComponent> entity, ref ComponentStartup args)
+    private void OnMapInit(Entity<ReagentColorComponent> entity, ref MapInitEvent args)
     {
         UpdateColor(entity);
     }

--- a/Content.Shared/Chemistry/Components/ReagentColorComponent.cs
+++ b/Content.Shared/Chemistry/Components/ReagentColorComponent.cs
@@ -15,9 +15,4 @@ public sealed partial class ReagentColorComponent : Component
     /// </summary>
     [DataField("solution"), AutoNetworkedField]
     public string SolutionName = "bloodstream";
-
-    /// <summary>
-    /// The solution entity that is being monitored.
-    /// </summary>
-    public Entity<SolutionComponent>? Solution;
 }

--- a/Content.Shared/Chemistry/Components/ReagentColorComponent.cs
+++ b/Content.Shared/Chemistry/Components/ReagentColorComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Chemistry.Components;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Chemistry.Components;
+
+/// <summary>
+/// This component is used for entities whose sprite and light color
+/// should match the color of a solution on them.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ReagentColorComponent : Component
+{
+    /// <summary>
+    /// The name of the solution that determines the color.
+    /// </summary>
+    [DataField("solution"), AutoNetworkedField]
+    public string SolutionName = "bloodstream";
+
+    /// <summary>
+    /// The solution entity that is being monitored.
+    /// </summary>
+    public Entity<SolutionComponent>? Solution;
+}

--- a/Content.Shared/Chemistry/Components/ReagentColorComponent.cs
+++ b/Content.Shared/Chemistry/Components/ReagentColorComponent.cs
@@ -13,6 +13,6 @@ public sealed partial class ReagentColorComponent : Component
     /// <summary>
     /// The name of the solution that determines the color.
     /// </summary>
-    [DataField("solution"), AutoNetworkedField]
-    public string SolutionName = "bloodstream";
+    [DataField(required: true), AutoNetworkedField]
+    public string? Solution;
 }

--- a/Content.Shared/Chemistry/Components/ReagentColorComponent.cs
+++ b/Content.Shared/Chemistry/Components/ReagentColorComponent.cs
@@ -13,6 +13,6 @@ public sealed partial class ReagentColorComponent : Component
     /// <summary>
     /// The name of the solution that determines the color.
     /// </summary>
-    [DataField("solution"), AutoNetworkedField]
-    public string SolutionName = "bloodstream";
+    [DataField(required: true), AutoNetworkedField]
+    public string Solution = default!;
 }

--- a/Content.Shared/Chemistry/Components/ReagentColorVisuals.cs
+++ b/Content.Shared/Chemistry/Components/ReagentColorVisuals.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Chemistry.Components;
+
+[Serializable, NetSerializable]
+public enum ReagentColorVisuals : byte
+{
+    Color
+}

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -315,6 +315,9 @@
   parent: [ MobAdultSlimes, MobCombat ]
   description: It consists of a liquid, and it wants to dissolve you in itself.
   components:
+  - type: ReagentColor
+    solution: bloodstream
+  - type: Appearance
   - type: GhostRole
     prob: 0
     description: ghost-role-information-angry-slimes-description
@@ -332,11 +335,9 @@
     layers:
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
-        color: "#75b1f0"
   - type: PointLight
     radius: 2.0
     energy: 3.5
-    color: "#75b1f0" # Edited through the LiquidAnomalySystem
   - type: MobState
     allowedStates:
     - Alive
@@ -424,15 +425,6 @@
       reagents:
       - ReagentId: Beer
         Quantity: 100
-  - type: PointLight
-    color: "#cfa85f"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#cfa85f"
 
 - type: entity
   id: ReagentSlimePax
@@ -444,15 +436,6 @@
       reagents:
       - ReagentId: Pax
         Quantity: 100
-  - type: PointLight
-    color: "#AAAAAA"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#AAAAAA"
   - type: MeleeChemicalInjector
     solution: bloodstream
     transferAmount: 1
@@ -467,15 +450,6 @@
       reagents:
       - ReagentId: Nocturine
         Quantity: 100
-  - type: PointLight
-    color: "#128e80"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#128e80"
   - type: MeleeChemicalInjector
     solution: bloodstream
     transferAmount: 3
@@ -490,15 +464,6 @@
       reagents:
       - ReagentId: THC
         Quantity: 100
-  - type: PointLight
-    color: "#808080"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#808080"
 
 - type: entity
   id: ReagentSlimeBicaridine
@@ -510,15 +475,6 @@
       reagents:
       - ReagentId: Bicaridine
         Quantity: 100
-  - type: PointLight
-    color: "#ffaa00"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#ffaa00"
 
 - type: entity
   id: ReagentSlimeToxin
@@ -530,15 +486,6 @@
       reagents:
       - ReagentId: Toxin
         Quantity: 100
-  - type: PointLight
-    color: "#cf3600"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#cf3600"
 
 - type: entity
   id: ReagentSlimeNapalm
@@ -550,15 +497,6 @@
       reagents:
       - ReagentId: Napalm
         Quantity: 100
-  - type: PointLight
-    color: "#FA00AF"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#FA00AF"
 
 - type: entity
   id: ReagentSlimeOmnizine
@@ -570,15 +508,6 @@
       reagents:
       - ReagentId: Omnizine
         Quantity: 100
-  - type: PointLight
-    color: "#fcf7f9"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#fcf7f9"
 
 - type: entity
   id: ReagentSlimeMuteToxin
@@ -590,15 +519,6 @@
       reagents:
       - ReagentId: MuteToxin
         Quantity: 100
-  - type: PointLight
-    color: "#0f0f0f"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#0f0f0f"
 
 - type: entity
   id: ReagentSlimeNorepinephricAcid
@@ -610,15 +530,6 @@
       reagents:
       - ReagentId: NorepinephricAcid
         Quantity: 100
-  - type: PointLight
-    color: "#96a8b5"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#96a8b5"
 
 - type: entity
   id: ReagentSlimeEphedrine
@@ -630,15 +541,6 @@
       reagents:
       - ReagentId: Ephedrine
         Quantity: 100
-  - type: PointLight
-    color: "#D2FFFA"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#D2FFFA"
 
 - type: entity
   id: ReagentSlimeRobustHarvest
@@ -650,12 +552,3 @@
       reagents:
       - ReagentId: RobustHarvest
         Quantity: 100
-  - type: PointLight
-    color: "#3e901c"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#3e901c"

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -316,6 +316,9 @@
   parent: [ MobAdultSlimes, MobCombat ]
   description: It consists of a liquid, and it wants to dissolve you in itself.
   components:
+  - type: ReagentColor
+    solution: bloodstream
+  - type: Appearance
   - type: GhostRole
     prob: 0
     description: ghost-role-information-angry-slimes-description
@@ -333,11 +336,9 @@
     layers:
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
-        color: "#75b1f0"
   - type: PointLight
     radius: 2.0
     energy: 3.5
-    color: "#75b1f0" # Edited through the LiquidAnomalySystem
   - type: MobState
     allowedStates:
     - Alive
@@ -425,15 +426,6 @@
       reagents:
       - ReagentId: Beer
         Quantity: 100
-  - type: PointLight
-    color: "#cfa85f"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#cfa85f"
 
 - type: entity
   id: ReagentSlimePax
@@ -445,15 +437,6 @@
       reagents:
       - ReagentId: Pax
         Quantity: 100
-  - type: PointLight
-    color: "#AAAAAA"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#AAAAAA"
   - type: MeleeChemicalInjector
     solution: bloodstream
     transferAmount: 1
@@ -468,15 +451,6 @@
       reagents:
       - ReagentId: Nocturine
         Quantity: 100
-  - type: PointLight
-    color: "#128e80"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#128e80"
   - type: MeleeChemicalInjector
     solution: bloodstream
     transferAmount: 3
@@ -491,15 +465,6 @@
       reagents:
       - ReagentId: THC
         Quantity: 100
-  - type: PointLight
-    color: "#808080"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#808080"
 
 - type: entity
   id: ReagentSlimeBicaridine
@@ -511,15 +476,6 @@
       reagents:
       - ReagentId: Bicaridine
         Quantity: 100
-  - type: PointLight
-    color: "#ffaa00"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#ffaa00"
 
 - type: entity
   id: ReagentSlimeToxin
@@ -531,15 +487,6 @@
       reagents:
       - ReagentId: Toxin
         Quantity: 100
-  - type: PointLight
-    color: "#cf3600"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#cf3600"
 
 - type: entity
   id: ReagentSlimeNapalm
@@ -551,15 +498,6 @@
       reagents:
       - ReagentId: Napalm
         Quantity: 100
-  - type: PointLight
-    color: "#FA00AF"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#FA00AF"
 
 - type: entity
   id: ReagentSlimeOmnizine
@@ -571,15 +509,6 @@
       reagents:
       - ReagentId: Omnizine
         Quantity: 100
-  - type: PointLight
-    color: "#fcf7f9"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#fcf7f9"
 
 - type: entity
   id: ReagentSlimeMuteToxin
@@ -591,15 +520,6 @@
       reagents:
       - ReagentId: MuteToxin
         Quantity: 100
-  - type: PointLight
-    color: "#0f0f0f"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#0f0f0f"
 
 - type: entity
   id: ReagentSlimeNorepinephricAcid
@@ -611,15 +531,6 @@
       reagents:
       - ReagentId: NorepinephricAcid
         Quantity: 100
-  - type: PointLight
-    color: "#96a8b5"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#96a8b5"
 
 - type: entity
   id: ReagentSlimeEphedrine
@@ -631,15 +542,6 @@
       reagents:
       - ReagentId: Ephedrine
         Quantity: 100
-  - type: PointLight
-    color: "#D2FFFA"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#D2FFFA"
 
 - type: entity
   id: ReagentSlimeRobustHarvest
@@ -651,12 +553,3 @@
       reagents:
       - ReagentId: RobustHarvest
         Quantity: 100
-  - type: PointLight
-    color: "#3e901c"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#3e901c"

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -874,6 +874,8 @@
   parent: BaseAnomaly
   suffix: Liquid
   components:
+  - type: ReagentColor
+    solution: anomaly
   - type: Sprite
     sprite: Structures/Specific/Anomalies/liquid_anom.rsi
     layers:
@@ -883,7 +885,7 @@
       map: ["enum.AnomalyVisualLayers.Animated"]
       visible: false
   - type: RandomSprite
-    selected: # Initialized layer values. Edited through the ReagentProducerAnomalySystem
+    selected: # Initialized layer values. Color managed by ReagentColorSystem
       enum.AnomalyVisualLayers.Base:
         anom: "#ffffff"
       enum.AnomalyVisualLayers.Animated:
@@ -891,7 +893,6 @@
   - type: PointLight
     radius: 4.0
     energy: 3.5
-    color: "#bbbbbb"
   - type: BadFood
   - type: Anomaly
     corePrototype: AnomalyCoreLiquid
@@ -920,7 +921,6 @@
     superCriticalInjectRadius: 10
   - type: ReagentProducerAnomaly
     solution: anomaly
-    needRecolor: true
     dangerousChemicals:
     - UnstableMutagen
     - Mold

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -825,6 +825,8 @@
   parent: BaseAnomaly
   suffix: Liquid
   components:
+  - type: ReagentColor
+    solution: anomaly
   - type: Sprite
     sprite: Structures/Specific/Anomalies/liquid_anom.rsi
     layers:
@@ -834,7 +836,7 @@
       map: ["enum.AnomalyVisualLayers.Animated"]
       visible: false
   - type: RandomSprite
-    selected: # Initialized layer values. Edited through the ReagentProducerAnomalySystem
+    selected: # Initialized layer values. Color managed by ReagentColorSystem
       enum.AnomalyVisualLayers.Base:
         anom: "#ffffff"
       enum.AnomalyVisualLayers.Animated:
@@ -842,7 +844,6 @@
   - type: PointLight
     radius: 4.0
     energy: 3.5
-    color: "#bbbbbb"
   - type: BadFood
   - type: Anomaly
     corePrototype: AnomalyCoreLiquid
@@ -871,7 +872,6 @@
     superCriticalInjectRadius: 10
   - type: ReagentProducerAnomaly
     solution: anomaly
-    needRecolor: true
     dangerousChemicals:
     - UnstableMutagen
     - Mold


### PR DESCRIPTION
## About the PR
New system/component for coloring an entity based on reagents in the solution

## Why / Balance
More dynamic, less hardcoding. Easier to add more variants of reagent slimes (upcoming PR after this)

## Technical details
ReagentColorVisualizerSystem on client-side
ReagentColorSystem on server-side
ReagentColorComponent in shared

Updates color on AppearanceComponent, RandomSpriteComponent + PointLightComponent

## Media
<img width="1914" height="1275" alt="slimes" src="https://github.com/user-attachments/assets/41664c44-29af-4fc5-bfdd-bf4b1217e6c0" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
NeedRecolor removed from ReagentProducerAnomalyComponent so anything using this should instead use ReagentColorComponent

**Changelog**
No noticeable change for players