### PR TITLE
Refresh gas canister UI on canister startup

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
@@ -48,18 +48,14 @@ public sealed class GasCanisterSystem : SharedGasCanisterSystem
 
     protected override void DirtyUI(EntityUid uid, GasCanisterComponent? canister = null, NodeContainerComponent? nodeContainer = null)
     {
-        if (!Resolve(uid, ref canister))
+        if (!Resolve(uid, ref canister, ref nodeContainer, logMissing: false))
             return;
 
         var portStatus = false;
         var tankPressure = 0f;
 
-        // All real canisters should have a nodeContainer, but the ones during AllComponentsOneToOneDeleteTest do not. Don't fail the test
-        if (nodeContainer != null || TryComp<NodeContainerComponent>(uid, out nodeContainer))
-        {
-            if (_nodeContainer.TryGetNode(nodeContainer, canister.PortName, out PipeNode? portNode) && portNode.NodeGroup?.Nodes.Count > 1)
-                portStatus = true;
-        }
+        if (_nodeContainer.TryGetNode(nodeContainer, canister.PortName, out PipeNode? portNode) && portNode.NodeGroup?.Nodes.Count > 1)
+            portStatus = true;
 
         if (canister.GasTankSlot.Item != null)
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Gas Canisters now update their UI upon spawn/startup. Fixes https://github.com/space-wizards/space-station-14/issues/42593

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/42593. This also allows gas canister UIs to work before mapinit.

## Technical details
<!-- Summary of code changes for easier review. -->
I'm not a dev, and frankly have no understanding of the performance impact of this, if this could impact tests, or if this is the "correct" way of fixing the issue. Feedback is welcome and scrutiny is encouraged.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

**Video** (from Starlight fork with extra empty canisters. I did test on wizden master branch as well)
https://github.com/user-attachments/assets/d581bc69-8efd-4f2e-a937-03b8642fdcac


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: Empty gas canisters now have a populated UI.
