### PR TITLE
Move food, drink, and vending random spawners to tables + minor cleanup

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/donkpocketbox.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/donkpocketbox.yml
@@ -1,23 +1,24 @@
 - type: entity
-  name: Donkpocket Box Spawner
-  id: DonkpocketBoxSpawner
   parent: MarkerBase
+  id: DonkpocketBoxSpawner
+  name: Donkpocket Box Spawner
   components:
-    - type: Sprite
-      layers:
-        - state: red
-        - sprite: Objects/Consumable/Food/Baked/donkpocket.rsi
-          state: box
-    - type: RandomSpawner
-      prototypes:
-        - FoodBoxDonkpocket
-        - FoodBoxDonkpocketSpicy
-        - FoodBoxDonkpocketTeriyaki
-        - FoodBoxDonkpocketPizza
-        - FoodBoxDonkpocketStonk
-        - FoodBoxDonkpocketBerry
-        - FoodBoxDonkpocketHonk
-        - FoodBoxDonkpocketDink
-        - FoodBoxDonkpocketMoth
-      chance: 0.5
-      offset: 0.0
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Objects/Consumable/Food/Baked/donkpocket.rsi
+        state: box
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      prob: 0.5
+      children:
+      - id: FoodBoxDonkpocket
+      - id: FoodBoxDonkpocketSpicy
+      - id: FoodBoxDonkpocketTeriyaki
+      - id: FoodBoxDonkpocketPizza
+      - id: FoodBoxDonkpocketStonk
+      - id: FoodBoxDonkpocketBerry
+      - id: FoodBoxDonkpocketHonk
+      - id: FoodBoxDonkpocketDink
+      - id: FoodBoxDonkpocketMoth
+    offset: 0.0

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/donkpocketbox.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/donkpocketbox.yml
@@ -5,9 +5,9 @@
   components:
   - type: Sprite
     layers:
-      - state: red
-      - sprite: Objects/Consumable/Food/Baked/donkpocket.rsi
-        state: box
+    - state: red
+    - sprite: Objects/Consumable/Food/Baked/donkpocket.rsi
+      state: box
   - type: EntityTableSpawner
     table: !type:GroupSelector
       prob: 0.5

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_glass.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_glass.yml
@@ -1,140 +1,143 @@
 - type: entity
+  parent: MarkerBase
   id: RandomDrinkGlass
   name: random drink spawner
   suffix: Glass
-  parent: MarkerBase
   placement:
     mode: AlignTileAny
   components:
   - type: Sprite
     layers:
