### PR TITLE
Make candy bowl ordering actually random

### DIFF
--- a/Content.Shared/Storage/Components/BinComponent.cs
+++ b/Content.Shared/Storage/Components/BinComponent.cs
@@ -58,9 +58,8 @@ public sealed partial class BinComponent : Component
     public int MaxItems = 20;
 
     /// <summary>
-    /// Whether this bin is shuffled.
+    /// Whether newly inserted items are put in a random order or not.
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool Shuffle;
-
 }

--- a/Content.Shared/Storage/Components/BinComponent.cs
+++ b/Content.Shared/Storage/Components/BinComponent.cs
@@ -56,4 +56,11 @@ public sealed partial class BinComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public int MaxItems = 20;
+
+    /// <summary>
+    /// Whether this bin is shuffled.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Shuffle;
+
 }

--- a/Content.Shared/Storage/EntitySystems/BinSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/BinSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
+using Robust.Shared.Random;
 
 namespace Content.Shared.Storage.EntitySystems;
 
@@ -23,6 +24,7 @@ public sealed class BinSystem : EntitySystem
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -70,7 +72,10 @@ public sealed class BinSystem : EntitySystem
         if (args.Container.ID != ent.Comp.ContainerId)
             return;
 
-        ent.Comp.Items.Add(args.Entity);
+        if (ent.Comp.Shuffle)
+            ent.Comp.Items.Insert(_random.Next(ent.Comp.Items.Count), args.Entity);
+        else
+            ent.Comp.Items.Add(args.Entity);
     }
 
     private void OnEntRemoved(Entity<BinComponent> ent, ref EntRemovedFromContainerMessage args)

--- a/Content.Shared/Storage/EntitySystems/BinSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/BinSystem.cs
@@ -11,7 +11,6 @@ using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
-using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.Storage.EntitySystems;

--- a/Resources/Prototypes/Entities/Objects/Misc/candy_bowl.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/candy_bowl.yml
@@ -12,6 +12,7 @@
   - type: Appearance
   - type: Bin
     maxItems: 100
+    shuffle: true
     whitelist:
       components:
         - Pill


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Apparently candy bowls had last-in-first-out ordering and never actually shuffled. WHY?!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Because why the frick is taking something from a candy bowl not randomized?!

## Technical details
<!-- Summary of code changes for easier review. -->

- Added "shuffle" attribute to BinComponent
- Added shuffle logic to BinSystem:
  - A random insertion index will be picked that can be anywhere except the last spot (= first out).
  - This has the effect that the last item is practically constant and as such perfectly predicted every time. Yay.
  - (The only side effect is that the first item ever inserted is guaranteed to be the first out, but practically speaking that's not really an issue.)
- Enabled "shuffle" on candy bowl.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/eaeb5738-c377-4e14-b41a-fa65386bc284

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl: redmushie
- tweak: Pills in candy bowls are now actually randomly ordered.
