### PR TITLE
Fix MagicMirror UI

### DIFF
--- a/Content.Client/MagicMirror/MagicMirrorBoundUserInterface.cs
+++ b/Content.Client/MagicMirror/MagicMirrorBoundUserInterface.cs
@@ -20,6 +20,9 @@ public sealed class MagicMirrorBoundUserInterface : BoundUserInterface
         base.Open();
 
         _window = this.CreateWindow<MagicMirrorWindow>();
+
+        _window.Title = EntMan.GetComponent<MetaDataComponent>(Owner).EntityName;
+
         _window.MarkingsPicker.SetModel(_markingsModel);
 
         _markingsModel.MarkingsChanged += (_, _) =>

--- a/Content.Client/MagicMirror/MagicMirrorWindow.xaml
+++ b/Content.Client/MagicMirror/MagicMirrorWindow.xaml
@@ -1,6 +1,5 @@
 <DefaultWindow xmlns="https://spacestation14.io"
                xmlns:humanoid="clr-namespace:Content.Client.Humanoid"
-               Title="{Loc 'magic-mirror-window-title'}"
                MinSize="700 500">
    <humanoid:MarkingPicker Name="MarkingsPicker" Access="Public" HorizontalExpand="True" VerticalExpand="True" />
 </DefaultWindow>

--- a/Content.Shared/MagicMirror/MagicMirrorSystem.cs
+++ b/Content.Shared/MagicMirror/MagicMirrorSystem.cs
@@ -142,6 +142,9 @@ public sealed class MagicMirrorSystem : EntitySystem
         if (!args.CanReach || args.Target == null)
             return;
 
+        if (!HasComp<VisualBodyComponent>(args.Target.Value))
+            return;
+
         UpdateInterface(mirror, args.Target.Value);
         _userInterface.TryOpenUi(mirror.Owner, MagicMirrorUiKey.Key, args.User);
     }

--- a/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
+++ b/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
@@ -1,6 +1,5 @@
 magic-mirror-component-activate-user-has-no-hair = You can't have any hair!
 
-magic-mirror-window-title = Magic Mirror
 magic-mirror-add-slot-self = You're giving yourself some hair.
 magic-mirror-remove-slot-self = You're removing some of your hair.
 magic-mirror-change-slot-self = You're changing your hairstyle.


### PR DESCRIPTION
Recreated PR (original: #42336) because silly me messed up the branch

## About the PR
This PR fixes two problems:

1) The scissors UI has an incorrect "Magic Mirror" title. This is because the scissors use the `MagicMirror` UI, which always has the same title.
Now it uses the entity name as its title.

2) The client tries to open the `MagicMirror` UI for entities without the `VisualBody` component, which causes the UI to open and then close quickly.
Just added a check for the presence of a component.

## Why / Balance
Bugfix.
Resolves https://github.com/space-wizards/space-station-14/issues/41430


## Media
Using a mirror
<img width="698" height="495" alt="1" src="https://github.com/user-attachments/assets/d6f83c42-c214-4fb3-be8b-bb8f86169c72" />


Using scissors
<img width="698" height="495" alt="2" src="https://github.com/user-attachments/assets/3163647c-7d69-471b-937a-3261191d5c39" />



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl: B_Kirill
- tweak: Hair styling tools, such as mirrors and scissors, now use their own names as UI window titles.
- fix: Hair styling tools, such as mirrors and scissors, no longer attempt to open UI on non-humanoids.
