### PR TITLE
Add Kudzu Removal to Plant-B-Gone

### DIFF
--- a/Content.Server/EntityEffects/Effects/Botany/PlantAttributes/PlantPlantBGoneEntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/Effects/Botany/PlantAttributes/PlantPlantBGoneEntityEffectSystem.cs
@@ -1,0 +1,16 @@
+using Content.Server.Botany.Components;
+using Content.Shared.EntityEffects;
+using Content.Shared.EntityEffects.Effects.Botany.PlantAttributes;
+
+namespace Content.Server.EntityEffects.Effects.Botany.PlantAttributes;
+
+public sealed partial class PlantPlantBGoneEntityEffectSystem : EntityEffectSystem<PlantHolderComponent, PlantPlantBGone>
+{
+    protected override void Effect(Entity<PlantHolderComponent> entity, ref EntityEffectEvent<PlantPlantBGone> args)
+    {
+        if (entity.Comp.Seed == null || entity.Comp.Dead || entity.Comp.Seed.Immutable)
+            return;
+
+        entity.Comp.Seed.TurnIntoKudzu = false;
+    }
+}

--- a/Content.Shared/EntityEffects/Effects/Botany/PlantAttributes/PlantPlantBGone.cs
+++ b/Content.Shared/EntityEffects/Effects/Botany/PlantAttributes/PlantPlantBGone.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.EntityEffects.Effects.Botany.PlantAttributes;
+
+public sealed partial class PlantPlantBGone : EntityEffectBase<PlantPlantBGone>
+{
+    /// <inheritdoc/>
+    public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys) =>
+        Loc.GetString("entity-effect-guidebook-plant-plantbgone", ("chance", Probability));
+}

--- a/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
@@ -489,6 +489,12 @@ entity-effect-guidebook-plant-phalanximine =
         *[other] restore
     } viability to a plant rendered nonviable by a mutation
 
+entity-effect-guidebook-plant-plantbgone =
+    { $chance ->
+        [1] Removes
+        *[other] remove
+    } fast and thin weeds from a plant
+
 entity-effect-guidebook-plant-diethylamine =
     { $chance ->
         [1] Increases

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -89,6 +89,7 @@
       amount: -20
     - !type:PlantAdjustMutationMod
       amount: 0.1
+    - !type:PlantPlantBGone
   metabolisms:
     Medicine:
       effects:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a Kudzu Removal effect to Plant-B-Gone.  One unit of Plant-B-Gone will now get rid of the Kudzu Gene.

## Why / Balance
This currently already exists for sick and wilting plants in the form of Phalanximine.  Most botanists remove kudzu by getting seeds for the plant, then, since the seeds aren't made unique until reagents are processed, intentionally letting one plant kudzu to remove the gene on all of them.  This is janky, unintuitive, and fragile because any reagents processing now makes the seed unique.

Giving an option to remove the gene with Plant-B-Gone will create a more intuitive experience - it is weed killer after all and the description for Plant-B-Gone already mentions how effective it is against Kudzu!

Balance wise, Plant-B-Gone is significantly more harmful to the plant than Phalanximine, but this makes sense as unviability quickly kills the plant, but kudzu can be raked until you get the plant healthy enough to treat.

Additionally, by being much more toxic, it means that you can't create a mix where you just dump in all the chemicals and are hands free.  It's also made a bit more unique by requiring just a single unit to remove fast and thin, whereas Phalanximine requires 5u.


## Technical details
Added new effect, PlantPlantBGoneEntityEffect

## Media
I tested in game that it works as expected and other botany stuff still works fine.

<img width="650" height="297" alt="image" src="https://github.com/user-attachments/assets/d6d96642-a62a-4675-a6de-d366ae52aea2" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: A Kudzu gene removal effect to plant-B-gone
