### PR TITLE
Add `OccursDuringRoundEnd` as an `EntityTableCondition`

### DIFF
--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -81,10 +81,4 @@ public sealed partial class StationEventComponent : Component
     [DataField("endTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoPausedField]
     public TimeSpan? EndTime;
-
-    /// <summary>
-    /// If false, the event won't trigger during ongoing evacuation.
-    /// </summary>
-    [DataField]
-    public bool OccursDuringRoundEnd = true;
 }

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -20,7 +20,6 @@ public sealed class EventManagerSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly EntityTableSystem _entityTable = default!;
     [Dependency] public readonly GameTicker GameTicker = default!;
-    [Dependency] private readonly RoundEndSystem _roundEnd = default!;
 
     public bool EventsEnabled { get; private set; }
     private void SetEnabled(bool value) => EventsEnabled = value;
@@ -268,11 +267,6 @@ public sealed class EventManagerSystem : EntitySystem
         var lastRun = TimeSinceLastEvent(prototype);
         if (lastRun != TimeSpan.Zero && currentTime.TotalMinutes <
             stationEvent.ReoccurrenceDelay + lastRun.TotalMinutes)
-        {
-            return false;
-        }
-
-        if (_roundEnd.IsRoundEndRequested() && !stationEvent.OccursDuringRoundEnd)
         {
             return false;
         }

--- a/Content.Shared/EntityTable/Conditions/OccursDuringRoundEndCondition.cs
+++ b/Content.Shared/EntityTable/Conditions/OccursDuringRoundEndCondition.cs
@@ -1,0 +1,27 @@
+using Content.Shared.EntityTable.EntitySelectors;
+using Content.Shared.RoundEnd;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.EntityTable.Conditions;
+
+public sealed partial class OccursDuringRoundEndCondition : EntityTableCondition
+{
+    /// <summary>
+    /// If false, the event won't trigger during ongoing evacuation.
+    /// </summary>
+    [DataField]
+    public bool OccursDuringRoundEnd = true;
+
+    private static SharedRoundEndSystem? _sharedRoundEnd;
+
+    protected override bool EvaluateImplementation(
+        EntityTableSelector root,
+        IEntityManager entMan,
+        IPrototypeManager proto,
+        EntityTableContext ctx)
+    {
+        _sharedRoundEnd ??= IoCManager.Resolve<SharedRoundEndSystem>();
+
+        return OccursDuringRoundEnd || !_sharedRoundEnd.IsRoundEndRequested();
+    }
+}

--- a/Content.Shared/EntityTable/Conditions/OccursDuringRoundEndCondition.cs
+++ b/Content.Shared/EntityTable/Conditions/OccursDuringRoundEndCondition.cs
@@ -20,7 +20,7 @@ public sealed partial class OccursDuringRoundEndCondition : EntityTableCondition
         IPrototypeManager proto,
         EntityTableContext ctx)
     {
-        _sharedRoundEnd ??= IoCManager.Resolve<SharedRoundEndSystem>();
+        _sharedRoundEnd ??= entMan.System<SharedRoundEndSystem>();
 
         return OccursDuringRoundEnd || !_sharedRoundEnd.IsRoundEndRequested();
     }

--- a/Content.Shared/RoundEnd/SharedRoundEndSystem.cs
+++ b/Content.Shared/RoundEnd/SharedRoundEndSystem.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+
+namespace Content.Shared.RoundEnd
+{
+    public abstract class SharedRoundEndSystem : EntitySystem
+    {
+        private CancellationTokenSource? _roundEndCountdownTokenSource = null;
+
+        public void CancelCountdown()
+        {
+            if (_roundEndCountdownTokenSource != null)
+            {
+                _roundEndCountdownTokenSource.Cancel();
+                _roundEndCountdownTokenSource = null;
+            }
+        }
+
+        public CancellationTokenSource GetOrStartCountdown()
+        {
+            if (_roundEndCountdownTokenSource == null)
+            {
+                _roundEndCountdownTokenSource = new();
+            }
+            return _roundEndCountdownTokenSource;
+        }
+
+        public bool IsRoundEndRequested()
+        {
+            return _roundEndCountdownTokenSource != null;
+        }
+    }
+}

--- a/Content.Shared/RoundEnd/SharedRoundEndSystem.cs
+++ b/Content.Shared/RoundEnd/SharedRoundEndSystem.cs
@@ -4,29 +4,6 @@ namespace Content.Shared.RoundEnd
 {
     public abstract class SharedRoundEndSystem : EntitySystem
     {
-        private CancellationTokenSource? _roundEndCountdownTokenSource = null;
-
-        public void CancelCountdown()
-        {
-            if (_roundEndCountdownTokenSource != null)
-            {
-                _roundEndCountdownTokenSource.Cancel();
-                _roundEndCountdownTokenSource = null;
-            }
-        }
-
-        public CancellationTokenSource GetOrStartCountdown()
-        {
-            if (_roundEndCountdownTokenSource == null)
-            {
-                _roundEndCountdownTokenSource = new();
-            }
-            return _roundEndCountdownTokenSource;
-        }
-
-        public bool IsRoundEndRequested()
-        {
-            return _roundEndCountdownTokenSource != null;
-        }
+        public abstract bool IsRoundEndRequested();
     }
 }

