### PR TITLE
Add an option for hold-to-attack in settings

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -20,8 +20,6 @@
                     Example="{Loc 'ui-options-highlights-color-example'}"/>
                 <Label Text="{Loc 'ui-options-accessability-header-content'}"
                        StyleClasses="LabelKeyText"/>
-                <CheckBox Name="HoldToAttackMeleeCheckBox" Text="{Loc 'ui-options-hold-to-attack-melee'}" />
-                <CheckBox Name="HoldToAttackRangedCheckBox" Text="{Loc 'ui-options-hold-to-attack-ranged'}" />
                 <CheckBox Name="CensorNudityCheckBox" Text="{Loc 'ui-options-censor-nudity'}" />
             </BoxContainer>
         </ScrollContainer>

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -23,8 +23,6 @@ public sealed partial class AccessibilityTab : Control
         Control.AddOptionCheckBox(CCVars.ChatAutoFillHighlights, AutoFillHighlightsCheckBox);
         Control.AddOptionColorSlider(CCVars.ChatHighlightsColor, HighlightsColorSlider);
 
-        Control.AddOptionCheckBox(CCVars.AccessibilityHoldToAttackMelee, HoldToAttackMeleeCheckBox);
-        Control.AddOptionCheckBox(CCVars.AccessibilityHoldToAttackRanged, HoldToAttackRangedCheckBox);
         Control.AddOptionCheckBox(CCVars.AccessibilityClientCensorNudity, CensorNudityCheckBox);
 
         Control.Initialize();

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -36,12 +36,6 @@ namespace Content.Client.Options.UI.Tabs
 
         private readonly List<Action> _deferCommands = new();
 
-        private void HandleToggleUSQWERTYCheckbox(BaseButton.ButtonToggledEventArgs args)
-        {
-            _cfg.SetCVar(CVars.DisplayUSQWERTYHotkeys, args.Pressed);
-            _cfg.SaveToFile();
-        }
-
         private void InitToggleWalk()
         {
             if (_cfg.GetCVar(CCVars.ToggleWalk))
@@ -150,8 +144,23 @@ namespace Content.Client.Options.UI.Tabs
                 KeybindsContainer.AddChild(newCheckBox);
             }
 
+            void AddToggleCvarCheckBox(string checkBoxName, CVarDef<bool> cvar)
+            {
+                CheckBox newCheckBox = new CheckBox() { Text = Loc.GetString(checkBoxName) };
+                newCheckBox.Pressed = _cfg.GetCVar(cvar);
+                newCheckBox.OnToggled += (e) =>
+                {
+                    _cfg.SetCVar(cvar, e.Pressed);
+                    _cfg.SaveToFile();
+                };
+
+                KeybindsContainer.AddChild(newCheckBox);
+            }
+
             AddHeader("ui-options-header-general");
-            AddCheckBox("ui-options-hotkey-keymap", _cfg.GetCVar(CVars.DisplayUSQWERTYHotkeys), HandleToggleUSQWERTYCheckbox);
+            AddToggleCvarCheckBox("ui-options-hotkey-keymap", CVars.DisplayUSQWERTYHotkeys);
+            AddToggleCvarCheckBox("ui-options-hold-to-attack-melee", CCVars.ControlHoldToAttackMelee);
+            AddToggleCvarCheckBox("ui-options-hold-to-attack-ranged", CCVars.ControlHoldToAttackRanged);
 
             AddHeader("ui-options-header-movement");
             AddButton(EngineKeyFunctions.MoveUp);

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -79,7 +79,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         var useDown = _inputSystem.CmdStates.GetState(EngineKeyFunctions.Use);
         var altDown = _inputSystem.CmdStates.GetState(EngineKeyFunctions.UseSecondary);
 
-        if (weapon.AutoAttack || useDown != BoundKeyState.Down && altDown != BoundKeyState.Down || _cfg.GetCVar(CCVars.AccessibilityHoldToAttackMelee))
+        if (weapon.AutoAttack || useDown != BoundKeyState.Down && altDown != BoundKeyState.Down || _cfg.GetCVar(CCVars.ControlHoldToAttackMelee))
         {
             if (weapon.Attacking)
             {

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -212,7 +212,7 @@ public sealed partial class GunSystem : SharedGunSystem
             Target = target,
             Coordinates = GetNetCoordinates(coordinates),
             Gun = GetNetEntity(gun),
-            Continuous = _cfg.GetCVar(CCVars.AccessibilityHoldToAttackRanged),
+            Continuous = _cfg.GetCVar(CCVars.ControlHoldToAttackRanged),
         });
     }
 

