### PR TITLE
Added the ability to hold the use key

### DIFF
--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -120,9 +120,9 @@ namespace Content.Client.Hands.Systems
         }
 
         /// <summary>
-        ///     Called when a user clicked on their hands GUI
+        ///     Called when a user used the use key on their hands GUI
         /// </summary>
-        public void UIHandClick(Entity<HandsComponent> ent, string handName)
+        public void UIHandUse(Entity<HandsComponent> ent, string handName, bool utilityInteraction = false)
         {
             var hands = ent.Comp;
             if (hands.ActiveHandId == null)
@@ -149,7 +149,7 @@ namespace Content.Client.Hands.Systems
             if (handName != hands.ActiveHandId && pressedEntity != null && activeEntity != null)
             {
                 // use active item on held item
-                RaisePredictiveEvent(new RequestHandInteractUsingEvent(handName));
+                RaisePredictiveEvent(new RequestHandInteractUsingEvent(handName, utilityInteraction));
                 return;
             }
 

--- a/Content.Client/Interactable/InteractionSystem.cs
+++ b/Content.Client/Interactable/InteractionSystem.cs
@@ -1,9 +1,119 @@
+using Content.Client.CombatMode;
+using Content.Client.Verbs;
 using Content.Shared.Interaction;
-using Content.Shared.Storage;
-using Robust.Shared.Containers;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Verbs;
+using Robust.Client.GameObjects;
+using Robust.Client.Player;
+using Robust.Shared.Input;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
 
-namespace Content.Client.Interactable
+namespace Content.Client.Interactable;
+
+/// <summary>
+/// This handles the logic whether an interaction was done by holding or pressing the Use key (Default: Left Click)
+/// </summary>
+public sealed class InteractionSystem : SharedInteractionSystem
 {
-    // TODO Remove Shared prefix
-    public sealed class InteractionSystem : SharedInteractionSystem;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly CombatModeSystem _combat = default!;
+    [Dependency] private readonly InputSystem _input = default!;
+    [Dependency] private readonly VerbSystem _verb = default!;
+
+    // This timespan will be added onto the time of a buttonpress to determine when it turns into a held button press.
+    private readonly TimeSpan RequiredButtonHeldTime = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    /// screen pos where the mouse down began for the drag
+    /// </summary>
+    private EntityCoordinates _mouseDownScreenPos;
+    private EntityUid _target;
+    private TimeSpan _threshold;
+    private bool _pressed;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        // UpdatesOutsidePrediction = true;
+        CommandBinds.Builder
+            .Bind(EngineKeyFunctions.Use,
+            new PointerInputCmdHandler(OnUse, false, true))
+            .Register<InteractionSystem>();
+    }
+
+    private bool OnUse(in PointerInputCmdHandler.PointerInputCmdArgs args)
+    {
+        if (_input.Predicted)
+            return false;
+
+        switch (args.State)
+        {
+            case BoundKeyState.Down:
+                _threshold = _timing.CurTime + RequiredButtonHeldTime;
+                _target = args.EntityUid;
+                _mouseDownScreenPos = args.Coordinates;
+                _pressed = true;
+                // If the player is in combat or has no utility verbs, do not check for held inputs.
+                if (NoVerbsOrInCombat())
+                    RaiseNonUtilityEvent(); // This will also reset _pressed to false, so no double dipping.
+
+                return true;
+            case BoundKeyState.Up:
+                if (!_pressed)
+                    return false;
+
+                RaiseNonUtilityEvent();
+                return true;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    private bool NoVerbsOrInCombat()
+    {
+        if (_combat.IsInCombatMode(_player.LocalEntity) || _player.LocalEntity == null)
+            return true;
+
+        var verb = _verb.GetLocalVerbs(_target, _player.LocalEntity.Value, typeof(UtilityVerb));
+        return verb.Count == 0;
+    }
+
+    private void RaiseNonUtilityEvent()
+    {
+        if (_player.LocalEntity == null)
+            return;
+
+        _pressed = false;
+        var ev = new InteractionRequestEvent(
+            GetNetEntity(_player.LocalEntity.Value),
+            GetNetEntity(_target),
+            GetNetEntity(_mouseDownScreenPos.EntityId),
+            _mouseDownScreenPos.Position,
+            false);
+
+        RaisePredictiveEvent(ev);
+    }
+
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        // When the timer reaches the threshold for holding the input, it'll automatically fire off the event.
+        if (!_pressed || !_timing.IsFirstTimePredicted || _timing.CurTime < _threshold || _player.LocalEntity == null)
+            return;
+
+        var ev = new InteractionRequestEvent(
+            GetNetEntity(_player.LocalEntity.Value),
+            GetNetEntity(_target),
+            GetNetEntity(_mouseDownScreenPos.EntityId),
+            _mouseDownScreenPos.Position,
+            true);
+
+        RaisePredictiveEvent(ev);
+        _pressed = false;
+    }
 }
+

--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Client.CombatMode;
 using Content.Client.Gameplay;
+using Content.Client.Interactable;
 using Content.Client.Outline;
 using Content.Shared.ActionBlocker;
 using Content.Shared.CCVar;
@@ -115,7 +116,7 @@ public sealed class DragDropSystem : SharedDragDropSystem
         _dropTargetOutOfRangeShader = _prototypeManager.Index(ShaderDropTargetOutOfRange).Instance();
         // needs to fire on mouseup and mousedown so we can detect a drag / drop
         CommandBinds.Builder
-            .BindBefore(EngineKeyFunctions.Use, new PointerInputCmdHandler(OnUse, false, true), new[] { typeof(SharedInteractionSystem) })
+            .BindBefore(EngineKeyFunctions.Use, new PointerInputCmdHandler(OnUse, false, true), typeof(InteractionSystem))
             .Register<DragDropSystem>();
     }
 

