### PR TITLE
Add Tail Drag to Rat King

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -33,6 +33,8 @@
     proto: regal
   - type: Physics
     bodyType: KinematicController
+  - type: Puller
+    needsHands: false
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
## About the PR
Added Puller to the Rat King YML, allowing it to tail drag objects.

## Why / Balance
Adds consistency to tail drag, really is no reason RK shouldn't have it. Rat King is also definitely not in a great spot currently and this is one of those small things that adds complexity to the role. The ability to drag away something like Alexander or an unguarded pizza crate to a place maybe a bit more out of the public eye offers a bit more interesting gameplay choices.

## Technical details
yaml warrior

## Media

https://github.com/user-attachments/assets/c5560b44-64a4-4dda-96c9-fcef3cf890e4



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
**Changelog**
:cl:
- tweak: Rat Kings can now pull objects.