### PR TITLE
Fix:  Make interaction popups require hands

### DIFF
--- a/Content.Shared/Interaction/Components/InteractionPopupComponent.cs
+++ b/Content.Shared/Interaction/Components/InteractionPopupComponent.cs
@@ -74,6 +74,12 @@ public sealed partial class InteractionPopupComponent : Component
     [DataField("soundPerceivedByOthers")]
     public bool SoundPerceivedByOthers = true;
 
+    /// <summary>
+    /// Does the user need hands to perform this interaction?
+    /// </summary>
+    [DataField]
+    public bool NeedsHands = true;
+
     [ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan LastInteractTime;
 

--- a/Content.Shared/Interaction/InteractionPopupSystem.cs
+++ b/Content.Shared/Interaction/InteractionPopupSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Bed.Sleep;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
@@ -22,6 +23,7 @@ public sealed class InteractionPopupSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
     [Dependency] private readonly INetManager _netMan = default!;
 
     public override void Initialize()
@@ -89,6 +91,9 @@ public sealed class InteractionPopupSystem : EntitySystem
                       && component.InteractFailureSpawn == null;
 
         if (_netMan.IsClient && !predict)
+            return;
+
+        if (component.NeedsHands && _handsSystem.GetHandCount(uid) == 0)
             return;
 
         if (_random.Prob(component.SuccessChance))

--- a/Content.Shared/Interaction/InteractionPopupSystem.cs
+++ b/Content.Shared/Interaction/InteractionPopupSystem.cs
@@ -93,7 +93,7 @@ public sealed class InteractionPopupSystem : EntitySystem
         if (_netMan.IsClient && !predict)
             return;
 
-        if (component.NeedsHands && _handsSystem.GetHandCount(uid) == 0)
+        if (component.NeedsHands && _handsSystem.GetHandCount(user) == 0)
             return;
 
         if (_random.Prob(component.SuccessChance))

--- a/Content.Shared/Interaction/InteractionPopupSystem.cs
+++ b/Content.Shared/Interaction/InteractionPopupSystem.cs
@@ -71,6 +71,9 @@ public sealed class InteractionPopupSystem : EntitySystem
             return;
         }
 
+        if (component.NeedsHands && _handsSystem.GetHandCount(user) == 0)
+            return;
+
         args.Handled = true;
 
         var curTime = _gameTiming.CurTime;
@@ -91,9 +94,6 @@ public sealed class InteractionPopupSystem : EntitySystem
                       && component.InteractFailureSpawn == null;
 
         if (_netMan.IsClient && !predict)
-            return;
-
-        if (component.NeedsHands && _handsSystem.GetHandCount(user) == 0)
             return;
 
         if (_random.Prob(component.SuccessChance))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made interaction popups require hands.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #32567.

## Technical details
<!-- Summary of code changes for easier review. -->
The default ``NeedsHands`` value is ``true`` because all current in-game uses of the ``InteractionPopupComponent`` logically require hands.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
``InteractionPopupComponent`` now by default requires user to have hands (``NeedsHands`` field).
