### PR TITLE
Empty Crayon Box

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -270,7 +270,7 @@
 
 - type: entity
   parent: BoxCardboard
-  id: CrayonBox
+  id: CrayonBoxEmpty
   name: crayon box
   description: It's a box of crayons.
   components:
@@ -287,18 +287,6 @@
     shape:
     - 0,0,1,1
     heldPrefix: box
-  - type: EntityTableContainerFill
-    containers:
-      storagebase: !type:AllSelector
-        children:
-        - id: CrayonRed
-        - id: CrayonOrange
-        - id: CrayonYellow
-        - id: CrayonGreen
-        - id: CrayonBlue
-        - id: CrayonPurple
-        - id: CrayonBlack
-        - id: CrayonWhite
   - type: ItemMapper
     mapLayers:
       black_box:
@@ -334,3 +322,21 @@
           tags:
           - CrayonWhite
   - type: Appearance
+
+- type: entity
+  parent: CrayonBoxEmpty
+  id: CrayonBox
+  suffix: Filled
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: CrayonRed
+        - id: CrayonOrange
+        - id: CrayonYellow
+        - id: CrayonGreen
+        - id: CrayonBlue
+        - id: CrayonPurple
+        - id: CrayonBlack
+        - id: CrayonWhite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a new crayon box prototype without the autofill, and makes it the parent of the autofill crayon box.

## Why / Balance
I've had cases where I wanted to map empty crayon boxes. Besides that, I think it's generally sensible to have prototypes for empty versions of things be the bases for the autofilled versions of those things, rather than having the autofill version being the default: It's more flexible, better organized, and avoids messes down the road.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
I've deliberately kept the name and ID of the filled version of the box the same, so nothing should break.