### PR TITLE
Fix handheld grinder and reaction mixer audio stacking

### DIFF
--- a/Content.Shared/Chemistry/Reaction/ReactionMixerSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactionMixerSystem.cs
@@ -36,16 +36,11 @@ public sealed partial class ReactionMixerSystem : EntitySystem
 
         if (ent.Comp.MixerType != ReactionMixerType.Handheld)
             return;
-        
-        ent.Comp.AudioStream = _audio.Stop(ent.Comp.AudioStream);
 
         args.Handled = true;
 
         if (!CanMix(ent.AsNullable(), ent))
             return;
-
-        if (_net.IsServer) // Cannot cancel predicted audio.
-            ent.Comp.AudioStream = _audio.PlayPvs(ent.Comp.MixingSound, ent)?.Entity;
 
         var doAfterArgs = new DoAfterArgs(EntityManager,
             args.User,
@@ -62,7 +57,8 @@ public sealed partial class ReactionMixerSystem : EntitySystem
             BreakOnMove = true
         };
 
-        _doAfter.TryStartDoAfter(doAfterArgs);
+        if (_doAfter.TryStartDoAfter(doAfterArgs))
+            ent.Comp.AudioStream = _audio.PlayPredicted(ent.Comp.MixingSound, ent, args.User)?.Entity ?? ent.Comp.AudioStream;
     }
 
     private void OnAfterInteract(Entity<ReactionMixerComponent> ent, ref AfterInteractEvent args)
@@ -73,12 +69,11 @@ public sealed partial class ReactionMixerSystem : EntitySystem
         if (!CanMix(ent.AsNullable(), args.Target.Value))
             return;
 
-        if (_net.IsServer) // Cannot cancel predicted audio.
-            ent.Comp.AudioStream = _audio.PlayPvs(ent.Comp.MixingSound, ent)?.Entity;
-
         var doAfterArgs = new DoAfterArgs(EntityManager, args.User, ent.Comp.TimeToMix, new ReactionMixDoAfterEvent(), ent, args.Target.Value, ent);
 
-        _doAfter.TryStartDoAfter(doAfterArgs);
+        if (_doAfter.TryStartDoAfter(doAfterArgs))
+            ent.Comp.AudioStream = _audio.PlayPredicted(ent.Comp.MixingSound, ent, args.User)?.Entity ?? ent.Comp.AudioStream;
+
         args.Handled = true;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made the mortar, juicer and paperfuge audio not stack endlessly if used too fast.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
KSH KSH KSHKSHKSH KSH KSH KSHKSHK KSH KSH KSHKSHK but infinitely.

## Technical details
<!-- Summary of code changes for easier review. -->
We cancel the audio in the interact event instead of only on DoAfter cancel/end.
Apparently DoAfter cancelling cannot trigger fast enough to cancel the audio if spam clicked, leading to an infinitely looping mess.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/5ccd65b1-4b04-493a-a55b-c7f14a39b4d6

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Audio for mortars, juicers and the paperfuge can no longer be stacked infinitely.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
