### PR TITLE
Change(fix?) hyper convection autolathe build cost

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -450,7 +450,7 @@
         - id: WeaponSubMachineGunC20r
         - id: MagazinePistolSubMachineGun
           amount: 3
-        - id: MagazinePistolHighCapacity
+        - id: MagazinePistol
         - id: SyndicateJawsOfLife
         - id: C4
           amount: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the AutolatheHyperConvection Manipulator count to match the Autolathe

## Why / Balance
All other hyper versions of the lathes require the same amount of materials (plus the igniter). Doesn't make sense that the hyper auto lathe cost one less. Also it always bugs me when building them as a scientist and end up with one extra manipulator.

## Technical details
Changed manipulator count in AutolatheHyperConvection to 4 from 3 to match the Autolathe count

## Media
Before
<img width="316" height="195" alt="image" src="https://github.com/user-attachments/assets/429179df-4006-494b-87c0-68f7ecc40b6f" />
<img width="303" height="176" alt="image" src="https://github.com/user-attachments/assets/7524116c-57ff-4c40-a208-2845b98cc535" />
After
<img width="330" height="197" alt="Screenshot 2026-02-15 234305" src="https://github.com/user-attachments/assets/1971342d-7efd-4a1b-aaf0-54e036f268c6" />
<img width="331" height="214" alt="image" src="https://github.com/user-attachments/assets/69d170b1-0c4c-4fe2-8920-4d2ffebf833f" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:

- tweak: Changed hyper convection autolathe cost 
