### PR TITLE
Elkridge - EVA Storage tweaks + Library/Newsroom airlock updates

### DIFF
--- a/Resources/Maps/elkridge.yml
+++ b/Resources/Maps/elkridge.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 271.1.0
   forkId: ""
   forkVersion: ""
-  time: 01/23/2026 14:21:26
-  entityCount: 18708
+  time: 01/23/2026 16:18:13
+  entityCount: 18710
 maps:
 - 1
 grids:
@@ -9430,20 +9430,16 @@ entities:
             2: 2184
           4,-8:
             2: 8738
-            4: 8
-            3: 2176
+            3: 2184
           3,-8:
             0: 35727
           4,-7:
             2: 14
-            0: 1568
-            5: 34816
+            0: 36384
           3,-7:
             0: 15167
           4,-6:
-            0: 61287
-            6: 8
-            5: 128
+            0: 61423
           3,-6:
             0: 52294
           4,-9:
@@ -9454,34 +9450,20 @@ entities:
             2: 34952
           5,-7:
             2: 15
-            7: 256
-            8: 4096
-            9: 512
-            5: 59392
-            10: 1024
+            0: 65280
           5,-6:
-            11: 1
-            5: 16946
-            0: 46468
-            7: 2120
+            0: 65535
           5,-9:
             2: 36616
             3: 131
           6,-7:
-            5: 1286
-            10: 8704
-            11: 4096
-            0: 51432
+            0: 65518
           6,-6:
-            0: 65485
-            5: 48
-            7: 2
+            0: 65535
           6,-5:
             2: 4080
           6,-8:
-            0: 42666
-            10: 4
-            5: 16448
+            0: 59118
           6,-9:
             0: 61166
           7,-8:
@@ -9516,7 +9498,7 @@ entities:
             0: 65520
           10,-9:
             0: 16384
-            12: 1
+            6: 1
             2: 2444
             3: 1600
           11,-7:
@@ -9888,7 +9870,7 @@ entities:
           4,-10:
             3: 793
             2: 8226
-            13: 2048
+            4: 2048
           4,-13:
             3: 4369
             2: 17508
@@ -9897,7 +9879,7 @@ entities:
             3: 36096
           5,-10:
             3: 2051
-            13: 768
+            4: 768
             2: 32904
           5,-12:
             2: 40960
@@ -9921,8 +9903,7 @@ entities:
           7,-13:
             2: 5372
           8,-12:
-            14: 1
-            3: 272
+            3: 273
             2: 52428
           8,-11:
             2: 143
@@ -10129,17 +10110,17 @@ entities:
           9,-10:
             2: 4113
             3: 268
-            15: 3072
+            5: 3072
           9,-9:
             2: 1025
             3: 2832
-            12: 12
+            6: 12
           10,-11:
             2: 295
             3: 17920
           10,-10:
             3: 1025
-            15: 256
+            5: 256
             2: 18508
           10,-12:
             2: 8192
@@ -10765,58 +10746,17 @@ entities:
           temperature: 293.15
           moles: {}
         - volume: 2500
-          temperature: 166.07811
-          moles: {}
-        - volume: 2500
-          temperature: 293.14987
-          moles:
-            Oxygen: 21.824879
-            Nitrogen: 82.10312
-        - volume: 2500
-          temperature: 293.14996
-          moles:
-            Oxygen: 21.824879
-            Nitrogen: 82.10312
-        - volume: 2500
-          temperature: 293.14993
-          moles:
-            Oxygen: 21.824879
-            Nitrogen: 82.10312
-        - volume: 2500
-          temperature: 293.1497
-          moles:
-            Oxygen: 21.824879
-            Nitrogen: 82.10312
-        - volume: 2500
-          temperature: 293.14972
-          moles:
-            Oxygen: 21.824879
-            Nitrogen: 82.10312
-        - volume: 2500
-          temperature: 293.14975
-          moles:
-            Oxygen: 21.824879
-            Nitrogen: 82.10312
-        - volume: 2500
-          temperature: 293.1498
-          moles:
-            Oxygen: 21.824879
-            Nitrogen: 82.10312
-        - volume: 2500
-          temperature: 293.15
-          moles:
-            Nitrogen: 6666.982
-        - volume: 2500
           temperature: 293.15
           moles:
             Plasma: 6666.982
         - volume: 2500
-          temperature: 220.53748
-          moles: {}
-        - volume: 2500
           temperature: 293.15
           moles:
             Oxygen: 6666.982
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Nitrogen: 6666.982
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
@@ -13654,15 +13594,6 @@ entities:
     - type: Transform
       pos: -19.5,-1.5
       parent: 2
-  - uid: 18606
-    components:
-    - type: MetaData
-      name: glass airlock (EVA)
-    - type: Transform
-      pos: -18.5,-8.5
-      parent: 2
-    - type: AccessReader
-      accessListsOriginal: []
 - proto: AirlockExternalGlass
   entities:
   - uid: 5137
@@ -124746,6 +124677,20 @@ entities:
       rot: 3.141592653589793 rad
       pos: 23.5,-10.5
       parent: 2
+- proto: WindoorSecureEVALocked
+  entities:
+  - uid: 18606
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,-10.5
+      parent: 2
+  - uid: 18709
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,-10.5
+      parent: 2
 - proto: WindoorSecureHeadOfPersonnelLocked
   entities:
   - uid: 2732
@@ -125690,6 +125635,12 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-38.5
+      parent: 2
+  - uid: 18710
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,-10.5
       parent: 2
 - proto: WoodblockInstrument
   entities:

--- a/Resources/Maps/elkridge.yml
+++ b/Resources/Maps/elkridge.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 268.0.0
+  engineVersion: 271.1.0
   forkId: ""
   forkVersion: ""
-  time: 12/07/2025 22:51:59
+  time: 01/23/2026 14:21:26
   entityCount: 18708
 maps:
 - 1
@@ -10822,6 +10822,8 @@ entities:
     - type: RadiationGridResistance
     - type: ImplicitRoof
     - type: ExplosionAirtightGrid
+    - type: TileHistory
+      chunkHistory: {}
 - proto: AcousticGuitarInstrument
   entities:
   - uid: 15607
@@ -13643,6 +13645,8 @@ entities:
     - type: Transform
       pos: -18.5,-1.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal: []
   - uid: 15548
     components:
     - type: MetaData
@@ -13657,6 +13661,8 @@ entities:
     - type: Transform
       pos: -18.5,-8.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal: []
 - proto: AirlockExternalGlass
   entities:
   - uid: 5137
@@ -14332,6 +14338,8 @@ entities:
     - type: Transform
       pos: -29.5,-34.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal: []
   - uid: 12004
     components:
     - type: Transform
@@ -14472,6 +14480,15 @@ entities:
     - type: Transform
       pos: -21.5,-40.5
       parent: 2
+- proto: AirlockLibraryLocked
+  entities:
+  - uid: 3184
+    components:
+    - type: MetaData
+      name: airlock (Library)
+    - type: Transform
+      pos: -21.5,-26.5
+      parent: 2
 - proto: AirlockMaintBarLocked
   entities:
   - uid: 38
@@ -14581,6 +14598,17 @@ entities:
     - type: Transform
       pos: -21.5,-44.5
       parent: 2
+- proto: AirlockMaintLibraryLocked
+  entities:
+  - uid: 3122
+    components:
+    - type: MetaData
+      name: maintenance access (Library)
+    - type: Transform
+      pos: -25.5,-26.5
+      parent: 2
+    - type: AccessReader
+      accessListsOriginal: []
 - proto: AirlockMaintLocked
   entities:
   - uid: 692
@@ -14788,6 +14816,8 @@ entities:
     - type: Transform
       pos: -26.5,-20.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal: []
   - uid: 9962
     components:
     - type: MetaData
@@ -14845,6 +14875,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5,-8.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal: []
   - uid: 15764
     components:
     - type: Transform
@@ -14936,6 +14968,24 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 44.5,14.5
       parent: 2
+- proto: AirlockMaintNewsroomLocked
+  entities:
+  - uid: 3126
+    components:
+    - type: MetaData
+      name: maintenance access (Newsroom)
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -27.5,-29.5
+      parent: 2
+  - uid: 3129
+    components:
+    - type: MetaData
+      name: maintenance access (Newsroom)
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -27.5,-32.5
+      parent: 2
 - proto: AirlockMaintRnDLocked
   entities:
   - uid: 11229
@@ -14984,29 +15034,6 @@ entities:
       name: airlock (Security)
     - type: Transform
       pos: -6.5,-36.5
-      parent: 2
-- proto: AirlockMaintServiceLocked
-  entities:
-  - uid: 3126
-    components:
-    - type: MetaData
-      name: maintenance access (Library)
-    - type: Transform
-      pos: -25.5,-26.5
-      parent: 2
-  - uid: 3184
-    components:
-    - type: MetaData
-      name: maintenance access (Newsroom)
-    - type: Transform
-      pos: -27.5,-32.5
-      parent: 2
-  - uid: 3189
-    components:
-    - type: MetaData
-      name: maintenance access (Newsroom)
-    - type: Transform
-      pos: -27.5,-29.5
       parent: 2
 - proto: AirlockMaintTheatreLocked
   entities:
@@ -15108,6 +15135,18 @@ entities:
     - type: Transform
       pos: 40.5,10.5
       parent: 2
+- proto: AirlockNewsroomGlassLocked
+  entities:
+  - uid: 3183
+    components:
+    - type: MetaData
+      name: glass airlock (Newsroom)
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -26.5,-34.5
+      parent: 2
+    - type: AccessReader
+      accessListsOriginal: []
 - proto: AirlockQuartermasterLocked
   entities:
   - uid: 1564
@@ -15354,24 +15393,8 @@ entities:
     - type: Transform
       pos: -2.5,-34.5
       parent: 2
-- proto: AirlockServiceGlassLocked
-  entities:
-  - uid: 3183
-    components:
-    - type: MetaData
-      name: glass airlock (Newsroom)
-    - type: Transform
-      pos: -26.5,-34.5
-      parent: 2
 - proto: AirlockServiceLocked
   entities:
-  - uid: 3129
-    components:
-    - type: MetaData
-      name: airlock (Library)
-    - type: Transform
-      pos: -21.5,-26.5
-      parent: 2
   - uid: 14327
     components:
     - type: MetaData
@@ -22060,28 +22083,6 @@ entities:
     components:
     - type: Transform
       pos: 49.556282,3.5894375
-      parent: 2
-- proto: BaseChemistryEmptyVial
-  entities:
-  - uid: 4094
-    components:
-    - type: Transform
-      pos: 19.960098,21.84556
-      parent: 2
-  - uid: 4095
-    components:
-    - type: Transform
-      pos: 20.116348,21.62681
-      parent: 2
-  - uid: 8822
-    components:
-    - type: Transform
-      pos: 24.581747,10.684262
-      parent: 2
-  - uid: 15849
-    components:
-    - type: Transform
-      pos: 27.824532,35.632626
       parent: 2
 - proto: BaseComputerAiAccess
   entities:
@@ -51831,6 +51832,28 @@ entities:
     - type: Transform
       pos: 26.385427,37.27761
       parent: 2
+- proto: ChemistryEmptyVial
+  entities:
+  - uid: 4094
+    components:
+    - type: Transform
+      pos: 19.960098,21.84556
+      parent: 2
+  - uid: 4095
+    components:
+    - type: Transform
+      pos: 20.116348,21.62681
+      parent: 2
+  - uid: 8822
+    components:
+    - type: Transform
+      pos: 24.581747,10.684262
+      parent: 2
+  - uid: 15849
+    components:
+    - type: Transform
+      pos: 27.824532,35.632626
+      parent: 2
 - proto: ChemistryHotplate
   entities:
   - uid: 316
@@ -53014,8 +53037,8 @@ entities:
     - type: Transform
       parent: 15428
     - type: Clothing
-      inSlotFlag: HEAD
       inSlot: head
+      inSlotFlag: HEAD
     - type: Physics
       canCollide: False
 - proto: ClothingHeadHatBlacksoft
@@ -53317,8 +53340,8 @@ entities:
     - type: Transform
       parent: 15428
     - type: Clothing
-      inSlotFlag: NECK
       inSlot: neck
+      inSlotFlag: NECK
     - type: Physics
       canCollide: False
 - proto: ClothingNeckCloakTrans
@@ -54024,6 +54047,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: -22.5,-35.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - Newsroom
 - proto: ComputerMedicalRecords
   entities:
   - uid: 3908
@@ -55529,6 +55555,13 @@ entities:
     - type: Transform
       pos: 41.5,13.5
       parent: 2
+- proto: DefaultStationBeaconNewsroom
+  entities:
+  - uid: 18696
+    components:
+    - type: Transform
+      pos: -25.5,-32.5
+      parent: 2
 - proto: DefaultStationBeaconPowerBank
   entities:
   - uid: 14601
@@ -55556,13 +55589,6 @@ entities:
     components:
     - type: Transform
       pos: -19.5,25.5
-      parent: 2
-- proto: DefaultStationBeaconReporter
-  entities:
-  - uid: 18696
-    components:
-    - type: Transform
-      pos: -25.5,-32.5
       parent: 2
 - proto: DefaultStationBeaconRND
   entities:
@@ -90525,11 +90551,14 @@ entities:
   - uid: 18607
     components:
     - type: MetaData
-      name: lockable button (Emergency EVA Access)
+      name: emergency EVA Storage access
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-5.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - Command
     - type: DeviceLinkSource
       linkedPorts:
         15548:
@@ -90538,11 +90567,6 @@ entities:
         - - Pressed
           - DoorBolt
         13799:
-        - - Pressed
-          - Open
-        - - Pressed
-          - DoorBolt
-        18606:
         - - Pressed
           - Open
         - - Pressed
@@ -92533,6 +92557,11 @@ entities:
     - type: Transform
       pos: -17.5,-10.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - Atmospherics
+      - - Engineering
+      - - Research
   - uid: 5972
     components:
     - type: Transform
@@ -92721,6 +92750,11 @@ entities:
     - type: Transform
       pos: -16.5,-10.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - Atmospherics
+      - - Engineering
+      - - Research
   - uid: 6298
     components:
     - type: Transform
@@ -104025,7 +104059,7 @@ entities:
     - type: Transform
       pos: 28.5,-30.5
       parent: 2
-- proto: SpacemenFigureSpawner
+- proto: SpacemenFigurineSpawner90
   entities:
   - uid: 3089
     components:
@@ -124567,6 +124601,14 @@ entities:
       rot: 3.141592653589793 rad
       pos: 13.5,2.5
       parent: 2
+- proto: WindoorLibraryLocked
+  entities:
+  - uid: 3189
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,-24.5
+      parent: 2
 - proto: WindoorSecure
   entities:
   - uid: 1899
@@ -124875,14 +124917,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,29.5
-      parent: 2
-- proto: WindoorServiceLocked
-  entities:
-  - uid: 3122
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -18.5,-24.5
       parent: 2
 - proto: Window
   entities:

--- a/Resources/Maps/elkridge.yml
+++ b/Resources/Maps/elkridge.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 271.1.0
   forkId: ""
   forkVersion: ""
-  time: 01/23/2026 16:18:13
-  entityCount: 18710
+  time: 01/24/2026 12:36:13
+  entityCount: 18702
 maps:
 - 1
 grids:
@@ -134,7 +134,7 @@ entities:
           version: 7
         -2,-1:
           ind: -2,-1
