### PR TITLE
Predict TransferAmountBoundUserInterface

### DIFF
--- a/Content.Client/Chemistry/UI/TransferAmountBoundUserInterface.cs
+++ b/Content.Client/Chemistry/UI/TransferAmountBoundUserInterface.cs
@@ -2,41 +2,31 @@ using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.FixedPoint;
 using JetBrains.Annotations;
-using Robust.Client.GameObjects;
 using Robust.Client.UserInterface;
 
-namespace Content.Client.Chemistry.UI
+namespace Content.Client.Chemistry.UI;
+
+[UsedImplicitly]
+public sealed class TransferAmountBoundUserInterface(EntityUid owner, Enum uiKey) : BoundUserInterface(owner, uiKey)
 {
-    [UsedImplicitly]
-    public sealed class TransferAmountBoundUserInterface : BoundUserInterface
+    [ViewVariables]
+    private TransferAmountWindow? _window;
+
+    protected override void Open()
     {
-        private IEntityManager _entManager;
-        private EntityUid _owner;
-        [ViewVariables]
-        private TransferAmountWindow? _window;
+        base.Open();
+        _window = this.CreateWindow<TransferAmountWindow>();
 
-        public TransferAmountBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
+        if (EntMan.TryGetComponent<SolutionTransferComponent>(Owner, out var comp))
+            _window.SetBounds(comp.MinimumTransferAmount.Int(), comp.MaximumTransferAmount.Int());
+
+        _window.ApplyButton.OnPressed += _ =>
         {
-          _owner = owner;
-          _entManager = IoCManager.Resolve<IEntityManager>();
-        }
-
-        protected override void Open()
-        {
-            base.Open();
-            _window = this.CreateWindow<TransferAmountWindow>();
-
-            if (_entManager.TryGetComponent<SolutionTransferComponent>(_owner, out var comp))
-                _window.SetBounds(comp.MinimumTransferAmount.Int(), comp.MaximumTransferAmount.Int());
-
-            _window.ApplyButton.OnPressed += _ =>
+            if (int.TryParse(_window.AmountLineEdit.Text, out var i))
             {
-                if (int.TryParse(_window.AmountLineEdit.Text, out var i))
-                {
-                    SendMessage(new TransferAmountSetValueMessage(FixedPoint2.New(i)));
-                    _window.Close();
-                }
-            };
-        }
+                SendPredictedMessage(new TransferAmountSetValueMessage(FixedPoint2.New(i)));
+                _window.Close();
+            }
+        };
     }
 }

--- a/Content.Client/Chemistry/UI/TransferAmountWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/TransferAmountWindow.xaml.cs
@@ -3,34 +3,33 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Client.UserInterface.XAML;
 
-namespace Content.Client.Chemistry.UI
+namespace Content.Client.Chemistry.UI;
+
+[GenerateTypedNameReferences]
+public sealed partial class TransferAmountWindow : DefaultWindow
 {
-    [GenerateTypedNameReferences]
-    public sealed partial class TransferAmountWindow : DefaultWindow
+    private int _max = Int32.MaxValue;
+    private int _min = 1;
+
+    public TransferAmountWindow()
     {
-        private int _max = Int32.MaxValue;
-        private int _min = 1;
+        RobustXamlLoader.Load(this);
+        AmountLineEdit.OnTextChanged += OnValueChanged;
+    }
 
-        public TransferAmountWindow()
-        {
-            RobustXamlLoader.Load(this);
-            AmountLineEdit.OnTextChanged += OnValueChanged;
-        }
+    public void SetBounds(int min, int max)
+    {
+        _min = min;
+        _max = max;
+        MinimumAmount.Text = Loc.GetString("comp-solution-transfer-set-amount-min", ("amount", _min));
+        MaximumAmount.Text = Loc.GetString("comp-solution-transfer-set-amount-max", ("amount", _max));
+    }
 
-        public void SetBounds(int min, int max)
-        {
-          _min = min;
-          _max = max;
-          MinimumAmount.Text = Loc.GetString("comp-solution-transfer-set-amount-min", ("amount", _min));
-          MaximumAmount.Text = Loc.GetString("comp-solution-transfer-set-amount-max", ("amount", _max));
-        }
-
-        private void OnValueChanged(LineEdit.LineEditEventArgs args)
-        {
-            if (!int.TryParse(AmountLineEdit.Text, out var amount)  || amount > _max || amount < _min)
-                ApplyButton.Disabled = true;
-            else 
-                ApplyButton.Disabled = false; 
-        }
+    private void OnValueChanged(LineEdit.LineEditEventArgs args)
+    {
+        if (!int.TryParse(AmountLineEdit.Text, out var amount) || amount > _max || amount < _min)
+            ApplyButton.Disabled = true;
+        else
+            ApplyButton.Disabled = false;
     }
 }

