### PR TITLE
Add Emergency Access wire to airlocks

### DIFF
--- a/Content.Server/Doors/WireActions/DoorEmergencyAccessWireAction.cs
+++ b/Content.Server/Doors/WireActions/DoorEmergencyAccessWireAction.cs
@@ -1,0 +1,39 @@
+﻿using Content.Server.Doors.Systems;
+using Content.Server.Wires;
+using Content.Shared.Doors;
+using Content.Shared.Doors.Components;
+using Content.Shared.Wires;
+
+namespace Content.Server.Doors.WireActions;
+
+public sealed partial class DoorEmergencyAccessWireAction : ComponentWireAction<AirlockComponent>
+{
+    public override Color Color { get; set; } = Color.Yellow;
+    public override string Name { get; set; } = "wire-name-door-emergency-access";
+
+    public override StatusLightState? GetLightState(Wire wire, AirlockComponent comp)
+    {
+        return comp.EmergencyAccess ? StatusLightState.On : StatusLightState.Off;
+    }
+
+    public override object StatusKey => AirlockWireStatus.EmergencyAccessIndicator;
+
+    public override bool Cut(EntityUid user, Wire wire, AirlockComponent airlock)
+    {
+        EntityManager.System<AirlockSystem>().SetEmergencyAccessWireCut((wire.Owner, airlock), true);
+        EntityManager.System<AirlockSystem>().SetEmergencyAccess((wire.Owner, airlock), true);
+        return true;
+    }
+
+    public override bool Mend(EntityUid user, Wire wire, AirlockComponent airlock)
+    {
+        EntityManager.System<AirlockSystem>().SetEmergencyAccessWireCut((wire.Owner, airlock), false);
+        return true;
+    }
+
+    public override void Pulse(EntityUid user, Wire wire, AirlockComponent airlock)
+    {
+        if (IsPowered(wire.Owner))
+            EntityManager.System<AirlockSystem>().SetEmergencyAccess((wire.Owner, airlock), !airlock.EmergencyAccess);
+    }
+}

--- a/Content.Shared/Doors/AirlockWireStatus.cs
+++ b/Content.Shared/Doors/AirlockWireStatus.cs
@@ -12,5 +12,6 @@ namespace Content.Shared.Doors
         AiVisionIndicator,
         TimingIndicator,
         SafetyIndicator,
+        EmergencyAccessIndicator,
     }
 }

--- a/Content.Shared/Doors/Components/AirlockComponent.cs
+++ b/Content.Shared/Doors/Components/AirlockComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class AirlockComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField, AutoNetworkedField]
     public bool EmergencyAccess = false;
-	
+
     /// <summary>
     /// Sound to play when the airlock emergency access is turned on.
     /// </summary>
@@ -36,6 +36,12 @@ public sealed partial class AirlockComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier EmergencyOffSound = new SoundPathSpecifier("/Audio/Machines/airlock_emergencyoff.ogg");
+
+    /// <summary>
+    /// True if the emergency access wire is cut, which will force the airlock to always be emergency access as long as it has power.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool EmergencyAccessWireCut;
 
     /// <summary>
     /// Pry modifier for a powered airlock.

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -161,6 +161,12 @@ public abstract class SharedAirlockSystem : EntitySystem
             Audio.PlayPvs(sound, ent);
     }
 
