### PR TITLE
Remove every usage of System.Random I could find.

### DIFF
--- a/Content.Benchmarks/ColorInterpolateBenchmark.cs
+++ b/Content.Benchmarks/ColorInterpolateBenchmark.cs
@@ -30,7 +30,7 @@ namespace Content.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
-            var random = new Random(3005);
+            var random = new RobustRandom(3005);
 
             _colors = new (Color, Color)[N];
             _output = new Color[N];

--- a/Content.Client/Orbit/OrbitVisualsSystem.cs
+++ b/Content.Client/Orbit/OrbitVisualsSystem.cs
@@ -27,11 +27,11 @@ public sealed class OrbitVisualsSystem : EntitySystem
 
     private void OnComponentInit(EntityUid uid, OrbitVisualsComponent component, ComponentInit args)
     {
-        _robustRandom.SetSeed((int)_timing.CurTime.TotalMilliseconds);
+        IRobustRandom rng = new RobustRandom((int)_timing.CurTime.TotalMilliseconds);
         component.OrbitDistance =
-            _robustRandom.NextFloat(0.75f * component.OrbitDistance, 1.25f * component.OrbitDistance);
+            rng.NextFloat(0.75f * component.OrbitDistance, 1.25f * component.OrbitDistance);
 
-        component.OrbitLength = _robustRandom.NextFloat(0.5f * component.OrbitLength, 1.5f * component.OrbitLength);
+        component.OrbitLength = rng.NextFloat(0.5f * component.OrbitLength, 1.5f * component.OrbitLength);
 
         if (TryComp<SpriteComponent>(uid, out var sprite))
         {

--- a/Content.Client/Paper/UI/StampCollection.xaml.cs
+++ b/Content.Client/Paper/UI/StampCollection.xaml.cs
@@ -40,7 +40,7 @@ public sealed partial class StampCollection : Container
 
     protected override Vector2 ArrangeOverride(Vector2 finalSize)
     {
-        var random = new Random(PlacementSeed);
+        var random = new RobustRandom(PlacementSeed);
         var r = (finalSize * 0.5f).Length();
         var dtheta = -MathHelper.DegreesToRadians(90);
         var theta0 = random.Next(0, 3) * dtheta;

--- a/Content.Client/Parallax/ParallaxGenerator.cs
+++ b/Content.Client/Parallax/ParallaxGenerator.cs
@@ -408,7 +408,7 @@ namespace Content.Client.Parallax
             private void GenPoints(Image<Rgba32> buffer)
             {
                 var o = PointSize - 1;
-                var random = new Random(Seed);
+                var random = new RobustRandom(Seed);
                 var span = buffer.GetPixelSpan();
 
                 for (var i = 0; i < PointCount; i++)
@@ -435,7 +435,7 @@ namespace Content.Client.Parallax
             private void GenPointsMasked(Image<Rgba32> buffer)
             {
                 var o = PointSize - 1;
-                var random = new Random(Seed);
+                var random = new RobustRandom(Seed);
                 var noise = new FastNoiseLite((int)MaskSeed);
                 noise.SetFractalType(MaskNoiseType);
                 noise.SetFractalLacunarity(MaskLacunarity);

--- a/Content.Client/UserInterface/RichText/ScrambleTag.cs
+++ b/Content.Client/UserInterface/RichText/ScrambleTag.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using JetBrains.Annotations;
 using Robust.Client.UserInterface.RichText;
+using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -29,7 +30,9 @@ public sealed class ScrambleTag : IMarkupTagHandler
             return string.Empty;
 
         var seed = (int) (_timing.CurTime.TotalMilliseconds / rate);
-        var rand = new Random(seed + node.GetHashCode());
+        // TODO(Kaylie): Using GetHashCode here is really sus and not documented. Is this meant to be consistently
+        //               different for every player?
+        var rand = new RobustRandom(seed + node.GetHashCode());
         var charOptions = chars.ToCharArray();
         var realLength = MathF.Min(length.Value, MaxScrambleLength);
         var sb = new StringBuilder();

--- a/Content.Client/Wires/UI/WiresMenu.cs
+++ b/Content.Client/Wires/UI/WiresMenu.cs
@@ -11,6 +11,7 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Animations;
 using Robust.Shared.Input;
+using Robust.Shared.Random;
 using static Robust.Client.UserInterface.Controls.BoxContainer;
 
 namespace Content.Client.Wires.UI
@@ -237,7 +238,7 @@ namespace Content.Client.Wires.UI
             _serialLabel.Text = state.SerialNumber;
 
             _wiresHBox.RemoveAllChildren();
-            var random = new Random(state.WireSeed);
+            var random = new RobustRandom(state.WireSeed);
             foreach (var wire in state.WiresList)
             {
                 var mirror = random.Next(2) == 0;

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -1078,7 +1078,7 @@ public sealed partial class AdminVerbSystem
         // I would do it now but theres a massive rod rewrite, and I don't wanna poke it for this.
         // find reasonable spawn location (use gamerule and find rod?) but respect map not on grid etc etc
 
-        var offset = new Random(target.Id).NextAngle().RotateVec(new Vector2(distance, 0));
+        var offset = _random.NextAngle().RotateVec(new Vector2(distance, 0));
         var spawnCoords = _transformSystem.GetMapCoordinates(target).Offset(offset);
         var rod = Spawn(proto, spawnCoords);
         // Here we abuse the ChasingWalkComp by making it skip targetting logic and dialling its frequency up

--- a/Content.Server/Anomaly/Effects/ProjectileAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/ProjectileAnomalySystem.cs
@@ -72,7 +72,7 @@ public sealed class ProjectileAnomalySystem : EntitySystem
             Log.Debug($"{projectileCount}");
             var target = priority.Count > 0
                 ? _random.PickAndTake(priority)
-                : _random.Pick(_inRange);
+                : _random.PickSlow(_inRange);
 
             var targetXForm= _xFormQuery.GetComponent(target);
             var targetCoords = targetXForm.Coordinates.Offset(_random.NextVector2(0.5f));

--- a/Content.Server/Anomaly/Effects/TechAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/TechAnomalySystem.cs
@@ -69,15 +69,15 @@ public sealed class TechAnomalySystem : EntitySystem
 
         for (var i = 0; i < count; i++)
         {
-            var device = _random.Pick(devices);
+            var device = _random.PickSlow(devices);
             CreateNewLink(tech, (tech, sourceComp), device);
         }
     }
 
     private void CreateNewLink(Entity<TechAnomalyComponent> tech, Entity<DeviceLinkSourceComponent> source, Entity<DeviceLinkSinkComponent> target)
     {
-        var sourcePort = _random.Pick(source.Comp.Ports);
-        var sinkPort = _random.Pick(target.Comp.Ports);
+        var sourcePort = _random.PickSlow(source.Comp.Ports);
+        var sinkPort = _random.PickSlow(target.Comp.Ports);
 
         _signal.SaveLinks(null, source, target,new()
         {
@@ -107,10 +107,10 @@ public sealed class TechAnomalySystem : EntitySystem
             if (sinks.Count < 1)
                 return;
 
-            var source = _random.Pick(sources);
+            var source = _random.PickSlow(sources);
             sources.Remove(source);
 
-            var sink = _random.Pick(sinks);
+            var sink = _random.PickSlow(sinks);
             sinks.Remove(sink);
 
             if (_random.Prob(tech.Comp.EmagSupercritProbability))

--- a/Content.Server/Arcade/SpaceVillainGame/SpaceVillainArcadeSystem.cs
+++ b/Content.Server/Arcade/SpaceVillainGame/SpaceVillainArcadeSystem.cs
@@ -73,7 +73,7 @@ public sealed partial class SpaceVillainArcadeSystem : EntitySystem
     private void OnComponentInit(EntityUid uid, SpaceVillainArcadeComponent component, ComponentInit args)
     {
         // Random amount of prizes
-        component.RewardAmount = new Random().Next(component.RewardMinAmount, component.RewardMaxAmount + 1);
+        component.RewardAmount = _random.Next(component.RewardMinAmount, component.RewardMaxAmount + 1);
     }
 
     private void OnSVPlayerAction(EntityUid uid, SpaceVillainArcadeComponent component, SharedSpaceVillainArcadeComponent.SpaceVillainArcadePlayerActionMessage msg)

--- a/Content.Server/Chat/Systems/EmoteOnDamageSystem.cs
+++ b/Content.Server/Chat/Systems/EmoteOnDamageSystem.cs
@@ -38,7 +38,7 @@ public sealed class EmoteOnDamageSystem : EntitySystem
         if (!_random.Prob(emoteOnDamage.EmoteChance))
             return;
 
-        var emote = _random.Pick(emoteOnDamage.Emotes);
+        var emote = _random.PickSlow(emoteOnDamage.Emotes);
         if (emoteOnDamage.WithChat)
         {
             _chatSystem.TryEmoteWithChat(uid, emote, emoteOnDamage.HiddenFromChatWindow ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal);

--- a/Content.Server/Cloning/RandomCloneSpawnerSystem.cs
+++ b/Content.Server/Cloning/RandomCloneSpawnerSystem.cs
@@ -39,7 +39,7 @@ public sealed class RandomCloneSpawnerSystem : EntitySystem
         if (allHumans.Count == 0)
             return;
 
-        var bodyToClone = _random.Pick(allHumans).Comp.OwnedEntity;
+        var bodyToClone = _random.PickSlow(allHumans).Comp.OwnedEntity;
 
         if (bodyToClone != null)
             _cloning.TryCloning(bodyToClone.Value, _transformSystem.GetMapCoordinates(ent.Owner), settings, out _);

--- a/Content.Server/Defusable/Components/DefusableComponent.cs
+++ b/Content.Server/Defusable/Components/DefusableComponent.cs
@@ -1,5 +1,6 @@
 using Content.Server.Defusable.Systems;
 using Content.Server.Explosion.Components;
+using Content.Shared.Explosion.Components;
 using Robust.Shared.Audio;
 
 namespace Content.Server.Defusable.Components;

--- a/Content.Server/Destructible/Thresholds/Behaviors/DumpRestockInventory.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/DumpRestockInventory.cs
@@ -29,7 +29,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                 !system.EntityManager.TryGetComponent<TransformComponent>(owner, out var xform))
                 return;
 
-            var randomInventory = system.Random.Pick(packagecomp.CanRestock);
+            var randomInventory = system.Random.PickSlow(packagecomp.CanRestock);
 
             if (!system.PrototypeManager.TryIndex(randomInventory, out VendingMachineInventoryPrototype? packPrototype))
                 return;

--- a/Content.Server/Destructible/Thresholds/Behaviors/ExplodeBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/ExplodeBehavior.cs
@@ -1,4 +1,5 @@
 using Content.Server.Explosion.Components;
+using Content.Shared.Explosion.Components;
 using JetBrains.Annotations;
 
 namespace Content.Server.Destructible.Thresholds.Behaviors

--- a/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
@@ -69,7 +69,7 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
             }
 
             // pick a random player
-            var randomHumanoidMind = _random.Pick(allAliveHumanoids);
+            var randomHumanoidMind = _random.PickSlow(allAliveHumanoids);
             ent.Comp.OriginalMind = randomHumanoidMind;
             ent.Comp.OriginalBody = randomHumanoidMind.Comp.OwnedEntity;
 

--- a/Content.Server/Gateway/Systems/GatewayGeneratorSystem.cs
+++ b/Content.Server/Gateway/Systems/GatewayGeneratorSystem.cs
@@ -99,7 +99,7 @@ public sealed class GatewayGeneratorSystem : EntitySystem
         const int MaxOffset = 256;
         var tiles = new List<(Vector2i Index, Tile Tile)>();
         var seed = _random.Next();
-        var random = new Random(seed);
+        var random = new RobustRandom(seed);
         var mapUid = _maps.CreateMap();
 
         var gatewayName = _salvage.GetFTLName(_protoManager.Index(PlanetNames), seed);
@@ -179,7 +179,7 @@ public sealed class GatewayGeneratorSystem : EntitySystem
         // Do dungeon
         var seed = ent.Comp.Seed;
         var origin = ent.Comp.Origin;
-        var random = new Random(seed);
+        var random = new RobustRandom(seed);
         var dungeonDistance = random.Next(3, 6);
         var dungeonRotation = _dungeon.GetDungeonRotation(seed);
         var dungeonPosition = (origin + dungeonRotation.RotateVec(new Vector2i(0, dungeonDistance))).Floored();

--- a/Content.Server/Ghost/Roles/Components/GhostRoleRaffleComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleRaffleComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server.Ghost.Roles.Raffles;
+using Content.Shared.Ghost.Roles.Raffles;
 using Robust.Shared.Player;
 
 namespace Content.Server.Ghost.Roles.Components;

--- a/Content.Server/Mind/TransferMindOnGibSystem.cs
+++ b/Content.Server/Mind/TransferMindOnGibSystem.cs
@@ -33,7 +33,7 @@ public sealed class TransferMindOnGibSystem : EntitySystem
         if (!validParts.Any())
             return;
 
-        var transfer = _random.Pick(validParts);
+        var transfer = _random.PickSlow(validParts);
         _mindSystem.TransferTo(mindId, transfer, mind: mind);
     }
 }

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/SpeakOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/SpeakOperator.cs
@@ -58,12 +58,12 @@ public sealed partial class SpeakOperator : HTNOperator
         LocId speechLocId;
         switch (Speech)
         {
-            case LocalizedSetSpeakOperatorSpeech localizedDataSet:
+            case SpeakOperatorSpeech.LocalizedSetSpeakOperatorSpeech localizedDataSet:
                 if (!_proto.TryIndex(localizedDataSet.LineSet, out var speechSet))
                     return HTNOperatorStatus.Failed;
                 speechLocId = _random.Pick(speechSet);
                 break;
-            case SingleSpeakOperatorSpeech single:
+            case SpeakOperatorSpeech.SingleSpeakOperatorSpeech single:
                 speechLocId = single.Line;
                 break;
             default:

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.BFS.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.BFS.cs
@@ -104,7 +104,7 @@ public sealed partial class PathfindingSystem
         }
 
         // Pick a random node to use?
-        (currentNode, _) = random.Pick(request.CostSoFar);
+        (currentNode, _) = random.PickSlow(request.CostSoFar);
 
         var route = ReconstructPath(request.CameFrom, currentNode);
         var path = new Queue<EntityCoordinates>(route.Count);

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Splines.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Splines.cs
@@ -37,7 +37,7 @@ public sealed partial class PathfindingSystem
     /// <summary>
     /// Gets a spline path from start to end.
     /// </summary>
-    public SplinePathResult GetSplinePath(SplinePathArgs args, Random random)
+    public SplinePathResult GetSplinePath(SplinePathArgs args, IRobustRandom random)
     {
         var start = args.Args.Start;
         var end = args.Args.End;

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Widen.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Widen.cs
@@ -8,7 +8,7 @@ public sealed partial class PathfindingSystem
     /// <summary>
     /// Widens the path by the specified amount.
     /// </summary>
-    public HashSet<Vector2i> GetWiden(WidenArgs args, Random random)
+    public HashSet<Vector2i> GetWiden(WidenArgs args, IRobustRandom random)
     {
         var tiles = new HashSet<Vector2i>(args.Path.Count * 2);
         var variance = (args.MaxWiden - args.MinWiden) / 2f + args.MinWiden;

--- a/Content.Server/NPC/Queries/Considerations/TargetIsStunnedCon.cs
+++ b/Content.Server/NPC/Queries/Considerations/TargetIsStunnedCon.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Stunnable;
+
 namespace Content.Server.NPC.Queries.Considerations;
 
 /// <summary>

--- a/Content.Server/NPC/Queries/Considerations/TargetTargetingCon.cs
+++ b/Content.Server/NPC/Queries/Considerations/TargetTargetingCon.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Turrets;
+
 namespace Content.Server.NPC.Queries.Considerations;
 
 /// <summary>

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -492,7 +492,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
                 // inadvertantly spawn too many near the edges.
                 var layerProto = ProtoManager.Index<BiomeMarkerLayerPrototype>(layer);
                 var markerSeed = seed + chunk.X * ChunkSize + chunk.Y + localIdx;
-                var rand = new Random(markerSeed);
+                var rand = new RobustRandom(seed);
                 var buffer = (int)(layerProto.Radius / 2f);
                 var bounds = new Box2i(chunk + buffer, chunk + layerProto.Size - buffer);
                 var count = (int)(bounds.Area / (layerProto.Radius * layerProto.Radius));
@@ -575,7 +575,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         bool forced,
         Box2i bounds,
         int count,
-        Random rand,
+        IRobustRandom rand,
         out Dictionary<Vector2i, string?> spawnSet,
         out HashSet<EntityUid> existingEnts,
         bool emptyTiles = true)
@@ -646,7 +646,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
             // While we have remaining tiles keep iterating
             while (groupSize > 0 && remainingTiles.Count > 0)
             {
-                var startNode = rand.PickAndTake(remainingTiles);
+                var startNode = rand.PickAndTakeSlow(remainingTiles);
                 frontier.Clear();
                 frontier.Add(startNode);
 

--- a/Content.Server/Physics/Controllers/ChasingWalkSystem.cs
+++ b/Content.Server/Physics/Controllers/ChasingWalkSystem.cs
@@ -67,7 +67,7 @@ public sealed class ChasingWalkSystem : VirtualController
         //We find our coordinates and calculate the radius of the target search.
         var xform = Transform(uid);
         var range = component.MaxChaseRadius;
-        var compType = _random.Pick(component.ChasingComponent.Values).Component.GetType();
+        var compType = _random.PickSlow(component.ChasingComponent.Values).Component.GetType();
         _potentialChaseTargets.Clear();
         _lookup.GetEntitiesInRange(compType, _transform.GetMapCoordinates(xform), range, _potentialChaseTargets, LookupFlags.Uncontained);
 
@@ -76,7 +76,7 @@ public sealed class ChasingWalkSystem : VirtualController
             return;
 
         //In the case of finding required components, we choose a random one of them and remember its uid.
-        component.ChasingEntity = _random.Pick(_potentialChaseTargets).Owner;
+        component.ChasingEntity = _random.PickSlow(_potentialChaseTargets).Owner;
         component.Speed = _random.NextFloat(component.MinSpeed, component.MaxSpeed);
     }
 

--- a/Content.Server/Power/Components/PowerNetworkBatteryComponent.cs
+++ b/Content.Server/Power/Components/PowerNetworkBatteryComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.Power.Pow3r;
 using Content.Shared.Guidebook;
+using Content.Shared.Power.Components;
 
 namespace Content.Server.Power.Components
 {

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.AutoCabling.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.AutoCabling.cs
@@ -13,7 +13,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="AutoCablingDunGen"/>
     /// </summary>
-    private async Task PostGen(AutoCablingDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(AutoCablingDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         // There's a lot of ways you could do this.
         // For now we'll just connect every LV cable in the dungeon.

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Biome.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Biome.cs
@@ -5,6 +5,7 @@ using Content.Shared.Parallax.Biomes;
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.PostGeneration;
 using Robust.Shared.Map;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Procedural.DungeonJob;
@@ -14,7 +15,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="BiomeDunGen"/>
     /// </summary>
-    private async Task PostGen(BiomeDunGen dunGen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(BiomeDunGen dunGen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         if (!_prototype.Resolve(dunGen.BiomeTemplate, out var indexedBiome))
             return;

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.BiomeMarkerLayer.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.BiomeMarkerLayer.cs
@@ -6,6 +6,7 @@ using Content.Shared.Procedural;
 using Content.Shared.Procedural.PostGeneration;
 using Content.Shared.Random.Helpers;
 using Robust.Shared.Map;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Procedural.DungeonJob;
@@ -15,7 +16,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="BiomeMarkerLayerDunGen"/>
     /// </summary>
-    private async Task PostGen(BiomeMarkerLayerDunGen dunGen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(BiomeMarkerLayerDunGen dunGen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         // If we're adding biome then disable it and just use for markers.
         if (_entManager.EnsureComponent(_gridUid, out BiomeComponent biomeComp))

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.BoundaryWall.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.BoundaryWall.cs
@@ -3,6 +3,7 @@ using Content.Shared.Maps;
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.PostGeneration;
 using Robust.Shared.Map;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Procedural.DungeonJob;
@@ -12,7 +13,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="BoundaryWallDunGen"/>
     /// </summary>
-    private async Task PostGen(BoundaryWallDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(BoundaryWallDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var tileDef = _tileDefManager[gen.Tile];
         var tiles = new List<(Vector2i Index, Tile Tile)>(dungeon.RoomExteriorTiles.Count);

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.CornerClutter.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.CornerClutter.cs
@@ -10,7 +10,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="CornerClutterDunGen"/>
     /// </summary>
-    private async Task PostGen(CornerClutterDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(CornerClutterDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var contentsTable = _prototype.Index(gen.Contents);
 

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Corridor.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Corridor.cs
@@ -4,6 +4,7 @@ using Content.Shared.Maps;
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.PostGeneration;
 using Robust.Shared.Map;
+using Robust.Shared.Random;
 
 namespace Content.Server.Procedural.DungeonJob;
 
@@ -12,7 +13,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="CorridorDunGen"/>
     /// </summary>
-    private async Task PostGen(CorridorDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(CorridorDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var entrances = new List<Vector2i>(dungeon.Rooms.Count);
 

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.CorridorClutter.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.CorridorClutter.cs
@@ -12,7 +12,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="CorridorClutterDunGen"/>
     /// </summary>
-    private async Task PostGen(CorridorClutterDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(CorridorClutterDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var physicsQuery = _entManager.GetEntityQuery<PhysicsComponent>();
         var count = (int) Math.Ceiling(dungeon.CorridorTiles.Count * gen.Chance);
@@ -20,7 +20,7 @@ public sealed partial class DungeonJob
 
         while (count > 0)
         {
-            var tile = random.Pick(dungeon.CorridorTiles);
+            var tile = random.PickSlow(dungeon.CorridorTiles);
 
             var enumerator = _maps.GetAnchoredEntitiesEnumerator(_gridUid, _grid, tile);
             var blocked = false;

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.CorridorDecalSkirting.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.CorridorDecalSkirting.cs
@@ -4,6 +4,7 @@ using Content.Shared.Procedural;
 using Content.Shared.Procedural.PostGeneration;
 using Robust.Shared.Collections;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Procedural.DungeonJob;
@@ -13,7 +14,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="CorridorDecalSkirtingDunGen"/>
     /// </summary>
-    private async Task PostGen(CorridorDecalSkirtingDunGen decks, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(CorridorDecalSkirtingDunGen decks, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var directions = new ValueList<DirectionFlag>(4);
         var pocketDirections = new ValueList<Direction>(4);

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.DunGenNoiseDistance.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.DunGenNoiseDistance.cs
@@ -5,6 +5,7 @@ using Content.Shared.Procedural;
 using Content.Shared.Procedural.Distance;
 using Content.Shared.Procedural.DungeonGenerators;
 using Robust.Shared.Map;
+using Robust.Shared.Random;
 
 namespace Content.Server.Procedural.DungeonJob;
 
@@ -25,7 +26,7 @@ public sealed partial class DungeonJob
         NoiseDistanceDunGen dungen,
         HashSet<Vector2i> reservedTiles,
         int seed,
-        Random random)
+        IRobustRandom random)
     {
         var tiles = new List<(Vector2i, Tile)>();
         var matrix = Matrix3Helpers.CreateTranslation(position);

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.DunGenPrefab.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.DunGenPrefab.cs
@@ -14,7 +14,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="PrefabDunGen"/>
     /// </summary>
-    private async Task<Dungeon> GeneratePrefabDunGen(Vector2i position, PrefabDunGen prefab, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task<Dungeon> GeneratePrefabDunGen(Vector2i position, PrefabDunGen prefab, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var preset = prefab.Presets[random.Next(prefab.Presets.Count)];
         var gen = _prototype.Index(preset);
@@ -297,7 +297,7 @@ public sealed partial class DungeonJob
         return dungeon;
     }
 
-    private void SetDungeonEntrance(Dungeon dungeon, DungeonRoom room, HashSet<Vector2i> reservedTiles, Random random)
+    private void SetDungeonEntrance(Dungeon dungeon, DungeonRoom room, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         // TODO: Move to dungeonsystem.
 

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.DunGenReplaceTile.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.DunGenReplaceTile.cs
@@ -12,7 +12,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="ReplaceTileDunGen"/>
     /// </summary>
-    private async Task GenerateTileReplacementDunGen(ReplaceTileDunGen gen, List<Dungeon> dungeons, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task GenerateTileReplacementDunGen(ReplaceTileDunGen gen, List<Dungeon> dungeons, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var replacements = new List<(Vector2i Index, Tile Tile)>();
 

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.DungeonEntrance.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.DungeonEntrance.cs
@@ -12,7 +12,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="DungeonEntranceDunGen"/>
     /// </summary>
-    private async Task PostGen(DungeonEntranceDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(DungeonEntranceDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var rooms = new List<DungeonRoom>(dungeon.Rooms);
         var roomTiles = new List<Vector2i>();

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.EntityTableDunGen.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.EntityTableDunGen.cs
@@ -7,6 +7,7 @@ using Content.Shared.Physics;
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.DungeonLayers;
 using Robust.Shared.Collections;
+using Robust.Shared.Random;
 
 namespace Content.Server.Procedural.DungeonJob;
 
@@ -16,7 +17,7 @@ public sealed partial class DungeonJob
         EntityTableDunGen gen,
         List<Dungeon> dungeons,
         HashSet<Vector2i> reservedTiles,
-        Random random)
+        IRobustRandom random)
     {
         var count = random.Next(gen.MinCount, gen.MaxCount + 1);
         var npcs = _entManager.System<NPCSystem>();

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.EntranceFlank.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.EntranceFlank.cs
@@ -5,6 +5,7 @@ using Content.Shared.Procedural.PostGeneration;
 using Content.Shared.Storage;
 using Robust.Shared.Collections;
 using Robust.Shared.Map;
+using Robust.Shared.Random;
 
 namespace Content.Server.Procedural.DungeonJob;
 
@@ -13,7 +14,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="EntranceFlankDunGen"/>
     /// </summary>
-    private async Task PostGen(EntranceFlankDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(EntranceFlankDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var tiles = new List<(Vector2i Index, Tile)>();
         var tileDef = _tileDefManager[gen.Tile];

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Exterior.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Exterior.cs
@@ -13,7 +13,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="ExteriorDunGen"/>
     /// </summary>
-    private async Task<List<Dungeon>> GenerateExteriorDungen(Vector2i position, ExteriorDunGen dungen, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task<List<Dungeon>> GenerateExteriorDungen(Vector2i position, ExteriorDunGen dungen, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         DebugTools.Assert(_grid.ChunkCount > 0);
 
@@ -49,7 +49,8 @@ public sealed partial class DungeonJob
 
         var config = _prototype.Index(dungen.Proto);
         var nextSeed = random.Next();
-        var dungeons = await GetDungeons(dungeonSpawn.Value, config, config.Layers, reservedTiles, nextSeed, new Random(nextSeed));
+        var rng = new RobustRandom(nextSeed);
+        var dungeons = await GetDungeons(dungeonSpawn.Value, config, config.Layers, reservedTiles, nextSeed, rng);
 
         return dungeons;
     }

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.ExternalWindow.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.ExternalWindow.cs
@@ -24,7 +24,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="ExternalWindowDunGen"/>
     /// </summary>
-    private async Task PostGen(ExternalWindowDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(ExternalWindowDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         // Iterate every tile with N chance to spawn windows on that wall per cardinal dir.
         var chance = 0.25 / 3f;

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.InternalWindow.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.InternalWindow.cs
@@ -4,6 +4,7 @@ using Content.Shared.Maps;
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.PostGeneration;
 using Content.Shared.Storage;
+using Robust.Shared.Random;
 
 namespace Content.Server.Procedural.DungeonJob;
 
@@ -12,7 +13,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="InternalWindowDunGen"/>
     /// </summary>
-    private async Task PostGen(InternalWindowDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(InternalWindowDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         // Iterate every room and check if there's a gap beyond it that leads to another room within N tiles
         // If so then consider windows

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Junction.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Junction.cs
@@ -4,6 +4,7 @@ using Content.Shared.Procedural;
 using Content.Shared.Procedural.PostGeneration;
 using Content.Shared.Storage;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Random;
 
 namespace Content.Server.Procedural.DungeonJob;
 
@@ -12,7 +13,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="JunctionDunGen"/>
     /// </summary>
-    private async Task PostGen(JunctionDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(JunctionDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var tileDef = _tileDefManager[gen.Tile];
         var contents = _prototype.Index(gen.Contents);

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.MiddleConnection.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.MiddleConnection.cs
@@ -4,6 +4,7 @@ using Content.Shared.Maps;
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.PostGeneration;
 using Content.Shared.Storage;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Procedural.DungeonJob;
@@ -13,7 +14,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="MiddleConnectionDunGen"/>
     /// </summary>
-    private async Task PostGen(MiddleConnectionDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(MiddleConnectionDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         // Grab all of the room bounds
         // Then, work out connections between them

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Mobs.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Mobs.cs
@@ -19,7 +19,7 @@ public sealed partial class DungeonJob
     private async Task PostGen(
         MobsDunGen gen,
         Dungeon dungeon,
-        Random random)
+        IRobustRandom random)
     {
         var availableRooms = new ValueList<DungeonRoom>();
         availableRooms.AddRange(dungeon.Rooms);

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Noise.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Noise.cs
@@ -19,7 +19,7 @@ public sealed partial class DungeonJob
         NoiseDunGen dungen,
         HashSet<Vector2i> reservedTiles,
         int seed,
-        Random random)
+        IRobustRandom random)
     {
         var tiles = new List<(Vector2i, Tile)>();
         var matrix = Matrix3Helpers.CreateTranslation(position);

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Ore.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Ore.cs
@@ -17,7 +17,7 @@ public sealed partial class DungeonJob
         OreDunGen gen,
         List<Dungeon> dungeons,
         HashSet<Vector2i> reservedTiles,
-        Random random)
+        IRobustRandom random)
     {
         foreach (var dungeon in dungeons)
         {

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.RoomEntrance.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.RoomEntrance.cs
@@ -4,6 +4,7 @@ using Content.Shared.Procedural;
 using Content.Shared.Procedural.PostGeneration;
 using Content.Shared.Storage;
 using Robust.Shared.Map;
+using Robust.Shared.Random;
 
 namespace Content.Server.Procedural.DungeonJob;
 
@@ -12,7 +13,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="RoomEntranceDunGen"/>
     /// </summary>
-    private async Task PostGen(RoomEntranceDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(RoomEntranceDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var setTiles = new List<(Vector2i, Tile)>();
         var tileDef = _tileDefManager[gen.Tile];

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.SplineDungeonConnector.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.SplineDungeonConnector.cs
@@ -17,7 +17,7 @@ public sealed partial class DungeonJob
         SplineDungeonConnectorDunGen gen,
         List<Dungeon> dungeons,
         HashSet<Vector2i> reservedTiles,
-        Random random)
+        IRobustRandom random)
     {
         // NOOP
         if (dungeons.Count <= 1)

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.WallMount.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.WallMount.cs
@@ -12,7 +12,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="WallMountDunGen"/>
     /// </summary>
-    private async Task PostGen(WallMountDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(WallMountDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var checkedTiles = new HashSet<Vector2i>();
         var allExterior = new HashSet<Vector2i>(dungeon.CorridorExteriorTiles);

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Worm.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Worm.cs
@@ -15,7 +15,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="WormCorridorDunGen"/>
     /// </summary>
-    private async Task PostGen(WormCorridorDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(WormCorridorDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var networks = new List<(Vector2i Start, HashSet<Vector2i> Network)>();
 
@@ -100,7 +100,7 @@ public sealed partial class DungeonJob
                 frontier.Clear();
                 costSoFar.Clear();
 
-                var targetNode = random.Pick(main.Network);
+                var targetNode = random.PickSlow(main.Network);
 
                 var other = networks[i];
                 var startNode = other.Network.First();

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.cs
@@ -118,7 +118,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
         List<IDunGenLayer> layers,
         HashSet<Vector2i> reservedTiles,
         int seed,
-        Random random,
+        IRobustRandom random,
         List<Dungeon>? existing = null)
     {
         var dungeons = new List<Dungeon>();
@@ -163,7 +163,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
     {
         _sawmill.Info($"Generating dungeon {_gen} with seed {_seed} on {_entManager.ToPrettyString(_gridUid)}");
         _grid.CanSplit = false;
-        var random = new Random(_seed);
+        var random = new RobustRandom(_seed);
         var position = (_position + random.NextPolarVector2(_gen.MinOffset, _gen.MaxOffset)).Floored();
 
         // Tiles we can no longer generate on due to being reserved elsewhere.
@@ -203,7 +203,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
         IDunGenLayer layer,
         HashSet<Vector2i> reservedTiles,
         int seed,
-        Random random)
+        IRobustRandom random)
     {
         _sawmill.Debug($"Doing postgen {layer.GetType()} for {_gen} with seed {_seed}");
 

--- a/Content.Server/Procedural/DungeonSystem.Helpers.cs
+++ b/Content.Server/Procedural/DungeonSystem.Helpers.cs
@@ -1,12 +1,13 @@
 using Content.Shared.NPC;
 using Robust.Shared.Collections;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Procedural;
 
 public sealed partial class DungeonSystem
 {
-    public List<(Vector2i Start, Vector2i End)> MinimumSpanningTree(List<Vector2i> tiles, System.Random random)
+    public List<(Vector2i Start, Vector2i End)> MinimumSpanningTree(List<Vector2i> tiles, IRobustRandom random)
     {
         // Generate connections between all rooms.
         var connections = new Dictionary<Vector2i, List<(Vector2i Tile, float Distance)>>(tiles.Count);

--- a/Content.Server/Procedural/DungeonSystem.Rooms.cs
+++ b/Content.Server/Procedural/DungeonSystem.Rooms.cs
@@ -6,6 +6,7 @@ using Content.Shared.Random.Helpers;
 using Content.Shared.Whitelist;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Procedural;
@@ -19,7 +20,7 @@ public sealed partial class DungeonSystem
     /// <summary>
     /// Gets a random dungeon room matching the specified area, whitelist and size.
     /// </summary>
-    public DungeonRoomPrototype? GetRoomPrototype(Vector2i size, Random random, EntityWhitelist? whitelist = null)
+    public DungeonRoomPrototype? GetRoomPrototype(Vector2i size, IRobustRandom random, EntityWhitelist? whitelist = null)
     {
         return GetRoomPrototype(random, whitelist, minSize: size, maxSize: size);
     }
@@ -27,7 +28,7 @@ public sealed partial class DungeonSystem
     /// <summary>
     /// Gets a random dungeon room matching the specified area and whitelist and size range
     /// </summary>
-    public DungeonRoomPrototype? GetRoomPrototype(Random random,
+    public DungeonRoomPrototype? GetRoomPrototype(IRobustRandom random,
         EntityWhitelist? whitelist = null,
         Vector2i? minSize = null,
         Vector2i? maxSize = null)
@@ -77,7 +78,7 @@ public sealed partial class DungeonSystem
         MapGridComponent grid,
         Vector2i origin,
         DungeonRoomPrototype room,
-        Random random,
+        IRobustRandom random,
         HashSet<Vector2i>? reservedTiles,
         bool clearExisting = false,
         bool rotation = false)
@@ -96,7 +97,7 @@ public sealed partial class DungeonSystem
         SpawnRoom(gridUid, grid, finalTransform, room, reservedTiles, clearExisting);
     }
 
-    public Angle GetRoomRotation(DungeonRoomPrototype room, Random random)
+    public Angle GetRoomRotation(DungeonRoomPrototype room, IRobustRandom random)
     {
         var roomRotation = Angle.Zero;
 
@@ -250,7 +251,7 @@ public sealed partial class DungeonSystem
                 // but place 1 nanometre off grid and fail the add.
                 if (!_maps.TryGetTileRef(gridUid, grid, tilePos, out var tileRef) || tileRef.Tile.IsEmpty)
                 {
-                    _maps.SetTile(gridUid, grid, tilePos, _tile.GetVariantTile((ContentTileDefinition)_tileDefManager[FallbackTileId], _random.GetRandom()));
+                    _maps.SetTile(gridUid, grid, tilePos, _tile.GetVariantTile((ContentTileDefinition)_tileDefManager[FallbackTileId], _random));
                 }
 
                 var result = _decals.TryAddDecal(

--- a/Content.Server/Procedural/RoomFillSystem.cs
+++ b/Content.Server/Procedural/RoomFillSystem.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.Map.Components;
+using Robust.Shared.Random;
 
 namespace Content.Server.Procedural;
 
@@ -6,6 +7,7 @@ public sealed class RoomFillSystem : EntitySystem
 {
     [Dependency] private readonly DungeonSystem _dungeon = default!;
     [Dependency] private readonly SharedMapSystem _maps = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()
     {
@@ -19,7 +21,9 @@ public sealed class RoomFillSystem : EntitySystem
 
         if (xform.GridUid != null)
         {
-            var random = new Random();
+            var random = new RobustRandom(_random); // Dungeon thread shenanigans.
+                                                    // TODO(Kaylie): Seperate IRobustRandom into its own little thing as a "this is global" marker.
+                                                    //               Then using the global rng by mistake is impossible.
             var room = _dungeon.GetRoomPrototype(random, component.RoomWhitelist, component.MinSize, component.MaxSize);
 
             if (room != null)

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -92,7 +92,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         var mapUid = _map.CreateMap(out var mapId, runMapInit: false);
         MetaDataComponent? metadata = null;
         var grid = _entManager.EnsureComponent<MapGridComponent>(mapUid);
-        var random = new Random(_missionParams.Seed);
+        var random = new RobustRandom(_missionParams.Seed);
         var destComp = _entManager.AddComponent<FTLDestinationComponent>(mapUid);
         destComp.BeaconsOnly = true;
         destComp.RequireCoordinateDisk = true;
@@ -289,7 +289,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         return true;
     }
 
-    private async Task SpawnRandomEntry(Entity<MapGridComponent> grid, IBudgetEntry entry, Dungeon dungeon, Random random)
+    private async Task SpawnRandomEntry(Entity<MapGridComponent> grid, IBudgetEntry entry, Dungeon dungeon, IRobustRandom random)
     {
         await SuspendIfOutOfTime();
 

--- a/Content.Server/Shuttles/Events/EmergencyShuttleAuthorizedEvent.cs
+++ b/Content.Server/Shuttles/Events/EmergencyShuttleAuthorizedEvent.cs
@@ -1,4 +1,5 @@
 using Content.Server.Shuttles.Components;
+using Content.Shared.Shuttles.Components;
 
 namespace Content.Server.Shuttles.Events;
 

--- a/Content.Server/Spawners/Components/GridSpawnPointWhitelistComponent.cs
+++ b/Content.Server/Spawners/Components/GridSpawnPointWhitelistComponent.cs
@@ -1,3 +1,4 @@
+using Content.Server.GameTicking.Rules;
 using Content.Shared.Whitelist;
 
 namespace Content.Server.Spawners.Components;

--- a/Content.Server/Sprite/RandomSpriteSystem.cs
+++ b/Content.Server/Sprite/RandomSpriteSystem.cs
@@ -47,14 +47,14 @@ public sealed class RandomSpriteSystem: SharedRandomSpriteSystem
             {
                 Color? color = null;
 
-                var selectedState = _random.Pick(layer.Value);
+                var selectedState = _random.PickSlow(layer.Value);
                 if (!string.IsNullOrEmpty(selectedState.Value))
                 {
                     if (selectedState.Value == $"Inherit")
                         color = previousColor;
                     else
                     {
-                        color = _random.Pick(_prototype.Index<ColorPalettePrototype>(selectedState.Value).Colors.Values);
+                        color = _random.PickSlow(_prototype.Index<ColorPalettePrototype>(selectedState.Value).Colors.Values);
                         previousColor = color;
                     }
                 }

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -248,7 +248,7 @@ public sealed partial class StationJobsSystem
                                 continue;
 
                             // Picking players it finds that have the job set.
-                            var player = _random.Pick(jobPlayerOptions[job]);
+                            var player = _random.PickSlow(jobPlayerOptions[job]);
                             AssignPlayer(player, job, station);
                             stationShares[station]--;
 

--- a/Content.Server/Station/Systems/StationJobsSystem.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.cs
@@ -468,7 +468,7 @@ public sealed partial class StationJobsSystem : EntitySystem
         if (overflows.Count == 0)
             return null;
 
-        return _random.Pick(overflows);
+        return _random.PickSlow(overflows);
     }
 
     #endregion Public API

--- a/Content.Server/StationEvents/Events/ClericalErrorRule.cs
+++ b/Content.Server/StationEvents/Events/ClericalErrorRule.cs
@@ -33,7 +33,7 @@ public sealed class ClericalErrorRule : StationEventSystem<ClericalErrorRuleComp
         var keys = new List<uint>();
         for (var i = 0; i < toRemove; i++)
         {
-            keys.Add(RobustRandom.Pick(stationRecords.Records.Keys));
+            keys.Add(RobustRandom.PickSlow(stationRecords.Records.Keys));
         }
 
         foreach (var id in keys)

--- a/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
+++ b/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
@@ -66,7 +66,7 @@ public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
 
             var angle = component.NonDirectional
                 ? RobustRandom.NextAngle()
-                : new Random(uid.Id).NextAngle();
+                : ((IRobustRandom)new RobustRandom(uid.Id)).NextAngle();
 
             var offset = angle.RotateVec(new Vector2((maximumDistance - minimumDistance) * RobustRandom.NextFloat() + minimumDistance, 0));
 

--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -232,7 +232,7 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         if (ent.Comp.Records.Keys.Count == 0)
             return false;
 
-        var key = _random.Pick(ent.Comp.Records.Keys);
+        var key = _random.PickSlow(ent.Comp.Records.Keys);
 
         return ent.Comp.Records.TryGetRecordEntry(key, out entry);
     }

--- a/Content.Server/Temperature/Components/InternalTemperatureComponent.cs
+++ b/Content.Server/Temperature/Components/InternalTemperatureComponent.cs
@@ -1,4 +1,5 @@
 using Content.Server.Temperature.Systems;
+using Content.Shared.Temperature.Components;
 
 namespace Content.Server.Temperature.Components;
 

--- a/Content.Server/Vocalization/Components/DatasetVocalizerComponent.cs
+++ b/Content.Server/Vocalization/Components/DatasetVocalizerComponent.cs
@@ -1,3 +1,4 @@
+using Content.Server.Vocalization.Systems;
 using Content.Shared.Dataset;
 using Robust.Shared.Prototypes;
 

--- a/Content.Server/Vocalization/Components/VocalizerRequiresPowerComponent.cs
+++ b/Content.Server/Vocalization/Components/VocalizerRequiresPowerComponent.cs
@@ -1,3 +1,5 @@
+using Content.Server.Power.Components;
+
 namespace Content.Server.Vocalization.Components;
 
 /// <summary>

--- a/Content.Server/Vocalization/Systems/RadioVocalizationSystem.cs
+++ b/Content.Server/Vocalization/Systems/RadioVocalizationSystem.cs
@@ -62,7 +62,7 @@ public sealed partial class RadioVocalizationSystem : EntitySystem
             return false;
         }
 
-        channel = _random.Pick(potentialChannels);
+        channel = _random.PickSlow(potentialChannels);
 
         return true;
     }

--- a/Content.Server/Worldgen/Systems/Debris/BlobFloorPlanBuilderSystem.cs
+++ b/Content.Server/Worldgen/Systems/Debris/BlobFloorPlanBuilderSystem.cs
@@ -67,7 +67,7 @@ public sealed class BlobFloorPlanBuilderSystem : BaseWorldSystem
 
         for (var i = 0; i < comp.FloorPlacements; i++)
         {
-            var point = _random.Pick(spawnPoints);
+            var point = _random.PickSlow(spawnPoints);
             PlaceTile(point);
 
             if (comp.BlobDrawProb > 0.0f)

--- a/Content.Shared/Destructible/Thresholds/MinMax.cs
+++ b/Content.Shared/Destructible/Thresholds/MinMax.cs
@@ -21,9 +21,4 @@ public partial struct MinMax
     {
         return random.Next(Min, Max + 1);
     }
-
-    public readonly int Next(System.Random random)
-    {
-        return random.Next(Min, Max + 1);
-    }
 }

--- a/Content.Shared/EntityTable/EntitySelectors/AllSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/AllSelector.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 
 namespace Content.Shared.EntityTable.EntitySelectors;
 
@@ -11,7 +12,7 @@ public sealed partial class AllSelector : EntityTableSelector
     [DataField(required: true)]
     public List<EntityTableSelector> Children;
 
-    protected override IEnumerable<EntProtoId> GetSpawnsImplementation(System.Random rand,
+    protected override IEnumerable<EntProtoId> GetSpawnsImplementation(IRobustRandom rand,
         IEntityManager entMan,
         IPrototypeManager proto,
         EntityTableContext ctx)

--- a/Content.Shared/EntityTable/EntitySelectors/EntSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/EntSelector.cs
@@ -1,5 +1,6 @@
 using Content.Shared.EntityTable.ValueSelector;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 
 namespace Content.Shared.EntityTable.EntitySelectors;
 
@@ -16,7 +17,7 @@ public sealed partial class EntSelector : EntityTableSelector
     [DataField]
     public NumberSelector Amount = new ConstantNumberSelector(1);
 
-    protected override IEnumerable<EntProtoId> GetSpawnsImplementation(System.Random rand,
+    protected override IEnumerable<EntProtoId> GetSpawnsImplementation(IRobustRandom rand,
         IEntityManager entMan,
         IPrototypeManager proto,
         EntityTableContext ctx)

--- a/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
@@ -26,7 +26,7 @@ public abstract partial class EntityTableSelector
     /// A simple chance that the selector will run.
     /// </summary>
     [DataField]
-    public double Prob = 1;
+    public float Prob = 1;
 
     /// <summary>
     /// A list of conditions that must evaluate to 'true' for the selector to apply.
@@ -41,7 +41,7 @@ public abstract partial class EntityTableSelector
     [DataField]
     public bool RequireAll = true;
 
-    public IEnumerable<EntProtoId> GetSpawns(System.Random rand,
+    public IEnumerable<EntProtoId> GetSpawns(IRobustRandom rand,
         IEntityManager entMan,
         IPrototypeManager proto,
         EntityTableContext ctx)
@@ -112,7 +112,7 @@ public abstract partial class EntityTableSelector
         }
     }
 
-    protected abstract IEnumerable<EntProtoId> GetSpawnsImplementation(System.Random rand,
+    protected abstract IEnumerable<EntProtoId> GetSpawnsImplementation(IRobustRandom rand,
         IEntityManager entMan,
         IPrototypeManager proto,
         EntityTableContext ctx);

--- a/Content.Shared/EntityTable/EntitySelectors/GroupSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/GroupSelector.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Shared.Random.Helpers;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 
 namespace Content.Shared.EntityTable.EntitySelectors;
 
@@ -12,7 +13,7 @@ public sealed partial class GroupSelector : EntityTableSelector
     [DataField(required: true)]
     public List<EntityTableSelector> Children = new();
 
-    protected override IEnumerable<EntProtoId> GetSpawnsImplementation(System.Random rand,
+    protected override IEnumerable<EntProtoId> GetSpawnsImplementation(IRobustRandom rand,
         IEntityManager entMan,
         IPrototypeManager proto,
         EntityTableContext ctx)
@@ -30,7 +31,7 @@ public sealed partial class GroupSelector : EntityTableSelector
         if (children.Count == 0)
             return Array.Empty<EntProtoId>();
 
-        var pick = SharedRandomExtensions.Pick(children, rand);
+        var pick = rand.Pick(children);
 
         return pick.GetSpawns(rand, entMan, proto, ctx);
     }

--- a/Content.Shared/EntityTable/EntitySelectors/NestedSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/NestedSelector.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 
 namespace Content.Shared.EntityTable.EntitySelectors;
 
@@ -11,7 +12,7 @@ public sealed partial class NestedSelector : EntityTableSelector
     [DataField(required: true)]
     public ProtoId<EntityTablePrototype> TableId;
 
-    protected override IEnumerable<EntProtoId> GetSpawnsImplementation(System.Random rand,
+    protected override IEnumerable<EntProtoId> GetSpawnsImplementation(IRobustRandom rand,
         IEntityManager entMan,
         IPrototypeManager proto,
         EntityTableContext ctx)

--- a/Content.Shared/EntityTable/EntitySelectors/NoneSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/NoneSelector.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 
 namespace Content.Shared.EntityTable.EntitySelectors;
 
@@ -7,7 +8,7 @@ namespace Content.Shared.EntityTable.EntitySelectors;
 /// </summary>
 public sealed partial class NoneSelector : EntityTableSelector
 {
-    protected override IEnumerable<EntProtoId> GetSpawnsImplementation(System.Random rand,
+    protected override IEnumerable<EntProtoId> GetSpawnsImplementation(IRobustRandom rand,
         IEntityManager entMan,
         IPrototypeManager proto,
         EntityTableContext ctx)

--- a/Content.Shared/EntityTable/EntityTableSystem.cs
+++ b/Content.Shared/EntityTable/EntityTableSystem.cs
@@ -11,18 +11,18 @@ public sealed class EntityTableSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
-    public IEnumerable<EntProtoId> GetSpawns(EntityTablePrototype entTableProto, System.Random? rand = null, EntityTableContext? ctx = null)
+    public IEnumerable<EntProtoId> GetSpawns(EntityTablePrototype entTableProto, IRobustRandom? rand = null, EntityTableContext? ctx = null)
     {
         // convenient
         return GetSpawns(entTableProto.Table, rand, ctx);
     }
 
-    public IEnumerable<EntProtoId> GetSpawns(EntityTableSelector? table, System.Random? rand = null, EntityTableContext? ctx = null)
+    public IEnumerable<EntProtoId> GetSpawns(EntityTableSelector? table, IRobustRandom? rand = null, EntityTableContext? ctx = null)
     {
         if (table == null)
             return new List<EntProtoId>();
 
-        rand ??= _random.GetRandom();
+        rand ??= _random;
         ctx ??= new EntityTableContext();
         return table.GetSpawns(rand, EntityManager, _prototypeManager, ctx);
     }

--- a/Content.Shared/EntityTable/ValueSelector/BinomialNumberSelector.cs
+++ b/Content.Shared/EntityTable/ValueSelector/BinomialNumberSelector.cs
@@ -22,14 +22,13 @@ public sealed partial class BinomialNumberSelector : NumberSelector
     [DataField]
     public float Chance = .5f;
 
-    public override int Get(System.Random rand)
+    public override int Get(IRobustRandom rand)
     {
-        var random = IoCManager.Resolve<IRobustRandom>();
         int count = 0;
 
         for (int i = 0; i < Trials; i++)
         {
-            if (random.Prob(Chance))
+            if (rand.Prob(Chance))
                 count++;
         }
         return count;

--- a/Content.Shared/EntityTable/ValueSelector/ConstantNumberSelector.cs
+++ b/Content.Shared/EntityTable/ValueSelector/ConstantNumberSelector.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Random;
+
 namespace Content.Shared.EntityTable.ValueSelector;
 
 /// <summary>
@@ -13,7 +15,7 @@ public sealed partial class ConstantNumberSelector : NumberSelector
         Value = value;
     }
 
-    public override int Get(System.Random rand)
+    public override int Get(IRobustRandom rand)
     {
         return Value;
     }

--- a/Content.Shared/EntityTable/ValueSelector/NumberSelector.cs
+++ b/Content.Shared/EntityTable/ValueSelector/NumberSelector.cs
@@ -1,5 +1,6 @@
 using Content.Shared.EntityTable.EntitySelectors;
 using JetBrains.Annotations;
+using Robust.Shared.Random;
 
 namespace Content.Shared.EntityTable.ValueSelector;
 
@@ -9,7 +10,7 @@ namespace Content.Shared.EntityTable.ValueSelector;
 [ImplicitDataDefinitionForInheritors, UsedImplicitly(ImplicitUseTargetFlags.WithInheritors)]
 public abstract partial class NumberSelector
 {
-    public abstract int Get(System.Random rand);
+    public abstract int Get(IRobustRandom rand);
 
     /// <summary>
     /// Odds of occurrence

--- a/Content.Shared/EntityTable/ValueSelector/RangeNumberSelector.cs
+++ b/Content.Shared/EntityTable/ValueSelector/RangeNumberSelector.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Random;
+
 namespace Content.Shared.EntityTable.ValueSelector;
 
 /// <summary>
@@ -13,7 +15,7 @@ public sealed partial class RangeNumberSelector : NumberSelector
         Range = range;
     }
 
-    public override int Get(System.Random rand)
+    public override int Get(IRobustRandom rand)
     {
         // rand.Next() is inclusive on the first number and exclusive on the second number,
         // so we add 1 to the second number.

--- a/Content.Shared/Light/EntitySystems/UnpoweredFlashlightSystem.cs
+++ b/Content.Shared/Light/EntitySystems/UnpoweredFlashlightSystem.cs
@@ -88,7 +88,7 @@ public sealed class UnpoweredFlashlightSystem : EntitySystem
 
         if (_prototypeManager.Resolve(component.EmaggedColorsPrototype, out var possibleColors))
         {
-            var pick = _random.Pick(possibleColors.Colors.Values);
+            var pick = _random.PickSlow(possibleColors.Colors.Values);
             _light.SetColor(uid, pick, light);
         }
 

--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -22,7 +22,7 @@ public sealed class TileSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IMapManager _mapManager = default!;
-    [Dependency] private readonly IRobustRandom _robustRandom = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ITileDefinitionManager _tileDefinitionManager = default!;
     [Dependency] private readonly SharedDecalSystem _decal = default!;
     [Dependency] private readonly SharedMapSystem _maps = default!;
@@ -105,22 +105,13 @@ public sealed class TileSystem : EntitySystem
     /// </summary>
     public byte PickVariant(ContentTileDefinition tile)
     {
-        return PickVariant(tile, _robustRandom.GetRandom());
+        return PickVariant(tile, _random);
     }
 
     /// <summary>
     ///     Returns a weighted pick of a tile variant.
     /// </summary>
-    public byte PickVariant(ContentTileDefinition tile, int seed)
-    {
-        var rand = new System.Random(seed);
-        return PickVariant(tile, rand);
-    }
-
-    /// <summary>
-    ///     Returns a weighted pick of a tile variant.
-    /// </summary>
-    public byte PickVariant(ContentTileDefinition tile, System.Random random)
+    public byte PickVariant(ContentTileDefinition tile, IRobustRandom random)
     {
         var variants = tile.PlacementVariants;
 
@@ -143,18 +134,9 @@ public sealed class TileSystem : EntitySystem
     /// <summary>
     ///     Returns a tile with a weighted random variant.
     /// </summary>
-    public Tile GetVariantTile(ContentTileDefinition tile, System.Random random)
+    public Tile GetVariantTile(ContentTileDefinition tile, IRobustRandom random)
     {
         return new Tile(tile.TileId, variant: PickVariant(tile, random));
-    }
-
-    /// <summary>
-    ///     Returns a tile with a weighted random variant.
-    /// </summary>
-    public Tile GetVariantTile(ContentTileDefinition tile, int seed)
-    {
-        var rand = new System.Random(seed);
-        return new Tile(tile.TileId, variant: PickVariant(tile, rand));
     }
 
     public bool PryTile(Vector2i indices, EntityUid gridId)
@@ -268,8 +250,8 @@ public sealed class TileSystem : EntitySystem
         var indices = tileRef.GridIndices;
         var coordinates = _maps.GridTileToLocal(gridUid, mapGrid, indices)
             .Offset(new Vector2(
-                (_robustRandom.NextFloat() - 0.5f) * bounds,
-                (_robustRandom.NextFloat() - 0.5f) * bounds));
+                (_random.NextFloat() - 0.5f) * bounds,
+                (_random.NextFloat() - 0.5f) * bounds));
 
         var historyComp = EnsureComp<TileHistoryComponent>(gridUid);
         ProtoId<ContentTileDefinition> previousTileId;
@@ -308,7 +290,7 @@ public sealed class TileSystem : EntitySystem
         {
             //Actually spawn the relevant tile item at the right position and give it some random offset.
             var tileItem = Spawn(tileDef.ItemDropPrototypeName, coordinates);
-            Transform(tileItem).LocalRotation = _robustRandom.NextDouble() * Math.Tau;
+            Transform(tileItem).LocalRotation = _random.NextDouble() * Math.Tau;
         }
 
         //Destroy any decals on the tile

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -637,7 +637,7 @@ public abstract partial class SharedMindSystem : EntitySystem
         if (_pickingMinds.Count == 0)
             return null;
 
-        return _random.Pick(_pickingMinds);
+        return _random.PickSlow(_pickingMinds);
     }
 
     /// <summary>

--- a/Content.Shared/Parallax/Biomes/SharedBiomeSystem.cs
+++ b/Content.Shared/Parallax/Biomes/SharedBiomeSystem.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Noise;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
 
@@ -179,7 +180,8 @@ public abstract class SharedBiomeSystem : EntitySystem
         if (variantCount > 1)
         {
             var variantValue = (noise.GetNoise(indices.X * 8, indices.Y * 8, variantCount) + 1f) * 100;
-            variant = _tile.PickVariant(tileDef, (int)variantValue);
+            var rng = new RobustRandom((int)variantValue);
+            variant = _tile.PickVariant(tileDef, rng);
         }
 
         tile = new Tile(tileDef.TileId, variant);

--- a/Content.Shared/Procedural/PostGeneration/WallMountDunGen.cs
+++ b/Content.Shared/Procedural/PostGeneration/WallMountDunGen.cs
@@ -14,7 +14,7 @@ public sealed partial class WallMountDunGen : IDunGenLayer
     /// Chance per free tile to spawn a wallmount.
     /// </summary>
     [DataField]
-    public double Prob = 0.1;
+    public float Prob = 0.1f;
 
     [DataField(required: true)]
     public ProtoId<ContentTileDefinition> Tile;

--- a/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
+++ b/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
@@ -23,28 +23,6 @@ namespace Content.Shared.Random.Helpers
             return Loc.GetString(prototype.Values[index]);
         }
 
-        public static string Pick(this IWeightedRandomPrototype prototype, System.Random random)
-        {
-            var picks = prototype.Weights;
-            var sum = picks.Values.Sum();
-            var accumulated = 0f;
-
-            var rand = random.NextFloat() * sum;
-
-            foreach (var (key, weight) in picks)
-            {
-                accumulated += weight;
-
-                if (accumulated >= rand)
-                {
-                    return key;
-                }
-            }
-
-            // Shouldn't happen
-            throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
-        }
-
         public static string Pick(this IWeightedRandomPrototype prototype, IRobustRandom? random = null)
         {
             IoCManager.Resolve(ref random);
@@ -107,27 +85,6 @@ namespace Content.Shared.Random.Helpers
             }
             pick = PickAndTake(random, weights);
             return true;
-        }
-
-        public static T Pick<T>(Dictionary<T, float> weights, System.Random random)
-            where T : notnull
-        {
-            var sum = weights.Values.Sum();
-            var accumulated = 0f;
-
-            var rand = random.NextFloat() * sum;
-
-            foreach (var (key, weight) in weights)
-            {
-                accumulated += weight;
-
-                if (accumulated >= rand)
-                {
-                    return key;
-                }
-            }
-
-            throw new InvalidOperationException("Invalid weighted pick");
         }
 
         public static (string reagent, FixedPoint2 quantity) Pick(this WeightedRandomFillSolutionPrototype prototype, IRobustRandom? random = null)
@@ -214,7 +171,7 @@ namespace Content.Shared.Random.Helpers
 
         // TODO: REPLACE ALL OF THIS WITH PREDICTED RANDOM WHEN ENGINE PR IS MERGED
         /// <summary>
-        /// Creates an instance of System.Random that will be the same for both the server and client.
+        /// Creates an instance of IRobustRandom that will be the same for both the server and client.
         /// This allows for the client and server to roll the same results when determining things randomly, preventing mispredictions.
         /// We generate a unique seed by getting 2-3 unique but predictable integers into a Hashcode.
         /// </summary>
@@ -225,10 +182,11 @@ namespace Content.Shared.Random.Helpers
         /// <param name="netEnt2">An optional relevant net entity to our seed.
         /// Typically used if we have an entity checking random potentially multiple times per tick, to ensure we get a unique seed each time.
         /// This entity should not be the same entity as <see cref="netEnt"/>.</param>
-        public static System.Random PredictedRandom(IGameTiming timing, NetEntity netEnt, NetEntity? netEnt2 = null)
+        public static IRobustRandom PredictedRandom(IGameTiming timing, NetEntity netEnt, NetEntity? netEnt2 = null)
         {
             var seed = HashCodeCombine((int)timing.CurTick.Value, netEnt.Id, netEnt2?.Id ?? 0);
-            return new System.Random(seed);
+            var random = new RobustRandom(seed);
+            return random;
         }
 
         /// <summary>

--- a/Content.Shared/Random/RandomSystem.cs
+++ b/Content.Shared/Random/RandomSystem.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Random;
 
 public sealed class RandomSystem : EntitySystem
 {
-    public IBudgetEntry? GetBudgetEntry(ref float budget, ref float probSum, IList<IBudgetEntry> entries, System.Random random)
+    public IBudgetEntry? GetBudgetEntry(ref float budget, ref float probSum, IList<IBudgetEntry> entries, IRobustRandom random)
     {
         DebugTools.Assert(budget > 0f);
 
@@ -39,7 +39,7 @@ public sealed class RandomSystem : EntitySystem
     /// <summary>
     /// Gets a random entry based on each entry having a different probability.
     /// </summary>
-    public IProbEntry GetProbEntry(IEnumerable<IProbEntry> entries, float probSum, System.Random random)
+    public IProbEntry GetProbEntry(IEnumerable<IProbEntry> entries, float probSum, IRobustRandom random)
     {
         var value = random.NextFloat() * probSum;
 

--- a/Content.Shared/Research/TechnologyDisk/Systems/TechnologyDiskSystem.cs
+++ b/Content.Shared/Research/TechnologyDisk/Systems/TechnologyDiskSystem.cs
@@ -56,7 +56,7 @@ public sealed class TechnologyDiskSystem : EntitySystem
 
         //pick one
         ent.Comp.Recipes = [];
-        ent.Comp.Recipes.Add(_random.Pick(techs));
+        ent.Comp.Recipes.Add(_random.PickSlow(techs));
         Dirty(ent);
         _nameModifier.RefreshNameModifiers(ent.Owner);
     }

--- a/Content.Shared/Salvage/SharedSalvageSystem.Magnet.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.Magnet.cs
@@ -40,9 +40,9 @@ public abstract partial class SharedSalvageSystem
 
     public ISalvageMagnetOffering GetSalvageOffering(int seed)
     {
-        var rand = new System.Random(seed);
+        var rand = new RobustRandom(seed);
 
-        var type = SharedRandomExtensions.Pick(_offeringWeights, rand);
+        var type = rand.Pick(_offeringWeights);
         switch (type)
         {
             case AsteroidOffering:

--- a/Content.Shared/Salvage/SharedSalvageSystem.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.cs
@@ -25,17 +25,18 @@ public abstract partial class SharedSalvageSystem : EntitySystem
     /// </summary>
     public static readonly ProtoId<SalvageLootPrototype> ExpeditionsLootProto = "SalvageLoot";
 
+    // TODO(Kaylie): Replace this with RngSeed once it's in engine.
     public string GetFTLName(LocalizedDatasetPrototype dataset, int seed)
     {
-        var random = new System.Random(seed);
+        var random = new RobustRandom(seed);
         return $"{Loc.GetString(dataset.Values[random.Next(dataset.Values.Count)])}-{random.Next(10, 100)}-{(char) (65 + random.Next(26))}";
     }
 
     public SalvageMission GetMission(SalvageDifficultyPrototype difficulty, int seed)
     {
+        var rand = new RobustRandom(seed);
         // This is on shared to ensure the client display for missions and what the server generates are consistent
         var modifierBudget = difficulty.ModifierBudget;
-        var rand = new System.Random(seed);
 
         // Run budget in order of priority
         // - Biome
@@ -73,7 +74,7 @@ public abstract partial class SharedSalvageSystem : EntitySystem
         return new SalvageMission(seed, dungeon.ID, faction.ID, biome.ID, air.ID, temp.Temperature, light.Color, duration, mods);
     }
 
-    public T GetBiomeMod<T>(string biome, System.Random rand, ref float rating) where T : class, IPrototype, IBiomeSpecificMod
+    public T GetBiomeMod<T>(string biome, IRobustRandom rand, ref float rating) where T : class, IPrototype, IBiomeSpecificMod
     {
         var mods = _proto.EnumeratePrototypes<T>().ToList();
         mods.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal));
@@ -92,7 +93,7 @@ public abstract partial class SharedSalvageSystem : EntitySystem
         throw new InvalidOperationException();
     }
 
-    public T GetMod<T>(System.Random rand, ref float rating) where T : class, IPrototype, ISalvageMod
+    public T GetMod<T>(IRobustRandom rand, ref float rating) where T : class, IPrototype, ISalvageMod
     {
         var mods = _proto.EnumeratePrototypes<T>().ToList();
         mods.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal));

--- a/Content.Shared/Storage/EntitySpawnEntry.cs
+++ b/Content.Shared/Storage/EntitySpawnEntry.cs
@@ -82,12 +82,6 @@ public static class EntitySpawnCollection
         return GetSpawns(protoManager.Index(proto).Entries, random);
     }
 
-    public static List<string?> GetSpawns(ProtoId<EntitySpawnEntryPrototype> proto, System.Random random, IPrototypeManager? protoManager = null)
-    {
-        IoCManager.Resolve(ref protoManager);
-        return GetSpawns(protoManager.Index(proto).Entries, random);
-    }
-
     /// <summary>
     ///     Using a collection of entity spawn entries, picks a random list of entity prototypes to spawn from that collection.
     /// </summary>
@@ -155,71 +149,6 @@ public static class EntitySpawnCollection
         }
 
         return spawned;
-    }
-
-    public static List<string?> GetSpawns(IEnumerable<EntitySpawnEntry> entries,
-        System.Random random)
-    {
-        var spawned = new List<string?>();
-        var ungrouped = CollectOrGroups(entries, out var orGroupedSpawns);
-
-        foreach (var entry in ungrouped)
-        {
-            // Check random spawn
-            // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (entry.SpawnProbability != 1f && !random.Prob(entry.SpawnProbability))
-                continue;
-
-            var amount = (int) entry.GetAmount(random);
-
-            for (var i = 0; i < amount; i++)
-            {
-                spawned.Add(entry.PrototypeId);
-            }
-        }
-
-        // Handle OrGroup spawns
-        foreach (var spawnValue in orGroupedSpawns)
-        {
-            // For each group use the added cumulative probability to roll a double in that range
-            var diceRoll = random.NextDouble() * spawnValue.CumulativeProbability;
-
-            // Add the entry's spawn probability to this value, if equals or lower, spawn item, otherwise continue to next item.
-            var cumulative = 0.0;
-
-            foreach (var entry in spawnValue.Entries)
-            {
-                cumulative += entry.SpawnProbability;
-                if (diceRoll > cumulative)
-                    continue;
-
-                // Dice roll succeeded, add item and break loop
-                var amount = (int) entry.GetAmount(random);
-
-                for (var i = 0; i < amount; i++)
-                {
-                    spawned.Add(entry.PrototypeId);
-                }
-
-                break;
-            }
-        }
-
-        return spawned;
-    }
-
-    public static double GetAmount(this EntitySpawnEntry entry, System.Random random, bool getAverage = false)
-    {
-        // Max amount is less or equal than amount, so just return the amount
-        if (entry.MaxAmount <= entry.Amount)
-            return entry.Amount;
-
-        // If we want the average, just calculate the expected amount
-        if (getAverage)
-            return (entry.Amount + entry.MaxAmount) / 2.0;
-
-        // Otherwise get a random value in between
-        return random.Next(entry.Amount, entry.MaxAmount);
     }
 
     /// <summary>

--- a/Content.Shared/StoryGen/EntitySystems/StoryGeneratorSystem.cs
+++ b/Content.Shared/StoryGen/EntitySystems/StoryGeneratorSystem.cs
@@ -30,9 +30,13 @@ public sealed partial class StoryGeneratorSystem : EntitySystem
             return false;
         }
 
+        IRobustRandom rng;
+
         // If given a seed, use it
         if (seed != null)
-            _random.SetSeed(seed.Value);
+            rng = new RobustRandom(seed.Value);
+        else
+            rng = _random;
 
         // Pick values for all of the variables in the template
         var variables = new ValueList<(string, object)>(templateProto.Variables.Count);
@@ -43,7 +47,7 @@ public sealed partial class StoryGeneratorSystem : EntitySystem
                 continue; // Missed one, but keep going with the rest of the story
 
             // Pick a random word from the dataset and localize it
-            var chosenWord = Loc.GetString(_random.Pick(listProto.Values));
+            var chosenWord = Loc.GetString(rng.Pick(listProto.Values));
             variables.Add((name, chosenWord));
         }
 

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -127,7 +127,7 @@ public abstract class SharedPortalSystem : EntitySystem
                 return;
 
             // pick a target and teleport there
-            var target = _random.Pick(link.LinkedEntities);
+            var target = _random.PickSlow(link.LinkedEntities);
 
             if (HasComp<PortalComponent>(target))
             {

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Maps;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
+using Content.Shared.Random.Helpers;
 using Content.Shared.Stacks;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -196,7 +197,7 @@ public sealed class FloorTileSystem : EntitySystem
         _adminLogger.Add(LogType.Tile, LogImpact.Low, $"{ToPrettyString(user):actor} placed tile {_tileDefinitionManager[tileId].Name} at {ToPrettyString(gridUid)} {location}");
 
         var tileDef = (ContentTileDefinition) _tileDefinitionManager[tileId];
-        var random = new System.Random((int)_timing.CurTick.Value);
+        var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(user));
         var variant = _tile.PickVariant(tileDef, random);
 
         var tileRef = _map.GetTileRef(gridUid, mapGrid, location.Offset(new Vector2(offset, offset)));


### PR DESCRIPTION
This is a cleanup PR, System.Random is already obsolete in engine and this allows me to simply remove those APIs entirely.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes obsoleted method usages to match cleanup PR on the engine side. Should be merged after that PR is. Requires https://github.com/space-wizards/RobustToolbox/pull/6422

## Why / Balance
N/A

## Technical details
tl;dr this is a simple cleanup. A bunch of RNG APIs were duplicated for `System.Random` instead of engine's built-in RNG and this made a big mess. This undoes everything I could find that made sense to change.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A