### PR TITLE
Add handled check to VomitSystem.TryVomitSolution

### DIFF
--- a/Content.Shared/Medical/VomitSystem.cs
+++ b/Content.Shared/Medical/VomitSystem.cs
@@ -52,6 +52,9 @@ public sealed class VomitSystem : EntitySystem
 
     private void TryVomitSolution(Entity<StomachComponent> ent, ref BodyRelayedEvent<TryVomitEvent> args)
     {
+        if (args.Args.Handled)
+            return;
+
         if (_solutionContainer.ResolveSolution(ent.Owner, StomachSystem.DefaultSolutionName, ref ent.Comp.Solution, out var sol))
             _solutionContainer.TryTransferSolution(ent.Comp.Solution.Value, args.Args.Sol, sol.AvailableVolume);
 


### PR DESCRIPTION
## About the PR
Added a missing `Handled` check in `VomitSystem.TryVomitSolution` to prevent multiple systems from handling the same `TryVomitEvent`.

## Why / Balance
Resolves #42518

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
