### PR TITLE
Disposal/mailing UI minor improvements

### DIFF
--- a/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
+++ b/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
@@ -4,7 +4,7 @@
                       MinSize="300 400"
             SetSize="300 400"
             Resizable="False">
-    <BoxContainer Orientation="Vertical">
+    <BoxContainer Orientation="Vertical" Margin="10">
         <BoxContainer Orientation="Horizontal" SeparationOverride="8">
             <Label Text="{Loc 'ui-mailing-unit-target-label'}" />
             <Label Name="Target"

--- a/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
+++ b/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
@@ -5,6 +5,9 @@
             SetSize="300 400"
             Resizable="False">
     <BoxContainer Orientation="Vertical" Margin="10">
+        <controls:SwitchButton Name="Power"
+                Access="Public"
+                Margin="0 0 0 8" />
         <BoxContainer Orientation="Horizontal" SeparationOverride="8">
             <Label Text="{Loc 'ui-mailing-unit-target-label'}" />
             <Label Name="Target"
@@ -46,11 +49,7 @@
             <Button Name="Eject"
                     Access="Public"
                     Text="{Loc 'ui-disposal-unit-button-eject'}"
-                    StyleClasses="OpenBoth" />
-            <Button Name="Power"
-                         Access="Public"
-                         Text="{Loc 'ui-disposal-unit-button-power'}"
-                         StyleClasses="OpenLeft" />
+                    StyleClasses="OpenLeft" />
         </BoxContainer>
     </BoxContainer>
 </controls:FancyWindow>

--- a/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
+++ b/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
@@ -4,10 +4,9 @@
                       MinSize="300 400"
             SetSize="300 400"
             Resizable="False">
-    <BoxContainer Orientation="Vertical" Margin="10">
+    <BoxContainer Orientation="Vertical" Margin="10" SeparationOverride="8">
         <controls:SwitchButton Name="Power"
-                Access="Public"
-                Margin="0 0 0 8" />
+                Access="Public" />
         <BoxContainer Orientation="Horizontal" SeparationOverride="8">
             <Label Text="{Loc 'ui-mailing-unit-target-label'}" />
             <Label Name="Target"
@@ -18,15 +17,13 @@
                   Access="Public"
                   SelectMode="Single"
                   VerticalExpand="True"
-                  HorizontalExpand="True"
-                  Margin="0 0 0 16">
+                  HorizontalExpand="True">
         </ItemList>
         <BoxContainer Orientation="Horizontal" SeparationOverride="4">
             <Label Text="{Loc 'ui-disposal-unit-label-state'}" />
             <Label Name="UnitState" Access="Public"
                    Text="{Loc 'ui-disposal-unit-label-status'}" />
         </BoxContainer>
-        <Control MinSize="0 5" />
         <BoxContainer Orientation="Horizontal"
                       SeparationOverride="4">
             <Label Text="{Loc 'ui-disposal-unit-label-pressure'}" />
@@ -39,7 +36,6 @@
                          Page="0"
                          Value="0.5" />
         </BoxContainer>
-        <Control MinSize="0 10" />
         <BoxContainer Orientation="Horizontal">
             <Button Name="Engage"
                     Access="Public"

--- a/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
+++ b/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
@@ -40,11 +40,13 @@
                     Access="Public"
                     Text="{Loc 'ui-mailing-unit-button-flush'}"
                     StyleClasses="OpenRight"
-                    ToggleMode="True" />
+                    ToggleMode="True"
+                    HorizontalExpand="True" />
             <Button Name="Eject"
                     Access="Public"
                     Text="{Loc 'ui-disposal-unit-button-eject'}"
-                    StyleClasses="OpenLeft" />
+                    StyleClasses="OpenLeft"
+                    HorizontalExpand="True" />
         </BoxContainer>
     </BoxContainer>
 </controls:FancyWindow>

--- a/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
+++ b/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
@@ -29,8 +29,7 @@
             <Label Text="{Loc 'ui-disposal-unit-label-pressure'}" />
             <disposal:PressureBar Name="PressureBar"
                             Access="Public"
-                         MinSize="190 20"
-                         HorizontalAlignment="Right"
+                         HorizontalExpand="True"
                          MinValue="0"
                          MaxValue="1"
                          Page="0"

--- a/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml
+++ b/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml
@@ -22,16 +22,18 @@
                          Page="0"
                          Value="0.5" />
         </BoxContainer>
-        <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
+        <BoxContainer Orientation="Horizontal">
             <Button Name="Engage"
                     Access="Public"
                     Text="{Loc 'ui-disposal-unit-button-flush'}"
                     StyleClasses="OpenRight"
