### PR TITLE
Make hostile turrets take structural damage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
@@ -73,6 +73,8 @@
   - type: NpcFactionMember
     factions:
     - SimpleHostile
+  - type: Damageable
+    damageContainer: StructuralInorganic
 
 - type: entity
   parent: BaseWeaponBallisticTurret
@@ -82,6 +84,8 @@
   - type: NpcFactionMember
     factions:
     - AllHostile
+  - type: Damageable
+    damageContainer: StructuralInorganic
 
 - type: entity
   parent: BaseWeaponBallisticTurret

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
@@ -33,7 +33,7 @@
   - type: CombatMode
     toggleMouseRotator: false
   - type: Damageable
-    damageContainer: StructuralInorganic
+    damageContainer: Inorganic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
@@ -33,7 +33,7 @@
   - type: CombatMode
     toggleMouseRotator: false
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
## About the PR
Makes hostile space turrets take structural damage because they didn't before

## Why / Balance
There's a lot of magnet pull and random spawn wrecks with turrets on the outside of them, and some with rooms that are just packed with turrets as well. This should help mitigate the issue of salvagers or anyone in space just dying the moment they get near or enter wrecks.

## Technical details
Damage container change

## Media
<img width="708" height="459" alt="image" src="https://github.com/user-attachments/assets/f3d13f4e-168b-45c2-99e5-e4eaffc7c1e7" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Turrets now take structural damage
