### PR TITLE
[EXPERIMENTAL] Removes Blunt and Burn Damage Threshold Gib Behavior

### DIFF
--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -121,28 +121,6 @@
     thresholds:
     - trigger:
         !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 400
-      behaviors:
-      - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          FoodMeatChickenFriedVox:
-            min: 3
-            max: 5
-      - !type:BurnBodyBehavior
-        popupMessage: bodyburn-vox-text-others
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
-    - trigger:
-        !type:DamageTypeTrigger
         damageType: Radiation
         damage: 15
       behaviors:

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -74,27 +74,6 @@
     thresholds:
     - trigger:
         !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 400
-      behaviors:
-      - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          Ash:
-            min: 1
-            max: 1
-      - !type:BurnBodyBehavior
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
-    - trigger:
-        !type:DamageTypeTrigger
         damageType: Radiation
         damage: 15
       behaviors:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed Gib Behavior from base mob, as well as Vox since they have their own specific gib behavior defined for the fried chicken meme. Skeletons should be unaffected.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Blunt gib is excessively simple to do, and extremely fast to pull off with minimal effort, ashing gib is the same but worse, and is also extremely simple to do due to the way bodies currently retain heat. This change is intended to push antagonists away from simple "3 second gibs" and make them create a plan around how they intend to get rid of a body. It is important to note, the recycler, artifact crushers, wizard smite, and acidifiers still work with this change. Anything that logically and currently triggers an instantaneous gib still works. This change may negatively affect cargo with organ bounties, or science in borgification of crew until they research an artifact crusher to gib crew with or use a meatspike. Butchering of mobs is unchanged.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed the gib behaviour from base.yml and body/vox.yml. This is in no way a clean way to do this, but it's simple to review and revert in favor of a better system of doing gib per mob.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1920" height="1080" alt="{8F798901-1AE0-4AFD-AA14-57A0DE9DD784}" src="https://github.com/user-attachments/assets/e0ee6b25-e040-4fd4-8d91-a8d6011ff10b" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
This is an experimental PR. If you merge this commit, you will merge gib behavior being removed from base mob and vox.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

🆑 
- remove: EXPERIMENTAL Removed blunt and burn based gibbing.