-                    ToggleMode="True" />
+                    ToggleMode="True"
+                    HorizontalExpand="True" />
             <Button Name="Eject"
                     Access="Public"
                     Text="{Loc 'ui-disposal-unit-button-eject'}"
-                    StyleClasses="OpenLeft" />
+                    StyleClasses="OpenLeft"
+                    HorizontalExpand="True" />
         </BoxContainer>
     </BoxContainer>
 </controls:FancyWindow>

--- a/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml
+++ b/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml
@@ -16,8 +16,7 @@
                       SeparationOverride="4">
             <Label Text="{Loc 'ui-disposal-unit-label-pressure'}" />
             <disposal:PressureBar Name="PressureBar"
-                         MinSize="190 20"
-                         HorizontalAlignment="Right"
+                         HorizontalExpand="True"
                          MinValue="0"
                          MaxValue="1"
                          Page="0"

--- a/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml
+++ b/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml
@@ -3,17 +3,15 @@
                       xmlns:disposal="clr-namespace:Content.Client.Disposal"
                       MinSize="300 180"
             Resizable="False">
-    <BoxContainer Orientation="Vertical" Margin="10">
+    <BoxContainer Orientation="Vertical" Margin="10" SeparationOverride="8">
         <controls:SwitchButton Name="Power"
-                               Access="Public"
-                               Margin="0 0 0 8" />
+                               Access="Public" />
         <BoxContainer Orientation="Horizontal"
                       SeparationOverride="4">
             <Label Text="{Loc 'ui-disposal-unit-label-state'}" />
             <Label Name="UnitState" Access="Public"
                    Text="{Loc 'ui-disposal-unit-label-status'}" />
         </BoxContainer>
-        <Control MinSize="0 5" />
         <BoxContainer Orientation="Horizontal"
                       SeparationOverride="4">
             <Label Text="{Loc 'ui-disposal-unit-label-pressure'}" />
@@ -25,7 +23,6 @@
                          Page="0"
                          Value="0.5" />
         </BoxContainer>
-        <Control MinSize="0 10" />
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
             <Button Name="Engage"
                     Access="Public"

--- a/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml
+++ b/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml
@@ -1,10 +1,12 @@
 ﻿<controls:FancyWindow xmlns="https://spacestation14.io"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:disposal="clr-namespace:Content.Client.Disposal"
-                      MinSize="300 140"
-            SetSize="300 160"
+                      MinSize="300 180"
             Resizable="False">
     <BoxContainer Orientation="Vertical" Margin="10">
+        <controls:SwitchButton Name="Power"
+                               Access="Public"
+                               Margin="0 0 0 8" />
         <BoxContainer Orientation="Horizontal"
                       SeparationOverride="4">
             <Label Text="{Loc 'ui-disposal-unit-label-state'}" />
@@ -33,11 +35,7 @@
             <Button Name="Eject"
                     Access="Public"
                     Text="{Loc 'ui-disposal-unit-button-eject'}"
-                    StyleClasses="OpenBoth" />
-            <Button Name="Power"
-                         Access="Public"
-                         Text="{Loc 'ui-disposal-unit-button-power'}"
-                         StyleClasses="OpenLeft" />
+                    StyleClasses="OpenLeft" />
         </BoxContainer>
     </BoxContainer>
 </controls:FancyWindow>

--- a/Resources/Locale/en-US/disposal/unit/components/disposal-unit-component.ftl
+++ b/Resources/Locale/en-US/disposal/unit/components/disposal-unit-component.ftl
@@ -8,7 +8,6 @@ ui-disposal-unit-label-status = Ready
 
 ui-disposal-unit-button-flush = Flush
 ui-disposal-unit-button-eject = Eject Contents
-ui-disposal-unit-button-power = Power
 
 ## Verbs
 disposal-flush-verb-get-data-text = Flush


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed disposal & mailing unit power buttons to switch buttons and moved them to the top right; cleaned up spacing.

## Why / Balance
Switch buttons are easier to read at a glance. Also I don't think power switches belong in the flush/send/eject button groups conceptually, since the other buttons are for controlling what happens to the units content and the power switch is not. I don't love the top left location, but I didn't think any other location was better, and this is at least consistent with gas devices, which are the most common other items with power switches.

The spacing fixes just look nice, I think.

## Technical details
* Replaced power buttons in bottom button groups with switch buttons at top left.
* Replaced various margins and spacer controls with using the `SeparationOverride` property on BoxContainers.
* Made the pressure bars and button groups use the full window width.
* Adjusted disposal unit window minimum size for changes.
* Removed now-unused localization string.

## Media
<img width="627" height="611" alt="image" src="https://github.com/user-attachments/assets/2707e942-beb5-4dab-90ea-0120ddbc2c68" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
