### PR TITLE
Buff blue pumpkin.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -2580,14 +2580,18 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 55
         reagents:
         - ReagentId: Ammonia
           Quantity: 10
         - ReagentId: Chlorine
           Quantity: 5
+        - ReagentId: Nutriment
+          Quantity: 10
         - ReagentId: Vitamin
           Quantity: 10
+        - ReagentId: PumpkinFlesh
+          Quantity: 20
   - type: Extractable
     juiceSolution:
       reagents:

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -1878,6 +1878,14 @@
       Min: 1
       Max: 5
       PotencyDivisor: 5
+    PumpkinFlesh:
+      Min: 1
+      Max: 20
+      PotencyDivisor: 5
+    Nutriment:
+      Min: 1
+      Max: 10
+      PotencyDivisor: 5
     Vitamin:
       Min: 1
       Max: 10

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -1850,8 +1850,8 @@
       PotencyDivisor: 5
     Vitamin:
       Min: 1
-      Max: 5
-      PotencyDivisor: 20
+      Max: 10
+      PotencyDivisor: 7
 
 - type: seed
   id: bluePumpkin
@@ -1870,6 +1870,14 @@
   idealHeat: 288
   growthStages: 3
   chemicals:
+    Nutriment:
+      Min: 2
+      Max: 10
+      PotencyDivisor: 10
+    Vitamin:
+      Min: 1
+      Max: 10
+      PotencyDivisor: 7
     Ammonia:
       Min: 1
       Max: 15
@@ -1882,14 +1890,6 @@
       Min: 1
       Max: 20
       PotencyDivisor: 5
-    Nutriment:
-      Min: 1
-      Max: 10
-      PotencyDivisor: 5
-    Vitamin:
-      Min: 1
-      Max: 10
-      PotencyDivisor: 3
 
 - type: seed
   id: cotton


### PR DESCRIPTION
## About the PR
Buffs the **blue pumpkin** to make it useful.

Changes:
- Now blue pumpkin contain more **Nutriment/Biomass** than apples (3u at potency 10 | 7u at potency 50), as well as **Pumpkin Flesh** (same amount as regular pumpkin).

## Why / Balance
Blue pumpkins are currently never used. This change aims to give them a clear niche without breaking existing botany meta.

**Main use-cases:**
1. **High biomass production**  
   High-potency blue pumpkins become a very strong alternative to apples/bungo for biogenerator fuel. 
2. **Plant treatment**  
   When used with Dylovene (to neutralize toxins from chlorine), blue pumpkin provides excellent healing (31hp ≈ 3u cryoxadone), restores nutrients, removes weeds (thanks to chlorine) and accelerates growth when combined with Diethylamine (produced from ethanol + ammonia from the pumpkin itself).
3. **Interesting production chain**  
   → Transfer tower cap genes → mutate to blue pumpkin  
   → Use for biomass / plant treatment 
   → Mixing in a tray ethanol from biogenerator + ammonia from pumpkin→ Diethylamine

**Balance considerations:**
- Blue pumpkin requires **mutation** to blue variant **and** ideally **tower cap gene transfer**
- For plant treatment, it is necessary to combine with Dylovene to neutralize chlorine toxins, which is why cocoa/apples and cryoxadone retain their niches.
- For pure biomass farming apples remain more convenient (no mutation and crossbreeding needed)
- However, if genes from such a blue pumpkin are transferred to any perennial plant or a perennial mutation is obtained, it will undoubtedly surpass apples (7 vs 6 biomass).
- Overall impact: **small positive shift** for dedicated botanists; creates fun synergy without making any path overpowered


## Technical details
- YAML-only change, no C# modifications

## Media
https://github.com/user-attachments/assets/64937527-68e3-44c2-afc8-9a69fbeff773

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.  
Purely additive.

**Changelog**
:cl:
- tweak: Added high nutriment content and pumpkin flesh to blue pumpkin reagents.
upd1 (pumpkin and blue pumpkin change):
  - The amount of vitamins in a regular pumpkin has been increased (3u → 8u at potency 50), as blue pumpkins inherit them. The amount of nutriment of blue pumpkin were balanced (10u → 7u at potency 50)

