### PR TITLE
Added accuracy values for pistols, SMGs and rifles, including spread increase per shot and spread recovery time

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -75,6 +75,11 @@
   id: WeaponPistolViper
   description: A common handgun illegally modified by the Syndicate. The Viper sports a selector switch between semi-auto and ‘rock and roll’. The standard sidearm for any soldier who fights under the three serpents. Feeds from .35 pistol magazines.
   components:
+  - type: Gun
+    minAngle: 2
+    maxAngle: 25
+    angleIncrease: 2
+    angleDecay: 20
   - type: Sprite
     sprite: Objects/Weapons/Guns/Pistols/viper.rsi
   - type: ItemSlots
@@ -157,6 +162,10 @@
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
   - type: Gun
+    minAngle: 2
+    maxAngle: 8
+    angleIncrease: 1
+    angleDecay: 14
     fireRate: 4
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/silenced.ogg
@@ -207,6 +216,10 @@
   - type: Item
     storedOffset: 0,-2
   - type: Gun
+    minAngle: 2
+    maxAngle: 17
+    angleIncrease: 2
+    angleDecay: 14
     fireRate: 5
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -66,7 +66,12 @@
         map: ["enum.GunVisualLayers.Base"]
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
+  - type: GunWieldBonus
+    minAngle: -20
+    maxAngle: -16
   - type: Gun
+    angleIncrease: 1.5
+    angleDecay: 9.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
   - type: ChamberMagazineAmmoProvider
@@ -158,7 +163,12 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: Clothing
     sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
+  - type: GunWieldBonus
+    minAngle: -20
+    maxAngle: -18
   - type: Gun
+    angleIncrease: 1
+    angleDecay: 9.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg
   - type: ItemSlots
@@ -237,8 +247,8 @@
   - type: Gun
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/estocshot.ogg
-    minAngle: 30
-    maxAngle: 43
+    angleIncrease: 1
+    angleDecay: 9.5
     shotsPerBurst: 3
     selectedMode: Burst
     availableModes:
@@ -246,8 +256,8 @@
     - SemiAuto
     burstFireRate: 14
   - type: GunWieldBonus
-    minAngle: -28
-    maxAngle: -25
+    minAngle: -19
+    maxAngle: -22
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -101,10 +101,12 @@
     unwieldOnUse: false
   - type: GunWieldBonus
     minAngle: -19
-    maxAngle: -16
+    maxAngle: -12
   - type: Gun
     minAngle: 21
     maxAngle: 32
+    angleIncrease: 1.25
+    angleDecay: 20
     shotsPerBurst: 5
     availableModes:
     - Burst
@@ -183,10 +185,12 @@
       unwieldOnUse: false
     - type: GunWieldBonus
       minAngle: -19
-      maxAngle: -16
+      maxAngle: -14
     - type: Gun
       minAngle: 21
       maxAngle: 32
+      angleIncrease: 1.5
+      angleDecay: 16
       fireRate: 6
       burstFireRate: 18
       soundGunshot:
@@ -248,9 +252,9 @@
   - type: Gun
     fireRate: 5.5
     minAngle: 1
-    maxAngle: 6
+    maxAngle: 16
     angleIncrease: 1.5
-    angleDecay: 6
+    angleDecay: 12
     selectedMode: FullAuto
     shotsPerBurst: 5
     burstCooldown: 0.2


### PR DESCRIPTION
## About the PR
Commonly-available pistols, SMGs and rifles now have accuracy modifiers. 

**This affects:**

- Viper
- Cobra
- Mk 58
- C20R
- Drozd
- WT550
- AKMS
- Lecter 
- Estoc DMR

Revolvers were left out of this PR; based on the previous PR (#41630) discussions, revolvers are meant to be highly accurate, and the low ROF would ultimately make any increase/spread negligible.

**What this does:**

- Adds a base spread range
- Adds a spread increase per-shot
- Adds a spread recovery per-second

## Why / Balance
Weapons have a differing level of accuracy performance across categories, in a way that either has no downsides (i.e. projectile weapons performing with the same accuracy as a laser) or otherwise inconsistent with other projectile weapons. The overall idea of the PR is to make it so using guns in combat more deliberate, instead of it coming down to who magdumps who first.

Based on the values included with this PR, this generally fits weapons of each category into comparable accuracy, per-shot spread increases, and spread recovery times. Certain weapons have performance that breaks this convention, but these have external factors that this performance is based on.

The values included generally will allow the wielder to get to about half of their magazine before reaching full spread.

Again, **these values are NOT FINAL,** they are a combination of data-informed calculation and in-game feeling to get a good start.



## Technical details


## Media

<img width="1920" height="302" alt="image" src="https://github.com/user-attachments/assets/a33473c1-85b7-49aa-a979-b771b8dd4358" />

**Viper**


https://github.com/user-attachments/assets/d79dcc08-a8c5-4551-9101-ebd5270586cd



**Cobra**



https://github.com/user-attachments/assets/ece9fe17-4662-4197-bdaa-e30df577150a



**Mk58**



https://github.com/user-attachments/assets/107dbfbe-dd84-4592-9247-113359274722




**C20R**



https://github.com/user-attachments/assets/2aa39969-137e-471c-b792-f18b50e25c1b



**Drozd**



https://github.com/user-attachments/assets/7caed6ba-0314-42f9-a5a7-fd7faa53f07c



**WT550**


https://github.com/user-attachments/assets/81a703f4-1a1d-4c4e-bae7-7a38178db982



**AKMS**


https://github.com/user-attachments/assets/ec8f0fa7-0652-4d6c-bb02-8bff95688065


**Lecter**


https://github.com/user-attachments/assets/04b09695-b929-4267-91dc-91dcf21c0f84



**Estoc**


https://github.com/user-attachments/assets/65ccb6c6-76f6-46d3-8cc0-c2b62095710e



## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes


**Changelog**

:cl:

- tweak: Commonly-available pistols, SMGs and rifles now lose accuracy with sustained fire. Ceasing fire resets this accuracy.

