### PR TITLE
add wood-coal convertion to an ore proceser

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -592,6 +592,7 @@
       whitelist:
         tags:
           - Ore
+          - RawMaterial
     - type: Lathe
       idleState: icon
       runningState: building

--- a/Resources/Prototypes/Recipes/Lathes/Packs/ore.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/ore.yml
@@ -11,6 +11,7 @@
   - IngotSilver1
   - MaterialBananium1
   - MaterialDiamond
+  - Coal
 
 - type: latheRecipePack
   id: RGlassSmelting

--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -1,3 +1,10 @@
+- type: latheRecipe #yes it's not sheet but it's atleast have some logic to be here
+  id: Coal
+  result: Coal1
+  completetime: 0
+  materials:
+    Wood: 200
+
 - type: latheRecipe
   id: SheetSteel
   result: SheetSteel1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ore proceser now can smelt wood to a coal

## Why / Balance
it's will be useful as an alternative surce of coal, becouse right now it's only posible to get coal from mining ateroids.
For example it's would be useful for a chemists becouse they can get a lot of carbon, or it's will be useful if you mined a lot of ore but not much of coal, so you can't smelt all ore, but now you can craft some coal from wood and smelt all ore.

## Technical details
just few strings of yml

## Media
<img width="950" height="630" alt="Знімок екрана 2026-01-18 204248" src="https://github.com/user-attachments/assets/0856bfe2-4296-43d5-94b4-96117cb0c0fa" />

smelts 2 wood planks to one coal

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: Svetoslav228
- add: Added wood to coal convertion to an ore proceser
