### PR TITLE
Fixed redundant bar sign windows

### DIFF
--- a/Content.Client/BarSign/Ui/BarSignBoundUserInterface.cs
+++ b/Content.Client/BarSign/Ui/BarSignBoundUserInterface.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Shared.BarSign;
 using JetBrains.Annotations;
+using Robust.Client.UserInterface;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client.BarSign.Ui;
@@ -16,13 +17,12 @@ public sealed class BarSignBoundUserInterface(EntityUid owner, Enum uiKey) : Bou
     {
         base.Open();
 
-        var sign = EntMan.GetComponentOrNull<BarSignComponent>(Owner)?.Current is { } current
-            ? _prototype.Index(current)
-            : null;
         var allSigns = BarSignSystem.GetAllBarSigns(_prototype)
             .OrderBy(p => Loc.GetString(p.Name))
             .ToList();
-        _menu = new(sign, allSigns);
+
+        _menu = this.CreateWindow<BarSignMenu>();
+        _menu.LoadSigns(allSigns);
 
         _menu.OnSignSelected += id =>
         {
@@ -30,16 +30,17 @@ public sealed class BarSignBoundUserInterface(EntityUid owner, Enum uiKey) : Bou
         };
 
         _menu.OnClose += Close;
-        _menu.OpenCentered();
+        _menu.OpenToLeft();
     }
 
     public override void Update()
     {
-        if (!EntMan.TryGetComponent<BarSignComponent>(Owner, out var signComp))
+        if (!EntMan.TryGetComponent<BarSignComponent>(Owner, out var signComp)
+            || !_prototype.Resolve(signComp.Current, out var signPrototype))
             return;
 
-        if (_prototype.Resolve(signComp.Current, out var signPrototype))
-            _menu?.UpdateState(signPrototype);
+        _menu?.UpdateState(signPrototype);
     }
+
 }
 

--- a/Content.Client/BarSign/Ui/BarSignMenu.xaml.cs
+++ b/Content.Client/BarSign/Ui/BarSignMenu.xaml.cs
@@ -8,23 +8,13 @@ namespace Content.Client.BarSign.Ui;
 [GenerateTypedNameReferences]
 public sealed partial class BarSignMenu : FancyWindow
 {
-    private string? _currentId;
-
-    private readonly List<BarSignPrototype> _cachedPrototypes = new();
+    private List<BarSignPrototype> _cachedPrototypes = new();
 
     public event Action<string>? OnSignSelected;
 
-    public BarSignMenu(BarSignPrototype? currentSign, List<BarSignPrototype> signs)
+    public BarSignMenu()
     {
         RobustXamlLoader.Load(this);
-        _currentId = currentSign?.ID;
-
-        _cachedPrototypes.Clear();
-        _cachedPrototypes = signs;
-        foreach (var proto in _cachedPrototypes)
-        {
-            SignOptions.AddItem(Loc.GetString(proto.Name));
-        }
 
         SignOptions.OnItemSelected += idx =>
         {
@@ -32,18 +22,21 @@ public sealed partial class BarSignMenu : FancyWindow
             SignOptions.SelectId(idx.Id);
         };
 
-        if (currentSign != null)
+    }
+
+    public void LoadSigns(List<BarSignPrototype> signs)
+    {
+        _cachedPrototypes.Clear();
+        _cachedPrototypes = signs;
+
+        foreach (var proto in _cachedPrototypes)
         {
-            var idx = _cachedPrototypes.IndexOf(currentSign);
-            SignOptions.TrySelectId(idx);
+            SignOptions.AddItem(Loc.GetString(proto.Name));
         }
     }
 
     public void UpdateState(BarSignPrototype newSign)
     {
-        if (_currentId != null && newSign.ID == _currentId)
-            return;
-        _currentId = newSign.ID;
         var idx = _cachedPrototypes.IndexOf(newSign);
         SignOptions.TrySelectId(idx);
     }

--- a/Content.Shared/BarSign/BarSignSystem.cs
+++ b/Content.Shared/BarSign/BarSignSystem.cs
@@ -31,10 +31,12 @@ public sealed class BarSignSystem : EntitySystem
 
     private void OnMapInit(Entity<BarSignComponent> ent, ref MapInitEvent args)
     {
-        if (ent.Comp.Current != null)
+        BarSignPrototype? newPrototype;
+        if (ent.Comp.Current is null)
+            newPrototype = _random.Pick(GetAllBarSigns(_prototypeManager));
+        else if (!_prototypeManager.Resolve(ent.Comp.Current, out newPrototype))
             return;
 
-        var newPrototype = _random.Pick(GetAllBarSigns(_prototypeManager));
         SetBarSign(ent, newPrototype);
     }
 
@@ -77,9 +79,6 @@ public sealed class BarSignSystem : EntitySystem
     /// </summary>
     public void SetBarSign(Entity<BarSignComponent> ent, BarSignPrototype newPrototype)
     {
-        if (ent.Comp.Current == newPrototype.ID)
-            return;
-
         if (HasComp<EmpDisabledComponent>(ent))
             return;
 


### PR DESCRIPTION
## About the PR
* Fixes the extra bar sign popups bug introduced in #42364 by making BarSignBUI use CreateWindow
* Fixes bar signs placed from Entity Spawn Window

## Why / Balance
This fixes two issues with Bar Signs that I found while testing unrelated code for emping bar signs
* The BarSignBoundUserInterface was popping up lots of windows when you tried to close it:
<img width="1920" height="991" alt="image" src="https://github.com/user-attachments/assets/51fdcc26-f14f-4a51-a050-5fdb532f75aa" />

* When spawning a bar sign from the admin (F5) menu, the empty bar sign sprite would be shown instead


## Technical details
BarSignBoundUserInterface was refactored in #42364 but some parts were missed (e.g. Dispose() was removed but it wasn't calling CreateWindow<T>(), so not all elements were disposed properly.

Also, the change BarSignVisualizerSystem in #42364 stopped updating the appearance of signs placed from the entity spawn window, leading them to spawn in broken.

## Media
small fix / see #42950 for an example normal working bar sign
 
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
:cl:
- fix: Fixed bar sign UI not closing correctly