### PR TITLE
Fix bug in HideableHumanoidLayers system

### DIFF
--- a/Content.Shared/Humanoid/SharedHideableHumanoidLayersSystem.cs
+++ b/Content.Shared/Humanoid/SharedHideableHumanoidLayersSystem.cs
@@ -52,7 +52,7 @@ public abstract partial class SharedHideableHumanoidLayersSystem : EntitySystem
 
         Dirty(ent);
 
-        var evt = new HumanoidLayerVisibilityChangedEvent(layer, ent.Comp.HiddenLayers.ContainsKey(layer));
+        var evt = new HumanoidLayerVisibilityChangedEvent(layer, !ent.Comp.HiddenLayers.ContainsKey(layer));
         RaiseLocalEvent(ent, ref evt);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added one boolean negation operator.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's a bugfix

## Technical details
<!-- Summary of code changes for easier review. -->
Basically, names got confused or something and the event that says "layers are or are not hidden now" was sending the info about layers being hidden in the negated state.
ie. a `it's hidden` was assigned to an `it's visible`.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
The pumpkin mask is a downstream thing. It occludes layers just like the existing pumpkin mask (plus snouts, idk if that's upstream), but it can be equipped in the mask slot rather than the head slot. Don't question it.

<img width="1928" height="1389" alt="image" src="https://github.com/user-attachments/assets/556982a0-3d36-4a11-aa18-8664246ef221" />

Before the fix, the mask alone would hide layers, but as soon as something else was equipped in a different slot which hides the same layers, those hidden layers would be visible and remain visible even with the other thing equipped (eg. the mask in this example).

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Shouldn't really be any, unless somebody is depending on the buggy event value.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

tbh I have no idea how I'd describe this CL, so I'd like to just not include one.