### PR TITLE
Of Hats and Hardsuit Helmets

### DIFF
--- a/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
@@ -15,6 +15,7 @@ namespace Content.Shared.Clothing.Components;
 public sealed partial class ToggleableClothingComponent : Component
 {
     public const string DefaultClothingContainerId = "toggleable-clothing";
+    public const string DefaultUnderneathClothingContainerId = "toggleable-under-clothing";
 
     /// <summary>
     ///     Action used to toggle the clothing on or off.
@@ -71,4 +72,16 @@ public sealed partial class ToggleableClothingComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public string? VerbText;
+
+    /// <summary>
+    ///     The container ID of <see cref="UnderClothingContainer"/>.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string UnderClothingContainerId = DefaultUnderneathClothingContainerId;
+
+    /// <summary>
+    ///     The container where the item that the toggled clothing replaced is put.
+    /// </summary>
+    [ViewVariables]
+    public ContainerSlot? UnderClothingContainer;
 }

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.UnderClothing.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.UnderClothing.cs
@@ -1,0 +1,92 @@
+using Content.Shared.Clothing.Components;
+
+namespace Content.Shared.Clothing.EntitySystems;
+
+/// <summary>
+/// Provides methods that store and re-equip clothing when toggleable clothing is put on or taken off.
+/// Sidenote; god, I hate naming things.
+/// </summary>
+public sealed partial class ToggleableClothingSystem : EntitySystem
+{
+    /// <summary>
+    ///     Tries to store clothing in <see cref="ToggleableClothingComponent.UnderClothingContainer"/>
+    /// </summary>
+    /// <param name="clothing">The clothing to be stored.</param>
+    /// <param name="component">The ToggleableClothingComponent to store the clothing in.</param>
+    /// <returns>True if clothing can be inserted and was inserted.</returns>
+    private bool TryStoreUnderClothing(EntityUid clothing, ToggleableClothingComponent component)
+    {
+        if (component.UnderClothingContainer == null)
+            return false;
+
+        // There is already something in there? Either way, return false because we
+        // expect one entity.
+        if (component.UnderClothingContainer.ContainedEntity.HasValue)
+            return false;
+
+        return _containerSystem.Insert(clothing, component.UnderClothingContainer);
+    }
+
+    /// <summary>
+    ///     Tries to equip any stored clothing kept in <see cref="ToggleableClothingComponent.UnderClothingContainer"/>.
+    /// </summary>
+    /// <param name="actor">The person wearing the ToggleableClothing.</param>
+    /// <param name="component">The ToggleableClothingComponent to check for an stored items.</param>
+    /// <returns>True if something was equipped OR if there is nothing to equip.</returns>
+    private bool TryEquipUnderClothing(EntityUid actor, ToggleableClothingComponent component)
+    {
+        return TryEquipUnderClothing(actor, actor, component);
+    }
+
+    /// <summary>
+    ///     Tries to equip any stored clothing kept in <see cref="ToggleableClothingComponent.UnderClothingContainer"/>.
+    /// </summary>
+    /// <param name="actor">The person trying to equip the clothing.</param>
+    /// <param name="target">The person who to equip the clothing on.</param>
+    /// <param name="component">The ToggleableClothingComponent to check for an stored items.</param>
+    /// <returns>True if something was equipped OR if there is nothing to equip.</returns>
+    private bool TryEquipUnderClothing(EntityUid actor, EntityUid target, ToggleableClothingComponent component)
+    {
+        // if there is no UnderClothingContainer, then why are we here?
+        if (component.UnderClothingContainer == null)
+            return true;
+
+        // if nothing is contained so technically dropping nothing counts as a success
+        if (!component.UnderClothingContainer.ContainedEntity.HasValue)
+            return true;
+
+        return _inventorySystem.TryEquip(actor, target, component.UnderClothingContainer.ContainedEntity.Value, component.Slot, force: true);
+    }
+
+    /// <summary>
+    ///     Tries to equip any stored clothing kept in <see cref="ToggleableClothingComponent.UnderClothingContainer"/>.
+    /// </summary>
+    /// <param name="actor">The person trying to equip the clothing.</param>
+    /// <param name="component">The AttachedClothing of the ToggleableClothing to check for an stored items.</param>
+    /// <returns>True if something was equipped OR if there is nothing to equip.</returns>
+    private bool TryEquipUnderClothing(EntityUid actor, AttachedClothingComponent component)
+    {
+        if (!TryComp<ToggleableClothingComponent>(component.AttachedUid, out var toggleableComp))
+            return false;
+
+        return TryEquipUnderClothing(actor, toggleableComp);
+    }
+
+    /// <summary>
+    ///     Tries to drop any stored clothing kept in <see cref="ToggleableClothingComponent.UnderClothingContainer"/>.
+    /// </summary>
+    /// <param name="component">The ToggleableClothingComponent that is holding the item to be dropped.</param>
+    /// <returns>True if there is not an item to be dropped OR it was successfully dropped.</returns>
+    private bool TryDropUnderClothing(ToggleableClothingComponent component)
+    {
+        // if there is no UnderClothingContainer, then why are we here?
+        if (component.UnderClothingContainer == null)
+            return true;
+
+        // if nothing is contained so technically dropping nothing counts as a success
+        if (!component.UnderClothingContainer.ContainedEntity.HasValue)
+            return true;
+
+        return _containerSystem.TryRemoveFromContainer(component.UnderClothingContainer.ContainedEntity.Value);
+    }
+}

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -160,6 +160,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
 
 - type: entity
   parent: ClothingNeckBase
