### PR TITLE
Added recipe for **Spaceman's Cake**

### DIFF
--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1574,6 +1574,18 @@
     FoodBerries: 1 #dark colouring
 
 - type: microwaveMealRecipe
+  id: RecipeCakeSpaceman
+  name: spaceman cake recipe
+  result: FoodCakeSpaceman
+  time: 5
+  group: Cake
+  solids:
+    FoodCakePlain: 1
+    FoodSpacemansTrumpet: 2
+  reagents:
+    Sugar: 30
+
+- type: microwaveMealRecipe
   id: RecipeOrangeCake
   name: orange cake recipe
   result: FoodCakeOrange


### PR DESCRIPTION
## About the PR
Added a new microwave recipe for **Spaceman's Cake**:

- 2x Spaceman's Trumpet + 1x Cake + 30u Sugar → 1x Spaceman's Cake


## Why / Balance
- Expands Cook's recipe repertoire.
- Gives **Spaceman's Trumpets** an additional practical use.
- The resulting cake contains **15u Polypyrylium Oligomers**, offering light healing for the crew.

**Balance impact:**
Doesn't compete with Medical chems  - purely additive fun for kitchen experimentation.

## Technical details
- New `microwaveMealRecipe` prototype added (pure YAML, no C# changes).

## Media
https://github.com/user-attachments/assets/6401bb73-04a6-418f-a118-f7091d65d395

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.  
Purely additive feature.

**Changelog**
:cl:
- add: Added Spaceman's Cake recipe.