### PR TITLE
Fix sound issues with arti crusher.

### DIFF
--- a/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
@@ -121,7 +121,7 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
         crusher.Crushing = true;
         crusher.NextSecond = _timing.CurTime + TimeSpan.FromSeconds(1);
         crusher.CrushEndTime = _timing.CurTime + crusher.CrushDuration;
-        crusher.CrushingSoundEntity = AudioSystem.PlayPvs(crusher.CrushingSound, ent)?.Entity;
+        crusher.CrushingSoundEntity = AudioSystem.PlayPredicted(crusher.CrushingSound, ent, user)?.Entity ?? crusher.CrushingSoundEntity;
         _appearance.SetData(ent, ArtifactCrusherVisuals.Crushing, true);
         Dirty(ent, ent.Comp1);
     }
@@ -135,10 +135,7 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
         _appearance.SetData(ent, ArtifactCrusherVisuals.Crushing, false);
 
         if (early)
-        {
-            AudioSystem.Stop(ent.Comp.CrushingSoundEntity);
-            ent.Comp.CrushingSoundEntity = null;
-        }
+            ent.Comp.CrushingSoundEntity = AudioSystem.Stop(ent.Comp.CrushingSoundEntity);
 
         Dirty(ent, ent.Comp);
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Noticed this when testing the new gibbing PR but the sound repeats because it plays multiple sounds during prediction which is not ideal. In addition the sound isn't properly saved so exiting early to stop the sound wasn't working and this fixes it with the same workaround used in the [internals sound fix](https://github.com/space-wizards/space-station-14/pull/42328). 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Playing a sound 10+ times is bad especially when it cannot be stopped. 
Buge.

## Technical details
<!-- Summary of code changes for easier review. -->
PlayPVS -> PlayPredicted with a ?? so that if we're in prediction we don't override the cached sound effect.
One line cleanup on the StopCrushing method. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/307b13d9-080c-4312-a9c0-b3a82b0a967f

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
