### PR TITLE
Remove stun from tesla anomaly

### DIFF
--- a/Content.Server/Anomaly/Effects/ElectricityAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/ElectricityAnomalySystem.cs
@@ -63,7 +63,7 @@ public sealed class ElectricityAnomalySystem : EntitySystem
 
             foreach (var (ent, comp) in _lookup.GetEntitiesInRange<StatusEffectsComponent>(_transform.GetMapCoordinates(uid, xform), range))
             {
-                _electrocution.TryDoElectrocution(ent, uid, damage, duration, true, statusEffects: comp);
+                _electrocution.TryDoElectrocution(ent, uid, damage, duration, true, siemensCoefficient: 0.5f, ignoreInsulation: true, statusEffects: comp);
             }
         }
     }

--- a/Content.Server/Anomaly/Effects/ElectricityAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/ElectricityAnomalySystem.cs
@@ -63,7 +63,7 @@ public sealed class ElectricityAnomalySystem : EntitySystem
 
             foreach (var (ent, comp) in _lookup.GetEntitiesInRange<StatusEffectsComponent>(_transform.GetMapCoordinates(uid, xform), range))
             {
-                _electrocution.TryDoElectrocution(ent, uid, damage, duration, true, statusEffects: comp, ignoreInsulation: true);
+                _electrocution.TryDoElectrocution(ent, uid, damage, duration, true, statusEffects: comp);
             }
         }
     }


### PR DESCRIPTION
## About the PR
Removes stun electrocution from tesla anom

## Why / Balance
100% verified microbalance pr
Update is evil so right now this is most dangerous anomaly because sometimes it even doesn't allows to scan anomaly
There is still shock damage

## Technical details
Electrocution is cursed so damage without stun can be only hardcoded via siemensCoefficient

## Media
https://github.com/user-attachments/assets/4c98edba-ba9e-4251-bfda-5964fae277b9

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- tweak: Tesla anomaly no longer stun