### PR TITLE
Xml weblink tag

### DIFF
--- a/Content.Client/UserInterface/RichText/WeblinkTag.cs
+++ b/Content.Client/UserInterface/RichText/WeblinkTag.cs
@@ -7,8 +7,11 @@ using Robust.Shared.Input;
 using Robust.Shared.Utility;
 using Content.Client.Guidebook.RichText;
 
-namespace Content.Client._Starlight.UserInterface.RichText;
+namespace Content.Client.UserInterface.RichText;
 
+/// <summary>
+/// Assigns a link that opens a web address in the user's default browser when clicked.
+/// </summary>
 [UsedImplicitly]
 public sealed class WebLinkTag : IMarkupTagHandler
 {

--- a/Content.Client/UserInterface/RichText/WeblinkTag.cs
+++ b/Content.Client/UserInterface/RichText/WeblinkTag.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.RichText;
+using Robust.Shared.Input;
+using Robust.Shared.Utility;
+using Content.Client.Guidebook.RichText;
+
+namespace Content.Client._Starlight.UserInterface.RichText;
+
+[UsedImplicitly]
+public sealed class WebLinkTag : IMarkupTagHandler
+{
+
+    public string Name => "weblink";
+
+    /// <inheritdoc/>
+    public bool TryCreateControl(MarkupNode node, [NotNullWhen(true)] out Control? control)
+    {
+        if (!node.Value.TryGetString(out var text)
+            || !node.Attributes.TryGetValue("link", out var linkParameter)
+            || !linkParameter.TryGetString(out var link))
+        {
+            control = null;
+            return false;
+        }
+
+        var label = new Label();
+        label.Text = text;
+
+        label.MouseFilter = Control.MouseFilterMode.Stop;
+        label.FontColorOverride = TextLinkTag.LinkColor;
+        label.DefaultCursorShape = Control.CursorShape.Hand;
+
+        label.OnMouseEntered += _ => label.FontColorOverride = Color.LightSkyBlue;
+        label.OnMouseExited += _ => label.FontColorOverride = Color.CornflowerBlue;
+        label.OnKeyBindDown += args => OnKeybindDown(args, link, label);
+
+        control = label;
+        return true;
+    }
+
+    private void OnKeybindDown(GUIBoundKeyEventArgs args, string link, Control? control)
+    {
+        if (args.Function != EngineKeyFunctions.UIClick)
+            return;
+        if (control == null)
+            return;
+
+        IoCManager.Resolve<IUriOpener>().OpenUri(link);
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Creates a XML tag that opens a web address in the user's default browser when clicked.

- `[weblink="<text>" link="<web address>"]`

Code entirely created by [walksanatora](https://github.com/walksanatora) https://github.com/space-wizards/space-station-14/pull/42961/commits/c8863b193e9426d42c80de64be552765e0cf5f1b. My only contribution was to remove the Starlight part of the code and add documentation https://github.com/space-wizards/space-station-14/pull/42961/commits/f9ed0460d88e06068666136fcb642b668ce97db9.

### Permission
Obtained from PR author [walksanatora](https://github.com/walksanatora) within [#development](https://discord.com/channels/310555209753690112/310555209753690112/1471998000564797480) of [Wizard's Den Discord server](https://discord.ss14.io/). I have elected to credit them than to 'steal' their code.

<img width="565" height="210" alt="image" src="https://github.com/user-attachments/assets/443d8cfc-b0f9-4526-b14e-24d3455296a2" />

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Needed as you can't currently click on or select URLs in the rules and guidebooks.

It would also significantly reduce the length of the sentence I'm typing.
<img width="2059" height="129" alt="image" src="https://github.com/user-attachments/assets/cd4547ef-c0de-4479-98cb-de346a03b53a" />

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Using `[weblink="Test link to the SS14 website" link="https://spacestation14.com/"]`

https://github.com/space-wizards/space-station-14/commit/f9ed0460d88e06068666136fcb642b668ce97db9
![explorer_L6NmJwi5li](https://github.com/user-attachments/assets/d9230830-83fb-4453-bc6d-85af4548dc5f)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

Not player-facing.