### PR TITLE
Change basic viper magazine to high capacity in operative bundle 

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -78,7 +78,7 @@
     - Tail
 
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing,]
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
   id: ClothingOuterSuitAtmosFire
   name: atmos fire suit
   description: An expensive firesuit that protects against even the most deadly of station fires. Designed to protect even if the wearer is set aflame.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the basic pistol magazine in the basic operative bundle to the high capacity magazine introduced in #42392 

## Why / Balance
It doesn't make sense that you would receive less ammo for buying a bundle compared to buying everything separate, plus all vipers start with the high capacity magazine and I believe the bundle was never changed to fit with the new vipers.

## Technical details
Changed "MagazinePistol" to "MagazinePistolHighCapacity" in the basic operative bundle

## Media
Before
<img width="349" height="322" alt="image" src="https://github.com/user-attachments/assets/eec9d4fa-d1da-46e6-8192-dc77b0db36da" />
After
<img width="415" height="350" alt="Screenshot 2026-02-15 013145" src="https://github.com/user-attachments/assets/a8946c6b-53c2-40c1-9640-cf2e490ad7e7" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Changed viper magazine to high capacity in the basic operative bundle 
