### PR TITLE
Reworks destruction Space Law to include Silicons

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
@@ -625,7 +625,7 @@
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Includes destruction of station machinery such as ID card computers or telecommunications servers,
-		power devices such as substations, and non-hostile silicon units.
+        power devices such as substations, and non-hostile silicon units.
       </Box>
     </ColorBox>
     <ColorBox>
@@ -782,7 +782,7 @@
         4-02
       </Box>
     </ColorBox>
-	    <ColorBox>
+    <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
         Destruction of Vital Infrastructure
       </Box>


### PR DESCRIPTION
## About the PR
Reworked destruction laws to include the destruction of Silicons.

## Why / Balance
As discussed by the Silicon work group, they wanted to see space law regarding destruction of Borgs. Well here it is.

This PR adds a new crime, (D)/03 - Destruction of Critical Property, that includes the destruction of normal Silicons. Mass Destruction has been renamed to Destruction of Vital Infrastructure. It was formally (D)/03, but has been moved up one tier to (D)/04 and now includes the destruction of the station AI.

The new (D)/03 - **Destruction of Critical Property** reads like this:

> To destroy critical station equipment and systems.
> Includes destruction of station machinery such as ID card computers or telecommunications servers, power devices such as substations, and non-hostile silicon units.

This list isn't exhaustive, but could also include communication computers, the salvage magnet, etc. That's for the lawyers to argue.

Previously, (D)/03 - Mass Destruction read like this:

> To cause massive damage to an area or major station system.
> This is mostly used for deadly bombings or sabotage of major station systems such as power production, chemistry, substations, or atmos.

As a (D)/04 - **Destruction of Vital Infrastructure** now reads like this:

> Destruction of equipment or infrastructure that renders a department inoperable or severely degraded.
> This is mostly used for large-scale bombings or the sabotage of major station systems such as power production, the Cargo shuttle, or station AI.

I removed the blurb about Chemistry because ChemMasters are much more easily replaced than say, the PA or TEG. When you read "Destruction of Vital Infrastructure" what should come to mind is a syndicate hard-bomb or setting the AME to overload. What I don't want to happen, as Slam commented, is Security trying to bring this charge against someone who just uses C4 on a wall. That's what prompted the rename.

Also, as an aside here, why was completely leveling a department the same crime tier as just having Syndicate Contra or Assault? Like I get that if you blow up Med there are likely to be some casualties which stacks some other crimes, but in a vacuum you could completely obliterate a department or part of the station and only get the same brig timer as the guy who got in a bar fight...

All of this is readable in guidebook format in the media, and once I get someone to tell me how, this PR will coincide with Wiki changes.

## Technical details
XML edits. Nothing big.

## Media
Quick Crime Guide
<img width="1023" height="317" alt="QuickCrime" src="https://github.com/user-attachments/assets/da3aeefb-fa27-49b0-8847-cb1c8cbe94f9" />


3-03 / (D)/03 - Destruction of Critical Property
<img width="956" height="368" alt="3-03" src="https://github.com/user-attachments/assets/fc858e0a-5119-4c31-a199-4d4a03dc5824" />


4-03 / (D)/04 - Destruction of Vital Infrastructure
<img width="1021" height="413" alt="4-04" src="https://github.com/user-attachments/assets/6d014c00-4ea6-4f17-b0ff-1ec887925732" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None that I know of.

**Changelog**
:cl:
- tweak: Changed the destruction category of Space Law to be more accurate and include Silicons.