@@ -186,6 +187,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
   - type: TypingIndicatorClothing
     proto: moth
 
@@ -205,6 +207,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
   - type: TypingIndicatorClothing
     proto: alien
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -101,6 +101,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
       storagebase: !type:Container
         ents: []
 
@@ -138,6 +139,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
   - type: GroupExamine
   - type: Tag
     tags:
@@ -198,6 +200,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
       storagebase: !type:Container
         ents: []
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -59,6 +59,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
   - type: Tag
     tags:
     - CorgiWearable
@@ -169,6 +170,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
   - type: Tag
     tags:
     - CorgiWearable

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -138,6 +138,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
   - type: HideLayerClothing
@@ -261,6 +262,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
 
@@ -281,6 +283,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
   - type: Construction
     graph: ClothingOuterSuitIan
     node: suit
@@ -311,6 +314,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
   - type: HideLayerClothing
     slots:
     - Tail

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -50,6 +50,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
       storagebase: !type:Container
         ents: []
 
@@ -376,6 +377,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot { }
+      toggleable-under-clothing: !type:ContainerSlot {}
       storagebase: !type:Container
         ents: [ ]
 ##########################################################
@@ -740,6 +742,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot { }
+      toggleable-under-clothing: !type:ContainerSlot {}
       storagebase: !type:Container
         ents: [ ]
 ################################################################


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
You can now toggle your hardsuit helmet while you have something on your head and it will unequip and store your hat in a hidden slot in the component until you or someone else removes the suit or toggles the hardsuit helmet off.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. Less micromanaging of equipped gear. Hardsuit helmets will 'just work' when you press the button instead of being stopped by a small piece of cloth.
2. Pretty much a QoL feature.
3. I like wearing hats.
4. Consider the captain's aura when they put their hardsuit helmet down and they look drippy as hell with that deep blue beret on.

## Technical details
<!-- Summary of code changes for easier review. -->
Made `ToggleableClothingSystem` partial and extended it. I did this instead of just adding to the main class to separate the logic between the attached entity's container and the container to store the hat a bit better. Added another container to `ToggleableClothingComponent` to store the item, and then just manage that container based on if it was unequipped or equipped.

I did consider making a blacklist for certain hats/helms, such as the atmos fire helm, EVA suit helm and regular fire helm, since they seem more bulky, but that seems like its not really a huge issue nor something that would really happen very often at all. But I can implement it if you all would like, complete with its own pop-up text saying its too bulky.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/d0bdb159-10c0-4279-9d68-486018f7f80a


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: You can now toggle your hardsuit helmet on over your hat or beret!