### PR TITLE
Fix broken state when attempting to escape a locker while cuffed

### DIFF
--- a/Content.Server/Resist/ResistLockerSystem.cs
+++ b/Content.Server/Resist/ResistLockerSystem.cs
@@ -57,9 +57,12 @@ public sealed class ResistLockerSystem : EntitySystem
             NeedHand = false, //No hands 'cause we be kickin'
         };
 
+        // Make sure the do after is able to start
+        if (!_doAfterSystem.TryStartDoAfter(doAfterEventArgs))
+            return;
+
         resistLockerComponent.IsResisting = true;
         _popupSystem.PopupEntity(Loc.GetString("resist-locker-component-start-resisting"), user, user, PopupType.Large);
-        _doAfterSystem.TryStartDoAfter(doAfterEventArgs);
     }
 
     private void OnDoAfter(EntityUid uid, ResistLockerComponent component, DoAfterEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Attempting to break out of a locked locker while cuffed now fails correctly instead of leaving the `IsResisting` field in the wrong state and breaking future attempts to escape.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/42220.

## Technical details
<!-- Summary of code changes for easier review. -->
The result of the `TryStartDoAfter` call is now checked before setting `IsResisting` and displaying the popup. If the DoAfter fails to start (for example, because the user is handcuffed), `AttemptResist` returns early.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->