### PR TITLE
Dragon rift no longer deletes all rifts when destroyed

### DIFF
--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -268,9 +268,6 @@ public sealed partial class DragonSystem : EntitySystem
         if (!Resolve(uid, ref comp))
             return;
 
-        // do reset the rift count since crew destroyed the rift, not deleted by the dragon dying.
-        DeleteRifts(uid, true, comp);
-
         // We can't predict the rift being destroyed anyway so no point adding weakened to shared.
         comp.WeakenedAccumulator = comp.WeakenedDuration;
         _movement.RefreshMovementSpeedModifiers(uid);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title
also saw the issue and said why not :3

## Why / Balance
The (self)antag QoL strike team wants it issue #41971

Might aswell put their reasoning here
> This behavior should be removed; it's undocumented in the guidebook and resets any momentum the dragon may have had.

## Technical details
removed `DeleteRifts` from `RiftDestroyed` since all it did was destroy all rifts then reset the objective
## Media
https://github.com/user-attachments/assets/8fabe08f-2faa-481e-a1f1-3030f34afa39

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Other Dragon rifts now remain intact when one is destroyed.

