### PR TITLE
Fix emergency shuttle authorization bypass via ID rename

### DIFF
--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -260,8 +260,7 @@ public sealed partial class EmergencyShuttleSystem
             return;
         }
 
-        // TODO: This is fucking bad
-        if (!component.AuthorizedEntities.Remove(MetaData(idCard).EntityName))
+        if (!component.AuthorizedEntities.Remove(idCard.Owner))
             return;
 
         _logger.Add(LogType.EmergencyShuttle, LogImpact.High, $"Emergency shuttle early launch REPEAL by {args.Actor:user}");
@@ -281,9 +280,12 @@ public sealed partial class EmergencyShuttleSystem
             return;
         }
 
-        // TODO: This is fucking bad
-        if (!component.AuthorizedEntities.Add(MetaData(idCard).EntityName))
+        var idCardUid = idCard.Owner;
+
+        if (component.AuthorizedEntities.ContainsKey(idCardUid))
             return;
+
+        component.AuthorizedEntities[idCardUid] = MetaData(idCard).EntityName;
 
         _logger.Add(LogType.EmergencyShuttle, LogImpact.High, $"Emergency shuttle early launch AUTH by {args.Actor:user}");
         var remaining = component.AuthorizationsRequired - component.AuthorizedEntities.Count;
@@ -327,7 +329,7 @@ public sealed partial class EmergencyShuttleSystem
     {
         var auths = new List<string>();
 
-        foreach (var auth in component.AuthorizedEntities)
+        foreach (var auth in component.AuthorizedEntities.Values)
         {
             auths.Add(auth);
         }

--- a/Content.Shared/Shuttles/Components/EmergencyShuttleConsoleComponent.cs
+++ b/Content.Shared/Shuttles/Components/EmergencyShuttleConsoleComponent.cs
@@ -5,13 +5,13 @@ namespace Content.Shared.Shuttles.Components;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class EmergencyShuttleConsoleComponent : Component
 {
-    // TODO: Okay doing it by string is kinda suss but also ID card tracking doesn't seem to be robust enough
-
     /// <summary>
     /// ID cards that have been used to authorize an early launch.
+    /// Key is the UID of the ID card,
+    /// value is the card's name at the time of authorization.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("authorized")]
-    public HashSet<string> AuthorizedEntities = new();
+    public Dictionary<EntityUid, string> AuthorizedEntities = new();
 
     [ViewVariables(VVAccess.ReadWrite), DataField("authorizationsRequired")]
     public int AuthorizationsRequired = 3;


### PR DESCRIPTION
## About the PR
Fixed a bug where the emergency shuttle console used the name of the ID card for authorization. This allowed a single card to grant multiple authorizations simply by renaming it.

## Why / Balance
Bugfix.
Resolves #37659

## Technical details
Server-side checks now use the UID instead of the name.

## Media
Before:

https://github.com/user-attachments/assets/603f09e7-9bfd-43a9-ba90-1af436da360d


After:

https://github.com/user-attachments/assets/7a95a0bc-4517-4c9e-ab81-5f9ae2902ba6
