### PR TITLE
Fix guidebook links not being displayed

### DIFF
--- a/Content.Client/Guidebook/DocumentParsingManager.static.cs
+++ b/Content.Client/Guidebook/DocumentParsingManager.static.cs
@@ -82,7 +82,8 @@ public sealed partial class DocumentParsingManager
                     }
 
                     msg.Pop();
-                    rt.SetMessage(msg);
+                    // Pass null to allow all markup tags, including custom ones like TextLinkTag, KeyBindTag, etc.
+                    rt.SetMessage(msg, tagsAllowed: null);
                     return rt;
                 },
                 TextParser)


### PR DESCRIPTION
## About the PR

Fixes guidebook links (including server rules) not being displayed.

## Why / Balance

Fixes #42156

The RobustToolbox `RichTextLabel.SetMessage` method was updated to use a whitelist of safe tags (`DefaultTags`) by default. This whitelist only includes basic formatting tags like `BoldTag`, `ColorTag`, `ItalicTag`, etc., but does **not** include custom tags like:
- `TextLinkTag` (for `[textlink]` links in guidebooks)
- `KeyBindTag` (for `[keybind]` display)
- `ProtodataTag` (for `[protodata]` values)

This fix passes `null` for `tagsAllowed` when calling `SetMessage` in the guidebook document parser, allowing all registered markup tag handlers to be used. This is safe since guidebook content is trusted (not user-generated input).

## Technical details

Changed `rt.SetMessage(msg);` to `rt.SetMessage(msg, tagsAllowed: null);` in `DocumentParsingManager.static.cs`.

## Media

N/A - restores previous functionality

## Requirements

- [x] I have read and I am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).

## Breaking changes

None.

**Changelog**

:cl:
- fix: Fixed guidebook links (including server rules) not being displayed