### PR TITLE
Ratking is no longer stunned by electric shocks

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -109,6 +109,8 @@
   - type: MobsterAccent
   - type: Speech
     speechVerb: SmallMob
+  - type: Insulated
+    coefficient: 0.5
   - type: Butcherable
     spawned:
     - id: ClothingHeadHatFancyCrown #how did that get there?


### PR DESCRIPTION

## About the PR
I gave ratkings inherent imperfect electrical insulation, to prevent easy door zap stuns by AI, and to allow ratkings a more fair chance against the crew.

## Why / Balance
AIs have the ability to electrify doors, which currently makes the ratking extremely easy to kill; zap every door, get sec to shoot the ratking; this creates extremely frustrating gameplay for the ratking, who has to rely on hit & runs to stay alive, and encourages validhunting by the AI; the purpose of this PR is to make door zaps less oppressive against ratkings, to allow them a chance to actually evade security, instead of being stunned for 5 seconds with every door they touch.

## Technical details
Added   `- type: Insulated
coefficient: 0.5` to regalrat.yml

## Media

https://github.com/user-attachments/assets/b49b9b94-3863-4edb-9ffe-84f43c584ac8



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- add: Ratkings now have imperfect electrical insulation.