### PR TITLE
Firelock nerf

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -34,7 +34,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 500
+          damage: 75
         behaviors:
         - !type:DoActsBehavior
           acts: ["Destruction"]

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/frame.yml
@@ -33,7 +33,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 500
+        damage: 75
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]


### PR DESCRIPTION
## About the PR
Significantly reduced firelock health from 500 to 75.

## Why / Balance
Firelocks have been identified as comically tanky, even moreso than stuff like solid steel walls. They will still be extremely difficult to break without active, constant effort, but now a desperate nukie or traitor can realistically chew through one in a couple of esword swings instead of clawing helplessly at the red door of doom. 

## Technical details
yaml

## Media
line changes, not needed.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
:cl:
- tweak: Significantly reduced the health of firelocks. 

