### PR TITLE
Replace recently added StorageFill with EntityTableContainerFill

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -325,11 +325,13 @@
   suffix: Military O2
   description: It's a box with basic internals inside. This one is labelled to contain an double extended-capacity tank.
   components:
-  - type: StorageFill
-    contents:
-    - id: DoubleEmergencyOxygenTankFilled
-    - id: EmergencyMedipen
-    - id: Flare
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: DoubleEmergencyOxygenTankFilled
+        - id: EmergencyMedipen
+        - id: Flare
   - type: Sprite
     layers:
     - state: internals
@@ -340,11 +342,13 @@
   id: BoxSurvivalMilitaryDoubleNitrogen
   suffix: Military N2
   components:
-  - type: StorageFill
-    contents:
-    - id: DoubleEmergencyNitrogenTankFilled
-    - id: EmergencyMedipen
-    - id: Flare
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: DoubleEmergencyNitrogenTankFilled
+        - id: EmergencyMedipen
+        - id: Flare
   - type: Sprite
     layers:
     - state: internals


### PR DESCRIPTION
## About the PR
Replaced StorageFills for military survival boxes with EntityTableContainerFills.

## Why / Balance
Component obsolete.

## Technical details
Minor YAML work.

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
