### PR TITLE
Control Entity keybind

### DIFF
--- a/Content.Client/Gameplay/GameplayStateBase.cs
+++ b/Content.Client/Gameplay/GameplayStateBase.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using Content.Client.Clickable;
 using Content.Client.UserInterface;
 using Content.Client.Viewport;
+using Content.Shared.Administration.Events;
 using Content.Shared.CCVar;
 using Content.Shared.Input;
 using Robust.Client.ComponentTrees;
@@ -88,6 +89,7 @@ namespace Content.Client.Gameplay
                 .Bind(ContentKeyFunctions.InspectEntity, new PointerInputCmdHandler(HandleInspect, outsidePrediction: true))
                 .Bind(ContentKeyFunctions.InspectServerComponent, new PointerInputCmdHandler(HandleInspectServerComponent, outsidePrediction: true))
                 .Bind(ContentKeyFunctions.InspectClientComponent, new PointerInputCmdHandler(HandleInspectClientComponent, outsidePrediction: true))
+                .Bind(ContentKeyFunctions.ControlEntity, new PointerInputCmdHandler(HandleControl, outsidePrediction: true))
                 .Register<GameplayStateBase>();
         }
 
@@ -101,6 +103,13 @@ namespace Content.Client.Gameplay
         private bool HandleInspect(ICommonSession? session, EntityCoordinates coords, EntityUid uid)
         {
             _conHost.ExecuteCommand($"vv /c/enthover");
+            return true;
+        }
+
+        private bool HandleControl(ICommonSession? session, EntityCoordinates coords, EntityUid uid)
+        {
+            var target = _entityManager.GetNetEntity(uid);
+            _entityManager.RaisePredictiveEvent(new DebugControlEntityEvent(target));
             return true;
         }
 
@@ -268,3 +277,4 @@ namespace Content.Client.Gameplay
         }
     }
 }
+

--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -40,6 +40,7 @@ namespace Content.Client.Input
             common.AddFunction(ContentKeyFunctions.InspectEntity);
             common.AddFunction(ContentKeyFunctions.InspectServerComponent);
             common.AddFunction(ContentKeyFunctions.InspectClientComponent);
+            common.AddFunction(ContentKeyFunctions.ControlEntity);
             common.AddFunction(ContentKeyFunctions.ToggleRoundEndSummaryWindow);
 
             // Not in engine, because engine cannot check for sanbox/admin status before starting placement.

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -270,6 +270,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.InspectEntity);
             AddButton(ContentKeyFunctions.InspectServerComponent);
             AddButton(ContentKeyFunctions.InspectClientComponent);
+            AddButton(ContentKeyFunctions.ControlEntity);
 
             AddHeader("ui-options-header-text-cursor");
             AddButton(EngineKeyFunctions.TextCursorLeft);

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Administration.Logs;
 using Content.Server.GameTicking;
 using Content.Server.Ghost;
+using Content.Shared.Administration.Events;
 using Content.Shared.Database;
 using Content.Shared.Ghost;
 using Content.Shared.Mind;
@@ -12,6 +13,7 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 using System.Diagnostics.CodeAnalysis;
+
 
 namespace Content.Server.Mind;
 
@@ -30,6 +32,22 @@ public sealed class MindSystem : SharedMindSystem
 
         SubscribeLocalEvent<MindContainerComponent, EntityTerminatingEvent>(OnMindContainerTerminating);
         SubscribeLocalEvent<MindComponent, ComponentShutdown>(OnMindShutdown);
+
+        SubscribeNetworkEvent<DebugControlEntityEvent>(OnControlEntity);
+    }
+
+    private void OnControlEntity(DebugControlEntityEvent msg, EntitySessionEventArgs args)
+    {
+        var target = GetEntity(msg.Target);
+        var user = args.SenderSession.AttachedEntity;
+
+        if (user is null)
+            return;
+
+        //TODO:ERRANT validation/admincheck
+
+        ControlMob(user.Value, target);
+
     }
 
     private void OnMindShutdown(EntityUid uid, MindComponent mind, ComponentShutdown args)

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -179,12 +179,18 @@ public sealed class MindSystem : SharedMindSystem
 
         if (owned.HasValue)
         {
-            _adminLogger.Add(LogType.Mind, LogImpact.Low,
+            _adminLogger.Add(
+                LogType.Mind,
+                LogImpact.Low,
                 $"{session.Name} returned to {ToPrettyString(owned.Value)}");
         }
     }
 
