### PR TITLE
Some bonfire fixes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
@@ -44,6 +44,7 @@
   - type: IgnitionSource
     temperature: 700
     ignited: true
+  - type: RequireProjectileTarget
 
 - type: entity
   parent: BaseBonfire
@@ -71,7 +72,7 @@
     offset: "0, 0.5"
   - type: Strap
     position: Stand
-    buckleOffset: "0, 0.5"
+    buckleOffset: "0, 0.4"
     buckleDoafterTime: 5
   - type: IgniteOnBuckle
   - type: Construction

--- a/Resources/Prototypes/Entities/Structures/Decoration/fireplace.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/fireplace.yml
@@ -46,3 +46,6 @@
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
   - type: AlwaysHot
+  - type: IgnitionSource
+    temperature: 700
+    ignited: true


### PR DESCRIPTION
## About the PR
- The buckle offset has been slightly modified so that the buckled entity does not suffocate in the wall above the bonfire.
(Reported in [discord](https://discord.com/channels/310555209753690112/1461978994554572931/1461978994554572931))
- The `RequireProjectileTarget` component has been added so that bullets only hit the bonfire when the cursor is over it.

Also, in the past PR, I forgot to add the `IgnitionSource` component to the fireplace. This has also been fixed.

## Why / Balance
Bugfixes

## Media
No more suffocation
<img width="1920" height="1013" alt="image" src="https://github.com/user-attachments/assets/14491ece-50bb-4ab9-b998-1f6c3005fd52" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl: B_Kirill
- tweak: Fireplaces can now ignite gases.
- fix: Entities buckled to the bonfire with stake no longer suffocate in the walls above the bonfire.
