### PR TITLE
Cargo order for zombie treatment kit, make ambuzol+ require zombie blood

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -89,6 +89,16 @@
   group: market
 
 - type: cargoProduct
+  id: EmergencyZombieKit
+  icon:
+    sprite: Objects/Specific/Medical/firstaidkits.rsi
+    state: toxinkit
+  product: CrateEmergencyZombieKit
+  cost: 5000
+  category: cargoproduct-category-name-medical
+  group: market
+
+- type: cargoProduct
   id: MedicalBodybags
   icon:
     sprite: Objects/Specific/Medical/Morgue/bodybags.rsi

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -189,3 +189,14 @@
           rolls: 2
         - id: ClothingMaskSterile
           amount: 2
+
+- type: entity
+  parent: CrateMedical
+  id: CrateEmergencyZombieKit
+  name: emergency zombie kit
+  description: Crate filled with a zombie treatment kit.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage:
+        id: MedkitZombieFilled

--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -126,3 +126,18 @@
       storagebase:
         id: StimpackMini
         amount: 6
+
+- type: entity
+  id: MedkitZombieFilled
+  suffix: Filled, DO NOT MAP
+  parent: MedkitZombie
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: Brutepack
+        - id: Gauze
+        - id: Bloodpack
+        - id: PillAmbuzol
+        - id: PillCanisterDylovene

--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -139,5 +139,5 @@
         - id: Brutepack
         - id: Gauze
         - id: Bloodpack
-        - id: PillAmbuzol
+        - id: SyringeAmbuzolPartial # todo: replace with PillAmbuzol after #42774 is fixed
         - id: PillCanisterDylovene

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -797,8 +797,8 @@
         food:
           maxVol: 20
           reagents:
-            - ReagentId: Ambuzol
-              Quantity: 10
+          - ReagentId: Ambuzol
+            Quantity: 10
 
 - type: entity
   name: ambuzol plus pill

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -983,6 +983,21 @@
           - ReagentId: Ambuzol
             Quantity: 15
 
+- type: entity #todo: remove after #42774 is fixed
+  suffix: ambuzol
+  parent: PrefilledSyringe
+  id: SyringeAmbuzolPartial
+  components:
+  - type: Label
+    currentLabel: reagent-name-ambuzol
+  - type: SolutionContainerManager
+    solutions:
+      injector:
+        maxVol: 15
+        reagents:
+          - ReagentId: Ambuzol
+            Quantity: 10
+
 - type: entity
   suffix: sigynate
   parent: PrefilledSyringe

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -100,3 +100,12 @@
     heldPrefix: blackkit
     size: Normal
 
+- type: entity
+  name: zombie treatment kit
+  description: When there's no more room in hell, the dead will walk the station.
+  parent: Medkit
+  id: MedkitZombie
+  suffix: DO NOT MAP
+  components:
+  - type: Sprite
+    state: toxinkit

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -222,11 +222,13 @@
   id: AmbuzolPlus
   reactants:
     Ambuzol:
-      amount: 5
+      amount: 1
     Omnizine:
-      amount: 5
+      amount: 1
+    ZombieBlood:
+      amount: 1
   products:
-    AmbuzolPlus: 10
+    AmbuzolPlus: 3
 
 - type: reaction
   id: Synaptizine


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Adds zombie treatment kits that can ordered from cargo for 5000 spesos. Each kit contains:
- One stack of ten bruise packs
- One stack of ten gauze
- One stack of ten bloodpacks
- One dylovene pill canister with five dylovene pills (10u)
- One ambuzol syringe (10u)

Changes ambuzol plus recipe to require zombie blood in addition to ambuzol and omnizine (1u zombie blood + 1u ambuzol + 1u omnizine = 1u ambuzol plus).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Part of an effort to promote mechanics-based design over rules-based design, which would be to reduce reliance on and eventually remove Rule 2.9

As seen in https://github.com/space-wizards/space-station-14/pull/42875, electrifying chem machines is a bad approach since chemists will block off doors with them. It also does not solve the underlying issue of chem being a massive target for zombies, much in the same way how the armory is a massive target for nuclear operatives. The difference being that zombies have an unwritten rule against damaging chem machines that is enforced, which feels as though you are punishing an antagonist for playing to win.

By giving cargo the ability to order zombie treatment kits, zombie players will have to target both chemistry and cargo. Adding another source of ambuzol should allow 2.9 to be relaxed for zombies.

Each kit contains enough ambuzol to cure only one player. The dylovene pills act as a stopgap to delay zombification for other players. The cost may go up or down depending on feedback. (For comparison, the mindshield crate costs 5000 spesos but shields three players, and conversion requires both a living headrev and a flash.)

Ambuzol plus recipe now requires zombie blood so players can't take the ambuzol and turn it into ambuzol plus roundstart.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

### Zombie treatment kit order and fill
https://github.com/space-wizards/space-station-14/pull/42895/commits/9b5177c9cf034d64689976ac8f754c6959db6d6e
<img width="1270" height="756" alt="image" src="https://github.com/user-attachments/assets/13fdb794-3edf-4d57-90b8-eb77e8db4d38" />
![dotnet_VkpoTfi2ol](https://github.com/user-attachments/assets/e2601a7d-4349-49d2-b759-3a88e9b79dbb)

### Ambuzol plus recipe
https://github.com/space-wizards/space-station-14/pull/42895/commits/9b5177c9cf034d64689976ac8f754c6959db6d6e
<img width="818" height="278" alt="image" src="https://github.com/user-attachments/assets/6ea7a6b2-abe7-471c-9045-c4223df4e391" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Zombie treatment kits can now be ordered for 5000 spesos. Each kit contains 1 stack of bruise packs, 1 stack of gauze, 1 stack of blood packs, 5 (10u) dylovene pills, and 1 (10u) ambuzol syringe
- tweak: Ambuzol plus recipe now requires zombie blood (1u zombie blood + 1u ambuzol + 1u omnizine = 1u ambuzol plus).