--- a/Content.Client/Inventory/ClientInventorySystem.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.cs
@@ -194,9 +194,9 @@ namespace Content.Client.Inventory
             return true;
         }
 
-        public void UIInventoryActivate(string slot)
+        public void UIInventoryActivate(string slot, bool heldInteraction = false)
         {
-            RaisePredictiveEvent(new UseSlotNetworkMessage(slot));
+            RaisePredictiveEvent(new UseSlotNetworkMessage(slot, heldInteraction));
         }
 
         public void UIInventoryStorageActivate(string slot)

--- a/Content.Client/UserInterface/Systems/Hands/HandsUIController.cs
+++ b/Content.Client/UserInterface/Systems/Hands/HandsUIController.cs
@@ -21,6 +21,7 @@ public sealed class HandsUIController : UIController, IOnStateEntered<GameplaySt
 {
     [Dependency] private readonly IEntityManager _entities = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     [UISystemDependency] private readonly HandsSystem _handsSystem = default!;
     [UISystemDependency] private readonly UseDelaySystem _useDelay = default!;
@@ -35,6 +36,15 @@ public sealed class HandsUIController : UIController, IOnStateEntered<GameplaySt
     // ("middle" hands are hardcoded as right, whatever)
     private HandButton? _statusHandLeft;
     private HandButton? _statusHandRight;
+
+    // This timespan will be added onto the time of a buttonpress to determine when it turns into a held button press.
+    private readonly TimeSpan RequiredButtonHeldTime = TimeSpan.FromMilliseconds(500);
+    // This is the threshold that will hold the above value.
+    private TimeSpan _threshold;
+    // These values act as storage for when the click is finalized.
+    private string _pressedSlot = default!;
+    private Entity<HandsComponent>? _usedHand;
+    private bool _useKeyPressed;
 
     private HotbarGui? HandsGui => UIManager.GetActiveUIWidgetOrNull<HotbarGui>();
 
@@ -83,10 +93,37 @@ public sealed class HandsUIController : UIController, IOnStateEntered<GameplaySt
     {
         if (!_handsSystem.TryGetPlayerHands(out var hands))
             return;
-
-        if (args.Function == EngineKeyFunctions.UIClick)
+        // Save the time when it counts as a utility interaction.
+        _threshold = _timing.CurTime + RequiredButtonHeldTime;
+        // If they Use key was used, we want to see how long they'll press it.
+        if (args.Function == EngineKeyFunctions.Use)
         {
-            _handsSystem.UIHandClick(hands.Value, hand.SlotName);
+            _pressedSlot = hand.SlotName;
+            _useKeyPressed = true;
+            _usedHand = hands;
+
+            args.Handle();
+            return;
+        }
+        // For anything that isn't the use key, run the click as normal.
+        HandUnpressed(args, hand);
+    }
+
+    private void HandUnpressed(GUIBoundKeyEventArgs args, SlotControl hand)
+    {
+        if (args.State == BoundKeyState.Up && !_useKeyPressed)
+        {
+            args.Handle();
+            return;
+        }
+
+        if (!_handsSystem.TryGetPlayerHands(out var hands))
+            return;
+
+        if (args.Function == EngineKeyFunctions.Use)
+        {
+            _handsSystem.UIHandUse(hands.Value, hand.SlotName);
+            _useKeyPressed = false;
             args.Handle();
         }
         else if (args.Function == EngineKeyFunctions.UseSecondary)
@@ -285,6 +322,7 @@ public sealed class HandsUIController : UIController, IOnStateEntered<GameplaySt
         var button = new HandButton(handName, hand.Location);
         button.StoragePressed += StorageActivate;
         button.Pressed += HandPressed;
+        button.Unpressed += HandUnpressed;
 
         HandsGui?.HandContainer.TryAddButton(button);
 
@@ -378,6 +416,14 @@ public sealed class HandsUIController : UIController, IOnStateEntered<GameplaySt
             hand.CooldownDisplay.Visible = true;
             hand.CooldownDisplay.FromTime(delay.StartTime, delay.EndTime);
         }
+        // This is for holding the use input on hands.
+        // When the timer reaches the threshold for holding the input, it'll automatically fire off the event.
+        if (!_useKeyPressed || !_timing.IsFirstTimePredicted || _timing.CurTime < _threshold || !_usedHand.HasValue)
+            return;
+
+        DebugTools.Assert(!string.IsNullOrEmpty(_pressedSlot),"HandSlot name was not set when reaching the held interaction threshold.");
+        _handsSystem.UIHandUse(_usedHand.Value, _pressedSlot, true);
+        _useKeyPressed = false;
     }
 
     private void UpdateHandStatus(HandButton hand, EntityUid? entity, Hand? handData)

