### PR TITLE
Increase trit-to-frezon ratio from 1:8 to 1:50

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -267,7 +267,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     1 mol of Tritium is required per X mol of oxygen.
         /// </summary>
-        public const float FrezonProductionTritRatio = 8.0f;
+        public const float FrezonProductionTritRatio = 50.0f;
 
         /// <summary>
         ///     1 / X of the tritium is converted into Frezon each tick


### PR DESCRIPTION
## About the PR
You now need less tritium in order to make frezon. The ratio is now 1:50 instead of 1:8. Atmos oldheads remember this as the old ratio before it was nerfed significantly.

## Why / Balance
While testing #41870 I noticed that burn chambers don't produce the amount of tritium that I like for a standard round. Rather than hold that PR up for months it was decided that we just merge it and then overbuff frezon generation.

As a result frezon production is basically unviable. As such we need to buff it back to something that's actually worth doing plus some more because I believe that Frezon was not enough of an impact as it should be considering the overall timesink.

In general we've wanted to roll Frezon over into a "make a lot thats worth a little" instead of "make a little thats worth a lot" because it overall feels better for players, so this is also moving towards that trend.

## Technical details
It's effectively a revert.
Also why can't these be cached CVARs.

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- tweak: The frezon production conversion rate has been increased. Tritium combines with oxygen to make frezon at a 1:50 ratio instead of a 1:8 ratio. This means you'll be making more frezon for less tritium inputted in a standard frezon setup.
