### PR TITLE
Fix GenpopLockerBoundUserInterface prediction

### DIFF
--- a/Content.Client/Security/Ui/GenpopLockerBoundUserInterface.cs
+++ b/Content.Client/Security/Ui/GenpopLockerBoundUserInterface.cs
@@ -16,7 +16,7 @@ public sealed class GenpopLockerBoundUserInterface(EntityUid owner, Enum uiKey) 
 
         _menu.OnConfigurationComplete += (name, time, crime) =>
         {
-            SendMessage(new GenpopLockerIdConfiguredMessage(name, time, crime));
+            SendPredictedMessage(new GenpopLockerIdConfiguredMessage(name, time, crime));
             Close();
         };
 

--- a/Content.Shared/Security/Systems/SharedGenpopSystem.cs
+++ b/Content.Shared/Security/Systems/SharedGenpopSystem.cs
@@ -59,7 +59,7 @@ public abstract class SharedGenpopSystem : EntitySystem
         // Instead, we just fill in the spot temporarily til the checks pass.
         ent.Comp.LinkedId = EntityUid.Invalid;
 
-        _lock.Lock(ent.Owner, null);
+        _lock.Lock(ent.Owner, args.Actor);
         _entityStorage.CloseStorage(ent);
 
         CreateId(ent, args.Name, args.Sentence, args.Crime);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Small prediction bugfix for the genpop locker UI

## Why / Balance
bugfix

## Technical details
`SendMessage` -> `SendPredictedMessage`
Pass in the user into `Lock` so that the popup and audio will be predicted correctly.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
nah
