### PR TITLE
Predict ResistLockerSystem

### DIFF
--- a/Content.Server/StationEvents/Events/BluespaceLockerRule.cs
+++ b/Content.Server/StationEvents/Events/BluespaceLockerRule.cs
@@ -1,4 +1,3 @@
-using Content.Server.Resist;
 using Content.Server.StationEvents.Components;
 using Content.Server.Storage.Components;
 using Content.Server.Storage.EntitySystems;
@@ -6,6 +5,7 @@ using Content.Shared.Access.Components;
 using Content.Shared.Station.Components;
 using Content.Shared.Storage.Components;
 using Content.Shared.GameTicking.Components;
+using Content.Shared.Resist;
 
 namespace Content.Server.StationEvents.Events;
 

--- a/Content.Server/Storage/EntitySystems/BluespaceLockerSystem.cs
+++ b/Content.Server/Storage/EntitySystems/BluespaceLockerSystem.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Content.Server.Explosion.EntitySystems;
-using Content.Server.Resist;
 using Content.Server.Storage.Components;
 using Content.Shared.Access;
 using Content.Shared.Access.Components;
@@ -17,6 +16,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Prototypes;
 using Content.Server.Shuttles.Components;
+using Content.Shared.Resist;
 using Robust.Shared.Physics;
 
 namespace Content.Server.Storage.EntitySystems;

--- a/Content.Shared/Resist/ResistLockerComponent.cs
+++ b/Content.Shared/Resist/ResistLockerComponent.cs
@@ -1,8 +1,8 @@
-using System.Threading;
+using Robust.Shared.GameStates;
 
-namespace Content.Server.Resist;
+namespace Content.Shared.Resist;
 
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(ResistLockerSystem))]
 public sealed partial class ResistLockerComponent : Component
 {
@@ -15,6 +15,6 @@ public sealed partial class ResistLockerComponent : Component
     /// <summary>
     /// For quick exit if the player attempts to move while already resisting
     /// </summary>
-    [ViewVariables]
+    [ViewVariables, AutoNetworkedField]
     public bool IsResisting = false;
 }

--- a/Content.Shared/Resist/ResistLockerDoAfterEvent.cs
+++ b/Content.Shared/Resist/ResistLockerDoAfterEvent.cs
@@ -4,6 +4,4 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Resist;
 
 [Serializable, NetSerializable]
-public sealed partial class ResistLockerDoAfterEvent : SimpleDoAfterEvent
-{
-}
+public sealed partial class ResistLockerDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/Resist/ResistLockerSystem.cs
+++ b/Content.Shared/Resist/ResistLockerSystem.cs
@@ -54,6 +54,7 @@ public sealed class ResistLockerSystem : EntitySystem
             BreakOnMove = true,
             BreakOnDamage = true,
             NeedHand = false, //No hands 'cause we be kickin'
+            MovementThreshold = 0.1f,
         };
 
         // Make sure the do after is able to start
@@ -61,7 +62,11 @@ public sealed class ResistLockerSystem : EntitySystem
             return;
 
         resistLockerComponent.IsResisting = true;
-        _popupSystem.PopupEntity(Loc.GetString("resist-locker-component-start-resisting"), user, user, PopupType.Large);
+
+        var kickerPopupText = Loc.GetString("resist-locker-component-start-resisting", ("user", user));
+        var targetPopupText = Loc.GetString("resist-locker-component-start-resisting-other", ("target", target));
+
+        _popupSystem.PopupPredicted(kickerPopupText, targetPopupText, user, user, PopupType.Large);
     }
 
     private void OnDoAfter(Entity<ResistLockerComponent> ent, ref ResistLockerDoAfterEvent args)

