### PR TITLE
Janiborg Module Cleanup

### DIFF
--- a/Content.Shared/Tools/Components/ToolComponent.cs
+++ b/Content.Shared/Tools/Components/ToolComponent.cs
@@ -16,7 +16,7 @@ public sealed partial class ToolComponent : Component
     ///     For tool interactions that have a delay before action this will modify the rate, time to wait is divided by this value
     /// </summary>
     [DataField]
-    public float SpeedModifier  = 1;
+    public float SpeedModifier = 1f;
 
     [DataField]
     public SoundSpecifier? UseSound;

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -371,3 +371,12 @@
         Piercing: 3
     soundHit:
       path: "/Audio/Weapons/bladeslice.ogg"
+
+- type: entity
+  parent: WireBrush
+  id: WireBrushElectrical
+  name: electrical wire brush
+  description: A bristly steel wire brush with a moving head, allowing for a way easier time cleaning.
+  components:
+  - type: Tool
+    speedModifier: 1.5

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -142,15 +142,23 @@
   id: BorgMegaSprayBottle
   name: adv. internal spray jet
   suffix: Filled
-  description: An upgraded version of the integrated spray bottle, installed directly into a custodial cyborg. Typically filled with space cleaner for dealing with those nasty spills.
+  description: An upgraded version of the integrated spray bottle, installed directly into a custodial cyborg. This one is capable of creating space cleaner from moisture in the air.
   components:
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 500
+        maxVol: 250
         reagents:
         - ReagentId: SpaceCleaner
-          Quantity: 500
+          Quantity: 250
+  - type: SolutionTransfer
+    canSend: false # No giving away infinite space cleaner!
+  - type: SolutionRegeneration
+    solution: spray
+    generated:
+      reagents:
+      - ReagentId: SpaceCleaner
+        Quantity: 1
 
 # Vapor
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -811,6 +811,7 @@
   - type: ItemBorgModule
     hands:
     - item: MopItem
+    - item: WireBrush
     - item: BorgBucket
     - item: BorgSprayBottle
     - item: HoloprojectorBorg
@@ -830,6 +831,7 @@
   - type: ItemBorgModule
     hands:
     - item: AdvMopItem
+    - item: WireBrushElectrical
     - item: BorgMegaSprayBottle
     - item: HoloprojectorBorg
     - item: BorgDropper


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Gave both of the janiborg modules a wirebrush.
Lowered the volume of the spray in the adv module, made it self refill.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Wirebrushes were supposed to be part of the modules but were never added.

Changing the adv spray to self refill actually serves two purposes:
Doesn't waste 500u of space cleaner from jani's tanks.
Doesn't allow to fill the spray with any harmful chemicals (Looking at you, flamethrowers). Or at least makes it way more difficult to do so. As an alternative, the beaker could be made undroppable, but that is a more boring solution.

## Technical details
<!-- Summary of code changes for easier review. -->
New entities.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="541" height="106" alt="image" src="https://github.com/user-attachments/assets/c357210f-50bb-4623-927e-1bae93483eb3" />

<img width="585" height="101" alt="image" src="https://github.com/user-attachments/assets/72570602-559a-4953-889f-2dae4f601f52" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Janitor Cyborg's modules now feature a wirebrush.
- tweak: The spray in the advanced cleaning module now self refills with space cleaner, but has been halved in volume.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
