### PR TITLE
allow shuttle to Scan for Objects while FTL is on cooldown

### DIFF
--- a/Content.Client/Shuttles/UI/MapScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml.cs
@@ -413,14 +413,11 @@ public sealed partial class MapScreen : BoxContainer
     /// </summary>
     private bool IsPingBlocked()
     {
-        switch (_state)
+        return _state switch
         {
-            case FTLState.Available:
-            case FTLState.Cooldown:
-                return false;
-            default:
-                return true;
-        }
+            FTLState.Available or FTLState.Cooldown => false,
+            _ => true,
+        };
     }
 
     private void OnMapObjectPress(IMapObject mapObject)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

The "Scan for Objects" button in the FTL/Map tab of the Shuttle Console will now be enabled as soon as the shuttle exits FTL.

Previously it was only enabled once the FTL **cooldown** completes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

QoL improvement. Allows players to use the console's FTL screen to gather situational awareness / plan their next FTL jump while they are waiting for the cooldown to complete.

Technically a very slight buff to xenoborgs, which often use FTL to evade crew that are pursuing the ship with jetpacks.

## Technical details
<!-- Summary of code changes for easier review. -->

The Scan for Objects concept has various names in the ui code: "Ping", "MapRebuildButton"

OnMapObjectPress is handling the list of points-of-interest, which have buttons on the right side of the screen that let you focus the map on them.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

### Before

Have to wait for cooldown to complete before you can use the rest of the Map tab.

![shuttle_scan_early_before](https://github.com/user-attachments/assets/f1a226da-4bd3-48e5-addc-8203508c52ca)


### After

Now you can use the Map tab while the FTL is still recharging (though you can't FTL).

![shuttle_scan_early_after](https://github.com/user-attachments/assets/c338bc30-d7bb-4f29-baf2-86777b96e2cd)


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
