### PR TITLE
Changed Atmos fire suit to engineering contraband (like the helmet)

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -78,7 +78,7 @@
     - Tail
 
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseEngineeringContraband]
   id: ClothingOuterSuitAtmosFire
   name: atmos fire suit
   description: An expensive firesuit that protects against even the most deadly of station fires. Designed to protect even if the wearer is set aflame.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added  BaseEngineeringContraband to Atmos fire suit

## Why / Balance
The Atmos fire suit is a pretty good suit (space faring, high fire resistance, fits in bag) and it doesn't make sense that it isn't engineering contraband even though the Atmos fire helmet is.

## Technical details
Added BaseEngineeringContraband to Atmos fire suit parent

## Media
Before
<img width="535" height="276" alt="image" src="https://github.com/user-attachments/assets/2f18f587-b85d-4a41-813c-e1aad07557f8" />
After
<img width="699" height="437" alt="Screenshot 2026-02-14 110617" src="https://github.com/user-attachments/assets/3b11daee-bac0-4e91-9862-cb98c3c389ec" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: 
- tweak: Made Atmos fire suit engineering contraband