### PR TITLE
GasLeak and PowerGridCheck rules components cleanup

### DIFF
--- a/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
@@ -7,41 +7,100 @@ namespace Content.Server.StationEvents.Components;
 [RegisterComponent, Access(typeof(GasLeakRule))]
 public sealed partial class GasLeakRuleComponent : Component
 {
-    public readonly Gas[] LeakableGases =
+    /// <summary>
+    /// Gas types that can be selected for the leak event.
+    /// </summary>
+    [DataField]
+    public Gas[] LeakableGases =
     {
         Gas.Ammonia,
         Gas.Plasma,
         Gas.Tritium,
         Gas.Frezon,
-        Gas.WaterVapor, // the fog
+        Gas.WaterVapor,
     };
 
     /// <summary>
-    ///     Running cooldown of how much time until another leak.
+    /// Time remaining until the next gas addition to the leak tile.
     /// </summary>
+    [DataField]
     public float TimeUntilLeak;
 
     /// <summary>
-    ///     How long between more gas being added to the tile.
+    /// Fixed interval in seconds between gas additions to the leak tile.
     /// </summary>
+    [DataField]
     public float LeakCooldown = 1.0f;
 
-    // Event variables
+    /// <summary>
+    /// The station where the leak is located.
+    /// </summary>
+    [DataField]
     public EntityUid TargetStation;
-    public EntityUid TargetGrid;
-    public Vector2i TargetTile;
-    public EntityCoordinates TargetCoords;
-    public bool FoundTile;
-    public Gas LeakGas;
-    public float MolesPerSecond;
-    public readonly int MinimumMolesPerSecond = 80;
 
     /// <summary>
-    ///     Don't want to make it too fast to give people time to flee.
+    /// The specific grid where the leak is located.
     /// </summary>
+    [DataField]
+    public EntityUid TargetGrid;
+
+    /// <summary>
+    /// The tile coordinates where the leak is located.
+    /// </summary>
+    [DataField]
+    public Vector2i TargetTile;
+
+    /// <summary>
+    /// The world coordinates of the leak location.
+    /// </summary>
+    [DataField]
+    public EntityCoordinates TargetCoords;
+
+    /// <summary>
+    /// Whether a suitable tile for leaking has been found.
+    /// </summary>
+    [DataField]
+    public bool FoundTile;
+
+    /// <summary>
+    /// The specific gas type currently leaking.
+    /// </summary>
+    [DataField]
+    public Gas LeakGas;
+
+    /// <summary>
+    /// Current leak rate in moles per second.
+    /// </summary>
+    [DataField]
+    public float MolesPerSecond;
+
+    /// <summary>
+    /// Minimum leak rate in moles per second.
+    /// </summary>
+    [DataField]
+    public int MinimumMolesPerSecond = 80;
+
+    /// <summary>
+    /// Maximum leak rate in moles per second. Limited to give people time to flee.
+    /// </summary>
+    [DataField]
     public int MaximumMolesPerSecond = 200;
 
+    /// <summary>
+    /// Minimum total amount of gas to leak over the entire event duration.
+    /// </summary>
+    [DataField]
     public int MinimumGas = 1000;
+
+    /// <summary>
+    /// Maximum total amount of gas to leak over the entire event duration.
+    /// </summary>
+    [DataField]
     public int MaximumGas = 4000;
+
+    /// <summary>
+    /// Chance to create an ignition spark when the event ends.
+    /// </summary>
+    [DataField]
     public float SparkChance = 0.05f;
 }

--- a/Content.Server/StationEvents/Components/PowerGridCheckRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/PowerGridCheckRuleComponent.cs
@@ -9,25 +9,59 @@ namespace Content.Server.StationEvents.Components;
 public sealed partial class PowerGridCheckRuleComponent : Component
 {
     /// <summary>
-    /// Default sound of the announcement when power is back on.
+    /// Default sound for power restoration announcement.
     /// </summary>
     private static readonly ProtoId<SoundCollectionPrototype> DefaultPowerOn = new("PowerOn");
 
     /// <summary>
-    /// Sound of the announcement to play when power is back on.
+    /// Sound to play when power is restored.
     /// </summary>
     [DataField]
     public SoundSpecifier PowerOnSound = new SoundCollectionSpecifier(DefaultPowerOn, AudioParams.Default.WithVolume(-4f));
 
+    /// <summary>
+    /// Token source for cancelling the power restoration announcement.
+    /// </summary>
     public CancellationTokenSource? AnnounceCancelToken;
 
+    /// <summary>
+    /// Station affected by the power grid event.
+    /// </summary>
+    [DataField]
     public EntityUid AffectedStation;
-    public readonly List<EntityUid> Powered = new();
-    public readonly List<EntityUid> Unpowered = new();
 
+    /// <summary>
+    /// List of APC entities that will be sequentially turned off during the event.
+    /// </summary>
+    [DataField]
+    public List<EntityUid> Powered = new();
+
+    /// <summary>
+    /// List of APC entities that have been turned off.
+    /// </summary>
+    [DataField]
+    public List<EntityUid> Unpowered = new();
+
+    /// <summary>
+    /// Time delay in seconds before starting to turn off APCs.
+    /// </summary>
+    [DataField]
     public float SecondsUntilOff = 30.0f;
 
+    /// <summary>
+    /// Number of APC toggles to process per second during the shutdown phase.
+    /// Dynamically calculated based on total APC count and <see cref="SecondsUntilOff"/>.
+    /// </summary>
     public int NumberPerSecond = 0;
+
+    /// <summary>
+    /// Computed time interval between APC toggles.
+    /// </summary>
     public float UpdateRate => 1.0f / NumberPerSecond;
+
+    /// <summary>
+    /// Accumulated frame time to track when to process the next APC toggle.
+    /// </summary>
+    [DataField]
     public float FrameTimeAccumulator = 0.0f;
 }


### PR DESCRIPTION
## About the PR
A little cleanup in `GasLeakRuleComponent` and `PowerGridCheckRuleComponent`.

Changes:
- Missing documentation has been added, and the existing one has been slightly improved.
- The `DataField` attribute has been added to most fields (where appropriate).

## Why / Balance
The lack of documentation is bad.
The absence of the `DataField` attribute breaks persistence.

Resolves #42285

**Suggestions for improving the documentation are welcome.**

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
