### PR TITLE
Replace Bicaridine in Lily with Tranexamic acid.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1623,7 +1623,7 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 2
-        - ReagentId: Bicaridine
+        - ReagentId: TranexamicAcid
           Quantity: 20
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/lily.rsi

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -1232,7 +1232,7 @@
       Min: 1
       Max: 2
       PotencyDivisor: 50
-    Bicaridine:
+    TranexamicAcid:
       Min: 1
       Max: 20
       PotencyDivisor: 5


### PR DESCRIPTION
## About the PR
Replaces **Bicaridine** with **Tranexamic Acid** in the **Lily** plant's reagent output.

- Lily now produces 3u Tranexamic Acid instead of 3u Bicaridine.

## Why / Balance
Lily is essentially a second Poppy in terms of medical properties (both produce Bicaridine), which makes it feel redundant and underutilized in botany.

Replacing Bicaridine with Tranexamic Acid:
- Creates a logical progression: Bicaridine (brute damage heal) → Tranexamic Acid (bleeding control, transitional step toward Polypyrylium Oligomers).
- Tranexamic Acid stops bleeding, similar to how Polypyrylium Oligomers.
- Allows Botanists to craft **Medicated Sutures** once they obtain **Cryptobiolin**, synergizing nicely with my PR that enables Botanists to produce Regenerative Meshes: https://github.com/space-wizards/space-station-14/pull/42471


**Balance impact:**
- Medicated Sutures remain gated - Botanists still need Cryptobiolin, which is RNG-dependent from plant mutations (or can be synthesized by chemists).
- Cryptobiolin from random mutations becomes more useful instead of dead weight.
- Gives Botanists a niche way to produce advanced medical items for personal use or medbay supply.
- Near-zero overall balance impact: Medicated Sutures are not meta-defining or overpowered; they remain a nice QoL/utility option.

**Gameplay improvements:**
- Makes Lily less redundant and more interesting for Botany.
- Gives random Cryptobiolin mutations actual value.
- Adds one more small, flavorful occupation for Botanists.

## Technical details
- YAML-only change.

## Media
https://github.com/user-attachments/assets/af3bdb64-f69c-48f9-a52a-ef29c8e09fdf

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.  
Purely additive / tweak to existing plant output.

**Changelog**
:cl:
- tweak: Replaced Bicaridine with Tranexamic Acid in Lily plant output.