-          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAGIAAAAAAgBiAAAAAAIAYgAAAAABAGIAAAAAAQBiAAAAAAEAYgAAAAACAGIAAAAAAgBiAAAAAAIAYgAAAAACAGIAAAAAAgBiAAAAAAAAYgAAAAABAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAAEAAAAAAAABAAAAAAAAggAAAAAAAIIAAAAAAAAgAAAAAAEAIAAAAAABACAAAAAAAgCCAAAAAAAAggAAAAAAAIIAAAAAAAAGAAAAAAEAAQAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAABiAAAAAAEAYgAAAAAAAIIAAAAAAAAgAAAAAAAAIAAAAAACACAAAAAAAwAgAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAYgAAAAADAGIAAAAAAwCCAAAAAAAAIAAAAAADACAAAAAAAAAgAAAAAAIAIAAAAAACACAAAAAAAwAgAAAAAAIAIAAAAAADACAAAAAAAwCCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAGIAAAAAAQBiAAAAAAMAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAwAgAAAAAAAAggAAAAAAAIIAAAAAAAABAAAAAAAAggAAAAAAAIIAAAAAAABiAAAAAAAAYgAAAAAAAIIAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAIAAAAAAAACAAAAAAAwAgAAAAAAEAIAAAAAADAAEAAAAAAAAgAAAAAAEAIAAAAAADACAAAAAAAwABAAAAAAAAYgAAAAAAAGIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAACAAAAAAAQAgAAAAAAEAIAAAAAACACAAAAAAAwCCAAAAAAAAIAAAAAABACAAAAAAAgAgAAAAAAIAggAAAAAAAGIAAAAAAwBiAAAAAAMAggAAAAAAAIIAAAAAAAABAAAAAAAAggAAAAAAAIIAAAAAAAAgAAAAAAEAIAAAAAABACAAAAAAAAAgAAAAAAIAAQAAAAAAACAAAAAAAgAgAAAAAAEAIAAAAAABAAEAAAAAAABiAAAAAAIAYgAAAAABAAEAAAAAAACCAAAAAAAAIAAAAAADAHAAAAAAAABwAAAAAAAAIAAAAAAAACAAAAAAAgAgAAAAAAEAIAAAAAABAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAYgAAAAABAGIAAAAAAwABAAAAAAAAggAAAAAAACAAAAAAAwCCAAAAAAAAggAAAAAAACAAAAAAAwAgAAAAAAEAIAAAAAACACAAAAAAAQCCAAAAAAAAIAAAAAACACAAAAAAAAAgAAAAAAAAggAAAAAAAGIAAAAAAABiAAAAAAEAggAAAAAAAIIAAAAAAAAgAAAAAAMAcAAAAAAAAHAAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAAABAAAAAAAAggAAAAAAACAAAAAAAwAgAAAAAAEAIAAAAAABAIIAAAAAAABiAAAAAAEAYgAAAAAAAIIAAAAAAAAgAAAAAAMAIAAAAAABAHAAAAAAAABwAAAAAAAAggAAAAAAAAIAAAAAAACCAAAAAAAABwAAAAADAH4AAAAAAwAgAAAAAAIAIAAAAAABACAAAAAAAwCCAAAAAAAAYgAAAAADAGIAAAAAAwCCAAAAAAAAIAAAAAABACAAAAAAAgCCAAAAAAAAggAAAAAAAAIAAAAAAAAAAAAAAAAAggAAAAAAAH4AAAAAAQAHAAAAAAQAIAAAAAAAACAAAAAAAAAgAAAAAAEAggAAAAAAAGIAAAAAAwBiAAAAAAMAggAAAAAAACAAAAAAAAAgAAAAAAIAcAAAAAAAAHAAAAAAAAACAAAAAAAAAgAAAAAAAIIAAAAAAAB+AAAAAAMAfgAAAAADACAAAAAAAgAgAAAAAAEAIAAAAAACAIIAAAAAAABiAAAAAAIAYgAAAAADAIIAAAAAAAABAAAAAAAAAQAAAAAAAIIAAAAAAACCAAAAAAAAAgAAAAAAAAAAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAAQAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAGIAAAAAAgBiAAAAAAIAYgAAAAABAGIAAAAAAQBiAAAAAAEAYgAAAAACAGIAAAAAAgBiAAAAAAIAYgAAAAACAGIAAAAAAgBiAAAAAAAAYgAAAAABAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAAEAAAAAAAABAAAAAAAAggAAAAAAAIIAAAAAAAAgAAAAAAEAIAAAAAABACAAAAAAAgCCAAAAAAAAggAAAAAAAIIAAAAAAAAGAAAAAAEAAQAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAABiAAAAAAEAYgAAAAAAAIIAAAAAAAAgAAAAAAAAIAAAAAACACAAAAAAAwAgAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAYgAAAAADAGIAAAAAAwCCAAAAAAAAIAAAAAADACAAAAAAAAAgAAAAAAIAIAAAAAACACAAAAAAAwAgAAAAAAIAIAAAAAADACAAAAAAAwCCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAGIAAAAAAQBiAAAAAAMAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAwAgAAAAAAAAggAAAAAAAIIAAAAAAAABAAAAAAAAggAAAAAAAIIAAAAAAABiAAAAAAAAYgAAAAAAAIIAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAIAAAAAAAACAAAAAAAwAgAAAAAAEAIAAAAAADAAEAAAAAAAAgAAAAAAEAIAAAAAADACAAAAAAAwABAAAAAAAAYgAAAAAAAGIAAAAAAACCAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAACAAAAAAAQAgAAAAAAEAIAAAAAACACAAAAAAAwCCAAAAAAAAIAAAAAABACAAAAAAAgAgAAAAAAIAggAAAAAAAGIAAAAAAwBiAAAAAAMAggAAAAAAAIIAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAAAgAAAAAAEAIAAAAAABACAAAAAAAAAgAAAAAAIAAQAAAAAAACAAAAAAAgAgAAAAAAEAIAAAAAABAAEAAAAAAABiAAAAAAIAYgAAAAABAAEAAAAAAACCAAAAAAAAIAAAAAADAHAAAAAAAABwAAAAAAAAIAAAAAAAACAAAAAAAgAgAAAAAAEAIAAAAAABAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAYgAAAAABAGIAAAAAAwABAAAAAAAAggAAAAAAACAAAAAAAwCCAAAAAAAAggAAAAAAACAAAAAAAwAgAAAAAAEAIAAAAAACACAAAAAAAQCCAAAAAAAAIAAAAAACACAAAAAAAAAgAAAAAAAAggAAAAAAAGIAAAAAAABiAAAAAAEAggAAAAAAAIIAAAAAAAAgAAAAAAMAcAAAAAAAAHAAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAAABAAAAAAAAggAAAAAAACAAAAAAAwAgAAAAAAEAIAAAAAABAIIAAAAAAABiAAAAAAEAYgAAAAAAAIIAAAAAAAAgAAAAAAMAIAAAAAABAHAAAAAAAABwAAAAAAAAggAAAAAAAAIAAAAAAACCAAAAAAAABwAAAAADAH4AAAAAAwAgAAAAAAIAIAAAAAABACAAAAAAAwCCAAAAAAAAYgAAAAADAGIAAAAAAwCCAAAAAAAAIAAAAAABACAAAAAAAgCCAAAAAAAAggAAAAAAAAIAAAAAAAAAAAAAAAAAggAAAAAAAH4AAAAAAQAHAAAAAAQAIAAAAAAAACAAAAAAAAAgAAAAAAEAggAAAAAAAGIAAAAAAwBiAAAAAAMAggAAAAAAACAAAAAAAAAgAAAAAAIAcAAAAAAAAHAAAAAAAAACAAAAAAAAAgAAAAAAAIIAAAAAAAB+AAAAAAMAfgAAAAADACAAAAAAAgAgAAAAAAEAIAAAAAACAIIAAAAAAABiAAAAAAIAYgAAAAADAIIAAAAAAAABAAAAAAAAAQAAAAAAAIIAAAAAAACCAAAAAAAAAgAAAAAAAAAAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAAQAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
           version: 7
         -2,0:
           ind: -2,0
@@ -7523,7 +7523,6 @@ entities:
             14786: 3,-33
             14893: 9,-22
             14904: 9,-17
-            14920: -19,-9
             14921: -19,-2
             14923: -13,-12
             14929: -14,-5
@@ -8129,7 +8128,6 @@ entities:
             14787: 3,-33
             14903: 9,-17
             14924: -20,-2
-            14925: -19,-9
             14926: -13,-12
             14928: -14,-5
         - node:
@@ -9166,7 +9164,7 @@ entities:
           -4,-3:
             0: 61416
           -5,-3:
-            0: 12272
+            0: 61424
           -4,-2:
             0: 20206
           -5,-2:
@@ -13043,7 +13041,6 @@ entities:
     - type: MetaData
       name: airlock (Bathroom)
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-32.5
       parent: 2
 - proto: AirlockArmoryGlassLocked
@@ -13093,7 +13090,6 @@ entities:
     - type: MetaData
       name: airlock (Bar)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-3.5
       parent: 2
   - uid: 245
@@ -13101,7 +13097,6 @@ entities:
     - type: MetaData
       name: airlock (Bar)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 2
   - uid: 5991
@@ -13109,7 +13104,6 @@ entities:
     - type: MetaData
       name: airlock (Bar)
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-7.5
       parent: 2
 - proto: AirlockBrigGlassLocked
