### PR TITLE
feat: Smart Equip hotkey for last opened container (instead of specific slot)

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -78,6 +78,7 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.SmartEquipPocket1);
             human.AddFunction(ContentKeyFunctions.SmartEquipPocket2);
             human.AddFunction(ContentKeyFunctions.SmartEquipSuitStorage);
+            human.AddFunction(ContentKeyFunctions.SmartEquipLastInteracted);
             human.AddFunction(ContentKeyFunctions.OpenBackpack);
             human.AddFunction(ContentKeyFunctions.OpenBelt);
             human.AddFunction(ContentKeyFunctions.MouseMiddle);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -201,6 +201,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.SmartEquipPocket1);
             AddButton(ContentKeyFunctions.SmartEquipPocket2);
             AddButton(ContentKeyFunctions.SmartEquipSuitStorage);
+            AddButton(ContentKeyFunctions.SmartEquipLastInteracted);
             AddButton(ContentKeyFunctions.OpenBackpack);
             AddButton(ContentKeyFunctions.OpenBelt);
             AddButton(ContentKeyFunctions.ThrowItemInHand);

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -35,6 +35,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction SmartEquipPocket1 = "SmartEquipPocket1";
         public static readonly BoundKeyFunction SmartEquipPocket2 = "SmartEquipPocket2";
         public static readonly BoundKeyFunction SmartEquipSuitStorage = "SmartEquipSuitStorage";
+        public static readonly BoundKeyFunction SmartEquipLastInteracted = "SmartEquipLastInteracted";
         public static readonly BoundKeyFunction OpenBackpack = "OpenBackpack";
         public static readonly BoundKeyFunction OpenBelt = "OpenBelt";
         public static readonly BoundKeyFunction OpenAHelp = "OpenAHelp";

--- a/Content.Shared/Interaction/Components/SmartEquipUserComponent.cs
+++ b/Content.Shared/Interaction/Components/SmartEquipUserComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Interaction.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SmartEquipUserComponent : Component
+{
+    [DataField]
+    public EntityUid? LastOpenedStorage;
+}

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -267,6 +267,10 @@ binds:
   type: State
   key: H
   mod1: Shift
+- function: SmartEquipLastInteracted
+  type: State
+  key: Q
+  mod1: Shift
 - function: OpenBackpack
   type: State
   key: V


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The PR introduces a new hotkey that functions like smart-equip for backpack and other inventory slots, except the target of the smart-equip is always the last opened container (TODO: code is currently using the last "item removed" container which is incorrect)

## Why / Balance
Currently it is not possible to use a hotkey to move items from containers that are not in your inventory. But also for the containers in your inventory this hotkey is very convinient because you don't have to remember which container you have open (toolbelt or backpack) and the hotkey that belongs to that specific container, you can just press  the hotkey and see the item move from your hands into the open container.

## Technical details
So the code is definitely a work in progress, a large portion is currently duplicated. I also seem to hit some exceptions now and then while using nested containers.

## Media

https://github.com/user-attachments/assets/11e39e74-57e3-4d00-8741-a4b2bc058123


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
New hotkey added with a default of SHIFT+Q: please verify there is no existing hotkey for this and update accordingly otherwise.

**Changelog**
:cl:
- add: Added new hotkey to smart-equip items to the last opened container.
