### PR TITLE
Small dragon update

### DIFF
--- a/Content.Server/Dragon/Components/DragonComponent.cs
+++ b/Content.Server/Dragon/Components/DragonComponent.cs
@@ -35,14 +35,14 @@ namespace Content.Server.Dragon
         /// <summary>
         /// The time after which the dragon will receive a popup that it needs to set the Rift.
         /// </summary>
-        [DataField] 
+        [DataField]
         public int RiftPopupAlertAccumulator = 200;
 
         /// <summary>
         /// The popup alert message shown to the dragon when they need to spawn a rift.
         /// </summary>
         [DataField]
-        public string RiftPopupAlert = "dragon-rift-alert";
+        public LocId RiftPopupAlert = "dragon-rift-alert";
 
         /// <summary>
         /// Announcement of fully charging rift
@@ -53,7 +53,7 @@ namespace Content.Server.Dragon
         /// <summary>
         /// Maximum time the dragon can go without spawning a rift before they die.
         /// </summary>
-        [DataField] 
+        [DataField]
         public float RiftMaxAccumulator = 300f;
 
         [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]

--- a/Content.Server/Dragon/Components/DragonComponent.cs
+++ b/Content.Server/Dragon/Components/DragonComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Dragon
         /// <summary>
         /// If we have active rifts.
         /// </summary>
-        [DataField("rifts")]
+        [DataField]
         public List<EntityUid> Rifts = new();
 
         public bool Weakened => WeakenedAccumulator > 0f;
@@ -20,39 +20,58 @@ namespace Content.Server.Dragon
         /// <summary>
         /// When any rift is destroyed how long is the dragon weakened for
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite), DataField("weakenedDuration")]
+        [DataField]
         public float WeakenedDuration = 120f;
 
         /// <summary>
         /// Has a rift been destroyed and the dragon in a temporary weakened state?
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite), DataField("weakenedAccumulator")]
+        [DataField]
         public float WeakenedAccumulator = 0f;
 
-        [ViewVariables(VVAccess.ReadWrite), DataField("riftAccumulator")]
+        [DataField]
         public float RiftAccumulator = 0f;
+
+        /// <summary>
+        /// The time after which the dragon will receive a popup that it needs to set the Rift.
+        /// </summary>
+        [DataField] 
+        public int RiftPopupAlertAccumulator = 200;
+
+        /// <summary>
+        /// The popup alert message shown to the dragon when they need to spawn a rift.
+        /// </summary>
+        [DataField]
+        public string RiftPopupAlert = "dragon-rift-alert";
+
+        /// <summary>
+        /// Announcement of fully charging rift
+        /// </summary>
+        [DataField]
+        public bool DragonAlerted;
 
         /// <summary>
         /// Maximum time the dragon can go without spawning a rift before they die.
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite), DataField("maxAccumulator")] public float RiftMaxAccumulator = 300f;
+        [DataField] 
+        public float RiftMaxAccumulator = 300f;
 
