### PR TITLE
Only rebuild organ markings when sex or group has changed

### DIFF
--- a/Content.Client/Humanoid/MarkingsViewModel.cs
+++ b/Content.Client/Humanoid/MarkingsViewModel.cs
@@ -54,7 +54,7 @@ public sealed class MarkingsViewModel
         set
         {
             _organProfileData = value.ShallowClone();
-            OrganProfileDataChanged?.Invoke();
+            OrganProfileDataChanged?.Invoke(true);
         }
     }
 
@@ -64,7 +64,7 @@ public sealed class MarkingsViewModel
         {
             _organProfileData[organ] = data with { Sex = sex };
         }
-        OrganProfileDataChanged?.Invoke();
+        OrganProfileDataChanged?.Invoke(true);
     }
 
     public void SetOrganSkinColor(Color skinColor)
@@ -73,7 +73,7 @@ public sealed class MarkingsViewModel
         {
             _organProfileData[organ] = data with { SkinColor = skinColor };
         }
-        OrganProfileDataChanged?.Invoke();
+        OrganProfileDataChanged?.Invoke(false);
     }
 
     public void SetOrganEyeColor(Color eyeColor)
@@ -82,10 +82,10 @@ public sealed class MarkingsViewModel
         {
             _organProfileData[organ] = data with { EyeColor = eyeColor };
         }
-        OrganProfileDataChanged?.Invoke();
+        OrganProfileDataChanged?.Invoke(false);
     }
 
-    public event Action? OrganProfileDataChanged;
+    public event Action<bool>? OrganProfileDataChanged;
 
     private Dictionary<ProtoId<OrganCategoryPrototype>, Dictionary<HumanoidVisualLayers, List<Marking>>> _markings = new();
 

--- a/Content.Client/Humanoid/OrganMarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/OrganMarkingPicker.xaml.cs
@@ -42,7 +42,7 @@ public sealed partial class OrganMarkingPicker : Control
     {
         base.EnteredTree();
 
-        _markingsModel.OrganProfileDataChanged += UpdateMarkings;
+        _markingsModel.OrganProfileDataChanged += OnOrganProfileDataChanged;
         _markingsModel.EnforcementsChanged += UpdateMarkings;
     }
 
@@ -50,11 +50,17 @@ public sealed partial class OrganMarkingPicker : Control
     {
         base.ExitedTree();
 
-        _markingsModel.OrganProfileDataChanged -= UpdateMarkings;
+        _markingsModel.OrganProfileDataChanged -= OnOrganProfileDataChanged;
         _markingsModel.EnforcementsChanged -= UpdateMarkings;
     }
 
     public bool Empty => LayerTabs.ChildCount == 0;
+
+    private void OnOrganProfileDataChanged(bool refresh)
+    {
+        if (refresh)
+            UpdateMarkings();
+    }
 
     private void UpdateMarkings()
     {


### PR DESCRIPTION
Closes https://github.com/space-wizards/space-station-14/issues/42781

## About the PR
- performance optimization for markings UI

## Why / Balance
- makes it run at a smooth 60fps

## Technical details
- don't always rebuild the UI when organ profile data changes, only if the data changed is relevant for the set of possible markings

## Media
https://github.com/user-attachments/assets/84366a80-7edd-40e2-b2c4-9c90caadf821

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