-    public override void TransferTo(EntityUid mindId, EntityUid? entity, bool ghostCheckOverride = false, bool createGhost = true,
+    public override void TransferTo(
+        EntityUid mindId,
+        EntityUid? entity,
+        bool ghostCheckOverride = false,
+        bool createGhost = true,
         MindComponent? mind = null)
     {
         if (mind == null && !Resolve(mindId, ref mind))

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -43,12 +43,7 @@ public sealed class MindSystem : SharedMindSystem
         var target = GetEntity(msg.Target);
         var user = session.AttachedEntity;
 
-        if (user is null)
-            return;
-
-        // This is mainly here to filter out if there was no actual target, aka Entity 0
-        // There are probably more elegant ways to filter this on the client, but doing it here is safer
-        if (!HasComp<MetaDataComponent>(target))
+        if (user is null || !target.IsValid())
             return;
 
         if (!_admin.IsAdmin(session))

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -46,6 +46,11 @@ public sealed class MindSystem : SharedMindSystem
         if (user is null)
             return;
 
+        // This is mainly here to filter out if there was no actual target, aka Entity 0
+        // There are probably more elegant ways to filter this on the client, but doing it here is safer
+        if (!HasComp<MetaDataComponent>(target))
+            return;
+
         if (!_admin.IsAdmin(session))
             return;
 

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -14,7 +14,6 @@ using Robust.Shared.Player;
 using Robust.Shared.Utility;
 using System.Diagnostics.CodeAnalysis;
 
-
 namespace Content.Server.Mind;
 
 public sealed class MindSystem : SharedMindSystem

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Administration.Logs;
+using Content.Server.Administration.Managers;
 using Content.Server.GameTicking;
 using Content.Server.Ghost;
 using Content.Shared.Administration.Events;
@@ -18,6 +19,7 @@ namespace Content.Server.Mind;
 
 public sealed class MindSystem : SharedMindSystem
 {
+    [Dependency] private readonly IAdminManager _admin = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IPlayerManager _players = default!;
@@ -37,16 +39,17 @@ public sealed class MindSystem : SharedMindSystem
 
     private void OnControlEntity(DebugControlEntityEvent msg, EntitySessionEventArgs args)
     {
+        var session = args.SenderSession;
         var target = GetEntity(msg.Target);
-        var user = args.SenderSession.AttachedEntity;
+        var user = session.AttachedEntity;
 
         if (user is null)
             return;
 
-        //TODO:ERRANT validation/admincheck
+        if (!_admin.IsAdmin(session))
+            return;
 
         ControlMob(user.Value, target);
-
     }
 
     private void OnMindShutdown(EntityUid uid, MindComponent mind, ComponentShutdown args)

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Administration;
 
 namespace Content.Server.Mind;
 
@@ -39,14 +40,13 @@ public sealed class MindSystem : SharedMindSystem
 
     private void OnControlEntity(DebugControlEntityEvent msg, EntitySessionEventArgs args)
     {
-        var session = args.SenderSession;
+        var user = args.SenderSession.AttachedEntity;
         var target = GetEntity(msg.Target);
-        var user = session.AttachedEntity;
 
         if (user is null || !target.IsValid())
             return;
 
-        if (!_admin.IsAdmin(session))
+        if (!_admin.HasAdminFlag(user.Value, AdminFlags.Debug))
             return;
 
         ControlMob(user.Value, target);

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -28,6 +28,8 @@ public sealed class MindSystem : SharedMindSystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly PvsOverrideSystem _pvsOverride = default!;
 
+    private const AdminFlags DebugControlFlags = AdminFlags.Admin | AdminFlags.Debug | AdminFlags.Fun;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -46,7 +48,7 @@ public sealed class MindSystem : SharedMindSystem
         if (user is null || !target.IsValid())
             return;
 
-        if (!_admin.HasAdminFlag(user.Value, AdminFlags.Debug))
+        if (!_admin.HasAdminFlag(user.Value, DebugControlFlags))
             return;
 
         ControlMob(user.Value, target);

--- a/Content.Shared/Administration/Events/DebugControlEntityEvent.cs
+++ b/Content.Shared/Administration/Events/DebugControlEntityEvent.cs
@@ -1,0 +1,15 @@
+﻿using Robust.Shared.Serialization;
+
+namespace Content.Shared.Administration.Events;
+
+/// <summary>
+/// Event raised to indicate that the player wants to take direct control of a different entity.
+/// </summary>
+/// <remarks>This is only to be used for certain kinds of debug, as it breaks some expectations regarding minds
+/// (it retains the current one, even when targeting a ghostrole's mob)</remarks>
+/// <param name="target">The entity that the player is trying to control</param>
+[NetSerializable, Serializable]
+public sealed class DebugControlEntityEvent(NetEntity target) : EntityEventArgs
+{
+    public NetEntity Target = target;
+}

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -125,6 +125,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction InspectEntity = "InspectEntity";
         public static readonly BoundKeyFunction InspectServerComponent = "InspectServerComponent";
         public static readonly BoundKeyFunction InspectClientComponent = "InspectClientComponent";
+        public static readonly BoundKeyFunction ControlEntity = "ControlEntity";
         public static readonly BoundKeyFunction MappingUnselect = "MappingUnselect";
         public static readonly BoundKeyFunction SaveMap = "SaveMap";
         public static readonly BoundKeyFunction MappingEnablePick = "MappingEnablePick";

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -232,6 +232,8 @@ ui-options-function-inspect-server-component = Inspect Server Component
 ui-options-function-inspect-server-component-tooltip = Open a ViewVariables window with the server component set by the "quickinspect" command for the entity your mouse is currently hovering over.
 ui-options-function-inspect-client-component = Inspect Client Component
 ui-options-function-inspect-client-component-tooltip = Open a ViewVariables window with the client component set by the "quickinspect" command for the entity your mouse is currently hovering over.
+ui-options-function-control-entity = Control Entity
+ui-options-function-control-entity-tooltip = Immediately take control of the entity your mouse is currently hovering over, granting it sentience in the process.
 ui-options-function-hide-ui = Hide UI
 
 ui-options-function-hotbar1 = Hotbar slot 1

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -289,6 +289,10 @@ binds:
   type: State
   key: c
   mod1: Alt
+- function: ControlEntity
+  type: State
+  key: N
+  mod1: Alt
 - function: MouseMiddle
   type: State
   key: MouseMiddle


### PR DESCRIPTION
## About the PR
Add keybind for the Control Entity verb, allowing it to be used as easily as Inspect Entity

Does not require, but benefits from #42525

## Why / Balance
I use it fairly often while testing certain changes/fixes/features, would be neat if it took less UI interactions to do it

## Technical details
Keybind raises a network event. The server takes the target from the event, but the user is derived from the client session, to remove the possibility of a modified client trolling another player. Admin status is checked before executing the transfer of control.

Because the client will report "entity 0" as the target if there was no entity under the mouse, the server checks the reported target for the presence of a MetaDataComponent to make sure the reported target is actually a real thing. There might be a more proper way to ensure this, I am open to suggestions. But it works

## Media

<img width="2414" height="732" alt="Screenshot_2026-01-19_162320" src="https://github.com/user-attachments/assets/ddc6af00-52cf-4fa4-b96a-8211217a5523" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
I don't think one is necessary, this is not player facing, and while admins can use it, I don't imagine they often do. This is primarily for debugging
