### PR TITLE
SliceableFoodSystem expansion, Stackable Botany produce slice amounts scale with potency.

### DIFF
--- a/Content.Server/Nutrition/Components/SliceableFoodComponent.cs
+++ b/Content.Server/Nutrition/Components/SliceableFoodComponent.cs
@@ -33,5 +33,21 @@ public sealed partial class SliceableFoodComponent : Component
     /// all the pieces will be shifted in random directions.
     /// </summary>
     [DataField]
-    public float SpawnOffset = 0.5f;
+    public float SpawnOffset = 2f;
+
+    /// <summary>
+    /// For botany produe, should the number of slices be dependant on its potency (true), or static (false). If there is no potency found, defaults to false outcome.
+    /// </summary>
+    /// <remarks>
+    /// for most plants this won't be relevent, as potency will only effect reagent amount which is already accounted for as long as reagents are transferred.
+    /// would instead be relevent for stackable produce stuch as towercap or cotton
+    /// </remarks>
+    [DataField]
+    public bool PotencyEffectsCount = false;
+
+    /// <summary>
+    /// whether or not any sharp object can be used to cut this (true), or only a knife utensil (false)
+    /// </summary>
+    [DataField]
+    public bool AnySharp = false;
 }

--- a/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
@@ -90,7 +90,7 @@ public sealed class SliceableFoodSystem : EntitySystem
             if (TryComp<ProduceComponent>(entity, out var prod))
             {
                 if (prod.Seed != null) //Is seed data defined? Wouldn't be for produce not coming from a plant.
-                    entity.Comp2.TotalCount = (ushort)Math.Ceiling(entity.Comp2.TotalCount * prod.Seed.Potency / 100);
+                    entity.Comp2.TotalCount = (ushort)Math.Ceiling(entity.Comp2.TotalCount * Math.Min(prod.Seed.Potency, 100f) / 100);
             }
         }
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -148,9 +148,12 @@
   - type: SolutionContainerManager
   - type: Produce
     seedId: papercane
-  - type: Log
-    spawnedPrototype: SheetPaper1
-    spawnCount: 2
+  - type: SliceableFood
+    slice: SheetPaper1
+    count: 4
+    sliceTime: 0.5
+    potencyEffectsCount: true
+    anySharp: true
 
 - type: entity
   parent: FoodProduceBase
@@ -205,7 +208,12 @@
         Blunt: 10
   - type: Produce
     seedId: towercap
-  - type: Log
+  - type: SliceableFood
+    slice: MaterialWoodPlank1
+    count: 5
+    sliceTime: 0.5
+    potencyEffectsCount: true
+    anySharp: true
 
 - type: entity
   name: steel-cap log
@@ -224,9 +232,12 @@
         Blunt: 12
   - type: Produce
     seedId: steelcap
-  - type: Log
-    spawnedPrototype: SheetSteel1
-    spawnCount: 1
+  - type: SliceableFood
+    slice: SheetSteel1
+    count: 2
+    sliceTime: 0.5
+    potencyEffectsCount: true
+    anySharp: true
 
 - type: entity
   name: nettle
@@ -2635,9 +2646,12 @@
         reagents:
         - ReagentId: Fiber
           Quantity: 10
-  - type: Log
-    spawnedPrototype: MaterialCotton1
-    spawnCount: 2
+  - type: SliceableFood
+    slice: MaterialCotton1
+    count: 4
+    sliceTime: 0.5
+    potencyEffectsCount: true
+    anySharp: true
   - type: Produce
     seedId: cotton
   - type: Tag
@@ -2669,9 +2683,12 @@
           Quantity: 5
         - ReagentId: Phlogiston
           Quantity: 5
-  - type: Log
-    spawnedPrototype: MaterialPyrotton1
-    spawnCount: 2
+  - type: SliceableFood
+    slice: MaterialPyrotton1
+    count: 2
+    sliceTime: 0.5
+    potencyEffectsCount: true
+    anySharp: true
   - type: Produce
     seedId: pyrotton
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -2685,7 +2685,7 @@
           Quantity: 5
   - type: SliceableFood
     slice: MaterialPyrotton1
-    count: 2
+    count: 4
     sliceTime: 0.5
     potencyEffectsCount: true
     anySharp: true

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -234,7 +234,7 @@
     seedId: steelcap
   - type: SliceableFood
     slice: SheetSteel1
-    count: 2
+    count: 3
     sliceTime: 0.5
     potencyEffectsCount: true
     anySharp: true


### PR DESCRIPTION
## About the PR
SliceableFoodSystem can now optionally scale the amount of slices with the potency of botany produce, stackable produce will automatically be stacked. Also, food with multiple solution containers can now all be transferred rather than just the one specified by EdibleComponent, assuming there is a solution container of the same name in the slice.

## Why / Balance
Currently there is LogComponent, SliceableFoodComponent, and ButcherableComponent that can all be used to cut a thing to get something, this PR makes LogComponent Redundant by letting SliceableFood work better with stackable entities.

Also, from a player standpoint, botany produce that would be cut into a stackable entity, like Towercap, was unaffected by potency when it came to making more of that sliceable item which is a bit dissapointing. Potency can now scale the amount gained from cutting a towercap log, as well as steelcap, cotton, pyrotton, and papercane. For QOL, they then get stacked for you, so less spam clicking.

The amount of slices that can theoretically be made has been increased for all these produce, generally balanced that Potency 50 will produce slightly more than or equal to before, those that push beyond 50 will be rewarded, those that leave their plants at baseline will generally have less. 

## Technical details
LogComponent made redundant, although not deleted.
Removed function that ensured EdibleComponent on anything that had SliceableComponent, as it was suggested to be removed when FoodComponent was, and it's also no longer a requirement for SliceableFood to function.
Spawning Entities now uses SpawnMultipleAtPosition as this handles stackable and non-stackable entities.
SpawnOffset DataField now actually does something, previously these offsets were static values.
New DataField "AnySharp" lets anything with a sharpcomponent slice. Ideally UtensilComponent would be fused into ToolComponent which could then be made choosable in a DataField, then if you choose no tool it'd default to sharpcomponent but that's a bit too much for this PR.
New DataField "PotencyEffectsCount" checks to see if the cut entity has a produce component with seedData, and if it does, scales the TotalCount value appropriately.
Stackable entities don't have reagents transferred to them because stackable entities with inconsistent reagents behave don't store those reagents properly when stacked. 

## Media
https://github.com/user-attachments/assets/65a624f2-8800-422f-a22b-6ebae0037e09

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
Modifies SliceableFoodSystem

**Changelog**
:cl:
- tweak: Towercap, Steelcap, Cotton, Pyrotton, and Papercane's produce can be cut into more slices at higher potencies, but potentially less at low potencies. 
- tweak: Cutting Logs, Steel Logs, Cotton Bols, Pyrotton Bols, and Papercane rolls now has a short doafter.