### PR TITLE
Add the Syndicate Delivery Console to the Nukie planet + target station maps

### DIFF
--- a/Resources/Maps/Nonstations/nukieplanet.yml
+++ b/Resources/Maps/Nonstations/nukieplanet.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 01/10/2026 10:58:20
-  entityCount: 2547
+  time: 01/12/2026 09:57:30
+  entityCount: 2553
 maps:
 - 1295
 grids:
@@ -10943,6 +10943,33 @@ entities:
     - type: Transform
       pos: 11.5,-6.5
       parent: 104
+- proto: HandheldStationMapNukeops
+  entities:
+  - uid: 1703
+    components:
+    - type: Transform
+      pos: 2.4973226,-3.3453965
+      parent: 104
+  - uid: 1895
+    components:
+    - type: Transform
+      pos: 2.4973226,-3.3453965
+      parent: 104
+  - uid: 2292
+    components:
+    - type: Transform
+      pos: 2.4973226,-3.3453965
+      parent: 104
+  - uid: 2309
+    components:
+    - type: Transform
+      pos: 2.4973226,-3.3453965
+      parent: 104
+  - uid: 2310
+    components:
+    - type: Transform
+      pos: 2.4973226,-3.3453965
+      parent: 104
 - proto: HandLabeler
   entities:
   - uid: 1826
@@ -11204,15 +11231,15 @@ entities:
       parent: 104
 - proto: NukeOpsLootSpawner
   entities:
-  - uid: 1703
-    components:
-    - type: Transform
-      pos: 2.5,-3.5
-      parent: 104
   - uid: 1704
     components:
     - type: Transform
       pos: 0.5,-6.5
+      parent: 104
+  - uid: 1894
+    components:
+    - type: Transform
+      pos: 0.5,0.5
       parent: 104
 - proto: NukeOpsMedkitBruteSpawner
   entities:
@@ -13663,6 +13690,11 @@ entities:
     components:
     - type: Transform
       pos: 3.5,-2.5
+      parent: 104
+  - uid: 1739
+    components:
+    - type: Transform
+      pos: 0.5,0.5
       parent: 104
 - proto: TargetClown
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds the Syndicate Delivery Console and nukeops station maps to the Nukie planet, introduced in #41201 and #41248 respectively.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Replaces one of the computers on the nukie planet with the delivery console because it needs to be there for the feature to happen. 🤷 

Puts 5 maps showing the target station on the table; the equipment spawner was moved to a new side table.

Read #41201 for the motivation for the console. 

## Technical details
<!-- Summary of code changes for easier review. -->

Simple mapping change.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="1154" height="1003" alt="image" src="https://github.com/user-attachments/assets/0f627e0e-8cc3-4e7b-b0fa-e880fb0a16c3" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added the Corpsman Medicine Bundle, a duffelbag of basic healing reagents. It is available after 20 minutes for free via the new Syndicate Delivery Console on the Nukie planet.
- add: Added new handheld maps on the Nukie planet that shows the target station.
