### PR TITLE
Replace the Reach DoorRemoteAll with DoorRemoteCustom

### DIFF
--- a/Resources/Maps/reach.yml
+++ b/Resources/Maps/reach.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 267.3.0
+  engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 11/02/2025 23:05:17
+  time: 01/13/2026 00:18:31
   entityCount: 2641
 maps:
 - 1
@@ -1362,6 +1362,7 @@ entities:
     - type: RadiationGridResistance
     - type: SpreaderGrid
     - type: ImplicitRoof
+    - type: ExplosionAirtightGrid
 - proto: AirAlarm
   entities:
   - uid: 3
@@ -7642,12 +7643,12 @@ entities:
     - type: Transform
       pos: 21.5,-3.5
       parent: 2
-- proto: DoorRemoteAll
+- proto: DoorRemoteCustom
   entities:
   - uid: 1056
     components:
     - type: Transform
-      pos: 24.577494,2.096348
+      pos: 24.562723,2.0902877
       parent: 2
 - proto: DrinkMugRainbow
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Replaced a remote for PR #42370

## Why / Balance
Resolves a problem caused by #42370
Players should not have the shocking admeme remote

## Technical details
Just a YML map change.

## Media
<img width="1920" height="1216" alt="Reach-0" src="https://github.com/user-attachments/assets/af827f6b-4a90-46f8-ae29-995d3e00ca5c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
MAPS:
- tweak: On Reach station, replaced a door remote with its non-admin variant. 
