### PR TITLE
HoP now rolls after captain, but still before other members of Command

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -19,7 +19,7 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 2.5h
-  weight: 20
+  weight: 15
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"
   supervisors: job-supervisors-captain


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Head of Personnel now has a lower weight value than Captain (was previously identical, meaning that Captain wasn't prioritized if both roles were selected). Head of Personnel still rolls before all other non-Captain roles.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Small QoL change. Consider the scenario of a player who has HoP on High and Captain on Medium or Low when no other players have Captain selected:
- Before this PR:
  - Player is assigned HoP because they had its priority above Captain
  - Nobody is assigned Captain because everyone else had it set to Off
  - The HoP player likely becomes the acting captain, both because HoP is generally the default pick for that and because they're the only player that had wanted to play Captain anyway
  - Regardless of who's decided to be the acting captain, if there's no AI to let them into the captain's room, then someone will need to outright break into the captain's room in order to grab the captain's things
  - Eventually, the station has an acting captain who can start doing captain things

- After this PR:
  - Player is assigned Captain because its weight is higher than HoP and they had both roles selected
  - The station has a Captain. All is well.

## Technical details
<!-- Summary of code changes for easier review. -->
One-line YAML change to head_of_personnel.yml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A (backend change)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Head of Personnel now rolls after Captain (but still before other Command roles).
