### PR TITLE
Add attribution to Tippy.rsi

### DIFF
--- a/Resources/Textures/Tips/tippy.rsi/meta.json
+++ b/Resources/Textures/Tips/tippy.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-3.0",
-  "copyright": "",
+  "copyright": "Sourced from TG Station at https://github.com/tgstation/tgstation/commit/ab6f97bc7570b74fb04d0dc6c964eb9bcffc4352.",
     "size": {
         "x": 32,
         "y": 32


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added attribution to a commit from TG station in 2012 which has the earliest (that I've found so far) unmodified clown sprite for tippy. ~This is being marked as a draft pending more information. IE I'm still looking.~

See https://github.com/tgstation/tgstation/commit/ab6f97bc7570b74fb04d0dc6c964eb9bcffc4352
See #42307

<img width="544" height="544" alt="animal (3)" src="https://github.com/user-attachments/assets/7cf3f7a6-b748-46a0-aa02-d37d8a1a8077" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->