### PR TITLE
Fix: Added icon to ActionConfigureMeleeSpeech

### DIFF
--- a/Resources/Prototypes/Actions/speech.yml
+++ b/Resources/Prototypes/Actions/speech.yml
@@ -9,4 +9,5 @@
     priority: -20
     useDelay: 1
   - type: InstantAction
+    icon: { sprite: Interface/Actions/scream.png }
     event: !type:MeleeSpeechConfigureActionEvent


### PR DESCRIPTION
## About the PR
I added a missing icon definition to the `ActionConfigureMeleeSpeech` action. Previously, this action appeared as a blank button in the UI.

## Why / Balance
Fixes #42362.
The action button was invisible/blank, making it difficult for players to identify or use. I selected the existing `scream.png` icon as it fits the "Battle Cry/Speech" theme of the action.

## Technical details
- Modified `Resources/Prototypes/Entities/Mobs/Actions/speech.yml`.
- Added `icon: { sprite: Interface/Actions/scream.png }` to the `InstantAction` component of `ActionConfigureMeleeSpeech`.

## Media
*No media attached (Browser-based edit).*
*(Note to reviewers: This uses the existing standard `scream.png` sprite found in `Interface/Actions/`.)*

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
## Breaking changes
None.

**Changelog**
:cl:
- fix: Added a missing icon to the "Configure Melee Speech" action.