### PR TITLE
Fix core pinpointer pieces having a 5-pointer recipe

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -220,9 +220,6 @@
   - type: Tag
     tags:
     - MothershipPinpointerPiece
-  - type: Construction
-    graph: RepairMothershipPinpointer
-    node: start
 
 - type: entity
   parent: PinpointerMothership


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- fixes a bug where xenoborg core pinpointer pieces incorrectly had the `Construction` component, resulting in them having an alternate and more expensive crafting recipe when you used one on another one.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Using a core pinpointer piece on another piece no longer causes you to start an unintended construction recipe.
