### PR TITLE
Fix gas filter math

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -345,6 +345,26 @@ namespace Content.Server.Atmos.EntitySystems
         [PublicAPI]
         public static float FractionToMaxPressure(GasMixture mix1, GasMixture mix2, float targetPressure)
         {
+            var molesToTransfer = MolesToMaxPressure(mix1, mix2, targetPressure);
+            return molesToTransfer / mix1.TotalMoles;
+        }
+
+        /// <summary>
+        /// Determines the number of moles to be removed and transferred from a source
+        /// <see cref="GasMixture"/> to a target <see cref="GasMixture"/> to reach a target pressure
+        /// in the target <see cref="GasMixture"/>.
+        /// </summary>
+        /// <param name="mix1">The source <see cref="GasMixture"/> that gas will be removed from.
+        /// This should always be of higher pressure than the second <see cref="GasMixture"/>.</param>
+        /// <param name="mix2">The target <see cref="GasMixture"/> that will increase in pressure
+        /// to the target pressure.</param>
+        /// <param name="targetPressure">The target mixture's desired pressure to target.</param>
+        /// <returns>The difference in moles required to reach the target pressure.</returns>
+        /// <remarks>Note that this method doesn't take into account the heat capacity of the
+        /// transferred volume causing a pressure rise in the target <see cref="GasMixture"/>.</remarks>
+        [PublicAPI]
+        public static float MolesToMaxPressure(GasMixture mix1, GasMixture mix2, float targetPressure)
+        {
             /*
              Calculate the moles required to reach the target pressure.
              The formula is derived from the ideal gas law and the
@@ -388,7 +408,7 @@ namespace Content.Server.Atmos.EntitySystems
             var requiredMoles = (delta * mix2.Volume) / (mix1.Temperature * Atmospherics.R);
 
             // Return the fraction of moles to transfer.
-            return requiredMoles / mix1.TotalMoles;
+            return requiredMoles;
         }
 
         /// <summary>

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
@@ -75,9 +75,8 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
             if (filter.FilteredGas.HasValue)
             {
                 // Make sure we don't pump over the pressure limit.
-                var limitMolesFilterFraction =
-                    AtmosphereSystem.FractionToMaxPressure(removed, filterNode.Air, Atmospherics.MaxOutputPressure);
-                var limitMolesFilter = removed.TotalMoles * limitMolesFilterFraction;
+                var limitMolesFilter =
+                    AtmosphereSystem.MolesToMaxPressure(removed, filterNode.Air, Atmospherics.MaxOutputPressure);
 
                 var availableMoles = removed.GetMoles(filter.FilteredGas.Value);
                 var filteredMoles = Math.Max(Math.Min(limitMolesFilter, availableMoles), 0);


### PR DESCRIPTION
## About the PR
I'm just a genius, what can I say. They got me at the genius bar. Straight geniusing.

Fixes the gas filter math moving the incorrect amount of mols to the filter outlet

## Why / Balance
Clamp by `fraction*TotalMoles` instead of clamping by fraction. Smile.

## Technical details
yeah

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed the Gas Filter not transferring enough mols to the filter outlet.
