### PR TITLE
Add missing test pair cleanup to SharedGasSpecificHeatsTest

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/SharedGasSpecificHeatsTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/SharedGasSpecificHeatsTest.cs
@@ -13,7 +13,7 @@ namespace Content.IntegrationTests.Tests.Atmos;
 /// Tests for asserting that various gas specific heat operations agree with each other and do not deviate
 /// across client and server.
 /// </summary>
-[TestOf(nameof(SharedAtmosphereSystem)), NonParallelizable]
+[TestOf(nameof(SharedAtmosphereSystem)), FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 public sealed class SharedGasSpecificHeatsTest
 {
     private IConfigurationManager _sConfig;


### PR DESCRIPTION
and make it nonparallel because sometimes the basic tests blast through so fast that the pairs are reused before they're read (or something? I honestly don't know, but making it non-parallel fixed issues I was seeing)

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The tests grabs test pairs and never return them; now they do.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Good programs put away their toys.

## Technical details
<!-- Summary of code changes for easier review. -->
Just added a `[Teardown]` which returns the test.
Also I made them nonparallel because (quoting my explaino to Roomba)

> As far as I could tell, because the test doesn't actually do much with the pair, it blasts through the logic so fast that before the first test is ⁨⁨⁨Teardown⁩⁩⁩'d, the next one starts running and the lifecycles of the pair(s) get mangled.
>
> I honestly don't know exactly what's going on, but Nunit documentation says one instance of the fixture class is made, so I am assuming some fuckery w/r/t the shared ⁨⁨⁨`_pair`⁩⁩⁩ binding 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
no

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
n/a