### PR TITLE
Fix InstrumentSystem.Update exception when deleting band lead

### DIFF
--- a/Content.Server/Instruments/InstrumentSystem.cs
+++ b/Content.Server/Instruments/InstrumentSystem.cs
@@ -438,20 +438,22 @@ public sealed partial class InstrumentSystem : SharedInstrumentSystem
                 if (Deleted(master))
                 {
                     Clean(uid, instrument);
+                    continue;
                 }
 
                 var masterActive = activeQuery.CompOrNull(master);
                 if (masterActive == null)
                 {
                     Clean(uid, instrument);
+                    continue;
                 }
 
                 var trans = transformQuery.GetComponent(uid);
                 var masterTrans = transformQuery.GetComponent(master);
-                if (!_transform.InRange(masterTrans.Coordinates, trans.Coordinates, 10f)
-)
+                if (!_transform.InRange(masterTrans.Coordinates, trans.Coordinates, 10f))
                 {
                     Clean(uid, instrument);
+                    continue;
                 }
             }
 


### PR DESCRIPTION
## About the PR
Title.

## Why / Balance
Bugfix.
Resolves https://github.com/space-wizards/space-station-14/issues/40734
Resolves https://github.com/space-wizards/space-station-14/issues/41471 (duplicate)

## Technical details
Even if the band lead has been removed, the current code continues to execute, which will inevitably result in a component getting error. Now, we simply use `continue` to avoid this.
After several tests in game, everything works perfectly.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

