### PR TITLE
Add fontconfig and pipewire to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,7 @@ let
     libGL
     openal
     freetype
+    fontconfig
     fluidsynth
     soundfont-fluid
     gtk3
@@ -43,6 +44,7 @@ let
     xorg.libxshmfence
     mesa
     alsa-lib
+    pipewire
     dbus
     at-spi2-core
     cups


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Added fontconfig and pipewire packages to `shell.nix`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

fontconfig: This eliminates an non-critical error during `runclient.sh` startup, complaining `libfontconfig.so.1` not found.

pipewire: This fixes `runclient.sh` crashing with the following error.

```
ALSA lib dlmisc.c:339:(snd_dlobj_cache_get0) Cannot open shared library libasound_module_pcm_pipewire.so (/nix/store/gmpw5fapb46sm5fxirwsyl1zicx2mrax-alsa-lib-1.2.14/lib/alsa-lib/libasound_module_pcm_pipewire.so: cannot open shared object file: No such file or directory)
[ERRO] clyde.oal: [_audioOpenDevice:91] ALC error: InvalidValue
[ERRO] clyde.oal: Unable to open OpenAL device! {1}
```

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

