### PR TITLE
Fix holywater locale string usage.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-bottles.yml
@@ -475,7 +475,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-holy-water
+    currentLabel: reagent-name-holywater
   - type: SolutionContainerManager
     solutions:
       drink:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Looks like at some point the locale string changed to remove the hyphen on holywater and that of course broke this.
Simple fix, just removes the hyphen.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="529" height="382" alt="{BD059A64-E30F-4599-B964-A2DC94CE0672}" src="https://github.com/user-attachments/assets/ffebcecc-7b26-4e64-b7ff-dad5a980ef72" />
<img width="394" height="297" alt="{55E25FF0-0E85-4179-A2BA-E408FDAF2CF8}" src="https://github.com/user-attachments/assets/407d055c-8570-4642-acb0-2de53225dc27" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->