-      - state: red
-      - sprite: Objects/Consumable/Drinks/beerglass.rsi
-        state: icon
-  - type: RandomSpawner
-  #small item
-    prototypes:
-      - DrinkAbsintheGlass
-      - DrinkAleGlass
-      - DrinkAlienBrainHemorrhage
-      - DrinkAloe
-      - DrinkAndalusia
-      - DrinkAntifreeze
-      - DrinkArnoldPalmer
-      - DrinkB52Glass
-      - DrinkBahamaMama
-      - DrinkBananaHonkGlass
-      - DrinkBarefootGlass
-      - DrinkBeerglass
-      - DrinkBerryJuice
-      - DrinkBlackRussianGlass
-      - DrinkBlueCuracaoGlass
-      - DrinkBlueHawaiianGlass
-      - DrinkBloodyMaryGlass
-      - DrinkBooger
-      - DrinkBraveBullGlass
-      - DrinkBronxGlass
-      - BudgetInsulsDrinkGlass
-      - DrinkCarrotJuice
-      - DrinkCoconutRum
-      - DrinkChocolateGlass
-      - DrinkCognacGlass
-      - DrinkCosmopolitan
-      - DrinkCrushDepthGlass
-      - DrinkCubaLibreGlass
-      - DrinkDarkandStormyGlass
-      - DrinkDeadRumGlass
-      - DrinkDevilsKiss
-      - DrinkDriestMartiniGlass
-      - DrinkDrGibbGlass
-      - DrinkElectricSharkGlass
-      - DrinkErikaSurprise
-      - DrinkFourteenLokoGlass
-      - DrinkGargleBlasterGlass
-      - DrinkGinFizzGlass
-      - DrinkGinGlass
-      - DrinkGinTonicglass
-      - DrinkGildlagerGlass
-      - DrinkGrapeJuice
-      - DrinkGreenTeaGlass
-      - DrinkGrogGlass
-      - DrinkHippiesDelightGlass
-      - DrinkIcedCoffeeGlass
-      - DrinkIcedGreenTeaGlass
-      - DrinkIcedBeerGlass
-      - DrinkIceCreamGlass
-      - IrishBoolGlass
-      - DrinkIrishSlammer
-      - DrinkIrishCoffeeGlass
-      - DrinkLemonadeGlass
-      - DrinkJackRoseGlass
-      - DrinkJungleBirdGlass
-      - DrinkKalimotxoGlass
-      - DrinkOrangeLimeSodaGlass
-      - DrinkLongIslandIcedTeaGlass
-      - DrinkManhattanGlass
-      - DrinkManlyDorfGlass
-      - DrinkMargaritaGlass
-      - DrinkMartiniGlass
-      - DrinkMeadGlass
-      - DrinkMilkshake
-      - DrinkMojito
-      - DrinkMonkeyBusinessGlass
-      - DrinkNTCahors
-      - DrinkPainkillerGlass
-      - DrinkPatronGlass
-      - DrinkPinaColadaGlass
-      - DrinkPoscaGlass
-      - DrinkRadlerGlass
-      - DrinkRedMeadGlass
-      - DrinkRewriter
-      - DrinkRoyRogersGlass
-      - DrinkRootBeerFloatGlass
-      - RubberneckGlass
-      - DrinkRumGlass
-      - DrinkSakeGlass
-      - DrinkSbitenGlass
-      - DrinkScrewdriverCocktailGlass
-      - DrinkShirleyTempleGlass
-      - DrinkSuiDreamGlass
-      - DrinkSingulo
-      - DrinkSoyLatte
-      - DrinkSyndicatebomb
-      - DrinkTequilaSunriseGlass
-      - DrinkThreeMileIslandGlass
-      - DrinkTortugaGlass
-      - DrinkToxinsSpecialGlass
-      - DrinkVampiroGlass
-      - DrinkVodkaMartiniGlass
-      - DrinkVodkaRedBool
-      - DrinkVodkaTonicGlass
-      - DrinkWatermelonJuice
-      - DrinkWatermelonWakeup
-      - DrinkWhiskeyColaGlass
-      - DrinkWhiskeySodaGlass
-      - DrinkWhiteRussianGlass
-      - DrinkWineGlass
-      - XenoBasherGlass
-      - DrinkShakeBlue
-      - DrinkShakeWhite
-      - DrinkTheMartinez
-      - DrinkMoonshineGlass
-    chance: 0.8
+    - state: red
+    - sprite: Objects/Consumable/Drinks/beerglass.rsi
+      state: icon
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - !type:GroupSelector #small item
+        weight: 0.95
+        prob: 0.8
+        children:
+        - id: DrinkAbsintheGlass
+        - id: DrinkAleGlass
+        - id: DrinkAlienBrainHemorrhage
+        - id: DrinkAloe
+        - id: DrinkAndalusia
+        - id: DrinkAntifreeze
+        - id: DrinkArnoldPalmer
+        - id: DrinkB52Glass
+        - id: DrinkBahamaMama
+        - id: DrinkBananaHonkGlass
+        - id: DrinkBarefootGlass
+        - id: DrinkBeerglass
+        - id: DrinkBerryJuice
+        - id: DrinkBlackRussianGlass
+        - id: DrinkBlueCuracaoGlass
+        - id: DrinkBlueHawaiianGlass
+        - id: DrinkBloodyMaryGlass
+        - id: DrinkBooger
+        - id: DrinkBraveBullGlass
+        - id: DrinkBronxGlass
+        - id: BudgetInsulsDrinkGlass
+        - id: DrinkCarrotJuice
+        - id: DrinkCoconutRum
+        - id: DrinkChocolateGlass
+        - id: DrinkCognacGlass
+        - id: DrinkCosmopolitan
+        - id: DrinkCrushDepthGlass
+        - id: DrinkCubaLibreGlass
+        - id: DrinkDarkandStormyGlass
+        - id: DrinkDeadRumGlass
+        - id: DrinkDevilsKiss
+        - id: DrinkDriestMartiniGlass
+        - id: DrinkDrGibbGlass
+        - id: DrinkElectricSharkGlass
+        - id: DrinkErikaSurprise
+        - id: DrinkFourteenLokoGlass
+        - id: DrinkGargleBlasterGlass
+        - id: DrinkGinFizzGlass
+        - id: DrinkGinGlass
+        - id: DrinkGinTonicglass
+        - id: DrinkGildlagerGlass
+        - id: DrinkGrapeJuice
+        - id: DrinkGreenTeaGlass
+        - id: DrinkGrogGlass
+        - id: DrinkHippiesDelightGlass
+        - id: DrinkIcedCoffeeGlass
+        - id: DrinkIcedGreenTeaGlass
+        - id: DrinkIcedBeerGlass
+        - id: DrinkIceCreamGlass
+        - id: IrishBoolGlass
+        - id: DrinkIrishSlammer
+        - id: DrinkIrishCoffeeGlass
+        - id: DrinkLemonadeGlass
+        - id: DrinkJackRoseGlass
+        - id: DrinkJungleBirdGlass
+        - id: DrinkKalimotxoGlass
+        - id: DrinkOrangeLimeSodaGlass
+        - id: DrinkLongIslandIcedTeaGlass
+        - id: DrinkManhattanGlass
+        - id: DrinkManlyDorfGlass
+        - id: DrinkMargaritaGlass
+        - id: DrinkMartiniGlass
+        - id: DrinkMeadGlass
+        - id: DrinkMilkshake
+        - id: DrinkMojito
+        - id: DrinkMonkeyBusinessGlass
+        - id: DrinkNTCahors
+        - id: DrinkPainkillerGlass
+        - id: DrinkPatronGlass
+        - id: DrinkPinaColadaGlass
+        - id: DrinkPoscaGlass
+        - id: DrinkRadlerGlass
+        - id: DrinkRedMeadGlass
+        - id: DrinkRewriter
+        - id: DrinkRoyRogersGlass
+        - id: DrinkRootBeerFloatGlass
+        - id: RubberneckGlass
+        - id: DrinkRumGlass
+        - id: DrinkSakeGlass
+        - id: DrinkSbitenGlass
+        - id: DrinkScrewdriverCocktailGlass
+        - id: DrinkShirleyTempleGlass
+        - id: DrinkSuiDreamGlass
+        - id: DrinkSingulo
+        - id: DrinkSoyLatte
+        - id: DrinkSyndicatebomb
+        - id: DrinkTequilaSunriseGlass
+        - id: DrinkThreeMileIslandGlass
+        - id: DrinkTortugaGlass
+        - id: DrinkToxinsSpecialGlass
+        - id: DrinkVampiroGlass
+        - id: DrinkVodkaMartiniGlass
+        - id: DrinkVodkaRedBool
+        - id: DrinkVodkaTonicGlass
+        - id: DrinkWatermelonJuice
+        - id: DrinkWatermelonWakeup
+        - id: DrinkWhiskeyColaGlass
+        - id: DrinkWhiskeySodaGlass
+        - id: DrinkWhiteRussianGlass
+        - id: DrinkWineGlass
+        - id: XenoBasherGlass
+        - id: DrinkShakeBlue
+        - id: DrinkShakeWhite
+        - id: DrinkTheMartinez
+        - id: DrinkMoonshineGlass
+      - !type:GroupSelector #rare
+        weight: 0.05
+        children:
+        - id: DrinkAcidSpitGlass
+        - id: DrinkAlliesCocktail
+        - id: DrinkAmasecGlass
+        - id: DrinkAtomicBombGlass
+        - id: DrinkDemonsBlood
+        - id: DrinkDoctorsDelightGlass
+        - id: DrinkNeurotoxinGlass
+        - id: DrinkNuclearColaGlass
+        - id: DrinkSilencerGlass
+        - id: DrinkShakeMeat
+        - id: DrinkShakeRobo
+        - id: DrinkHoochGlass
+        - id: DrinkBeepskySmashGlass
+        - id: DrinkBacchusBlessing
     offset: 0.0
