### PR TITLE
Reduce unnecessary `ComponentInit` work for airtight entities

### DIFF
--- a/Content.Server/Atmos/Components/AirtightComponent.cs
+++ b/Content.Server/Atmos/Components/AirtightComponent.cs
@@ -45,10 +45,6 @@ namespace Content.Server.Atmos.Components
         [DataField("rotateAirBlocked")]
         public bool RotateAirBlocked { get; set; } = true;
 
-        // TODO ATMOS remove this? What is this even for??
-        [DataField("fixAirBlockedDirectionInitialize")]
-        public bool FixAirBlockedDirectionInitialize { get; set; } = true;
-
         /// <summary>
         /// If true, then the tile that this entity is on will have no air at all if all directions are blocked.
         /// </summary>

--- a/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
@@ -25,13 +25,17 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnAirtightInit(Entity<AirtightComponent> airtight, ref ComponentInit args)
         {
-            // TODO AIRTIGHT what FixAirBlockedDirectionInitialize even for?
-            if (!airtight.Comp.FixAirBlockedDirectionInitialize)
+            // If this entity blocks air in all directions (e.g. full tile walls, doors, and windows)
+            // we can skip some expensive logic.
+            if (airtight.Comp.InitialAirBlockedDirection == (int)AtmosDirection.All)
             {
+                airtight.Comp.CurrentAirBlockedDirection = airtight.Comp.InitialAirBlockedDirection;
                 UpdatePosition(airtight);
                 return;
             }
 
+            // Otherwise we need to determine its current blocked air directions based on rotation
+            // and check if it's still airtight.
             var xform = Transform(airtight);
             airtight.Comp.CurrentAirBlockedDirection =
                 (int) Rotate((AtmosDirection) airtight.Comp.InitialAirBlockedDirection, xform.LocalRotation);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Refactor initialization logic for airtight entities to actually skip rotation checks for entities that block air in all directions. Fixes #42099 .

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Should help reduce map loading times slightly.

## Technical details
<!-- Summary of code changes for easier review. -->

Instead of using a `fixAirBlockedDirectionInitialize` flag that isn't actually set to false for any airtight entity (as noted in the original issue), that field is removed from the code, and the initialization logic now filters entities based on their initial air blocked direction, which is conveniently already set for entities that only block air in certain directions.

Also sets `CurrentAirBlockedDirection` to `InitialAirBlockedDirection` on initialization for relevant entities since otherwise they wouldn't actually be airtight.

### Actual Timing of Loading Fland Station

**Before**: `system.map_loader: Loaded map in 00:00:09.1900961`, timing with a stopwatch showed 17.38 seconds.

**After**: `system.map_loader: Loaded map in 00:00:08.6949796`, timing with a stopwatch showed 16.66 seconds.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<details>
<summary>Sanity check on standard map</summary>
<img width="1116" height="725" alt="image" src="https://github.com/user-attachments/assets/d2621e2b-595c-455e-8885-76ca8cddcc46" />

<img width="558" height="404" alt="image" src="https://github.com/user-attachments/assets/b02b1d46-cc47-4d66-a676-3300a9dc159e" />

Box Station is not immediately spaced upon loading in, and isolated rooms like the artifact and TEG chambers are not being flooded with air.
</details>

<details>
<summary>Directional windows, blocking</summary>
<img width="715" height="659" alt="image" src="https://github.com/user-attachments/assets/1244a984-4deb-442f-8480-881abdf2e965" />

Directional windows and holofans are still airtight when oriented properly (ignore the broken glass, I originally put the vapour canister in its own box but accidentally broke the windows with too much pressure).
</details>

<details>
<summary>Directional windows, non-blocking</summary>
<img width="495" height="476" alt="image" src="https://github.com/user-attachments/assets/7237cc27-7a78-46e8-a31e-9b35b2fae483" />

Directional windows facing the wrong direction still do not block air.
</details>

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Entities that are airtight on all sides (such as full-tile walls, airlocks, and windows) now skip rotational checks for airtightness when initialized.