### PR TITLE
Allow RCDs be refilled with materials

### DIFF
--- a/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.RCD.Components;
+using Content.Shared.Stacks;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.RCD.Systems;
@@ -13,6 +14,7 @@ public sealed class RCDAmmoSystem : EntitySystem
     [Dependency] private readonly SharedChargesSystem _sharedCharges = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedStackSystem _stack = default!;
 
     public override void Initialize()
     {
@@ -27,7 +29,7 @@ public sealed class RCDAmmoSystem : EntitySystem
         if (!args.IsInDetailsRange)
             return;
 
-        var examineMessage = Loc.GetString("rcd-ammo-component-on-examine", ("charges", comp.Charges));
+        var examineMessage = Loc.GetString("rcd-ammo-component-on-examine", ("charges", comp.Charges * _stack.GetCount(uid)));
         args.PushText(examineMessage);
     }
 
@@ -45,6 +47,7 @@ public sealed class RCDAmmoSystem : EntitySystem
         var user = args.User;
         args.Handled = true;
         var count = Math.Min(charges.MaxCharges - current, comp.Charges);
+
         if (count <= 0)
         {
             _popup.PopupClient(Loc.GetString("rcd-ammo-component-after-interact-full"), target, user);
@@ -53,7 +56,8 @@ public sealed class RCDAmmoSystem : EntitySystem
 
         _popup.PopupClient(Loc.GetString("rcd-ammo-component-after-interact-refilled"), target, user);
         _sharedCharges.AddCharges(target, count);
-        comp.Charges -= count;
+        if (!_stack.TryUse(uid, count / comp.Charges))
+            comp.Charges -= count;
         Dirty(uid, comp);
 
         // prevent having useless ammo with 0 charges

--- a/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
@@ -46,7 +46,7 @@ public sealed class RCDAmmoSystem : EntitySystem
         var current = _sharedCharges.GetCurrentCharges((target, charges));
         var user = args.User;
         args.Handled = true;
-        var count = Math.Min(charges.MaxCharges - current, comp.Charges);
+        var count = Math.Min(charges.MaxCharges - current, comp.Charges * _stack.GetCount(uid));
 
         if (count <= 0)
         {
@@ -62,6 +62,6 @@ public sealed class RCDAmmoSystem : EntitySystem
 
         // prevent having useless ammo with 0 charges
         if (comp.Charges <= 0)
-            QueueDel(uid);
+            PredictedQueueDel(uid);
     }
 }

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -48,7 +48,7 @@ public sealed class FloorTileSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<FloorTileComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<FloorTileComponent, AfterInteractEvent>(OnAfterInteract, after: [typeof(RCDAmmoSystem)]);
     }
 
     private void OnAfterInteract(EntityUid uid, FloorTileComponent component, AfterInteractEvent args)

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -48,7 +48,7 @@ public sealed class FloorTileSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<FloorTileComponent, AfterInteractEvent>(OnAfterInteract, after: [typeof(RCDAmmoSystem)]);
+        SubscribeLocalEvent<FloorTileComponent, AfterInteractEvent>(OnAfterInteract);
     }
 
     private void OnAfterInteract(EntityUid uid, FloorTileComponent component, AfterInteractEvent args)

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Maps;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
+using Content.Shared.RCD.Systems;
 using Content.Shared.Stacks;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -47,7 +48,7 @@ public sealed class FloorTileSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<FloorTileComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<FloorTileComponent, AfterInteractEvent>(OnAfterInteract, after: [typeof(RCDAmmoSystem)]);
     }
 
     private void OnAfterInteract(EntityUid uid, FloorTileComponent component, AfterInteractEvent args)

--- a/Resources/Locale/en-US/rcd/components/rcd-ammo-component.ftl
+++ b/Resources/Locale/en-US/rcd/components/rcd-ammo-component.ftl
@@ -1,3 +1,3 @@
-rcd-ammo-component-on-examine = It holds {$charges} charges.
+rcd-ammo-component-on-examine = It can be inserted into RCD to get {$charges}.
 rcd-ammo-component-after-interact-full = The RCD is full!
 rcd-ammo-component-after-interact-refilled = You refill the RCD.

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -49,6 +49,8 @@
     solutions:
       glass:
         canReact: false
+  - type: RCDAmmo
+    charges: 1
 
 - type: entity
   parent: SheetGlassBase

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -34,6 +34,8 @@
   - type: GuideHelp
     guides:
     - ExpandingRepairingStation
+  - type: RCDAmmo
+    charges: 1
 
 - type: entity
   parent: SheetMetalBase

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -80,6 +80,8 @@
   - type: DeleteOnTrigger
   - type: StaticPrice
     price: 0
+  - type: RCDAmmo
+    charges: 1
 
 - type: entity
   parent: ShardBase


### PR DESCRIPTION
## About the PR
RCD now can be filled up with steel, glass and shards

## Why / Balance
https://forum.spacestation14.com/t/place-of-rcd/26082/2
So. There is two different opinions, I don't really understand what to do.
I have test branch with shitty-realization of the material based RCD in my wizden fork - RCDTest, but its requires some work. 

## Technical details
Floor tile system forces entity to be used as tile first, so I added after to them until fix

## Media
https://github.com/user-attachments/assets/b381a93f-3d89-4799-ae02-33fd94b7474c
Stack system mispredicts a little, so, it causes issues with entity deletion.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- add: RCDs now can be filled up with steel, glass and shards.