### PR TITLE
rift carps rebalance

### DIFF
--- a/Content.Server/Dragon/Components/DragonRiftComponent.cs
+++ b/Content.Server/Dragon/Components/DragonRiftComponent.cs
@@ -27,13 +27,13 @@ public sealed partial class DragonRiftComponent : SharedDragonRiftComponent
     /// Accumulation of the spawn timer.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("spawnAccumulator")]
-    public float SpawnAccumulator = 30f;
+    public float SpawnAccumulator = 50f;
 
     /// <summary>
     /// How long it takes for a new spawn to be added.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("spawnCooldown")]
-    public float SpawnCooldown = 30f;
+    public float SpawnCooldown = 50f;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("spawn", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string SpawnPrototype = "MobCarpDragon";

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -178,6 +178,15 @@
       mindRoles:
       - MindRoleGhostRoleTeamAntagonistFlock
     - type: GhostTakeoverAvailable
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        70: Dead
+    - type: MeleeWeapon
+      damage:
+        types:
+          Blunt: 8
+          Slash: 9
     - type: HTN
       rootTask:
         task: DragonCarpCompound
@@ -187,6 +196,7 @@
     - type: Temperature
     - type: TemperatureDamage
       heatDamageThreshold: 1200
+
 - type: entity
   id: MobCarpDungeon
   parent: MobCarp


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Now, instead of 30 seconds, a carp will spawn in the Rift every 50 seconds. Instead of 11 carps, only 7 will spawn, but the carps from the Rift now have 70 HP instead of 40 and 17 damage instead of 12.

## Why / Balance
A large number of carps has many disadvantages. Ghosts just don't want play for them, and their AI likes to get stuck in technical tunnels, where the dragon usually fights, and when there are too many of them, their intelligence stops working and they stop doing anything. By converting their number into their characteristics, ghosts'll have more motivation to play for the carps, because now you won't die from three bullets.

## Technical details
just yml

## Media

https://github.com/user-attachments/assets/4d56b27a-3a08-4f3a-a9fe-18d1f550bf21


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl: Golub
- tweak: Dragon Carps now have 70 health instead of 40, and deal 17 damage instead of 12
- tweak: Now a new carp appears from the rift every 50 seconds instead of 30