### PR TITLE
Use NextByte to properly construct colours

### DIFF
--- a/Content.Client/NetworkConfigurator/NetworkConfiguratorLinkOverlay.cs
+++ b/Content.Client/NetworkConfigurator/NetworkConfiguratorLinkOverlay.cs
@@ -41,9 +41,9 @@ public sealed class NetworkConfiguratorLinkOverlay : Overlay
             if (!Colors.TryGetValue(uid, out var color))
             {
                 color = new Color(
-                    _random.Next(0, 255),
-                    _random.Next(0, 255),
-                    _random.Next(0, 255));
+                    _random.NextByte(0, 255),
+                    _random.NextByte(0, 255),
+                    _random.NextByte(0, 255));
                 Colors.Add(uid, color);
             }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes network configurator colours when showing the link between entities on the device network.
Previously it would only ever show white lines between every object.

## Why / Balance
Showing white lines for everything is a bug and confusing as hell.

## Technical details
Seems like the `_random.Next` return value (int) was being interpreted as a float rather than a byte.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:
<img width="1004" height="630" alt="image" src="https://github.com/user-attachments/assets/35ee65b9-b92a-479e-8d03-b6bba58e32bf" />

After:
<img width="663" height="661" alt="image" src="https://github.com/user-attachments/assets/e302caa9-3ae2-4f4c-a666-c2a0152cfb6f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Network configurators now properly show colours between objects again.
