### PR TITLE
Inflatable inflation

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -39,6 +39,13 @@
         - id: ClothingEyesHudSyndicate
 
 - type: entityTable
+  id: FillEmergencyInflatables
+  table: !type:AllSelector
+    children:
+    - id: InflatableWallStack5
+    - id: InflatableDoorStack1
+
+- type: entityTable
   id: FillLockerEmergencyStandard
   table: !type:AllSelector
     children:
@@ -56,6 +63,8 @@
       prob: 0.1
     - id: BoxMRE
       prob: 0.1
+    - !type:NestedSelector
+      tableId: FillEmergencyInflatables
 
 - type: entity
   id: ClosetEmergencyFilledRandom
@@ -92,6 +101,8 @@
       - id: EmergencyNitrogenTankFilled
         weight: 4
       - id: NitrogenTankFilled
+    - !type:NestedSelector
+      tableId: FillEmergencyInflatables
 
 - type: entity
   id: ClosetEmergencyN2FilledRandom


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Inflatables are now provided in emergency O2/N2 lockers.

## Why / Balance
Despite inflatables being the "makeshift crew" option for dealing with spacing, they aren't actually that available to crew.
This remedies that.

## Technical details
- new table, add to fills

## Media
<img width="410" height="354" alt="Bildschirmfoto 2026-01-20 um 2 32 07 AM" src="https://github.com/user-attachments/assets/43f0ec75-9f6e-4da7-a866-21f54642f6a8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Inflatables can now be sourced from emergency lockers.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
