### PR TITLE
Add alternative Regenerative Mesh recipe using Siderlac instead of Sigynate.

### DIFF
--- a/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
@@ -34,3 +34,17 @@
   reagents:
     Sigynate: 20
     Dermaline: 20
+
+- type: microwaveMealRecipe
+  id: RecipeRegenerativeMeshAlt
+  name: regenerative mesh recipe alt
+  result: RegenerativeMesh
+  time: 10
+  group: Medicinal
+  solids:
+    FoodAloe: 1
+    Ointment: 1
+    MaterialCloth1: 1
+  reagents:
+    Siderlac: 20
+    Dermaline: 20


### PR DESCRIPTION
## About the PR
Adds an **alternative microwave recipe** for **Regenerative Mesh** that uses **Siderlac** instead of **Sigynate**.

New recipe:
- 1 Aloe
- 1 Ointment
- 1 Cloth
- 20u Siderlac
- 20u Dermaline

→ 1 Regenerative Mesh

This provides Botanists with a viable way to produce advanced burn-treatment medical items.

## Why / Balance
Microwave recipe additions are currently frozen, but this PR is effectively a small tweak rather than a net-new feature - it simply swaps one reagent for its botanical equivalent. In addition, the current advanced medical crafting system (via microwave) is already well-balanced: complex enough to feel rewarding, yet occasionally useful in practice.

**Siderlac** is the botanical counterpart to **Sigynate** - both specialize in acid damage treatment. This alternative recipe lets Botanists craft Regenerative Mesh directly, synergizing nicely with my previous PR that enables Botanists to produce Medicated Sutures:  
https://github.com/space-wizards/space-station-14/pull/42466

**Balance impact:**
- Botanists can now produce Regenerative Meshes for personal use or medbay supply on a par with chemists. 
- Recipe remains demanding, so it won't be spammed.
- Gives Botanists a specialized tool against burn damage.

**Gameplay improvements:**
- More practical uses for Siderlac.
- Chemists will appreciate Siderlac deliveries even more (less need to synthesize Sigynate for mesh).
- Adds one more useful niche for Botanists that benefits the station.
- Increases the chance of seeing Regenerative Mesh in medbay (chemists can request it from Botany instead of crafting it themselves).

Overall impact: very small and positive - a quality-of-life extension for Botany/Chemistry cooperation.

## Technical details
New alternative `microwaveMealRecipe` prototype added (YAML-only, no C# changes):

## Media
https://github.com/user-attachments/assets/a77709e0-018a-47d8-b0d2-e98d7071e560

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.  
Purely additive feature.

**Changelog**
:cl:
- add: Added alternative Regenerative Mesh recipe using Siderlac.