### PR TITLE
fix: Collision wake and ItemPlacer weirdness

### DIFF
--- a/Content.Shared/Placeable/ItemPlacerSystem.cs
+++ b/Content.Shared/Placeable/ItemPlacerSystem.cs
@@ -28,7 +28,13 @@ public sealed class ItemPlacerSystem : EntitySystem
             return;
 
         if (TryComp<CollisionWakeComponent>(args.OtherEntity, out var wakeComp))
+        {
+            var stored = EnsureComp<StoredCollisionWakeComponent>(args.OtherEntity);
+            stored.OriginalEnabled = wakeComp.Enabled;
+            Dirty(args.OtherEntity, stored);
+
             _wake.SetEnabled(args.OtherEntity, false, wakeComp);
+        }
 
         var count = comp.PlacedEntities.Count;
         if (comp.MaxEntities == 0 || count < comp.MaxEntities)
@@ -48,8 +54,16 @@ public sealed class ItemPlacerSystem : EntitySystem
 
     private void OnEndCollide(EntityUid uid, ItemPlacerComponent comp, ref EndCollideEvent args)
     {
+        if (_whitelistSystem.IsWhitelistFail(comp.Whitelist, args.OtherEntity))
+            return;
+
         if (TryComp<CollisionWakeComponent>(args.OtherEntity, out var wakeComp))
-            _wake.SetEnabled(args.OtherEntity, true, wakeComp);
+        {
+            var originalEnabled = TryComp<StoredCollisionWakeComponent>(args.OtherEntity, out var stored)
+                ? stored.OriginalEnabled : true;
+            _wake.SetEnabled(args.OtherEntity, originalEnabled, wakeComp);
+            RemCompDeferred<StoredCollisionWakeComponent>(args.OtherEntity);
+        }
 
         comp.PlacedEntities.Remove(args.OtherEntity);
 

--- a/Content.Shared/Placeable/StoredCollisionWakeComponent.cs
+++ b/Content.Shared/Placeable/StoredCollisionWakeComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Placeable;
+
+/// <summary>
+/// Utility for <see cref="ItemPlacerSystem"/> that stores the original state of
+/// a <see cref="CollisionWakeComponent"/> for later restoring.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(ItemPlacerSystem))]
+public sealed partial class StoredCollisionWakeComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool OriginalEnabled = true;
+}
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Added a check for whitelist in `ItemPlacerSystem.OnEndCollide` for consistency with `OnStartCollide`.
- Added `StoredCollisionWakeComponent` to store and restore original state of `CollisionWakeComponent`.

This will fix soap being not slippery after being put onto and then taken away from a hotplate.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes #39412.

## Technical details
<!-- Summary of code changes for easier review. -->

It is essentially just adding a whitelist check for `OnEndCollide`, and this will fix basically all of the problems.

If we want to be more accurate and restore `CollisionWakeComponent.Enabled`, either works:
- Add a component to store the original state (This PR)
- Change `PlacedEntities` into `Dictionary<EntityUid, bool>` to store the wake state, but this will break existing usages (in only one other system)
  ```cs
  public sealed partial class ItemPlacerComponent : Component {
    [DataField, AutoNetworkedField]
    public Dictionary<EntityUid, bool> PlacedEntities = new();
  // ...
  }
  ```

But I guess it would be fine if non of there are added?

tbh I do not know whether it should be named as `StoredCollisionWakeComponent`...

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
