### PR TITLE
fixing the handling of the RespiratorComponent without checking

### DIFF
--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -40,7 +40,7 @@ public sealed class InternalsSystem : SharedInternalsSystem
             return; // already connected
 
         // Can the entity breathe the air it is currently exposed to?
-        if (_respirator.CanMetabolizeInhaledAir(uid, false))
+        if (_respirator.CanMetabolizeInhaledAir(uid))
             return;
 
         var tank = FindBestGasTank(uid);

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -201,11 +201,10 @@ public sealed class RespiratorSystem : EntitySystem
     /// Checks if it's safe for a given entity to breathe the air from the environment it is currently situated in.
     /// </summary>
     /// <param name="ent">The entity attempting to metabolize the gas.</param>
-    /// <param name="logMissing">Do I need to get a log if he can't breathe the gas.</param>
     /// <returns>Returns true only if the air is not toxic, and it wouldn't suffocate.</returns>
-    public bool CanMetabolizeInhaledAir(Entity<RespiratorComponent?> ent, bool logMissing = false)
+    public bool CanMetabolizeInhaledAir(Entity<RespiratorComponent?> ent)
     {
-        if (!Resolve(ent, ref ent.Comp, logMissing))
+        if (!Resolve(ent, ref ent.Comp, false))
             return false;
 
         // Get the gas at our location but don't actually remove it from the gas mixture.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
When creating a race that doesn't need to breathe like a skeleton, mistakes arise that are relevant for forks.
NukeOpsTest now admits that a commander doesn't have to breathe if he doesn't want to.
OnStartingGear no longer returns the error log.

## Why / Balance
This led to exceptions.

## Technical details
NukeOpsTest now verify the existence of the RespiratorComponent before use.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
