### PR TITLE
Fix missing Loc string warning spam from `HealthExaminable`

### DIFF
--- a/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
+++ b/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
@@ -62,7 +62,7 @@ public sealed class HealthExaminableSystem : EntitySystem
             {
                 if (!Loc.TryGetString($"health-examinable-{component.LocPrefix}-{type}-{threshold}", out var tempLocStr, ("target", Identity.Entity(uid, EntityManager))))
                 {
-                    // i.e., this string doesn't exist, because theres nothing for that threshold
+                    // i.e., this string doesn't exist, because there's nothing for that threshold
                     continue;
                 }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Examining the health of entities with certain damage levels will no longer spam the console with missing Loc string warnings.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix. Console spam bad.

## Technical details
<!-- Summary of code changes for easier review. -->
`HealthExaminableSystem` checks whether localized strings exist for specific damage thresholds by calling `Loc.GetString` with a generated ID and seeing if the result is different from the ID. Since `GetString` now logs a warning in that situation, the client console can get flooded with warnings when showing the health examine window (specifically with asphyxiation and radiation damage).

To fix this, we now check for the existence of a Loc string the proper way - by calling `Loc.TryGetString` and using the return value.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nah.