### PR TITLE
Machines and assemblies destructible items pass

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
@@ -285,7 +285,7 @@
   - type: MultiHandedItem
   - type: PhysicalComposition
     materialComposition:
-      Steel: 2000 # 20 sheets
+      Steel: 1000 # 10 sheets
 
 - type: entity
   parent: BaseScrap
@@ -304,7 +304,7 @@
   - type: MultiHandedItem
   - type: PhysicalComposition
     materialComposition:
-      Steel: 2000 # 20 sheets
+      Steel: 1000 # 10 sheets
 
 - type: entity
   parent: BaseScrap

--- a/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
@@ -21,10 +21,31 @@
     thresholds:
       - trigger:
           !type:DamageTrigger
+          damage: 100
+        behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: WoodDestroy
+            params:
+              volume: -4
+      - trigger:
+          !type:DamageTrigger
           damage: 50
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: WoodDestroy
+            params:
+              volume: -4
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            MaterialWoodPlank1:
+              min: 1
+              max: 3
   - type: AmbientSound
     volume: -5
     range: 5

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -120,10 +120,30 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 2000
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalCrunch
+    - trigger:
+        !type:DamageTrigger
         damage: 1500
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalCrunch
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetPlasteel1:
+            min: 1
+            max: 2
+          SheetSteel1:
+            min: 1
+            max: 1
   - type: Construction
     graph: Airlock
     node: highSecDoor

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -34,10 +34,30 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 500
+          damage: 1000
         behaviors:
         - !type:DoActsBehavior
           acts: ["Destruction"]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalCrunch
+            params:
+              volume: -4
+      - trigger:
+          !type:DamageTrigger
+          damage: 500
+        behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalCrunch
+            params:
+              volume: -4
+        - !type:WeightedSpawnEntityBehavior
+          weightedEntityTable: "FirelockFrameDestructionSpawnTable"
+          minSpawn: 1
+          maxSpawn: 1
     - type: Sprite
       sprite: Structures/Doors/Airlocks/Standard/firelock.rsi
       snapCardinals: true
@@ -189,6 +209,39 @@
           - GlassAirlockLayer
     - type: Door
       occludes: false
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 1000
+        behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalGlassBreak
+            params:
+              volume: -4
+      - trigger:
+          !type:DamageTrigger
+          damage: 500
+        behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalGlassBreak
+            params:
+              volume: -4
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            ShardGlass:
+              min: 1
+              max: 1
+        - !type:WeightedSpawnEntityBehavior
+          weightedEntityTable: "FirelockFrameDestructionSpawnTable"
+          minSpawn: 1
+          maxSpawn: 1
     - type: Construction
       node: FirelockGlass
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -207,6 +207,8 @@
           - HighImpassable
           layer:
           - GlassAirlockLayer
+    - type: StaticPrice
+      price: 180
     - type: Door
       occludes: false
     - type: Destructible
@@ -280,7 +282,7 @@
     - type: Physics
       canCollide: false
     - type: StaticPrice
-      price: 100
+      price: 150
     - type: Construction
       graph: Firelock
       node: FirelockEdge

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/frame.yml
@@ -37,6 +37,21 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalCrunch
+          params:
+            volume: -4
+      - !type:WeightedSpawnEntityBehavior
+        weightedEntityTable: "FirelockFrameDestructionSpawnTable"
+        minSpawn: 1
+        maxSpawn: 1
   - type: Physics
     bodyType: Dynamic
   - type: Fixtures
@@ -52,3 +67,10 @@
         layer:
         - HighImpassable
         - MidImpassable
+
+- type: weightedRandomEntity
+  id: FirelockFrameDestructionSpawnTable
+  weights:
+    ScrapFirelock1: 1
+    ScrapFirelock2: 1
+    ScrapFirelock3: 1

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -114,10 +114,31 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+          params:
+            volume: -4
+    - trigger:
+        !type:DamageTrigger
         damage: 100
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+          params:
+            volume: -4
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 2
   - type: Construction
     graph: SecretDoor
     node: assembly

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -54,10 +54,23 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 400
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
         damage: 200
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+          params:
+            volume: -4
+      - !type:ChangeConstructionNodeBehavior
+        node: assembly
   - type: IconSmooth
     key: walls
     mode: NoSprite
