### PR TITLE
Reduced Surveillance Camera Health

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
@@ -79,13 +79,13 @@
     thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 200
+          damage: 25
         behaviors:
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
       - trigger:
           !type:DamageTrigger
-          damage: 100
+          damage: 15
         behaviors:
           - !type:DoActsBehavior
             acts: [ "Destruction" ]


### PR DESCRIPTION
## About the PR
Changed damage thresholds for cameras from 200 and 100 to 25 and 15. 

## Why / Balance
Structure health is often extremely high or extremely low to a crazy degree, and probably the biggest example of this is the common camera.

To make a long story short, these things are known to be ridiculously tanky to the point where they're harder to kill than actual secoffs. We're talking like 38 crowbar hits, 6 dragon attacks, 10 shots from a WT or 3 fireaxe swings to break these things, just insane amounts of damage to the point where player in general don't ever interact with them and damage / sabotage rarely occur. 

What this PR does is make cameras actually killable. This allows for interactions like heavy xenoborgs 2-shotting cameras with a heavy laser, baseball bats and WT breaking in 2 swings / shots, eswords and dragons breaking in one. Crowbars still take over half a dozen swings and toolboxes are 4. 

The Why: camera sight is extremely powerful and crew / antags really can't do anything about it right now. They're just too tanky and hacking is very obvious, relatively slow, requires insuls, and easily repairable. This reduction makes cameras a realistic possible target of both low-stakes and high-stakes antaggery and just something that will commonly break over the course of a round when a secoff beefs their shots on a tarantula, the clown and a tider have a knife fight, or a slime goes on a rampage, in addition to more dedicated sabotage that is suddenly much more feasible.

Cameras are extremely fast and cheap to create (2 steel, 1 LV cable, and a screwdriver) so cameras being more easily destroyed ideally gives something more for engineering to do as part of station upkeep without taxing current resource economy. Paired with https://github.com/space-wizards/space-station-14/pull/39684 and any AI that hates losing vision, this would become another core part of engineering's upkeep on the station, which often currently struggles to find things to do between emergencies.

Why did I pick 25 and 15? They just felt about right after testing, for making it relatively time-consuming and obvious for someone to just go around smashing cameras with roundstart tools while also being something dedicated antags can very easily destroy with the tools they have available. Happy to take any feedback on breakpoints that people may have.

## Technical details
Strictly yaml.

## Media
If you want to see cameras obliterated I can add a video if someone really wants, lol. 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
**Changelog**
:cl:
- tweak: Significantly reduced surveillance camera health. Improvised weapons such as toolboxes and baseball bats will now destroy a camera within a handful of hits.