-    #rare
-    rarePrototypes:
-      - DrinkAcidSpitGlass
-      - DrinkAlliesCocktail
-      - DrinkAmasecGlass
-      - DrinkAtomicBombGlass
-      - DrinkDemonsBlood
-      - DrinkDoctorsDelightGlass
-      - DrinkNeurotoxinGlass
-      - DrinkNuclearColaGlass
-      - DrinkSilencerGlass
-      - DrinkShakeMeat
-      - DrinkShakeRobo
-      - DrinkHoochGlass
-      - DrinkBeepskySmashGlass
-      - DrinkBacchusBlessing
-    rareChance: 0.05

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_baked_single.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_baked_single.yml
@@ -1,96 +1,100 @@
 - type: entity
+  parent: MarkerBase
   id: RandomFoodBakedSingle
   name: random baked food spawner
   suffix: Single Serving
-  parent: MarkerBase
   placement:
     mode: AlignTileAny
   components:
   - type: Sprite
     layers:
-      - state: red
-      - sprite: Objects/Consumable/Food/Baked/pie.rsi
-        state: plain-slice
-  - type: RandomSpawner
-    prototypes:
-      - FoodBreadPlainSlice
-      - FoodBreadMeatSlice
-      - FoodBreadBananaSlice
-      - FoodBreadCreamcheeseSlice
-      - FoodBreadMoldySlice
-      - FoodBreadGarlicSlice
-      - FoodBreadCornSlice
-      - FoodBreadSausageSlice
-      - FoodBreadButteredToast
-      - FoodBreadJellySlice
-      - FoodBreadFrenchToast
-      - FoodBreadTwoSlice
-      - FoodBreadVolcanicSlice
-      - FoodBreadTofuSlice
-      - FoodBreadBaguetteSlice
-      - FoodCakeBlueberrySlice
-      - FoodCakePlainSlice
-      - FoodCakeCarrotSlice
-      - FoodCakeCheeseSlice
-      - FoodCakeOrangeSlice
-      - FoodCakeLimeSlice
-      - FoodCakeLemonSlice
-      - FoodCakeChocolateSlice
-      - FoodCakeAppleSlice
-      - FoodCakeSlimeSlice
-      - FoodCakePumpkinSlice
-      - FoodCakeChristmasSlice
-      - FoodCakeVanillaSlice
-      - FoodCakeBirthdaySlice
-      - FoodCakeBerryDelightSlice
-      - FoodCakeCottonSlice
-      - FoodBakedMuffin
-      - FoodBakedMuffinBerry
-      - FoodBakedMuffinCherry
-      - FoodBakedMuffinBluecherry
-      - FoodBakedMuffinChocolate
-      - FoodBakedMuffinBanana
-      - FoodBakedBunHoney
-      - FoodBakedBunHotX
-      - FoodBakedBunMeat
-      - FoodBakedCookie
-      - FoodBakedCookieOatmeal
-      - FoodBakedCookieRaisin
-      - FoodBakedCookieSugar
-      - FoodBakedGrilledCheeseSandwich
-      - FoodBakedGrilledCheeseSandwichCotton
-      - FoodBakedNugget
-      - FoodBakedPancake
-      - FoodBakedPancakeBb
-      - FoodBakedPancakeCc
-      - FoodBakedWaffle
-      - FoodBakedWaffleSoy
-      - FoodBakedWaffleSoylent
-      - FoodBakedWaffleRoffle
-      - FoodBakedPretzel
-      - FoodBakedCannoli
-      - FoodPieAppleSlice
-      - FoodPieBaklavaSlice
-      - FoodPieClafoutisSlice
-      - FoodPieMeatSlice
-      - FoodPieCherrySlice
-      - FoodPieFrostySlice
-      - FoodTartGrape
-      - FoodTartCoco
-      - FoodBakedBrownie
-      - FoodPieBananaCreamSlice
-      - FoodTartMimeSlice
-    chance: 0.8
+    - state: red
+    - sprite: Objects/Consumable/Food/Baked/pie.rsi
+      state: plain-slice
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - !type:GroupSelector
+        weight: 0.95
+        prob: 0.8
+        children:
+        - id: FoodBreadPlainSlice
+        - id: FoodBreadMeatSlice
+        - id: FoodBreadBananaSlice
+        - id: FoodBreadCreamcheeseSlice
+        - id: FoodBreadMoldySlice
+        - id: FoodBreadGarlicSlice
+        - id: FoodBreadCornSlice
+        - id: FoodBreadSausageSlice
+        - id: FoodBreadButteredToast
+        - id: FoodBreadJellySlice
+        - id: FoodBreadFrenchToast
+        - id: FoodBreadTwoSlice
+        - id: FoodBreadVolcanicSlice
+        - id: FoodBreadTofuSlice
+        - id: FoodBreadBaguetteSlice
+        - id: FoodCakeBlueberrySlice
+        - id: FoodCakePlainSlice
+        - id: FoodCakeCarrotSlice
+        - id: FoodCakeCheeseSlice
+        - id: FoodCakeOrangeSlice
+        - id: FoodCakeLimeSlice
+        - id: FoodCakeLemonSlice
+        - id: FoodCakeChocolateSlice
+        - id: FoodCakeAppleSlice
+        - id: FoodCakeSlimeSlice
+        - id: FoodCakePumpkinSlice
+        - id: FoodCakeChristmasSlice
+        - id: FoodCakeVanillaSlice
+        - id: FoodCakeBirthdaySlice
+        - id: FoodCakeBerryDelightSlice
+        - id: FoodCakeCottonSlice
+        - id: FoodBakedMuffin
+        - id: FoodBakedMuffinBerry
+        - id: FoodBakedMuffinCherry
+        - id: FoodBakedMuffinBluecherry
+        - id: FoodBakedMuffinChocolate
+        - id: FoodBakedMuffinBanana
+        - id: FoodBakedBunHoney
+        - id: FoodBakedBunHotX
+        - id: FoodBakedBunMeat
+        - id: FoodBakedCookie
+        - id: FoodBakedCookieOatmeal
+        - id: FoodBakedCookieRaisin
+        - id: FoodBakedCookieSugar
+        - id: FoodBakedGrilledCheeseSandwich
+        - id: FoodBakedGrilledCheeseSandwichCotton
+        - id: FoodBakedNugget
+        - id: FoodBakedPancake
+        - id: FoodBakedPancakeBb
+        - id: FoodBakedPancakeCc
+        - id: FoodBakedWaffle
+        - id: FoodBakedWaffleSoy
+        - id: FoodBakedWaffleSoylent
+        - id: FoodBakedWaffleRoffle
+        - id: FoodBakedPretzel
+        - id: FoodBakedCannoli
+        - id: FoodPieAppleSlice
+        - id: FoodPieBaklavaSlice
+        - id: FoodPieClafoutisSlice
+        - id: FoodPieMeatSlice
+        - id: FoodPieCherrySlice
+        - id: FoodPieFrostySlice
+        - id: FoodTartGrape
+        - id: FoodTartCoco
+        - id: FoodBakedBrownie
+        - id: FoodPieBananaCreamSlice
+        - id: FoodTartMimeSlice
+      - !type:GroupSelector #rare
+        weight: 0.05
+        children:
+        - id: FoodBreadMeatSpiderSlice
+        - id: FoodBreadMimanaSlice
+        - id: FoodCakeBrainSlice
+        - id: FoodCakeClownSlice
+        - id: FoodCakeSpacemanSlice
+        - id: FoodTartGapple
+        - id: FoodBreadMeatXenoSlice
+        - id: FoodPieXenoSlice
+        - id: FoodBakedCannabisBrownie
     offset: 0.0
