### PR TITLE
Fix `IdCardConsoleSystem` missing prototype error

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleBoundUserInterface.cs
+++ b/Content.Client/Access/UI/IdCardConsoleBoundUserInterface.cs
@@ -75,7 +75,7 @@ namespace Content.Client.Access.UI
             _window?.UpdateState(castState);
         }
 
-        public void SubmitData(string newFullName, string newJobTitle, List<ProtoId<AccessLevelPrototype>> newAccessList, ProtoId<JobPrototype> newJobPrototype)
+        public void SubmitData(string newFullName, string newJobTitle, List<ProtoId<AccessLevelPrototype>> newAccessList, ProtoId<JobPrototype>? newJobPrototype)
         {
             if (newFullName.Length > _maxNameLength)
                 newFullName = newFullName[.._maxNameLength];

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -223,7 +223,7 @@ namespace Content.Client.Access.UI
                 JobTitleLineEdit.Text,
                 // Iterate over the buttons dictionary, filter by `Pressed`, only get key from the key/value pair
                 _accessButtons.ButtonsList.Where(x => x.Value.Pressed).Select(x => x.Key).ToList(),
-                jobProtoDirty ? _jobPrototypeIds[JobPresetOptionButton.SelectedId] : string.Empty);
+                jobProtoDirty ? _jobPrototypeIds[JobPresetOptionButton.SelectedId] : null);
         }
     }
 }

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -133,7 +133,7 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
         string newFullName,
         string newJobTitle,
         List<ProtoId<AccessLevelPrototype>> newAccessList,
-        ProtoId<JobPrototype> newJobProto,
+        ProtoId<JobPrototype>? newJobProto,
         EntityUid player,
         IdCardConsoleComponent? component = null)
     {

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -146,7 +146,7 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
         _idCard.TryChangeFullName(targetId, newFullName, player: player);
         _idCard.TryChangeJobTitle(targetId, newJobTitle, player: player);
 
-        if (_prototype.Resolve(newJobProto, out var job)
+        if (_prototype.TryIndex(newJobProto, out var job)
             && _prototype.Resolve(job.Icon, out var jobIcon))
         {
             _idCard.TryChangeJobIcon(targetId, jobIcon, player: player);

--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -26,9 +26,9 @@ public sealed partial class IdCardConsoleComponent : Component
         public readonly string FullName;
         public readonly string JobTitle;
         public readonly List<ProtoId<AccessLevelPrototype>> AccessList;
-        public readonly ProtoId<JobPrototype> JobPrototype;
+        public readonly ProtoId<JobPrototype>? JobPrototype;
 
-        public WriteToTargetIdMessage(string fullName, string jobTitle, List<ProtoId<AccessLevelPrototype>> accessList, ProtoId<JobPrototype> jobPrototype)
+        public WriteToTargetIdMessage(string fullName, string jobTitle, List<ProtoId<AccessLevelPrototype>> accessList, ProtoId<JobPrototype>? jobPrototype)
         {
             FullName = fullName;
             JobTitle = jobTitle;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed a prototype indexing error in `IdCardConsoleSystem`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix. Grafana logs show this error frequently:
```
Attempted to resolve invalid ProtoId<JobPrototype>:
   at System.Environment.get_StackTrace()
   at Robust.Shared.Prototypes.PrototypeManager.Resolve[T](ProtoId`1 id, T& prototype) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Prototypes/PrototypeManager.cs:line 822
   at Content.Server.Access.Systems.IdCardConsoleSystem.TryWriteToTargetId(EntityUid uid, String newFullName, String newJobTitle, List`1 newAccessList, ProtoId`1 newJobProto, EntityUid player, IdCardConsoleComponent component) in /home/runner/work/space-station-14/space-station-14/Content.Server/Access/Systems/IdCardConsoleSystem.cs:line 149
   at Content.Server.Access.Systems.IdCardConsoleSystem.OnWriteToTargetIdMessage(EntityUid uid, IdCardConsoleComponent component, WriteToTargetIdMessage args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Access/Systems/IdCardConsoleSystem.cs:line 65
   at Robust.Shared.GameObjects.EntityEventBus.EntDispatch(EntityUid euid, Type eventType, Unit& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 572
   at Robust.Shared.GameObjects.SharedUserInterfaceSystem.OnMessageReceived(BoundUIWrapMessage msg, EntityUid sender) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs:line 146
   at Robust.Server.GameObjects.ServerEntityManager.DispatchEntityNetworkMessage(MsgEntity message) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 230
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 166
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 733
   at Robust.Shared.Timing.GameLoop.Run() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 243
   at Robust.Server.BaseServer.MainLoop() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 587
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 42
   at Robust.Server.Program.Main(String[] args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 25
Sawmill=proto
```

## Technical details
<!-- Summary of code changes for easier review. -->
The error comes from this `PrototypeManager.Resolve` call on line 149:
https://github.com/space-wizards/space-station-14/blob/d8b83ba66ccd6067b16485d22f46268956a1bd33/Content.Server/Access/Systems/IdCardConsoleSystem.cs#L149-L154
which sometimes gets an empty string for `newJobProto`, which fails to be resolved and logs an error.

Why does it sometimes get an empty string? Because of this bit of logic in the UI:
https://github.com/space-wizards/space-station-14/blob/983457cfe332f77b473c48c7db6e067753ed1733/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs#L217-L226
which explicitly sends an empty string if the value hasn't changed. This makes it so that the job icon and department only get set when a job preset it chosen from the list, instead of every time an access is changed.

While we could add a check for an empty string before the `Resolve`, using an empty string to indicate "no change" is a bit clumsy. Instead, the protoid passed in the BUI message is now nullable and uses null to indicate no change. `PrototypeManager.Resolve` returns false without logging an error if the passed protoid is null, so there is no longer an issue.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`IdCardConsoleComponent.WriteToTargetIdMessage.JobPrototype` is now nullable.