### PR TITLE
Solved #42803 - Syndie contra explicitly has no allowed departments or jobs.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -30,6 +30,8 @@
   components:
   - type: Contraband
     severity: Syndicate
+    allowedDepartments: [  ]
+    allowedJobs: [  ]
 
 # minor contraband not departmentally restricted -- improvised weapons etc
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed #42803 by changing the `BaseSyndicateContraband` class to have empty list fields for `allowedDepartments` and `allowedJobs`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Syndicate contraband is illegal for everyone. No jobs or departments should have access to it. And the current legal loophole (in #42803) seems unintended.

## Technical details
<!-- Summary of code changes for easier review. -->
I noticed that the `fire axe` (syndie flameaxe) inherited from `BaseSyndicateContraband` and `FireAxe` (the regular axe). `FireAxe` inherits from `BaseItem` and `BaseEngineeringContraband` - the latter of which passes `allowedDepartments: [ Engineering ]` to the `FireAxe`, which seemingly gets inherited by the flame axe. (see [`Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml`](https://github.com/space-wizards/space-station-14/blob/4c62ce20255b3252dc52ad9c1e613581b5db5204/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml) and [`Resources/Prototypes/Entities/Objects/base_contraband.yml`](https://github.com/space-wizards/space-station-14/blob/4c62ce20255b3252dc52ad9c1e613581b5db5204/Resources/Prototypes/Entities/Objects/base_contraband.yml))

However, by making the `BaseSyndicateContraband` entity type override the `allowedDepartments` and `allowedJobs` (from `BaseRestrictedContraband`) to allow absolutely nobody to use them, this will ensure that all future instances of syndie contraband inheriting from department-specific contraband will correctly be marked as illegal for everyone to use.

(The alternative would have been to move the shared base stats/config/etc of the `FireAxe` into some sort of `AbstractFireAxeEntity`, and then make the `FireAxe` extend that and `BaseEngineeringContraband`, whilst `fire axe` would extend `AbstractFireAxe` and `BaseSyndicateContraband` - which *could* get a bit messy. And this approach is arguably more futureproof, preventing further instances of this loophole from appearing)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1920" height="1040" alt="MyServer - Space Station 14_004" src="https://github.com/user-attachments/assets/7a2672d7-9bb7-4708-9b30-debb7b9c6c74" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
* The `BaseSyndicateContraband` entity class (in `Resources/Prototypes/Entities/Objects/base_contraband.yml`) now defines `allowedDepartments: []` and `allowedJobs: []`.
  * This change has been made in order to override any lingering permitted departments or jobs for any syndicate contraband entities which extend an existing department-specific contraband entity (children of `BaseRestrictedContraband`).
  * If there was any syndicate contraband which *was* supposed to be usable by a specific department or job, you may need to manually override `allowedDepartments`/`allowedJobs` for that contraband, or make it re-inherit the department-specific restriction.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Closed the legal loophole which technically allowed engineers to open-carry the syndicate fire axe.