-    #rare
-    rarePrototypes:
-      - FoodBreadMeatSpiderSlice
-      - FoodBreadMimanaSlice
-      - FoodCakeBrainSlice
-      - FoodCakeClownSlice
-      - FoodCakeSpacemanSlice
-      - FoodTartGapple
-      - FoodBreadMeatXenoSlice
-      - FoodPieXenoSlice
-      - FoodBakedCannabisBrownie
-    rareChance: 0.05

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_baked_whole.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_baked_whole.yml
@@ -1,65 +1,68 @@
 - type: entity
+  parent: MarkerBase
   id: RandomFoodBakedWhole
   name: random baked food spawner
   suffix: Whole
-  parent: MarkerBase
   placement:
     mode: AlignTileAny
   components:
   - type: Sprite
     layers:
-      - state: red
-      - sprite: Objects/Consumable/Food/Baked/pie.rsi
-        state: plain
-  - type: RandomSpawner
-  #small item
-    prototypes:
-      - FoodBreadVolcanic
-      - FoodBreadPlain
-      - FoodBreadMeat
-      - FoodBreadCorn
-      - FoodBreadSausage
-      - FoodBreadBanana
-      - FoodBreadTofu
-      - FoodBreadCreamcheese
-      - FoodBreadBaguette
-      - FoodCakeBlueberry
-      - FoodCakePlain
-      - FoodCakeCheese
-      - FoodCakeCarrot
-      - FoodCakeOrange
-      - FoodCakeLime
-      - FoodCakeLemon
-      - FoodCakeChocolate
-      - FoodCakeApple
-      - FoodCakeSlime
-      - FoodCakePumpkin
-      - FoodCakeChristmas
-      - FoodCakeBirthday
-      - FoodCakeVanilla
-      - FoodCakeBerryDelight
-      - FoodCakeCotton
-      - FoodPieApple
-      - FoodPieBaklava
-      - FoodPieBananaCream
-      - FoodPieClafoutis
-      - FoodPieCherry
-      - FoodPieMeat
-      - FoodPieFrosty
-      - FoodBakedBrownieBatch
-    chance: 0.8
+    - state: red
+    - sprite: Objects/Consumable/Food/Baked/pie.rsi
+      state: plain
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - !type:GroupSelector #small item
+        weight: 0.95
+        prob: 0.8
+        children:
+        - id: FoodBreadVolcanic
+        - id: FoodBreadPlain
+        - id: FoodBreadMeat
+        - id: FoodBreadCorn
+        - id: FoodBreadSausage
+        - id: FoodBreadBanana
+        - id: FoodBreadTofu
+        - id: FoodBreadCreamcheese
+        - id: FoodBreadBaguette
+        - id: FoodCakeBlueberry
+        - id: FoodCakePlain
+        - id: FoodCakeCheese
+        - id: FoodCakeCarrot
+        - id: FoodCakeOrange
+        - id: FoodCakeLime
+        - id: FoodCakeLemon
+        - id: FoodCakeChocolate
+        - id: FoodCakeApple
+        - id: FoodCakeSlime
+        - id: FoodCakePumpkin
+        - id: FoodCakeChristmas
+        - id: FoodCakeBirthday
+        - id: FoodCakeVanilla
+        - id: FoodCakeBerryDelight
+        - id: FoodCakeCotton
+        - id: FoodPieApple
+        - id: FoodPieBaklava
+        - id: FoodPieBananaCream
+        - id: FoodPieClafoutis
+        - id: FoodPieCherry
+        - id: FoodPieMeat
+        - id: FoodPieFrosty
+        - id: FoodBakedBrownieBatch
+      - !type:GroupSelector #rare
+        weight: 0.05
+        children:
+        - id: FoodBreadMeatSpider
+        - id: FoodBreadMimana
+        - id: FoodCakeBrain
+        - id: FoodCakeClown
+        - id: FoodCakeSpaceman
+        - id: FoodPieXeno
+        - id: FoodPieAmanita
+        - id: FoodPiePlump
+        - id: FoodBreadMeatXeno
+        - id: FoodPieXeno
+        - id: FoodBakedCannabisBrownieBatch
     offset: 0.0
