### PR TITLE
Traitor Chemicals Rebalance

### DIFF
--- a/Content.Shared/EntityEffects/Effects/StatusEffects/ElectrocuteEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/StatusEffects/ElectrocuteEntityEffectSystem.cs
@@ -4,7 +4,6 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.EntityEffects.Effects.StatusEffects;
 
-// TODO: When Electrocution is moved to new Status, make this use StatusEffectsContainerComponent.
 /// <summary>
 /// Electrocutes this entity for a given amount of damage and time.
 /// The shock damage applied by this effect is modified by scale.
@@ -19,7 +18,13 @@ public sealed partial class ElectrocuteEntityEffectSystem : EntityEffectSystem<S
     {
         var effect = args.Effect;
 
-        _electrocution.TryDoElectrocution(entity, null, (int)(args.Scale * effect.ShockDamage), effect.ElectrocuteTime, effect.Refresh, ignoreInsulation: effect.BypassInsulation);
+        _electrocution.TryDoElectrocution(entity,
+            null,
+            (int)(args.Scale * effect.ShockDamage),
+            effect.ElectrocuteTime,
+            effect.Refresh,
+            siemensCoefficient: effect.SiemensCoefficient,
+            ignoreInsulation: effect.BypassInsulation);
     }
 }
 
@@ -29,23 +34,33 @@ public sealed partial class Electrocute : EntityEffectBase<Electrocute>
     /// <summary>
     /// Time we electrocute this entity
     /// </summary>
-    [DataField] public TimeSpan ElectrocuteTime = TimeSpan.FromSeconds(2);
+    [DataField]
+    public TimeSpan ElectrocuteTime = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// Shock damage we apply to the entity.
     /// </summary>
-    [DataField] public int ShockDamage = 5;
+    [DataField]
+    public int ShockDamage = 5;
 
     /// <summary>
     /// Do we refresh the duration? Or add more duration if it already exists.
     /// </summary>
-    [DataField] public bool Refresh = true;
+    [DataField]
+    public bool Refresh = true;
 
     /// <summary>
     /// Should we by bypassing insulation?
     /// </summary>
-    [DataField] public bool BypassInsulation = true;
+    [DataField]
+    public bool BypassInsulation = true;
+
+    /// <summary>
+    /// How much electricity is being passed through the body basically. Lower means less oomph.
+    /// </summary>
+    [DataField]
+    public float SiemensCoefficient = 1f;
 
     public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
-        => Loc.GetString("entity-effect-guidebook-electrocute", ("chance", Probability), ("time", ElectrocuteTime.TotalSeconds));
+        => Loc.GetString("entity-effect-guidebook-electrocute", ("chance", Probability), ("time", ElectrocuteTime.TotalSeconds), ("stuns", SiemensCoefficient > 0.5f));
 }

--- a/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
@@ -335,8 +335,14 @@ entity-effect-guidebook-drunk =
 
 entity-effect-guidebook-electrocute =
     { $chance ->
-        [1] Electrocutes
-        *[other] electrocute
+        [1] { $stuns ->
+            [true] Electrocutes
+            *[false] Shocks
+            }
+        *[other] { $stuns ->
+            [true] electrocute
+            *[false] shock
+            }
     } the metabolizer for {NATURALFIXED($time, 3)} {MANY("second", $time)}
 
 entity-effect-guidebook-emote =

--- a/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
@@ -30,7 +30,7 @@
         - id: Dropper
         # It would be cool to have special "syndicate" chemical analysis goggles
         - id: ClothingEyesGlassesChemical
-        - id: SyringeStimulants
+        - id: Syringe
         - id: VestineChemistryVial
           amount: 2
         - id: ChemistryEmptyVial

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -728,7 +728,7 @@
   discountDownTo:
     Telecrystal: 2
   cost:
-    Telecrystal: 5
+    Telecrystal: 3
   categories:
   - UplinkChemicals
 
@@ -741,7 +741,7 @@
   discountDownTo:
     Telecrystal: 2
   cost:
-    Telecrystal: 4
+    Telecrystal: 3
   categories:
   - UplinkChemicals
 