--- a/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
+++ b/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
@@ -21,6 +21,7 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using static Content.Client.Inventory.ClientInventorySystem;
 
@@ -30,10 +31,11 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
     IOnSystemChanged<ClientInventorySystem>, IOnSystemChanged<HandsSystem>
 {
     [Dependency] private readonly IEntityManager _entities = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     [UISystemDependency] private readonly ClientInventorySystem _inventorySystem = default!;
-    [UISystemDependency] private readonly HandsSystem _handsSystem = default!;
     [UISystemDependency] private readonly ContainerSystem _container = default!;
+    [UISystemDependency] private readonly HandsSystem _handsSystem = default!;
     [UISystemDependency] private readonly SpriteSystem _sprite = default!;
 
     private EntityUid? _playerUid;
@@ -43,6 +45,14 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
     private StrippingWindow? _strippingWindow;
     private ItemSlotButtonContainer? _inventoryHotbar;
     private SlotButton? _inventoryButton;
+
+    // This timespan will be added onto the time of a buttonpress to determine when it turns into a held button press.
+    private readonly TimeSpan RequiredButtonHeldTime = TimeSpan.FromMilliseconds(500);
+    // This is the threshold that will hold the above value.
+    private TimeSpan _threshold;
+    // These values act as storage for when the click is finalized.
+    private string _pressedSlot = default!;
+    private bool _useKeyPressed;
 
     private SlotControl? _lastHovered;
 
@@ -95,6 +105,7 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
     {
         var button = new SlotButton(data);
         button.Pressed += ItemPressed;
+        button.Unpressed += ItemUnpressed;
         button.StoragePressed += StoragePressed;
         button.Hover += SlotButtonHovered;
 
@@ -273,11 +284,35 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
 
     private void ItemPressed(GUIBoundKeyEventArgs args, SlotControl control)
     {
+        // Save the time when it counts as a utility interaction.
+        _threshold = _timing.CurTime + RequiredButtonHeldTime;
+        // If they Use key was used, we want to see how long they'll press it.
+        if (args.Function == EngineKeyFunctions.Use)
+        {
+            _pressedSlot = control.SlotName;
+            _useKeyPressed = true;
+
+            args.Handle();
+            return;
+        }
+        // For anything that isn't the use key, run the click as normal.
+        ItemUnpressed(args, control);
+    }
+
+    private void ItemUnpressed(GUIBoundKeyEventArgs args, SlotControl control)
+    {
+        if (args.State == BoundKeyState.Up && !_useKeyPressed)
+        {
+            args.Handle();
+            return;
+        }
+
         var slot = control.SlotName;
 
-        if (args.Function == EngineKeyFunctions.UIClick)
+        if (args.Function == EngineKeyFunctions.Use)
         {
             _inventorySystem.UIInventoryActivate(control.SlotName);
+            _useKeyPressed = false;
             args.Handle();
             return;
         }
@@ -493,5 +528,17 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
     {
         if (_lastHovered != null)
             UpdateHover(_lastHovered);
+    }
+
+    public override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+        // When the timer reaches the threshold for holding the input, it'll automatically fire off the event.
+        if (!_useKeyPressed || !_timing.IsFirstTimePredicted || _timing.CurTime < _threshold)
+            return;
+
+        DebugTools.Assert(!string.IsNullOrEmpty(_pressedSlot),"ItemSlot name was not set when reaching the held interaction threshold.");
+        _inventorySystem.UIInventoryActivate(_pressedSlot, true);
+        _useKeyPressed = false;
     }
 }

--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -1,6 +1,6 @@
 using Content.Shared.Interaction;
 
-namespace Content.Server.Interaction
-{
-    public sealed class InteractionSystem : SharedInteractionSystem;
-}
+namespace Content.Server.Interaction;
+
+public sealed class InteractionSystem : SharedInteractionSystem;
+

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
@@ -70,7 +70,7 @@ public abstract partial class SharedHandsSystem : EntitySystem
     private void HandleInteractUsingInHand(RequestHandInteractUsingEvent msg, EntitySessionEventArgs args)
     {
         if (args.SenderSession.AttachedEntity != null)
-            TryInteractHandWithActiveHand(args.SenderSession.AttachedEntity.Value, msg.HandName);
+            TryInteractHandWithActiveHand(args.SenderSession.AttachedEntity.Value, msg.HandName, utilityInteraction: msg.UtilityInteraction);
     }
 
     private void HandleHandAltInteract(RequestHandAltInteractEvent msg, EntitySessionEventArgs args)
@@ -132,7 +132,7 @@ public abstract partial class SharedHandsSystem : EntitySystem
         return _interactionSystem.InteractionActivate(uid, held.Value);
     }
 
