### PR TITLE
Implant Extractor Crate

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -147,3 +147,13 @@
   cost: 750
   category: cargoproduct-category-name-medical
   group: market
+
+- type: cargoProduct
+  id: MedicalImplantExtractors
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateImplantExtractors
+  cost: 1500
+  category: cargoproduct-category-name-medical
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -189,3 +189,15 @@
           rolls: 2
         - id: ClothingMaskSterile
           amount: 2
+
+- type: entity
+  parent: CrateMedical
+  id: CrateImplantExtractors
+  name: implant extractor crate
+  description: Crate filled with 3 implant extractors.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage:
+        id: Implanter
+        amount: 3


### PR DESCRIPTION
## About the PR
I am proposing an implant extractor crate, containing 3 implant extractors for $1500. The exact numbers are up for debate, but I feel it's important to keep the crate far above the actual manufacturing cost of extractors.

Currently, implant extractors are only available from the Medical Techfab for 5 steel and 5 glass.

## Why / Balance
Having played Security and many Revolution game mode rounds, implant removers can be a real sticking point. Sometimes, the Medical Techfab is just *gone*, or you can't get materials for it, or the department is under hostile control, or the CMO is being a jerk, you name it. 

Implant removal is an essential thing for security to do, and they're not equipped to do it. Implant removal is a powerful thing for revolutionaries to do, but if they always have to conquer medical to do it, it remains a meta. If you can't get them in either case, it just makes everyone's lives miserable, and if both the original techfab and the replacement board are gone, it's even worse.

This crate would be useful as a preemptive purchase from security from their budget, as in the majority of gamemodes they don't actually need or use their departmental budget to any real extent. I've had enough rounds where medbay just never stocks their Techfab, and I'm stuck running around for resources. There's also possible intrigue where an antagonist cargo technician deliberately loses this crate and its contents to prevent them from getting to Security.

In normal rounds, this is just a convenient, albeit expensive way, for Security to acquire implant extractors. In Revolution rounds, it would be a not-so-stealthy way for revolutionaries to acquire extractors. Outside of solar flares hitting the Supply channel, or a syndicate agent with an EMAG helping the revolution and tagging a cargo order console, any cargo order is going to be blasted over the Supply channel. At a minimum, it will be heard by the entire cargo team, the HoP, and the Captain. The Medical Techfab will still be their preferred method, but given the importance of cargo in Revolutionaries, being able to order implant extractors with impunity after overtaking the department, or being able to use a hidden cargo teleporter setup to acquire them, would be a possible tool for the revolution side.

I don't think that this will upset the meta much.

## Technical details
Basic YAML for adding a crate to cargo, and making a crate fill.

## Media
<img width="1864" height="894" alt="image" src="https://github.com/user-attachments/assets/cec4b9de-cc13-4f8f-8d8a-94559c3c3790" />
<img width="717" height="254" alt="image" src="https://github.com/user-attachments/assets/ed98ab22-ab0d-48c5-83b3-2770ff56ff1b" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
N/A

**Changelog**
:cl: AgentSmithRadio
- add: Added implant extractor crates to cargo.