--- a/Content.Shared/Chemistry/Components/SolutionTransferComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionTransferComponent.cs
@@ -12,43 +12,36 @@ public sealed partial class SolutionTransferComponent : Component
     /// <summary>
     ///     The amount of solution to be transferred from this solution when clicking on other solutions with it.
     /// </summary>
-    [DataField("transferAmount")]
-    [ViewVariables(VVAccess.ReadWrite)]
-    [AutoNetworkedField]
-    public FixedPoint2 TransferAmount { get; set; } = FixedPoint2.New(5);
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 TransferAmount = FixedPoint2.New(5);
 
     /// <summary>
     ///     The minimum amount of solution that can be transferred at once from this solution.
     /// </summary>
-    [DataField("minTransferAmount")]
-    [ViewVariables(VVAccess.ReadWrite)]
-    public FixedPoint2 MinimumTransferAmount { get; set; } = FixedPoint2.New(5);
+    [DataField("minTransferAmount"), AutoNetworkedField]
+    public FixedPoint2 MinimumTransferAmount = FixedPoint2.New(5);
 
     /// <summary>
     ///     The maximum amount of solution that can be transferred at once from this solution.
     /// </summary>
-    [DataField("maxTransferAmount")]
-    [ViewVariables(VVAccess.ReadWrite)]
-    public FixedPoint2 MaximumTransferAmount { get; set; } = FixedPoint2.New(100);
+    [DataField("maxTransferAmount"), AutoNetworkedField]
+    public FixedPoint2 MaximumTransferAmount = FixedPoint2.New(100);
 
     /// <summary>
     ///     Can this entity take reagent from reagent tanks?
     /// </summary>
-    [DataField("canReceive")]
-    [ViewVariables(VVAccess.ReadWrite)]
-    public bool CanReceive { get; set; } = true;
+    [DataField, AutoNetworkedField]
+    public bool CanReceive = true;
 
     /// <summary>
     ///     Can this entity give reagent to other reagent containers?
     /// </summary>
-    [DataField("canSend")]
-    [ViewVariables(VVAccess.ReadWrite)]
-    public bool CanSend { get; set; } = true;
+    [DataField, AutoNetworkedField]
+    public bool CanSend = true;
 
     /// <summary>
     /// Whether you're allowed to change the transfer amount.
     /// </summary>
-    [DataField("canChangeTransferAmount")]
-    [ViewVariables(VVAccess.ReadWrite)]
-    public bool CanChangeTransferAmount { get; set; } = false;
+    [DataField, AutoNetworkedField]
+    public bool CanChangeTransferAmount = false;
 }

--- a/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
@@ -99,7 +99,7 @@ public sealed class SolutionTransferSystem : EntitySystem
         ent.Comp.TransferAmount = newTransferAmount;
 
         if (message.Actor is { Valid: true } user)
-            _popup.PopupEntity(Loc.GetString("comp-solution-transfer-set-amount", ("amount", newTransferAmount)), ent.Owner, user);
+            _popup.PopupClient(Loc.GetString("comp-solution-transfer-set-amount", ("amount", newTransferAmount)), ent.Owner, user);
 
         Dirty(ent.Owner, ent.Comp);
     }

--- a/Content.Shared/Chemistry/SharedTransferAmount.cs
+++ b/Content.Shared/Chemistry/SharedTransferAmount.cs
@@ -3,28 +3,16 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Chemistry
 {
+    /// <summary>
+    /// Send by the client when setting the transfer amount using the BUI.
+    /// </summary>
     [Serializable, NetSerializable]
-    public sealed class TransferAmountBoundInterfaceState : BoundUserInterfaceState
+    public sealed class TransferAmountSetValueMessage(FixedPoint2 value) : BoundUserInterfaceMessage
     {
-        public FixedPoint2 Max;
-        public FixedPoint2 Min;
-
-        public TransferAmountBoundInterfaceState(FixedPoint2 max, FixedPoint2 min)
-        {
-            Max = max;
-            Min = min;
-        }
-    }
-
-    [Serializable, NetSerializable]
-    public sealed class TransferAmountSetValueMessage : BoundUserInterfaceMessage
-    {
-        public FixedPoint2 Value;
-
-        public TransferAmountSetValueMessage(FixedPoint2 value)
-        {
-            Value = value;
-        }
+        /// <summary>
+        /// The new transfer amount.
+        /// </summary>
+        public FixedPoint2 Value = value;
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
## About the PR
Predicted the BUI message for setting the transfer amount on beakers etc.

## Why / Balance
prediction good

## Technical details
`SendMessage` -> `SendPredictedMessage`
`PopupEntity` -> `PopupClient`
Deleted `TransferAmountBoundInterfaceState` because it was not used anywhere. The BUI is already directly reading from the component, which is networked.
Some additional minor cleanup.

## Media
![predicted](https://github.com/user-attachments/assets/375c5acf-0b81-49a7-820a-0046d0f70a45)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Deleted `TransferAmountBoundInterfaceState` which was unused.

**Changelog**
no one will notice