-    #rare
-    rarePrototypes:
-      - FoodBreadMeatSpider
-      - FoodBreadMimana
-      - FoodCakeBrain
-      - FoodCakeClown
-      - FoodCakeSpaceman
-      - FoodPieXeno
-      - FoodPieAmanita
-      - FoodPiePlump
-      - FoodBreadMeatXeno
-      - FoodPieXeno
-      - FoodBakedCannabisBrownieBatch
-    rareChance: 0.05

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_breakfast.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_breakfast.yml
@@ -2,7 +2,7 @@
   parent: MarkerBase
   id: RandomFoodBreakfast
   name: random food spawner
-  suffix: Meal
+  suffix: Breakfast
   placement:
     mode: AlignTileAny
   components:

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_breakfast.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_breakfast.yml
@@ -1,18 +1,19 @@
 - type: entity
+  parent: MarkerBase
   id: RandomFoodBreakfast
   name: random food spawner
   suffix: Meal
-  parent: MarkerBase
   placement:
     mode: AlignTileAny
   components:
   - type: Sprite
     layers:
-      - sprite: Objects/Consumable/Food/breakfast.rsi
-        state: fullamerican
-  - type: RandomSpawner
-    prototypes:
-      - FoodBreakfastAmerican
-      - FoodBreakfastEnglish
-    chance: 0.8
+    - sprite: Objects/Consumable/Food/breakfast.rsi
+      state: fullamerican
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      prob: 0.8
+      children:
+      - id: FoodBreakfastAmerican
+      - id: FoodBreakfastEnglish
     offset: 0.0

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_meal.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_meal.yml
@@ -1,97 +1,101 @@
 - type: entity
+  parent: MarkerBase
   id: RandomFoodMeal
   name: random food spawner
   suffix: Meal
-  parent: MarkerBase
   placement:
     mode: AlignTileAny
   components:
   - type: Sprite
     layers:
