### PR TITLE
Fixed Containment Generators not updating pointlight correctly

### DIFF
--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -402,6 +402,7 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
     private void ChangeOnLightVisualizer(Entity<ContainmentFieldGeneratorComponent> generator)
     {
         _visualizer.SetData(generator, ContainmentFieldGeneratorVisuals.OnLight, generator.Comp.IsConnected);
+        UpdateConnectionLights(generator);
     }
     #endregion
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a missing call when updating the sprite

## Why / Balance
it was a bug and a simple one that was bothering me for a LONG time

## Technical details
Added `UpdateConnectionLights` to `ChangeOnLightVisualizer`

## Media
Small fix imo but if you want media just tell me

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Containment units no longer contribute to light pollution

