### PR TITLE
Janiborgs' default spray jet is now self-refilling

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -148,7 +148,7 @@
 - type: entity
   parent: MegaSprayBottle
   id: BorgMegaSprayBottle
-  name: adv. internal spray jet
+  name: advanced internal spray jet
   suffix: Filled
   description: An upgraded version of the integrated spray bottle, installed directly into a custodial cyborg. Capable of creating space cleaner from moisture in the air.
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The internal spray jet in the cleaning cyborg module is now self-refilling, but has a halved capacity (100u rather than 200u).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
#42330 made the same changes to the advanced cleaning cyborg module's advanced internal spray jet (self-refilling, halved capacity), with the goal of making it harder to fill the bottle with harmful chemicals in order to spray crew. I figured the standard variant of the bottle should work the same way, since it'd be weird to try to stop borgs from weaponizing one version of the bottle but not the other.

I will note that it's harder to actually fill this spray bottle with weird reagents since this version of the module lacks a dropper, but it's still possible through some roundabout methods (e.g, fill the spray bottle with water, spill harmful chemicals on the floor, mop them up, and transfer reagents from the mop to the bottle). Fuel dispensers also allow you to just directly fill the bottle with welding fuel.

The spray bottle being self-refilling does make it stronger, but we have similar precedent with other self-recharging borg tools on standard modules so it's probably fine. This is also mostly just stronger in terms of convenience, since I don't think I've ever once seen the space cleaner dispenser in the janitor's closet actually run out of space cleaner.

## Technical details
<!-- Summary of code changes for easier review. -->
YAML changes to the internal spray jet (smaller maxVol, SolutionTransfer disabled, SolutionGeneration added)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A (small change)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The internal spray jet in the cleaning cyborg module now self-refills with space cleaner, but has been halved in volume.