### PR TITLE
Fix markings colour setting

### DIFF
--- a/Content.Client/Humanoid/MarkingsViewModel.cs
+++ b/Content.Client/Humanoid/MarkingsViewModel.cs
@@ -287,7 +287,8 @@ public sealed class MarkingsViewModel
         if (!markingSet.TryGetValue(layer, out var markings))
             return;
 
-        if (markings.FindIndex(it => it.MarkingId == markingId) is var markingIdx && markingIdx >= 0)
+        var markingIdx = markings.FindIndex(it => it.MarkingId == markingId);
+        if (markingIdx == -1)
             return;
 
         markings[markingIdx] = markings[markingIdx].WithColorAt(colorIndex, color);

--- a/Content.IntegrationTests/Tests/Markings/MarkingsViewModelTests.cs
+++ b/Content.IntegrationTests/Tests/Markings/MarkingsViewModelTests.cs
@@ -1,0 +1,136 @@
+using Content.Client.Humanoid;
+using Content.IntegrationTests.Pair;
+using Content.Shared.Body;
+using Content.Shared.Humanoid;
+using Content.Shared.Humanoid.Markings;
+using Content.Shared.Humanoid.Prototypes;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Commands;
+using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
+using Robust.UnitTesting;
+
+namespace Content.IntegrationTests.Tests.Markings;
+
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class MarkingTestAttribute : TestAttribute, IWrapTestMethod
+{
+    private sealed class MarkingTestCommand(TestCommand inner) : DelegatingTestCommand(inner)
+    {
+        public override TestResult Execute(TestExecutionContext context)
+        {
+            var fixture = inner.Test.Fixture as MarkingsViewModelTests;
+            fixture!.Client.WaitAssertion(() =>
+                {
+                    context.CurrentResult = inner.Execute(context);
+                })
+                .Wait();
+            return context.CurrentResult;
+        }
+    }
+
+    public TestCommand Wrap(TestCommand command)
+    {
+        return new MarkingTestCommand(command);
+    }
+}
+
+[TestFixture]
+[TestOf(typeof(MarkingsViewModel))]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+public sealed class MarkingsViewModelTests
+{
+    public ProtoId<SpeciesPrototype> TestSpecies = "Moth";
+    public ProtoId<OrganCategoryPrototype> Head = "Head";
+    public ProtoId<OrganCategoryPrototype> Torso = "Torso";
+    public ProtoId<MarkingPrototype> MothAntennasCharred = "MothAntennasCharred";
+    public ProtoId<MarkingPrototype> MothChestCharred = "MothChestCharred";
+    public ProtoId<MarkingPrototype> MothChestDeathhead = "MothChestDeathhead";
+    public ProtoId<MarkingPrototype> MothChestFan = "MothChestFan";
+    public ProtoId<MarkingPrototype> LizardHornsCurled = "LizardHornsCurled";
+    public ProtoId<MarkingPrototype> MothAntennasDefault = "MothAntennasDefault";
+
+    public TestPair Pair = default!;
+    public RobustIntegrationTest.ClientIntegrationInstance Client => Pair.Client;
+    public MarkingsViewModel Model = default!;
+    public MarkingManager Manager = default!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        Pair = await PoolManager.GetServerClient();
+        await Client.WaitPost(() =>
+        {
+            Model = new MarkingsViewModel();
+            Manager = Client.ResolveDependency<MarkingManager>();
+
+            Model.OrganData = Manager.GetMarkingData(TestSpecies);
+            Model.OrganProfileData = Manager.GetProfileData(TestSpecies, Sex.Male, Color.White, Color.White);
+            Model.ValidateMarkings();
+        });
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await Pair.CleanReturnAsync();
+    }
+
+    [MarkingTest]
+    public void MarkingSelection()
+    {
+        Assert.That(Model.TrySelectMarking(Head, HumanoidVisualLayers.HeadTop, MothAntennasCharred), Is.True, "You should be able to select a marking in a limit-1 category if another marking is selected");
+        Assert.That(Model.SelectedMarkings(Head, HumanoidVisualLayers.HeadTop)!, Has.Count.EqualTo(1), "The markings model should respect the limits when selecting markings");
+        Assert.That(Model.SelectedMarkings(Head, HumanoidVisualLayers.HeadTop)![0].MarkingId, Is.EqualTo(MothAntennasCharred), "The markings model should have replaced the default marking with charred antennae");
+
+        Assert.That(Model.TrySelectMarking(Torso, HumanoidVisualLayers.Chest, MothChestCharred), Is.True);
+        Assert.That(Model.SelectedMarkings(Torso, HumanoidVisualLayers.Chest)!, Has.Count.EqualTo(1));
+        Assert.That(Model.SelectedMarkings(Torso, HumanoidVisualLayers.Chest)![0].MarkingId, Is.EqualTo(MothChestCharred));
+
+        Assert.That(Model.TrySelectMarking(Torso, HumanoidVisualLayers.Chest, MothChestDeathhead), Is.True);
+        Assert.That(Model.SelectedMarkings(Torso, HumanoidVisualLayers.Chest)!, Has.Count.EqualTo(2));
+        Assert.That(Model.SelectedMarkings(Torso, HumanoidVisualLayers.Chest)![1].MarkingId, Is.EqualTo(MothChestDeathhead));
+
+        Assert.That(Model.TrySelectMarking(Torso, HumanoidVisualLayers.Chest, MothChestFan), Is.False);
+        Assert.That(Model.TrySelectMarking(Head, HumanoidVisualLayers.HeadTop, LizardHornsCurled), Is.False);
+
+        Model.EnforceLimits = false;
+        Assert.That(Model.TrySelectMarking(Torso, HumanoidVisualLayers.Chest, MothChestFan), Is.True);
+        Assert.That(Model.SelectedMarkings(Torso, HumanoidVisualLayers.Chest)!, Has.Count.EqualTo(3));
+        Assert.That(Model.SelectedMarkings(Torso, HumanoidVisualLayers.Chest)![2].MarkingId, Is.EqualTo(MothChestFan));
+    }
+
+    [MarkingTest]
+    public void MarkingDeselection()
+    {
+        Assert.That(Model.TryDeselectMarking(Head, HumanoidVisualLayers.HeadTop, MothAntennasDefault), Is.False);
+        Assert.That(Model.SelectedMarkings(Head, HumanoidVisualLayers.HeadTop)!, Has.Count.EqualTo(1));
+        Assert.That(Model.SelectedMarkings(Head, HumanoidVisualLayers.HeadTop)![0].MarkingId, Is.EqualTo(MothAntennasDefault));
+
+        Model.EnforceLimits = false;
+
+        Assert.That(Model.TryDeselectMarking(Head, HumanoidVisualLayers.HeadTop, MothAntennasDefault), Is.True);
+        Assert.That(Model.SelectedMarkings(Head, HumanoidVisualLayers.HeadTop)!, Has.Count.EqualTo(0));
+    }
+
+    [MarkingTest]
+    public void MarkingColors()
+    {
+        Model.TrySetMarkingColor(Head, HumanoidVisualLayers.HeadTop, MothAntennasDefault, 0, Color.AliceBlue);
+        Assert.That(Model.SelectedMarkings(Head, HumanoidVisualLayers.HeadTop)![0].MarkingColors[0], Is.EqualTo(Color.AliceBlue));
+    }
+
+    [MarkingTest]
+    public void MarkingColorRestoration()
+    {
+        Model.EnforceLimits = false;
+        Model.TrySetMarkingColor(Head, HumanoidVisualLayers.HeadTop, MothAntennasDefault, 0, Color.AliceBlue);
+        Assert.That(Model.SelectedMarkings(Head, HumanoidVisualLayers.HeadTop)![0].MarkingColors[0], Is.EqualTo(Color.AliceBlue));
+
+        Assert.That(Model.TryDeselectMarking(Head, HumanoidVisualLayers.HeadTop, MothAntennasDefault), Is.True);
+        Assert.That(Model.TrySelectMarking(Head, HumanoidVisualLayers.HeadTop, MothAntennasDefault), Is.True);
+
+        Assert.That(Model.SelectedMarkings(Head, HumanoidVisualLayers.HeadTop)![0].MarkingColors[0], Is.EqualTo(Color.AliceBlue));
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- fixes the ability to set colour in the markings editor

## Technical details
- 1 line fix
- 100 lines of tests

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Marking colours can now be changed again
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
