### PR TITLE
Ensure cat ears & tails cannot be selected by players

### DIFF
--- a/Content.Client/Humanoid/MarkingsViewModel.cs
+++ b/Content.Client/Humanoid/MarkingsViewModel.cs
@@ -325,7 +325,7 @@ public sealed class MarkingsViewModel
     public void GetMarkingCounts(ProtoId<OrganCategoryPrototype> organ, HumanoidVisualLayers layer, out bool isRequired, out int count, out int selected)
     {
         isRequired = false;
-        count = 0;
+        count = -1;
         selected = 0;
 
         if (!_organData.TryGetValue(organ, out var organData))

--- a/Resources/Locale/en-US/preferences/ui/markings-picker.ftl
+++ b/Resources/Locale/en-US/preferences/ui/markings-picker.ftl
@@ -6,12 +6,14 @@ markings-search = Search
 }
 markings-limits = { $required ->
     [true] { $count ->
-        [0] Select at least one marking.
+        [-1] Select at least one marking.
+        [0] You cannot select any markings, but somehow, you have to? This is a bug.
         [one] Select one marking.
        *[other] Select at least one marking and up to {$count} markings. { -markings-selection(selectable: $selectable) }
     }
    *[false] { $count ->
-        [0] Select any number of markings.
+        [-1] Select any number of markings.
+        [0] You cannot select any markings.
         [one] Select up to one marking.
        *[other] Select up to {$count} markings. { -markings-selection(selectable: $selectable) }
     }

--- a/Resources/Prototypes/Body/Species/human.yml
+++ b/Resources/Prototypes/Body/Species/human.yml
@@ -38,6 +38,12 @@
     enum.HumanoidVisualLayers.RFoot:
       limit: 1
       required: false
+    enum.HumanoidVisualLayers.Tail:
+      limit: 0
+      required: false
+    enum.HumanoidVisualLayers.Special:
+      limit: 0
+      required: false
 
 - type: entity
   parent: BaseSpeciesAppearance

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -44,6 +44,7 @@
       - Overlay
       - UndergarmentTop
       - UndergarmentBottom
+      - Special
 
 - type: entity
   parent: OrganBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- ensure cat ears and tails cannot be selected

## Why / Balance
- not intended

## Technical details
- rejiggle some strings to better indicate unselectable markings
- disallow their selection

## Media
<img width="1295" height="724" alt="Bildschirmfoto 2026-01-21 um 9 13 25 PM" src="https://github.com/user-attachments/assets/b05af44c-ffc2-411a-8faf-bb144c23ccfb" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Cat tails are no longer accessible to humans.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
