### PR TITLE
Add Attribution for Web Walls.

### DIFF
--- a/Resources/Textures/Structures/Walls/web.rsi/meta.json
+++ b/Resources/Textures/Structures/Walls/web.rsi/meta.json
@@ -5,7 +5,7 @@
 		"y": 32
 	},
 	"license": "CC-BY-SA-3.0",
-	"copyright": "",
+	"copyright": "Made by PixelTheKermit (github) for SS14.",
 	"states": [
 		{
 			"name": "wall0",


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Add attribution for https://github.com/space-wizards/space-station-14/blob/master/Resources/Textures/Structures/Walls/web.rsi/meta.json

Got ahold of the PR author and got confirmation that it was created for #18631.

Closes #42307

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->