### PR TITLE
Alternative Fire for Pistols | Pistol Whip

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -38,7 +38,7 @@
     soundRack:
       path: /Audio/Weapons/Guns/Cock/pistol_cock.ogg
   - type: MeleeWeapon
-    wideAnimationRotation: -85
+    wideAnimationRotation: 0
     damage:
       types:
         Blunt: 8


### PR DESCRIPTION
## About the PR
There are no changes to gun systems, and this change does not create any new guns.

Because pythons and potentially other revolvers are getting a new alternative fire, we have the opportunity to give pistols and alternate fire as well. This adds a pistol whip to 4 pistols that is no stronger than a crowbar.


## Why / Balance
The intent of this change isn't to make pistols more powerful but to create more humorous scenarios between crew, antagonists, and security. The damage on the pistol whip is equivalent to a crowbar.
This affects the following pistols:
- viper
- cobra
- mk 58
- N1984

## Technical details
Added an alternate fire to the BasePistol entity: yaml only change.
Uses the same sound as a crowbar with a different rotation angle.

## Media
https://github.com/user-attachments/assets/361bc896-6ded-4269-94b6-c17d14b88b72


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None. Yaml change only.

**Changelog**
:cl:
- add: Added pistol whip alternative fire.

