### PR TITLE
Add borg construction interaction test

### DIFF
--- a/Content.IntegrationTests/Tests/Construction/Interaction/BorgConstruction.cs
+++ b/Content.IntegrationTests/Tests/Construction/Interaction/BorgConstruction.cs
@@ -3,7 +3,6 @@ using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.Construction.Interaction;
 
-[TestFixture]
 public sealed class BorgConstruction : InteractionTest
 {
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds an integration test that has the player construct a cyborg from the needed parts.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A bug was recently identified and fixed that caused a debug assert when constructing a borg (see https://github.com/space-wizards/space-station-14/issues/42354). This test will catch any future errors that might pop up during borg construction.

## Technical details
<!-- Summary of code changes for easier review. -->
The integration test is a simple interaction test that spawns the endoskeleton and then makes the player add all the parts needed and finish the construction. The prototype of the resulting entity is checked to make sure that construction has completed correctly.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->