### PR TITLE
Illeism Revival

### DIFF
--- a/Content.Server/Speech/Components/IlleismAccentComponent.cs
+++ b/Content.Server/Speech/Components/IlleismAccentComponent.cs
@@ -6,6 +6,10 @@ namespace Content.Server.Speech.Components;
 [Access(typeof(IlleismAccentSystem))]
 public sealed partial class IlleismAccentComponent : Component
 {
+    /// <summary>
+    /// The strings that should be used to split the character's name.
+    /// Only the part up to the first occurrence is kept.
+    /// </summary>
     [DataField]
     public List<string> SplitOnStrings = new();
 }

--- a/Content.Server/Speech/Components/IlleismAccentComponent.cs
+++ b/Content.Server/Speech/Components/IlleismAccentComponent.cs
@@ -1,0 +1,11 @@
+using Content.Server.Speech.EntitySystems;
+
+namespace Content.Server.Speech.Components;
+
+[RegisterComponent]
+[Access(typeof(IlleismAccentSystem))]
+public sealed partial class IlleismAccentComponent : Component
+{
+    [DataField]
+    public List<string> SplitOnStrings = new();
+}

--- a/Content.Server/Speech/EntitySystems/IlleismAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/IlleismAccentSystem.cs
@@ -51,10 +51,12 @@ public sealed class IlleismAccentSystem : EntitySystem
             name = name.Split(sep)[0];
         }
 
-        var upperName = name.ToUpper();
-
-        message = message.Replace(LocNameKey, MostlyUppercase(message) ? upperName : name);
-
+        // TODO: Might be nice in the future to replace some instances with pronouns as well
+        // e.g. "I'm new here, and I could use some help" -> "Urist is new here, and he could use some help"
+        message = MostlyUppercase(message)
+            // ToUpper is needed on both because ApplyReplacements will capitalize the key
+            ? message.Replace(LocNameKey.ToUpper(), name.ToUpper())
+            : message.Replace(LocNameKey, name);
         args.Message = message;
     }
 }

--- a/Content.Server/Speech/EntitySystems/IlleismAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/IlleismAccentSystem.cs
@@ -1,0 +1,60 @@
+using Content.Server.Speech.Components;
+using Content.Shared.Speech;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class IlleismAccentSystem : EntitySystem
+{
+    [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
+
+    private const string LocNameKey = "{$name}";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<IlleismAccentComponent, AccentGetEvent>(OnAccent);
+    }
+
+    private bool MostlyUppercase(string message)
+    {
+        int totalLetters = 0;
+        int uppercaseLetters = 0;
+
+        // Iterate through each character in the string
+        foreach (char c in message)
+        {
+            if (char.IsLetter(c)) // Check if the character is a letter
+            {
+                totalLetters++;
+                if (char.IsUpper(c)) // Check if the letter is uppercase
+                {
+                    uppercaseLetters++;
+                }
+            }
+        }
+
+        if (totalLetters < 2)
+        {
+            return false;
+        }
+
+        return uppercaseLetters > totalLetters / 2;
+    }
+
+    private void OnAccent(EntityUid uid, IlleismAccentComponent component, AccentGetEvent args)
+    {
+        var message = _replacement.ApplyReplacements(args.Message, "illeism");
+
+        var name = Name(uid);
+        foreach (var sep in component.SplitOnStrings)
+        {
+            name = name.Split(sep)[0];
+        }
+
+        var upperName = name.ToUpper();
+
+        message = message.Replace(LocNameKey, MostlyUppercase(message) ? upperName : name);
+
+        args.Message = message;
+    }
+}

--- a/Resources/Locale/en-US/accent/illeism.ftl
+++ b/Resources/Locale/en-US/accent/illeism.ftl
@@ -1,0 +1,25 @@
+accent-illeism-is-1 = i am
+accent-illeism-is-2 = i'm
+accent-illeism-is-replace = {$name} is
+
+accent-illeism-has-1 = i have
+accent-illeism-has-2 = i've
+accent-illeism-has-replace = {$name} has
+
+accent-illeism-does = i do
+accent-illeism-does-replace = {$name} has
+
+accent-illeism-doesnt = i don't
+accent-illeism-doesnt-replace = {$name} doesn't
+
+accent-illeism-just-name-1 = me
+accent-illeism-just-name-2 = myself
+accent-illeism-just-name-3 = i
+accent-illeism-just-name-replace = {$name}
+
+accent-illeism-possessive-1 = my
+accent-illeism-possessive-2 = mine
+accent-illeism-possessive-replace = {$name}'s
+
+accent-illeism-will = i'll
+accent-illeism-will-replace = {$name} will

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -54,6 +54,12 @@ trait-cowboy-desc = You speak with a distinct cowboy accent!
 trait-german-name = German accent
 trait-german-desc = You seem to come from space Germany.
 
