### PR TITLE
Simplify modular grenade and land mine recipes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/land_mine.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/land_mine.yml
@@ -87,7 +87,7 @@
   - type: PayloadCase
   - type: Construction
     graph: ModularMineGraph
-    node: emptyCase
+    node: wiredCase
 
 - type: entity
   id: LandMineModular

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -335,7 +335,7 @@
   - type: PayloadCase
   - type: Construction
     graph: ModularGrenadeGraph
-    node: emptyCase
+    node: wiredCase
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/Recipes/Construction/Graphs/weapons/modular_grenade.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/weapons/modular_grenade.yml
@@ -24,6 +24,13 @@
       steps:
       - tool: Welding
         doAfter: 2
+        completed:
+        - !type:SpawnPrototype
+          prototype: SheetSteel1
+          amount: 5
+        - !type:SpawnPrototype
+          prototype: CableApcStack1
+        - !type:DeleteEntity
     - to: caseWithTrigger
       steps:
       - component: PayloadTrigger

--- a/Resources/Prototypes/Recipes/Construction/Graphs/weapons/modular_grenade.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/weapons/modular_grenade.yml
@@ -5,30 +5,13 @@
 
   - node: start
     edges:
-    - to: emptyCase
+    - to: wiredCase
       steps:
       - material: Steel
         amount: 5
         doAfter: 1
-
-  - node: emptyCase
-    entity: ModularGrenade
-    actions:
-    - !type:AppearanceChange
-    edges:
-    - to: wiredCase
-      steps:
       - material: Cable
         doAfter: 0.5
-    - to: start
-      completed:
-      - !type:SpawnPrototype
-        prototype: SheetSteel1
-        amount: 5
-      - !type:DeleteEntity
-      steps:
-      - tool: Welding
-        doAfter: 2
 
   - node: wiredCase
     entity: ModularGrenade
@@ -37,13 +20,10 @@
     - !type:PlaySound
       sound: /Audio/Machines/button.ogg
     edges:
-    - to: emptyCase
+    - to: start
       steps:
-      - tool: Cutting
-        doAfter: 0.5
-        completed:
-        - !type:SpawnPrototype
-          prototype: CableApcStack1
+      - tool: Welding
+        doAfter: 2
     - to: caseWithTrigger
       steps:
       - component: PayloadTrigger

--- a/Resources/Prototypes/Recipes/Construction/Graphs/weapons/modular_mine.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/weapons/modular_mine.yml
@@ -5,17 +5,11 @@
 
   - node: start
     edges:
-    - to: emptyCase
+    - to: wiredCase
       steps:
       - material: Steel
         amount: 5
         doAfter: 1
-
-  - node: emptyCase
-    entity: LandMineModularUnarmed
-    edges:
-    - to: wiredCase
-      steps:
       - material: Cable
         doAfter: 0.5
       - tag: ProximitySensor
@@ -23,15 +17,6 @@
           sprite: Objects/Misc/proximity_sensor.rsi
           state: icon
         name: construction-graph-tag-proximity-sensor
-    - to: start
-      completed:
-      - !type:SpawnPrototype
-        prototype: SheetSteel1
-        amount: 5
-      - !type:DeleteEntity
-      steps:
-      - tool: Welding
-        doAfter: 2
 
   - node: wiredCase
     entity: LandMineModularUnarmed
@@ -39,15 +24,19 @@
     - !type:PlaySound
       sound: /Audio/Machines/button.ogg
     edges:
-    - to: emptyCase
+    - to: start
       steps:
-      - tool: Cutting
-        doAfter: 0.5
+      - tool: Welding
+        doAfter: 2
         completed:
+        - !type:SpawnPrototype
+          prototype: SheetSteel1
+          amount: 5
         - !type:SpawnPrototype
           prototype: CableApcStack1
         - !type:SpawnPrototype
           prototype: ProximitySensor
+        - !type:DeleteEntity
     - to: mine
       steps:
       - tag: Payload


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Removed 'emptyCase' step from modular grenade and land mine crafting. You now directly craft the wired case for both the modular grenade and land mine.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Crafting is already complicated for new players and there's no reason why there should be separate steps when you have the materials.

You already need to secure a trigger and payload to finish crafting anyway, so don't expect grenades and land mines to be spammed.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/space-wizards/space-station-14/commit/9a8a87b69b709d7d066c45438785180f26dec918
### Modular grenade construction
![dotnet_5pLgoakkqK](https://github.com/user-attachments/assets/2874a081-d8c2-4d1f-924a-bc3455ec3ec3)

### Modular grenade deconstruction
![dotnet_iyORRrEv2b](https://github.com/user-attachments/assets/bffbcad2-a57b-4224-81b3-cea35945e5a0)

### Modular land mine construction 
![dotnet_6KV6ZqofpJ](https://github.com/user-attachments/assets/a3a73aa1-8b68-45b8-a5a4-00c7b4cf7a2c)

### Modular land mine deconstruction
![dotnet_DhGe0kJH1J](https://github.com/user-attachments/assets/9f3c37b0-e6ef-418f-9fa2-cfd6eb06e323)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Removed a step in crafting modular grenade and land mine recipes. You now directly craft the wired shell if you already have the steel and cables.