### PR TITLE
Added Insulated Components to RK and Servants.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -291,7 +291,7 @@
       - FootstepSound
   - type: NoSlip
   - type: Insulated
-    coefficient: 0.2 # he don't make da roolz, but he sneaky
+    coefficient: 0.2 # they don't make da roolz, but they sneaky
   - type: MobPrice
     price: 500 # rat wealth
   - type: MobsterAccent


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Resolves #41987.
Partially improves #41984 

## About the PR
Rat King has been given a significant buff, and has had the `Insulated` component added to its entity to mitigate the effect of stuns from shocks.

Having run through some testing, the impact of these changes becomes a significant balance shift in favor of the Rat King, explained below.

## Why / Balance
To my recollection, Rat Kings were recently transitioned from a "Free Agent" to an "Antagonist", without much of a change in their abilities.
Now that Rat King is Kill on Sight as opposed to having their threat evaluated, a further advantage might be needed to make them a little more threatening.

This PR was created to resolve an issue above, which was created as a result of a round where Rat King stunlocked and killed by an AI who weaponized Electrified Airlocks.

### Changes
This change will ensure AI can contribute to the effort to contain them which will be visible to the AI player, but no longer can fully stop them on their own.

Rat Kings will take 2 HP Shock damage on entering a tile containing an electrified airlock.
Rat Servants will take 1 HP Shock damage under the same conditions.

> Admittedly, it could be argued that Servants should not have a larger buff, and RK takes a risk by running out of a door to attack a dept (Risk of electrocution), but I wanted to see how this would land for balance, we could adjust it later if they get too powerful like this.


This natural insulation means that Rat Kings can also damage wires and lights effectively:

- Breaking a light: 10 HP per hit (10 damage per light).
- Damaging LV wires: 2 HP per hit (10 damage per destroyed wire).
- Damaging MV wires: 5 HP per hit (25 damage per destroyed wire).
- Damaging HV wires: 8 HP per hit (40 damage per destroyed wire).

> A counter-argument here against is that Rat Kings are now able to Singuloose/Tesloose.
> It's fair to say that this might increase Admin workload in the short term if Rat Kings decide to loose, but I feel that this would be a pretty clear 2.9 violation if they did so. Keen to hear discussion on it if the Admins feel like this might factor in.


### Balance

This change gives Rat Kings more effective strategies for distraction in order to help with their objective. As a few examples:
- Disable power for security department, while we go raid the kitchen.
- Darken the power to arrivals by killing lights, so we can then freely snack on the vending machines until we can kill the chef.

In addition, being able to disable doors by cutting wires also allows the Rat King to make a hideout and securely dump ammonia in a domain at which they can heal.

This should put the onus on Security to search and destroy in Maints if a Rat King is good at their job.

I wanted to note that this does **not** impact:
 - Stun Baton interactions
 - Taser interactions
 - Disablers

Sec still can use all the tools at their disposal to make the Rat King follow da roolz.

### Author's note
As an addendum, the only other thing I'd love to see with this antagonist is the addition of night vision, but that's well outside the scope of this PR.

## Technical details
`Resources\Prototypes\Entities\Mobs\NPCs\regalrat.yml`
Added Insulated components to:
`MobRatKing`
```
  - type: Insulated
    coefficient: 0.5
```
0.5 was chosen as it was the middle ground between maximum damage while overriding the stun threshold.

`MobRatServant`
```
  - type: Insulated
    coefficient: 0.2
```
0.2 was chosen to reduce the damage to 1, as the servant will crit at 15 damage.

No changes needed for `MobRatKingBuff` as it inherits from the changes to `MobRatKing`.

## Media

https://github.com/user-attachments/assets/2f1b1882-00dd-4674-a9ab-7855be964acc

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Rat King and Rat Servants now have partial shock resistance, preventing electrified doors from stunning them while still dealing reduced damage.