### PR TITLE
Remove Security Access from Detective

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -12,7 +12,6 @@
   supervisors: job-supervisors-hos
   canBeAntag: false
   access:
-  - Security
   - Brig
   - Maintenance
   - Detective


### PR DESCRIPTION
det do they job PR

## About the PR
This PR removes Security access from Detective, while otherwise keeping the role identical. 

## Why / Balance
Detective has an issue where, to be frank, they don't actually do their job. They will simply go get secoff gear roundstart and act like a secoff all round and ignore all detective aspects of their job. So, let's put a barrier in place to stop that and see what happens.

This does *not* change them having a mindshield or access to the security entryway. They still have brig access, still have their gun. They just can't donut cop so, realistically, they should instead seek out crime scenes to have things to do much more often.

## Technical details
Yaml warrior.

## Media
<img width="847" height="606" alt="image" src="https://github.com/user-attachments/assets/085f3f73-7a17-47c2-ac1d-75ee92074746" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
**Changelog**
:cl:
- tweak: Removed Security access from Detective to encourage them to focus on forensic work. 
