### PR TITLE
Increase TEG power generation by 75%

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
@@ -63,6 +63,7 @@
     - type: AtmosDevice
     - type: TegGenerator
       thermalEfficiency: 0.1
+      powerFactor: 1.75
 
     - type: DeviceNetwork
       deviceNetId: AtmosDevices


### PR DESCRIPTION
## About the PR
This PR increases the TEG's `PowerFactor` to 1.75. So the TEG will generate 75% more power than previously.

## Why / Balance
When the heat of tritium burns were decreased (because they now no longer produce 10x the heat they should be producing lol), they had the effect of decreasing the overall temperature of plasmafires. This actually turned out to be a desirable effect as it allowed atmos techs to control the temperature of their burn chambers better and thus see better mol/s of tritium and thus frezon.

However it also impacted TEGs to the point where you had to supplement them pretty hard to the point where the gameplay is more so tedious rather than engaging. By increasing the power scaling of the TEG we bring things back to where they were previously, though note that a little bit more management is required which I don't see as a massive dealbreaker. If this is still a problem then we can adjust it again.

## Technical details
n/a

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- tweak: The TEG now produces 75% more power. This is to counteract tritium fires no longer producing 10x the amount of heat they used to output, due to a bug.
