### PR TITLE
restore tritium fire energy to reenable maxcaps

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -217,7 +217,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     Amount of heat released per mole of burnt hydrogen or tritium (hydrogen isotope)
         /// </summary>
-        public const float FireHydrogenEnergyReleased = 284e3f; // hydrogen is 284 kJ/mol
+        public const float FireHydrogenEnergyReleased = 284e4f;
         public const float FireMinimumTemperatureToExist = T0C + 100f;
         public const float FireMinimumTemperatureToSpread = T0C + 150f;
         public const float FireSpreadRadiosityScale = 0.85f;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This corrects the 90% reduction in Tritium energy output introduced by PR 41870.

That reduction made maxcaps impossible for many recipes. For the remaining recipes, maxcaps have become nearly impossible due to the precision requirements, unreliable for reasons I don't fully understand, much less powerful, and much less flexible (fuse time/power tradeoff).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

PR 41870 was intended to be a bug fix, but it unintentionally removed an important antag feature for the atmos role, and made the TEG harder to use.

That PR had little discussion from the authorized reviewers regarding maxcaps. The main comment regarding maxcaps at https://github.com/space-wizards/space-station-14/pull/41870#issuecomment-3746349038 suggested that Ilya's maxcap calculator ( https://github.com/Ilya246/atmosim ) would easily be able to find new recipes. That turned out not to work.

I've heard opinions from about 20~25 people in-game and on Discord. I don't know of anyone who likes the change. Most people don't like that the TEG is harder to set up. Everyone who knew about maxcaps said they either disliked the change, or they didn't care because they only played on servers that would never merge that change. Nobody said they were glad maxcaps were gone.

## Technical details
<!-- Summary of code changes for easier review. -->

A typical Ilya-style maxcap recipe from before PR 41870:

```
STATS: [ time 21.0s | radius 12.72til ]
MIX:   [ 54% plasma | 46% tritium | 383.5K | 662.5kPa ]
CAN:   [ 100% oxygen | 293.15K | >1369kPa ]
REQ:   [ 213mol plasma | 183mol tritium | 1071mol oxygen ]

Tolerances:
  Fuel temp: 382.9771K - 385.02438K
  Fuel pressure: 661.7741kPa - 663.1439kPa
  Primer temp: 292.47784K - 293.62457K
  Release pressure: 1012.7098kPa - 1014.02313kPa
  Mix plasma: 53.803986% - 55.475967%
  Mix tritium: 44.524036% - 46.19602%
```

A maxcap recipe using the same ingredients, after PR 41870:

```
STATS: [ time 26.5s | radius 4.25til | optstat 4.2464123 ]
MIX:   [ 50.166% plasma | 49.834% tritium | 382.60K | 688.8kPa ]
CAN:   [ 100.000% oxygen | 293.15K | release 1013.2kPa | >1341kPa ]
REQ:   [ 207mol plasma | 206mol tritium | 1048mol oxygen ]

Serialized string: ft=382.6 fp=688.8 tp=1013.25 tt=293.15 mi=[[plasma,0.50166],[tritium,0.49833998]] pm=[[oxygen,1]]
0.95x tolerances:
  Fuel temp: 382.4859K - 382.6035K
  Fuel pressure: 688.7986kPa - 688.90546kPa
  Primer temp: 293.14868K - 293.2364K
  Release pressure: 1013.15857kPa - 1013.2514kPa
  Mix plasma: 50.165672% - 51.51139%
  Mix tritium: 48.488613% - 49.834328%
```

This explosion radius seems to be too small to actually explode. I tried the formula, and it did not produce an explosion.

This branch keeps the bugfix of PR 41870 intact, but restores the effective energy output that tritium previously had (by multiplying FireHydrogenEnergyReleased by 10). With this change, Ilya's maxcap calculator produces the following recipe.

