### PR TITLE
Fix NpcFactionMemberComponent serialization

### DIFF
--- a/Content.Shared/NPC/Components/NpcFactionMemberComponent.cs
+++ b/Content.Shared/NPC/Components/NpcFactionMemberComponent.cs
@@ -5,13 +5,13 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.NPC.Components;
 
-[RegisterComponent, NetworkedComponent, Access(typeof(NpcFactionSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(NpcFactionSystem))]
 public sealed partial class NpcFactionMemberComponent : Component
 {
     /// <summary>
     /// Factions this entity is a part of.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public HashSet<ProtoId<NpcFactionPrototype>> Factions = new();
 
     /// <summary>

--- a/Content.Shared/NPC/Systems/NpcFactionSystem.cs
+++ b/Content.Shared/NPC/Systems/NpcFactionSystem.cs
@@ -115,7 +115,10 @@ public sealed partial class NpcFactionSystem : EntitySystem
             return;
 
         if (dirty)
+        {
             RefreshFactions((ent, ent.Comp));
+            Dirty(ent, ent.Comp);
+        }
     }
 
     /// <summary>
@@ -137,7 +140,10 @@ public sealed partial class NpcFactionSystem : EntitySystem
         }
 
         if (dirty)
+        {
             RefreshFactions((ent, ent.Comp));
+            Dirty(ent, ent.Comp);
+        }
     }
 
     /// <summary>
@@ -158,7 +164,10 @@ public sealed partial class NpcFactionSystem : EntitySystem
             return;
 
         if (dirty)
+        {
             RefreshFactions((ent, ent.Comp));
+            Dirty(ent, ent.Comp);
+        }
     }
 
     /// <summary>
@@ -172,7 +181,10 @@ public sealed partial class NpcFactionSystem : EntitySystem
         ent.Comp.Factions.Clear();
 
         if (dirty)
+        {
             RefreshFactions((ent, ent.Comp));
+            Dirty(ent, ent.Comp);
+        }
     }
 
     public IEnumerable<EntityUid> GetNearbyHostiles(Entity<NpcFactionMemberComponent?, FactionExceptionComponent?> ent, float range)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fix `NpcFactionMemberComponent.Factions` field not synchronizing to clients when a player becomes an antagonist (e.g., traitor).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #42286

When a player becomes an antagonist, the `NpcFactionSystem` adds new factions (e.g., Syndicate) to the player's `NpcFactionMemberComponent`. However, this change was never synchronized to the client because:
1. The component was missing `[AutoGenerateComponentState]` attribute
2. The `Factions` field was missing `[AutoNetworkedField]` attribute  
3. The system never called `Dirty()` after modifying the component

This caused client-side faction checks to use stale data.

## Technical details
<!-- Summary of code changes for easier review. -->
- Added `[AutoGenerateComponentState]` to `NpcFactionMemberComponent`
- Added `[AutoNetworkedField]` to the `Factions` field
- Added `Dirty()` calls in `NpcFactionSystem` after `AddFaction`, `AddFactions`, `RemoveFaction`, and `ClearFactions` methods modify the component

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A - This is a networking/serialization bugfix with no visual changes.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer's discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed NPC faction membership not synchronizing to clients, which caused issues with antagonist faction changes.
