### PR TITLE
Fix Holosign Placement

### DIFF
--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -1,7 +1,6 @@
 using Content.Server.Objectives.Components;
 using Content.Server.Objectives.Systems;
 using Content.Server.Popups;
-using Content.Server.Roles;
 using Content.Shared.Actions;
 using Content.Shared.Dragon;
 using Content.Shared.Maps;
@@ -13,7 +12,6 @@ using Content.Shared.Movement.Systems;
 using Content.Shared.NPC.Systems;
 using Content.Shared.Zombies;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 
 namespace Content.Server.Dragon;
@@ -167,6 +165,8 @@ public sealed partial class DragonSystem : EntitySystem
         }
 
         var carpUid = Spawn(component.RiftPrototype, _transform.GetMapCoordinates(uid, xform: xform));
+        Transform(carpUid).LocalRotation = Angle.Zero;
+
         component.Rifts.Add(carpUid);
         Comp<DragonRiftComponent>(carpUid).Dragon = uid;
     }

--- a/Content.Shared/Holosign/HolosignSystem.cs
+++ b/Content.Shared/Holosign/HolosignSystem.cs
@@ -48,7 +48,12 @@ public sealed class HolosignSystem : EntitySystem
 
         // overlapping of the same holo on one tile remains allowed to allow holofan refreshes
         if (ent.Comp.PredictedSpawn || _net.IsServer)
-            PredictedSpawnAtPosition(ent.Comp.SignProto, args.ClickLocation);
+        {
+            var spawn = PredictedSpawnAtPosition(ent.Comp.SignProto, args.ClickLocation);
+            // Sign faces same direction as player
+            // Note that clicking to place the sign also rotates the player
+            Transform(spawn).LocalRotation = Transform(args.User).LocalRotation.RoundToCardinalAngle();
+        }
 
         args.Handled = true;
     }

--- a/Content.Shared/Holosign/HolosignSystem.cs
+++ b/Content.Shared/Holosign/HolosignSystem.cs
@@ -1,7 +1,9 @@
+using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.PowerCell;
 using Content.Shared.Storage;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
 
 namespace Content.Shared.Holosign;
@@ -9,6 +11,7 @@ namespace Content.Shared.Holosign;
 public sealed class HolosignSystem : EntitySystem
 {
     [Dependency] private readonly PowerCellSystem _powerCell = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly INetManager _net = default!;
 
     public override void Initialize()
@@ -49,9 +52,16 @@ public sealed class HolosignSystem : EntitySystem
         // overlapping of the same holo on one tile remains allowed to allow holofan refreshes
         if (ent.Comp.PredictedSpawn || _net.IsServer)
         {
-            var spawn = PredictedSpawnAtPosition(ent.Comp.SignProto, args.ClickLocation);
-            // Sign always faces south relative to its grid
-            Transform(spawn).LocalRotation = Angle.Zero;
+            var coordinates = args.ClickLocation;
+
+            // Snap to grid coordinates if one exists
+            var gridUid = _transform.GetGrid(coordinates);
+            if (TryComp<MapGridComponent>(gridUid, out var grid))
+            {
+                coordinates = coordinates.SnapToGrid(grid);
+            }
+
+            PredictedSpawnAttachedTo(ent.Comp.SignProto, coordinates);
         }
 
         args.Handled = true;

--- a/Content.Shared/Holosign/HolosignSystem.cs
+++ b/Content.Shared/Holosign/HolosignSystem.cs
@@ -61,7 +61,8 @@ public sealed class HolosignSystem : EntitySystem
                 coordinates = coordinates.SnapToGrid(grid);
             }
 
-            PredictedSpawnAttachedTo(ent.Comp.SignProto, coordinates);
+            var holosign = PredictedSpawnAtPosition(ent.Comp.SignProto, coordinates);
+            Transform(holosign).LocalRotation = Angle.Zero;
         }
 
         args.Handled = true;

--- a/Content.Shared/Holosign/HolosignSystem.cs
+++ b/Content.Shared/Holosign/HolosignSystem.cs
@@ -1,9 +1,7 @@
-using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.PowerCell;
 using Content.Shared.Storage;
-using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
 
 namespace Content.Shared.Holosign;
@@ -11,7 +9,6 @@ namespace Content.Shared.Holosign;
 public sealed class HolosignSystem : EntitySystem
 {
     [Dependency] private readonly PowerCellSystem _powerCell = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly INetManager _net = default!;
 
     public override void Initialize()
@@ -52,16 +49,7 @@ public sealed class HolosignSystem : EntitySystem
         // overlapping of the same holo on one tile remains allowed to allow holofan refreshes
         if (ent.Comp.PredictedSpawn || _net.IsServer)
         {
-            var coordinates = args.ClickLocation;
-
-            // Snap to grid coordinates if one exists
-            var gridUid = _transform.GetGrid(coordinates);
-            if (TryComp<MapGridComponent>(gridUid, out var grid))
-            {
-                coordinates = coordinates.SnapToGrid(grid);
-            }
-
-            var holosign = PredictedSpawnAtPosition(ent.Comp.SignProto, coordinates);
+            var holosign = PredictedSpawnAtPosition(ent.Comp.SignProto, args.ClickLocation);
             Transform(holosign).LocalRotation = Angle.Zero;
         }
 

--- a/Content.Shared/Holosign/HolosignSystem.cs
+++ b/Content.Shared/Holosign/HolosignSystem.cs
@@ -50,9 +50,8 @@ public sealed class HolosignSystem : EntitySystem
         if (ent.Comp.PredictedSpawn || _net.IsServer)
         {
             var spawn = PredictedSpawnAtPosition(ent.Comp.SignProto, args.ClickLocation);
-            // Sign faces same direction as player
-            // Note that clicking to place the sign also rotates the player
-            Transform(spawn).LocalRotation = Transform(args.User).LocalRotation.RoundToCardinalAngle();
+            // Sign always faces south relative to its grid
+            Transform(spawn).LocalRotation = Angle.Zero;
         }
 
         args.Handled = true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Holosigns are now placed always facing south, relative to the grid they were placed on.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Due to an engine change (according to [this conversation](https://discord.com/channels/310555209753690112/770682801607278632/1467679289544671243) on Discord) entities are now spawned with map rotation instead of grid rotation, causing holosigns to spawn facing weird directions (see "Before" below). As far as I can tell this is purely a visual bug, but it still looks weird.

This PR makes the signs face south, which was the previous behaviour.

## Technical details
<!-- Summary of code changes for easier review. -->
Modifies `HolosignSystem` to set the local rotation of the spawned entity to zero, which is south, relative to the grid.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<details>
<summary>Before</summary>
<img width="691" height="671" alt="Screenshot 2026-02-13 034335" src="https://github.com/user-attachments/assets/6a4efe2b-8a16-46a2-be4f-05f4c3ab62f7" />
<img width="331" height="258" alt="Screenshot 2026-02-13 034535" src="https://github.com/user-attachments/assets/7266bc58-99b1-40b7-86ff-5c48bc76d3ed" />
</details>

<details>
<summary>After</summary>
<img width="640" height="644" alt="image" src="https://github.com/user-attachments/assets/d674b15b-1ae8-4108-942f-af60605056d5" />
<img width="300" height="207" alt="image" src="https://github.com/user-attachments/assets/ced2b433-cd74-4a45-bc71-06076a93e53c" />
</details>

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Holosign projectors and dragon rifts no longer place signs at strange angles.

