### PR TITLE
fix: APC sprites stuck in fully drained states on round start

### DIFF
--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -87,12 +87,8 @@ public sealed class ApcSystem : EntitySystem
     // Change the APC's state only when the battery state changes, or when it's first created.
     private void OnBatteryChargeChanged(EntityUid uid, ApcComponent component, ref ChargeChangedEvent args)
     {
-        if (component.NeedStateUpdate) {
-            // Let the Update loop handle the first update to prevent race condition.
-            // Otherwise it breaks what OnApcStartup is intended for.
-            return;
-        }
-        UpdateApcState(uid, component);
+        // Defer until the next tick.
+        component.NeedStateUpdate = true;
     }
 
     private static void OnApcStartup(EntityUid uid, ApcComponent component, ComponentStartup args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Title. Fixes #42169

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

- Fixed a bug causing APC charge being stuck in "Lack" on map startup

## Technical details
<!-- Summary of code changes for easier review. -->

Seems to be a race condition between `ChargeChangedEvent` event handler and the update loop.

`OnApcStartup` initialized the flag `NeedStateUpdate` for an initial call to `UpdateApcState`. However during map load, `ChargeChangedEvent` would fire, making `UpdateApcState` called first.

Since APC's `LastChargeState` defaults to  `ApcChargeState.Lack`, this will skip the visuals update:

https://github.com/space-wizards/space-station-14/blob/41dddf4d99d30839730011a8c64d1203cdedddbf/Content.Server/Power/EntitySystems/ApcSystem.cs#L175C1-L185

However, the `NeedStateUpdate` flag is still flipped, putting it in stucked state:

https://github.com/space-wizards/space-station-14/blob/41dddf4d99d30839730011a8c64d1203cdedddbf/Content.Server/Power/EntitySystems/ApcSystem.cs#L194

The fix adds a guard in `OnBatteryChargeChanged`, preventing it from calling `UpdateApcState` when a state update is scheduled in the update loop. This will prevent `ChargeChangedEvent` from clearing the initialization flag.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: APC sprites now shows the correct state on round start.
