### PR TITLE
Revert "[EXPERIMENTAL] Removes Blunt and Burn Damage Threshold Gib Behavior"

### DIFF
--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -181,6 +181,28 @@
     thresholds:
     - trigger:
         !type:DamageTypeTrigger
+        damageType: Blunt
+        damage: 400
+      behaviors:
+      - !type:GibBehavior { }
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Heat
+        damage: 1500
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawnInContainer: true
+        spawn:
+          FoodMeatChickenFriedVox:
+            min: 3
+            max: 5
+      - !type:BurnBodyBehavior
+        popupMessage: bodyburn-vox-text-others
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MeatLaserImpact
+    - trigger:
+        !type:DamageTypeTrigger
         damageType: Radiation
         damage: 15
       behaviors:

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -74,6 +74,27 @@
     thresholds:
     - trigger:
         !type:DamageTypeTrigger
+        damageType: Blunt
+        damage: 400
+      behaviors:
+      - !type:GibBehavior { }
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Heat
+        damage: 1500
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawnInContainer: true
+        spawn:
+          Ash:
+            min: 1
+            max: 1
+      - !type:BurnBodyBehavior
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MeatLaserImpact
+    - trigger:
+        !type:DamageTypeTrigger
         damageType: Radiation
         damage: 15
       behaviors:


### PR DESCRIPTION
This reverts commit d4fe565b2e5de65ae2f38cf32893faa9f15c6f4e.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Readds normal gibbing 

## Why / Balance
Uhhh it's almost impossible to borg people now,
Makes the minibomb useless since it can't gib people now,
People also might really hate it being removed so merge this if they do

also it was "experimental" so like if the experiment goes wrong merge this

ss13 paridy also

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Readded blunt and burn based gibbing!