### PR TITLE
update basic operative bundle contents

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -450,14 +450,13 @@
         - id: WeaponSubMachineGunC20r
         - id: MagazinePistolSubMachineGun
           amount: 3
-        - id: MagazinePistolHighCapacity
+        - id: EnergySword
         - id: SyndicateJawsOfLife
         - id: C4
           amount: 2
         - id: MedkitCombatFilled
         - id: EmpImplanter
         - id: ClothingShoesBootsMagSyndie
-        - id: AgentIDCard
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
removed agent ID and viper magazine from basic operative bundle
added esword

bundle contents are now:
- C-20r
- 3 mags
- esword
- jaws of death
- 2 C4
- combat medkit
- EMP implanter
- blood-red magboots

## Why / Balance
a lot of the items in the bundle have had their price buffed since i made it, and the agent ID isn't necessary anymore because nukie IDs can copy accesses innately.
these changes combined means there was 7 wasted TC in the bundle
viper magazine isn't super useful and was mostly there as a 1 TC cost sink, so i axed it in favour of the esword, which is very useful as a backup weapon and for destroying things

## Technical details
<!-- Summary of code changes for easier review. -->
three lines of yaml

## Media
before:
<img width="347" height="196" alt="image" src="https://github.com/user-attachments/assets/25655ad0-ab12-40da-b39f-3ac978e317bb" />
after:
<img width="349" height="185" alt="image" src="https://github.com/user-attachments/assets/4856a432-161d-4671-94cb-66e01b2c3013" />


<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The basic operative bundle now contains an esword, instead of a viper magazine and agent ID card.