### PR TITLE
Cleanup warnings: CS0414

### DIFF
--- a/Content.Server/Maps/MapMigrationSystem.cs
+++ b/Content.Server/Maps/MapMigrationSystem.cs
@@ -17,9 +17,9 @@ namespace Content.Server.Maps;
 /// </summary>
 public sealed class MapMigrationSystem : EntitySystem
 {
-#pragma warning disable CS0414
+#if DEBUG
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
-#pragma warning restore CS0414
+#endif
     [Dependency] private readonly IResourceManager _resMan = default!;
 
     private const string MigrationFile = "/migration.yml";

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -24,7 +24,6 @@ public partial class SharedBodySystem
      */
 
     [Dependency] private readonly InventorySystem _inventory = default!;
-    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
 
     private const float GibletLaunchImpulse = 8;
     private const float GibletLaunchImpulseVariance = 3;

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -29,12 +29,10 @@ namespace Content.Shared.Mind;
 public abstract partial class SharedMindSystem : EntitySystem
 {
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
-    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
     [Dependency] private readonly SharedPlayerSystem _player = default!;
-    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
     [Dependency] private readonly MetaDataSystem _metadata = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;


### PR DESCRIPTION
## About the PR
Cleanup 3x `CS0414` warnings.

[CS0414](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0414): The private field 'field' is assigned but its value is never used.

## Why / Balance
[https://github.com/space-wizards/space-station-14/issues/33279](https://github.com/space-wizards/space-station-14/issues/33279)

## Technical details
Also, the suppression of the warning has been replaced with `if DEBUG` because it is more correct (the suppressed dependency is used only in the debug build).

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