@@ -120,7 +133,7 @@
         acts: ["Destruction"]
       - !type:PlaySoundBehavior
         sound:
-          collection: MetalGlassBreak
+          collection: MetalBreak
           params:
             volume: -4
     - trigger:
@@ -131,7 +144,7 @@
         acts: ["Destruction"]
       - !type:PlaySoundBehavior
         sound:
-          collection: MetalGlassBreak
+          collection: MetalBreak
           params:
             volume: -4
       - !type:SpawnEntitiesBehavior

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -88,6 +88,27 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+          params:
+            volume: -4
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+          params:
+            volume: -4
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetPlasteel1:
+            min: 2
+            max: 4
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -173,6 +194,27 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+          params:
+            volume: -4
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+          params:
+            volume: -4
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetPlasteel1:
+            min: 2
+            max: 4
   - type: Physics
     bodyType: Static
   - type: Fixtures

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -84,7 +84,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 400
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -95,7 +95,7 @@
             volume: -4
     - trigger:
         !type:DamageTrigger
-        damage: 200
+        damage: 300
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -190,7 +190,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 400
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -201,7 +201,7 @@
             volume: -4
     - trigger:
         !type:DamageTrigger
-        damage: 200
+        damage: 300
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -228,7 +228,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 600
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -239,7 +239,7 @@
             volume: -4
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 500
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -228,10 +228,31 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 500
+        damage: 300
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+          params:
+            volume: -4
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+          params:
+            volume: -4
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 2
   - type: Physics
     bodyType: Dynamic
   - type: Fixtures

--- a/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
@@ -51,10 +51,26 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 1000
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
         damage: 500
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+          params:
+            volume: -4
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          PartRodMetal1:
+            min: 1
+            max: 4
   - type: AccessReader
   - type: Construction
     graph: Turnstile

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -111,11 +111,6 @@
           collection: WindowShatter
           params:
             volume: -4
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          ShardGlass:
-            min: 1
-            max: 1
   - type: Explosive
     explosionType: Default
     maxIntensity: 10

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -80,16 +80,42 @@
     thresholds:
     - trigger: # Excess damage, don't spawn entities
         !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
         damage: 200
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+          params:
+            volume: -4
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 2
     - trigger:
         !type:DamageTrigger
         damage: 100
       behaviors:
       - !type:DoActsBehavior
         acts: ["Breakage"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WindowShatter
+          params:
+            volume: -4
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          ShardGlass:
+            min: 1
+            max: 1
   - type: Explosive
     explosionType: Default
     maxIntensity: 10

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
@@ -323,14 +323,38 @@
     thresholds:
     - trigger: # Excess damage, don't spawn entities
         !type:DamageTrigger
-        damage: 200
+        damage: 300
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalCrunch
+          params:
+            volume: -4
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 2
+            max: 3
+          CableApcStack1:
+            min: 0
+            max: 1
+    - trigger:
+        !type:DamageTrigger
         damage: 100
       behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+          params:
+            volume: -4
       - !type:DoActsBehavior
         acts: ["Breakage"]
   - type: Anchorable
@@ -378,10 +402,21 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 300
       behaviors:
       - !type:DoActsBehavior
-        acts: ["Breakage"]
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+      - !type:ChangeConstructionNodeBehavior
+        node: solarassembly
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
   - type: Anchorable
   - type: Pullable
   - type: Construction

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -291,6 +291,25 @@
       behaviors:
         - !type:DoActsBehavior
           acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+          params:
+            volume: -4
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialWoodPlank1:
+            min: 1
+            max: 1
+          SheetSteel1:
+            min: 1
+            max: 2
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shuttles/pirate_cannon.rsi
     layers:
@@ -375,13 +394,30 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 200
       behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          FoodMeatXeno:
+            min: 1
+            max: 1
+          SheetSteel1:
+            min: 1
+            max: 2
   - type: Gun
     projectileSpeed: 20
     fireRate: 0.2

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -287,13 +287,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 400
       behaviors:
         - !type:DoActsBehavior
           acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
-        damage: 200
+        damage: 300
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]

--- a/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
@@ -80,7 +80,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 300
+          damage: 150
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Breakage" ]