--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -66,6 +66,8 @@
         - id: SleeperAgents
           weight: 15
           conditions:
+          - !type:OccursDuringRoundEndCondition
+            occursDuringRoundEnd: false
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
           - !type:RoundDurationCondition
@@ -95,6 +97,8 @@
         - id: ZombieOutbreak
           weight: 2.5
           conditions:
+          - !type:OccursDuringRoundEndCondition
+            occursDuringRoundEnd: false
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -43,7 +43,13 @@
     - id: NinjaSpawn
     - id: ParadoxCloneSpawn
     - id: SleeperAgents
+      conditions:
+        - !type:OccursDuringRoundEndCondition
+          occursDuringRoundEnd: false
     - id: ZombieOutbreak
+      conditions:
+        - !type:OccursDuringRoundEndCondition
+          occursDuringRoundEnd: false
     - id: LoneOpsSpawn
     - id: WizardSpawn
     - !type:NestedSelector
@@ -532,7 +538,6 @@
     minimumPlayers: 40
     weight: 1 # Zombies was happening basically every single survival round, so now it's super rare
     duration: 1
-    occursDuringRoundEnd: false
   - type: ZombieRule
   - type: AntagSelection
     definitions:
@@ -610,7 +615,6 @@
     startAudio:
       path: /Audio/Announcements/intercept.ogg
     duration: null # the rule has to last the whole round not 1 second
-    occursDuringRoundEnd: false
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     definitions:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a new entity table condition called `OccursDuringRoundEndCondition`, meant to replace the functionality of the equivalent field in `StationEventComponent`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Part of #36782. Pretty much all the selection logic-related fields in the component can be moved to entity tables now, since this was the last missing condition.

## Technical details
<!-- Summary of code changes for easier review. -->
Created `SharedRoundEndSystem` in `Content.Shared` and made the existing `RoundEndSystem` in `Content.Server` inherit from it. This is to make the `IsRoundEndRequested` function accessible to `Content.Shared` so entity table conditions can use it. The existing function in the server code is now an implementation of the shared function.

The two station events that made use of this field, `SleeperAgents` and `ZombieOutbreak`, were modified to use the new entity table condition instead.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

### Before

<details>
<summary>Theoretical event probabilities, evac shuttle not called</summary>
<pre>
[INFO] CON: > stationevent:lsprobtheoretical BasicStationEventScheduler 40 90
[INFO] CON: (AnomalySpawn, 0.04040404),
(BluespaceArtifact, 0.04040404),
(BluespaceLocker, 0.01010101),
(BreakerFlip, 0.035353534),
(BureaucraticError, 0.015151516),
(ClericalError, 0.025252525),
(CockroachMigration, 0.030303031),
(GasLeak, 0.04040404),
(GreytideVirus, 0.025252525),
(IonStorm, 0.04040404),
(KudzuGrowth, 0.035353534),
(MassHallucinations, 0.035353534),
(MimicVendorRule, 0.025252525),
(MouseMigration, 0.030303031),
(PowerGridCheck, 0.025252525),
(RandomSentience, 0.030303031),
(SlimesSpawn, 0.025252525),
(SolarFlare, 0.04040404),
(SnakeSpawn, 0.025252525),
(SpiderClownSpawn, 0.007575758),
(SpiderSpawn, 0.025252525),
(VentClog, 0.025252525),
(ClosetSkeleton, 0.025252525),
(KingRatMigration, 0.030303031),
(RevenantSpawn, 0.03787879),
(DerelictGenericCyborgSpawn, 0.012626262),
(DragonSpawn, 0.032828283),
(NinjaSpawn, 0.030303031),
(ParadoxCloneSpawn, 0.025252525),
<strong>(SleeperAgents, 0.04040404),</strong>
<strong>(ZombieOutbreak, 0.005050505),</strong>
(LoneOpsSpawn, 0.027777778),
(WizardSpawn, 0.005050505),
(DerelictMiningCyborgSpawn, 0.012626262),
(GiftsSpacingSupplies, 0.02020202),
(SnailMigrationLowPop, 0.030303031),
(SnailMigration, 0.030303031)
</pre>
</details>

