### PR TITLE
Add chemical solidification of liquid uranium and plasma using Fresium

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -201,6 +201,36 @@
     entity: IngotSilver1
 
 - type: reaction
+  id: SolidifyUranium
+  impact: Low
+  quantized: true
+  reactants:
+    Uranium:
+      amount: 10
+    FrostOil:
+      amount: 5
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetUranium1
+
+- type: reaction
+  id: SolidifyPlasma
+  impact: Low
+  quantized: true
+  reactants:
+    Plasma:
+      amount: 10
+    FrostOil:
+      amount: 5
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetPlasma1
+
+- type: reaction
   id: WehHewExplosion
   impact: High
   priority: 20

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -208,9 +208,7 @@
     Uranium:
       amount: 10
     FrostOil:
-      amount: 5
-    Fresium:
-      amount: 5
+      amount: 10
   effects:
   - !type:SpawnEntity
     entity: SheetUranium1
@@ -222,10 +220,8 @@
   reactants:
     Plasma:
       amount: 10
-    FrostOil:
-      amount: 5
     Fresium:
-      amount: 5
+      amount: 2
   effects:
   - !type:SpawnEntity
     entity: SheetPlasma1


### PR DESCRIPTION
## About the PR
Adds two new chemical reactions that allow players to solidify **liquid plasma** and **liquid uranium** into usable material sheets.

Reactions:
- 10u Liquid Uranium + 5u Fresium + 5u Frost Oil → 1 Uranium Sheet
- 10u Liquid Plasma + 5u Fresium + 5u Frost Oil → 1 Plasma Sheet

Thanks to medic2089 for the idea.

## Why / Balance
 Recent updates to plant mutation systems have added  **Fresium** to the random mutation reagent pool. This makes Fresium obtainable through botany, while still remaining inconsistent and gated compared to reliably farmable reagents like Frost Oil from chilly peppers.

Adding solidification paths for plasma and uranium is a natural extension of the existing Frost Oil mechanics for gold and silver ingots. It gives players new meaningful uses for Fresium now that it can appear through plant mutations. It is also logical that more advanced/complex materials require lower temperatures for solidification. 

**Balance impact:**
- **Salvage/mining remain ~1000× more efficient** for bulk resource acquisition - these chemistry reactions are never going to replace standard material farming.
- **Fresium** is obtained randomly (mutation RNG), unlike Frost Oil which can be reliably produced from chilly peppers → reactions are intentionally inconsistent and gated.
- **Uranium** also relies on random mutations → uranium sheet synthesis is roughly **twice as difficult** as silver production.
- **Plasma** can only be liquefied from gas → there is no "free" liquid plasma in the reagent pool, adding another layer of setup and risk.
- These reactions provide **alternative, stealthy, low-volume paths** to obtain small amounts of plasma/uranium.

**Gameplay improvements:**
- Gives traitors/syndicate agents a quiet way to gather plasma for the **Biocube Fabricator** (printing hostile bio-cubes that cost plasma but are aggressive to everyone).
- Adds one more niche occupation for botanists (chilly → Frost Oil chain) without breaking balance.
- Encourages creative chemistry play and long-term planning.
- In practice this feature will probably see use in **1 out of 1000 shifts** - it's a rare, flavorful option, not a meta shift.

No significant balance disruption is expected - it's a small, high-risk/high-skill side path for dedicated botanists and antagonists.

## Technical details
Two new `reaction` prototypes added (YAML-only, no C# changes).

## Media
https://github.com/user-attachments/assets/bbe8cb99-d222-4a64-a3e3-6bf6aa51b04f 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.  
Purely additive feature. 

**Changelog**

:cl:
- add: Added chemical reactions to solidify liquid uranium and plasma into sheets using Fresium + Frost Oil.
