### PR TITLE
fixed barber scissors misgendering when blocked by a hat

### DIFF
--- a/Content.Shared/MagicMirror/MagicMirrorSystem.cs
+++ b/Content.Shared/MagicMirror/MagicMirrorSystem.cs
@@ -59,7 +59,7 @@ public sealed class MagicMirrorSystem : EntitySystem
             _popup.PopupEntity(
                 ent.Comp.Target == args.Actor
                     ? Loc.GetString("magic-mirror-blocked-by-hat-self")
-                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target", ("target", Identity.Entity(args.Actor, EntityManager))),
+                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target", ("target", Identity.Entity(target, EntityManager))),
                 args.Actor,
                 args.Actor,
                 PopupType.Medium);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made barber scissors use the pronouns of the target, not the user, when saying it was blocked by a hat.

## Why / Balance
Misgendering is bad.

## Technical details
Change args.Actor to target in MagicMirrorSystem.

## Media
<img width="400" height="188" alt="Screenshot From 2026-02-16 16-09-25" src="https://github.com/user-attachments/assets/2d874a10-288d-46e4-8a09-b04e07d6ab20" />
<img width="381" height="75" alt="Screenshot From 2026-02-16 16-09-38" src="https://github.com/user-attachments/assets/26d65126-457c-41fe-9b37-38fe10c31f82" />
<img width="288" height="126" alt="Screenshot From 2026-02-16 16-09-45" src="https://github.com/user-attachments/assets/73ac420c-75c8-46f2-b4b1-39d9fbc6dba5" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Barber Scissors no longer misgender the target when blocked by a hat.

