### PR TITLE
Slimes can go under doors

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -19,7 +19,7 @@
           radius: 0.30
         density: 80
         mask:
-        - MobMask
+        - SmallMobMask
         layer:
         - MobLayer
   - type: MobThresholds


### PR DESCRIPTION
## About the PR
Simple 1 Line Change
-changes slimes (reagent, vent critter, and Smile) to have smallmobmask. let's them go under doors

## Why / Balance
Spider Vent Antags have the ability to pull, make webs, AND pry doors. Seeing a critter event as a ghost and seeing it was Slimes instead of Spiders really sucks, because you know they're so lame to play.
This doesn't fix all their issues, but it brings them closer in line in round impact to spiders, and lets them do some unique antaggery spiders can't.

🆑
-tweak: Slime Mobs can now go under doors like mice.