### PR TITLE
Add Necrosol to random plant mutation reagent table.

### DIFF
--- a/Resources/Prototypes/Hydroponics/randomChemicals.yml
+++ b/Resources/Prototypes/Hydroponics/randomChemicals.yml
@@ -5,6 +5,7 @@
     weight: 0.5
     reagents:
     - Omnizine
+    - Necrosol
     - Impedrezene
     - Fresium
     - HeartbreakerToxin


### PR DESCRIPTION
## About the PR
Adds **Necrosol** to the random mutation reagent pool for plants.

## Why / Balance
Necrosol is currently extremely rare in medbay. Adding it to the random mutation table gives it a better chance to show up without making it common or easy to farm.

**Key points:**
- **Synthesis from Omni** remains a valid method for producing Necrosol.
- Random mutations currently lack "exciting" or high-value reagents - this adds a flavorful, rare surprise.
- Parallels the existing pattern: Cognizine appears randomly, even though we have a unique mutation only for the production of its component - Carpotoxin.
- Once the mutation table is fixed, Necrosol will remain **extremely rare** even with this change.
- **Balance impact:** Effectively zero. Medbay will see Necrosol slightly more often, but it won't affect meta due to the extreme rarity of this mutation.

This is a tiny tweak that makes random mutations feel more interesting without any meaningful disruption.

## Technical details
- YAML-only change.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.  
Purely additive feature.

**Changelog**
:cl:
- add: Necrosol can now rarely appear as a random plant mutation reagent.