### PR TITLE
UICommandButton now opens just one instance of a window.

### DIFF
--- a/Content.Client/Administration/UI/CustomControls/UICommandButton.cs
+++ b/Content.Client/Administration/UI/CustomControls/UICommandButton.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Robust.Client.UserInterface.CustomControls;
-using Robust.Shared.IoC;
+﻿using Robust.Client.UserInterface.CustomControls;
 
 namespace Content.Client.Administration.UI.CustomControls
 {
@@ -13,7 +11,9 @@ namespace Content.Client.Administration.UI.CustomControls
         {
             if (WindowType == null)
                 return;
-            _window = (DefaultWindow) IoCManager.Resolve<IDynamicTypeFactory>().CreateInstance(WindowType);
+
+            if (_window is not { IsOpen: true })
+                _window = (DefaultWindow) IoCManager.Resolve<IDynamicTypeFactory>().CreateInstance(WindowType);
             _window?.OpenCentered();
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Closes #20154

Tweaks UICommandButton to only open one window. I was looking at how I could rework/cleanup the EscapeMenu code and noticed this little gem hidden in the admin UI. It opens a window of a given type. This could be quite useful in reducing line count in other areas by slimming down the window open logic.

While I feel it would be cleaner to just update this button to only allow one window open at a time, it may be desired to not change the existing functionality, at which point I will just create a new control for it. Close or merge this as you will.

## Technical details
Adds a check before spawning a window to see if an existing window is open.
Instead of just opening a new window every time the button is pressed, it limits you to one. All other functionality remains the same.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
UICommandButton now only opens one window, if for some reason you were using this to open a limitless amount of windows as an intended feature.