### PR TITLE
Fix TritiumFireReaction low fuel limiting behavior

### DIFF
--- a/Content.Server/Atmos/Reactions/TritiumFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/TritiumFireReaction.cs
@@ -31,7 +31,8 @@ namespace Content.Server.Atmos.Reactions
             }
             else
             {
-                burnedFuel = Math.Max(initialTrit, mixture.GetMoles(Gas.Oxygen) / Atmospherics.TritiumBurnFuelRatio) / Atmospherics.TritiumBurnTritFactor;
+                // Limit the amount of fuel burned by the limiting reactant, either our initial tritium or the amount of oxygen available given the burn ratio.
+                burnedFuel = Math.Min(initialTrit, mixture.GetMoles(Gas.Oxygen) / Atmospherics.TritiumBurnFuelRatio) / Atmospherics.TritiumBurnTritFactor;
                 mixture.AdjustMoles(Gas.Tritium, -burnedFuel);
                 mixture.AdjustMoles(Gas.Oxygen, -burnedFuel / Atmospherics.TritiumBurnFuelRatio);
                 energyReleased += (Atmospherics.FireHydrogenEnergyReleased * burnedFuel * (Atmospherics.TritiumBurnTritFactor - 1));


### PR DESCRIPTION
## About the PR
Fixes the `TritiumFireReaction` not correctly limiting the amount of fuel/oxygen that can be burned in the high oxygen state.

Previously the `Math.Max` would actually take the highest of what could burn, either the tritium in its entirety or the amount of oxygen needed to burn the tritium. This fixes the limiting logic so that the amount of burned fuel is properly limited to what can actually be consumed.

## Why / Balance
Currently trying to resolve the funky behavior that my atmos friends are seeing when testing these changes out using multiple setups. This was brought to my attention and the overall reasoning makes sense.

In the end the tritium fixes are admittedly very experimental and I'm working to make sure that things are working properly. If things aren't fixed to my liking in time then the tritfire changes will likely see another master cycle and be delayed for two weeks.

## Technical details
Either limit by `initalTrit` or `mixture.GetMoles(Gas.Oxygen) / Atmospherics.TritiumBurnFuelRatio)` instead of maxxing by either one.

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- fix: The tritiumfire reaction now properly limits the amount of tritium burned by the limiting gas in the mix instead of limiting by which gas is in excess.
