### PR TITLE
fix: Crit animals in chef's hat freezes the wearer

### DIFF
--- a/Content.Shared/Clothing/Components/ActiveClothingPilotComponent.cs
+++ b/Content.Shared/Clothing/Components/ActiveClothingPilotComponent.cs
@@ -6,12 +6,12 @@ namespace Content.Shared.Clothing.Components;
 /// <summary>
 /// Back-referencing the pilot of the <see cref="PilotedClothingComponent"/>.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ActiveClothingPilotComponent : Component
 {
     /// <summary>
     /// The clothing this pilot is currently operating.
     /// </summary>
-    [DataField]
-    public EntityUid Clothing;
+    [DataField, AutoNetworkedField]
+    public EntityUid? Clothing;
 }

--- a/Content.Shared/Clothing/Components/ActiveClothingPilotComponent.cs
+++ b/Content.Shared/Clothing/Components/ActiveClothingPilotComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Clothing.Components;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Clothing.Components;
+
+/// <summary>
+/// Back-referencing the pilot of the <see cref="PilotedClothingComponent"/>.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ActiveClothingPilotComponent : Component
+{
+    /// <summary>
+    /// The clothing this pilot is currently operating.
+    /// </summary>
+    [DataField]
+    public EntityUid Clothing;
+}

--- a/Content.Shared/Clothing/EntitySystems/PilotedClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/PilotedClothingSystem.cs
@@ -97,7 +97,7 @@ public sealed partial class PilotedClothingSystem : EntitySystem
 
         if (_mobState.IsIncapacitated(entity))
         {
-            StopPiloting((entity.Comp.Clothing, clothing));
+            StopPiloting((entity.Comp.Clothing.Value, clothing));
         }
     }
 
@@ -120,6 +120,7 @@ public sealed partial class PilotedClothingSystem : EntitySystem
         // Setup back reference.
         var activePilot = EnsureComp<ActiveClothingPilotComponent>(pilotEnt);
         activePilot.Clothing = entity.Owner;
+        Dirty(pilotEnt, activePilot);
 
         // Add component to block prediction of wearer
         EnsureComp<PilotedByClothingComponent>(wearerEnt);

--- a/Content.Shared/Clothing/EntitySystems/PilotedClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/PilotedClothingSystem.cs
@@ -40,10 +40,6 @@ public sealed partial class PilotedClothingSystem : EntitySystem
         if (_whitelist.IsWhitelistFail(entity.Comp.PilotWhitelist, args.Entity))
             return;
 
-        // Make sure the entity is not crit or dead.
-        if (_mobState.IsIncapacitated(args.Entity))
-            return;
-
         entity.Comp.Pilot = args.Entity;
         Dirty(entity);
 
@@ -51,6 +47,10 @@ public sealed partial class PilotedClothingSystem : EntitySystem
         var activePilot = EnsureComp<ActiveClothingPilotComponent>(args.Entity);
         activePilot.Clothing = entity.Owner;
         Dirty(args.Entity, activePilot);
+
+        // Make sure the entity is not crit or dead before they start piloting.
+        if (_mobState.IsIncapacitated(args.Entity))
+            return;
 
         // Attempt to setup control link, if Pilot and Wearer are both present.
         StartPiloting(entity);
@@ -97,6 +97,7 @@ public sealed partial class PilotedClothingSystem : EntitySystem
 
     /// <summary>
     /// Stops the movement control when the pilot is crit or dead.
+    /// Resumes when the pilot is revived.
     /// </summary>
     private void OnPilotMobStateChanged(Entity<ActiveClothingPilotComponent> entity, ref MobStateChangedEvent args)
     {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

A rather quick fix for the issue mentioned in the title. Worked, but not so elegant.

Current behaviour:

- If the pilot is crit or dead when being inserted into the cloth inventory, they won't take pilot.
- If the pilot is crit or dead when they are piloting the wearer, the wearer will be free after their next movement.
- If the pilot is revived in the inventory, they will start piloting again.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes #29288.

## Technical details
<!-- Summary of code changes for easier review. -->

I think a better approach might be working on some other part of the mechanism, but I don't know what it is.

Some other things that can be improved:

- The moment when the pilot is crit or dead, if the wearer is moving, they will get stuck before they move towards some
  other directions, or stops and moves again.
- ~~If the pilot is somehow revived in the inventory, they will not take pilot again automatically.~~
- If the pilot is deleted??

I am quite new to the code base, not sure how `Dirty` works.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Mouse in a chef's hat no longer freezes the wearer after being crit or dead.