### PR TITLE
Buildable and destructible button frames

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
@@ -438,73 +438,96 @@
 # button frames
 
 - type: entity
-  id: ButtonFrame
-  name: button frame
-  categories: [ HideSpawnMenu ]
-  description: It's a frame to help distinguish switches visually.
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wallmount
+  parent: BaseWallmountMetallic
+  id: BaseButtonFrame
+  abstract: true
   components:
-  - type: Clickable
   - type: WallMount
     arc: 360
-  - type: Physics
-    canCollide: false
   - type: Sprite
     drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch_frame.rsi
-    state: grey
-  - type: Rotatable
-  - type: Fixtures
+  - type: Destructible # Like for buttons, but 50%
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 40
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+      - trigger:
+          !type:DamageTrigger
+          damage: 20
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+          - !type:PlaySoundBehavior
+            sound:
+              collection: MetalBreak
+              params:
+                volume: -8
 
 - type: entity
+  parent: BaseButtonFrame
   id: ButtonFrameGrey
-  parent: ButtonFrame
+  name: grey button frame
+  description: It's a frame to help distinguish switches visually. Grey means... Something boring.
   suffix: grey
   components:
   - type: Sprite
-    drawdepth: SmallObjects
-    sprite: Structures/Wallmounts/switch_frame.rsi
     state: grey
+  - type: Construction
+    graph: ButtonFrameGreyGraph
+    node: ButtonFrameGreyNode
 
 - type: entity
+  parent: BaseButtonFrame
   id: ButtonFrameCaution
-  parent: ButtonFrame
+  name: yellow button frame
+  description: It's a frame to help distinguish switches visually. Yellow means something dangerous, be careful!
   suffix: caution
   components:
   - type: Sprite
-    drawdepth: SmallObjects
-    sprite: Structures/Wallmounts/switch_frame.rsi
     state: caution
+  - type: Construction
+    graph: ButtonFrameCautionGraph
+    node: ButtonFrameCautionNode
 
 - type: entity
+  parent: BaseButtonFrame
   id: ButtonFrameCautionSecurity
-  parent: ButtonFrame
+  name: red button frame
+  description: It's a frame to help distinguish switches visually. Red means something really dangerous, be very careful!
   suffix: caution
   components:
   - type: Sprite
-    drawdepth: SmallObjects
-    sprite: Structures/Wallmounts/switch_frame.rsi
     state: caution_security
+  - type: Construction
+    graph: ButtonFrameCautionSecurityGraph
+    node: ButtonFrameCautionSecurityNode
 
 - type: entity
+  parent: BaseButtonFrame
   id: ButtonFrameExit
-  parent: ButtonFrame
+  name: exit button frame
+  description: It's a frame to help distinguish switches visually. Exit means exit.
   suffix: exit
   components:
   - type: Sprite
-    drawdepth: SmallObjects
-    sprite: Structures/Wallmounts/switch_frame.rsi
     state: exit
+  - type: Construction
+    graph: ButtonFrameExitGraph
+    node: ButtonFrameExitNode
 
 - type: entity
+  parent: BaseButtonFrame
   id: ButtonFrameJanitor
-  parent: ButtonFrame
+  name: janitor button frame
+  description: It's a frame to help distinguish switches visually. Purple means something janitorial.
   suffix: janitor
   components:
   - type: Sprite
-    drawdepth: SmallObjects
-    sprite: Structures/Wallmounts/switch_frame.rsi
     state: janitor
+  - type: Construction
+    graph: ButtonFrameJanitorGraph
+    node: ButtonFrameJanitorNode

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
@@ -466,6 +466,8 @@
               collection: MetalBreak
               params:
                 volume: -8
+  - type: Construction
+    graph: ButtonFrameGraph
 
 - type: entity
   parent: BaseButtonFrame
@@ -477,7 +479,6 @@
   - type: Sprite
     state: grey
   - type: Construction
-    graph: ButtonFrameGreyGraph
     node: ButtonFrameGreyNode
 
 - type: entity
@@ -490,7 +491,6 @@
   - type: Sprite
     state: caution
   - type: Construction
-    graph: ButtonFrameCautionGraph
     node: ButtonFrameCautionNode
 
 - type: entity
@@ -503,7 +503,6 @@
   - type: Sprite
     state: caution_security
   - type: Construction
-    graph: ButtonFrameCautionSecurityGraph
     node: ButtonFrameCautionSecurityNode
 
 - type: entity
@@ -516,7 +515,6 @@
   - type: Sprite
     state: exit
   - type: Construction
-    graph: ButtonFrameExitGraph
     node: ButtonFrameExitNode
 
 - type: entity
@@ -529,5 +527,4 @@
   - type: Sprite
     state: janitor
   - type: Construction
-    graph: ButtonFrameJanitorGraph
     node: ButtonFrameJanitorNode

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/switching.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/switching.yml
@@ -204,3 +204,95 @@
               prototype: CableApcStack1
               amount: 1
             - !type:DeleteEntity {}
+
+- type: constructionGraph
+  id: ButtonFrameGraph
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: ButtonFrameGreyNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+        - to: ButtonFrameCautionNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+        - to: ButtonFrameCautionSecurityNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+        - to: ButtonFrameExitNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+        - to: ButtonFrameJanitorNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+    - node: ButtonFrameGreyNode
+      entity: ButtonFrameGrey
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+    - node: ButtonFrameCautionSecurityNode
+      entity: ButtonFrameCautionSecurity
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+    - node: ButtonFrameCautionNode
+      entity: ButtonFrameCaution
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+    - node: ButtonFrameExitNode
+      entity: ButtonFrameExit
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+    - node: ButtonFrameJanitorNode
+      entity: ButtonFrameJanitor
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -1354,3 +1354,58 @@
   canBuildInImpassable: false
   conditions:
   - !type:TileNotBlocked
+
+- type: construction
+  id: ButtonFrameGrey
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameGreyNode
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  canRotate: true
+
+- type: construction
+  id: CautionButtonFrame
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameCautionNode
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  canRotate: true
+
+- type: construction
+  id: CautionSecurityButtonFrame
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameCautionSecurityNode
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  canRotate: true
+
+- type: construction
+  id: ExitButtonFrame
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameExitNode
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  canRotate: true
+
+- type: construction
+  id: JanitorButtonFrame
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameJanitorNode
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  canRotate: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Remake of #33195 
As in original, making button frames buildable by craft menu and destructible with some tech fixes of button frame protos.

Ah, and, with merging it will really close #33857.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Engis will like this :godo:

## Technical details
<!-- Summary of code changes for easier review. -->
* Button frame prototypes changes with adding parrent `BaseWallmountMetallic`, making `BaseButtonFrame` from `ButtonFrame` with removing unnecessary components and changing `Sprite` component to make it take less lines.
* Own description and names for all button frames
* New building nodes and graphs for all button frames
* `Destructible` component from signal buttons, but with less damage trigger (40 for buttons and 20 for frames).
 
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/8645f3d9-8277-4646-a241-6252bae74ed9

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`ButtonFrame` prototype changed to `BasicButtonFrame`

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Button frames can be constructed, deconstructed, and destroyed.