--- a/Content.Shared/Resist/ResistLockerSystem.cs
+++ b/Content.Shared/Resist/ResistLockerSystem.cs
@@ -71,6 +71,8 @@ public sealed class ResistLockerSystem : EntitySystem
 
     private void OnDoAfter(Entity<ResistLockerComponent> ent, ref ResistLockerDoAfterEvent args)
     {
+        Dirty(ent);
+
         if (args.Cancelled)
         {
             ent.Comp.IsResisting = false;

--- a/Content.Shared/Resist/ResistLockerSystem.cs
+++ b/Content.Shared/Resist/ResistLockerSystem.cs
@@ -1,22 +1,20 @@
-using Content.Server.Popups;
-using Content.Server.Storage.EntitySystems;
 using Content.Shared.DoAfter;
 using Content.Shared.Lock;
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
-using Content.Shared.Resist;
 using Content.Shared.Storage.Components;
 using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared.ActionBlocker;
+using Content.Shared.Storage.EntitySystems;
 
-namespace Content.Server.Resist;
+namespace Content.Shared.Resist;
 
 public sealed class ResistLockerSystem : EntitySystem
 {
-    [Dependency] private readonly EntityStorageSystem _entityStorage = default!;
+    [Dependency] private readonly SharedEntityStorageSystem _entityStorage = default!;
     [Dependency] private readonly LockSystem _lockSystem = default!;
-    [Dependency] private readonly PopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly WeldableSystem _weldable = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
@@ -28,20 +26,21 @@ public sealed class ResistLockerSystem : EntitySystem
         SubscribeLocalEvent<ResistLockerComponent, ResistLockerDoAfterEvent>(OnDoAfter);
     }
 
-    private void OnRelayMovement(EntityUid uid, ResistLockerComponent component, ref ContainerRelayMovementEntityEvent args)
+    private void OnRelayMovement(Entity<ResistLockerComponent> ent, ref ContainerRelayMovementEntityEvent args)
     {
-        if (component.IsResisting)
+        if (ent.Comp.IsResisting)
             return;
 
-        if (!TryComp(uid, out EntityStorageComponent? storageComponent))
+        if (!TryComp(ent, out EntityStorageComponent? storageComponent))
             return;
 
         if (!_actionBlocker.CanMove(args.Entity))
             return;
 
-        if (TryComp<LockComponent>(uid, out var lockComponent) && lockComponent.Locked || _weldable.IsWelded(uid))
+        if (TryComp<LockComponent>(ent, out var lockComponent) && lockComponent.Locked || _weldable.IsWelded(ent))
         {
-            AttemptResist(args.Entity, uid, storageComponent, component);
+            AttemptResist(args.Entity, ent, storageComponent, ent.Comp);
+            Dirty(ent);
         }
     }
 
@@ -65,30 +64,30 @@ public sealed class ResistLockerSystem : EntitySystem
         _popupSystem.PopupEntity(Loc.GetString("resist-locker-component-start-resisting"), user, user, PopupType.Large);
     }
 
-    private void OnDoAfter(EntityUid uid, ResistLockerComponent component, DoAfterEvent args)
+    private void OnDoAfter(Entity<ResistLockerComponent> ent, ref ResistLockerDoAfterEvent args)
     {
         if (args.Cancelled)
         {
-            component.IsResisting = false;
-            _popupSystem.PopupEntity(Loc.GetString("resist-locker-component-resist-interrupted"), args.Args.User, args.Args.User, PopupType.Medium);
+            ent.Comp.IsResisting = false;
+            _popupSystem.PopupClient(Loc.GetString("resist-locker-component-resist-interrupted"), args.Args.User, args.Args.User, PopupType.Medium);
             return;
         }
 
         if (args.Handled || args.Args.Target == null)
             return;
 
-        component.IsResisting = false;
+        ent.Comp.IsResisting = false;
 
-        if (HasComp<EntityStorageComponent>(uid))
+        if (HasComp<EntityStorageComponent>(ent))
         {
             WeldableComponent? weldable = null;
-            if (_weldable.IsWelded(uid, weldable))
-                _weldable.SetWeldedState(uid, false, weldable);
+            if (_weldable.IsWelded(ent, weldable))
+                _weldable.SetWeldedState(ent, false, weldable);
 
             if (TryComp<LockComponent>(args.Args.Target.Value, out var lockComponent))
-                _lockSystem.Unlock(uid, args.Args.User, lockComponent);
+                _lockSystem.Unlock(ent, args.Args.User, lockComponent);
 
-            _entityStorage.TryOpenStorage(args.Args.User, uid);
+            _entityStorage.TryOpenStorage(args.Args.User, ent);
         }
 
         args.Handled = true;

--- a/Resources/Locale/en-US/resist/components/resist-locker-component.ftl
+++ b/Resources/Locale/en-US/resist/components/resist-locker-component.ftl
@@ -1,3 +1,3 @@
 resist-locker-component-start-resisting = You begin to kick at the door!
-resist-locker-component-start-resisting-other = Someones kicking down this door!
+resist-locker-component-start-resisting-other = Something's kicking down this door!
 resist-locker-component-resist-interrupted = Your attempts to kick at the door were interrupted!

--- a/Resources/Locale/en-US/resist/components/resist-locker-component.ftl
+++ b/Resources/Locale/en-US/resist/components/resist-locker-component.ftl
@@ -1,2 +1,3 @@
 resist-locker-component-start-resisting = You begin to kick at the door!
+resist-locker-component-start-resisting-other = Someones kicking down this door!
 resist-locker-component-resist-interrupted = Your attempts to kick at the door were interrupted!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title & a Popup whenever a Locker is being resisted against. To be fair, I thought it was already like this.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
For #40655, better to get this out of the way. And an indication of an action should be displayed. For now it's a popup but maybe a shaking animation with an accompanying sound might be good in the future.

If the above are done, the duration of the action should be shortened. But that's my bias showing.

## Technical details
<!-- Summary of code changes for easier review. -->
Moving, Dirtying, and a Movement Threshold for whenever the container opens and the occupant/occupants get out. Any movement should cancel the DoAfter, would be better if it canceled when the container opens but my implementations of it didn't work. So this'll do.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


![Showcase](https://github.com/user-attachments/assets/f04b0f3e-abce-4bfc-a18e-19902d72d28a)




## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: A locked/welded container will show a popup when something's trying to get out of it.
