### PR TITLE
Fix gas filter always outputting 20C filtered gas

### DIFF
--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
@@ -80,10 +80,12 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
 
                 var availableMoles = removed.GetMoles(filter.FilteredGas.Value);
                 var filteredMoles = Math.Max(Math.Min(limitMolesFilter, availableMoles), 0);
+                var filteredGasMixture = new GasMixture { Temperature = removed.Temperature };
 
-                filterNode.Air.AdjustMoles(filter.FilteredGas.Value, filteredMoles);
-                removed.SetMoles(filter.FilteredGas.Value, 0f);
-                inletNode.Air.AdjustMoles(filter.FilteredGas.Value, availableMoles - filteredMoles);
+                filteredGasMixture.SetMoles(filter.FilteredGas.Value, filteredMoles);
+                removed.AdjustMoles(filter.FilteredGas.Value, -filteredMoles);
+
+                _atmosphereSystem.Merge(filterNode.Air, filteredGasMixture);
 
                 _ambientSoundSystem.SetAmbience(uid, filteredMoles > 0f);
             }


### PR DESCRIPTION
## About the PR
Fixes the filter outputting 20C filtered gas.
I'm just a genius.

## Why / Balance
bug

## Technical details
The previous code that created a temporary GasMixture was removed. This tempmix was set to the temperature of the inlet gas and used as an accumulator for the filtered gas to reside in before it was merged into the outlet. The latest filter changes removed that tempmix and instead adjusted the moles inside of the source and recipient GasMixture directly which does not transfer heat. As such no actual heat would carry over.

We now use a temporary GasMixture like last time. There's also a microopt where we don't do unnecessary work.

## Media
i tested two configs, one filtering out heated gas and another that tested conservation of mass, both worked to my liking.

might write tests for filter just because

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- fix: Fixed filters not transferring heat energy from the inlet to the filter outlet while still transferring physical gas.
