### PR TITLE
Laser Rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -489,7 +489,7 @@
       path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: BatteryAmmoProvider
     proto: XrayLaser
-    fireCost: 62.5
+    fireCost: 100
   - type: MagazineVisuals
     magState: mag
     steps: 5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -426,6 +426,9 @@
   - type: BatteryAmmoProvider
     proto: RedHeavyLaser
     fireCost: 40
+  - type: SpeedModifiedOnWield
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: Tag
     tags:
     - TurretCompatibleWeapon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -53,8 +53,8 @@
     availableModes:
     - SemiAuto
   - type: BatteryAmmoProvider
-    proto: RedLaser
-    fireCost: 62.5
+    proto: RedMediumLaser
+    fireCost: 33.3
   - type: StaticPrice
     price: 420
   - type: Tag
@@ -420,12 +420,12 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/laser_cannon.rsi
   - type: Gun
-    fireRate: 1.5
+    fireRate: .7
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: BatteryAmmoProvider
     proto: RedHeavyLaser
-    fireCost: 100
+    fireCost: 40
   - type: Tag
     tags:
     - TurretCompatibleWeapon
@@ -486,7 +486,7 @@
       path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: BatteryAmmoProvider
     proto: XrayLaser
-    fireCost: 100
+    fireCost: 62.5
   - type: MagazineVisuals
     magState: mag
     steps: 5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -424,7 +424,7 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: BatteryAmmoProvider
-    proto: RedHeavyLaser
+    proto: RedSniperLaser
     fireCost: 40
   - type: SpeedModifiedOnWield
     walkModifier: 0.85
@@ -986,6 +986,9 @@
   id: WeaponLaserCannonXenoborg
   name: xenoborg laser cannon
   components:
+  - type: BatteryAmmoProvider
+    proto: RedHeavyLaser
+    fireCost: 100
   - type: BatterySelfRecharger
     autoRechargeRate: 30
   # "remove" wield bonus and penalty so borgs can use it

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -78,7 +78,7 @@
   - type: HitscanBasicDamage
     damage:
       types:
-        Heat: 28
+        Heat: 42
   - type: HitscanBasicVisuals
     muzzleFlash:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -78,7 +78,7 @@
   - type: HitscanBasicDamage
     damage:
       types:
-        Heat: 42
+        Heat: 28
   - type: HitscanBasicVisuals
     muzzleFlash:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
@@ -89,6 +89,18 @@
     impactFlash:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
       state: impact_beam_heavy
+
+- type: entity
+  parent: RedHeavyLaser
+  id: RedSniperLaser
+  name: red high-precision laser ray
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: HitscanBasicDamage
+    damage:
+      types:
+        Heat: 42
+
 
 - type: entity
   parent: BasicHitscan

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -100,8 +100,6 @@
     damage:
       types:
         Heat: 42
-
-
 - type: entity
   parent: BasicHitscan
   id: RedLaserPractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -100,6 +100,7 @@
     damage:
       types:
         Heat: 42
+
 - type: entity
   parent: BasicHitscan
   id: RedLaserPractice


### PR DESCRIPTION
PR given the go-ahead by @SlamBamActionman from the Combat Workgroup. The values can be changed and tested on vulture as needed.

## About the PR
More damage! More ammo! And a very interesting Laser Cannon.

## Why / Balance
Laser Carbines got extra ammo (16 -> 30) and damage (14 -> 17) because, frankly, they're far too weak for normal usage. They now do equal damage to the captain's laser with thrice the ammo capacity of one, but with no recharge, of course. This makes the carbine a genuine upgrade from the captain's pistol. (a desired change as, while the captain should be well-armed, they shouldn't easily outclass armoury weaponry)

The Laser Cannon was reworked to be the crew's equivalent of the Hristov: a high-damage (28 -> 42) sniper that takes a speed penalty (15%) and a longer cooldown (.6 seconds -> 1.4 seconds). This makes them more unique than "carbine but better" (also, it wasn't even better due to the crippled ammo capacity, which has been buffed (12 -> 25))

## Technical details
YAML!!

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: UpAndLeaves
- tweak: Laser carbines had their damage and ammo capacity increased.
- tweak: Laser cannons had their damage and ammo capacity increased, at the expense of slower firing rate and a movement penalty.