--- a/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
@@ -80,10 +80,12 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 150
+          damage: 300
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Breakage" ]
+        - !type:ChangeConstructionNodeBehavior
+          node: machineFrame
       - trigger:
           !type:DamageTrigger
           damage: 600

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -132,7 +132,12 @@
           acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound:
-            collection: MetalBreak
+            collection: MetalSlam
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            SheetPlasteel1:
+              min: 5
+              max: 10
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Structures/lever.yml
+++ b/Resources/Prototypes/Entities/Structures/lever.yml
@@ -32,10 +32,21 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
+          damage: 200
+        behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+      - trigger:
+          !type:DamageTrigger
           damage: 100
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            SheetSteel1:
+              min: 1
+              max: 1
     - type: Construction
       graph: LeverGraph
       node: LeverNode

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -35,10 +35,21 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 250
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetPlastic1:
+            min: 2
+            max: 3
   - type: StaticPrice
     price: 100
 
@@ -84,14 +95,6 @@
   suffix: Airtight, Clear
   description: Heavy duty, slightly stronger, airtight plastic flaps. Definitely can't get past those. No way.
   components:
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
   - type: Airtight
   - type: StaticPrice
     price: 100
@@ -103,14 +106,6 @@
   suffix: Airtight, Opaque
   description: Heavy duty, slightly stronger, airtight plastic flaps. Definitely can't get past those. No way.
   components:
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
   - type: Airtight
   - type: StaticPrice
     price: 100

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/firelock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/firelock.yml
@@ -9,7 +9,7 @@
             - !type:SnapToGrid { }
           steps:
             - material: Steel
-              amount: 3
+              amount: 10
               doAfter: 1
 
 
@@ -30,7 +30,7 @@
           completed:
             - !type:SpawnPrototype
               prototype: SheetSteel1
-              amount: 3
+              amount: 10
             - !type:DeleteEntity {}
           conditions:
             - !type:EntityAnchored


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Part 2 of #42147

Changes outside of straight up destructibles: 
- Firelock assemblies now take 10 steel instead of 3 to build
- Firelock door scraps now recycles into 10 steel instead of 20


```
BaseSecretDoorAssembly | secret door assembly | 1-2 steel (secret doors also break into the assembly)
BlastDoorFrame | blast door frame | 2-4 plasteel
BlastDoorXenoFrame | xeno blast door frame | 2-4 plasteel
Bonfire | bonfire | 1-3 wood
FirelockFrame | firelock frame | 1 firelock frame scrap (recycles into 10 or 7). firelock frames now take 10 steel to build
HighSecDoor | high security door | 1-2 plasteel, 1 steel
KitchenMicrowave | microwave | first stage is 1 glass shard (microwave is visibly broken), second stage is breaking into 1-2 steel. (no more microwave) 
PlasticFlapsAirtightClear | airtight plastic flaps | 2-3 plastic |
PlasticFlapsAirtightOpaque | airtight plastic flaps | 2-3 plastic | reformatted yaml a bit
ShuttersFrame | shutter frame | 1-2 steel | lowered damage to 100, 500 is a huge amount for a frame
ShuttleGunKineticOld | exomorphic dematerializer | 1 xeno meat, 1-2 steel, its biomechanical. xeno meat.
ShuttleGunPirateCannon | pirate ship cannon | 1 wood, 1-2 steel
SolarAssembly | solar assembly | 0-1 lv wire, 2-3 steel
SolarTracker | solar tracker | back into solar assembly node
StationAnchor | station anchor | machine frame at 300
ThrusterLarge | large thruster | 5-10 plasteel
Turnstile | turnstile | 1-4 rods
TwoWayLever | two way lever | 1 steel
```


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's not satisfying when something breaks and you don't get anything.

Rationale for the firelock changes are that it had to go either way, the scrap right now is worth 20 steel each, the frames take 3 steel. 10 feels like a good middle ground.

## Technical details
<!-- Summary of code changes for easier review. -->
just yaml, made a spawn table for the firelock drops

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
highlight reel (satisfying destruction)

https://github.com/user-attachments/assets/76146886-4501-4159-b316-6c45bfc2b48a



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Firelocks now take 10 steel sheets to construct
- tweak: Firelock door scrap now recycles into 10 steel sheets