### PR TITLE
Ammonia restores Rat King Bloodlevel

### DIFF
--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -266,13 +266,13 @@
           types:
             Bloodloss: -5
       - !type:ModifyBloodLevel
+        amount: 1
         conditions:
         - !type:MetabolizerTypeCondition
           type: [ Rat ]
         - !type:ReagentCondition
           reagent: Ammonia
           min: 1
-          amount: 6
       - !type:Oxygenate # ammonia displaces nitrogen in vox blood
         conditions:
         - !type:MetabolizerTypeCondition


### PR DESCRIPTION
## About the PR
Adds a saline effect to ammonia for creatures with the rat metabolizer type condition (aka, rat kings and their servants). A maintainer gave the OK for this antag PR here: https://forum.spacestation14.com/t/rat-king-bloodloss-situation-kinda-sucks/25795

## Why / Balance
Rat Kings have an awkward situation where they can limp away from a fight after getting shot up, retreat to their ammonia den, heal all the way up, and be completely unable to leave because while they heal brute, heat, and bloodloss from ammonia, it doesn’t actually stop bleeding or restore their blood level. They will continue to bleed out but will just heal the damage.

This issue SUCKS for the RK becaue they have to wait for passive blood regen to actually leave their hotbox without actively dying, and even if you only take 4-5 shots that’s more than enough to force you to sit in a 1-2 tile box in the dark for ~10 or so minutes, not moving or making noise to avoid detection, while you regen about 12% of your blood / minute and have to wait for any bleed ticks you have to fully expire. This is honestly worse than if you just got shot down outright.

This PR would make it so ammonia gas would act like saline in addition to its other healing properties, similar to how dragons also restore blood when eating players, which should help RKs cut down on frustrating downtime.

## Technical details
yaml only
I added a blood restore effect to ammonia gas with conditions to restrict it to specifically rats, mirroring how the ammonia heal effect currently works.

## Media
https://github.com/user-attachments/assets/b59eb83d-41e6-4f2a-bf7f-e80c04f94368

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
**Changelog**
:cl:
- tweak: Rat creatures will now restore bloodlevel when exposed to ammonia gas.