@@ -13172,7 +13166,6 @@ entities:
     - type: MetaData
       name: airlock (Captain's Office)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-4.5
       parent: 2
   - uid: 4596
@@ -13249,7 +13242,6 @@ entities:
     - type: MetaData
       name: airlock (Chapel)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -31.5,-23.5
       parent: 2
 - proto: AirlockChemistryGlassLocked
@@ -13268,7 +13260,6 @@ entities:
     - type: MetaData
       name: airlock (Chemistry)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,14.5
       parent: 2
 - proto: AirlockChiefEngineerLocked
@@ -13278,7 +13269,6 @@ entities:
     - type: MetaData
       name: airlock (CE's Office)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 34.5,-15.5
       parent: 2
   - uid: 2523
@@ -13295,7 +13285,6 @@ entities:
     - type: MetaData
       name: airlock (CMO's Office)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,20.5
       parent: 2
   - uid: 3912
@@ -13434,7 +13423,6 @@ entities:
     - type: MetaData
       name: airlock (Central Service Substation)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-8.5
       parent: 2
   - uid: 1186
@@ -13470,7 +13458,6 @@ entities:
     - type: MetaData
       name: airlock (Engineering)
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 29.5,-6.5
       parent: 2
   - uid: 3206
@@ -13499,7 +13486,6 @@ entities:
     - type: MetaData
       name: airlock (Bridge Substation)
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -35.5,-13.5
       parent: 2
   - uid: 5476
@@ -13528,7 +13514,6 @@ entities:
     - type: MetaData
       name: airlock (Science Substation)
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,30.5
       parent: 2
   - uid: 7213
@@ -13536,7 +13521,6 @@ entities:
     - type: MetaData
       name: airlock (Arrivals Substation)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,55.5
       parent: 2
   - uid: 7712
@@ -13544,7 +13528,6 @@ entities:
     - type: MetaData
       name: airlock (North Solars)
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,29.5
       parent: 2
   - uid: 7942
@@ -13559,7 +13542,6 @@ entities:
     - type: MetaData
       name: airlock (Medical Substation)
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 43.5,19.5
       parent: 2
   - uid: 9617
@@ -14072,7 +14054,6 @@ entities:
     - type: MetaData
       name: airlock (Freezer)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,2.5
       parent: 2
 - proto: AirlockGlass
@@ -14372,7 +14353,6 @@ entities:
     - type: MetaData
       name: airlock (Botany)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,9.5
       parent: 2
 - proto: AirlockJanitorLocked
@@ -14382,7 +14362,6 @@ entities:
     - type: MetaData
       name: airlock (Janitor's Closet)
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,11.5
       parent: 2
   - uid: 423
@@ -14390,7 +14369,6 @@ entities:
     - type: MetaData
       name: airlock (Janitor's Closet)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 2
 - proto: AirlockKitchenLocked
@@ -14450,7 +14428,6 @@ entities:
     - type: MetaData
       name: maintenance access (Cargo)
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,32.5
       parent: 2
 - proto: AirlockMaintChapelLocked
@@ -14460,7 +14437,6 @@ entities:
     - type: MetaData
       name: maintenance access (Chapel)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-23.5
       parent: 2
 - proto: AirlockMaintChemLocked
@@ -14493,7 +14469,6 @@ entities:
     - type: MetaData
       name: maintenance access (Maintenance)
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,-0.5
       parent: 2
   - uid: 9757
@@ -14517,7 +14492,6 @@ entities:
     - type: MetaData
       name: maintenance access (Kitchen)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-2.5
       parent: 2
 - proto: AirlockMaintLawyerLocked
@@ -14580,13 +14554,11 @@ entities:
   - uid: 1693
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 40.5,0.5
       parent: 2
   - uid: 1803
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-15.5
       parent: 2
   - uid: 2033
@@ -14612,7 +14584,6 @@ entities:
   - uid: 3395
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -27.5,-17.5
       parent: 2
   - uid: 3458
@@ -14623,7 +14594,6 @@ entities:
   - uid: 3626
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,-33.5
       parent: 2
   - uid: 3771
@@ -14653,7 +14623,6 @@ entities:
   - uid: 4427
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-15.5
       parent: 2
   - uid: 4712
@@ -14661,13 +14630,11 @@ entities:
     - type: MetaData
       name: maintenance access
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,4.5
       parent: 2
   - uid: 4738
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,4.5
       parent: 2
   - uid: 6659
@@ -14683,7 +14650,6 @@ entities:
   - uid: 7209
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,53.5
       parent: 2
   - uid: 7505
@@ -14694,7 +14660,6 @@ entities:
   - uid: 7684
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,-11.5
       parent: 2
   - uid: 8113
@@ -14803,7 +14768,6 @@ entities:
     - type: MetaData
       name: maintenance access (Service)
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-8.5
       parent: 2
     - type: AccessReader
@@ -14896,7 +14860,6 @@ entities:
     - type: MetaData
       name: maintenance access (Morgue)
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,14.5
       parent: 2
 - proto: AirlockMaintNewsroomLocked
@@ -14906,7 +14869,6 @@ entities:
     - type: MetaData
       name: maintenance access (Newsroom)
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -27.5,-29.5
       parent: 2
   - uid: 3129
@@ -14914,7 +14876,6 @@ entities:
     - type: MetaData
       name: maintenance access (Newsroom)
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -27.5,-32.5
       parent: 2
 - proto: AirlockMaintRnDLocked
@@ -14940,7 +14901,6 @@ entities:
     - type: MetaData
       name: maintenance access (Salvage)
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,33.5
       parent: 2
 - proto: AirlockMaintSecLocked
@@ -15047,7 +15007,6 @@ entities:
     - type: MetaData
       name: airlock (Surgery)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,4.5
       parent: 2
 - proto: AirlockMedicalMorgueLocked
@@ -15340,7 +15299,6 @@ entities:
     - type: MetaData
       name: airlock (Theatre)
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 2
 - proto: AirlockTheatreLocked
@@ -15350,7 +15308,6 @@ entities:
     - type: MetaData
       name: airlock (Theatre)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,8.5
       parent: 2
 - proto: AirlockVirologyLocked
@@ -15360,7 +15317,6 @@ entities:
     - type: MetaData
       name: airlock (Virology)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,21.5
       parent: 2
     - type: DeviceLinkSink
@@ -15375,7 +15331,6 @@ entities:
     - type: MetaData
       name: airlock (Virology)
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,22.5
       parent: 2
     - type: DeviceLinkSink
@@ -15541,7 +15496,6 @@ entities:
   - uid: 7952
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,-29.5
       parent: 2
     - type: AccessReader
@@ -16174,7 +16128,6 @@ entities:
   - uid: 13521
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,-30.5
       parent: 2
     - type: DeviceNetwork
@@ -16188,7 +16141,6 @@ entities:
   - uid: 13744
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,-34.5
       parent: 2
     - type: DeviceNetwork
@@ -45920,7 +45872,6 @@ entities:
   - uid: 12718
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,0.5
       parent: 2
   - uid: 13801
@@ -45931,7 +45882,6 @@ entities:
   - uid: 14780
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,1.5
       parent: 2
   - uid: 15080
@@ -49507,11 +49457,6 @@ entities:
     - type: Transform
       pos: 35.5,-27.5
       parent: 2
-  - uid: 14477
-    components:
-    - type: Transform
-      pos: -19.5,-9.5
-      parent: 2
   - uid: 14482
     components:
     - type: Transform
@@ -49645,11 +49590,6 @@ entities:
     components:
     - type: Transform
       pos: 16.5,-59.5
-      parent: 2
-  - uid: 14583
-    components:
-    - type: Transform
-      pos: -17.5,-9.5
       parent: 2
   - uid: 14595
     components:
@@ -49857,11 +49797,6 @@ entities:
     - type: Transform
       pos: 36.5,-16.5
       parent: 2
-  - uid: 16199
-    components:
-    - type: Transform
-      pos: -18.5,-9.5
-      parent: 2
   - uid: 16204
     components:
     - type: Transform
@@ -49966,11 +49901,6 @@ entities:
     components:
     - type: Transform
       pos: -22.5,3.5
-      parent: 2
-  - uid: 16746
-    components:
-    - type: Transform
-      pos: -16.5,-9.5
       parent: 2
   - uid: 16779
     components:
@@ -53423,10 +53353,10 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingShoesBootsMag
   entities:
-  - uid: 1758
+  - uid: 1751
     components:
     - type: Transform
-      pos: -18.475437,-10.494583
+      pos: -19.522215,-9.469273
       parent: 2
   - uid: 3203
     components:
@@ -63236,7 +63166,6 @@ entities:
   - uid: 1619
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 2
     - type: DeviceNetwork
@@ -63257,37 +63186,31 @@ entities:
   - uid: 2595
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,5.5
       parent: 2
   - uid: 2601
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-45.5
       parent: 2
   - uid: 2654
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-18.5
       parent: 2
   - uid: 3169
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,31.5
       parent: 2
   - uid: 10390
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,-42.5
       parent: 2
   - uid: 10888
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,31.5
       parent: 2
     - type: DeviceNetwork
@@ -63299,7 +63222,6 @@ entities:
   - uid: 10889
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,31.5
       parent: 2
     - type: DeviceNetwork
@@ -63378,73 +63300,61 @@ entities:
   - uid: 15905
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-20.5
       parent: 2
   - uid: 15907
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-41.5
       parent: 2
   - uid: 15909
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -32.5,-13.5
       parent: 2
   - uid: 15910
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,-9.5
       parent: 2
   - uid: 15911
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,28.5
       parent: 2
   - uid: 15912
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,52.5
       parent: 2
   - uid: 15913
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,13.5
       parent: 2
   - uid: 15914
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,29.5
       parent: 2
   - uid: 15915
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 34.5,27.5
       parent: 2
   - uid: 15916
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,29.5
       parent: 2
   - uid: 15917
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 34.5,1.5
       parent: 2
   - uid: 15918
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 45.5,13.5
       parent: 2
   - uid: 16100
@@ -63455,7 +63365,6 @@ entities:
   - uid: 16468
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,16.5
       parent: 2
     - type: DeviceNetwork
@@ -63469,7 +63378,6 @@ entities:
   - uid: 16469
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,17.5
       parent: 2
     - type: DeviceNetwork
@@ -63888,7 +63796,6 @@ entities:
   - uid: 1029
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 30.5,-22.5
       parent: 2
     - type: DeviceNetwork
@@ -63898,7 +63805,6 @@ entities:
   - uid: 1620
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 2
     - type: DeviceNetwork
@@ -63910,7 +63816,6 @@ entities:
   - uid: 1621
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 2
     - type: DeviceNetwork
@@ -63922,7 +63827,6 @@ entities:
   - uid: 1622
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 2
     - type: DeviceNetwork
@@ -63997,7 +63901,6 @@ entities:
   - uid: 4374
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,14.5
       parent: 2
     - type: DeviceNetwork
@@ -64007,7 +63910,6 @@ entities:
   - uid: 4736
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,-12.5
       parent: 2
   - uid: 6856
@@ -64044,7 +63946,6 @@ entities:
   - uid: 9755
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 26.5,-29.5
       parent: 2
     - type: DeviceNetwork
@@ -64064,7 +63965,6 @@ entities:
   - uid: 10718
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,-14.5
       parent: 2
   - uid: 10803
@@ -64554,7 +64454,6 @@ entities:
   - uid: 10874
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -41.5,-10.5
       parent: 2
     - type: DeviceNetwork
@@ -64566,7 +64465,6 @@ entities:
   - uid: 10875
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -40.5,-10.5
       parent: 2
     - type: DeviceNetwork
@@ -64578,7 +64476,6 @@ entities:
   - uid: 10876
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,-7.5
       parent: 2
     - type: DeviceNetwork
@@ -64590,7 +64487,6 @@ entities:
   - uid: 10877
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,-9.5
       parent: 2
     - type: DeviceNetwork
@@ -64602,7 +64498,6 @@ entities:
   - uid: 10878
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,-14.5
       parent: 2
     - type: DeviceNetwork
@@ -64613,7 +64508,6 @@ entities:
   - uid: 10879
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,-14.5
       parent: 2
     - type: DeviceNetwork
@@ -64635,7 +64529,6 @@ entities:
   - uid: 10898
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 29.5,8.5
       parent: 2
     - type: DeviceNetwork
@@ -64647,7 +64540,6 @@ entities:
   - uid: 10899
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 29.5,7.5
       parent: 2
     - type: DeviceNetwork
@@ -64659,7 +64551,6 @@ entities:
   - uid: 10900
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,10.5
       parent: 2
     - type: DeviceNetwork
@@ -64671,7 +64562,6 @@ entities:
   - uid: 10901
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 31.5,10.5
       parent: 2
     - type: DeviceNetwork
@@ -64683,7 +64573,6 @@ entities:
   - uid: 10902
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,18.5
       parent: 2
     - type: DeviceNetwork
@@ -64695,7 +64584,6 @@ entities:
   - uid: 10907
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,20.5
       parent: 2
     - type: DeviceNetwork
@@ -64706,7 +64594,6 @@ entities:
   - uid: 12011
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,-14.5
       parent: 2
     - type: DeviceNetwork
@@ -64803,7 +64690,6 @@ entities:
   - uid: 16194
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,-29.5
       parent: 2
     - type: DeviceNetwork
@@ -64857,7 +64743,6 @@ entities:
   - uid: 16750
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,-13.5
       parent: 2
   - uid: 16807
@@ -84834,7 +84719,6 @@ entities:
   - uid: 858
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 29.5,56.5
       parent: 2
   - uid: 1108
@@ -84865,13 +84749,11 @@ entities:
   - uid: 1180
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,-19.5
       parent: 2
   - uid: 1189
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,-19.5
       parent: 2
   - uid: 1197
@@ -84887,7 +84769,6 @@ entities:
   - uid: 1337
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,-19.5
       parent: 2
   - uid: 1339
@@ -84898,25 +84779,21 @@ entities:
   - uid: 1349
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,-21.5
       parent: 2
   - uid: 1350
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,-19.5
       parent: 2
   - uid: 1351
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,-20.5
       parent: 2
   - uid: 1352
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,-21.5
       parent: 2
   - uid: 1379
@@ -85107,7 +84984,6 @@ entities:
   - uid: 1704
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,-30.5
       parent: 2
   - uid: 1707
@@ -85253,13 +85129,11 @@ entities:
   - uid: 2236
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-37.5
       parent: 2
   - uid: 2238
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-36.5
       parent: 2
   - uid: 2239
@@ -85390,7 +85264,6 @@ entities:
   - uid: 2408
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-39.5
       parent: 2
   - uid: 2449
@@ -85406,13 +85279,11 @@ entities:
   - uid: 2474
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-38.5
       parent: 2
   - uid: 2494
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-40.5
       parent: 2
   - uid: 2521
@@ -85628,7 +85499,6 @@ entities:
   - uid: 3480
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,19.5
       parent: 2
   - uid: 3508
@@ -85654,7 +85524,6 @@ entities:
   - uid: 3608
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -66.5,-28.5
       parent: 2
   - uid: 3627
@@ -85665,103 +85534,86 @@ entities:
   - uid: 3630
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -65.5,-28.5
       parent: 2
   - uid: 3631
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -64.5,-28.5
       parent: 2
   - uid: 3632
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -66.5,-32.5
       parent: 2
   - uid: 3633
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -65.5,-32.5
       parent: 2
   - uid: 3634
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -64.5,-32.5
       parent: 2
   - uid: 3635
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,-28.5
       parent: 2
   - uid: 3636
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,-28.5
       parent: 2
   - uid: 3637
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,-28.5
       parent: 2
   - uid: 3638
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,-28.5
       parent: 2
   - uid: 3639
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,-28.5
       parent: 2
   - uid: 3640
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -48.5,-28.5
       parent: 2
   - uid: 3641
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -48.5,-32.5
       parent: 2
   - uid: 3642
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,-32.5
       parent: 2
   - uid: 3643
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,-32.5
       parent: 2
   - uid: 3644
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,-32.5
       parent: 2
   - uid: 3645
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,-32.5
       parent: 2
   - uid: 3646
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,-32.5
       parent: 2
   - uid: 3698
@@ -85802,7 +85654,6 @@ entities:
   - uid: 3735
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,-5.5
       parent: 2
   - uid: 3750
@@ -85818,7 +85669,6 @@ entities:
   - uid: 3823
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 53.5,-28.5
       parent: 2
   - uid: 3889
@@ -85829,43 +85679,36 @@ entities:
   - uid: 3937
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 31.5,20.5
       parent: 2
   - uid: 3938
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 32.5,20.5
       parent: 2
   - uid: 3939
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 35.5,6.5
       parent: 2
   - uid: 3940
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 36.5,6.5
       parent: 2
   - uid: 3941
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,6.5
       parent: 2
   - uid: 3974
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,43.5
       parent: 2
   - uid: 3992
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,42.5
       parent: 2
   - uid: 4155
@@ -85891,61 +85734,51 @@ entities:
   - uid: 4345
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-7.5
       parent: 2
   - uid: 4346
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -36.5,-4.5
       parent: 2
   - uid: 4356
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,-4.5
       parent: 2
   - uid: 4375
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,-13.5
       parent: 2
   - uid: 4377
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-6.5
       parent: 2
   - uid: 4385
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -32.5,-4.5
       parent: 2
   - uid: 4403
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,-4.5
       parent: 2
   - uid: 4416
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-8.5
       parent: 2
   - uid: 4436
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-4.5
       parent: 2
   - uid: 4439
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,-4.5
       parent: 2
   - uid: 4441
@@ -85971,61 +85804,51 @@ entities:
   - uid: 4509
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-8.5
       parent: 2
   - uid: 4510
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-7.5
       parent: 2
   - uid: 4511
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-6.5
       parent: 2
   - uid: 4512
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-1.5
       parent: 2
   - uid: 4513
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,-1.5
       parent: 2
   - uid: 4516
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,-1.5
       parent: 2
   - uid: 4519
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-2.5
       parent: 2
   - uid: 4521
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,-1.5
       parent: 2
   - uid: 4522
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-3.5
       parent: 2
   - uid: 4523
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-1.5
       parent: 2
   - uid: 4525
@@ -86066,7 +85889,6 @@ entities:
   - uid: 4741
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,-10.5
       parent: 2
   - uid: 4900
@@ -86137,13 +85959,11 @@ entities:
   - uid: 5548
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,-44.5
       parent: 2
   - uid: 5568
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,-19.5
       parent: 2
   - uid: 5585
@@ -86174,7 +85994,6 @@ entities:
   - uid: 5945
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 21.5,-26.5
       parent: 2
   - uid: 6004
@@ -86670,97 +86489,81 @@ entities:
   - uid: 7145
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,57.5
       parent: 2
   - uid: 7194
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,48.5
       parent: 2
   - uid: 7195
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,47.5
       parent: 2
   - uid: 7196
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,46.5
       parent: 2
   - uid: 7197
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,51.5
       parent: 2
   - uid: 7198
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,50.5
       parent: 2
   - uid: 7199
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,49.5
       parent: 2
   - uid: 7200
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,48.5
       parent: 2
   - uid: 7201
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,44.5
       parent: 2
   - uid: 7202
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,43.5
       parent: 2
   - uid: 7203
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,42.5
       parent: 2
   - uid: 7204
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,41.5
       parent: 2
   - uid: 7205
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,37.5
       parent: 2
   - uid: 7206
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,36.5
       parent: 2
   - uid: 7207
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,35.5
       parent: 2
   - uid: 7208
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,34.5
       parent: 2
   - uid: 7486
@@ -86776,25 +86579,21 @@ entities:
   - uid: 7660
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,41.5
       parent: 2
   - uid: 7661
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,41.5
       parent: 2
   - uid: 7662
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 20.5,41.5
       parent: 2
   - uid: 7665
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,43.5
       parent: 2
   - uid: 7731
@@ -86875,115 +86674,96 @@ entities:
   - uid: 7909
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 31.5,32.5
       parent: 2
   - uid: 7910
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,32.5
       parent: 2
   - uid: 7958
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,-19.5
       parent: 2
   - uid: 7959
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,-19.5
       parent: 2
   - uid: 8001
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,-3.5
       parent: 2
   - uid: 8036
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,-1.5
       parent: 2
   - uid: 8037
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,-1.5
       parent: 2
   - uid: 8041
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 60.5,0.5
       parent: 2
   - uid: 8043
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 60.5,-1.5
       parent: 2
   - uid: 8044
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 58.5,-3.5
       parent: 2
   - uid: 8045
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 57.5,-3.5
       parent: 2
   - uid: 8046
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 56.5,-3.5
       parent: 2
   - uid: 8150
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 62.5,-2.5
       parent: 2
   - uid: 8151
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 62.5,-1.5
       parent: 2
   - uid: 8152
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 62.5,-0.5
       parent: 2
   - uid: 8154
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 62.5,1.5
       parent: 2
   - uid: 8158
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 55.5,-5.5
       parent: 2
   - uid: 8159
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 56.5,-5.5
       parent: 2
   - uid: 8161
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,-5.5
       parent: 2
   - uid: 8166
@@ -87004,181 +86784,151 @@ entities:
   - uid: 8196
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,30.5
       parent: 2
   - uid: 8197
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,29.5
       parent: 2
   - uid: 8198
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,28.5
       parent: 2
   - uid: 8199
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,31.5
       parent: 2
   - uid: 8200
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,30.5
       parent: 2
   - uid: 8201
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,29.5
       parent: 2
   - uid: 8202
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,28.5
       parent: 2
   - uid: 8204
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,24.5
       parent: 2
   - uid: 8205
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,23.5
       parent: 2
   - uid: 8206
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,22.5
       parent: 2
   - uid: 8209
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,23.5
       parent: 2
   - uid: 8210
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,22.5
       parent: 2
   - uid: 8211
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,19.5
       parent: 2
   - uid: 8212
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,18.5
       parent: 2
   - uid: 8213
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,17.5
       parent: 2
   - uid: 8214
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,16.5
       parent: 2
   - uid: 8215
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,20.5
       parent: 2
   - uid: 8216
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,20.5
       parent: 2
   - uid: 8219
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,17.5
       parent: 2
   - uid: 8220
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,16.5
       parent: 2
   - uid: 8221
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,12.5
       parent: 2
   - uid: 8222
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,11.5
       parent: 2
   - uid: 8223
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 62.5,11.5
       parent: 2
   - uid: 8224
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,11.5
       parent: 2
   - uid: 8225
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,10.5
       parent: 2
   - uid: 8226
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,9.5
       parent: 2
   - uid: 8227
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 60.5,9.5
       parent: 2
   - uid: 8228
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,9.5
       parent: 2
   - uid: 8231
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,13.5
       parent: 2
   - uid: 8232
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,12.5
       parent: 2
   - uid: 8262
@@ -87199,199 +86949,166 @@ entities:
   - uid: 8294
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -69.5,-10.5
       parent: 2
   - uid: 8295
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,14.5
       parent: 2
   - uid: 8296
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,14.5
       parent: 2
   - uid: 8297
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -66.5,-10.5
       parent: 2
   - uid: 8298
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -68.5,-10.5
       parent: 2
   - uid: 8299
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,-10.5
       parent: 2
   - uid: 8300
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,-10.5
       parent: 2
   - uid: 8301
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -62.5,-10.5
       parent: 2
   - uid: 8302
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -61.5,-10.5
       parent: 2
   - uid: 8305
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -59.5,-13.5
       parent: 2
   - uid: 8306
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -60.5,-13.5
       parent: 2
   - uid: 8307
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -61.5,-13.5
       parent: 2
   - uid: 8309
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,-13.5
       parent: 2
   - uid: 8310
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -66.5,-13.5
       parent: 2
   - uid: 8312
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -68.5,-13.5
       parent: 2
   - uid: 8313
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -69.5,-13.5
       parent: 2
   - uid: 8314
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,-13.5
       parent: 2
   - uid: 8315
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,63.5
       parent: 2
   - uid: 8317
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,63.5
       parent: 2
   - uid: 8318
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,63.5
       parent: 2
   - uid: 8319
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,65.5
       parent: 2
   - uid: 8328
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,65.5
       parent: 2
   - uid: 8329
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,65.5
       parent: 2
   - uid: 8330
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,65.5
       parent: 2
   - uid: 8331
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,65.5
       parent: 2
   - uid: 8332
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,65.5
       parent: 2
   - uid: 8333
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,65.5
       parent: 2
   - uid: 8334
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,65.5
       parent: 2
   - uid: 8335
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,65.5
       parent: 2
   - uid: 8344
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,63.5
       parent: 2
   - uid: 8346
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,63.5
       parent: 2
   - uid: 8347
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,63.5
       parent: 2
   - uid: 8350
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,63.5
       parent: 2
   - uid: 8386
@@ -87452,7 +87169,6 @@ entities:
   - uid: 8687
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-48.5
       parent: 2
   - uid: 8743
@@ -87463,25 +87179,21 @@ entities:
   - uid: 8876
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,-28.5
       parent: 2
   - uid: 8946
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-37.5
       parent: 2
   - uid: 8947
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-39.5
       parent: 2
   - uid: 8948
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-35.5
       parent: 2
   - uid: 9043
@@ -87507,31 +87219,26 @@ entities:
   - uid: 9211
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,-19.5
       parent: 2
   - uid: 9212
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,-26.5
       parent: 2
   - uid: 9232
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,-19.5
       parent: 2
   - uid: 9314
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-49.5
       parent: 2
   - uid: 9315
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-45.5
       parent: 2
   - uid: 9555
@@ -87562,7 +87269,6 @@ entities:
   - uid: 10231
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-44.5
       parent: 2
   - uid: 10251
@@ -87593,7 +87299,6 @@ entities:
   - uid: 10681
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-55.5
       parent: 2
   - uid: 10774
@@ -87614,7 +87319,6 @@ entities:
   - uid: 10800
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-56.5
       parent: 2
   - uid: 11129
@@ -87640,7 +87344,6 @@ entities:
   - uid: 11244
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -18.5,14.5
       parent: 2
   - uid: 11256
@@ -87731,7 +87434,6 @@ entities:
   - uid: 12673
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-34.5
       parent: 2
   - uid: 12781
@@ -87767,7 +87469,6 @@ entities:
   - uid: 13973
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,-4.5
       parent: 2
   - uid: 13986
@@ -87793,13 +87494,11 @@ entities:
   - uid: 14222
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,-48.5
       parent: 2
   - uid: 14230
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-48.5
       parent: 2
   - uid: 14244
@@ -87935,7 +87634,6 @@ entities:
   - uid: 14534
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-35.5
       parent: 2
   - uid: 14618
@@ -87976,19 +87674,16 @@ entities:
   - uid: 15658
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,-6.5
       parent: 2
   - uid: 15659
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,-7.5
       parent: 2
   - uid: 15676
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-47.5
       parent: 2
   - uid: 15682
@@ -88029,85 +87724,71 @@ entities:
   - uid: 15732
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-52.5
       parent: 2
   - uid: 15733
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-53.5
       parent: 2
   - uid: 15740
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-57.5
       parent: 2
   - uid: 15741
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-56.5
       parent: 2
   - uid: 15742
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-53.5
       parent: 2
   - uid: 15743
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-52.5
       parent: 2
   - uid: 15744
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-51.5
       parent: 2
   - uid: 15745
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-49.5
       parent: 2
   - uid: 15746
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-48.5
       parent: 2
   - uid: 15748
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-45.5
       parent: 2
   - uid: 15749
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-44.5
       parent: 2
   - uid: 15750
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-43.5
       parent: 2
   - uid: 15757
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,56.5
       parent: 2
   - uid: 15758
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,55.5
       parent: 2
   - uid: 15835
@@ -88128,19 +87809,16 @@ entities:
   - uid: 15906
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 20.5,-26.5
       parent: 2
   - uid: 15959
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -44.5,-33.5
       parent: 2
   - uid: 15960
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -44.5,-34.5
       parent: 2
   - uid: 15975
@@ -88201,7 +87879,6 @@ entities:
   - uid: 16167
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,19.5
       parent: 2
   - uid: 16205
@@ -88267,19 +87944,16 @@ entities:
   - uid: 16621
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 31.5,-44.5
       parent: 2
   - uid: 16636
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,3.5
       parent: 2
   - uid: 16637
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,5.5
       parent: 2
   - uid: 17083
@@ -88475,25 +88149,21 @@ entities:
   - uid: 18168
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 54.5,5.5
       parent: 2
   - uid: 18169
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 55.5,5.5
       parent: 2
   - uid: 18171
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 57.5,5.5
       parent: 2
   - uid: 18172
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 58.5,5.5
       parent: 2
   - uid: 18226
@@ -88504,13 +88174,11 @@ entities:
   - uid: 18664
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,-30.5
       parent: 2
   - uid: 18677
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,-44.5
       parent: 2
 - proto: GrilleBroken
@@ -90086,7 +89754,7 @@ entities:
   - uid: 1788
     components:
     - type: Transform
-      pos: -18.491062,-10.213333
+      pos: -19.466658,-9.205383
       parent: 2
   - uid: 5333
     components:
@@ -95502,6 +95170,12 @@ entities:
     - type: Transform
       pos: 25.5,-17.5
       parent: 2
+  - uid: 1747
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-8.5
+      parent: 2
   - uid: 1810
     components:
     - type: Transform
@@ -95530,11 +95204,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-13.5
-      parent: 2
-  - uid: 4972
-    components:
-    - type: Transform
-      pos: -17.5,-9.5
       parent: 2
   - uid: 4974
     components:
@@ -95781,12 +95450,6 @@ entities:
     - type: Transform
       pos: -25.5,1.5
       parent: 2
-  - uid: 14158
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -17.5,-7.5
-      parent: 2
   - uid: 14161
     components:
     - type: Transform
@@ -96028,15 +95691,15 @@ entities:
     - type: Transform
       pos: 49.5,3.5
       parent: 2
-  - uid: 1751
-    components:
-    - type: Transform
-      pos: -18.5,-10.5
-      parent: 2
   - uid: 1752
     components:
     - type: Transform
       pos: -19.5,-10.5
+      parent: 2
+  - uid: 1758
+    components:
+    - type: Transform
+      pos: -19.5,-9.5
       parent: 2
   - uid: 1841
     components:
@@ -96518,8 +96181,7 @@ entities:
   - uid: 2959
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,-7.5
+      pos: -16.5,-7.5
       parent: 2
   - uid: 5113
     components:
@@ -96781,6 +96443,12 @@ entities:
       parent: 2
 - proto: RailingCorner
   entities:
+  - uid: 4972
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,-7.5
+      parent: 2
   - uid: 6976
     components:
     - type: Transform
@@ -96926,19 +96594,16 @@ entities:
   - uid: 1237
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,-22.5
       parent: 2
   - uid: 1587
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,-23.5
       parent: 2
   - uid: 1595
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,-11.5
       parent: 2
   - uid: 14415
@@ -97494,7 +97159,6 @@ entities:
   - uid: 10371
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,-34.5
       parent: 2
   - uid: 10386
@@ -98202,11 +97866,6 @@ entities:
     - type: Transform
       pos: -15.5,-7.5
       parent: 2
-  - uid: 18620
-    components:
-    - type: Transform
-      pos: -17.5,-8.5
-      parent: 2
   - uid: 18621
     components:
     - type: Transform
@@ -98409,7 +98068,6 @@ entities:
   - uid: 1708
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,-30.5
       parent: 2
   - uid: 1870
@@ -98425,19 +98083,16 @@ entities:
   - uid: 2381
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-37.5
       parent: 2
   - uid: 2469
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-39.5
       parent: 2
   - uid: 2473
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-35.5
       parent: 2
   - uid: 9754
@@ -98453,25 +98108,21 @@ entities:
   - uid: 14235
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,-30.5
       parent: 2
   - uid: 18678
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 31.5,-44.5
       parent: 2
   - uid: 18679
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,-44.5
       parent: 2
   - uid: 18680
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,-44.5
       parent: 2
 - proto: ReinforcedWindow
@@ -98479,7 +98130,6 @@ entities:
   - uid: 79
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,-19.5
       parent: 2
   - uid: 325
@@ -98500,7 +98150,6 @@ entities:
   - uid: 1122
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,-19.5
       parent: 2
   - uid: 1125
@@ -98591,7 +98240,6 @@ entities:
   - uid: 1762
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,-26.5
       parent: 2
   - uid: 1839
@@ -98732,7 +98380,6 @@ entities:
   - uid: 2963
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,-19.5
       parent: 2
   - uid: 3193
@@ -98743,109 +98390,91 @@ entities:
   - uid: 3647
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -66.5,-28.5
       parent: 2
   - uid: 3648
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -65.5,-28.5
       parent: 2
   - uid: 3649
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -64.5,-28.5
       parent: 2
   - uid: 3650
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -64.5,-32.5
       parent: 2
   - uid: 3651
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -66.5,-32.5
       parent: 2
   - uid: 3652
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -65.5,-32.5
       parent: 2
   - uid: 3653
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,-28.5
       parent: 2
   - uid: 3654
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,-28.5
       parent: 2
   - uid: 3655
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,-28.5
       parent: 2
   - uid: 3656
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,-32.5
       parent: 2
   - uid: 3657
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,-32.5
       parent: 2
   - uid: 3658
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,-32.5
       parent: 2
   - uid: 3659
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,-28.5
       parent: 2
   - uid: 3660
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,-28.5
       parent: 2
   - uid: 3661
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -48.5,-28.5
       parent: 2
   - uid: 3662
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -48.5,-32.5
       parent: 2
   - uid: 3663
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,-32.5
       parent: 2
   - uid: 3664
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,-32.5
       parent: 2
   - uid: 3673
@@ -98876,43 +98505,36 @@ entities:
   - uid: 4023
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,20.5
       parent: 2
   - uid: 4024
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,20.5
       parent: 2
   - uid: 4326
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -32.5,-4.5
       parent: 2
   - uid: 4342
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,-4.5
       parent: 2
   - uid: 4348
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-7.5
       parent: 2
   - uid: 4349
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,-4.5
       parent: 2
   - uid: 4353
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-4.5
       parent: 2
   - uid: 4360
@@ -98923,25 +98545,21 @@ entities:
   - uid: 4366
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,-4.5
       parent: 2
   - uid: 4367
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -36.5,-4.5
       parent: 2
   - uid: 4378
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-8.5
       parent: 2
   - uid: 4380
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-6.5
       parent: 2
   - uid: 4422
@@ -99082,7 +98700,6 @@ entities:
   - uid: 6499
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,41.5
       parent: 2
   - uid: 6508
@@ -99128,7 +98745,6 @@ entities:
   - uid: 6950
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,11.5
       parent: 2
   - uid: 6989
@@ -99199,49 +98815,41 @@ entities:
   - uid: 7137
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,57.5
       parent: 2
   - uid: 7191
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,48.5
       parent: 2
   - uid: 7192
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,47.5
       parent: 2
   - uid: 7193
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,46.5
       parent: 2
   - uid: 7655
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 20.5,41.5
       parent: 2
   - uid: 7658
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,43.5
       parent: 2
   - uid: 7781
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,32.5
       parent: 2
   - uid: 7782
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,32.5
       parent: 2
   - uid: 7893
@@ -99262,43 +98870,36 @@ entities:
   - uid: 8010
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 60.5,0.5
       parent: 2
   - uid: 8011
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,-1.5
       parent: 2
   - uid: 8012
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,-1.5
       parent: 2
   - uid: 8028
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 60.5,-1.5
       parent: 2
   - uid: 8029
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 58.5,-3.5
       parent: 2
   - uid: 8030
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 57.5,-3.5
       parent: 2
   - uid: 8031
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 56.5,-3.5
       parent: 2
   - uid: 8054
@@ -99319,7 +98920,6 @@ entities:
   - uid: 8156
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 54.5,5.5
       parent: 2
   - uid: 8229
@@ -99330,7 +98930,6 @@ entities:
   - uid: 8236
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-34.5
       parent: 2
   - uid: 8349
@@ -99341,13 +98940,11 @@ entities:
   - uid: 8786
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-40.5
       parent: 2
   - uid: 8788
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-37.5
       parent: 2
   - uid: 9602
@@ -99358,13 +98955,11 @@ entities:
   - uid: 9751
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,-42.5
       parent: 2
   - uid: 9752
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 21.5,-26.5
       parent: 2
   - uid: 10527
@@ -99375,7 +98970,6 @@ entities:
   - uid: 10763
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,-19.5
       parent: 2
   - uid: 10981
@@ -99396,13 +98990,11 @@ entities:
   - uid: 11171
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,12.5
       parent: 2
   - uid: 11221
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,19.5
       parent: 2
   - uid: 11234
@@ -99433,25 +99025,21 @@ entities:
   - uid: 12551
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,-42.5
       parent: 2
   - uid: 12652
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 20.5,-26.5
       parent: 2
   - uid: 12655
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,-30.5
       parent: 2
   - uid: 12713
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-39.5
       parent: 2
   - uid: 12757
@@ -99462,19 +99050,16 @@ entities:
   - uid: 12902
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,13.5
       parent: 2
   - uid: 13451
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-48.5
       parent: 2
   - uid: 13452
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,-48.5
       parent: 2
   - uid: 13637
@@ -99485,7 +99070,6 @@ entities:
   - uid: 13854
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-36.5
       parent: 2
   - uid: 13972
@@ -99501,19 +99085,16 @@ entities:
   - uid: 14530
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,-4.5
       parent: 2
   - uid: 14533
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-35.5
       parent: 2
   - uid: 14535
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-38.5
       parent: 2
   - uid: 14773
@@ -99524,13 +99105,11 @@ entities:
   - uid: 14828
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,19.5
       parent: 2
   - uid: 14867
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,22.5
       parent: 2
   - uid: 14918
@@ -99546,7 +99125,6 @@ entities:
   - uid: 15244
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,43.5
       parent: 2
   - uid: 15262
@@ -99567,19 +99145,16 @@ entities:
   - uid: 15725
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,42.5
       parent: 2
   - uid: 15922
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -44.5,-33.5
       parent: 2
   - uid: 15923
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -44.5,-34.5
       parent: 2
   - uid: 16116
@@ -99605,7 +99180,6 @@ entities:
   - uid: 17079
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -44.5,-39.5
       parent: 2
   - uid: 17625
@@ -99636,7 +99210,6 @@ entities:
   - uid: 18167
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 58.5,5.5
       parent: 2
   - uid: 18603
@@ -99652,7 +99225,6 @@ entities:
   - uid: 18681
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 31.5,-42.5
       parent: 2
 - proto: RemoteSignaller
@@ -107643,7 +107215,6 @@ entities:
   - uid: 1596
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,-18.5
       parent: 2
   - uid: 1673
@@ -107669,13 +107240,11 @@ entities:
   - uid: 2568
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,-22.5
       parent: 2
   - uid: 2670
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,-21.5
       parent: 2
   - uid: 3766
@@ -107706,7 +107275,6 @@ entities:
   - uid: 6395
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,-22.5
       parent: 2
   - uid: 7169
@@ -107717,19 +107285,16 @@ entities:
   - uid: 8134
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-11.5
       parent: 2
   - uid: 8136
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-17.5
       parent: 2
   - uid: 8260
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,-20.5
       parent: 2
   - uid: 9005
@@ -107740,49 +107305,41 @@ entities:
   - uid: 9618
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,2.5
       parent: 2
   - uid: 9619
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,1.5
       parent: 2
   - uid: 9620
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,0.5
       parent: 2
   - uid: 9624
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,-0.5
       parent: 2
   - uid: 9625
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,1.5
       parent: 2
   - uid: 9626
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,0.5
       parent: 2
   - uid: 9627
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,-0.5
       parent: 2
   - uid: 9628
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,-1.5
       parent: 2
   - uid: 11125
@@ -107808,13 +107365,11 @@ entities:
   - uid: 11700
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,-21.5
       parent: 2
   - uid: 11791
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,-20.5
       parent: 2
   - uid: 11811
@@ -107825,13 +107380,11 @@ entities:
   - uid: 12880
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,2.5
       parent: 2
   - uid: 12881
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,23.5
       parent: 2
   - uid: 13682
@@ -107852,13 +107405,11 @@ entities:
   - uid: 14106
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,-17.5
       parent: 2
   - uid: 14107
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -39.5,-32.5
       parent: 2
   - uid: 14210
@@ -107979,31 +107530,26 @@ entities:
   - uid: 114
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,2.5
       parent: 2
   - uid: 201
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,1.5
       parent: 2
   - uid: 202
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,0.5
       parent: 2
   - uid: 203
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-0.5
       parent: 2
   - uid: 204
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-1.5
       parent: 2
   - uid: 289
@@ -108029,25 +107575,21 @@ entities:
   - uid: 406
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,9.5
       parent: 2
   - uid: 407
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,8.5
       parent: 2
   - uid: 408
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,7.5
       parent: 2
   - uid: 429
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-1.5
       parent: 2
   - uid: 438
@@ -108063,19 +107605,16 @@ entities:
   - uid: 441
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-3.5
       parent: 2
   - uid: 445
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-2.5
       parent: 2
   - uid: 625
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,1.5
       parent: 2
   - uid: 729
@@ -108096,43 +107635,36 @@ entities:
   - uid: 1623
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,-10.5
       parent: 2
   - uid: 1624
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-10.5
       parent: 2
   - uid: 1694
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,5.5
       parent: 2
   - uid: 1695
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,5.5
       parent: 2
   - uid: 1890
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,-26.5
       parent: 2
   - uid: 2251
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-13.5
       parent: 2
   - uid: 2622
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,-25.5
       parent: 2
   - uid: 3110
@@ -108143,25 +107675,21 @@ entities:
   - uid: 3137
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,2.5
       parent: 2
   - uid: 3170
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,-32.5
       parent: 2
   - uid: 3171
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,-32.5
       parent: 2
   - uid: 3176
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,-32.5
       parent: 2
   - uid: 3241
@@ -108172,31 +107700,26 @@ entities:
   - uid: 3931
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,19.5
       parent: 2
   - uid: 3932
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,19.5
       parent: 2
   - uid: 3933
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,19.5
       parent: 2
   - uid: 4013
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 40.5,12.5
       parent: 2
   - uid: 4014
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 40.5,13.5
       parent: 2
   - uid: 4047
@@ -108242,7 +107765,6 @@ entities:
   - uid: 5254
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,21.5
       parent: 2
   - uid: 5274
@@ -108263,19 +107785,16 @@ entities:
   - uid: 5887
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -18.5,-14.5
       parent: 2
   - uid: 5888
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,-14.5
       parent: 2
   - uid: 5889
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-14.5
       parent: 2
   - uid: 5929
@@ -108286,7 +107805,6 @@ entities:
   - uid: 6026
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,-41.5
       parent: 2
   - uid: 6118
@@ -108312,7 +107830,6 @@ entities:
   - uid: 6605
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,8.5
       parent: 2
   - uid: 6650
@@ -108328,13 +107845,11 @@ entities:
   - uid: 6883
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,20.5
       parent: 2
   - uid: 6952
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,22.5
       parent: 2
   - uid: 7361
@@ -108360,19 +107875,16 @@ entities:
   - uid: 8259
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,19.5
       parent: 2
   - uid: 9504
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,27.5
       parent: 2
   - uid: 9505
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,26.5
       parent: 2
   - uid: 9576
@@ -108403,13 +107915,11 @@ entities:
   - uid: 11346
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,-43.5
       parent: 2
   - uid: 12780
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,-44.5
       parent: 2
   - uid: 12786
@@ -108460,7 +107970,6 @@ entities:
   - uid: 14185
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-44.5
       parent: 2
   - uid: 14353
@@ -108516,7 +108025,6 @@ entities:
   - uid: 16080
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,-42.5
       parent: 2
   - uid: 16148
@@ -108527,7 +108035,6 @@ entities:
   - uid: 16243
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-12.5
       parent: 2
   - uid: 16317
@@ -108600,19 +108107,16 @@ entities:
   - uid: 271
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,10.5
       parent: 2
   - uid: 272
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,10.5
       parent: 2
   - uid: 274
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,10.5
       parent: 2
   - uid: 312
@@ -108633,25 +108137,21 @@ entities:
   - uid: 982
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,-7.5
       parent: 2
   - uid: 1264
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,-4.5
       parent: 2
   - uid: 3093
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-24.5
       parent: 2
   - uid: 3094
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,-24.5
       parent: 2
   - uid: 3233
@@ -108662,19 +108162,16 @@ entities:
   - uid: 3236
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -33.5,-20.5
       parent: 2
   - uid: 3237
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -35.5,-20.5
       parent: 2
   - uid: 3628
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -35.5,-37.5
       parent: 2
   - uid: 4553
@@ -108690,7 +108187,6 @@ entities:
   - uid: 6207
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -35.5,-38.5
       parent: 2
   - uid: 6302
@@ -108721,7 +108217,6 @@ entities:
   - uid: 11317
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,-35.5
       parent: 2
   - uid: 12804
@@ -108732,7 +108227,6 @@ entities:
   - uid: 13765
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,19.5
       parent: 2
   - uid: 14242
@@ -108748,7 +108242,6 @@ entities:
   - uid: 15421
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-1.5
       parent: 2
   - uid: 15425
@@ -108884,7 +108377,6 @@ entities:
   - uid: 6721
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 33.5,19.5
       parent: 2
   - uid: 9040
@@ -108905,13 +108397,11 @@ entities:
   - uid: 16211
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 32.5,13.5
       parent: 2
   - uid: 16212
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 26.5,20.5
       parent: 2
 - proto: TableReinforced
@@ -108934,7 +108424,6 @@ entities:
   - uid: 1376
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,-15.5
       parent: 2
   - uid: 1493
@@ -108950,7 +108439,6 @@ entities:
   - uid: 1638
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 26.5,-15.5
       parent: 2
   - uid: 1705
@@ -108991,7 +108479,6 @@ entities:
   - uid: 2189
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 32.5,-28.5
       parent: 2
   - uid: 2488
@@ -109002,13 +108489,11 @@ entities:
   - uid: 2543
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,-12.5
       parent: 2
   - uid: 2745
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,-10.5
       parent: 2
   - uid: 2942
@@ -109019,7 +108504,6 @@ entities:
   - uid: 2958
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,-9.5
       parent: 2
   - uid: 3011
@@ -109050,7 +108534,6 @@ entities:
   - uid: 3513
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -35.5,-32.5
       parent: 2
   - uid: 3517
@@ -109061,7 +108544,6 @@ entities:
   - uid: 3942
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,15.5
       parent: 2
   - uid: 3959
@@ -109152,13 +108634,11 @@ entities:
   - uid: 4940
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,-16.5
       parent: 2
   - uid: 5151
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,13.5
       parent: 2
   - uid: 5321
@@ -109184,7 +108664,6 @@ entities:
   - uid: 6390
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,-10.5
       parent: 2
   - uid: 6578
@@ -109220,7 +108699,6 @@ entities:
   - uid: 6913
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,12.5
       parent: 2
   - uid: 7107
@@ -109231,19 +108709,16 @@ entities:
   - uid: 7383
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,29.5
       parent: 2
   - uid: 7912
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-25.5
       parent: 2
   - uid: 8091
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 28.5,-15.5
       parent: 2
   - uid: 8637
@@ -109259,7 +108734,6 @@ entities:
   - uid: 9396
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,22.5
       parent: 2
   - uid: 10228
@@ -109295,7 +108769,6 @@ entities:
   - uid: 11230
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,11.5
       parent: 2
   - uid: 11801
@@ -109321,7 +108794,6 @@ entities:
   - uid: 16181
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,-16.5
       parent: 2
   - uid: 16739
@@ -110743,43 +110215,36 @@ entities:
   - uid: 67
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-8.5
       parent: 2
   - uid: 68
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-10.5
       parent: 2
   - uid: 85
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-10.5
       parent: 2
   - uid: 86
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-9.5
       parent: 2
   - uid: 166
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-11.5
       parent: 2
   - uid: 169
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-11.5
       parent: 2
   - uid: 170
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,-8.5
       parent: 2
   - uid: 300
@@ -110840,7 +110305,6 @@ entities:
   - uid: 1093
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,-17.5
       parent: 2
   - uid: 1094
@@ -110876,7 +110340,6 @@ entities:
   - uid: 1132
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-32.5
       parent: 2
   - uid: 1133
@@ -110957,25 +110420,21 @@ entities:
   - uid: 1255
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 47.5,-12.5
       parent: 2
   - uid: 1316
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,-22.5
       parent: 2
   - uid: 1317
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,-23.5
       parent: 2
   - uid: 1318
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 38.5,-23.5
       parent: 2
   - uid: 1320
@@ -110986,7 +110445,6 @@ entities:
   - uid: 1321
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 41.5,-23.5
       parent: 2
   - uid: 1323
@@ -110997,25 +110455,21 @@ entities:
   - uid: 1324
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,-23.5
       parent: 2
   - uid: 1327
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,-18.5
       parent: 2
   - uid: 1328
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,-23.5
       parent: 2
   - uid: 1330
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,-17.5
       parent: 2
   - uid: 1331
@@ -111026,13 +110480,11 @@ entities:
   - uid: 1340
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,-25.5
       parent: 2
   - uid: 1343
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 41.5,-25.5
       parent: 2
   - uid: 1371
@@ -111043,13 +110495,11 @@ entities:
   - uid: 1373
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 41.5,-28.5
       parent: 2
   - uid: 1374
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 41.5,-29.5
       parent: 2
   - uid: 1378
@@ -111080,13 +110530,11 @@ entities:
   - uid: 1432
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,-14.5
       parent: 2
   - uid: 1453
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,-13.5
       parent: 2
   - uid: 1465
@@ -111127,7 +110575,6 @@ entities:
   - uid: 1482
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,-28.5
       parent: 2
   - uid: 1484
@@ -111158,13 +110605,11 @@ entities:
   - uid: 1495
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,-28.5
       parent: 2
   - uid: 1499
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,-28.5
       parent: 2
   - uid: 1516
@@ -111195,13 +110640,11 @@ entities:
   - uid: 1658
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,9.5
       parent: 2
   - uid: 1659
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 25.5,9.5
       parent: 2
   - uid: 1661
@@ -111287,7 +110730,6 @@ entities:
   - uid: 1797
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-16.5
       parent: 2
   - uid: 1811
@@ -111308,7 +110750,6 @@ entities:
   - uid: 1845
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-23.5
       parent: 2
   - uid: 1847
@@ -111319,7 +110760,6 @@ entities:
   - uid: 1855
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,-26.5
       parent: 2
   - uid: 1868
@@ -111345,7 +110785,6 @@ entities:
   - uid: 1888
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,-18.5
       parent: 2
   - uid: 1894
@@ -111361,7 +110800,6 @@ entities:
   - uid: 1922
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,-31.5
       parent: 2
   - uid: 1924
@@ -111382,13 +110820,11 @@ entities:
   - uid: 1945
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,-18.5
       parent: 2
   - uid: 1946
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-18.5
       parent: 2
   - uid: 1948
@@ -111419,7 +110855,6 @@ entities:
   - uid: 1979
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,19.5
       parent: 2
   - uid: 1981
@@ -111430,7 +110865,6 @@ entities:
   - uid: 2019
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 28.5,-18.5
       parent: 2
   - uid: 2022
@@ -111561,7 +110995,6 @@ entities:
   - uid: 2235
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 25.5,-41.5
       parent: 2
   - uid: 2244
@@ -111677,7 +111110,6 @@ entities:
   - uid: 2320
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,-28.5
       parent: 2
   - uid: 2328
@@ -111693,25 +111125,21 @@ entities:
   - uid: 2382
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-34.5
       parent: 2
   - uid: 2498
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-19.5
       parent: 2
   - uid: 2499
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 28.5,-19.5
       parent: 2
   - uid: 2509
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 29.5,-16.5
       parent: 2
   - uid: 2511
@@ -111737,7 +111165,6 @@ entities:
   - uid: 2529
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 44.5,-2.5
       parent: 2
   - uid: 2544
@@ -111763,13 +111190,11 @@ entities:
   - uid: 2615
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,-31.5
       parent: 2
   - uid: 2624
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,-26.5
       parent: 2
   - uid: 2630
@@ -111780,7 +111205,6 @@ entities:
   - uid: 2636
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 57.5,-28.5
       parent: 2
   - uid: 2647
@@ -111791,7 +111215,6 @@ entities:
   - uid: 2649
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,9.5
       parent: 2
   - uid: 2656
@@ -111827,7 +111250,6 @@ entities:
   - uid: 2804
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,-16.5
       parent: 2
   - uid: 2836
@@ -111843,13 +111265,11 @@ entities:
   - uid: 2912
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,-26.5
       parent: 2
   - uid: 2957
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,45.5
       parent: 2
   - uid: 3004
@@ -111865,13 +111285,11 @@ entities:
   - uid: 3019
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,-24.5
       parent: 2
   - uid: 3020
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,-17.5
       parent: 2
   - uid: 3044
@@ -111882,25 +111300,21 @@ entities:
   - uid: 3197
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,-28.5
       parent: 2
   - uid: 3200
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,-27.5
       parent: 2
   - uid: 3201
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,-26.5
       parent: 2
   - uid: 3202
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,-25.5
       parent: 2
   - uid: 3425
@@ -112026,7 +111440,6 @@ entities:
   - uid: 3569
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,13.5
       parent: 2
   - uid: 3574
@@ -112052,19 +111465,16 @@ entities:
   - uid: 3600
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,-32.5
       parent: 2
   - uid: 3606
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -67.5,-28.5
       parent: 2
   - uid: 3607
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -67.5,-32.5
       parent: 2
   - uid: 3666
@@ -112115,7 +111525,6 @@ entities:
   - uid: 3700
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -27.5,-5.5
       parent: 2
   - uid: 3708
@@ -112146,7 +111555,6 @@ entities:
   - uid: 3725
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,17.5
       parent: 2
   - uid: 3730
@@ -112192,31 +111600,26 @@ entities:
   - uid: 3779
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,17.5
       parent: 2
   - uid: 3781
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 26.5,17.5
       parent: 2
   - uid: 3782
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,12.5
       parent: 2
   - uid: 3801
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 23.5,13.5
       parent: 2
   - uid: 3804
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 23.5,16.5
       parent: 2
   - uid: 3805
@@ -112377,19 +111780,16 @@ entities:
   - uid: 3899
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 28.5,9.5
       parent: 2
   - uid: 3911
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,45.5
       parent: 2
   - uid: 3936
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,26.5
       parent: 2
   - uid: 3990
@@ -112400,25 +111800,21 @@ entities:
   - uid: 4003
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 50.5,-12.5
       parent: 2
   - uid: 4005
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,54.5
       parent: 2
   - uid: 4010
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,52.5
       parent: 2
   - uid: 4027
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 57.5,-12.5
       parent: 2
   - uid: 4034
@@ -112434,7 +111830,6 @@ entities:
   - uid: 4123
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,-24.5
       parent: 2
   - uid: 4127
@@ -112465,7 +111860,6 @@ entities:
   - uid: 4289
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -27.5,-11.5
       parent: 2
   - uid: 4325
@@ -112481,25 +111875,21 @@ entities:
   - uid: 4330
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-10.5
       parent: 2
   - uid: 4331
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-8.5
       parent: 2
   - uid: 4334
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-6.5
       parent: 2
   - uid: 4336
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,-12.5
       parent: 2
   - uid: 4344
@@ -112515,91 +111905,76 @@ entities:
   - uid: 4357
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -27.5,-6.5
       parent: 2
   - uid: 4365
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-10.5
       parent: 2
   - uid: 4371
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -44.5,-10.5
       parent: 2
   - uid: 4373
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -27.5,-12.5
       parent: 2
   - uid: 4376
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,-12.5
       parent: 2
   - uid: 4381
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-9.5
       parent: 2
   - uid: 4383
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -36.5,-13.5
       parent: 2
   - uid: 4386
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-4.5
       parent: 2
   - uid: 4388
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,-12.5
       parent: 2
   - uid: 4391
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-4.5
       parent: 2
   - uid: 4393
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -43.5,-18.5
       parent: 2
   - uid: 4397
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,-10.5
       parent: 2
   - uid: 4398
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -36.5,-10.5
       parent: 2
   - uid: 4402
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -27.5,-10.5
       parent: 2
   - uid: 4406
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -32.5,-12.5
       parent: 2
   - uid: 4408
@@ -112610,7 +111985,6 @@ entities:
   - uid: 4413
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,-11.5
       parent: 2
   - uid: 4415
@@ -112626,13 +112000,11 @@ entities:
   - uid: 4419
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,-13.5
       parent: 2
   - uid: 4420
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -34.5,-13.5
       parent: 2
   - uid: 4421
@@ -112643,7 +112015,6 @@ entities:
   - uid: 4429
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,-10.5
       parent: 2
   - uid: 4444
@@ -112654,19 +112025,16 @@ entities:
   - uid: 4460
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,-11.5
       parent: 2
   - uid: 4462
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-11.5
       parent: 2
   - uid: 4463
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-4.5
       parent: 2
   - uid: 4479
@@ -112697,7 +112065,6 @@ entities:
   - uid: 4569
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,6.5
       parent: 2
   - uid: 4577
@@ -112708,31 +112075,26 @@ entities:
   - uid: 4580
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,-6.5
       parent: 2
   - uid: 4582
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,-0.5
       parent: 2
   - uid: 4585
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,1.5
       parent: 2
   - uid: 4587
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,-1.5
       parent: 2
   - uid: 4593
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,-0.5
       parent: 2
   - uid: 4605
@@ -112743,25 +112105,21 @@ entities:
   - uid: 4614
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,5.5
       parent: 2
   - uid: 4615
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,6.5
       parent: 2
   - uid: 4616
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,-1.5
       parent: 2
   - uid: 4670
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,6.5
       parent: 2
   - uid: 4683
@@ -112777,67 +112135,56 @@ entities:
   - uid: 4715
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,5.5
       parent: 2
   - uid: 4719
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -18.5,8.5
       parent: 2
   - uid: 4720
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -18.5,9.5
       parent: 2
   - uid: 4727
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,7.5
       parent: 2
   - uid: 4729
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,9.5
       parent: 2
   - uid: 4730
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,10.5
       parent: 2
   - uid: 4742
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -43.5,-14.5
       parent: 2
   - uid: 4744
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -43.5,-16.5
       parent: 2
   - uid: 4745
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -43.5,-17.5
       parent: 2
   - uid: 4747
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -36.5,-11.5
       parent: 2
   - uid: 4819
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -43.5,-24.5
       parent: 2
   - uid: 4850
@@ -112848,7 +112195,6 @@ entities:
   - uid: 4882
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-0.5
       parent: 2
   - uid: 4902
@@ -112869,13 +112215,11 @@ entities:
   - uid: 5065
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,-29.5
       parent: 2
   - uid: 5085
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,36.5
       parent: 2
   - uid: 5099
@@ -112896,7 +112240,6 @@ entities:
   - uid: 5138
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,14.5
       parent: 2
   - uid: 5140
@@ -112922,7 +112265,6 @@ entities:
   - uid: 5171
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,37.5
       parent: 2
   - uid: 5178
@@ -112988,19 +112330,16 @@ entities:
   - uid: 5259
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,27.5
       parent: 2
   - uid: 5260
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,27.5
       parent: 2
   - uid: 5267
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,35.5
       parent: 2
   - uid: 5269
@@ -113036,7 +112375,6 @@ entities:
   - uid: 5303
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,26.5
       parent: 2
   - uid: 5320
@@ -113067,7 +112405,6 @@ entities:
   - uid: 5359
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,41.5
       parent: 2
   - uid: 5365
@@ -113263,7 +112600,6 @@ entities:
   - uid: 5997
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,-42.5
       parent: 2
   - uid: 6091
@@ -113284,7 +112620,6 @@ entities:
   - uid: 6162
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,-11.5
       parent: 2
   - uid: 6173
@@ -113320,7 +112655,6 @@ entities:
   - uid: 6209
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 30.5,-17.5
       parent: 2
   - uid: 6220
@@ -113426,7 +112760,6 @@ entities:
   - uid: 6501
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,41.5
       parent: 2
   - uid: 6531
@@ -113487,7 +112820,6 @@ entities:
   - uid: 6658
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,30.5
       parent: 2
   - uid: 6661
@@ -113498,37 +112830,31 @@ entities:
   - uid: 6664
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,42.5
       parent: 2
   - uid: 6680
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,32.5
       parent: 2
   - uid: 6685
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,30.5
       parent: 2
   - uid: 6686
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,33.5
       parent: 2
   - uid: 6688
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,33.5
       parent: 2
   - uid: 6689
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,33.5
       parent: 2
   - uid: 6717
@@ -113639,7 +112965,6 @@ entities:
   - uid: 7047
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,45.5
       parent: 2
   - uid: 7048
@@ -113650,13 +112975,11 @@ entities:
   - uid: 7049
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,40.5
       parent: 2
   - uid: 7050
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,47.5
       parent: 2
   - uid: 7052
@@ -113692,103 +113015,86 @@ entities:
   - uid: 7078
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,54.5
       parent: 2
   - uid: 7079
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,54.5
       parent: 2
   - uid: 7080
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,54.5
       parent: 2
   - uid: 7082
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,54.5
       parent: 2
   - uid: 7083
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,54.5
       parent: 2
   - uid: 7087
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,36.5
       parent: 2
   - uid: 7089
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,53.5
       parent: 2
   - uid: 7092
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,53.5
       parent: 2
   - uid: 7093
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,38.5
       parent: 2
   - uid: 7095
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,45.5
       parent: 2
   - uid: 7099
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,39.5
       parent: 2
   - uid: 7100
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,38.5
       parent: 2
   - uid: 7102
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,56.5
       parent: 2
   - uid: 7103
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,55.5
       parent: 2
   - uid: 7115
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,52.5
       parent: 2
   - uid: 7116
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,49.5
       parent: 2
   - uid: 7117
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,51.5
       parent: 2
   - uid: 7131
@@ -113799,13 +113105,11 @@ entities:
   - uid: 7134
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,49.5
       parent: 2
   - uid: 7136
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,57.5
       parent: 2
   - uid: 7140
@@ -113816,55 +113120,46 @@ entities:
   - uid: 7149
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,44.5
       parent: 2
   - uid: 7159
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,49.5
       parent: 2
   - uid: 7172
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,50.5
       parent: 2
   - uid: 7176
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,54.5
       parent: 2
   - uid: 7177
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,55.5
       parent: 2
   - uid: 7184
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,58.5
       parent: 2
   - uid: 7187
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,55.5
       parent: 2
   - uid: 7188
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,56.5
       parent: 2
   - uid: 7214
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,55.5
       parent: 2
   - uid: 7362
@@ -113875,139 +113170,116 @@ entities:
   - uid: 7635
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,44.5
       parent: 2
   - uid: 7689
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,31.5
       parent: 2
   - uid: 7690
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,33.5
       parent: 2
   - uid: 7692
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,33.5
       parent: 2
   - uid: 7693
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,33.5
       parent: 2
   - uid: 7695
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 29.5,33.5
       parent: 2
   - uid: 7697
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,32.5
       parent: 2
   - uid: 7699
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,30.5
       parent: 2
   - uid: 7702
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,30.5
       parent: 2
   - uid: 7703
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,30.5
       parent: 2
   - uid: 7705
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,30.5
       parent: 2
   - uid: 7723
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,29.5
       parent: 2
   - uid: 7739
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,31.5
       parent: 2
   - uid: 7741
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,32.5
       parent: 2
   - uid: 7742
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,32.5
       parent: 2
   - uid: 7744
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,34.5
       parent: 2
   - uid: 7754
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 41.5,33.5
       parent: 2
   - uid: 7758
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,37.5
       parent: 2
   - uid: 7775
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -53.5,-8.5
       parent: 2
   - uid: 7776
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,39.5
       parent: 2
   - uid: 7783
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,32.5
       parent: 2
   - uid: 7786
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,30.5
       parent: 2
   - uid: 7816
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 45.5,33.5
       parent: 2
   - uid: 7897
@@ -114018,7 +113290,6 @@ entities:
   - uid: 7898
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,-10.5
       parent: 2
   - uid: 7899
@@ -114049,61 +113320,51 @@ entities:
   - uid: 7917
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,29.5
       parent: 2
   - uid: 7919
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,26.5
       parent: 2
   - uid: 7921
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,24.5
       parent: 2
   - uid: 7922
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,22.5
       parent: 2
   - uid: 7923
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,21.5
       parent: 2
   - uid: 7924
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 47.5,21.5
       parent: 2
   - uid: 7926
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,51.5
       parent: 2
   - uid: 7930
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,19.5
       parent: 2
   - uid: 7931
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 49.5,19.5
       parent: 2
   - uid: 7933
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,18.5
       parent: 2
   - uid: 7934
@@ -114114,115 +113375,92 @@ entities:
   - uid: 7935
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,16.5
       parent: 2
   - uid: 7938
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 49.5,15.5
       parent: 2
   - uid: 7939
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 49.5,14.5
       parent: 2
   - uid: 7940
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 49.5,13.5
       parent: 2
   - uid: 7965
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 28.5,29.5
       parent: 2
   - uid: 7966
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,7.5
       parent: 2
   - uid: 7967
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 49.5,11.5
       parent: 2
   - uid: 7970
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,10.5
       parent: 2
   - uid: 7986
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 49.5,10.5
       parent: 2
   - uid: 8000
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 47.5,-2.5
       parent: 2
   - uid: 8002
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,-1.5
       parent: 2
   - uid: 8005
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 53.5,-1.5
       parent: 2
   - uid: 8018
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 60.5,-2.5
       parent: 2
   - uid: 8020
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 59.5,-3.5
       parent: 2
   - uid: 8024
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 55.5,-3.5
       parent: 2
   - uid: 8027
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,-1.5
       parent: 2
   - uid: 8034
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 53.5,5.5
       parent: 2
   - uid: 8035
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 52.5,5.5
-      parent: 2
-  - uid: 8040
-    components:
-    - type: Transform
-      pos: -16.5,-8.5
       parent: 2
   - uid: 8048
     components:
@@ -114232,25 +113470,21 @@ entities:
   - uid: 8052
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,0.5
       parent: 2
   - uid: 8059
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,-2.5
       parent: 2
   - uid: 8060
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,-1.5
       parent: 2
   - uid: 8062
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,-3.5
       parent: 2
   - uid: 8074
@@ -114261,13 +113495,11 @@ entities:
   - uid: 8078
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,-3.5
       parent: 2
   - uid: 8104
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-24.5
       parent: 2
   - uid: 8109
@@ -114348,13 +113580,11 @@ entities:
   - uid: 8437
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-34.5
       parent: 2
   - uid: 8465
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,49.5
       parent: 2
   - uid: 8633
@@ -114375,13 +113605,11 @@ entities:
   - uid: 8655
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,18.5
       parent: 2
   - uid: 8828
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,47.5
       parent: 2
   - uid: 8891
@@ -114412,13 +113640,11 @@ entities:
   - uid: 9002
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,-19.5
       parent: 2
   - uid: 9017
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-22.5
       parent: 2
   - uid: 9124
@@ -114429,7 +113655,6 @@ entities:
   - uid: 9217
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-27.5
       parent: 2
   - uid: 9234
@@ -114490,7 +113715,6 @@ entities:
   - uid: 10440
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 28.5,-27.5
       parent: 2
   - uid: 10496
@@ -114531,7 +113755,6 @@ entities:
   - uid: 11132
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,12.5
       parent: 2
   - uid: 11136
@@ -114657,7 +113880,6 @@ entities:
   - uid: 12555
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,-16.5
       parent: 2
   - uid: 12558
@@ -114693,7 +113915,6 @@ entities:
   - uid: 12768
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-24.5
       parent: 2
   - uid: 12783
@@ -114719,7 +113940,6 @@ entities:
   - uid: 13467
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,46.5
       parent: 2
   - uid: 13473
@@ -114745,19 +113965,16 @@ entities:
   - uid: 13545
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,16.5
       parent: 2
   - uid: 13579
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,14.5
       parent: 2
   - uid: 13616
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,-3.5
       parent: 2
   - uid: 13620
@@ -114773,19 +113990,16 @@ entities:
   - uid: 13749
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,16.5
       parent: 2
   - uid: 13798
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,16.5
       parent: 2
   - uid: 13832
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,19.5
       parent: 2
   - uid: 13873
@@ -114891,7 +114105,6 @@ entities:
   - uid: 13990
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-25.5
       parent: 2
   - uid: 14010
@@ -114917,31 +114130,26 @@ entities:
   - uid: 14184
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,-27.5
       parent: 2
   - uid: 14190
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,-44.5
       parent: 2
   - uid: 14197
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,-47.5
       parent: 2
   - uid: 14227
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-38.5
       parent: 2
   - uid: 14232
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,-47.5
       parent: 2
   - uid: 14283
@@ -114952,7 +114160,6 @@ entities:
   - uid: 14305
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,57.5
       parent: 2
   - uid: 14359
@@ -114973,13 +114180,11 @@ entities:
   - uid: 14426
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,58.5
       parent: 2
   - uid: 14429
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,55.5
       parent: 2
   - uid: 14475
@@ -115085,7 +114290,6 @@ entities:
   - uid: 15218
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,-54.5
       parent: 2
   - uid: 15219
@@ -115131,13 +114335,11 @@ entities:
   - uid: 15368
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -51.5,-9.5
       parent: 2
   - uid: 15369
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -55.5,-8.5
       parent: 2
   - uid: 15431
@@ -115168,7 +114370,6 @@ entities:
   - uid: 15586
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,27.5
       parent: 2
   - uid: 15613
@@ -115204,13 +114405,11 @@ entities:
   - uid: 15896
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,23.5
       parent: 2
   - uid: 15924
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-35.5
       parent: 2
   - uid: 16004
@@ -115261,7 +114460,6 @@ entities:
   - uid: 16103
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,9.5
       parent: 2
   - uid: 16164
@@ -115277,7 +114475,6 @@ entities:
   - uid: 16168
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,11.5
       parent: 2
   - uid: 16201
@@ -115303,7 +114500,6 @@ entities:
   - uid: 16390
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -30.5,17.5
       parent: 2
   - uid: 16451
@@ -115319,13 +114515,11 @@ entities:
   - uid: 16614
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,-32.5
       parent: 2
   - uid: 16619
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-31.5
       parent: 2
   - uid: 16642
@@ -115356,13 +114550,11 @@ entities:
   - uid: 16784
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,-30.5
       parent: 2
   - uid: 16785
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,-32.5
       parent: 2
   - uid: 17067
@@ -115528,37 +114720,31 @@ entities:
   - uid: 17658
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,-26.5
       parent: 2
   - uid: 18163
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 60.5,4.5
       parent: 2
   - uid: 18165
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 60.5,2.5
       parent: 2
   - uid: 18330
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,-26.5
       parent: 2
   - uid: 18661
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,-28.5
       parent: 2
   - uid: 18665
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,-29.5
       parent: 2
   - uid: 18668
@@ -115936,7 +115122,6 @@ entities:
   - uid: 1242
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,52.5
       parent: 2
   - uid: 1315
@@ -116008,11 +115193,6 @@ entities:
     components:
     - type: Transform
       pos: 13.5,-22.5
-      parent: 2
-  - uid: 1747
-    components:
-    - type: Transform
-      pos: -17.5,-8.5
       parent: 2
   - uid: 1756
     components:
@@ -116387,7 +115567,6 @@ entities:
   - uid: 2233
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-33.5
       parent: 2
   - uid: 2237
@@ -116423,7 +115602,6 @@ entities:
   - uid: 2295
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-41.5
       parent: 2
   - uid: 2297
@@ -116494,7 +115672,6 @@ entities:
   - uid: 2695
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 49.5,-12.5
       parent: 2
   - uid: 2696
@@ -116505,7 +115682,6 @@ entities:
   - uid: 2708
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 56.5,-12.5
       parent: 2
   - uid: 2715
@@ -116671,7 +115847,6 @@ entities:
   - uid: 2847
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,-23.5
       parent: 2
   - uid: 2849
@@ -116817,7 +115992,6 @@ entities:
   - uid: 2983
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,-16.5
       parent: 2
   - uid: 3003
@@ -116843,7 +116017,6 @@ entities:
   - uid: 3016
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 56.5,-28.5
       parent: 2
   - uid: 3017
@@ -117344,7 +116517,6 @@ entities:
   - uid: 3869
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,53.5
       parent: 2
   - uid: 3871
@@ -117410,13 +116582,11 @@ entities:
   - uid: 3934
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,50.5
       parent: 2
   - uid: 4006
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,50.5
       parent: 2
   - uid: 4126
@@ -117942,7 +117112,6 @@ entities:
   - uid: 4705
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -31.5,10.5
       parent: 2
   - uid: 4714
@@ -117983,13 +117152,11 @@ entities:
   - uid: 5082
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,41.5
       parent: 2
   - uid: 5086
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,37.5
       parent: 2
   - uid: 5087
@@ -118050,7 +117217,6 @@ entities:
   - uid: 5156
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,34.5
       parent: 2
   - uid: 5162
@@ -118066,13 +117232,11 @@ entities:
   - uid: 5164
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,48.5
       parent: 2
   - uid: 5169
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,36.5
       parent: 2
   - uid: 5179
@@ -118193,7 +117357,6 @@ entities:
   - uid: 5563
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,19.5
       parent: 2
   - uid: 5570
@@ -118244,19 +117407,16 @@ entities:
   - uid: 6277
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-50.5
       parent: 2
   - uid: 6323
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-50.5
       parent: 2
   - uid: 6325
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,-50.5
       parent: 2
   - uid: 6335
@@ -118337,19 +117497,16 @@ entities:
   - uid: 7096
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,36.5
       parent: 2
   - uid: 7097
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,36.5
       parent: 2
   - uid: 7098
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,40.5
       parent: 2
   - uid: 7142
@@ -118375,13 +117532,11 @@ entities:
   - uid: 7215
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,-14.5
       parent: 2
   - uid: 7223
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,48.5
       parent: 2
   - uid: 7766
@@ -118392,7 +117547,6 @@ entities:
   - uid: 7990
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -51.5,-8.5
       parent: 2
   - uid: 8137
@@ -118418,13 +117572,11 @@ entities:
   - uid: 8457
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,26.5
       parent: 2
   - uid: 8617
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,44.5
       parent: 2
   - uid: 8644
@@ -118435,7 +117587,6 @@ entities:
   - uid: 8656
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,17.5
       parent: 2
   - uid: 8890
@@ -118456,13 +117607,11 @@ entities:
   - uid: 9044
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,55.5
       parent: 2
   - uid: 9397
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 44.5,-1.5
       parent: 2
   - uid: 9588
@@ -118663,13 +117812,11 @@ entities:
   - uid: 12669
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,-29.5
       parent: 2
   - uid: 12682
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,-16.5
       parent: 2
   - uid: 12765
@@ -118690,7 +117837,6 @@ entities:
   - uid: 13502
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -50.5,-10.5
       parent: 2
   - uid: 13569
@@ -118711,7 +117857,6 @@ entities:
   - uid: 13686
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,-0.5
       parent: 2
   - uid: 13741
@@ -118722,7 +117867,6 @@ entities:
   - uid: 13764
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,44.5
       parent: 2
   - uid: 13796
@@ -118758,7 +117902,6 @@ entities:
   - uid: 13911
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-40.5
       parent: 2
   - uid: 13912
@@ -118804,19 +117947,16 @@ entities:
   - uid: 13979
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 43.5,16.5
       parent: 2
   - uid: 13980
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,17.5
       parent: 2
   - uid: 13981
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,18.5
       parent: 2
   - uid: 14201
@@ -118832,13 +117972,11 @@ entities:
   - uid: 14219
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-40.5
       parent: 2
   - uid: 14231
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,-47.5
       parent: 2
   - uid: 14239
@@ -118869,7 +118007,6 @@ entities:
   - uid: 14284
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,59.5
       parent: 2
   - uid: 14315
@@ -118880,7 +118017,6 @@ entities:
   - uid: 14343
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,57.5
       parent: 2
   - uid: 14399
@@ -118896,31 +118032,26 @@ entities:
   - uid: 14411
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,58.5
       parent: 2
   - uid: 14414
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,-31.5
       parent: 2
   - uid: 14427
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,58.5
       parent: 2
   - uid: 14442
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 28.5,-28.5
       parent: 2
   - uid: 14443
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 28.5,-29.5
       parent: 2
   - uid: 14519
@@ -118936,7 +118067,6 @@ entities:
   - uid: 14531
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-36.5
       parent: 2
   - uid: 14536
@@ -119062,13 +118192,11 @@ entities:
   - uid: 15366
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,-9.5
       parent: 2
   - uid: 15367
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -53.5,-9.5
       parent: 2
   - uid: 15480
@@ -119114,13 +118242,11 @@ entities:
   - uid: 15920
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-37.5
       parent: 2
   - uid: 15921
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-36.5
       parent: 2
   - uid: 15976
@@ -119181,13 +118307,11 @@ entities:
   - uid: 16608
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,-29.5
       parent: 2
   - uid: 16620
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-30.5
       parent: 2
   - uid: 16639
@@ -119213,43 +118337,36 @@ entities:
   - uid: 16782
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,-31.5
       parent: 2
   - uid: 17068
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -45.5,-49.5
       parent: 2
   - uid: 17072
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -45.5,-45.5
       parent: 2
   - uid: 17075
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -44.5,-43.5
       parent: 2
   - uid: 17081
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -44.5,-50.5
       parent: 2
   - uid: 17085
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-53.5
       parent: 2
   - uid: 17086
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -44.5,-53.5
       parent: 2
   - uid: 17262
@@ -119295,7 +118412,6 @@ entities:
   - uid: 17326
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-48.5
       parent: 2
   - uid: 17375
@@ -119358,427 +118474,356 @@ entities:
   - uid: 6
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 2
   - uid: 8
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-3.5
       parent: 2
   - uid: 10
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-4.5
       parent: 2
   - uid: 11
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 2
   - uid: 13
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,3.5
       parent: 2
   - uid: 14
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,4.5
       parent: 2
   - uid: 24
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,-8.5
       parent: 2
   - uid: 25
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,-8.5
       parent: 2
   - uid: 27
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-8.5
       parent: 2
   - uid: 28
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,-8.5
       parent: 2
   - uid: 31
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,-7.5
       parent: 2
   - uid: 34
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 2
   - uid: 36
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-7.5
       parent: 2
   - uid: 37
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-4.5
       parent: 2
   - uid: 40
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-4.5
       parent: 2
   - uid: 42
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,-3.5
       parent: 2
   - uid: 43
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,-2.5
       parent: 2
   - uid: 44
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,-2.5
       parent: 2
   - uid: 52
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,3.5
       parent: 2
   - uid: 54
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,2.5
       parent: 2
   - uid: 55
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,4.5
       parent: 2
   - uid: 56
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,2.5
       parent: 2
   - uid: 62
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,6.5
       parent: 2
   - uid: 63
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-11.5
       parent: 2
   - uid: 64
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,-11.5
       parent: 2
   - uid: 69
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,14.5
       parent: 2
   - uid: 70
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-10.5
       parent: 2
   - uid: 71
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-10.5
       parent: 2
   - uid: 73
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,14.5
       parent: 2
   - uid: 74
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,-10.5
       parent: 2
   - uid: 77
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-10.5
       parent: 2
   - uid: 78
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 2
   - uid: 80
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-10.5
       parent: 2
   - uid: 84
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-7.5
       parent: 2
   - uid: 90
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,7.5
       parent: 2
   - uid: 92
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,7.5
       parent: 2
   - uid: 93
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,7.5
       parent: 2
   - uid: 97
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,10.5
       parent: 2
   - uid: 98
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,7.5
       parent: 2
   - uid: 99
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,7.5
       parent: 2
   - uid: 102
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,7.5
       parent: 2
   - uid: 103
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 2
   - uid: 105
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,7.5
       parent: 2
   - uid: 108
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,5.5
       parent: 2
   - uid: 111
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 2
   - uid: 120
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,8.5
       parent: 2
   - uid: 121
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,11.5
       parent: 2
   - uid: 122
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,11.5
       parent: 2
   - uid: 124
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,11.5
       parent: 2
   - uid: 125
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 2
   - uid: 128
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 2
   - uid: 129
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,11.5
       parent: 2
   - uid: 131
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,11.5
       parent: 2
   - uid: 133
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,11.5
       parent: 2
   - uid: 134
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,10.5
       parent: 2
   - uid: 135
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,9.5
       parent: 2
   - uid: 143
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,8.5
       parent: 2
   - uid: 144
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,12.5
       parent: 2
   - uid: 146
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,12.5
       parent: 2
   - uid: 152
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,3.5
       parent: 2
   - uid: 154
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,-11.5
       parent: 2
   - uid: 156
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-11.5
       parent: 2
   - uid: 159
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-8.5
       parent: 2
   - uid: 162
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-5.5
       parent: 2
   - uid: 164
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 2
   - uid: 175
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,12.5
       parent: 2
   - uid: 176
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,14.5
       parent: 2
   - uid: 178
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,14.5
       parent: 2
   - uid: 179
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,14.5
       parent: 2
   - uid: 180
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,14.5
       parent: 2
   - uid: 181
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,14.5
       parent: 2
   - uid: 186
@@ -119789,25 +118834,21 @@ entities:
   - uid: 188
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,4.5
       parent: 2
   - uid: 191
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,7.5
       parent: 2
   - uid: 192
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,8.5
       parent: 2
   - uid: 196
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,10.5
       parent: 2
   - uid: 251
@@ -119818,13 +118859,11 @@ entities:
   - uid: 259
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,7.5
       parent: 2
   - uid: 261
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,11.5
       parent: 2
   - uid: 288
@@ -119845,7 +118884,6 @@ entities:
   - uid: 503
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-4.5
       parent: 2
   - uid: 698
@@ -119886,7 +118924,6 @@ entities:
   - uid: 733
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 2
   - uid: 816
@@ -119907,7 +118944,6 @@ entities:
   - uid: 962
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,10.5
       parent: 2
   - uid: 1176
@@ -119933,73 +118969,61 @@ entities:
   - uid: 1642
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,-1.5
       parent: 2
   - uid: 1646
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,2.5
       parent: 2
   - uid: 1649
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,8.5
       parent: 2
   - uid: 1650
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,9.5
       parent: 2
   - uid: 1653
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,3.5
       parent: 2
   - uid: 1656
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,2.5
       parent: 2
   - uid: 1662
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 29.5,1.5
       parent: 2
   - uid: 1663
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 28.5,1.5
       parent: 2
   - uid: 1665
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,1.5
       parent: 2
   - uid: 1667
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 29.5,6.5
       parent: 2
   - uid: 1668
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 29.5,4.5
       parent: 2
   - uid: 1670
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,10.5
       parent: 2
   - uid: 1678
@@ -120010,25 +119034,21 @@ entities:
   - uid: 1698
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 23.5,-0.5
       parent: 2
   - uid: 1699
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 23.5,0.5
       parent: 2
   - uid: 1700
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 23.5,1.5
       parent: 2
   - uid: 1710
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-24.5
       parent: 2
   - uid: 1767
@@ -120039,7 +119059,6 @@ entities:
   - uid: 2290
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,-40.5
       parent: 2
   - uid: 2673
@@ -120060,7 +119079,6 @@ entities:
   - uid: 2814
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-27.5
       parent: 2
   - uid: 2819
@@ -120076,13 +119094,11 @@ entities:
   - uid: 2909
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-26.5
       parent: 2
   - uid: 2923
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-24.5
       parent: 2
   - uid: 3013
@@ -120098,97 +119114,81 @@ entities:
   - uid: 3064
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,-18.5
       parent: 2
   - uid: 3065
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,-19.5
       parent: 2
   - uid: 3071
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,-23.5
       parent: 2
   - uid: 3073
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,-26.5
       parent: 2
   - uid: 3074
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -18.5,-27.5
       parent: 2
   - uid: 3075
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,-27.5
       parent: 2
   - uid: 3080
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,-18.5
       parent: 2
   - uid: 3081
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,-18.5
       parent: 2
   - uid: 3091
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,-24.5
       parent: 2
   - uid: 3097
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,-18.5
       parent: 2
   - uid: 3098
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,-19.5
       parent: 2
   - uid: 3102
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,-23.5
       parent: 2
   - uid: 3104
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,-24.5
       parent: 2
   - uid: 3113
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,-27.5
       parent: 2
   - uid: 3114
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,-25.5
       parent: 2
   - uid: 3124
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -36.5,-19.5
       parent: 2
   - uid: 3127
@@ -120254,13 +119254,11 @@ entities:
   - uid: 3172
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,-32.5
       parent: 2
   - uid: 3175
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,-30.5
       parent: 2
   - uid: 3188
@@ -120351,31 +119349,26 @@ entities:
   - uid: 3392
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-17.5
       parent: 2
   - uid: 3393
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,-17.5
       parent: 2
   - uid: 3397
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,-17.5
       parent: 2
   - uid: 3400
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -34.5,-19.5
       parent: 2
   - uid: 3402
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -32.5,-19.5
       parent: 2
   - uid: 3470
@@ -120391,7 +119384,6 @@ entities:
   - uid: 3502
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,5.5
       parent: 2
   - uid: 3531
@@ -120412,7 +119404,6 @@ entities:
   - uid: 3619
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 47.5,15.5
       parent: 2
   - uid: 3620
@@ -120423,7 +119414,6 @@ entities:
   - uid: 3625
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -39.5,-33.5
       parent: 2
   - uid: 3690
@@ -120464,7 +119454,6 @@ entities:
   - uid: 3723
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 32.5,12.5
       parent: 2
   - uid: 3726
@@ -120485,7 +119474,6 @@ entities:
   - uid: 3732
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 33.5,13.5
       parent: 2
   - uid: 3737
@@ -120566,49 +119554,41 @@ entities:
   - uid: 3778
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,15.5
       parent: 2
   - uid: 3784
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,13.5
       parent: 2
   - uid: 3786
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 36.5,12.5
       parent: 2
   - uid: 3787
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 35.5,12.5
       parent: 2
   - uid: 3789
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 34.5,12.5
       parent: 2
   - uid: 3797
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 33.5,16.5
       parent: 2
   - uid: 3799
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,12.5
       parent: 2
   - uid: 3806
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,11.5
       parent: 2
   - uid: 3808
@@ -120664,19 +119644,16 @@ entities:
   - uid: 3891
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 32.5,16.5
       parent: 2
   - uid: 3894
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 33.5,15.5
       parent: 2
   - uid: 3896
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,16.5
       parent: 2
   - uid: 4115
@@ -120842,31 +119819,26 @@ entities:
   - uid: 4315
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -36.5,-16.5
       parent: 2
   - uid: 4320
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -32.5,-16.5
       parent: 2
   - uid: 4333
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,-16.5
       parent: 2
   - uid: 4341
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,-16.5
       parent: 2
   - uid: 4404
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -32.5,-14.5
       parent: 2
   - uid: 4405
@@ -120877,13 +119849,11 @@ entities:
   - uid: 4410
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-14.5
       parent: 2
   - uid: 4504
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,52.5
       parent: 2
   - uid: 4533
@@ -120899,19 +119869,16 @@ entities:
   - uid: 4696
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,3.5
       parent: 2
   - uid: 4699
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,7.5
       parent: 2
   - uid: 4700
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,9.5
       parent: 2
   - uid: 4848
@@ -120927,7 +119894,6 @@ entities:
   - uid: 5168
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,35.5
       parent: 2
   - uid: 5217
@@ -120943,7 +119909,6 @@ entities:
   - uid: 5225
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,13.5
       parent: 2
   - uid: 5276
@@ -120964,13 +119929,11 @@ entities:
   - uid: 5883
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,-14.5
       parent: 2
   - uid: 5885
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,-13.5
       parent: 2
   - uid: 5928
@@ -121036,7 +119999,6 @@ entities:
   - uid: 6171
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -36.5,-44.5
       parent: 2
   - uid: 6210
@@ -121052,13 +120014,11 @@ entities:
   - uid: 6292
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -38.5,-39.5
       parent: 2
   - uid: 6293
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -38.5,-38.5
       parent: 2
   - uid: 6296
@@ -121094,7 +120054,6 @@ entities:
   - uid: 6621
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,26.5
       parent: 2
   - uid: 6652
@@ -121105,7 +120064,6 @@ entities:
   - uid: 6656
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,36.5
       parent: 2
   - uid: 6667
@@ -121116,31 +120074,26 @@ entities:
   - uid: 6673
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -18.5,31.5
       parent: 2
   - uid: 6674
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,31.5
       parent: 2
   - uid: 6676
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,31.5
       parent: 2
   - uid: 6692
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,29.5
       parent: 2
   - uid: 6694
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -18.5,30.5
       parent: 2
   - uid: 6760
@@ -121161,49 +120114,41 @@ entities:
   - uid: 7150
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,40.5
       parent: 2
   - uid: 7151
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,48.5
       parent: 2
   - uid: 7156
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,47.5
       parent: 2
   - uid: 7161
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,50.5
       parent: 2
   - uid: 7165
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,39.5
       parent: 2
   - uid: 7167
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,37.5
       parent: 2
   - uid: 7168
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,37.5
       parent: 2
   - uid: 7170
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,42.5
       parent: 2
   - uid: 7174
@@ -121229,55 +120174,46 @@ entities:
   - uid: 7645
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,33.5
       parent: 2
   - uid: 7649
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,33.5
       parent: 2
   - uid: 7681
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,29.5
       parent: 2
   - uid: 7707
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 20.5,30.5
       parent: 2
   - uid: 7716
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 35.5,27.5
       parent: 2
   - uid: 7717
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 35.5,26.5
       parent: 2
   - uid: 7719
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 35.5,24.5
       parent: 2
   - uid: 7721
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,23.5
       parent: 2
   - uid: 7722
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,23.5
       parent: 2
   - uid: 7725
@@ -121293,55 +120229,46 @@ entities:
   - uid: 7727
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,23.5
       parent: 2
   - uid: 7730
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,23.5
       parent: 2
   - uid: 7734
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,27.5
       parent: 2
   - uid: 7735
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,27.5
       parent: 2
   - uid: 7736
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,26.5
       parent: 2
   - uid: 7738
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,23.5
       parent: 2
   - uid: 7960
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 35.5,28.5
       parent: 2
   - uid: 7961
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 36.5,28.5
       parent: 2
   - uid: 7964
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,28.5
       parent: 2
   - uid: 7981
@@ -121422,55 +120349,46 @@ entities:
   - uid: 9045
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 41.5,31.5
       parent: 2
   - uid: 9046
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 41.5,30.5
       parent: 2
   - uid: 9047
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 45.5,21.5
       parent: 2
   - uid: 9050
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 45.5,1.5
       parent: 2
   - uid: 9051
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 44.5,-0.5
       parent: 2
   - uid: 9052
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 45.5,25.5
       parent: 2
   - uid: 9053
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 45.5,26.5
       parent: 2
   - uid: 9054
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 46.5,25.5
       parent: 2
   - uid: 9055
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 46.5,29.5
       parent: 2
   - uid: 9554
@@ -121491,25 +120409,21 @@ entities:
   - uid: 9596
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-48.5
       parent: 2
   - uid: 9597
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-47.5
       parent: 2
   - uid: 9598
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,-47.5
       parent: 2
   - uid: 9600
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-47.5
       parent: 2
   - uid: 9992
@@ -121595,7 +120509,6 @@ entities:
   - uid: 11237
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -43.5,-32.5
       parent: 2
   - uid: 11238
@@ -121636,7 +120549,6 @@ entities:
   - uid: 11629
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,-34.5
       parent: 2
   - uid: 11695
@@ -121732,19 +120644,16 @@ entities:
   - uid: 13900
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,-37.5
       parent: 2
   - uid: 13904
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,56.5
       parent: 2
   - uid: 13905
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,56.5
       parent: 2
   - uid: 13910
@@ -121755,7 +120664,6 @@ entities:
   - uid: 13937
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,43.5
       parent: 2
   - uid: 14402
@@ -121791,7 +120699,6 @@ entities:
   - uid: 15285
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,-36.5
       parent: 2
   - uid: 15462
@@ -121817,25 +120724,21 @@ entities:
   - uid: 15688
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -34.5,-44.5
       parent: 2
   - uid: 15690
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -38.5,-42.5
       parent: 2
   - uid: 15691
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -38.5,-44.5
       parent: 2
   - uid: 15699
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -38.5,-43.5
       parent: 2
   - uid: 15860
@@ -121846,7 +120749,6 @@ entities:
   - uid: 15926
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-35.5
       parent: 2
   - uid: 16023
@@ -121924,19 +120826,16 @@ entities:
   - uid: 216
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,-7.5
       parent: 2
   - uid: 257
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 2
   - uid: 295
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,2.5
       parent: 2
   - uid: 359
@@ -121947,13 +120846,11 @@ entities:
   - uid: 983
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 2
   - uid: 1263
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,-2.5
       parent: 2
   - uid: 2259
@@ -121964,7 +120861,6 @@ entities:
   - uid: 2718
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,3.5
       parent: 2
   - uid: 2789
@@ -121980,7 +120876,6 @@ entities:
   - uid: 4502
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-46.5
       parent: 2
   - uid: 4713
@@ -123346,7 +122241,6 @@ entities:
   - uid: 9062
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 46.5,21.5
       parent: 2
   - uid: 9065
@@ -123367,7 +122261,6 @@ entities:
   - uid: 9599
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-47.5
       parent: 2
   - uid: 9647
@@ -123393,7 +122286,6 @@ entities:
   - uid: 10405
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 45.5,22.5
       parent: 2
   - uid: 10483
@@ -123424,7 +122316,6 @@ entities:
   - uid: 10904
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 45.5,24.5
       parent: 2
   - uid: 10920
@@ -123480,37 +122371,31 @@ entities:
   - uid: 11159
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 45.5,28.5
       parent: 2
   - uid: 11166
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 45.5,29.5
       parent: 2
   - uid: 11168
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 47.5,25.5
       parent: 2
   - uid: 11172
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 47.5,29.5
       parent: 2
   - uid: 11191
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,5.5
       parent: 2
   - uid: 11192
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,6.5
       parent: 2
   - uid: 11303
@@ -123636,43 +122521,36 @@ entities:
   - uid: 13903
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,56.5
       parent: 2
   - uid: 13908
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-49.5
       parent: 2
   - uid: 13914
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-47.5
       parent: 2
   - uid: 13915
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-47.5
       parent: 2
   - uid: 13916
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-49.5
       parent: 2
   - uid: 13917
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,-37.5
       parent: 2
   - uid: 13919
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-37.5
       parent: 2
   - uid: 13995
@@ -123693,7 +122571,6 @@ entities:
   - uid: 14698
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,-3.5
       parent: 2
   - uid: 14738
@@ -123709,25 +122586,21 @@ entities:
   - uid: 14823
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-33.5
       parent: 2
   - uid: 14842
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,-33.5
       parent: 2
   - uid: 14848
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,-35.5
       parent: 2
   - uid: 14851
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-32.5
       parent: 2
   - uid: 15011
@@ -123738,7 +122611,6 @@ entities:
   - uid: 15052
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-42.5
       parent: 2
   - uid: 15245
@@ -123749,13 +122621,11 @@ entities:
   - uid: 15263
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-48.5
       parent: 2
   - uid: 15281
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -43.5,-37.5
       parent: 2
   - uid: 15327
@@ -123796,7 +122666,6 @@ entities:
   - uid: 15712
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-38.5
       parent: 2
   - uid: 15714
@@ -123822,7 +122691,6 @@ entities:
   - uid: 16217
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,-8.5
       parent: 2
   - uid: 16244
@@ -123833,25 +122701,21 @@ entities:
   - uid: 17091
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-45.5
       parent: 2
   - uid: 17092
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-45.5
       parent: 2
   - uid: 17134
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-41.5
       parent: 2
   - uid: 17227
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-42.5
       parent: 2
   - uid: 17272
@@ -124679,17 +123543,17 @@ entities:
       parent: 2
 - proto: WindoorSecureEVALocked
   entities:
-  - uid: 18606
+  - uid: 8040
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
+      rot: 1.5707963267948966 rad
       pos: -19.5,-10.5
       parent: 2
-  - uid: 18709
+  - uid: 14158
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -18.5,-10.5
+      rot: 1.5707963267948966 rad
+      pos: -19.5,-9.5
       parent: 2
 - proto: WindoorSecureHeadOfPersonnelLocked
   entities:
@@ -124928,19 +123792,16 @@ entities:
   - uid: 3944
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 35.5,6.5
       parent: 2
   - uid: 3945
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 36.5,6.5
       parent: 2
   - uid: 3946
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,6.5
       parent: 2
   - uid: 4157
@@ -124966,13 +123827,11 @@ entities:
   - uid: 4306
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,-19.5
       parent: 2
   - uid: 4307
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,-19.5
       parent: 2
   - uid: 5499
@@ -125635,12 +124494,6 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-38.5
-      parent: 2
-  - uid: 18710
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,-10.5
       parent: 2
 - proto: WoodblockInstrument
   entities:

--- a/Resources/Maps/elkridge.yml
+++ b/Resources/Maps/elkridge.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 271.1.0
   forkId: ""
   forkVersion: ""
-  time: 01/24/2026 12:36:13
-  entityCount: 18702
+  time: 01/24/2026 13:08:18
+  entityCount: 18701
 maps:
 - 1
 grids:
@@ -14295,17 +14295,15 @@ entities:
       rot: 3.141592653589793 rad
       pos: 9.5,42.5
       parent: 2
-- proto: AirlockHeadOfPersonnelGlassLocked
+- proto: AirlockHeadOfPersonnelLocked
   entities:
-  - uid: 11003
+  - uid: 1717
     components:
     - type: MetaData
-      name: glass airlock (EVA)
+      name: airlock (HoP's Office)
     - type: Transform
       pos: -15.5,-9.5
       parent: 2
-- proto: AirlockHeadOfPersonnelLocked
-  entities:
   - uid: 10830
     components:
     - type: MetaData
@@ -84991,11 +84989,6 @@ entities:
     - type: Transform
       pos: -11.5,-5.5
       parent: 2
-  - uid: 1717
-    components:
-    - type: Transform
-      pos: -15.5,-10.5
-      parent: 2
   - uid: 1808
     components:
     - type: Transform
@@ -98976,11 +98969,6 @@ entities:
     components:
     - type: Transform
       pos: -11.5,-5.5
-      parent: 2
-  - uid: 11070
-    components:
-    - type: Transform
-      pos: -15.5,-10.5
       parent: 2
   - uid: 11139
     components:
@@ -113731,6 +113719,11 @@ entities:
     components:
     - type: Transform
       pos: 6.5,-23.5
+      parent: 2
+  - uid: 11003
+    components:
+    - type: Transform
+      pos: -15.5,-10.5
       parent: 2
   - uid: 11068
     components:

--- a/Resources/Maps/elkridge.yml
+++ b/Resources/Maps/elkridge.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 271.1.0
   forkId: ""
   forkVersion: ""
-  time: 01/24/2026 13:08:18
-  entityCount: 18701
+  time: 01/26/2026 15:09:51
+  entityCount: 18698
 maps:
 - 1
 grids:
@@ -96156,25 +96156,14 @@ entities:
   - uid: 1745
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,-4.5
+      rot: 3.141592653589793 rad
+      pos: -16.5,-8.5
       parent: 2
   - uid: 1759
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,-5.5
-      parent: 2
-  - uid: 2831
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,-2.5
-      parent: 2
-  - uid: 2959
-    components:
-    - type: Transform
-      pos: -16.5,-7.5
+      rot: 3.141592653589793 rad
+      pos: -17.5,-8.5
       parent: 2
   - uid: 5113
     components:
@@ -96436,12 +96425,6 @@ entities:
       parent: 2
 - proto: RailingCorner
   entities:
-  - uid: 4972
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,-7.5
-      parent: 2
   - uid: 6976
     components:
     - type: Transform

--- a/Resources/Maps/elkridge.yml
+++ b/Resources/Maps/elkridge.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 271.1.0
+  engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 01/26/2026 15:09:51
+  time: 02/26/2026 21:23:20
   entityCount: 18698
 maps:
 - 1
@@ -89568,6 +89568,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 44.5,-28.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: IntercomCommand
   entities:
   - uid: 4470
@@ -90140,17 +90142,14 @@ entities:
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 18607
+- proto: LockableButtonCommandEmergencyEVA
+  entities:
+  - uid: 2831
     components:
-    - type: MetaData
-      name: emergency EVA Storage access
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-5.5
       parent: 2
-    - type: AccessReader
-      accessListsOriginal:
-      - - Command
     - type: DeviceLinkSource
       linkedPorts:
         15548:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Updates the airlocks in the Library and Newsroom on Elkridge, and makes a few tweaks to the EVA Storage room. Requires #41416 and #41740.

Exact changes are as follows:
- The EVA Storage room has had a slight layout tweak. (See attached media.)
  - The tiny side room (containing the magboots, mini-jetpacks, and gas canisters) has been merged into the main room. The magboots and mini-jetpacks are now behind secure windoors requiring the same accesses as the main doors. The emergency-access wall button doesn't open these secure windoors.
  - Railings have been repositioned to not overlap the suit storage lockers.
  - The glass airlock connecting to the HoP's office is now a regular (opaque) airlock.
- The Librarian's desk and back room are now Library access.
- The Newsroom is now Newsroom access.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
For explanation of Library/Newsroom changes, see required PR.

The EVA Storage tweak was made because I think Command opening EVA Storage to all crew is usually just for the sake of a stationwide atmopsheric emergency; magboots and jetpacks are likely not something they want random crew to just grab without supervision, so the windoors aren't linked to an emergency button. If a member of Command _does_ want regular crew to have them, they can just open the windoors themselves at the same time as they hit the wall button (since windoors just stay open until manually closed); if Command isn't around and someone _really_ wants these items, they can just break the glass with some kind of weapon.

## Technical details
<!-- Summary of code changes for easier review. -->
This PR is just mapping changes. For changes related to prototypes, see required PR.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="505" height="858" alt="image" src="https://github.com/user-attachments/assets/c0897500-b425-4f3e-b66d-b3886a63dcd8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
MAPS:
- tweak: On Elkridge, the EVA Storage room's layout has been tweaked.
- tweak: On Elkridge, the Library's back room and desk are now Library access.
- tweak: On Elkridge, the Newsroom is now Newsroom access.