### PR TITLE
Fixes Opporozidone Instarot issues

### DIFF
--- a/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
+++ b/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
@@ -25,7 +25,6 @@ public abstract class SharedRottingSystem : EntitySystem
         SubscribeLocalEvent<PerishableComponent, MobStateChangedEvent>(OnMobStateChanged);
         SubscribeLocalEvent<PerishableComponent, ExaminedEvent>(OnPerishableExamined);
 
-        SubscribeLocalEvent<RottingComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<RottingComponent, MobStateChangedEvent>(OnRottingMobStateChanged);
         SubscribeLocalEvent<RottingComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<RottingComponent, ExaminedEvent>(OnExamined);
@@ -61,14 +60,6 @@ public abstract class SharedRottingSystem : EntitySystem
         var isMob = HasComp<MobStateComponent>(perishable);
         var description = "perishable-" + stage + (!isMob ? "-nonmob" : string.Empty);
         args.PushMarkup(Loc.GetString(description, ("target", Identity.Entity(perishable, EntityManager))));
-    }
-
-    private void OnShutdown(Entity<RottingComponent> ent, ref ComponentShutdown args)
-    {
-        if (TryComp<PerishableComponent>(ent, out var perishable))
-        {
-            perishable.RotNextUpdate = TimeSpan.Zero;
-        }
     }
 
     private void OnRottingMobStateChanged(EntityUid uid, RottingComponent component, MobStateChangedEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I removed a vestigial handler which would cause oppo-unrotted patients to rot at 150 times speed during the period of time in which RotNextUpdate was catching up to _timing.CurTime

Upstreamed version of https://github.com/new-frontiers-14/frontier-station-14/pull/4251

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugs are bad and must die
Opporozidone will become very janky to use as the server runs longer, with a span of time in which unrotted patients immediately re-rot. This was very noticeable on frontier, due to our long shift time.

## Technical details
<!-- Summary of code changes for easier review. -->
When opporozidone removes the RottingComponent (via `ReduceAccumulator`), the PerishableComponent's RotNextUpdate is set to 0 - and then it undergoes a period of catch-up to the current time. If the entity is susceptible to rot in that interval, it'll accumulate 2 minutes 30 seconds worth of rot, per second.

This gets worse the longer the server has been running, as there's a greater value in _timing.CurTime to catch up to. 

This handler seems to be vestigial from the MiasmaSystem and does not seem to be necessary for anything anymore. The RotNextUpdate value is already set every cycle passively, and so is already around _timing.CurTime.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
I killed and rotted an urist, then spaced and filled that with oppo to demonstrate it all still works OK
<img width="554" height="220" alt="image" src="https://github.com/user-attachments/assets/324b1d05-9627-4512-826a-43b55c265461" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Deletes the method OnShutdown in SharedRottingSystem and the ComponentShutdown listener registration from RottingComponent

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Marlyn
- fix: Opporozidone no longer has instarot issues that get worse the longer the server has been running