```
STATS: [ time 25.5s | radius 14.07til | optstat 14.065651 ]
MIX:   [ 49.898% plasma | 50.103% tritium | 382.93K | 682.4kPa ]
CAN:   [ 100.000% oxygen | 293.15K | release 1013.2kPa | >1348kPa ]
REQ:   [ 204mol plasma | 205mol tritium | 1053mol oxygen ]

Serialized string: ft=382.93 fp=682.4 tp=1013.25 tt=293.15 mi=[[plasma,0.49897504],[tritium,0.501025]] pm=[[oxygen,1]]
0.95x tolerances:
  Fuel temp: 382.81442K - 382.93164K
  Fuel pressure: 682.3993kPa - 682.4722kPa
  Primer temp: 293.1492K - 293.20847K
  Release pressure: 1013.1869kPa - 1013.25085kPa
  Mix plasma: 49.897358% - 51.913578%
  Mix tritium: 48.086426% - 50.102646%
```

For a OT+P maxcap, here is what it looked like before PR 41870:

```
STATS: [ time 2.0s | radius 29.13til ]
MIX:   [ 82% oxygen | 18% tritium | 30.1K | 245kPa ]
CAN:   [ 100% plasma | 605K | >1788kPa ]
REQ:   [ 1630mol oxygen | 400mol tritium | 680mol plasma ]

Tolerances:
  Fuel temp: 30.06561K - 30.534548K
  Fuel pressure: 236.82718kPa - 245.29996kPa
  Primer temp: 557.55963K - 605.9423K
  Release pressure: 1007.77405kPa - 1016.1699kPa
  Mix oxygen: 80.916885% - 82.61804%
  Mix tritium: 17.381971% - 19.083122%
```

OT+P after PR 41870:

```
STATS: [ time 5.5s | radius 9.88til | optstat 9.879333 ]
MIX:   [ 80.726% oxygen | 19.274% tritium | 84.13K | 346.9kPa ]
CAN:   [ 100.000% plasma | 445.21K | release 1013.2kPa | >1684kPa ]
REQ:   [ 763mol oxygen | 182mol tritium | 867mol plasma ]

Serialized string: ft=84.13 fp=346.9 tp=1013.25 tt=445.21 mi=[[oxygen,0.80726004],[tritium,0.19274001]] pm=[[plasma,1]]
0.95x tolerances:
  Fuel temp: 84.12966K - 84.13552K
  Fuel pressure: 346.8411kPa - 346.9014kPa
  Primer temp: 445.07797K - 445.21243K
  Release pressure: 1013.2168kPa - 1013.26874kPa
  Mix oxygen: 80.72097% - 80.72715%
  Mix tritium: 19.27285% - 19.279032%
```

OT+P after this proposed PR:

```
STATS: [ time 1.0s | radius 40.96til | optstat 40.956146 ]
MIX:   [ 67.742% oxygen | 32.258% tritium | 74.00K | 433.4kPa ]
CAN:   [ 100.000% plasma | 500.00K | release 1013.2kPa | >1597kPa ]
REQ:   [ 909mol oxygen | 433mol tritium | 732mol plasma ]

Serialized string: ft=74 fp=433.4 tp=1013.25 tt=500 mi=[[oxygen,0.67742324],[tritium,0.3225768]] pm=[[plasma,1]]
0.95x tolerances:
  Fuel temp: 73.93413K - 74.000175K
  Fuel pressure: 433.39673kPa - 433.67545kPa
  Primer temp: 499.94302K - 502.57037K
  Release pressure: 1013.24835kPa - 1126.8771kPa
  Mix oxygen: 67.74217% - 67.92873%
  Mix tritium: 32.071304% - 32.25783%
```

For the OT+P maxcap, the precisions were just too tight to make them actually work in a post-41870 game. I never managed to use them productively as an antag, though I spent several antag rounds making and testing them.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="3840" height="2010" alt="media" src="https://github.com/user-attachments/assets/e6ebe359-fe3b-40e1-8ab2-df8a63a6ce24" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl
- fix: Tritium's thermal output is increased to its previous value, to reenable maxcap explosives and make the TEG easier to run.