+    public void SetEmergencyAccessWireCut(Entity<AirlockComponent> ent, bool value)
+    {
+        ent.Comp.EmergencyAccessWireCut = value;
+        Dirty(ent, ent.Comp);
+    }
+
     public void SetAutoCloseDelayModifier(AirlockComponent component, float value)
     {
         if (component.AutoCloseDelayModifier.Equals(value))

--- a/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
+++ b/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
@@ -109,7 +109,7 @@ public abstract class SharedDoorRemoteSystem : EntitySystem
 
                 break;
             case OperatingMode.ToggleEmergencyAccess:
-                if (airlockComp != null)
+                if (airlockComp is { EmergencyAccessWireCut: false })
                 {
                     _airlock.SetEmergencyAccess((args.Target.Value, airlockComp), !airlockComp.EmergencyAccess, user: args.User, predicted: true);
                     _adminLogger.Add(LogType.Action,

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Airlock.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Airlock.cs
@@ -57,7 +57,7 @@ public abstract partial class SharedStationAiSystem
     /// </summary>
     private void OnAirlockEmergencyAccess(EntityUid ent, AirlockComponent component, StationAiEmergencyAccessEvent args)
     {
-        if (!PowerReceiver.IsPowered(ent))
+        if (component.EmergencyAccessWireCut || !PowerReceiver.IsPowered(ent))
         {
             ShowDeviceNotRespondingPopup(args.User);
             _adminLogger.Add(LogType.Action,

--- a/Resources/Locale/en-US/wires/wire-names.ftl
+++ b/Resources/Locale/en-US/wires/wire-names.ftl
@@ -56,6 +56,7 @@ wire-name-bolt-light = BLIT
 wire-name-door-bolt = BOLT
 wire-name-door-safety = SAFE
 wire-name-door-timer = TIMR
+wire-name-door-emergency-access = EMRG
 wire-name-lock = LOCK
 wire-name-power = POWR
 wire-name-arcade-invincible = MNGR

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -9,6 +9,7 @@
   - !type:DoorBoltLightWireAction
   - !type:DoorTimingWireAction
   - !type:DoorSafetyWireAction
+  - !type:DoorEmergencyAccessWireAction
   - !type:AiInteractWireAction
 
 - type: wireLayout
@@ -56,6 +57,7 @@
   - !type:DoorBoltLightWireAction
   - !type:DoorTimingWireAction
   - !type:DoorSafetyWireAction
+  - !type:DoorEmergencyAccessWireAction
   - !type:AiInteractWireAction
   dummyWires: 4
 
@@ -140,6 +142,7 @@
   - !type:DoorBoltLightWireAction
   - !type:DoorTimingWireAction
   - !type:DoorSafetyWireAction
+  - !type:DoorEmergencyAccessWireAction
 
 - type: wireLayout
   id: Defusable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the previously absent Emergency Access wire to airlocks. Behaves identical to bolt wire but for Emergency Access.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Every single feature of airlocks is accessible by players with a toolbelt and insuls, with the notable omission of the Emergency Access functionality. Even something as obscure as a "bolt light indicator" has a dedicated wire while actual functionality (EA) is missing.

There's many situations on station where it's beneficial for crew to DIY EA an airlock. As it stands this is often done by cutting every single wire in the airlock and prying it open, and then leaving it in that state. This feels 'wrong' since we all know EA exists but we cannot reach it.

Additionally there's the inverse problem. Sometimes Station AIs or heads of staff will EA a door, and then it will remain EA even when it *really* shouldn't. This involves calilng AI a bunch of times on radio or via holopad to get the AI player to fix it. This really shouldn't be necessary.

## Technical details
<!-- Summary of code changes for easier review. -->

The short version is I copied and adjusted bolt wire functionality to fit Emergency Access functionality.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

### Wire panel

Yellow EMRG wire added to regular- and high security airlocks.

<img width="613" height="419" alt="Content Client_rPj0WYNZP8" src="https://github.com/user-attachments/assets/8a54ea39-fb58-4f55-8373-e319f2029fa4" />

### Wire pulsing & cutting

https://github.com/user-attachments/assets/941a32b5-ef11-4eb5-9226-cfbe5c2c616e

### Door remote interactions

Matches Bolt behavior.

https://github.com/user-attachments/assets/ee190113-be24-4441-8255-aacd4449f038

### Station AI interactions

Matches Bolt behavior.

https://github.com/user-attachments/assets/b9932da3-aaab-42f2-b298-016d24d57dee


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: redmushie
- add: Added EMRG wire to airlocks that controls Emergency Access state
