### PR TITLE
Fix Thieving Beacon not detecting HUDs for said objective

### DIFF
--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -176,7 +176,6 @@
     minCollectionSize: 7
     maxCollectionSize: 12
     verifyMapExistence: false
-    checkStealAreas: false
   - type: Objective
     difficulty: 0.3
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Thieving Beacon wasn't detecting HUDs when placed next to the thieving beacon, forcing a thief to carry up to 12 for it to count. this fixes it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is the only objective which has this turned off. Discussed it with @archee1 the original objective maker and they confirmed it wasn't intended

## Technical details
<!-- Summary of code changes for easier review. -->
Literally just a single boolean change

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before
<img width="592" height="411" alt="Screenshot_2" src="https://github.com/user-attachments/assets/1ff04272-b632-48ff-9f7b-d29b13baec5c" />
After
<img width="578" height="307" alt="Screenshot_1" src="https://github.com/user-attachments/assets/62fc7106-e601-44fd-ae3f-5c59ddf891ff" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Thieves' "Steal the HUDs" objective can now be completed with the thieving beacon

