### PR TITLE
Fix RCD not being able to place hull tiles in space

### DIFF
--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -21,6 +21,7 @@
   parent: Plating
   name: tiles-rcd-plating
   baseWhitelist:
+    - Space
     - TrainLattice
     - FloorPlanetDirt
     - FloorDesert


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When using the RCD, the check for a map grid now uses any grid the player is standing on as a fallback, if the click location didn't have a grid of its own. This allows hull tiles to be built in space without lattices, assuming the player is on a grid.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #42548 

## Technical details
<!-- Summary of code changes for easier review. -->
Sets `gridUid` to whatever grid the player is currently on if there is no grid at `ClickLocation`, and passes the target grid to any `OnDoAfter...` logic.

Also explicitly aligns the RCD's visual effect to the grid, since that wasn't happening already.

YAML for PlatingRCD was updated to allow being placed on space.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/e988675d-4469-4a8b-987d-dcdc086fa266

Hull tiles can now be built in space without lattice, walls and steel tiles still cannot.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`TargetGridId` was added to `RCDDoAfterEvent` as a new required field.

The only existing reference was updated; if this is being used by anyone else then you now need to provide a new `NetEntity` to the constructor (this is the grid that is being built on).

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: RCDs can once again be used to construct hull tiles in space without requiring lattices first