--- a/Content.Shared/CCVar/CCVars.Accessibility.cs
+++ b/Content.Shared/CCVar/CCVars.Accessibility.cs
@@ -61,18 +61,6 @@ public sealed partial class CCVars
         CVarDef.Create("accessibility.speech_bubble_background_opacity", 0.75f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /// <summary>
-    ///     If enabled, melee weapons that have click-to-attack patterns (unarmed, slow weapons) will continue attacking if the button is held.
-    /// </summary>
-    public static readonly CVarDef<bool> AccessibilityHoldToAttackMelee =
-        CVarDef.Create("accessibility.hold_to_attack_melee", false, CVar.CLIENTONLY | CVar.ARCHIVE);
-
-    /// <summary>
-    ///     If enabled, ranged weapons that have click-to-attack patterns (burst and semi-auto guns) will continue attacking if the button is held.
-    /// </summary>
-    public static readonly CVarDef<bool> AccessibilityHoldToAttackRanged =
-        CVarDef.Create("accessibility.hold_to_attack_ranged", false, CVar.CLIENTONLY | CVar.ARCHIVE);
-
-    /// <summary>
     /// If enabled, censors character nudity by forcing clothes markings on characters, selected by the client.
     /// Both this and AccessibilityServerCensorNudity must be false to display nudity on the client.
     /// </summary>

--- a/Content.Shared/CCVar/CCVars.Interactions.cs
+++ b/Content.Shared/CCVar/CCVars.Interactions.cs
@@ -70,4 +70,17 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> NestedStorage =
         CVarDef.Create("control.nested_storage", true, CVar.REPLICATED | CVar.SERVER);
+
+    /// <summary>
+    ///     If enabled, melee weapons that have click-to-attack patterns (unarmed, slow weapons) will continue attacking if the button is held.
+    /// </summary>
+    public static readonly CVarDef<bool> ControlHoldToAttackMelee =
+        CVarDef.Create("control.hold_to_attack_melee", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    ///     If enabled, ranged weapons that have click-to-attack patterns (burst and semi-auto guns) will continue attacking if the button is held.
+    /// </summary>
+    public static readonly CVarDef<bool> ControlHoldToAttackRanged =
+        CVarDef.Create("control.hold_to_attack_ranged", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
 }

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -108,6 +108,9 @@ ui-options-hud-layout = HUD layout:
 
 ## Controls menu
 
+ui-options-hold-to-attack-melee = Hold to attack (melee)
+ui-options-hold-to-attack-ranged = Hold to attack (ranged)
+
 ui-options-binds-reset-all = Reset ALL keybinds
 ui-options-binds-explanation = Click to change binding, right-click to clear
 ui-options-unbound = Unbound
@@ -369,9 +372,6 @@ ui-options-chat-window-opacity = Chat window opacity
 ui-options-speech-bubble-text-opacity = Speech bubble text opacity
 ui-options-speech-bubble-speaker-opacity = Speech bubble speaker opacity
 ui-options-speech-bubble-background-opacity = Speech bubble background opacity
-
-ui-options-hold-to-attack-melee = Hold to attack (melee)
-ui-options-hold-to-attack-ranged = Hold to attack (ranged)
 
 ui-options-censor-nudity = Censor character nudity
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds two options under the accessibility tab named "Hold to attack (melee)" and "Hold to attack (ranged)". When checked, any attack (unarmed/melee or ranged) will continuously fire if the attack button is held down.

Fixes #42573

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This is an accessibility feature to reduce RSI strain. While I could've gone for simply removing the single-click feature altogether, I feel that it does provide some tactile feedback and may be a desirable option for some players. Even with this feature in place, weapons should be balanced such that utilizing them doesn't put heavy demands on the user's input. 

While it does make certain things redundant (such as making semi-auto equivalent to full-auto) I still feel it's fine to support both modes. 

## Technical details
<!-- Summary of code changes for easier review. -->

For melee attacks, every swing attempt is sent from the client so that's a simple || check. 

For ranged, it's a little bit more complicated. To ensure semi-auto/burst don't continuously fire, the code has a reset event for whenever the user lets go of the attack button, setting `ShotsFired` to 0. Since the button won't be let go of in this case, we simply opt to reset the `ShotsFired` counter after each shot. Full-auto does something similar by simply not incrementing the `ShotsFired` value. 

I removed the unique `HandleToggleUSQWERTYCheckbox(BaseButton.ButtonToggledEventArgs args)` in favor of a general toggle solution `AddToggleCvarCheckBox`.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="1099" height="736" alt="image" src="https://github.com/user-attachments/assets/6cfc1635-1415-4f84-9164-b5ebc43fbbfe" />

NOTE: Video uses an old build with ranged/melee options merged

https://github.com/user-attachments/assets/bbdaa18a-d743-41e4-aa0c-b646b8965485

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added an toggle for "hold-to-attack" under the accessibility tab.