### PR TITLE
Prevent picking up chameleon projector disguises via context menu

### DIFF
--- a/Content.Shared/Polymorph/Systems/SharedChameleonProjectorSystem.cs
+++ b/Content.Shared/Polymorph/Systems/SharedChameleonProjectorSystem.cs
@@ -46,6 +46,7 @@ public abstract class SharedChameleonProjectorSystem : EntitySystem
         SubscribeLocalEvent<ChameleonDisguiseComponent, DamageChangedEvent>(OnDisguiseDamaged);
         SubscribeLocalEvent<ChameleonDisguiseComponent, InsertIntoEntityStorageAttemptEvent>(OnDisguiseInsertAttempt);
         SubscribeLocalEvent<ChameleonDisguiseComponent, ComponentShutdown>(OnDisguiseShutdown);
+        SubscribeLocalEvent<ChameleonDisguiseComponent, BeforeGettingEquippedHandEvent>(OnDisguiseBeforeEquippedHand);
 
         SubscribeLocalEvent<ChameleonDisguisedComponent, EntGotInsertedIntoContainerMessage>(OnDisguisedInserted);
 
@@ -84,6 +85,12 @@ public abstract class SharedChameleonProjectorSystem : EntitySystem
     private void OnDisguiseShutdown(Entity<ChameleonDisguiseComponent> ent, ref ComponentShutdown args)
     {
         _actions.RemoveProvidedActions(ent.Comp.User, ent.Comp.Projector);
+    }
+
+    private void OnDisguiseBeforeEquippedHand(Entity<ChameleonDisguiseComponent> ent, ref BeforeGettingEquippedHandEvent args)
+    {
+        args.Cancelled = true;
+        TryReveal(ent.Comp.User);
     }
 
     #endregion


### PR DESCRIPTION
## About the PR
Title.
It's actually an invisibility exploit, although there's not much you can do in this state.

## Why / Balance
Bugfix.
Resolves #42410

## Media

https://github.com/user-attachments/assets/c270df25-fc50-4658-bdb8-70c88098d7b8


https://github.com/user-attachments/assets/a9bb9ab9-8ad5-4ca1-9f9e-9cb9f9de0ed4


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl: B_Kirill
- fix: Fixed being able to pick up chameleon projector disguises via context menu.
