### PR TITLE
Fix HealthExaminableSystem spamming locale string errors.

### DIFF
--- a/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
+++ b/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
@@ -45,6 +45,7 @@ public sealed class HealthExaminableSystem : EntitySystem
     public FormattedMessage CreateMarkup(EntityUid uid, HealthExaminableComponent component, DamageableComponent damage)
     {
         var msg = new FormattedMessage();
+        var target = Identity.Entity(uid, EntityManager);
 
         var first = true;
         foreach (var type in component.ExaminableTypes)
@@ -63,7 +64,7 @@ public sealed class HealthExaminableSystem : EntitySystem
                 Loc.TryGetString(
                     $"health-examinable-{component.LocPrefix}-{type}-{threshold}",
                     out var tempLocStr,
-                    ("target", Identity.Entity(uid, EntityManager)));
+                    ("target", target));
 
                 // i.e., this string doesn't exist, because theres nothing for that threshold
                 if (tempLocStr == null || dmg <= threshold || threshold <= closest)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes an issue where HealthExaminableSystem would spam locale message id errors to the console. Maybe not the right approach for this?

Fixes #42951 

## Technical details
<!-- Summary of code changes for easier review. -->
Replace use of Loc.GetString with Loc.TryGetString which works out better here anyway since it was previously comparing the return result with another variable anyway to check for success.


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->