-    public bool TryInteractHandWithActiveHand(EntityUid uid, string handName, HandsComponent? handsComp = null)
+    public bool TryInteractHandWithActiveHand(EntityUid uid, string handName, HandsComponent? handsComp = null, bool utilityInteraction = false)
     {
         if (!Resolve(uid, ref handsComp, false))
             return false;
@@ -143,7 +143,7 @@ public abstract partial class SharedHandsSystem : EntitySystem
         if (!TryGetHeldItem((uid, handsComp), handName, out var held))
             return false;
 
-        _interactionSystem.InteractUsing(uid, activeHeldItem.Value, held.Value, Transform(held.Value).Coordinates);
+        _interactionSystem.InteractUsing(uid, activeHeldItem.Value, held.Value, Transform(held.Value).Coordinates, utilityInteraction: utilityInteraction);
         return true;
     }
 

--- a/Content.Shared/Hands/HandEvents.cs
+++ b/Content.Shared/Hands/HandEvents.cs
@@ -303,9 +303,15 @@ namespace Content.Shared.Hands
     {
         public string HandName { get; }
 
-        public RequestHandInteractUsingEvent(string handName)
+        /// <summary>
+        /// Whether this interaction will use the utility interaction.
+        /// </summary>
+        public bool UtilityInteraction { get; }
+
+        public RequestHandInteractUsingEvent(string handName, bool utilityInteraction)
         {
             HandName = handName;
+            UtilityInteraction = utilityInteraction;
         }
     }
 

