### PR TITLE
[BUGFIX] Midround Wizards now show up on the end results screen

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -349,6 +349,7 @@
   - type: GhostRole
     name: ghost-role-information-wizard-name
     description: ghost-role-information-wizard-desc
+    rules: ghost-role-information-antagonist-rules
     mindRoles:
     - MindRoleWizard
     raffle:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -323,7 +323,7 @@
   components:
   - type: StationEvent
     weight: 1 # rare
-    duration: 1
+    duration: null
     earliestStart: 30
     reoccurrenceDelay: 60
     minimumPlayers: 30


### PR DESCRIPTION
## About the PR
Made midround Wizards show up on the end results screen.
Made Wizard Ghostroles have the Solo Antagonist rules when joining the raffle.

## Why / Balance
It should let the person who's joining the raffle know that the wizard is a Solo Antagonist, like the briefing in chat does.
I am also sick and tired of not knowing who got the midround Wizard. I will not disclose why.

## Technical details
1 line in events.yml:
changed `duration` from `1` to `null`, like all other midround antags with end results.

1 line in ghost_roles.yml:
added a `rules: ghost-role-information-antagonist-rules` for `SpawnPointGhostWizard`
## Media
Ignore the first guy, that was a different WizardSpawn.

https://github.com/user-attachments/assets/cba67a65-4f9a-4213-a1c9-f86e668278f9

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Midround Wizards now show up on the end results screen.