### PR TITLE
Allow hyposprays and jet injectors to draw from closed containers

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -5,7 +5,6 @@
   components:
   - type: Injector
     solutionName: hypospray
-    ignoreClosed: false
     activeModeProtoId: HyposprayDynamicMode
     allowedModes:
     - HyposprayDynamicMode
@@ -216,6 +215,7 @@
     solution: pen
   - type: Injector
     solutionName: pen
+    ignoreClosed: false
     currentTransferAmount: null
     activeModeProtoId: HyposprayInjectMode
     allowedModes:


### PR DESCRIPTION
## About the PR
Allowed hyposprays and jet injectors to draw from and inject into closed containers.

## Why / Balance
Resolves #42261.

## Technical details
Removed `ignoreClosed: false` from `BaseHypospray`, added it to `ChemicalMedipen`.

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Changelog commented out for now since it's on master only, if you feel it should be added feel free to uncomment it.
<!--
:cl:
- tweak: Jet injectors can now draw and inject from closed containers.
- fix: Hyposprays can once again draw and inject from closed containers.
-->
