### PR TITLE
EMP implant uplink texture (Addresses #42008)

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1449,7 +1449,7 @@
   id: UplinkEmpImplanter
   name: uplink-emp-implanter-name
   description: uplink-emp-implanter-desc
-  icon: { sprite: /Textures/Objects/Magic/magicactions.rsi, state: shield }
+  icon: { sprite: /Textures/Effects/emp.rsi, state: emp_disable }
   productEntity: EmpImplanter
   discountCategory: veryRareDiscounts
   discountDownTo:


### PR DESCRIPTION
## About the PR
Changes the EMP Implanter in the Nuclear Operative uplink to a texture harder to confuse with the Scram Implanter's.

## Why / Balance
It makes things clearer; see #42008.
Resolves #42008 

## Technical details
Simple YAML change in `Resources/Prototypes/Catalog/uplink_catalog.yml`

## Media
Before:
<img width="379" height="275" alt="Before" src="https://github.com/user-attachments/assets/d8df9155-bdbc-419e-aa2c-9b06a0f87e72" />
After:
<img width="379" height="275" alt="After" src="https://github.com/user-attachments/assets/f4f0728b-084b-497f-bec8-d3b160d626ea" />


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes
*Probably* none.

**Changelog**
:cl:
 - tweak: Changed the EMP Implanter's uplink icon so it is less easily confused with the Scram Implanter's.
