### PR TITLE
Make conveyors stack items that stop

### DIFF
--- a/Content.Shared/Physics/Controllers/SharedConveyorController.cs
+++ b/Content.Shared/Physics/Controllers/SharedConveyorController.cs
@@ -170,13 +170,10 @@ public abstract class SharedConveyorController : VirtualController
                 {
                     SetConveying(ent.Entity.Owner, ent.Entity.Comp1, true);
                 }
-                else
+                else if (ent.Entity.Comp1.Conveying)
                 {
-                    if (ent.Entity.Comp1.Conveying)
-                    {
-                        SetConveying(ent.Entity.Owner, ent.Entity.Comp1, false);
-                        _stack.TryMergeToContacts(ent.Entity.Owner);
-                    }
+                    SetConveying(ent.Entity.Owner, ent.Entity.Comp1, false);
+                    _stack.TryMergeToContacts(ent.Entity.Owner);
                 }
 
                 // We apply friction here so when we push items towards the center of the conveyor they don't go overspeed.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR makes it so that any stackable item (materials, pancakes) automatically stack once they stop after being conveyed, which is either when they bump into a wall, fall of a conveyor belt or the conveyor belt stops.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Recyclers already do this, but if the recycler isn't at the very end of a conveyor belt you end up getting a bunch of separate entities that otherwise would've stacked.

## Technical details
<!-- Summary of code changes for easier review. -->

Due to the `ConveyedComponent` being on an entity just by purely touching a conveyor, we want to ensure that the merging only triggers when the items stop; it looks weird if it happens during the actual conveying, and of course if the conveyor is already off placing an item on it shouldn't cause a merge. 

So we throw on the check specifically the tick when the movement ends, which is when `SetConveying` sets false, but only when the cause is a lack of speed (not just because gravity turns off or whatever).

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/4a913f5a-67d6-41f6-8f4e-c9d5a1904d1d

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Stackables items now merge when stopping on/after a conveyor belt.