### PR TITLE
Force-prying crit borgs opens borg panel

### DIFF
--- a/Content.Shared/Lock/BypassLock/Components/BypassLockComponent.cs
+++ b/Content.Shared/Lock/BypassLock/Components/BypassLockComponent.cs
@@ -21,5 +21,11 @@ public sealed partial class BypassLockComponent : Component
     /// Amount of time in seconds it takes to bypass
     /// </summary>
     [DataField]
-    public TimeSpan BypassDelay = TimeSpan.FromSeconds(5f);
+    public TimeSpan BypassDelay = TimeSpan.FromSeconds(4f);
+
+    /// <summary>
+    /// Whether the wirepanel should be opened as well, if one exists.
+    /// </summary>
+    [DataField]
+    public bool OpenWiresPanel = false;
 }

--- a/Content.Shared/Lock/BypassLock/Systems/BypassLockSystem.cs
+++ b/Content.Shared/Lock/BypassLock/Systems/BypassLockSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Lock.BypassLock.Components;
 using Content.Shared.Tools;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Verbs;
+using Content.Shared.Wires;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
@@ -16,6 +17,7 @@ public sealed partial class BypassLockSystem : EntitySystem
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly LockSystem _lock = default!;
     [Dependency] private readonly SharedToolSystem _tool = default!;
+    [Dependency] private readonly SharedWiresSystem _wires = default!;
 
     public override void Initialize()
     {
@@ -32,7 +34,7 @@ public sealed partial class BypassLockSystem : EntitySystem
     {
         if (target.Owner == args.User)
             return;
-        
+
         if (!_tool.HasQuality(args.Used, target.Comp.BypassingTool)
             || !_lock.IsLocked(target.Owner))
             return;
@@ -70,6 +72,11 @@ public sealed partial class BypassLockSystem : EntitySystem
             return;
 
         _lock.Unlock(target, args.User, target.Comp);
+
+        if (TryComp<WiresPanelComponent>(target, out var wiresPanel) &&
+            TryComp<BypassLockComponent>(target, out var bypassLock) && bypassLock.OpenWiresPanel)
+            _wires.TogglePanel(target, wiresPanel, true, args.User);
+
     }
 
     private void OnGetVerb(Entity<BypassLockComponent> target, ref GetVerbsEvent<InteractionVerb> args)

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -247,6 +247,7 @@
       flatReductions:
         Heat: 10 # capable of touching light bulbs and stoves without feeling pain!
   - type: BypassLock
+    openWiresPanel: true
   - type: BypassLockRequiresMobState
     requiredMobState:
     - Critical


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made it so that force-prying crit borgs now also opens their wirepanel.
Also made the pry time 4s instead of 5s.

Force-prying refers to the BypassLockComponent, which allows a Lock to be forced open by using a tool.
In this case, a borg in crit state (BypassLockRequiresMobStateComponent) has a crowbar used on them, which opens their lock and NOW also opens their WirePanelComponent (which is used for the borg UI).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Convenience, it also made little sense that you pry the panel open, but you still gotta unscrew it open. You cannot really pry a digital lock, so it makes sense we pry the wirepanel in this situation.

Timer was lowered to 4s from 5s because it felt a tad too long after all, but this is really just a microbalance.

## Technical details
<!-- Summary of code changes for easier review. -->
New datafield for opening the wirepanel.
After the DoAfter is complete, the LockComponent does some fancy TryComping business to see if it should open an existing wirepanel too.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/a44e85d6-46eb-4fce-89ce-174dd0a0bf4d

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Force-prying crit borgs now also opens their panel.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