-      - state: red
-      - sprite: Objects/Consumable/Food/meals.rsi
-        state: cornedbeef
-  - type: RandomSpawner
-    prototypes:
-      - FoodMealPotatoLoaded
-      - FoodMealFries
-      - FoodMealFriesCheesy
-      - FoodMealFriesCarrot
-      - FoodMealNachos
-      - FoodMealNachosCheesy
-      - FoodMealNachosCuban
-      - FoodMealEggplantParm
-      - FoodMealPotatoYaki
-      - FoodMealCubancarp
-      - FoodMealCornedbeef
-      - FoodMealPigblanket
-      - FoodMealRibs
-      - FoodMealEggsbenedict
-      - FoodMealOmelette
-      - FoodMealFriedegg
-      - FoodMealQueso
-      - FoodMealSashimi
-      - FoodMealEnchiladas
-      - FoodNoodlesChowmein
-      - FoodNoodlesSpesslaw
-      - FoodNoodlesMeatball
-      - FoodNoodlesBoiled
-      - FoodNoodles
-      - FoodNoodlesButter
-      - FoodMealHappyHonkClown
-      - FoodSoupPea
-      - FoodSaladHerb
-      - FoodSaladValid
-      - FoodSaladFruit
-      - FoodSaladJungle
-      - FoodSaladCitrus
-      - FoodSaladCaesar
-      - FoodSaladColeslaw
-      - FoodSaladKimchi
-      - FoodSaladWatermelonFruitBowl
-      - FoodRiceBoiled
-      - FoodRiceEgg
-      - FoodRicePork
-      - FoodRicePudding
-      - FoodRiceGumbo
-      - FoodOatmeal
-      - FoodSoupMeatball
-      - FoodSoupVegetable
-      - FoodSoupNettle
-      - FoodSoupChiliHot
-      - FoodSoupChiliCold
-      - FoodSoupTomato
-      - FoodSoupMiso
-      - FoodSoupMushroom
-      - FoodSoupBeet
-      - FoodSoupBeetRed
-      - FoodSoupPotato
-      - FoodSoupOnion
-      - FoodSoupBisque
-      - FoodSoupBungo
-      - FoodMealCornInButter
-      - FoodSoupStew
-    chance: 0.8
+    - state: red
+    - sprite: Objects/Consumable/Food/meals.rsi
+      state: cornedbeef
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - !type:GroupSelector
+        weight: 0.95
+        prob: 0.8
+        children:
+        - id: FoodMealPotatoLoaded
+        - id: FoodMealFries
+        - id: FoodMealFriesCheesy
+        - id: FoodMealFriesCarrot
+        - id: FoodMealNachos
+        - id: FoodMealNachosCheesy
+        - id: FoodMealNachosCuban
+        - id: FoodMealEggplantParm
+        - id: FoodMealPotatoYaki
+        - id: FoodMealCubancarp
+        - id: FoodMealCornedbeef
+        - id: FoodMealPigblanket
+        - id: FoodMealRibs
+        - id: FoodMealEggsbenedict
+        - id: FoodMealOmelette
+        - id: FoodMealFriedegg
+        - id: FoodMealQueso
+        - id: FoodMealSashimi
+        - id: FoodMealEnchiladas
+        - id: FoodNoodlesChowmein
+        - id: FoodNoodlesSpesslaw
+        - id: FoodNoodlesMeatball
+        - id: FoodNoodlesBoiled
+        - id: FoodNoodles
+        - id: FoodNoodlesButter
+        - id: FoodMealHappyHonkClown
+        - id: FoodSoupPea
+        - id: FoodSaladHerb
+        - id: FoodSaladValid
+        - id: FoodSaladFruit
+        - id: FoodSaladJungle
+        - id: FoodSaladCitrus
+        - id: FoodSaladCaesar
+        - id: FoodSaladColeslaw
+        - id: FoodSaladKimchi
+        - id: FoodSaladWatermelonFruitBowl
+        - id: FoodRiceBoiled
+        - id: FoodRiceEgg
+        - id: FoodRicePork
+        - id: FoodRicePudding
+        - id: FoodRiceGumbo
+        - id: FoodOatmeal
+        - id: FoodSoupMeatball
+        - id: FoodSoupVegetable
+        - id: FoodSoupNettle
+        - id: FoodSoupChiliHot
+        - id: FoodSoupChiliCold
+        - id: FoodSoupTomato
+        - id: FoodSoupMiso
+        - id: FoodSoupMushroom
+        - id: FoodSoupBeet
+        - id: FoodSoupBeetRed
+        - id: FoodSoupPotato
+        - id: FoodSoupOnion
+        - id: FoodSoupBisque
+        - id: FoodSoupBungo
+        - id: FoodMealCornInButter
+        - id: FoodSoupStew
+      - !type:GroupSelector #rare
+        weight: 0.05
+        children:
+        - id: FoodMealMint
+        - id: FoodMealBearsteak
+        - id: FoodMealMilkape
+        - id: DisgustingSweptSoup
+        - id: FoodMealMemoryleek
+        - id: FoodSaladAesir
+        - id: FoodSaladEden
+        - id: FoodJellyDuff
+        - id: FoodJellyAmanita
+        - id: FoodSoupSlime
+        - id: FoodSoupTomatoBlood
+        - id: FoodSoupWingFangChu
+        - id: FoodSoupClown
+        - id: FoodSoupMystery
+        - id: FoodSoupChiliClown
+        - id: FoodSoupMonkey
+        - id: FoodSoupEyeball
+        - id: FoodSoupElectron
+        - id: FoodNoodlesCopy
     offset: 0.0
-    #rare
-    rarePrototypes:
-      - FoodMealMint
-      - FoodMealBearsteak
-      - FoodMealMilkape
-      - DisgustingSweptSoup
-      - FoodMealMemoryleek
-      - FoodSaladAesir
-      - FoodSaladEden
-      - FoodJellyDuff
-      - FoodJellyAmanita
-      - FoodSoupSlime
-      - FoodSoupTomatoBlood
-      - FoodSoupWingFangChu
-      - FoodSoupClown
-      - FoodSoupMystery
-      - FoodSoupChiliClown
-      - FoodSoupMonkey
-      - FoodSoupEyeball
-      - FoodSoupElectron
-      - FoodNoodlesCopy
-    rareChance: 0.05

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_single.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_single.yml
@@ -1,71 +1,75 @@
 - type: entity
+  parent: MarkerBase
   id: RandomFoodSingle
   name: random food spawner
   suffix: Single Serving
-  parent: MarkerBase
   placement:
     mode: AlignTileAny
   components:
   - type: Sprite
     layers:
