### PR TITLE
Fix jetpacks not turning off when switching to another jetpack

### DIFF
--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -173,6 +173,14 @@ public abstract class SharedJetpackSystem : EntitySystem
 
         if (enabled)
         {
+            // If the user is already using another jetpack, disable it first
+            if (TryComp<JetpackUserComponent>(user, out var userComp) &&
+                userComp.Jetpack != uid &&
+                TryComp<JetpackComponent>(userComp.Jetpack, out var oldJetpack))
+            {
+                SetEnabled(userComp.Jetpack, oldJetpack, false, user);
+            }
+
             SetupUser(user.Value, uid, component);
             EnsureComp<ActiveJetpackComponent>(uid);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR fixes an issue where activating a new jetpack would not disable the previously active jetpack. The old jetpack would continue consuming fuel and emitting particles despite no longer affecting player movement.

Closes #34094
Closes #18035

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is a straightforward bugfix. Jetpacks are expected to turn off when another jetpack is activated. This change ensures that only one jetpack can be active per user at a time.

## Technical details
<!-- Summary of code changes for easier review. -->
Currently, `SharedJetpackSystem.SetEnabled` does not disable an already-active jetpack when a new one is enabled. This allows multiple jetpacks to retain `ActiveJetpackComponent` at the same time, even though only the most recently enabled jetpack affects player movement.

This PR adds a check when enabling a jetpack:
If the user already has a `JetpackUserComponent` and that component references a different jetpack than the one being enabled then the previously active jetpack is disabled first

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/2cd582f6-9796-4e54-9657-63a4cf154611


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
SharedJetpackSystem.SetEnabled is updated

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Steel
- fix: Jetpacks now turn off when another jetpack is activated.
