### PR TITLE
Fix being able to use crematorium from inside it

### DIFF
--- a/Content.Shared/Morgue/SharedCrematoriumSystem.cs
+++ b/Content.Shared/Morgue/SharedCrematoriumSystem.cs
@@ -74,6 +74,9 @@ public abstract class SharedCrematoriumSystem : EntitySystem
 
         if (!args.CanAccess || !args.CanInteract || args.Hands == null || storage.Open)
             return;
+        //hack fix to prevent use from within, should have been caught by args.CanAccess
+        if (storage.Contents.Contains(args.User))
+            return;
 
         if (HasComp<ActiveCrematoriumComponent>(uid))
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Prevented the use of the crematorium from inside of it.

## Why / Balance
Fixes #42761. I accidentally cremated myself and want to save others from the fate.

## Technical details
Checks if storage contains the user when creating the cremate verb in SharedCrematoriumSystem, and returns if so.

## Media
Note the lack of a cremate verb
<img width="649" height="439" alt="image" src="https://github.com/user-attachments/assets/88a47c91-3cc9-4b18-8a8b-c218c867e379" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: You can no longer cremate yourself.
