### PR TITLE
Fix attributions for /Resources/Audio/Misc/

### DIFF
--- a/Resources/Audio/Misc/attributions.yml
+++ b/Resources/Audio/Misc/attributions.yml
@@ -1,8 +1,3 @@
-- files: ["tension_session.ogg"]
-  license: "CC-BY-3.0"
-  copyright: "Created by qwertyquerty"
-  source: "https://www.youtube.com/@qwertyquerty"
-
 - files: ["ninja_greeting.ogg"]
   license: "CC-BY-SA-3.0"
   copyright: "Created by Chillyconmor"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds missing attributions for a sound files in /Resources/Audio/Misc/
Partially resolves issue #41940

I'm still missing attribution for delta_alt.ogg

Attributions added for the following:
notice1.ogg -> https://github.com/phil235/-tg-station/blob/462ce9c87771c6fa4a0ac29270ef78ea47364d6a/sound/misc/notice1.ogg

notice2.ogg -> https://github.com/phil235/-tg-station/blob/c80f22bf524a900ca484011f1bea55a2c182ac53/sound/misc/notice2.ogg

zip.ogg -> https://github.com/phil235/-tg-station/blob/c80f22bf524a900ca484011f1bea55a2c182ac53/sound/items/zip.ogg

delta.ogg -> https://github.com/Citadel-Station-13/Citadel-Station-13/blob/e31455667ebf3331255c1143e1e7215bc737a287/sound/misc/deltakalaxon.ogg

tension_session.ogg is located in \Resources\Audio\Expedition\ so this attribution isn't needed here.

I've put them all down as CC-BY-SA-3.0 but I'm not a lawyer or an artist so that may be incorrect.
For each of these files, I did not find any alternative attributions listed.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->