-      - state: red
-      - sprite: Objects/Consumable/Food/burger.rsi
-        state: plain
-  - type: RandomSpawner
-    prototypes:
-      - FoodBagel
-      - FoodBagelPoppy
-      - FoodBurgerJelly
-      - FoodBurgerCarp
-      - FoodBurgerTofu
-      - FoodBurgerXeno
-      - FoodBurgerBig
-      - FoodBurgerFive
-      - FoodBurgerRat
-      - FoodBurgerBacon
-      - FoodBurgerEmpowered
-      - FoodBurgerCrab
-      - FoodBurgerHuman
-      - FoodBurgerSoy
-      - FoodBurgerMcrib
-      - FoodBurgerMcguffin
-      - FoodBurgerChicken
-      - FoodBurgerDuck
-      - FoodBurgerCheese
-      - FoodNoodlesBoiled
-      - FoodNoodles
-      - FoodNoodlesCopy
-      - FoodNoodlesButter
-      - FoodPizzaMargheritaSlice
-      - FoodPizzaMeatSlice
-      - FoodPizzaMushroomSlice
-      - FoodPizzaVegetableSlice
-      - FoodPizzaDonkpocketSlice
-      - FoodPizzaDankSlice
-      - FoodPizzaSassysageSlice
-      - FoodPizzaPineappleSlice
-      - FoodPizzaMoldySlice
-      - FoodBakedDumplings
-      - FoodBakedChevreChaud
-      - FoodBakedNugget
-      - FoodTacoShell
-    chance: 0.8
+    - state: red
+    - sprite: Objects/Consumable/Food/burger.rsi
+      state: plain
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - !type:GroupSelector
+        weight: 0.95
+        prob: 0.8
+        children:
+        - id: FoodBagel
+        - id: FoodBagelPoppy
+        - id: FoodBurgerJelly
+        - id: FoodBurgerCarp
+        - id: FoodBurgerTofu
+        - id: FoodBurgerXeno
+        - id: FoodBurgerBig
+        - id: FoodBurgerFive
+        - id: FoodBurgerRat
+        - id: FoodBurgerBacon
+        - id: FoodBurgerEmpowered
+        - id: FoodBurgerCrab
+        - id: FoodBurgerHuman
+        - id: FoodBurgerSoy
+        - id: FoodBurgerMcrib
+        - id: FoodBurgerMcguffin
+        - id: FoodBurgerChicken
+        - id: FoodBurgerDuck
+        - id: FoodBurgerCheese
+        - id: FoodNoodlesBoiled
+        - id: FoodNoodles
+        - id: FoodNoodlesCopy
+        - id: FoodNoodlesButter
+        - id: FoodPizzaMargheritaSlice
+        - id: FoodPizzaMeatSlice
+        - id: FoodPizzaMushroomSlice
+        - id: FoodPizzaVegetableSlice
+        - id: FoodPizzaDonkpocketSlice
+        - id: FoodPizzaDankSlice
+        - id: FoodPizzaSassysageSlice
+        - id: FoodPizzaPineappleSlice
+        - id: FoodPizzaMoldySlice
+        - id: FoodBakedDumplings
+        - id: FoodBakedChevreChaud
+        - id: FoodBakedNugget
+        - id: FoodTacoShell
+      - !type:GroupSelector #rare
+        weight: 0.05
+        children:
+        - id: FoodBurgerAppendix
+        - id: FoodBurgerRobot
+        - id: FoodBurgerBaseball
+        - id: FoodBurgerBear
+        - id: FoodBurgerCat
+        - id: FoodBurgerClown
+        - id: FoodBurgerMime
+        - id: FoodBurgerBrain
+        - id: FoodBurgerGhost
+        - id: FoodBurgerSpell
+        - id: FoodBurgerSuper
+        - id: FoodBurgerCrazy
+        - id: FoodPizzaArnoldSlice
+        - id: FoodPizzaUraniumSlice
+        - id: FoodPizzaWorldpeasSlice
     offset: 0.0
-    #rare
-    rarePrototypes:
-      - FoodBurgerAppendix
-      - FoodBurgerRobot
-      - FoodBurgerBaseball
-      - FoodBurgerBear
-      - FoodBurgerCat
-      - FoodBurgerClown
-      - FoodBurgerMime
-      - FoodBurgerBrain
-      - FoodBurgerGhost
-      - FoodBurgerSpell
-      - FoodBurgerSuper
-      - FoodBurgerCrazy
-      - FoodPizzaArnoldSlice
-      - FoodPizzaUraniumSlice
-      - FoodPizzaWorldpeasSlice
-    rareChance: 0.05

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/vending.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/vending.yml
@@ -1,38 +1,38 @@
 - type: entity
+  parent: MarkerBase
   id: RandomVending
   name: random vending machine spawner
   suffix: Any
-  parent: MarkerBase
   components:
   - type: Sprite
     layers:
     - state: red
     - sprite: Structures/Machines/VendingMachines/random.rsi
       state: any
