### PR TITLE
Fixes grappling hook audio infinitely looping

### DIFF
--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -173,10 +173,11 @@ public abstract class SharedGrapplingGunSystem : VirtualController
         if (value)
         {
             // We null-coalesce here because playing the sound again will cause it to become eternally stuck playing
-            component.Stream = _audio.PlayPredicted(component.ReelSound, uid, user)?.Entity ?? component.Stream;
+            component.Stream ??= _audio.PlayPredicted(component.ReelSound, uid, user)?.Entity;
         }
-        else if (!value && component.Stream.HasValue)
+        else if (!value && component.Stream.HasValue && Timing.IsFirstTimePredicted)
         {
+            // The IsFirstTimePredicted check is important here because otherwise component.Stream will be set to null from an early cancellation if this isn't FirstTimePredicted
             component.Stream = _audio.Stop(component.Stream);
         }
 


### PR DESCRIPTION
## About the PR
This fixes a regression with the grappling hook audio by selectively reverting part of commit [3a314d4](https://github.com/space-wizards/space-station-14/commit/3a314d400e186fe7f8a1880573fbe5ccef91fa05)

## Why / Balance
Being able to make unmutable noise machines is bad!

## Technical details
The commit kinda trampled over the way the grappling hook's stream was managed. This reintroduced the bug allowing the grappling hook audio to permanently loop, and the reason for this is twofold.

By inverting the null-coalescence when playing the audio, the stream gets overridden by that freshly-playing audio without actually disposing of the currently-playing sound.

Additionally, by removing the `.IsFirstTimePredicted` check for `.Stop()`, the stream can get set to null if the codepath is run outside of first-time prediction (as `.Stop()` returns null if it cancels out-- this leads to `.Stream` getting set to null when it shouldn't be if it ends up mispredicting).

Reverting both of these changes fixes the infinite audio looping bug.

## Media
(turn audio on for both of these)
BEFORE

https://github.com/user-attachments/assets/bb82e20f-23ba-41ac-8a7f-0ca2443f8f57


AFTER

https://github.com/user-attachments/assets/37936265-f17d-4b5a-b23f-f8d7df4a0787


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
N/A

**Changelog**
N/A; this is a very minute bugfix and we're not sure if it's been encountered on Vulture yet