-        [DataField("spawnRiftAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+        [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
         public string SpawnRiftAction = "ActionSpawnRift";
 
         /// <summary>
         /// Spawns a rift which can summon more mobs.
         /// </summary>
-        [DataField("spawnRiftActionEntity")]
+        [DataField]
         public EntityUid? SpawnRiftActionEntity;
 
-        [ViewVariables(VVAccess.ReadWrite), DataField("riftPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+        [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
         public string RiftPrototype = "CarpRift";
 
-        [ViewVariables(VVAccess.ReadWrite), DataField("soundDeath")]
+        [DataField]
         public SoundSpecifier? SoundDeath = new SoundPathSpecifier("/Audio/Animals/space_dragon_roar.ogg");
 
-        [ViewVariables(VVAccess.ReadWrite), DataField("soundRoar")]
+        [DataField]
         public SoundSpecifier? SoundRoar =
             new SoundPathSpecifier("/Audio/Animals/space_dragon_roar.ogg")
             {

--- a/Content.Server/Dragon/Components/DragonRiftComponent.cs
+++ b/Content.Server/Dragon/Components/DragonRiftComponent.cs
@@ -1,6 +1,8 @@
 using Content.Shared.Dragon;
+using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using System.Collections.Generic;
 
 namespace Content.Server.Dragon;
 
@@ -10,31 +12,51 @@ public sealed partial class DragonRiftComponent : SharedDragonRiftComponent
     /// <summary>
     /// Dragon that spawned this rift.
     /// </summary>
-    [DataField("dragon")] public EntityUid? Dragon;
+    [DataField] 
+    public EntityUid? Dragon;
 
     /// <summary>
     /// How long the rift has been active.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("accumulator")]
+    [DataField]
     public float Accumulator = 0f;
 
     /// <summary>
     /// The maximum amount we can accumulate before becoming impervious.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("maxAccumuluator")] public float MaxAccumulator = 300f;
+    [DataField] public float MaxAccumulator = 300f;
+
+    /// <summary>
+    /// Announcement sound of partly charging rift
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? PartlyChargingAnnouncementSound = new SoundPathSpecifier("/Audio/Misc/notice1.ogg");
+
+
+    /// <summary>
+    /// Announcement sound of fully charging rift
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? FullChargingAnnouncementSound = new SoundPathSpecifier("/Audio/Announcements/attention.ogg");
+
+    /// <summary>
+    /// Announcement of fully charging rift
+    /// </summary>
+    [DataField]
+    public string FullChargingAnnouncement = "carp-rift-max-warning";
 
     /// <summary>
     /// Accumulation of the spawn timer.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("spawnAccumulator")]
+    [DataField]
     public float SpawnAccumulator = 30f;
 
     /// <summary>
     /// How long it takes for a new spawn to be added.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("spawnCooldown")]
+    [DataField]
     public float SpawnCooldown = 30f;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("spawn", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string SpawnPrototype = "MobCarpDragon";
 }

--- a/Content.Server/Dragon/Components/DragonRiftComponent.cs
+++ b/Content.Server/Dragon/Components/DragonRiftComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class DragonRiftComponent : SharedDragonRiftComponent
     /// <summary>
     /// Dragon that spawned this rift.
     /// </summary>
-    [DataField] 
+    [DataField]
     public EntityUid? Dragon;
 
     /// <summary>
@@ -43,7 +43,7 @@ public sealed partial class DragonRiftComponent : SharedDragonRiftComponent
     /// Announcement of fully charging rift
     /// </summary>
     [DataField]
-    public string FullChargingAnnouncement = "carp-rift-max-warning";
+    public LocId FullChargingAnnouncement = "carp-rift-max-warning";
 
     /// <summary>
     /// Accumulation of the spawn timer.

--- a/Content.Server/Dragon/DragonRiftSystem.cs
+++ b/Content.Server/Dragon/DragonRiftSystem.cs
@@ -61,6 +61,9 @@ public sealed class DragonRiftSystem : EntitySystem
                 if (comp.Dragon != null)
                     _dragon.RiftCharged(comp.Dragon.Value);
 
+                _chat.DispatchGlobalAnnouncement(Loc.GetString(comp.FullChargingAnnouncement), playSound: false, colorOverride: Color.DarkRed);
+                _audio.PlayGlobal(comp.FullChargingAnnouncementSound, Filter.Broadcast(), true);
+
                 comp.Accumulator = comp.MaxAccumulator;
                 RemComp<DamageableComponent>(uid);
                 comp.State = DragonRiftState.Finished;
@@ -81,7 +84,7 @@ public sealed class DragonRiftSystem : EntitySystem
                 var msg = Loc.GetString("carp-rift-warning",
                     ("location", FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, xform)))));
                 _chat.DispatchGlobalAnnouncement(msg, playSound: false, colorOverride: Color.Red);
-                _audio.PlayGlobal("/Audio/Misc/notice1.ogg", Filter.Broadcast(), true);
+                _audio.PlayGlobal(comp.PartlyChargingAnnouncementSound, Filter.Broadcast(), true);
                 _navMap.SetBeaconEnabled(uid, true);
             }
 

--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -97,6 +97,12 @@ public sealed partial class DragonSystem : EntitySystem
             if (!_mobState.IsDead(uid))
                 comp.RiftAccumulator += frameTime;
 
+            if (comp.RiftAccumulator >= comp.RiftPopupAlertAccumulator && !comp.DragonAlerted)
+            {
+                _popup.PopupEntity(Loc.GetString(comp.RiftPopupAlert), uid, uid);
+                comp.DragonAlerted = true;
+            }
+
             // Delete it, naughty dragon!
             if (comp.RiftAccumulator >= comp.RiftMaxAccumulator)
             {
@@ -169,6 +175,7 @@ public sealed partial class DragonSystem : EntitySystem
         var carpUid = Spawn(component.RiftPrototype, _transform.GetMapCoordinates(uid, xform: xform));
         component.Rifts.Add(carpUid);
         Comp<DragonRiftComponent>(carpUid).Dragon = uid;
+        component.DragonAlerted = false;
     }
 
     // TODO: just make this a move speed modifier component???

--- a/Content.Server/Objectives/Systems/CarpRiftsConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/CarpRiftsConditionSystem.cs
@@ -29,7 +29,7 @@ public sealed class CarpRiftsConditionSystem : EntitySystem
         if (comp.RiftsCharged >= target)
             return 1f;
 
-        return (float) comp.RiftsCharged / (float) target;
+        return (float)comp.RiftsCharged / (float)target;
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/dragon/dragon.ftl
+++ b/Resources/Locale/en-US/dragon/dragon.ftl
@@ -3,3 +3,5 @@ dragon-round-end-agent-name = dragon
 objective-issuer-dragon = [color=#7567b6]Space Dragon[/color]
 
 dragon-role-briefing = Summon 3 carp rifts and take over this quadrant! The station is located {$direction}.
+
+dragon-rift-alert = You're starting to disappear, so create a rift as soon as possible!

--- a/Resources/Locale/en-US/dragon/rifts.ftl
+++ b/Resources/Locale/en-US/dragon/rifts.ftl
@@ -1,4 +1,5 @@
 carp-rift-warning = A rift is causing an unnaturally large energy flux {$location}. Stop it at all costs!
+carp-rift-max-warning = The Rift has reached its maximum power! It cannot be destroyed. Immediately focus your efforts on destroying the dragon!
 carp-rift-duplicate = Cannot have 2 charging rifts at the same time!
 carp-rift-examine = It is [color=yellow]{$percentage}%[/color] charged!
 carp-rift-max = You have reached your maximum amount of rifts


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The dragon now receives a popup that it will disappear if it does not place the rift when 2/3 of the time expires. When the rift is fully charged, an alert is created for the station. Cleanup DragonComponent and DragonRiftComponent

## Why / Balance

This is convenient. In one dragon game, I was deleted because I didn't know that the timer started after the first Rift was fully charged.

## Technical details
Just call popup in the RiftAccumulator check in DragonSystem and DispatchGlobalAnnouncement when checking if the Rift is fully charged in DragonRiftSystem

## Media

https://github.com/user-attachments/assets/3fb97acf-751a-4915-8987-e1495ada43f1

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl: Golub
- tweak: The dragon now receives a notification if it doesn't create a rift for a long time. 
- tweak: When the dragon's rift is fully charged, the station receives an alert.