--- a/Content.Shared/Interaction/Events/InteractionRequestEvent.cs
+++ b/Content.Shared/Interaction/Events/InteractionRequestEvent.cs
@@ -1,0 +1,25 @@
+﻿using System.Numerics;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Interaction.Events;
+
+/// <summary>
+/// Raised on the client to the server requesting an interaction via the Use key.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class InteractionRequestEvent(NetEntity user, NetEntity target, NetEntity source, Vector2 vector, bool utilityInteraction) : EntityEventArgs
+{
+    public NetEntity User = user;
+    public NetEntity Target = target;
+
+    /// <summary>
+    /// This is the parent of the user. If they're on a grid, the grid UID is the source.
+    /// </summary>
+    public NetEntity Source = source;
+
+    /// <summary>
+    /// The vector is the position on said source. Both are used to reconstruct EntityCoordinates.
+    /// </summary>
+    public Vector2 Vector = vector;
+    public bool UtilityInteraction = utilityInteraction;
+}

--- a/Content.Shared/Interaction/InteractUsing.cs
+++ b/Content.Shared/Interaction/InteractUsing.cs
@@ -5,32 +5,31 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Interaction;
 
 /// <summary>
-///     Raised when a target entity is interacted with by a user while holding an object in their hand.
+/// The base interaction event.
 /// </summary>
