### PR TITLE
Fix hydroponics tray stacking | Trays block trays but not players

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -24,6 +24,8 @@ public enum CollisionGroup
     InteractImpassable = 1 << 7, // 128 Blocks interaction/InRangeUnobstructed
     // Y dis door passable when all the others impassable / collision.
     DoorPassable       = 1 << 8, // 256 Allows door to close over top, Like blast doors over conveyors for disposals rooms/cargo.
+    MobPassable        = 1 << 9, // 512 Can collide with each other and obstacles but not block players and mobs.
+
 
     MapGrid = MapGridHelpers.CollisionGroup, // Map grids, like shuttles. This is the actual grid itself, not the walls or other entities connected to the grid.
 
@@ -51,6 +53,10 @@ public enum CollisionGroup
     MachineMask = Impassable | MidImpassable | LowImpassable,
     MachineLayer = Opaque | MidImpassable | LowImpassable | BulletImpassable,
     ConveyorMask = Impassable | MidImpassable | LowImpassable | DoorPassable,
+
+    // Hydroponics trays, ect
+    TrayMask = Impassable | MidImpassable | LowImpassable | MobPassable,
+    TrayLayer = BulletImpassable | MobPassable,
 
     // Crates
     CrateMask = Impassable | HighImpassable | LowImpassable,

--- a/Resources/Prototypes/Entities/Structures/hydro_tray.yml
+++ b/Resources/Prototypes/Entities/Structures/hydro_tray.yml
@@ -9,13 +9,13 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.45,-0.45,0.45,0.1"
+          bounds: "-0.3,-0.45,0.3,0.45"
         density: 190
         hard: true
         mask:
-        - MachineMask
+        - TrayMask
         layer:
-        - BulletImpassable
+        - TrayLayer
   - type: Anchorable
   - type: Pullable
   - type: Sprite


### PR DESCRIPTION
## About the PR
Introduces a new collision group for hydroponics trays (`TrayLayer` / `TrayMask`) so that:

- Trays **collide with each other** and other machines/items.
- Players and mobs **can pass through them** freely.

This fixes a long-standing exploit where trays could be stacked infinitely in the same tile.

## Why / Balance
Currently hydroponics trays have **no collision between themselves** - they can be placed on top of each other endlessly. This creates broken mechanics:

- Allows infinite botany setups in one tile (e.g. killer tomato farm).
- Breaks potential future botany features (any new tray-based mechanic can be abused via stacking).

The new collision:
- Prevents stacking exploits while **preserving player convenience** - trays remain passable, just non-stackable.
- It can also be used for other machines/items, not just trays.
- Trays still fit through doorways.

## Technical details
- Added new collision flags in `Content.Shared.Physics.CollisionGroup.cs`:
  ```csharp
  MobPassable = 1 << 9, // 512 - Collides with obstacles but not players/mobs
  TrayMask = Impassable | MidImpassable | LowImpassable | MobPassable,
  TrayLayer = BulletImpassable | MobPassable
  

-  Updated hydro_tray.yml:
    ```csharp
    type: Fixtures
    fixtures:
      fix1:
        shape:
          !type:PhysShapeAabb
          bounds: "-0.3,-0.45,0.3,0.45"  # Adjusted 
        density: 190
        hard: true
        mask:
        - TrayMask
        layer:
        - TrayLayer
 ## Media


https://github.com/user-attachments/assets/bb3d9b40-c46f-4382-b27e-4c1c0851127d


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.





## Breaking changes

None.
Additive collision group + prototype tweak.

**Changelog**

:cl:

fix: Fixed hydroponics tray stacking exploit by adding custom collision group.