--- a/Resources/Prototypes/Entities/Objects/Fun/darts.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/darts.yml
@@ -121,13 +121,13 @@
   - type: SolutionContainerManager
     solutions:
       melee:
-        maxVol: 7
+        maxVol: 10
   - type: SolutionInjectOnEmbed
-    transferAmount: 7
+    transferAmount: 10
     blockSlots: NONE
     solution: melee
   - type: SolutionTransfer
-    maxTransferAmount: 7
+    maxTransferAmount: 10
 
 - type: entity
   name: dartboard

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -164,9 +164,11 @@
   color: "#FDD023"
   metabolisms:
     Poison:
+      metabolismRate : 2.0
       effects:
       - !type:Electrocute
-        probability: 0.35
+        siemensCoefficient: 0.5
+        probability: 0.5
 
 - type: reagent
   id: Razorium

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -169,10 +169,10 @@
         conditions:
         - !type:ReagentCondition
           reagent: Stimulants
-          min: 50
+          min: 45
         damage:
           types:
-            Poison: 1
+            Poison: 3
       # Interactions
       - !type:ModifyStatusEffect
         conditions:
@@ -333,7 +333,7 @@
           reagent: Nocturine
           min: 8
         effectProto: StatusEffectForcedSleeping
-        time: 6
+        time: 9
         delay: 5
 
 - type: reagent

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -674,9 +674,11 @@
   color: "#FDD023"
   metabolisms:
     Poison:
+      metabolismRate : 2.0
       effects:
       - !type:Electrocute
-        probability: 0.8
+        electrocuteTime: 1
+        probability: 0.5
 
 - type: reagent
   id: Lipolicide


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes as per Traitor Workgroup Discussion
Intended to be merged alongside: #42468, #42477 and #42482

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Tazinide has become a problem since being introduced to the crew, this brings it back into the realms of balance in two ways: Firstly it's metabolic rate has been quadrupled meaning Tazi stuns for at most 5 seconds per hypo injection when before it was at most 20. Second, it's stun chance has been reduced to 50%. Third, it's stun time has been reduced to 1 second. 
- Licoxide was changed to basically be useless. It's in the "fun" category of reagents so I balanced it with that in mind, half damage, doesn't stun but still shocks and the same quadruple metabolism. This makes it more of a silly item that causes jitters and stutters rather than anything actually useful, also has the same 50% application chance. 
- Nocturine now lasts 9 seconds instead of 6 seconds to make it a bit more consistent once the target falls asleep.
- Hyperzine has received a mild nerf. Its OD now deals 3 poison instead of 1 meaning it cannot be negated with omnizine. Its OD threshold is now 45 instead of 50 to give a clear boundary of any more than 1 injector or 3 microinjectors at once being unsafe. This chemical is intended to be easy to use but it was a little too easy before, may need further adjustments. 
- Hypodart has had its capacity raised to 10, same as the Hypopen. Its main balance concern was with nocturine instant sleep darts, but those now have a timer so it's been raised to be more consistent with similarly sized items. Cost may need to be raised in the future if it becomes overused. 
- Chemical Synthesis kit no longer comes with free hyperzine. Not sure why it ever did, but the reduced cost of both this and hyperzine should justify them being separate purchases anyways. 
- Combat Medkit and Combat Medipen have had their prices reduced to 3 TC. These are the go-to medical items in the uplink for medicine and should be cheaper as they shouldn't be competing with more useful and permanent items. Combat Medipen is a one use item that's extremely good exactly once, while the Medkit is great for long term healing options so long as you can find some downtime. Both are equally valuable in different scenarios hence the same prices being given. 

## Technical details
<!-- Summary of code changes for easier review. -->
YAML mostly, some C# on the EntityEffects end to allow for more tweaking of the electrocution effect. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/5fb4cae9-f2d4-49bb-bce5-931f0550b23c

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Tazinide and Licoxide now are less effective at shocking and don't last as long.
- tweak: Nocturine now lasts 9 seconds instead of 6 seconds.
- tweak: Hyperzine overdose can no longer be negated completely with Omnizine. 
- tweak: Hypodarts now have an increased chemical capacity of 10u up from 7u
- tweak: Combat Medkit and Combat Medipen have had their prices reduced to 3 TC
