### PR TITLE
Remove Uranium from Mute Toxin recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -349,8 +349,6 @@
   impact: Medium
   minTemp: 370
   reactants:
-    Uranium:
-      amount: 1
     Vestine:
       amount: 2
     SpaceGlue:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed uranium from the recipe to create mute toxin. Instead of taking 1 uranium / 2 vestine / 2 glue to produce 2 mute toxin when heated, it's just 2 vestine & 2 glue + heat for 2 mute tox. 

## Why / Balance
Makes mute toxin actually possible to create lol.

Uranium is a resource that is extremely unrealistic to get your hands on outside of the roundstart engineering supply, which everyone on the station has to fight over and Sci usually hoovers up anyway. The medical workgroup indicated that this is a reagent that was not going to get easier to acquire anytime soon and showed some interest in removing the reagent from the reaction. 
Mute toxin itself is an interesting chemical that is virtually nonexistent in use because of how difficult it is to create, basically being botany-locked when botany has better evil plans to work towards. Ideally, this change should make it a little more attractive for traitors to experiment with. 

## Technical details
yaml warrior

## Media
not needed

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
**Changelog**
:cl:
- tweak: Adjusted the Mute Toxin chemical reaction recipe to no longer require uranium.