+trait-illeism-full-name = Illeism (Full)
+trait-illeism-full-desc = Your actions deserve a narrator! You only refer to yourself in the third-person.
+
+trait-illeism-first-name = Illeism (First)
+trait-illeism-first-desc = Your actions deserve a narrator! You only refer to yourself in the third-person, but only with your first name.
+
 trait-italian-name = Italian accent
 trait-italian-desc = Mamma mia! You seem to have lived in space Italy!
 

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -614,3 +614,19 @@
     accent-skeleton-words-7: accent-skeleton-words-replace-7
     accent-skeleton-words-8: accent-skeleton-words-replace-8
     accent-skeleton-words-9: accent-skeleton-words-replace-9
+
+- type: accent
+  id: illeism
+  wordReplacements:
+    accent-illeism-is-1: accent-illeism-is-replace
+    accent-illeism-is-2: accent-illeism-is-replace
+    accent-illeism-has-1: accent-illeism-has-replace
+    accent-illeism-has-2: accent-illeism-has-replace
+    accent-illeism-does: accent-illeism-does-replace
+    accent-illeism-doesnt: accent-illeism-doesnt-replace
+    accent-illeism-just-name-1: accent-illeism-just-name-replace
+    accent-illeism-just-name-2: accent-illeism-just-name-replace
+    accent-illeism-just-name-3: accent-illeism-just-name-replace
+    accent-illeism-possessive-1: accent-illeism-possessive-replace
+    accent-illeism-possessive-2: accent-illeism-possessive-replace
+    accent-illeism-will: accent-illeism-will-replace

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -35,6 +35,7 @@
   - FrenchAccent
   - FrontalLisp
   - GermanAccent
+  - IlleismAccent
   - LizardAccent
   - MobsterAccent
   - MonkeyAccent

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -93,6 +93,27 @@
   - type: ReplacementAccent
     accent: liar
 
+- type: trait
+  id: IlleismFirst
+  name: trait-illeism-first-name
+  description: trait-illeism-first-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: IlleismAccent
+    splitOnStrings:
+    - " "
+    - "-"
+
+- type: trait
+  id: IlleismFull
+  name: trait-illeism-full-name
+  description: trait-illeism-full-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: IlleismAccent
+
 # 2 Cost
 
 - type: trait


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added two new character traits, "Illeism (Full)" and "Illeism (First)", which, if selected, will make a character refer to themselves in the third person. It's worth noting that verbs like "I think" will be converted to "NAME think" instead of the correct "NAME thinks". I'm open to suggestions for fixing this, but I'm not sure if there's a good way of doing so (Is there any case in English at least where "I" isn't followed by a verb? If not, then I guess you could just pluralize the word after).

This is a revival of #32643, which was previously closed as abandoned.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Roleplay reasons. I've also been told that this would be helpful for a lot of vox players.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a component and system for `IlleismAccent`.

- The component has one datafield that determines what strings should be used for splitting up character names
- The system uses the existing `ReplacementAccentSystem` and new localized strings to replace phrases, then inserts the split up character name where appropriate

There requisite YAML prototypes have also been added, including the accent itself, as well as two traits to select it. One trait will use the character's full name, while the other will split at the first occurrence of a space or dash.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Full Name:

https://github.com/user-attachments/assets/cb945a9a-fc17-4575-8080-c7a0f52de2b3

Only First Name:

https://github.com/user-attachments/assets/31b36ad1-1070-42cf-bf32-f53a75a9429d

Lobby:
<img width="174" height="60" alt="image" src="https://github.com/user-attachments/assets/c6f1658f-5a1c-493c-9b97-9aa353551f8c" />
<img width="886" height="91" alt="image" src="https://github.com/user-attachments/assets/c6add945-21c4-4b2e-ab78-2b283f1da7ac" />
<img width="631" height="72" alt="image" src="https://github.com/user-attachments/assets/a6748b25-4899-4a16-84a1-b26c9464e8a0" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: TriviaSolari, thetolbean (Original Author)
- add: Characters may now select illeism as a speech trait, and refer to themselves in the third person.