<details>
<summary>Theoretical event probabilities, evac shuttle is called</summary>
<pre>
[INFO] CON: > stationevent:lsprobtheoretical BasicStationEventScheduler 40 90
[INFO] CON: (AnomalySpawn, 0.04232804),
(BluespaceArtifact, 0.04232804),
(BluespaceLocker, 0.01058201),
(BreakerFlip, 0.037037037),
(BureaucraticError, 0.015873017),
(ClericalError, 0.026455026),
(CockroachMigration, 0.031746034),
(GasLeak, 0.04232804),
(GreytideVirus, 0.026455026),
(IonStorm, 0.04232804),
(KudzuGrowth, 0.037037037),
(MassHallucinations, 0.037037037),
(MimicVendorRule, 0.026455026),
(MouseMigration, 0.031746034),
(PowerGridCheck, 0.026455026),
(RandomSentience, 0.031746034),
(SlimesSpawn, 0.026455026),
(SolarFlare, 0.04232804),
(SnakeSpawn, 0.026455026),
(SpiderClownSpawn, 0.007936508),
(SpiderSpawn, 0.026455026),
(VentClog, 0.026455026),
(ClosetSkeleton, 0.026455026),
(KingRatMigration, 0.031746034),
(RevenantSpawn, 0.03968254),
(DerelictEngineerCyborgSpawn, 0.013227513),
(DragonSpawn, 0.034391534),
(NinjaSpawn, 0.031746034),
(ParadoxCloneSpawn, 0.026455026),
(LoneOpsSpawn, 0.02910053),
(WizardSpawn, 0.005291005),
(DerelictMiningCyborgSpawn, 0.013227513),
(GiftsVendingRestock, 0.02116402),
(SnailMigrationLowPop, 0.031746034),
(SnailMigration, 0.031746034)
</pre>
</details>

### After

YAML prototypes for `ZombieOutbreak` and `SleeperAgents` were modified to move the appropriate logic to entity table conditions.

<details>
<summary>Theoretical event probabilities, evac shuttle not called</summary>
<pre>
[INFO] CON: > stationevent:lsprobtheoretical BasicStationEventScheduler 40 90
[INFO] CON: (AnomalySpawn, 0.041237112),
(BluespaceArtifact, 0.041237112),
(BluespaceLocker, 0.010309278),
(BreakerFlip, 0.036082473),
(BureaucraticError, 0.0154639175),
(ClericalError, 0.025773196),
(CockroachMigration, 0.030927835),
(GasLeak, 0.041237112),
(GreytideVirus, 0.025773196),
(IonStorm, 0.041237112),
(KudzuGrowth, 0.036082473),
(MassHallucinations, 0.036082473),
(MimicVendorRule, 0.025773196),
(MouseMigration, 0.030927835),
(PowerGridCheck, 0.025773196),
(RandomSentience, 0.030927835),
(SlimesSpawn, 0.025773196),
(SolarFlare, 0.041237112),
(SnakeSpawn, 0.025773196),
(SpiderClownSpawn, 0.0077319588),
(SpiderSpawn, 0.025773196),
(VentClog, 0.025773196),
(ClosetSkeleton, 0.025773196),
(KingRatMigration, 0.030927835),
(RevenantSpawn, 0.038659792),
(DerelictSyndicateAssaultCyborgSpawn, 0.012886598),
(DragonSpawn, 0.033505153),
(NinjaSpawn, 0.030927835),
(ParadoxCloneSpawn, 0.025773196),
<strong>(SleeperAgents, 0.041237112),</strong>
<strong>(ZombieOutbreak, 0.005154639),</strong>
(LoneOpsSpawn, 0.028350515),
(WizardSpawn, 0.005154639),
(DerelictMedicalCyborgSpawn, 0.012886598),
(SnailMigrationLowPop, 0.030927835),
(SnailMigration, 0.030927835)
</pre>
</details>

<details>
<summary>Theoretical event probabilities, evac shuttle is called</summary>
<pre>
[INFO] CON: > stationevent:lsprobtheoretical BasicStationEventScheduler 40 90
[INFO] CON: (AnomalySpawn, 0.043360434),
(BluespaceArtifact, 0.043360434),
(BluespaceLocker, 0.010840109),
(BreakerFlip, 0.03794038),
(BureaucraticError, 0.016260162),
(ClericalError, 0.02710027),
(CockroachMigration, 0.032520324),
(GasLeak, 0.043360434),
(GreytideVirus, 0.02710027),
(IonStorm, 0.043360434),
(KudzuGrowth, 0.03794038),
(MassHallucinations, 0.03794038),
(MimicVendorRule, 0.02710027),
(MouseMigration, 0.032520324),
(PowerGridCheck, 0.02710027),
(RandomSentience, 0.032520324),
(SlimesSpawn, 0.02710027),
(SolarFlare, 0.043360434),
(SnakeSpawn, 0.02710027),
(SpiderClownSpawn, 0.008130081),
(SpiderSpawn, 0.02710027),
(VentClog, 0.02710027),
(ClosetSkeleton, 0.02710027),
(KingRatMigration, 0.032520324),
(RevenantSpawn, 0.040650405),
(DerelictEngineerCyborgSpawn, 0.013550135),
(DragonSpawn, 0.035230353),
(NinjaSpawn, 0.032520324),
(ParadoxCloneSpawn, 0.02710027),
(LoneOpsSpawn, 0.029810298),
(WizardSpawn, 0.0054200543),
(GiftsPizzaPartyLarge, 0.010840109),
(SnailMigrationLowPop, 0.032520324),
(SnailMigration, 0.032520324)
</pre>
</details>

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
The `occursDuringRoundEnd` field has been removed from `StationEventComponent`. Use the newly added `OccursDuringRoundEndCondition` instead.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
