### PR TITLE
Fix da rulez

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC3NoHate.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC3NoHate.xml
@@ -17,4 +17,5 @@
   - Calling someone gay in a context where gay is used as an insult or negative attribute.
   - Using a racial slur or variant in a positive context.
   - Using the word "retard" in any context.
+  - Using the word "clanker" in any context.
 </Document>


### PR DESCRIPTION
Adds "clanker" example to core rule 1.3: No Hate Speech or Discriminatory Language

Although cyborgs may not be treated as equals in game, still treat them with respect as they are still human players behind the screen and core rule 1.3 may be enforced similarly in cases involving them.

**Changelog**
:cl:
RULES:
- add: Clarified the usage of the word "clanker"