-[PublicAPI]
-public sealed class InteractUsingEvent : HandledEntityEventArgs
+public abstract class BaseInteractionEvent : HandledEntityEventArgs
 {
     /// <summary>
-    ///     Entity that triggered the interaction.
+    /// Entity that triggered the interaction.
     /// </summary>
     public EntityUid User { get; }
 
     /// <summary>
-    ///     Entity that the user used to interact.
+    /// Entity that the user used to interact.
     /// </summary>
     public EntityUid Used { get; }
 
     /// <summary>
-    ///     Entity that was interacted on.
+    /// Entity that was interacted on.
     /// </summary>
     public EntityUid Target { get; }
 
     /// <summary>
-    ///     The original location that was clicked by the user.
+    /// The original location that was clicked by the user.
     /// </summary>
     public EntityCoordinates ClickLocation { get; }
 
-    public InteractUsingEvent(EntityUid user, EntityUid used, EntityUid target, EntityCoordinates clickLocation)
+    protected BaseInteractionEvent(EntityUid user, EntityUid used, EntityUid target, EntityCoordinates clickLocation)
     {
         // Interact using should not have the same used and target.
         // That should be a use-in-hand event instead.
@@ -45,42 +44,25 @@ public sealed class InteractUsingEvent : HandledEntityEventArgs
 }
 
 /// <summary>
-/// Raised when a user entity interacts with a target while holding an object in their hand.
+/// Raised when a target entity is interacted with by a user while holding an object in their hand.
+/// This will be raised on the target entity.
 /// </summary>
 [PublicAPI]
-public sealed class UserInteractUsingEvent : HandledEntityEventArgs
-{
-    /// <summary>
-    ///     Entity that triggered the interaction.
-    /// </summary>
-    public EntityUid User { get; }
+public sealed class InteractUsingEvent(
+    EntityUid user,
+    EntityUid used,
+    EntityUid target,
+    EntityCoordinates clickLocation)
+    : BaseInteractionEvent(user, used, target, clickLocation);
 
-    /// <summary>
-    ///     Entity that the user used to interact.
-    /// </summary>
-    public EntityUid Used { get; }
-
-    /// <summary>
-    ///     Entity that was interacted on.
-    /// </summary>
-    public EntityUid Target { get; }
-
-    /// <summary>
-    ///     The original location that was clicked by the user.
-    /// </summary>
-    public EntityCoordinates ClickLocation { get; }
-
-    public UserInteractUsingEvent(EntityUid user, EntityUid used, EntityUid target, EntityCoordinates clickLocation)
-    {
-        // Interact using should not have the same used and target.
-        // That should be a use-in-hand event instead.
-        // If this is not the case, can lead to bugs (e.g., attempting to merge a item stack into itself).
-        DebugTools.Assert(used != target);
-
-        User = user;
-        Used = used;
-        Target = target;
-        ClickLocation = clickLocation;
-    }
-}
-
+/// <summary>
+/// Raised when a user entity interacts with a target while holding an object in their hand.
+/// This will be raised on the user entity.
+/// </summary>
+[PublicAPI]
+public sealed class UserInteractUsingEvent(
+    EntityUid user,
+    EntityUid used,
+    EntityUid target,
+    EntityCoordinates clickLocation)
+    : BaseInteractionEvent(user, used, target, clickLocation);

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -31,12 +31,9 @@ using Content.Shared.Verbs;
 using Content.Shared.Wall;
 using JetBrains.Annotations;
 using Robust.Shared.Containers;
-using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
-using Robust.Shared.Network;
 using Robust.Shared.Physics;
-using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
@@ -53,38 +50,39 @@ namespace Content.Shared.Interaction
     [UsedImplicitly]
     public abstract partial class SharedInteractionSystem : EntitySystem
     {
-        [Dependency] private readonly IGameTiming _gameTiming = default!;
-        [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
         [Dependency] private readonly ISharedChatManager _chat = default!;
+        [Dependency] private readonly IGameTiming _gameTiming = default!;
+        [Dependency] private readonly IMapManager _mapManager = default!;
+        [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
-        [Dependency] private readonly EntityLookupSystem _lookup = default!;
+        [Dependency] private readonly SharedPhysicsSystem _broadphase = default!;
+        [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
         [Dependency] private readonly SharedHandsSystem _hands = default!;
         [Dependency] private readonly InventorySystem _inventory = default!;
-        [Dependency] private readonly PullingSystem _pullSystem = default!;
-        [Dependency] private readonly RotateToFaceSystem _rotateToFaceSystem = default!;
-        [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
+        [Dependency] private readonly EntityLookupSystem _lookup = default!;
         [Dependency] private readonly SharedMapSystem _map = default!;
-        [Dependency] private readonly SharedPhysicsSystem _broadphase = default!;
-        [Dependency] private readonly SharedTransformSystem _transform = default!;
-        [Dependency] private readonly SharedVerbSystem _verbSystem = default!;
         [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
-        [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
-        [Dependency] private readonly SharedStrippableSystem _strippable = default!;
+        [Dependency] private readonly PullingSystem _pullSystem = default!;
         [Dependency] private readonly SharedPlayerRateLimitManager _rateLimit = default!;
+        [Dependency] private readonly RotateToFaceSystem _rotateToFaceSystem = default!;
+        [Dependency] private readonly SharedStrippableSystem _strippable = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
+        [Dependency] private readonly SharedTransformSystem _transform = default!;
+        [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
         [Dependency] private readonly UseDelaySystem _useDelay = default!;
+        [Dependency] private readonly SharedVerbSystem _verbSystem = default!;
 
-        private EntityQuery<IgnoreUIRangeComponent> _ignoreUiRangeQuery;
+        private EntityQuery<CombatModeComponent> _combatQuery;
+        private EntityQuery<UseDelayComponent> _delayQuery;
         private EntityQuery<FixturesComponent> _fixtureQuery;
+        private EntityQuery<HandsComponent> _handsQuery;
+        private EntityQuery<IgnoreUIRangeComponent> _ignoreUiRangeQuery;
         private EntityQuery<ItemComponent> _itemQuery;
         private EntityQuery<PhysicsComponent> _physicsQuery;
-        private EntityQuery<HandsComponent> _handsQuery;
         private EntityQuery<InteractionRelayComponent> _relayQuery;
-        private EntityQuery<CombatModeComponent> _combatQuery;
-        private EntityQuery<WallMountComponent> _wallMountQuery;
-        private EntityQuery<UseDelayComponent> _delayQuery;
         private EntityQuery<ActivatableUIComponent> _uiQuery;
+        private EntityQuery<WallMountComponent> _wallMountQuery;
 
         /// <summary>
         /// The collision mask used by default for
@@ -103,18 +101,19 @@ namespace Content.Shared.Interaction
 
         public override void Initialize()
         {
-            _ignoreUiRangeQuery = GetEntityQuery<IgnoreUIRangeComponent>();
+            _combatQuery = GetEntityQuery<CombatModeComponent>();
+            _delayQuery = GetEntityQuery<UseDelayComponent>();
             _fixtureQuery = GetEntityQuery<FixturesComponent>();
+            _handsQuery = GetEntityQuery<HandsComponent>();
+            _ignoreUiRangeQuery = GetEntityQuery<IgnoreUIRangeComponent>();
             _itemQuery = GetEntityQuery<ItemComponent>();
             _physicsQuery = GetEntityQuery<PhysicsComponent>();
-            _handsQuery = GetEntityQuery<HandsComponent>();
             _relayQuery = GetEntityQuery<InteractionRelayComponent>();
-            _combatQuery = GetEntityQuery<CombatModeComponent>();
-            _wallMountQuery = GetEntityQuery<WallMountComponent>();
-            _delayQuery = GetEntityQuery<UseDelayComponent>();
             _uiQuery = GetEntityQuery<ActivatableUIComponent>();
+            _wallMountQuery = GetEntityQuery<WallMountComponent>();
 
             SubscribeLocalEvent<BoundUserInterfaceCheckRangeEvent>(HandleUserInterfaceRangeCheck);
+            SubscribeAllEvent<InteractionRequestEvent>(HandleUseInteraction);
 
             // TODO make this a broadcast event subscription again when engine has updated.
             SubscribeLocalEvent<UserInterfaceComponent, BoundUserInterfaceMessageAttempt>(OnBoundInterfaceInteractAttempt);
@@ -129,8 +128,6 @@ namespace Content.Shared.Interaction
             CommandBinds.Builder
                 .Bind(ContentKeyFunctions.AltActivateItemInWorld,
                     new PointerInputCmdHandler(HandleAltUseInteraction))
-                .Bind(EngineKeyFunctions.Use,
-                    new PointerInputCmdHandler(HandleUseInteraction))
                 .Bind(ContentKeyFunctions.ActivateItemInWorld,
                     new PointerInputCmdHandler(HandleActivateItemInWorld))
                 .Bind(ContentKeyFunctions.TryPullObject,
@@ -330,18 +327,22 @@ namespace Content.Shared.Interaction
             return false;
         }
 
-        public bool HandleUseInteraction(ICommonSession? session, EntityCoordinates coords, EntityUid uid)
+        public void HandleUseInteraction(InteractionRequestEvent args)
         {
+            var target = GetEntity(args.Target);
+            // These need to be reconstructed as they are not serializable.
+            var coords = new EntityCoordinates(GetEntity(args.Source), args.Vector);
+            if (!_playerManager.TryGetSessionByEntity(GetEntity(args.User), out var session))
+                return;
+
             // client sanitization
-            if (!ValidateClientInput(session, coords, uid, out var userEntity))
+            if (!ValidateClientInput(session, coords, target, out var userEntity))
             {
                 Log.Info($"Use input validation failed");
-                return true;
+                return;
             }
 
-            UserInteraction(userEntity.Value, coords, !Deleted(uid) ? uid : null, checkAccess: ShouldCheckAccess(userEntity.Value));
-
-            return false;
+            UserInteraction(userEntity.Value, coords, !Deleted(target) ? target : null, checkAccess: ShouldCheckAccess(userEntity.Value), utilityInteraction: args.UtilityInteraction);
         }
 
         private bool ShouldCheckAccess(EntityUid user)
@@ -396,7 +397,8 @@ namespace Content.Shared.Interaction
             bool altInteract = false,
             bool checkCanInteract = true,
             bool checkAccess = true,
-            bool checkCanUse = true)
+            bool checkCanUse = true,
+            bool utilityInteraction = false)
         {
             if (_relayQuery.TryComp(user, out var relay) && relay.RelayEntity is not null)
             {
@@ -471,7 +473,8 @@ namespace Content.Shared.Interaction
                     target.Value,
                     coordinates,
                     checkCanInteract: false,
-                    checkCanUse: false);
+                    checkCanUse: false,
+                    utilityInteraction: utilityInteraction);
 
                 return;
             }
@@ -1042,7 +1045,8 @@ namespace Content.Shared.Interaction
             EntityUid target,
             EntityCoordinates clickLocation,
             bool checkCanInteract = true,
-            bool checkCanUse = true)
+            bool checkCanUse = true,
+            bool utilityInteraction = false)
         {
             if (IsDeleted(user) || IsDeleted(used) || IsDeleted(target))
                 return false;
@@ -1063,6 +1067,10 @@ namespace Content.Shared.Interaction
 
             DebugTools.Assert(!IsDeleted(user) && !IsDeleted(used) && !IsDeleted(target));
             // all interactions should only happen when in range / unobstructed, so no range check is needed
+            // Check first if it was a utility interaction (holding down the interaction key) before continuing.
+            if (utilityInteraction && UtilityInteract(user, target))
+                return true;
+
             var interactUsingEvent = new InteractUsingEvent(user, used, target, clickLocation);
             RaiseLocalEvent(target, interactUsingEvent, true);
 
@@ -1263,6 +1271,25 @@ namespace Content.Shared.Interaction
         {
             // Get list of alt-interact verbs
             var verbs = _verbSystem.GetLocalVerbs(target, user, typeof(AlternativeVerb));
+
+            if (verbs.Count == 0)
+                return false;
+
+            _verbSystem.ExecuteVerb(verbs.First(), user, target);
+            return true;
+        }
+
+        /// <summary>
+        /// Utility interactions on an entity.
+        /// </summary>
+        /// <remarks>
+        /// Uses the context menu verb list, and acts out the highest priority utility interaction verb.
+        /// </remarks>
+        /// <returns>True if the interaction was handled, false otherwise.</returns>
+        public bool UtilityInteract(EntityUid user, EntityUid target)
+        {
+            // Get list of alt-interact verbs
+            var verbs = _verbSystem.GetLocalVerbs(target, user, typeof(UtilityVerb));
 
             if (verbs.Count == 0)
                 return false;

--- a/Content.Shared/Inventory/Events/UseSlotNetworkMessage.cs
+++ b/Content.Shared/Inventory/Events/UseSlotNetworkMessage.cs
@@ -3,14 +3,14 @@
 namespace Content.Shared.Inventory.Events;
 
 [NetSerializable, Serializable]
-public sealed class UseSlotNetworkMessage : EntityEventArgs
+public sealed class UseSlotNetworkMessage(string slot, bool utilityInteraction) : EntityEventArgs
 {
     // The slot-owner is implicitly the client that is sending this message.
     // Otherwise clients could start forcefully undressing other clients.
-    public readonly string Slot;
+    public readonly string Slot = slot;
 
-    public UseSlotNetworkMessage(string slot)
-    {
-        Slot = slot;
-    }
+    /// <summary>
+    /// Whether the slot was interacted with via holding the interaction button.
+    /// </summary>
+    public readonly bool UtilityInteraction = utilityInteraction;
 }

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -90,8 +90,11 @@ public abstract partial class InventorySystem
         // attempt to perform some interaction
         if (held != null && itemUid != null)
         {
-            _interactionSystem.InteractUsing(actor, held.Value, itemUid.Value,
-                Transform(itemUid.Value).Coordinates);
+            _interactionSystem.InteractUsing(actor,
+                held.Value,
+                itemUid.Value,
+                Transform(itemUid.Value).Coordinates,
+                utilityInteraction: ev.UtilityInteraction);
             return;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I made it possible to hold the use key for interaction.
This allows to use the use key for activating the first utility verb - Just like how using the alt + click key activates the first alternative verb.
Currently, it's set on a 500ms delay. Can be shorter.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Better UX. Having to rightlick your item is undesirable compared to using controls to do the desired effect.
## Technical details
<!-- Summary of code changes for easier review. -->
Added a way to check for held inputs in client-side `InteractionSystem.cs`
The client-side system will now request interactions to server via an `InteractionRequestEvent.cs`
Added an if check in `SharedInteractionSystem.cs` to catch interactions that are used via held inputs.
Adjusted `HandsUiController.cs` and `InventoryUiController.cs` and their respective `-System.cs`'s to account for held inputs.

Sorted `SharedInteractionSystem.cs` imports alphabetically.
Reparented the `InteractUsingEvent`s to a base version.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Holding Left Click on the Backpack with the emergency box and vice versa

https://github.com/user-attachments/assets/451d9a41-8546-401a-87e6-7d0f8eacfab1

Holding Left Click on the Backpack with a labeller, and then just pressing Left Click

https://github.com/user-attachments/assets/005923d2-701d-4830-915d-780a356593cd


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added holding your Use Key as a way to interact with utility items without rightclicking!
- add: With the above, you can now label bags without putting the labeller into the bag!
- add: With the above, you can now transfer all things in a container to another. (Emergency box to bag)