### PR TITLE
Add TriggerOnRot Component

### DIFF
--- a/Content.Server/Atmos/Rotting/BeginRottingEvent.cs
+++ b/Content.Server/Atmos/Rotting/BeginRottingEvent.cs
@@ -1,0 +1,6 @@
+/// <summary>
+/// Raised when an entity starts to rot.
+/// </summary>
+public sealed partial class BeginRottingEvent : EntityEventArgs
+{
+}

--- a/Content.Server/Atmos/Rotting/RottingSystem.cs
+++ b/Content.Server/Atmos/Rotting/RottingSystem.cs
@@ -88,6 +88,7 @@ public sealed class RottingSystem : SharedRottingSystem
             if (perishable.RotAccumulator >= perishable.RotAfter)
             {
                 var rot = AddComp<RottingComponent>(uid);
+                RaiseLocalEvent(uid, new BeginRottingEvent());
                 rot.NextRotUpdate = _timing.CurTime + rot.RotUpdateRate;
             }
         }

--- a/Content.Server/Explosion/Components/TriggerOnRotComponent.cs
+++ b/Content.Server/Explosion/Components/TriggerOnRotComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Server.Explosion.Components
+{
+    /// <summary>
+    /// Sends a trigger when signal is received.
+    /// </summary>
+    [RegisterComponent]
+    public sealed partial class TriggerOnRotComponent : Component
+    {
+    }
+}

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -33,6 +33,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Player;
 using Content.Shared.Coordinates;
 using Robust.Shared.Utility;
+using Content.Shared.Atmos.Rotting;
 
 namespace Content.Server.Explosion.EntitySystems
 {
@@ -95,6 +96,7 @@ namespace Content.Server.Explosion.EntitySystems
             SubscribeLocalEvent<TriggerOnSlipComponent, SlipEvent>(OnSlipTriggered);
             SubscribeLocalEvent<TriggerWhenEmptyComponent, OnEmptyGunShotEvent>(OnEmptyTriggered);
             SubscribeLocalEvent<RepeatingTriggerComponent, MapInitEvent>(OnRepeatInit);
+            SubscribeLocalEvent<TriggerOnRotComponent, BeginRottingEvent>(OnRotTrigger);
 
             SubscribeLocalEvent<SpawnOnTriggerComponent, TriggerEvent>(OnSpawnTrigger);
             SubscribeLocalEvent<DeleteOnTriggerComponent, TriggerEvent>(HandleDeleteTrigger);
@@ -250,6 +252,10 @@ namespace Content.Server.Explosion.EntitySystems
             ent.Comp.NextTrigger = _timing.CurTime + ent.Comp.Delay;
         }
 
+        private void OnRotTrigger(EntityUid uid, TriggerOnRotComponent component, ref BeginRottingEvent args)
+        {
+            Trigger(uid);
+        }
         public bool Trigger(EntityUid trigger, EntityUid? user = null)
         {
             var triggerEvent = new TriggerEvent(trigger, user);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Add TriggerOnRot Component

The additions were tested via adding: 
- TriggerOnRot Component to a mouse
- Explosive Component to the same mouse (and adjust to ensure this component works)
- Kill the mouse
- Wait for the explosion

## Why

The trigger is intended for a downstream PR for medical implanters.
The Medical Implanter will send a message to the medical channel when a implantee rots. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
