### PR TITLE
fix: Artifact crushers gib organs if bodies are gibbed earlier inside

### DIFF
--- a/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
@@ -20,7 +20,7 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
     // TODO: Move to shared once StackSystem spawning is in Shared and we have RandomPredicted
     public override void FinishCrushing(Entity<ArtifactCrusherComponent, EntityStorageComponent> ent)
     {
-        var (_, crusher, storage) = ent;
+        var (uid, crusher, storage) = ent;
         StopCrushing((ent, ent.Comp1), false);
         AudioSystem.PlayPvs(crusher.CrushingCompleteSound, ent);
         crusher.CrushingSoundEntity = null;
@@ -39,6 +39,13 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
                     ContainerSystem.Insert((stack, null, null, null), crusher.OutputContainer);
                 }
             }
+
+            // Skip if this item is not marked as a crusher target.
+            if (!TryComp<ArtifactCrusherTargetComponent>(contained, out var crusherTargetComp) ||
+                crusherTargetComp.Crusher != uid)
+                continue;
+
+            RemCompDeferred<ArtifactCrusherTargetComponent>(contained);
 
             var gibs = _gibbing.Gib(contained);
             foreach (var gib in gibs)

--- a/Content.Shared/Xenoarchaeology/Equipment/Components/ArtifactCrusherTargetComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/Components/ArtifactCrusherTargetComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Xenoarchaeology.Equipment.Components;
+
+/// <summary>
+/// Marks an entity the target of an artifact crusher that is currently crushing it.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
+[Access(typeof(SharedArtifactCrusherSystem))]
+public sealed partial class ArtifactCrusherTargetComponent : Component
+{
+    /// <summary>
+    /// The crusher entity that is currently crushing the target.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? Crusher;
+}

--- a/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
@@ -184,8 +184,8 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
     {
         foreach (var target in targets)
         {
-            var target = EnsureComp<ArtifactCrusherTargetComponent>(target);
-            target.Crusher = uid;
+            var crusherTarget = EnsureComp<ArtifactCrusherTargetComponent>(target);
+            crusherTarget.Crusher = uid;
         }
     }
 

--- a/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
@@ -34,7 +34,7 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<ArtifactCrusherComponent, ComponentInit>(OnInit);
-        SubscribeLocalEvent<ArtifactCrusherComponent, StorageAfterOpenEvent>(OnStorageAfterOpen);
+        SubscribeLocalEvent<ArtifactCrusherComponent, StorageBeforeOpenEvent>(OnStorageBeforeOpen);
         SubscribeLocalEvent<ArtifactCrusherComponent, StorageOpenAttemptEvent>(OnStorageOpenAttempt);
         SubscribeLocalEvent<ArtifactCrusherComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<ArtifactCrusherComponent, GotEmaggedEvent>(OnEmagged);
@@ -47,7 +47,7 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
         ent.Comp.OutputContainer = ContainerSystem.EnsureContainer<Container>(ent, ent.Comp.OutputContainerName);
     }
 
-    private void OnStorageAfterOpen(Entity<ArtifactCrusherComponent> ent, ref StorageAfterOpenEvent args)
+    private void OnStorageBeforeOpen(Entity<ArtifactCrusherComponent> ent, ref StorageBeforeOpenEvent args)
     {
         StopCrushing(ent);
         ContainerSystem.EmptyContainer(ent.Comp.OutputContainer);
@@ -140,11 +140,7 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
             ent.Comp.CrushingSoundEntity = AudioSystem.Stop(ent.Comp.CrushingSoundEntity);
 
         if (TryComp<EntityStorageComponent>(ent, out var storageComp))
-        {
-            // FIXME: We do not have access to the storage in StorageAfterOpenEvent,
-            // so this is not getting called except when power is out.
             UnmarkCrusherTarget(storageComp.Contents.ContainedEntities);
-        }
 
         Dirty(ent, ent.Comp);
     }

--- a/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
@@ -110,13 +110,15 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
 
     public void StartCrushing(Entity<ArtifactCrusherComponent, EntityStorageComponent> ent, EntityUid? user = null)
     {
-        var (uid, crusher, _) = ent;
+        var (uid, crusher, storage) = ent;
 
         if (crusher.Crushing)
             return;
 
         if (crusher.AutoLock)
             _popup.PopupPredicted(Loc.GetString("artifact-crusher-autolocks-enable"), uid, user);
+
+        MarkCrusherTarget(storage.Contents.ContainedEntities, uid);
 
         crusher.Crushing = true;
         crusher.NextSecond = _timing.CurTime + TimeSpan.FromSeconds(1);
@@ -136,6 +138,13 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
 
         if (early)
             ent.Comp.CrushingSoundEntity = AudioSystem.Stop(ent.Comp.CrushingSoundEntity);
+
+        if (TryComp<EntityStorageComponent>(ent, out var storageComp))
+        {
+            // FIXME: We do not have access to the storage in StorageAfterOpenEvent,
+            // so this is not getting called except when power is out.
+            UnmarkCrusherTarget(storageComp.Contents.ContainedEntities);
+        }
 
         Dirty(ent, ent.Comp);
     }
@@ -165,6 +174,29 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
 
             if (crusher.CrushEndTime < _timing.CurTime)
                 FinishCrushing((uid, crusher, storage));
+        }
+    }
+
+    /// <summary>
+    /// Helper method to apply <see cref="ArtifactCrusherTargetComponent" /> to targets.
+    /// </summary>
+    private void MarkCrusherTarget(IEnumerable<EntityUid> targets, EntityUid uid)
+    {
+        foreach (var target in targets)
+        {
+            var target = EnsureComp<ArtifactCrusherTargetComponent>(target);
+            target.Crusher = uid;
+        }
+    }
+
+    /// <summary>
+    /// Helper method to remove <see cref="ArtifactCrusherTargetComponent" /> from targets.
+    /// </summary>
+    private void UnmarkCrusherTarget(IEnumerable<EntityUid> targets)
+    {
+        foreach (var target in targets)
+        {
+            RemCompDeferred<ArtifactCrusherTargetComponent>(target);
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixed the problem mentioned in the title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes #42858.

## Technical details
<!-- Summary of code changes for easier review. -->

`ArtifactCrusherTargetComponent` is added to explicitly mark an entity as the crusher target. Later we check for this component in `FinishCrushing`, and only gib the entities with that component.

Still WIP since we do not have the storage when `StorageAfterOpenEvent` is fired, we are unable to unmark the crusher targets in the handler.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Artifact crushers no longer make someone vanish entirely when gibbing them.