### PR TITLE
Tweak traitor deception items

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -899,19 +899,6 @@
   - UplinkDeception
 
 - type: listing
-  id: UplinkUltrabrightLantern
-  name: uplink-ultrabright-lantern-name
-  description: uplink-ultrabright-lantern-desc
-  productEntity: LanternFlash
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 1
-  cost:
-    Telecrystal: 2
-  categories:
-  - UplinkDeception
-
-- type: listing
   id: UplinkBribe
   name: uplink-bribe-name
   description: uplink-bribe-desc
@@ -933,20 +920,6 @@
 #     Telecrystal: 5
 #   categories:
 #   - UplinkDeception
-
-- type: listing
-  id: UplinkDecoyKit
-  name: uplink-decoy-kit-name
-  description: uplink-decoy-kit-desc
-  icon: { sprite: /Textures/Objects/Tools/Decoys/operative_decoy.rsi, state: folded }
-  productEntity: ClothingBackpackDuffelSyndicateDecoyKitFilled
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 3
-  cost:
-    Telecrystal: 6
-  categories:
-  - UplinkDeception
 
 - type: listing
   id: UplinkSyndicateBombFake
@@ -2013,6 +1986,17 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 3
+
+- type: listing
+  id: UplinkDecoyKit
+  name: uplink-decoy-kit-name
+  description: uplink-decoy-kit-desc
+  icon: { sprite: /Textures/Objects/Tools/Decoys/operative_decoy.rsi, state: folded }
+  productEntity: ClothingBackpackDuffelSyndicateDecoyKitFilled
+  cost:
+    Telecrystal: 1
+  categories:
+  - UplinkPointless
 
 # Job Specific
 

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -70,7 +70,7 @@
     - type: Stealth
       hadOutline: true
     - type: StealthOnMove
-      passiveVisibilityRate: -0.37
+      passiveVisibilityRate: -1 # very useful for going around the station concealed, if you start jitterstrafing you get seen
       movementVisibilityRate: 0.20
 
 - type: entity


### PR DESCRIPTION
## About the PR
Tweaks some various deception items.

Ultrabright lantern has been removed.
Decoy bundle has been moved to useless and is now 1 TC.
Stealthbox has been buffed.

## Why / Balance
Traitor Workgroup has been going through each uplink category and rebalancing the uplink in order to fit specific archetypes as well as reducing bloat. Overall metas have formed and we'd like to switch things up before we take a look at improving traitor roundflow in general (better objectives and the like). The reasoning for the changes has been enumerated:

**Extra Bright Lantern (Removal)**
This one has always been a meme/gag item whose use is effectively irrelevant considering that most targets either have flash protection or unprotected targets can be easily cleaned up by nearly any traitor gun. While it is indeed a very funny item we'd rather see it only avail. through the maints loot pool.

**Decoy Bundle (Tweak)**
The decoy bundle is another meme item that's effectively useless for causing a distraction, it's just another meme item. As such we've moved it to the useless category and reduced the price down to 1 TC. More interesting mechanics involving the decoy bundle (ex. HTN hardlight nukies shooting blanks) would be highly appreciated, but for right now it's not a very convincing distraction.

**Stealthbox (Tweak)**
The stealthbox has been in a poor spot, mainly because it's not very useful in getting around the station unconcealed and it's very bulky to carry around, effectively leading to people trying it out for 2 minutes and then leaving it in maints somewhere because it isn't carryable. In general it's a bit disappointing that this isn't used for tailgating, as it's easy to spot the effect.

Our original goal was to adjust the stealth behavior so that it would completely conceal you and turn you invisible (with no distortion) when moving slow, however it can't be tweaked like that via YAML so I have instead opted to move it towards keeping you cloaked while moving so you can use it to get around the station/maints concealed at a reasonable speed. We can bring it back down if the "completely invisible" behavior is added. 

## Technical details
YAML

## Media
Did some testing. Yeah stealthbox is pretty powerful now but I think it's fine since you can still see it.


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- remove: Extra-bright lantern has been removed from the traitor uplink.
- tweak: Stealthbox has been buffed significantly, you'll be able to remain in stealth for much longer when moving at speed.
- tweak: Decoy bundle has been moved to the Useless category and reduced to 1 TC in the traitor uplink.
