### PR TITLE
make freezers, heaters, space heaters actually start unpowered

### DIFF
--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -42,12 +42,15 @@ namespace Content.Server.Power.Components
         /// <summary>
         ///     When true, causes this to never appear powered.
         /// </summary>
-        [DataField("powerDisabled")]
+        [ViewVariables]
         public override bool PowerDisabled
         {
             get => !NetworkLoad.Enabled;
             set => NetworkLoad.Enabled = !value;
         }
+
+        [DataField("powerDisabled"), ViewVariables(VVAccess.ReadOnly)]
+        public bool StartingPowerDisabled = false;
 
         [ViewVariables]
         public PowerState.Load NetworkLoad { get; } = new PowerState.Load

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -50,7 +50,7 @@ namespace Content.Server.Power.Components
         }
 
         [DataField("powerDisabled"), ViewVariables(VVAccess.ReadOnly)]
-        public bool StartingPowerDisabled = false;
+        public bool StartingPowerDisabled = false; 
 
         [ViewVariables]
         public PowerState.Load NetworkLoad { get; } = new PowerState.Load

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -21,6 +21,7 @@ namespace Content.Server.Power.EntitySystems
         public override void Initialize()
         {
             base.Initialize();
+            SubscribeLocalEvent<ApcPowerReceiverComponent, ComponentStartup>(OnReceiverStartup);
             SubscribeLocalEvent<ApcPowerReceiverComponent, ExaminedEvent>(OnExamined);
 
             SubscribeLocalEvent<ApcPowerReceiverComponent, ExtensionCableSystem.ProviderConnectedEvent>(OnProviderConnected);
@@ -37,6 +38,11 @@ namespace Content.Server.Power.EntitySystems
 
             _recQuery = GetEntityQuery<ApcPowerReceiverComponent>();
             _provQuery = GetEntityQuery<ApcPowerProviderComponent>();
+        }
+
+        private void OnReceiverStartup(Entity<ApcPowerReceiverComponent> ent, ref ComponentStartup args)
+        {
+            ent.Comp.PowerDisabled = ent.Comp.StartingPowerDisabled;
         }
 
         private void OnExamined(Entity<ApcPowerReceiverComponent> ent, ref ExaminedEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes bug where the `powerDisabled: true` starting setting was not actually working; this was intended to allow variations of the GasThermoMachineHeater/Freezer and space heater prototypes that initialize with their power switches turned off.

There are still variations available in the Entity Spawn Menu which have their power switches start turned on -- mappers can still select those variations when building atmos areas.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes https://github.com/space-wizards/space-station-14/issues/36840

This is important so that mappers can put a lot of machines on one APC without tripping the APC immediately on roundstart (by making them unpowered machines).

## Technical details
<!-- Summary of code changes for easier review. -->

I *suspect* - but I don't know for sure - that we cannot have `[DataField]`s with custom C# Property getters / setters, for some reason. (that's how the `PowerDisabled` variable was originally implemented)

The reason I suspect this is that if you scroll up slightly from my changes in the ApcPowerReceiverComponent file, you'll see that for the `NeedsPower` variable, the original implementer decided that they needed to split that field into a public Property and a private backing Field (`_needsPower`). The Field has the `[DataField]` attribute (Fields can have that), while the custom Property is not a `[DataField]` -- it's not settable in the yaml. The point is moot for `NeedsPower` since the custom getter/setter for that variable is... kinda pointless, but regardless I think this points to the idea that you can't put `[DataField]` on custom getter/setters like `PowerDisabled` has.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

These GasThermoMachineHeater/GasThermoMachineFreezer (unpowered variations) on Bagel were incorrectly starting up both powered:

<img width="514" height="262" alt="image" src="https://github.com/user-attachments/assets/9f8293f7-2447-4880-b90b-33d9a2e62ab7" />

But now they properly start up unpowered:

<img width="596" height="332" alt="image" src="https://github.com/user-attachments/assets/138cb373-35e4-4b27-8d68-7e29245bb7d1" />

No yaml changes are necessary, because the DataField name has not been changed:

```
- type: entity
  parent: BaseGasThermoMachine
  id: GasThermoMachineHeater
  components:
    - type: ApcPowerReceiver
      powerDisabled: true     # the yamls are already set up to start these disabled...

- type: entity
  parent: GasThermoMachineHeater
  id: GasThermoMachineHeaterEnabled
  suffix: Enabled
  components:
  - type: ApcPowerReceiver
    powerDisabled: false      # ...or enabled, as appropriate
```

The startup setting is not able to be changed by clicking it in view variables, while the live `PowerDisabled` setting *is* clickable:

<img width="572" height="306" alt="image" src="https://github.com/user-attachments/assets/63837e5b-1b4b-4519-bb0f-d27bb3af842f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Freezers/heaters now *actually* start the round unpowered (where mappers have chosen that to be the case).
