### PR TITLE
Thieving beacons automatically set coordinates when unfolded.

### DIFF
--- a/Content.Shared/Thief/Systems/ThiefBeaconSystem.cs
+++ b/Content.Shared/Thief/Systems/ThiefBeaconSystem.cs
@@ -57,6 +57,15 @@ public sealed class ThiefBeaconSystem : EntitySystem
     {
         if (args.IsFolded)
             ClearCoordinate(beacon, args.User);
+
+        if (!args.IsFolded) // Set the beacon's coordinates automatically when its unfolded
+        {
+            if (args.User == null)
+                return;
+            var mind = _mind.GetMind(args.User.Value);
+            if (mind != null)
+                SetCoordinate(beacon, mind.Value, args.User);
+        }
     }
 
     private void OnExamined(Entity<ThiefBeaconComponent> beacon, ref ExaminedEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When Thieving Beacons are unfolded, they automatically set their coordinates.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Requiring an extra action to set coordinates adds nothing meaningful to the Thief experience, and only serves as a noob trap. This will prevent new or forgetful players from putting in the effort to steal things, only to fail their objective due to not pressing that specific button.

## Technical details
<!-- Summary of code changes for easier review. -->
Within ThiefBeaconSystem, calls SetCoordinate in OnFolded

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/0510cde6-9be0-4b0c-a0c9-7ec6381e53d1


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Thieving Beacons set their coordinates automatically when unfolded.