-  - type: RandomSpawner
-    prototypes:
-    - VendingMachineChang
-    - VendingMachineCigs
-    - VendingMachineCoffee
-    - VendingMachineCola #Robust Sofdrinks
-    - VendingMachineColaBlack #Robust Sofdrinks [Black]
-    - VendingMachineColaRed #Space Cola
-    - VendingMachineDiscount
-    - VendingMachineDonut
-    - VendingMachineDrGibb
-    - VendingMachinePwrGame
-    - VendingMachineShamblersJuice
-    - VendingMachineSmite
-    - VendingMachineSnack
-    - VendingMachineSnackBlue
-    - VendingMachineSnackGreen
-    - VendingMachineSnackOrange
-    - VendingMachineSnackTeal
-    - VendingMachineSoda #Robust Sofdrinks [Soda]
-    - VendingMachineSovietSoda #Boda
-    - VendingMachineSpaceUp
-    - VendingMachineStarkist
-    chance: 1
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - id: VendingMachineChang
+      - id: VendingMachineCigs
+      - id: VendingMachineCoffee
+      - id: VendingMachineCola #Robust Sofdrinks
+      - id: VendingMachineColaBlack #Robust Sofdrinks [Black]
+      - id: VendingMachineColaRed #Space Cola
+      - id: VendingMachineDiscount
+      - id: VendingMachineDonut
+      - id: VendingMachineDrGibb
+      - id: VendingMachinePwrGame
+      - id: VendingMachineShamblersJuice
+      - id: VendingMachineSmite
+      - id: VendingMachineSnack
+      - id: VendingMachineSnackBlue
+      - id: VendingMachineSnackGreen
+      - id: VendingMachineSnackOrange
+      - id: VendingMachineSnackTeal
+      - id: VendingMachineSoda #Robust Sofdrinks [Soda]
+      - id: VendingMachineSovietSoda #Boda
+      - id: VendingMachineSpaceUp
+      - id: VendingMachineStarkist
 
 
 - type: entityTable
@@ -40,19 +40,17 @@
   table: !type:GroupSelector
     children:
     - id: VendingMachineClothing
-      weight: 40
+      weight: 4
     - id: VendingMachineWinter
-      weight: 40
+      weight: 4
     - id: VendingMachinePride
-      weight: 10
     - id: VendingMachineTheater
-      weight: 10
 
 - type: entity
+  parent: MarkerBase
   id: RandomVendingClothing
   name: random vending machine spawner
   suffix: Clothing
-  parent: MarkerBase
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingdrinks.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingdrinks.yml
@@ -9,18 +9,18 @@
       - state: red
       - sprite: Structures/Machines/VendingMachines/random.rsi
         state: drink
-  - type: RandomSpawner
-    prototypes:
-      - VendingMachineCoffee
-      - VendingMachineCola #Robust Sofdrinks
-      - VendingMachineColaBlack #Robust Sofdrinks [Black]
-      - VendingMachineColaRed #Space Cola
-      - VendingMachineDrGibb
-      - VendingMachinePwrGame
-      - VendingMachineShamblersJuice
-      - VendingMachineSmite
-      - VendingMachineSoda #Robust Sofdrinks [Soda]
-      - VendingMachineSovietSoda #Boda
-      - VendingMachineSpaceUp
-      - VendingMachineStarkist
-    chance: 1
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - id: VendingMachineCoffee
+      - id: VendingMachineCola #Robust Sofdrinks
+      - id: VendingMachineColaBlack #Robust Sofdrinks [Black]
+      - id: VendingMachineColaRed #Space Cola
+      - id: VendingMachineDrGibb
+      - id: VendingMachinePwrGame
+      - id: VendingMachineShamblersJuice
+      - id: VendingMachineSmite
+      - id: VendingMachineSoda #Robust Sofdrinks [Soda]
+      - id: VendingMachineSovietSoda #Boda
+      - id: VendingMachineSpaceUp
+      - id: VendingMachineStarkist

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingdrinks.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingdrinks.yml
@@ -1,14 +1,14 @@
 - type: entity
+  parent: MarkerBase
   id: RandomVendingDrinks
   name: random vending machine spawner
   suffix: Drinks
-  parent: MarkerBase
   components:
   - type: Sprite
     layers:
-      - state: red
-      - sprite: Structures/Machines/VendingMachines/random.rsi
-        state: drink
+    - state: red
+    - sprite: Structures/Machines/VendingMachines/random.rsi
+      state: drink
   - type: EntityTableSpawner
     table: !type:GroupSelector
       children:

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingsnacks.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingsnacks.yml
@@ -9,14 +9,14 @@
       - state: red
       - sprite: Structures/Machines/VendingMachines/random.rsi
         state: snack
-  - type: RandomSpawner
-    prototypes:
-      - VendingMachineDiscount
-      - VendingMachineSnack
-      - VendingMachineSnackBlue
-      - VendingMachineSnackGreen
-      - VendingMachineSnackOrange
-      - VendingMachineSnackTeal
-      - VendingMachineChang
-      - VendingMachineDonut
-    chance: 1
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - id: VendingMachineDiscount
+      - id: VendingMachineSnack
+      - id: VendingMachineSnackBlue
+      - id: VendingMachineSnackGreen
+      - id: VendingMachineSnackOrange
+      - id: VendingMachineSnackTeal
+      - id: VendingMachineChang
+      - id: VendingMachineDonut

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingsnacks.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingsnacks.yml
@@ -1,14 +1,14 @@
 - type: entity
+  parent: MarkerBase
   id: RandomVendingSnacks
   name: random vending machine spawner
   suffix: Snacks
-  parent: MarkerBase
   components:
   - type: Sprite
     layers:
-      - state: red
-      - sprite: Structures/Machines/VendingMachines/random.rsi
-        state: snack
+    - state: red
+    - sprite: Structures/Machines/VendingMachines/random.rsi
+      state: snack
   - type: EntityTableSpawner
     table: !type:GroupSelector
       children:


### PR DESCRIPTION
## About the PR
Title.

## Why / Balance
Part of #42243.
Suffix changed for clarity.
Some indentation tweaks and shuffling of parents to fit convention.

## Technical details
Replace RandomSpawners used for food, drinks, and vending machine with EntityTableSpawners in a way meant to replicate prior functionality.

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
