### PR TITLE
Getmore Bakemore Crate Rebalance

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -146,11 +146,11 @@
       entity_storage: !type:AllSelector
         children:
         - id: FoodSnackRaisins
-          amount: 4
+          amount: 6
         - id: FoodSnackChocolate
           amount: 6
         - id: FoodSnackPistachios
-          amount: 4
+          amount: 2
         - id: ReagentContainerFlour
           amount: 3
         - id: ReagentContainerSugar
@@ -159,6 +159,8 @@
           amount: 3
         - id: DrinkMilkCarton
           amount: 2
+        - id: DrinkSoyMilkCarton
+          amount: 1
         - id: FoodContainerEgg
           amount: 2
         - id: FoodBoxCloth


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I added the Getmore Bakemore Crate in [33286](https://github.com/space-wizards/space-station-14/pull/33286) and have used it extensively since its merge. Currently, it slightly underperforms Kitchen Supplies as a general baking crate (it has 4 jugs of milk!!!), and the ingredient ratios felt off. I also made a key oversight, not being familiar with the soy milk cake recipe at the time.

I have removed 2 sweetie's pistachios from the crate, bringing the total from 4 to 2. I have yet to meet a chef who regularly makes Baklava, it has an ugly cut sprite, and 2 is already more than good for a single pie in a chef display. In exchange, I added 2 4no raisins, bringing the total from 4 to 6, allowing for a full batch of reptilian-friendly cookies in a single microwave cook. Also, noting the usage of soy milk in cake making, I've added 1 soy milk, bringing it to 1 total, so that a singular crate can be used for wider baking applications on upstream and downstream.

## Why / Balance
This is just a minor crate rebalance, to help make it more useful and streamlined for regular chef gameplay patterns.

## Technical details
Simple YAML change on the crate fill file.

## Media
<img width="851" height="610" alt="image" src="https://github.com/user-attachments/assets/f4cac69b-c27c-4717-b268-0eb310f9bdf3" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
N/A

**Changelog**
:cl: AgentSmithRadio
- tweak: Rebalanced the contents of the Getmore Bakemore crate.

