### PR TITLE
Put Content.Client.UserInterface.Controls into the SS14 xmlns

### DIFF
--- a/Content.Client/Administration/UI/AdminRemarks/AdminRemarksWindow.xaml
+++ b/Content.Client/Administration/UI/AdminRemarks/AdminRemarksWindow.xaml
@@ -1,5 +1,4 @@
-<ui:FancyWindow xmlns="https://spacestation14.io"
-                xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                 VerticalExpand="True" HorizontalExpand="True"
                 Title="{Loc admin-remarks-title}"
                 SetSize="600 400">
@@ -10,4 +9,4 @@
             </ScrollContainer>
         </BoxContainer>
     </PanelContainer>
-</ui:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
@@ -1,7 +1,6 @@
 ﻿<Control
     xmlns="https://spacestation14.io"
-    xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls">
+    xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls">
     <PanelContainer StyleClasses="BackgroundDark">
         <SplitContainer Orientation="Vertical" ResizeMode="NotResizable">
             <SplitContainer Orientation="Horizontal" VerticalExpand="True">
@@ -19,9 +18,9 @@
                 <Control HorizontalExpand="True" />
                 <Button Visible="False" Name="Bans" Text="{Loc 'admin-player-actions-bans'}" StyleClasses="OpenRight" />
                 <Button Visible="False" Access="Public" Name="Notes" Text="{Loc 'admin-player-actions-notes'}" StyleClasses="OpenBoth" />
-                <controls:ConfirmButton Visible="False" Name="Kick" Text="{Loc 'admin-player-actions-kick'}" ConfirmationText="{Loc 'admin-player-actions-confirm'}" StyleClasses="OpenBoth" />
+                <ConfirmButton Visible="False" Name="Kick" Text="{Loc 'admin-player-actions-kick'}" ConfirmationText="{Loc 'admin-player-actions-confirm'}" StyleClasses="OpenBoth" />
                 <Button Visible="False" Name="Ban" Text="{Loc 'admin-player-actions-ban'}" StyleClasses="OpenBoth" />
-                <controls:ConfirmButton Visible="False" Name="Respawn" Text="{Loc 'admin-player-actions-respawn'}" ConfirmationText="{Loc 'admin-player-actions-confirm'}" StyleClasses="OpenBoth" />
+                <ConfirmButton Visible="False" Name="Respawn" Text="{Loc 'admin-player-actions-respawn'}" ConfirmationText="{Loc 'admin-player-actions-confirm'}" StyleClasses="OpenBoth" />
                 <Button Visible="False" Name="Follow" Text="{Loc 'admin-player-actions-follow'}" StyleClasses="OpenLeft" />
             </BoxContainer>
         </SplitContainer>

--- a/Content.Client/Administration/UI/CustomControls/PlayerListControl.xaml
+++ b/Content.Client/Administration/UI/CustomControls/PlayerListControl.xaml
@@ -1,5 +1,4 @@
 ﻿<BoxContainer xmlns="https://spacestation14.io"
-              xmlns:controls="using:Content.Client.UserInterface.Controls"
               Orientation="Vertical">
     <Control MinSize="0 5" />
     <LineEdit Name="FilterLineEdit"
@@ -9,7 +8,7 @@
     <PanelContainer Name="BackgroundPanel"
                     VerticalExpand="True"
                     HorizontalExpand="True">
-        <controls:ListContainer Name="PlayerListContainer"
+        <ListContainer Name="PlayerListContainer"
                   Access="Public"
                   Toggle="True"
                   Group="True"

--- a/Content.Client/Administration/UI/Notes/AdminNotesLinePopup.xaml
+++ b/Content.Client/Administration/UI/Notes/AdminNotesLinePopup.xaml
@@ -1,6 +1,5 @@
 <Popup xmlns="https://spacestation14.io"
-       xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls">
+       xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client">
     <PanelContainer>
         <PanelContainer.PanelOverride>
             <gfx:StyleBoxFlat BorderThickness="2" BorderColor="#18181B" BackgroundColor="#25252a"/>
@@ -20,7 +19,7 @@
             <BoxContainer Orientation="Horizontal">
                 <Button Name="EditButton" Text="{Loc admin-notes-edit}"/>
                 <Control HorizontalExpand="True"/>
-                <controls:ConfirmButton Name="DeleteButton" Text="{Loc admin-notes-delete}" ConfirmationText="{Loc 'admin-player-actions-confirm'}" HorizontalAlignment="Right"/>
+                <ConfirmButton Name="DeleteButton" Text="{Loc admin-notes-delete}" ConfirmationText="{Loc 'admin-player-actions-confirm'}" HorizontalAlignment="Right"/>
             </BoxContainer>
         </BoxContainer>
     </PanelContainer>

--- a/Content.Client/Administration/UI/Notes/AdminNotesWindow.xaml
+++ b/Content.Client/Administration/UI/Notes/AdminNotesWindow.xaml
@@ -1,7 +1,6 @@
-<ui:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
             xmlns:notes="clr-namespace:Content.Client.Administration.UI.Notes"
-            xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
             SetSize="600 400"
             Title="Loading...">
     <notes:AdminNotesControl Name="Notes" Access="Public" Margin="4"/>
-</ui:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Administration/UI/Notes/NoteEdit.xaml
+++ b/Content.Client/Administration/UI/Notes/NoteEdit.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       Title="Loading..."
                       MinSize="400 200">
     <BoxContainer Orientation="Vertical" Margin="4">
@@ -20,4 +19,4 @@
             <Button Name="SubmitButton" Access="Public" Text="{Loc admin-note-editor-submit}" HorizontalAlignment="Right" />
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Administration/UI/PlayerPanel/PlayerPanel.xaml
+++ b/Content.Client/Administration/UI/PlayerPanel/PlayerPanel.xaml
@@ -1,7 +1,5 @@
-<ui:FancyWindow
+<FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-    xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
     Title="{Loc ban-panel-title}" MinSize="300 300">
     <BoxContainer Orientation="Vertical">
         <BoxContainer Orientation="Horizontal">
@@ -10,7 +8,7 @@
         </BoxContainer>
        <BoxContainer Orientation="Horizontal">
            <Label Name="Whitelisted"/>
-           <controls:ConfirmButton Name="WhitelistToggle" Text="{Loc 'player-panel-false'}" Visible="False"></controls:ConfirmButton>
+           <ConfirmButton Name="WhitelistToggle" Text="{Loc 'player-panel-false'}" Visible="False"></ConfirmButton>
        </BoxContainer>
        <Label Name="Playtime"/>
        <Label Name="Notes"/>
@@ -23,16 +21,16 @@
             <Button Name="NotesButton" Text="{Loc player-panel-show-notes}" SetWidth="136" Disabled="True"/>
             <Button Name="AhelpButton" Text="{Loc player-panel-help}" Disabled="True"/>
             <Button Name="FreezeButton" Text = "{Loc player-panel-freeze}" Disabled="True"/>
-            <controls:ConfirmButton Name="KickButton" Text="{Loc player-panel-kick}" Disabled="True"/>
-            <controls:ConfirmButton Name="DeleteButton" Text="{Loc player-panel-delete}" Disabled="True"/>
+            <ConfirmButton Name="KickButton" Text="{Loc player-panel-kick}" Disabled="True"/>
+            <ConfirmButton Name="DeleteButton" Text="{Loc player-panel-delete}" Disabled="True"/>
             <Button Name="FollowButton" Text="{Loc player-panel-follow}"/>
             <Button Name="ShowBansButton" Text="{Loc player-panel-show-bans}" SetWidth="136" Disabled="True"/>
             <Button Name="LogsButton" Text="{Loc player-panel-logs}" Disabled="True"/>
             <Button Name="FreezeAndMuteToggleButton" Text="{Loc player-panel-freeze-and-mute}" Disabled="True"/>
             <Button Name="BanButton" Text="{Loc player-panel-ban}" Disabled="True"/>
-            <controls:ConfirmButton Name="RejuvenateButton" Text="{Loc player-panel-rejuvenate}" Disabled="True"/>
+            <ConfirmButton Name="RejuvenateButton" Text="{Loc player-panel-rejuvenate}" Disabled="True"/>
             <Button Name="CameraButton" Text="{Loc player-panel-camera}" Disabled="True"/>
            </GridContainer>
        </BoxContainer>
     </BoxContainer>
-</ui:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Administration/UI/Tabs/ObjectsTab/ObjectsTab.xaml
+++ b/Content.Client/Administration/UI/Tabs/ObjectsTab/ObjectsTab.xaml
@@ -1,7 +1,6 @@
 ﻿<Control xmlns="https://spacestation14.io"
          xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls"
-         xmlns:ot="clr-namespace:Content.Client.Administration.UI.Tabs.ObjectsTab"
-         xmlns:co="clr-namespace:Content.Client.UserInterface.Controls">
+         xmlns:ot="clr-namespace:Content.Client.Administration.UI.Tabs.ObjectsTab">
     <BoxContainer Orientation="Vertical">
         <BoxContainer Orientation="Horizontal">
             <Label Text="{Loc object-tab-object-type}" />
@@ -14,7 +13,7 @@
         <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
             <ot:ObjectsTabHeader Name="ListHeader" />
             <cc:HSeparator />
-            <co:SearchListContainer Name="SearchList" Access="Public" VerticalExpand="True" />
+            <SearchListContainer Name="SearchList" Access="Public" VerticalExpand="True" />
         </BoxContainer>
     </BoxContainer>
 </Control>

--- a/Content.Client/Administration/UI/Tabs/ObjectsTab/ObjectsTabEntry.xaml
+++ b/Content.Client/Administration/UI/Tabs/ObjectsTab/ObjectsTabEntry.xaml
@@ -1,6 +1,5 @@
 ﻿<PanelContainer xmlns="https://spacestation14.io"
                 xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 Name="BackgroundColorPanel">
     <BoxContainer Orientation="Horizontal"
                   HorizontalExpand="True"
@@ -21,7 +20,7 @@
                HorizontalExpand="True"
                ClipText="True"/>
         <customControls:VSeparator/>
-        <controls:ConfirmButton Name="DeleteButton"
+        <ConfirmButton Name="DeleteButton"
                 Text="{Loc object-tab-entity-delete}"
                 SizeFlagsStretchRatio="3"
                 HorizontalExpand="True"

--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml
@@ -1,7 +1,6 @@
 ﻿<Control xmlns="https://spacestation14.io"
          xmlns:pt="clr-namespace:Content.Client.Administration.UI.Tabs.PlayerTab"
-         xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls"
-         xmlns:co="clr-namespace:Content.Client.UserInterface.Controls">
+         xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls">
     <BoxContainer Orientation="Vertical">
         <BoxContainer Orientation="Horizontal">
             <Label Name="PlayerCount" HorizontalExpand="True" Text="{Loc player-tab-player-count}" />
@@ -14,6 +13,6 @@
         <Control MinSize="0 5"/>
         <pt:PlayerTabHeader Name="ListHeader"/>
         <cc:HSeparator/>
-        <co:SearchListContainer Name="SearchList" Access="Public" VerticalExpand="True"/>
+        <SearchListContainer Name="SearchList" Access="Public" VerticalExpand="True"/>
     </BoxContainer>
 </Control>

--- a/Content.Client/Administration/UI/Tabs/RoundTab.xaml
+++ b/Content.Client/Administration/UI/Tabs/RoundTab.xaml
@@ -1,13 +1,12 @@
 ﻿<Control
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     Margin="4"
     MinSize="50 50">
     <GridContainer
         Columns="3">
-        <controls:ConfirmButton Name="StartRound" Text="{Loc administration-ui-round-tab-start-round}" />
-        <controls:ConfirmButton Name="EndRound" Text="{Loc administration-ui-round-tab-end-round}" />
-        <controls:ConfirmButton Name="RestartRound" Text="{Loc administration-ui-round-tab-restart-round}" />
-        <controls:ConfirmButton Name="RestartRoundNow" Text="{Loc administration-ui-round-tab-restart-round-now}" />
+        <ConfirmButton Name="StartRound" Text="{Loc administration-ui-round-tab-start-round}" />
+        <ConfirmButton Name="EndRound" Text="{Loc administration-ui-round-tab-end-round}" />
+        <ConfirmButton Name="RestartRound" Text="{Loc administration-ui-round-tab-restart-round}" />
+        <ConfirmButton Name="RestartRoundNow" Text="{Loc administration-ui-round-tab-restart-round-now}" />
     </GridContainer>
 </Control>

--- a/Content.Client/Administration/UI/Tabs/ServerTab.xaml
+++ b/Content.Client/Administration/UI/Tabs/ServerTab.xaml
@@ -1,12 +1,11 @@
 ﻿<Control
     xmlns="https://spacestation14.io"
     xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     Margin="4"
     MinSize="50 50">
     <GridContainer
         Columns="4" >
-        <controls:ConfirmButton Name="ServerShutdownButton" Text="{Loc server-shutdown}" />
+        <ConfirmButton Name="ServerShutdownButton" Text="{Loc server-shutdown}" />
         <cc:CommandButton Name="SetOocButton" Command="setooc" Text="{Loc server-ooc-toggle}" ToggleMode="True" />
         <cc:CommandButton Name="SetLoocButton" Command="setlooc" Text="{Loc server-looc-toggle}" ToggleMode="True" />
     </GridContainer>

--- a/Content.Client/Anomaly/Ui/AnomalyGeneratorWindow.xaml
+++ b/Content.Client/Anomaly/Ui/AnomalyGeneratorWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                 Title="{Loc 'anomaly-generator-ui-title'}"
 
                 Resizable="False">
@@ -59,4 +58,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Anomaly/Ui/AnomalyScannerMenu.xaml
+++ b/Content.Client/Anomaly/Ui/AnomalyScannerMenu.xaml
@@ -1,12 +1,11 @@
-<controls:FancyWindow
+<FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     Title="{Loc 'anomaly-scanner-ui-title'}"
     MinSize="350 400"
     SetSize="350 400">
     <BoxContainer Orientation="Vertical" VerticalExpand="True" Margin="10 0 10 10">
         <RichTextLabel Name="TextDisplay"></RichTextLabel>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>
 
 

--- a/Content.Client/Atmos/Consoles/AtmosAlarmEntryContainer.xaml
+++ b/Content.Client/Atmos/Consoles/AtmosAlarmEntryContainer.xaml
@@ -1,7 +1,6 @@
 <BoxContainer xmlns="https://spacestation14.io"
          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
          xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-         xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
          Orientation="Vertical" HorizontalExpand ="True" Margin="0 0 0 3">
 
     <!-- Device selection button -->
@@ -65,11 +64,11 @@
                 <Label Name="NoDataLabel" Text="{Loc 'atmos-alerts-window-no-data-available'}" HorizontalAlignment="Center" Margin="0 15" FontColorOverride="#a9a9a9" ReservesSpace="False" Visible="False"></Label>
 
                 <!-- Silencing progress bar -->
-                <controls:StripeBack Name="SilenceAlarmProgressBar" ReservesSpace="False" Visible="False" Access="Public">
+                <StripeBack Name="SilenceAlarmProgressBar" ReservesSpace="False" Visible="False" Access="Public">
                     <PanelContainer>
                         <Label Text="{Loc 'atmos-alerts-window-alerts-being-silenced'}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5 5 5 5"/>
                     </PanelContainer>
-                </controls:StripeBack>
+                </StripeBack>
             </Control>
 
             <!-- Check box for silencing this alarm -->

--- a/Content.Client/Atmos/Consoles/AtmosAlertsComputerWindow.xaml
+++ b/Content.Client/Atmos/Consoles/AtmosAlertsComputerWindow.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
                xmlns:ui="clr-namespace:Content.Client.Pinpointer.UI"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                Title="{Loc 'atmos-alerts-window-title'}"
                Resizable="False"
                SetSize="1120 750"
@@ -59,11 +58,11 @@
             <BoxContainer Orientation="Vertical" VerticalExpand="True" SetWidth="440" Margin="0 0 10 10">
 
                 <!-- Station name -->
-                <controls:StripeBack>
+                <StripeBack>
                     <PanelContainer>
                         <RichTextLabel Name="StationName" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0 5 0 3"/>
                     </PanelContainer>
-                </controls:StripeBack>
+                </StripeBack>
 
                 <!-- Alarm status (entries added by C# code) -->
                 <TabContainer Name="MasterTabContainer" VerticalExpand="True" HorizontalExpand="True" Margin="0 10 0 0">
@@ -104,4 +103,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Atmos/Consoles/AtmosMonitoringConsoleWindow.xaml
+++ b/Content.Client/Atmos/Consoles/AtmosMonitoringConsoleWindow.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
                xmlns:ui="clr-namespace:Content.Client.Atmos.Consoles"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                Title="{Loc 'atmos-monitoring-window-title'}"
                Resizable="False"
@@ -58,11 +57,11 @@
             <BoxContainer Orientation="Vertical" VerticalExpand="True" SetWidth="440" Margin="0 0 10 10">
 
                 <!-- Station name -->
-                <controls:StripeBack>
+                <StripeBack>
                     <PanelContainer>
                         <RichTextLabel Name="StationName" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0 5 0 3"/>
                     </PanelContainer>
-                </controls:StripeBack>
+                </StripeBack>
 
                 <!-- Alarm status (entries added by C# code) -->
                 <TabContainer Name="MasterTabContainer" VerticalExpand="True" HorizontalExpand="True" Margin="0 10 0 0">
@@ -96,4 +95,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Atmos/Consoles/AtmosMonitoringEntryContainer.xaml
+++ b/Content.Client/Atmos/Consoles/AtmosMonitoringEntryContainer.xaml
@@ -1,8 +1,5 @@
 <BoxContainer xmlns="https://spacestation14.io"
-         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-         xmlns:s="clr-namespace:Content.Client.Stylesheets"
          xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-         xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
          Orientation="Vertical" HorizontalExpand ="True" Margin="0 0 0 3">
 
     <!-- Network selection button -->

--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
@@ -1,6 +1,4 @@
-<ui:FancyWindow xmlns="https://spacestation14.io"
-            xmlns:x="http://schemas.microsoft.com/winfx/2007/xaml"
-            xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
             xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
             MinSize="500 500" Resizable="True" Title="{Loc air-alarm-ui-title}">
     <BoxContainer Orientation="Vertical" Margin="5 5 5 5">
@@ -76,12 +74,12 @@
             <Label Text="{Loc 'air-alarm-ui-window-mode-label'}" Margin="0 0 2 0" />
             <Control HorizontalExpand="True">
                 <OptionButton Name="CModeButton" />
-                <ui:StripeBack Name="CModeSelectLocked">
+                <StripeBack Name="CModeSelectLocked">
                     <RichTextLabel Text="{Loc 'air-alarm-ui-window-mode-select-locked-label'}"
                                    HorizontalAlignment="Center" />
-                </ui:StripeBack>
+                </StripeBack>
             </Control>
             <CheckBox Name="AutoModeCheckBox" Text="{Loc 'air-alarm-ui-window-auto-mode-label'}" />
         </BoxContainer>
     </BoxContainer>
-</ui:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Atmos/UI/GasFilterWindow.xaml
+++ b/Content.Client/Atmos/UI/GasFilterWindow.xaml
@@ -1,9 +1,7 @@
 <DefaultWindow xmlns="https://spacestation14.io"
-            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
             MinSize="480 400" Title="Filter">
     <BoxContainer Orientation="Vertical" Margin="5 5 5 5" SeparationOverride="10">
-        <controls:SwitchButton
+        <SwitchButton
             Name="ToggleStatusButton"
             HorizontalAlignment="Left"
             Pressed="True" />

--- a/Content.Client/Atmos/UI/GasMixerWindow.xaml
+++ b/Content.Client/Atmos/UI/GasMixerWindow.xaml
@@ -1,9 +1,7 @@
 <DefaultWindow xmlns="https://spacestation14.io"
-            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
             MinSize="200 200" Title="Gas Mixer">
     <BoxContainer Orientation="Vertical" Margin="5 5 5 5" SeparationOverride="10">
-        <controls:SwitchButton
+        <SwitchButton
             Name="ToggleStatusButton"
             HorizontalAlignment="Left"
             Pressed="True" />

--- a/Content.Client/Atmos/UI/GasPressurePumpWindow.xaml
+++ b/Content.Client/Atmos/UI/GasPressurePumpWindow.xaml
@@ -1,10 +1,8 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
             SetSize="340 110" MinSize="340 110" Title="Pressure Pump">
     <BoxContainer Orientation="Vertical" Margin="5 5 5 5" SeparationOverride="10">
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
-            <controls:SwitchButton
+            <SwitchButton
                 Name="ToggleStatusButton"
                 HorizontalAlignment="Left"
                 Pressed="True" />
@@ -17,4 +15,4 @@
             <FloatSpinBox HorizontalExpand="True" Name="PumpPressureOutputInput" MinSize="70 0" />
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Atmos/UI/GasPressureRegulatorWindow.xaml
+++ b/Content.Client/Atmos/UI/GasPressureRegulatorWindow.xaml
@@ -1,6 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                       SetSize="345 380"
                       MinSize="345 380"
                       Title="{Loc gas-pressure-regulator-ui-title}"
@@ -53,7 +51,7 @@
         </BoxContainer>
 
         <!-- Controls to Set Pressure -->
-        <controls:StripeBack Name="SetPressureStripeBack" HorizontalExpand="True">
+        <StripeBack Name="SetPressureStripeBack" HorizontalExpand="True">
             <BoxContainer Orientation="Vertical" HorizontalExpand="True" Margin="10 10 10 10">
                 <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
                     <LineEdit Name="ThresholdInput" HorizontalExpand="True" MinSize="70 0" />
@@ -89,8 +87,8 @@
                             Text="{Loc gas-pressure-regulator-ui-set-to-current-pressure}" HorizontalExpand="True" />
                 </BoxContainer>
             </BoxContainer>
-        </controls:StripeBack>
+        </StripeBack>
 
     </BoxContainer>
 
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Atmos/UI/GasThermomachineWindow.xaml
+++ b/Content.Client/Atmos/UI/GasThermomachineWindow.xaml
@@ -1,9 +1,7 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                MinSize="300 120" Title="{Loc comp-gas-thermomachine-ui-title-freezer}">
     <BoxContainer Name="VboxContainer" Orientation="Vertical" Margin="5 5 5 5" SeparationOverride="10">
-        <controls:SwitchButton
+        <SwitchButton
             Name="ToggleStatusButton"
             HorizontalAlignment="Left"
             Pressed="True"
@@ -12,4 +10,4 @@
             <Label Text="{Loc comp-gas-thermomachine-ui-temperature}"/>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Atmos/UI/GasVolumePumpWindow.xaml
+++ b/Content.Client/Atmos/UI/GasVolumePumpWindow.xaml
@@ -1,9 +1,7 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
             MinSize="200 120" Title="Volume Pump">
     <BoxContainer Orientation="Vertical" Margin="5 5 5 5" SeparationOverride="10">
-        <controls:SwitchButton
+        <SwitchButton
             Name="ToggleStatusButton"
             HorizontalAlignment="Left"
             Pressed="True" />
@@ -19,4 +17,4 @@
             <Button Name="SetTransferRateButton" Text="{Loc comp-gas-pump-ui-pump-set-rate}" HorizontalAlignment="Right" Disabled="True"/>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Atmos/UI/SpaceHeaterWindow.xaml
+++ b/Content.Client/Atmos/UI/SpaceHeaterWindow.xaml
@@ -1,12 +1,10 @@
 <DefaultWindow xmlns="https://spacestation14.io"
-               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                MinSize="280 160" Title="{Loc comp-space-heater-ui-title}">
 
     <BoxContainer Name="VboxContainer" Orientation="Vertical" Margin="5 5 5 5" SeparationOverride="10">
 
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
-            <controls:SwitchButton
+            <SwitchButton
                 Name="ToggleStatusButton"
                 HorizontalExpand="True"
                 Access="Public" />

--- a/Content.Client/Audio/Jukebox/JukeboxMenu.xaml
+++ b/Content.Client/Audio/Jukebox/JukeboxMenu.xaml
@@ -1,4 +1,4 @@
-<ui:FancyWindow xmlns="https://spacestation14.io" xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                 SetSize="400 500" Title="{Loc 'jukebox-menu-title'}">
     <BoxContainer Margin="4 0" Orientation="Vertical">
         <ItemList Name="MusicList" SelectMode="Button" Margin="3 3 3 3"
@@ -15,4 +15,4 @@
             <Label Name="DurationLabel" Text="00:00 / 00:00" HorizontalAlignment="Right" HorizontalExpand="True"/>
         </BoxContainer>
     </BoxContainer>
-</ui:FancyWindow>
+</FancyWindow>

--- a/Content.Client/BarSign/Ui/BarSignMenu.xaml
+++ b/Content.Client/BarSign/Ui/BarSignMenu.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow
+<FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
     Title="{Loc 'barsign-ui-menu'}"
     MinSize="280 180"
@@ -14,6 +13,6 @@
             <OptionButton Name="SignOptions" HorizontalAlignment="Center" VerticalAlignment="Center" MinSize="175 60" Margin="0 0 0 20"/>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>
 
 

--- a/Content.Client/Bed/Cryostorage/CryostorageMenu.xaml
+++ b/Content.Client/Bed/Cryostorage/CryostorageMenu.xaml
@@ -1,9 +1,6 @@
-<controls:FancyWindow
+<FancyWindow
     xmlns="https://spacestation14.io"
     xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-    xmlns:xNamespace="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:style="clr-namespace:Content.Client.Stylesheets"
     Title="{Loc 'cryostorage-ui-window-title'}"
     MinSize="350 350"
     SetSize="450 400">
@@ -28,4 +25,4 @@
             </ScrollContainer>
         </PanelContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Cargo/UI/CargoBountyMenu.xaml
+++ b/Content.Client/Cargo/UI/CargoBountyMenu.xaml
@@ -1,6 +1,5 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       Title="{Loc 'bounty-console-menu-title'}"
                       SetSize="550 420"
                       MinSize="400 350">
@@ -46,4 +45,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Cargo/UI/CargoConsoleMenu.xaml
+++ b/Content.Client/Cargo/UI/CargoConsoleMenu.xaml
@@ -1,7 +1,6 @@
-﻿<controls:FancyWindow
+﻿<FancyWindow
     xmlns="https://spacestation14.io"
     xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     MinSize="540 390"
     SetSize="995 600">
 
@@ -102,11 +101,11 @@
                       SizeFlagsStretchRatio="2">
 
                       <!-- Title -->
-                      <controls:StripeBack>
+                      <StripeBack>
                           <Label Text="{Loc 'cargo-console-menu-requests-label'}"
                               HorizontalAlignment="Center"
                               Margin="4"/>
-                      </controls:StripeBack>
+                      </StripeBack>
 
                       <PanelContainer VerticalExpand="True"
                           Margin="0 -4 0 0">
@@ -137,11 +136,11 @@
                       VerticalExpand="True">
 
                       <!-- Title -->
-                      <controls:StripeBack>
+                      <StripeBack>
                           <Label Text="{Loc 'cargo-console-menu-orders-label'}"
                               HorizontalAlignment="Center"
                               Margin="4"/>
-                      </controls:StripeBack>
+                      </StripeBack>
 
                       <PanelContainer VerticalExpand="True"
                           Margin="0 -4 0 0">
@@ -223,4 +222,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Cargo/UI/CargoPalletMenu.xaml
+++ b/Content.Client/Cargo/UI/CargoPalletMenu.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
             SetSize="300 150"
             MinSize="300 150"
                       Title="{Loc 'cargo-pallet-console-menu-title'}">
@@ -22,4 +21,4 @@
                 Text="{Loc 'cargo-pallet-sell-button'}"/>
         <TextureButton VerticalExpand="True" />
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Cargo/UI/CargoShuttleMenu.xaml
+++ b/Content.Client/Cargo/UI/CargoShuttleMenu.xaml
@@ -1,6 +1,5 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
+﻿<FancyWindow xmlns="https://spacestation14.io"
             xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-            xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
             SetSize="600 600"
             MinSize="600 600">
     <BoxContainer Orientation="Vertical">
@@ -37,4 +36,4 @@
         </PanelContainer>
         <TextureButton VerticalExpand="True" />
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Cargo/UI/FundingAllocationMenu.xaml
+++ b/Content.Client/Cargo/UI/FundingAllocationMenu.xaml
@@ -1,32 +1,31 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       Title="{Loc 'cargo-funding-alloc-console-menu-title'}">
     <BoxContainer Orientation="Vertical"
                   VerticalExpand="True"
                   HorizontalExpand="True"
                   Margin="10 5 10 10">
-        <controls:TableContainer Columns="2" HorizontalExpand="True" VerticalExpand="True">
+        <ContentTableContainer Columns="2" HorizontalExpand="True" VerticalExpand="True">
             <RichTextLabel Name="PrimaryCutLabel" Text="{Loc 'cargo-funding-alloc-console-label-primary-cut'}"/>
             <SpinBox Name="PrimaryCut"/>
             <RichTextLabel Name="LockboxCutLabel" Text="{Loc 'cargo-funding-alloc-console-label-lockbox-cut'}"/>
             <SpinBox Name="LockboxCut"/>
-        </controls:TableContainer>
+        </ContentTableContainer>
         <Label Name="HelpLabel" HorizontalAlignment="Center" StyleClasses="LabelSubText" Margin="0 10"/>
         <PanelContainer VerticalExpand="True" HorizontalExpand="True" VerticalAlignment="Top" MaxHeight="250">
             <PanelContainer.PanelOverride>
                 <graphics:StyleBoxFlat BackgroundColor="#1B1B1E"/>
             </PanelContainer.PanelOverride>
-            <controls:TableContainer Name="EntriesContainer" Columns="4" HorizontalExpand="True" VerticalExpand="True" Margin="5 0">
+            <ContentTableContainer Name="EntriesContainer" Columns="4" HorizontalExpand="True" VerticalExpand="True" Margin="5 0">
                 <RichTextLabel Text="{Loc 'cargo-funding-alloc-console-label-account'}" HorizontalAlignment="Center"/>
                 <RichTextLabel Text="{Loc 'cargo-funding-alloc-console-label-code'}" HorizontalAlignment="Center"/>
                 <RichTextLabel Text="{Loc 'cargo-funding-alloc-console-label-balance'}" HorizontalAlignment="Center"/>
                 <RichTextLabel Text="{Loc 'cargo-funding-alloc-console-label-cut'}" HorizontalAlignment="Center"/>
-            </controls:TableContainer>
+            </ContentTableContainer>
         </PanelContainer>
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="5 0">
             <Button Name="SaveButton" Text="{Loc 'cargo-funding-alloc-console-button-save'}"  Disabled="True"/>
             <RichTextLabel Name="SaveAlertLabel" HorizontalExpand="True" HorizontalAlignment="Right" Visible="False"/>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/CartridgeLoader/Cartridges/CrewManifestUiFragment.xaml
+++ b/Content.Client/CartridgeLoader/Cartridges/CrewManifestUiFragment.xaml
@@ -1,14 +1,13 @@
 ﻿<cartridges:CrewManifestUiFragment xmlns:cartridges="clr-namespace:Content.Client.CartridgeLoader.Cartridges"
-                                   xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                                    xmlns:ui="clr-namespace:Content.Client.CrewManifest.UI"
                                    xmlns="https://spacestation14.io" Margin="1 0 2 0">
     <PanelContainer StyleClasses="BackgroundDark"></PanelContainer>
     <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
-        <controls:StripeBack Name="StationNameContainer">
+        <StripeBack Name="StationNameContainer">
             <PanelContainer>
                 <Label Name="StationName" Align="Center" Text="{Loc 'crew-manifest-cartridge-loading'}"/>
             </PanelContainer>
-        </controls:StripeBack>
+        </StripeBack>
         <ScrollContainer HorizontalExpand="True" VerticalExpand="True">
             <ui:CrewManifestListing
                 Name="CrewManifestListing"

--- a/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml
+++ b/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml
@@ -1,6 +1,5 @@
 <cartridges:NewsReaderUiFragment xmlns:cartridges="clr-namespace:Content.Client.CartridgeLoader.Cartridges"
                                xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-                               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                                xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
                                xmlns="https://spacestation14.io"
                                Margin="1 0 2 0"
@@ -26,12 +25,12 @@
             Text="{Loc 'news-read-ui-next-text'}"
             ToolTip="{Loc 'news-read-ui-next-tooltip'}"/>
     </BoxContainer>
-    <controls:StripeBack Name="ArticleNameContainer">
+    <StripeBack Name="ArticleNameContainer">
         <PanelContainer>
             <Label Name="PageNum" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="4,0,0,0"/>
             <Label Name="PageName" Align="Center"/>
         </PanelContainer>
-    </controls:StripeBack>
+    </StripeBack>
     <PanelContainer VerticalExpand="True">
         <PanelContainer.PanelOverride>
             <gfx:StyleBoxFlat BackgroundColor="#80808005" />

--- a/Content.Client/CartridgeLoader/Cartridges/WantedListUiFragment.xaml
+++ b/Content.Client/CartridgeLoader/Cartridges/WantedListUiFragment.xaml
@@ -1,6 +1,5 @@
 <cartridges:WantedListUiFragment xmlns:cartridges="clr-namespace:Content.Client.CartridgeLoader.Cartridges"
         xmlns="https://spacestation14.io"
-        xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
         Orientation="Vertical"
         VerticalExpand="True"
         HorizontalExpand="True">
@@ -11,7 +10,7 @@
         <Label Name="NoRecords" Text="{Loc 'wanted-list-label-no-records'}" Align="Center" VAlign="Center" HorizontalExpand="True" FontColorOverride="DarkGray"/>
 
         <!-- Any attempts to set dimensions for ListContainer breaks the renderer, I have to roughly set sizes and margins in other controllers. -->
-        <controls:ListContainer
+        <ListContainer
             Name="RecordsList"
             HorizontalAlignment="Left"
             VerticalExpand="True"
@@ -42,7 +41,7 @@
                     <RichTextLabel Name="InitiatorName" VerticalAlignment="Stretch"/>
                     <RichTextLabel Name="WantedReason" VerticalAlignment="Stretch"/>
                     <PanelContainer StyleClasses="LowDivider" Margin="0 5 0 5" />
-                    <controls:TableContainer Name="HistoryTable" Columns="3" Visible="False" HorizontalAlignment="Stretch" />
+                    <ContentTableContainer Name="HistoryTable" Columns="3" Visible="False" HorizontalAlignment="Stretch" />
                 </BoxContainer>
             </ScrollContainer>
         </BoxContainer>

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -1,6 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+<FancyWindow xmlns="https://spacestation14.io"
                 xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                 MinSize="620 670"
                 Title="{Loc 'chem-master-bound-user-interface-title'}">
@@ -133,4 +131,4 @@
             </PanelContainer>
         </BoxContainer>
     </TabContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
                       xmlns:ui="clr-namespace:Content.Client.Chemistry.UI"
                       Title="{Loc 'reagent-dispenser-bound-user-interface-title'}"
@@ -75,4 +74,4 @@
             </ScrollContainer>
         </SplitContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml
+++ b/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
     Title="{Loc 'comms-console-menu-title'}"
     MinSize="400 300">
 
@@ -59,4 +58,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Construction/UI/ConstructionMenu.xaml
+++ b/Content.Client/Construction/UI/ConstructionMenu.xaml
@@ -1,12 +1,11 @@
-<DefaultWindow xmlns="https://spacestation14.io"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls">
+<DefaultWindow xmlns="https://spacestation14.io">
     <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
         <BoxContainer Orientation="Vertical" MinWidth="243" Margin="0 0 5 0">
             <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="0 0 0 5">
                 <LineEdit Name="SearchBar" PlaceHolder="{Loc 'construction-menu-search'}" HorizontalExpand="True"/>
                 <OptionButton Name="OptionCategories" Access="Public" MinSize="130 0"/>
             </BoxContainer>
-            <controls:ListContainer Name="Recipes" Access="Public" Group="True" Toggle="True" VerticalExpand="True" />
+            <ListContainer Name="Recipes" Access="Public" Group="True" Toggle="True" VerticalExpand="True" />
             <ScrollContainer Name="RecipesGridScrollContainer" VerticalExpand="True" Access="Public" Visible="False">
                 <GridContainer Name="RecipesGrid" Columns="5" Access="Public"/>
             </ScrollContainer>

--- a/Content.Client/Construction/UI/FlatpackCreatorMenu.xaml
+++ b/Content.Client/Construction/UI/FlatpackCreatorMenu.xaml
@@ -1,7 +1,6 @@
-<controls:FancyWindow
+<FancyWindow
     xmlns="https://spacestation14.io"
     xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:ui="clr-namespace:Content.Client.Materials.UI"
     Title="{Loc 'flatpacker-ui-title'}"
     MinSize="550 350">
@@ -41,4 +40,4 @@
             </PanelContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/CrewManifest/CrewManifestUi.xaml
+++ b/Content.Client/CrewManifest/CrewManifestUi.xaml
@@ -1,14 +1,13 @@
 <DefaultWindow xmlns="https://spacestation14.io"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                xmlns:ui="clr-namespace:Content.Client.CrewManifest.UI"
                Title="{Loc 'crew-manifest-window-title'}"
                SetSize="450 750">
     <BoxContainer Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True">
-        <controls:StripeBack Name="StationNameContainer">
+        <StripeBack Name="StationNameContainer">
             <PanelContainer>
                 <Label Name="StationName" Align="Center" />
             </PanelContainer>
-        </controls:StripeBack>
+        </StripeBack>
         <BoxContainer HorizontalExpand="True" VerticalExpand="True">
             <ScrollContainer HorizontalExpand="True" VerticalExpand="True">
                 <!-- this MIGHT have race conditions -->

--- a/Content.Client/CriminalRecords/CrimeHistoryWindow.xaml
+++ b/Content.Client/CriminalRecords/CrimeHistoryWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                Title="{Loc 'criminal-records-console-crime-history'}"
                MinSize="660 400">
     <BoxContainer Orientation="Vertical" HorizontalExpand="True" Margin="5">
@@ -12,4 +11,4 @@
             <ItemList Name="History"/> <!-- Populated when window opened -->
         </ScrollContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       Title="{Loc 'criminal-records-console-window-title'}"
                       MinSize="695 440">
     <BoxContainer Orientation="Vertical">
@@ -138,4 +137,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/DeviceLinking/UI/RandomGateSetupWindow.xaml
+++ b/Content.Client/DeviceLinking/UI/RandomGateSetupWindow.xaml
@@ -1,6 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
             Title="{Loc 'random-gate-menu-setup'}"
             MinSize="260 115">
     <BoxContainer Orientation="Vertical" Margin="5" SeparationOverride="10">
@@ -16,4 +14,4 @@
                     HorizontalAlignment="Right" />
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
+++ b/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml
@@ -1,5 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:disposal="clr-namespace:Content.Client.Disposal"
                       MinSize="300 400"
             SetSize="300 400"
@@ -53,4 +52,4 @@
                          StyleClasses="OpenLeft" />
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml
+++ b/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml
@@ -1,5 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:disposal="clr-namespace:Content.Client.Disposal"
                       MinSize="300 140"
             SetSize="300 160"
@@ -40,4 +39,4 @@
                          StyleClasses="OpenLeft" />
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Doors/Electronics/DoorElectronicsConfigurationMenu.xaml
+++ b/Content.Client/Doors/Electronics/DoorElectronicsConfigurationMenu.xaml
@@ -1,7 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                xmlns:ui="clr-namespace:Content.Client.UserInterface"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                 Title="{Loc door-electronics-configuration-title}">
     <Control Name="AccessLevelControlContainer" />
-
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/FeedbackPopup/FeedbackPopupWindow.xaml
+++ b/Content.Client/FeedbackPopup/FeedbackPopupWindow.xaml
@@ -1,5 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       Title="{Loc feedbackpopup-window-name}" MinSize="510 460" RectClipContent="True">
         <BoxContainer Orientation="Vertical">
@@ -21,4 +20,4 @@
                 </BoxContainer>
             </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Fluids/UI/AbsorbentItemStatus.xaml
+++ b/Content.Client/Fluids/UI/AbsorbentItemStatus.xaml
@@ -1,4 +1,3 @@
-﻿<controls:SplitBar xmlns="https://spacestation14.io"
-                   xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<SplitBar xmlns="https://spacestation14.io"
                    Name="Bar">
-</controls:SplitBar>
+</SplitBar>

--- a/Content.Client/Gateway/UI/GatewayWindow.xaml
+++ b/Content.Client/Gateway/UI/GatewayWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       Title="{Loc 'gateway-window-title'}"
                       MinSize="800 360">
     <BoxContainer Orientation="Vertical">
@@ -29,9 +28,9 @@
 	                     SetHeight="25"/>
 	        <Label Name="NextCloseText" Text="0" Margin="5"/>
 	    </BoxContainer>
-	    <controls:HLine Color="#404040" Thickness="2" Margin="0 5 0 5"/>
+	    <HLine Color="#404040" Thickness="2" Margin="0 5 0 5"/>
 	    <BoxContainer Name="Container"
 	                  Orientation="Vertical"
 	                  Margin="5 0 5 0"/>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
@@ -1,7 +1,5 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
                 xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls"
-                xmlns:fancyTree="clr-namespace:Content.Client.UserInterface.Controls.FancyTree"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 SetSize="900 700"
                 MinSize="100 200"
                 Resizable="True"
@@ -9,7 +7,7 @@
     <SplitContainer Orientation="Horizontal" HorizontalExpand="True" Name="Split">
         <!-- Guide select -->
         <BoxContainer Orientation="Horizontal" Name="TreeBox">
-            <fancyTree:FancyTree Name="Tree" VerticalExpand="True" HorizontalExpand="True" Access="Public"/>
+            <FancyTree Name="Tree" VerticalExpand="True" HorizontalExpand="True" Access="Public"/>
             <cc:VSeparator StyleClasses="LowDivider" Margin="0 -2"/>
         </BoxContainer>
         <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
@@ -36,4 +34,4 @@
             </ScrollContainer>
         </BoxContainer>
     </SplitContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Guidebook/Richtext/Table.cs
+++ b/Content.Client/Guidebook/Richtext/Table.cs
@@ -6,7 +6,7 @@ using Robust.Client.UserInterface;
 namespace Content.Client.Guidebook.Richtext;
 
 [UsedImplicitly]
-public sealed class Table : TableContainer, IDocumentTag
+public sealed class Table : ContentTableContainer, IDocumentTag
 {
     public bool TryParseTag(Dictionary<string, string> args, [NotNullWhen(true)] out Control? control)
     {

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow
+<FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:ui="clr-namespace:Content.Client.HealthAnalyzer.UI"
     MaxHeight="525"
     MinWidth="300">
@@ -12,4 +11,4 @@
         <ui:HealthAnalyzerControl
             Name="HealthAnalyzer"/>
     </ScrollContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Holopad/HolopadWindow.xaml
+++ b/Content.Client/Holopad/HolopadWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                Resizable="False"
                MaxSize="400 800"
@@ -8,11 +7,11 @@
 
         <BoxContainer Name="ControlsLockOutContainer" Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True" ReservesSpace="False" Visible="False">
             <!-- Header text -->
-            <controls:StripeBack>
+            <StripeBack>
                 <PanelContainer>
                     <RichTextLabel Name="EmergencyBroadcastText" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="10 10 10 10" ReservesSpace="False"/>
                 </PanelContainer>
-            </controls:StripeBack>
+            </StripeBack>
             
             <Label Text="{Loc 'holopad-window-controls-locked-out'}" HorizontalAlignment="Center" Margin="10 5 10 0" ReservesSpace="False"/>
             <RichTextLabel Name="LockOutIdText" HorizontalAlignment="Center" Margin="10 5 10 0" ReservesSpace="False"/>
@@ -49,14 +48,14 @@
             <!-- Call placement controls (either this or the active call controls will be active) -->
             <BoxContainer Name="CallPlacementControlsContainer" Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True" ReservesSpace="False">
 
-                <controls:StripeBack>
+                <StripeBack>
                     <PanelContainer>
                         <BoxContainer Orientation="Vertical">
                             <RichTextLabel Name="SubtitleText" HorizontalAlignment="Center" Margin="0 5 0 0"/>
                             <RichTextLabel Name="OptionsText" HorizontalAlignment="Center" Margin="0 0 0 5"/>
                         </BoxContainer>
                     </PanelContainer>
-                </controls:StripeBack>
+                </StripeBack>
 
                 <!-- Request the station AI or activate the holopad projector (only one of these should be active at a time) -->
                 <BoxContainer Name="RequestStationAiContainer" Orientation="Vertical" ReservesSpace="False" Visible="False">
@@ -115,4 +114,4 @@
         </BoxContainer>
     </BoxContainer>
 
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Implants/UI/ChameleonControllerMenu.xaml
+++ b/Content.Client/Implants/UI/ChameleonControllerMenu.xaml
@@ -1,5 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-             xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<FancyWindow xmlns="https://spacestation14.io"
              Title="{Loc 'chameleon-controller-ui-window-name'}"
              MinSize="250 300"
              SetSize="850 700">
@@ -9,4 +8,4 @@
             </GridContainer>
         </ScrollContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Implants/UI/DeimplantChoiceWindow.xaml
+++ b/Content.Client/Implants/UI/DeimplantChoiceWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                Title="{Loc 'implanter-set-draw-window'}"
                MinSize="5 30">
     <BoxContainer Orientation="Vertical" Margin="10 5">
@@ -9,4 +8,4 @@
             <OptionButton Name="ImplantSelector"/> <!-- Populated in LoadVerbs -->
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Info/PlaytimeStats/PlaytimeStatsWindow.xaml
+++ b/Content.Client/Info/PlaytimeStats/PlaytimeStatsWindow.xaml
@@ -1,5 +1,4 @@
-<ui:FancyWindow xmlns="https://spacestation14.io"
-                xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                 xmlns:pt="clr-namespace:Content.Client.Info.PlaytimeStats"
                 xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
                 VerticalExpand="True" HorizontalExpand="True"
@@ -22,4 +21,4 @@
             </ScrollContainer>
         </BoxContainer>
     </Control>
-</ui:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Instruments/UI/ChannelsMenu.xaml
+++ b/Content.Client/Instruments/UI/ChannelsMenu.xaml
@@ -1,5 +1,4 @@
-<DefaultWindow Title="{Loc 'instruments-component-channels-menu'}" MinSize="250 350" xmlns="https://spacestation14.io"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls">
+<DefaultWindow Title="{Loc 'instruments-component-channels-menu'}" MinSize="250 350" xmlns="https://spacestation14.io">
     <BoxContainer Orientation="Vertical" HorizontalExpand="true" VerticalExpand="true" Align="Center">
         <ItemList Name="ChannelList" SelectMode="Multiple" Margin="3 3 3 3" HorizontalExpand="true" VerticalExpand="true" SizeFlagsStretchRatio="8"/>
         <BoxContainer Orientation="Horizontal" HorizontalExpand="true" VerticalExpand="true" Align="Center"
@@ -7,7 +6,7 @@
             <Button Name="AllButton" Text="{Loc 'instruments-component-channels-all-button'}" HorizontalExpand="true" VerticalExpand="true" SizeFlagsStretchRatio="1"/>
             <Button Name="ClearButton" Text="{Loc 'instruments-component-channels-clear-button'}" HorizontalExpand="true" VerticalExpand="true" SizeFlagsStretchRatio="1"/>
         </BoxContainer>
-        <controls:SwitchButton Name="DisplayTrackNames"
+        <SwitchButton Name="DisplayTrackNames"
                 Text="{Loc 'instruments-component-channels-track-names-toggle'}"
                 Margin="0 5 0 0" />
     </BoxContainer>

--- a/Content.Client/Kitchen/UI/GrinderMenu.xaml
+++ b/Content.Client/Kitchen/UI/GrinderMenu.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
             xmlns:ui="clr-namespace:Content.Client.Kitchen.UI"
-            xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
             Title="{Loc grinder-menu-title}" MinSize="768 256">
     <BoxContainer Orientation="Horizontal">
         <BoxContainer Orientation="Vertical" VerticalAlignment="Top" Margin="8" MinWidth="100">
@@ -15,4 +14,4 @@
 
         <ui:LabelledContentBox Name="BeakerContentBox" LabelText="{Loc grinder-menu-beaker-content-box-label}" ButtonText="{Loc grinder-menu-beaker-content-box-button}" VerticalExpand="True" HorizontalExpand="True" Margin="8" SizeFlagsStretchRatio="2"/>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Kitchen/UI/MicrowaveMenu.xaml
+++ b/Content.Client/Kitchen/UI/MicrowaveMenu.xaml
@@ -1,6 +1,5 @@
-﻿<controls:FancyWindow
+﻿<FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     Title="{Loc 'microwave-menu-title'}"
     MinWidth="512"
@@ -109,4 +108,4 @@
             <gfx:StyleBoxFlat BackgroundColor="#1B1B1E66" />
         </PanelContainer.PanelOverride>
     </PanelContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Launcher/LauncherConnectingGui.xaml
+++ b/Content.Client/Launcher/LauncherConnectingGui.xaml
@@ -1,8 +1,6 @@
 <Control xmlns="https://spacestation14.io"
-         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
          xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-         xmlns:parallax="clr-namespace:Content.Client.Parallax"
-         xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls">
+         xmlns:parallax="clr-namespace:Content.Client.Parallax">
     <parallax:ParallaxControl SpeedX="20"/>
     <Control HorizontalAlignment="Center" VerticalAlignment="Center">
         <PanelContainer StyleClasses="BackgroundPanel" />
@@ -13,7 +11,7 @@
                 <Button Name="ExitButton" Text="{Loc 'connecting-exit'}"
                         HorizontalAlignment="Right" HorizontalExpand="True" />
             </BoxContainer>
-            <controls:HighDivider />
+            <HighDivider />
             <BoxContainer Orientation="Vertical" VerticalExpand="True" Margin="4 4 4 0">
                 <Control VerticalExpand="True" Margin="0 0 0 8">
                     <BoxContainer Orientation="Vertical" Name="ConnectingStatus">
@@ -70,11 +68,11 @@
     <!-- Bottom window for tips -->
     <PanelContainer Name="LoginTips" StyleClasses="BackgroundPanel" Margin="0 10" MaxWidth="600" VerticalExpand="True" VerticalAlignment="Bottom">
         <BoxContainer Orientation="Vertical" VerticalExpand="True">
-            <controls:StripeBack>
+            <StripeBack>
                 <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center">
                     <Label Name="LoginTipTitle" Text="Tip" StyleClasses="LabelHeading" Align="Center"/>
                 </BoxContainer>
-            </controls:StripeBack>
+            </StripeBack>
             <BoxContainer Orientation="Vertical" Margin="5 5 5 5" >
                 <RichTextLabel Name="LoginTip" VerticalExpand="True" />
             </BoxContainer>

--- a/Content.Client/Lobby/UI/Loadouts/LoadoutWindow.xaml
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutWindow.xaml
@@ -1,6 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-         xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
          xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
          SetSize="800 800"
          MinSize="800 128">
@@ -19,4 +17,4 @@
                               HorizontalExpand="True">
         </VerticalTabContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.xaml
+++ b/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.xaml
@@ -1,12 +1,8 @@
 <Control
     xmlns="https://spacestation14.io"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:profile="clr-namespace:Content.Client.Lobby.UI.ProfileEditorControls">
     <BoxContainer Name="VBox" Orientation="Vertical">
-        <controls:NanoHeading Name="Header" Text="{Loc 'lobby-character-preview-panel-header'}">
-
-        </controls:NanoHeading>
+        <NanoHeading Name="Header" Text="{Loc 'lobby-character-preview-panel-header'}" />
         <BoxContainer Name="Loaded" Orientation="Vertical"
                       Visible="False">
             <Label Name="Summary" HorizontalAlignment="Center" Margin="3 3"/>
@@ -18,7 +14,7 @@
                                                   Stretch="Fill"
                                                   Access="Public" />
             </BoxContainer>
-            <controls:VSpacer/>
+            <VSpacer/>
             <Button Name="CharacterSetup" Text="{Loc 'lobby-character-preview-panel-character-setup-button'}"
                     HorizontalAlignment="Center"
                     Margin="0 5 0 0"/>

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -3,7 +3,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:maths="clr-namespace:Robust.Shared.Maths;assembly=Robust.Shared.Maths"
     xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:vote="clr-namespace:Content.Client.Voting.UI"
     xmlns:style="clr-namespace:Content.Client.Stylesheets"
     xmlns:lobbyUi="clr-namespace:Content.Client.Lobby.UI"
@@ -25,7 +24,7 @@
                             <BoxContainer Orientation="Vertical" HorizontalAlignment="Center" MaxWidth="800">
                                 <info:LinkBanner Name="LinkBanner" VerticalExpand="false" HorizontalAlignment="Center"
                                                  Margin="3 3 3 3" />
-                                <controls:StripeBack>
+                                <StripeBack>
                                     <BoxContainer Orientation="Horizontal" SeparationOverride="6" Margin="3 3 3 3">
                                         <cc:UICommandButton Command="observe" Name="ObserveButton" Access="Public"
                                                             Text="{Loc 'ui-lobby-observe-button'}"
@@ -40,7 +39,7 @@
                                                 Text="{Loc 'ui-lobby-ready-up-button'}"
                                                 StyleClasses="ButtonBig" MinWidth="137" />
                                     </BoxContainer>
-                                </controls:StripeBack>
+                                </StripeBack>
                                 <RichTextLabel Name="PlaytimeComment" Visible="False" Access="Public" HorizontalAlignment="Center" />
                             </BoxContainer>
                         </PanelContainer>
@@ -76,8 +75,8 @@
                                HorizontalExpand="True" HorizontalAlignment="Center" />
                     </BoxContainer>
                     <!-- Gold line -->
-                    <controls:HLine StyleClasses="highlight" Thickness="2" />
-                    <controls:HSpacer Spacing="10" />
+                    <HLine StyleClasses="highlight" Thickness="2" />
+                    <HSpacer Spacing="10" />
                     <!-- Voting & misc button bar -->
                     <BoxContainer Orientation="Horizontal" MinSize="0 40" HorizontalAlignment="Right">
                         <Button Name="AHelpButton" Access="Public" Text="{Loc 'ui-lobby-ahelp-button'}"
@@ -88,20 +87,20 @@
                         <Button Name="LeaveButton" Access="Public" StyleClasses="ButtonBig"
                                 Text="{Loc 'ui-lobby-leave-button'}" />
                     </BoxContainer>
-                    <controls:HSpacer Spacing="10" />
+                    <HSpacer Spacing="10" />
                     <!-- Server info -->
-                    <controls:NanoHeading Text="{Loc 'ui-lobby-server-info-block'}" />
+                    <NanoHeading Text="{Loc 'ui-lobby-server-info-block'}" />
                     <info:ServerInfo Name="ServerInfo" Access="Public" MinSize="0 30" VerticalExpand="false"
                                      Margin="3 3 3 3" MaxWidth="400" HorizontalAlignment="Left" />
                     <Label Name="StationTime" Access="Public" FontColorOverride="{x:Static maths:Color.LightGray}"
                            Margin="3 3 3 3" HorizontalAlignment="Left" />
-                    <controls:HSpacer Spacing="5" />
+                    <HSpacer Spacing="5" />
                     <lobbyUi:LobbyCharacterPreviewPanel Name="CharacterPreview" Access="Public" />
-                    <controls:HSpacer Spacing="5" />
+                    <HSpacer Spacing="5" />
                     <BoxContainer MinHeight="10" />
                     <!-- Gold line -->
-                    <controls:HLine StyleClasses="highlight" Thickness="2" Access="Public" />
-                    <controls:HSpacer Spacing="10" />
+                    <HLine StyleClasses="highlight" Thickness="2" Access="Public" />
+                    <HSpacer Spacing="10" />
                     <widgets:ChatBox Name="Chat" Access="Public" VerticalExpand="True" Margin="3 3 3 3" MinHeight="50" />
                 </BoxContainer>
                 <TextureButton Name="CollapseButton"

--- a/Content.Client/Mapping/MappingScreen.xaml
+++ b/Content.Client/Mapping/MappingScreen.xaml
@@ -1,6 +1,5 @@
 ﻿<mapping:MappingScreen
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:widgets="clr-namespace:Content.Client.UserInterface.Systems.Chat.Widgets"
     xmlns:hotbar="clr-namespace:Content.Client.UserInterface.Systems.Hotbar.Widgets"
     xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
@@ -58,7 +57,7 @@
             <widgets:ChatBox Visible="False" />
         </BoxContainer>
         <LayoutContainer Name="ViewportContainer" HorizontalExpand="True" VerticalExpand="True">
-            <controls:MainViewport Name="MainViewport"/>
+            <MainViewport Name="MainViewport"/>
             <hotbar:HotbarGui Name="Hotbar" />
             <PanelContainer Name="Actions" VerticalExpand="True" HorizontalExpand="True"
                             MaxHeight="48">

--- a/Content.Client/MassMedia/Ui/NewsArticleCard.xaml
+++ b/Content.Client/MassMedia/Ui/NewsArticleCard.xaml
@@ -1,7 +1,6 @@
 <Control xmlns="https://spacestation14.io"
          xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
          xmlns:system="clr-namespace:System;assembly=System.Runtime"
-         xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
          Margin="0 0 0 8">
     <PanelContainer StyleClasses="BackgroundPanel" ModulateSelfOverride="#2b2b31"/>
     <BoxContainer Orientation="Vertical" SetHeight="60">
@@ -17,13 +16,13 @@
             <Label FontColorOverride="#b1b1b2" StyleClasses="LabelSmall" Name="AuthorLabel" Margin="14 6 6 6"/>
             <Control HorizontalExpand="True"/>
             <Label FontColorOverride="#b1b1b2" StyleClasses="LabelSmall" Name="PublishTimeLabel" Margin="6 6 6 6"/>
-            <controls:ConfirmButton Name="DeleteButton" Text="{Loc news-write-ui-delete-text}"
+            <ConfirmButton Name="DeleteButton" Text="{Loc news-write-ui-delete-text}"
                     HorizontalAlignment="Right" Margin="8 6 6 6" SetHeight="19" SetWidth="52" Access="Public">
                 <Button.StyleClasses>
                     <system:String>ButtonSmall</system:String>
                     <system:String>negative</system:String>
                 </Button.StyleClasses>
-            </controls:ConfirmButton>
+            </ConfirmButton>
         </BoxContainer>
     </BoxContainer>
 </Control>

--- a/Content.Client/MassMedia/Ui/NewsWriterMenu.xaml
+++ b/Content.Client/MassMedia/Ui/NewsWriterMenu.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow
+<FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:ui="clr-namespace:Content.Client.MassMedia.Ui"
     xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     Title="{Loc 'news-write-ui-default-title'}"
@@ -42,4 +41,4 @@
             </BoxContainer>
         </Control>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Materials/UI/OreSiloMenu.xaml
+++ b/Content.Client/Materials/UI/OreSiloMenu.xaml
@@ -1,5 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                      xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                      xmlns:ui="clr-namespace:Content.Client.Materials.UI"
                      Title="{Loc 'ore-silo-ui-title'}"
@@ -39,4 +38,4 @@
             </PanelContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Mech/Ui/MechMenu.xaml
+++ b/Content.Client/Mech/Ui/MechMenu.xaml
@@ -1,4 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       Title="{Loc 'mech-menu-title'}"
@@ -68,4 +68,4 @@
             </PanelContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
                xmlns:ui="clr-namespace:Content.Client.Medical.CrewMonitoring"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                Title="{Loc crew-monitoring-ui-title}"
                Resizable="False"
                SetSize="1210 700"
@@ -9,11 +8,11 @@
         <BoxContainer Orientation="Horizontal" VerticalExpand="True" HorizontalExpand="True">
             <ui:CrewMonitoringNavMapControl Name="NavMap" HorizontalExpand="True" VerticalExpand="True" Margin="5 20"/>
             <BoxContainer Orientation="Vertical" Margin="0 0 10 0">
-                <controls:StripeBack>
+                <StripeBack>
                     <PanelContainer>
                         <Label Name="StationName" Text="{Loc crew-monitoring-ui-no-station-label}" Align="Center" Margin="0 5 0 3"/>
                     </PanelContainer>
-                </controls:StripeBack>
+                </StripeBack>
 
                 <LineEdit Name="SearchLineEdit" HorizontalExpand="True"
                           PlaceHolder="{Loc crew-monitoring-ui-filter-line-placeholder}" />
@@ -50,4 +49,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Medical/Cryogenics/CryoPodWindow.xaml
+++ b/Content.Client/Medical/Cryogenics/CryoPodWindow.xaml
@@ -1,7 +1,6 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
                xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                xmlns:health="clr-namespace:Content.Client.HealthAnalyzer.UI"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                xmlns:cryogenics="clr-namespace:Content.Client.Medical.Cryogenics"
                MinSize="250 300"
                Resizable="False">
@@ -62,7 +61,7 @@
 
             <!-- Gas mix -->
             <Control Margin="0 0 0 22">
-                <controls:SplitBar Name="GasMixChart"
+                <SplitBar Name="GasMixChart"
                                    MinHeight="8"
                                    MaxHeight="8"/>
             </Control>
@@ -229,4 +228,4 @@
 
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/NPC/NPCWindow.xaml
+++ b/Content.Client/NPC/NPCWindow.xaml
@@ -1,18 +1,17 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
             Title="{Loc npc-debug-overlay-window-title}"
             MinSize="200 200">
     <BoxContainer Name="Options" Orientation="Vertical" Margin="8 8">
-        <controls:StripeBack>
+        <StripeBack>
             <Label Text="{Loc npc-debug-overlay-window-section-npc-label}" HorizontalAlignment="Center"/>
-        </controls:StripeBack>
+        </StripeBack>
         <BoxContainer Name="NPCBox" Orientation="Vertical">
             <CheckBox Name="NPCThonk" Text="{Loc npc-debug-overlay-window-show-htn-tree-checkbox}"/>
         </BoxContainer>
-        <controls:StripeBack>
+        <StripeBack>
             <Label Text="{Loc npc-debug-overlay-window-section-pathfinder-label}" HorizontalAlignment="Center"/>
-        </controls:StripeBack>
+        </StripeBack>
         <BoxContainer Name="PathfinderBox" Orientation="Vertical">
             <CheckBox Name="PathCrumbs" Text="{Loc npc-debug-overlay-window-path-breadcrumbs-checkbox}"/>
             <CheckBox Name="PathPolys" Text="{Loc npc-debug-overlay-window-path-polygons-checkbox}"/>
@@ -21,4 +20,4 @@
             <CheckBox Name="PathRoutes" Text="{Loc npc-debug-overlay-window-path-routes-checkbox}"/>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/NetworkConfigurator/NetworkConfiguratorConfigurationMenu.xaml
+++ b/Content.Client/NetworkConfigurator/NetworkConfiguratorConfigurationMenu.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                 xmlns:networkConfigurator="clr-namespace:Content.Client.NetworkConfigurator"
                 Title="{Loc 'network-configurator-title-device-configuration'}" MinSize="350 100">
     <BoxContainer Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True">
@@ -17,4 +16,4 @@
         </BoxContainer>
         <Label Name="Count" StyleClasses="LabelSubText" HorizontalAlignment="Right" Margin="0 0 12 8"/>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/NetworkConfigurator/NetworkConfiguratorLinkMenu.xaml
+++ b/Content.Client/NetworkConfigurator/NetworkConfiguratorLinkMenu.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                 xmlns:networkConfigurator="clr-namespace:Content.Client.NetworkConfigurator"
                 Title="Network Configurator" MinSize="620 400" RectClipContent="True">
     <BoxContainer Orientation="Vertical" VerticalExpand="True">
@@ -44,4 +43,4 @@
             </BoxContainer>
         </Control>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/NetworkConfigurator/NetworkConfiguratorListMenu.xaml
+++ b/Content.Client/NetworkConfigurator/NetworkConfiguratorListMenu.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                 xmlns:networkConfigurator="clr-namespace:Content.Client.NetworkConfigurator"
                 Title="{Loc 'network-configurator-title-saved-devices'}" MinSize="220 400">
     <BoxContainer Orientation="Vertical" VerticalExpand="True">
@@ -10,4 +9,4 @@
             <Button Name="ClearButton" Access="Public" Text="{Loc 'network-configurator-ui-clear-button'}" />
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/NukeOps/WarDeclaratorWindow.xaml
+++ b/Content.Client/NukeOps/WarDeclaratorWindow.xaml
@@ -1,6 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                Title="{Loc 'war-declarator-ui-header'}">
     <BoxContainer Orientation="Vertical" SeparationOverride="4" MinWidth="440">
         <TextEdit Name="MessageEdit"
@@ -20,4 +18,4 @@
                    Access="Public"/>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Options/UI/OptionsTabControlRow.xaml
+++ b/Content.Client/Options/UI/OptionsTabControlRow.xaml
@@ -1,6 +1,5 @@
-<Control xmlns="https://spacestation14.io"
-         xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls">
-    <controls:StripeBack HasBottomEdge="False">
+<Control xmlns="https://spacestation14.io">
+    <StripeBack HasBottomEdge="False">
         <BoxContainer Orientation="Horizontal" Align="End" Margin="2">
             <Button Name="DefaultButton"
                     Text="{Loc 'ui-options-default'}"
@@ -14,5 +13,5 @@
                     Text="{Loc 'ui-options-apply'}"
                     StyleClasses="OpenLeft" />
         </BoxContainer>
-    </controls:StripeBack>
+    </StripeBack>
 </Control>

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml
@@ -1,5 +1,4 @@
-﻿<Control xmlns="https://spacestation14.io"
-         xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls">
+﻿<Control xmlns="https://spacestation14.io">
     <BoxContainer Orientation="Vertical">
         <ScrollContainer VerticalExpand="True">
             <BoxContainer Name="KeybindsContainer" Orientation="Vertical" Margin="8 8 8 8">
@@ -8,7 +7,7 @@
 
             </BoxContainer>
         </ScrollContainer>
-        <controls:StripeBack HasBottomEdge="False" HasMargins="False">
+        <StripeBack HasBottomEdge="False" HasMargins="False">
             <BoxContainer Orientation="Horizontal" Margin="8 8">
                 <Control MinSize="8 0" />
                 <Label Text="{Loc 'ui-options-binds-explanation'}" StyleClasses="LabelSubText" />
@@ -17,6 +16,6 @@
                         HorizontalExpand="True"
                         HorizontalAlignment="Right" />
             </BoxContainer>
-        </controls:StripeBack>
+        </StripeBack>
     </BoxContainer>
 </Control>

--- a/Content.Client/PDA/PdaMenu.xaml
+++ b/Content.Client/PDA/PdaMenu.xaml
@@ -1,6 +1,5 @@
 <pda:PdaWindow  xmlns="https://spacestation14.io"
                 xmlns:pda="clr-namespace:Content.Client.PDA"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 MinSize="576 450"
                 SetSize="576 450">
     <!-- This: (Margin="1 1 3 0") is necessary so the navigation bar doesn't sticks into the black content border. -->
@@ -90,9 +89,9 @@
         </BoxContainer>
     </BoxContainer>
     <BoxContainer Name="ContentFooter" HorizontalExpand="True" SetHeight="28" Margin="1 0 2 1">
-        <controls:StripeBack HasBottomEdge="False" HasMargins="False" HorizontalExpand="True">
+        <StripeBack HasBottomEdge="False" HasMargins="False" HorizontalExpand="True">
             <Label Text="Robust#OS ™" VerticalAlignment="Center" Margin="6 0" StyleClasses="PdaContentFooterText"/>
             <Label Name="AddressLabel" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="6 0" StyleClasses="PdaContentFooterText"/>
-        </controls:StripeBack>
+        </StripeBack>
     </BoxContainer>
 </pda:PdaWindow>

--- a/Content.Client/PDA/Ringer/RingtoneMenu.xaml
+++ b/Content.Client/PDA/Ringer/RingtoneMenu.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       Title="{Loc 'comp-ringer-ui-menu-title'}"
             MinSize="320 100"
             SetSize="320 100">
@@ -91,4 +90,4 @@
                 </BoxContainer>
             </PanelContainer>
         </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/ParticleAccelerator/UI/ParticleAcceleratorControlMenu.xaml
+++ b/Content.Client/ParticleAccelerator/UI/ParticleAcceleratorControlMenu.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
     xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:ui="clr-namespace:Content.Client.ParticleAccelerator.UI"
     Title="{Loc 'particle-accelerator-control-menu-device-version-label'}"
     MinSize="320 120">
@@ -77,7 +76,7 @@
                     VerticalAlignment="Center"
                     Visible="False">
 
-                    <controls:StripeBack Margin="-8 0">
+                    <StripeBack Margin="-8 0">
                         <BoxContainer Orientation="Vertical">
                             <RichTextLabel Name="BigAlarmLabel"
                                 HorizontalAlignment="Center"/>
@@ -85,7 +84,7 @@
                             <RichTextLabel Name="BigAlarmLabelTwo"
                                 HorizontalAlignment="Center"/>
                         </BoxContainer>
-                    </controls:StripeBack>
+                    </StripeBack>
 
                     <Label Text="{Loc 'particle-accelerator-control-menu-service-manual-reference'}"
                         HorizontalAlignment="Center"
@@ -150,12 +149,12 @@
         <BoxContainer Orientation="Vertical"
             VerticalAlignment="Bottom">
 
-            <controls:StripeBack>
+            <StripeBack>
                 <Label Text="{Loc 'particle-accelerator-control-menu-check-containment-field-warning'}"
                     HorizontalAlignment="Center"
                     StyleClasses="LabelSubText"
                     Margin="0 4"/>
-            </controls:StripeBack>
+            </StripeBack>
 
             <BoxContainer Orientation="Horizontal"
                 Margin="12 0 6 2"
@@ -180,4 +179,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Pinpointer/UI/NavMapBeaconWindow.xaml
+++ b/Content.Client/Pinpointer/UI/NavMapBeaconWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       Title="{Loc 'nav-beacon-window-title'}"
                       MinSize="250 230"
                       SetSize="320 230">
@@ -14,4 +13,4 @@
         <Button Name="ApplyButton" Text="{Loc 'nav-beacon-button-apply'}" HorizontalAlignment="Right"/>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Pinpointer/UI/StationMapWindow.xaml
+++ b/Content.Client/Pinpointer/UI/StationMapWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:ui="clr-namespace:Content.Client.Pinpointer.UI"
                       Title="{Loc 'station-map-window-title'}"
                       Resizable="False"
@@ -7,11 +6,11 @@
                       MinSize="868 748">
     <BoxContainer Orientation="Vertical">
         <!-- Station name -->
-        <controls:StripeBack>
+        <StripeBack>
             <PanelContainer>
                 <Label Name="StationName" Text="{Loc 'station-map-unknown-station'}" StyleClasses="LabelBig" Align="Center"/>
             </PanelContainer>
-        </controls:StripeBack>
+        </StripeBack>
 
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True" VerticalAlignment="Top">
             <ui:NavMapControl Name="NavMapScreen"/>
@@ -39,4 +38,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Power/APC/UI/ApcMenu.xaml
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml
@@ -1,6 +1,4 @@
-<controls:FancyWindow  xmlns="https://spacestation14.io"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow  xmlns="https://spacestation14.io"
     Name="APCMenu"
     Title="{Loc 'apc-menu-title'}"
     Resizable="False">
@@ -18,7 +16,7 @@
                         <!-- Power On/Off -->
                         <Label Text="{Loc 'apc-menu-breaker-label'}" HorizontalExpand="True"
                                 StyleClasses="highlight" MinWidth="120"/>
-                        <controls:SwitchButton Name="BreakerButton" MinWidth="150"/>
+                        <SwitchButton Name="BreakerButton" MinWidth="150"/>
                         <!--Charging Status-->
                         <Label Text="{Loc 'apc-menu-external-label'}" StyleClasses="highlight" MinWidth="120" />
                         <Label Name="ExternalPowerStateLabel" Text="{Loc 'apc-menu-power-state-good'}" />
@@ -53,4 +51,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Power/Battery/BatteryMenu.xaml
+++ b/Content.Client/Power/Battery/BatteryMenu.xaml
@@ -1,6 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       SetSize="650 330"
                       Resizable="False">
@@ -21,7 +19,7 @@
                             <BoxContainer Orientation="Horizontal">
                                 <Label Text="{Loc 'battery-menu-in'}" HorizontalExpand="True" VerticalAlignment="Top"
                                        StyleClasses="LabelKeyText" />
-                                <controls:OnOffButton Name="InBreaker" />
+                                <OnOffButton Name="InBreaker" />
                             </BoxContainer>
                             <Label Name="InValue" />
                         </BoxContainer>
@@ -51,7 +49,7 @@
                             <BoxContainer Orientation="Horizontal">
                                 <Label Text="{Loc 'battery-menu-out'}" HorizontalExpand="True" VerticalAlignment="Top"
                                        StyleClasses="LabelKeyText" />
-                                <controls:OnOffButton Name="OutBreaker" />
+                                <OnOffButton Name="OutBreaker" />
                             </BoxContainer>
                             <Label Name="OutValue" />
                         </BoxContainer>
@@ -143,4 +141,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Power/Generator/GeneratorWindow.xaml
+++ b/Content.Client/Power/Generator/GeneratorWindow.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
                 xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 MinSize="450 250"
                 SetSize="450 250"
                 Resizable="False"
@@ -45,4 +44,4 @@
             <SpriteView Name="EntityView" SetSize="64 64" Scale="2 2" OverrideDirection="South" Margin="15"/>
         </PanelContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Power/PowerCharge/PowerChargeWindow.xaml
+++ b/Content.Client/Power/PowerCharge/PowerChargeWindow.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow
+<FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     MinSize="320 180"
     Resizable="False">
     <BoxContainer
@@ -85,4 +84,4 @@
                 OverrideDirection="South" />
         </PanelContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Power/PowerMonitoringWindow.xaml
+++ b/Content.Client/Power/PowerMonitoringWindow.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
                xmlns:ui="clr-namespace:Content.Client.Power"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                Title="{Loc 'power-monitoring-window-title'}"
                Resizable="False"
@@ -59,11 +58,11 @@
             <BoxContainer Orientation="Vertical" VerticalExpand="True" SetWidth="440" Margin="0 0 10 10">
 
                 <!-- Station name -->
-                <controls:StripeBack>
+                <StripeBack>
                     <PanelContainer>
                         <RichTextLabel Name="StationName" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0 5 0 3"/>
                     </PanelContainer>
-                </controls:StripeBack>
+                </StripeBack>
 
                 <!-- Power overview -->
                 <GridContainer Columns="2">
@@ -115,4 +114,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Radio/Ui/IntercomMenu.xaml
+++ b/Content.Client/Radio/Ui/IntercomMenu.xaml
@@ -1,5 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                      Title="{Loc 'intercom-menu-title'}"
                      MinSize="300 170"
                      SetSize="300 170">
@@ -28,4 +27,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Research/UI/DiskConsoleMenu.xaml
+++ b/Content.Client/Research/UI/DiskConsoleMenu.xaml
@@ -1,5 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                      xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                      Title="{Loc 'tech-disk-ui-name'}"
                      MinSize="400 260"
@@ -33,4 +32,4 @@
             </BoxContainer>
         </PanelContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Research/UI/ResearchConsoleMenu.xaml
+++ b/Content.Client/Research/UI/ResearchConsoleMenu.xaml
@@ -1,6 +1,5 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
                       Title="{Loc 'research-console-menu-title'}"
                       MinSize="625 400"
@@ -95,4 +94,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Revolutionary/UI/DeconvertedMenu.xaml
+++ b/Content.Client/Revolutionary/UI/DeconvertedMenu.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       Title="{Loc 'rev-deconverted-title'}">
     <BoxContainer Orientation="Vertical" Margin="5">
         <Label Text="{Loc 'rev-deconverted-text'}"/>
@@ -7,4 +6,4 @@
             <Button Name="ConfirmButton" Text="{Loc 'rev-deconverted-confirm'}"/>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml
+++ b/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml
@@ -1,5 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                      Title="{Loc 'robotics-console-window-title'}"
                      MinSize="600 450">
     <BoxContainer Orientation="Vertical">
@@ -28,13 +27,13 @@
                 </PanelContainer>
                 <!-- TODO: button to open camera window for this borg -->
             </BoxContainer>
-            <controls:StripeBack>
+            <StripeBack>
                 <BoxContainer Name="DangerZone" Margin="5" Orientation="Horizontal" HorizontalExpand="True" HorizontalAlignment="Center" Visible="False">
                     <Button Name="DisableButton" Text="{Loc 'robotics-console-disable'}" StyleClasses="OpenRight"/>
                     <Button Name="DestroyButton" Text="{Loc 'robotics-console-destroy'}" StyleClasses="OpenLeft"/>
                 </BoxContainer>
                 <Label Name="LockedMessage" Text="{Loc 'robotics-console-locked-message'}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-            </controls:StripeBack>
+            </StripeBack>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Salvage/UI/OfferingWindow.xaml
+++ b/Content.Client/Salvage/UI/OfferingWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       MinSize="800 360">
     <BoxContainer Orientation="Vertical">
         <BoxContainer Orientation="Horizontal" Name="ProgressionBox" Visible="False">
@@ -28,9 +27,9 @@
             <Label Name="NextOfferText" Text="0.00"
                    Margin="5"/>
         </BoxContainer>
-        <controls:HLine Color="#404040" Thickness="2" Margin="0 5 0 5"/>
+        <HLine Color="#404040" Thickness="2" Margin="0 5 0 5"/>
         <BoxContainer Name="Container"
                       Orientation="Horizontal"
                       Margin="5 0 5 0"/>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Salvage/UI/OfferingWindowOption.xaml
+++ b/Content.Client/Salvage/UI/OfferingWindowOption.xaml
@@ -1,16 +1,15 @@
 <PanelContainer xmlns="https://spacestation14.io"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 HorizontalExpand="True"
                 Name="BigPanel"
                 Margin="5 0">
     <BoxContainer Orientation="Vertical"
                   Margin="5 5">
         <!-- Title box -->
-        <controls:StripeBack>
+        <StripeBack>
             <Label Name="TitleStripe"
                    HorizontalAlignment="Center"
                    Margin="0 5 0 5"/>
-        </controls:StripeBack>
+        </StripeBack>
         <BoxContainer Orientation="Vertical" Name="ContentBox"/>
         <!-- Buffer so all claim buttons are in the same position -->
         <Control VerticalExpand="True"/>

--- a/Content.Client/Salvage/UI/SalvageJobBoardMenu.xaml
+++ b/Content.Client/Salvage/UI/SalvageJobBoardMenu.xaml
@@ -1,6 +1,5 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       Title="{Loc 'job-board-ui-window-title'}"
                       SetSize="550 550"
                       Resizable="False">
@@ -42,4 +41,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Security/Ui/GenpopLockerMenu.xaml
+++ b/Content.Client/Security/Ui/GenpopLockerMenu.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow
+<FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     MinSize="400 230"
     SetSize="450 260">
     <BoxContainer Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True" Margin="10 5 10 10">
@@ -19,6 +18,6 @@
             <Button Name="DoneButton" Text="{Loc 'genpop-locket-ui-button-done'}" Disabled="True"/>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>
 
 

--- a/Content.Client/SensorMonitoring/SensorMonitoringWindow.xaml
+++ b/Content.Client/SensorMonitoring/SensorMonitoringWindow.xaml
@@ -1,10 +1,7 @@
-<contentControls:FancyWindow
+<FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:contentControls="clr-namespace:Content.Client.UserInterface.Controls"
     Title="{Loc 'sensor-monitoring-window-title'}" MinWidth="640" MinHeight="480">
     <ScrollContainer>
-        <BoxContainer Name="Asdf" Orientation="Vertical" Margin="4 0">
-
-        </BoxContainer>
+        <BoxContainer Name="Asdf" Orientation="Vertical" Margin="4 0" />
     </ScrollContainer>
-</contentControls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Shuttles/UI/BaseShuttleControl.xaml
+++ b/Content.Client/Shuttles/UI/BaseShuttleControl.xaml
@@ -1,2 +1,1 @@
-<controls1:MapGridControl
-    xmlns:controls1="clr-namespace:Content.Client.UserInterface.Controls" />
+<MapGridControl xmlns="https://spacestation14.io" />

--- a/Content.Client/Shuttles/UI/DockingScreen.xaml
+++ b/Content.Client/Shuttles/UI/DockingScreen.xaml
@@ -1,7 +1,6 @@
-<controls:BoxContainer Visible="False"
+<BoxContainer xmlns="https://spacestation14.io"
+               Visible="False"
                HorizontalExpand="True"
-               xmlns:controls="https://spacestation14.io"
-               xmlns:controls1="clr-namespace:Content.Client.UserInterface.Controls"
                xmlns:ui="clr-namespace:Content.Client.Shuttles.UI">
     <ui:ShuttleDockControl Name="DockingControl"
                        MouseFilter="Stop"
@@ -9,7 +8,7 @@
                        VerticalExpand="True"
                        HorizontalExpand="True"
                        Margin="5 4 10 5"/>
-    <controls:BoxContainer Name="RightDisplayDock"
+    <BoxContainer Name="RightDisplayDock"
                            VerticalAlignment="Top"
                            HorizontalAlignment="Right"
                            MinWidth="256"
@@ -17,12 +16,12 @@
                            Align="Center"
                            Margin="5 0 5 5"
                            Orientation="Vertical">
-        <controls1:StripeBack MinSize="48 48">
-            <controls:Label Name="DockingPortsLabel" Text="{controls:Loc 'shuttle-console-docks-label'}" HorizontalAlignment="Center"/>
-        </controls1:StripeBack>
-        <controls:ScrollContainer VerticalExpand="True" HScrollEnabled="False"
+        <StripeBack MinSize="48 48">
+            <Label Name="DockingPortsLabel" Text="{Loc 'shuttle-console-docks-label'}" HorizontalAlignment="Center"/>
+        </StripeBack>
+        <ScrollContainer VerticalExpand="True" HScrollEnabled="False"
                                   ReturnMeasure="True">
-            <controls:BoxContainer Name="DockPorts" Orientation="Vertical"/>
-        </controls:ScrollContainer>
-    </controls:BoxContainer>
-</controls:BoxContainer>
+            <BoxContainer Name="DockPorts" Orientation="Vertical"/>
+        </ScrollContainer>
+    </BoxContainer>
+</BoxContainer>

--- a/Content.Client/Shuttles/UI/EmergencyConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/EmergencyConsoleWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                           xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                            Title="{Loc 'emergency-shuttle-console-window-title'}"
                            MinSize="400 400">
 <BoxContainer Orientation="Vertical"
@@ -37,4 +36,4 @@
     <!-- Spacer -->
     <BoxContainer Name="AuthorizationsContainer" Orientation="Vertical"/>
 </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                           xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                            Title="{Loc 'iff-console-window-title'}"
                            MinSize="200 200">
     <BoxContainer Orientation="Vertical" HorizontalExpand="True">
@@ -11,4 +10,4 @@
             </BoxContainer>
         </GridContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Shuttles/UI/MapScreen.xaml
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml
@@ -1,7 +1,6 @@
-<controls:BoxContainer Visible="False"
+<BoxContainer Visible="False"
        HorizontalExpand="True"
-       xmlns:controls="https://spacestation14.io"
-       xmlns:controls1="clr-namespace:Content.Client.UserInterface.Controls"
+       xmlns="https://spacestation14.io"
        xmlns:ui="clr-namespace:Content.Client.Shuttles.UI">
             <ui:ShuttleMapControl Name="MapRadar"
                              MouseFilter="Stop"
@@ -9,7 +8,7 @@
                              HorizontalExpand="True"
                              VerticalExpand="True"
                              VerticalAlignment="Stretch"/>
-            <controls:BoxContainer Name="RightDisplayMap"
+            <BoxContainer Name="RightDisplayMap"
                           VerticalAlignment="Top"
                           HorizontalAlignment="Right"
                           MinWidth="256"
@@ -17,50 +16,50 @@
                           Margin="5 0 5 5"
                           Orientation="Vertical"
                           VerticalExpand="True">
-                <controls1:StripeBack
+                <StripeBack
                     MinSize="48 48">
-                    <controls:Label Name="MapDisplayLabel" Text="{controls:Loc 'shuttle-console-ftl-label'}"
+                    <Label Name="MapDisplayLabel" Text="{Loc 'shuttle-console-ftl-label'}"
                                     VerticalExpand="True"
                                     HorizontalAlignment="Center"/>
-                </controls1:StripeBack>
-                <controls:Label Name="MapFTLState"
-                                Text="{controls:Loc 'shuttle-console-ftl-state-Available'}"
+                </StripeBack>
+                <Label Name="MapFTLState"
+                                Text="{Loc 'shuttle-console-ftl-state-Available'}"
                                 VerticalAlignment="Stretch"
                                 HorizontalAlignment="Center"/>
-                <controls:ProgressBar Name="FTLBar" HorizontalExpand="True"
+                <ProgressBar Name="FTLBar" HorizontalExpand="True"
                                       Margin="5"
                                       MinValue="0.0"
                                       MaxValue="1.0"
                                       Value="1.0"/>
-                <controls:BoxContainer Orientation="Vertical">
+                <BoxContainer Orientation="Vertical">
                 <!-- Normal buttons -->
-                <controls1:StripeBack MinSize="48 48">
-                    <controls:Label Name="SettingsLabel" Text="{controls:Loc 'shuttle-console-map-settings'}"
+                <StripeBack MinSize="48 48">
+                    <Label Name="SettingsLabel" Text="{Loc 'shuttle-console-map-settings'}"
                            HorizontalAlignment="Center"/>
-                </controls1:StripeBack>
-                <controls:Button Name="MapBeaconsButton"
-                                 Text="{controls:Loc 'shuttle-console-map-beacons'}"
+                </StripeBack>
+                <Button Name="MapBeaconsButton"
+                                 Text="{Loc 'shuttle-console-map-beacons'}"
                                  TextAlign="Center"
                                  ToggleMode="True"
                                  Pressed="True"/>
-                <controls:Button Name="MapFTLButton"
+                <Button Name="MapFTLButton"
                                  ToggleMode="True"
-                                 Text="{controls:Loc 'shuttle-console-ftl-button'}"
+                                 Text="{Loc 'shuttle-console-ftl-button'}"
                                  TextAlign="Center"/>
-                <controls:Button Name="MapRebuildButton"
-                        Text="{controls:Loc 'shuttle-console-map-rebuild'}"
+                <Button Name="MapRebuildButton"
+                        Text="{Loc 'shuttle-console-map-rebuild'}"
                         TextAlign="Center"/>
                 <!-- Map objects -->
-                <controls1:StripeBack MinSize="48 48">
-                    <controls:Label Name="HyperspaceLabel" Text="{controls:Loc 'shuttle-console-map-objects'}"
+                <StripeBack MinSize="48 48">
+                    <Label Name="HyperspaceLabel" Text="{Loc 'shuttle-console-map-objects'}"
                            HorizontalAlignment="Center"/>
-                </controls1:StripeBack>
-                <controls:ScrollContainer VerticalExpand="True" HScrollEnabled="False"
+                </StripeBack>
+                <ScrollContainer VerticalExpand="True" HScrollEnabled="False"
                                  ReturnMeasure="True">
-                    <controls:BoxContainer Name="HyperspaceDestinations"
+                    <BoxContainer Name="HyperspaceDestinations"
                                   Orientation="Vertical"
                                   VerticalExpand="True"/>
-                </controls:ScrollContainer>
-            </controls:BoxContainer>
-        </controls:BoxContainer>
-</controls:BoxContainer>
+                </ScrollContainer>
+            </BoxContainer>
+        </BoxContainer>
+</BoxContainer>

--- a/Content.Client/Shuttles/UI/NavScreen.xaml
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml
@@ -1,8 +1,7 @@
-<controls:BoxContainer Visible="False"
+<BoxContainer Visible="False"
               HorizontalExpand="True"
-              xmlns:controls="https://spacestation14.io"
-              xmlns:ui="clr-namespace:Content.Client.Shuttles.UI"
-              xmlns:controls1="clr-namespace:Content.Client.UserInterface.Controls">
+              xmlns="https://spacestation14.io"
+              xmlns:ui="clr-namespace:Content.Client.Shuttles.UI">
                 <ui:ShuttleNavControl Name="NavRadar"
                                  MouseFilter="Stop"
                                  VerticalAlignment="Stretch"
@@ -10,7 +9,7 @@
                                  HorizontalExpand="True"
                                  Margin="5 4 10 5"/>
                 <!-- Nav controls -->
-                <controls:BoxContainer Name="RightDisplayNav"
+                <BoxContainer Name="RightDisplayNav"
                       VerticalAlignment="Top"
                       HorizontalAlignment="Right"
                       VerticalExpand="True"
@@ -18,52 +17,52 @@
                       MaxWidth="256"
                       Margin="5 0 5 5"
                       Orientation="Vertical">
-                    <controls1:StripeBack
+                    <StripeBack
                         MinSize="48 48">
-                        <controls:Label Name="NavDisplayLabel" Text="{controls:Loc 'shuttle-console-display-label'}"
+                        <Label Name="NavDisplayLabel" Text="{Loc 'shuttle-console-display-label'}"
                                VerticalExpand="True"
                                HorizontalAlignment="Center"/>
-                    </controls1:StripeBack>
-                    <controls:GridContainer Columns="2"
+                    </StripeBack>
+                    <GridContainer Columns="2"
                                    HorizontalAlignment="Stretch"
                                    VerticalAlignment="Top"
                                    HorizontalExpand="True"
                                    Margin="3"
                                    Name="ReadonlyDisplay">
-                        <controls:Label Text="{controls:Loc 'shuttle-console-position'}"/>
-                        <controls:Label Name="GridPosition"
+                        <Label Text="{Loc 'shuttle-console-position'}"/>
+                        <Label Name="GridPosition"
                                Text="0.0, 0.0"
                                HorizontalExpand="True"
                                Align="Right"/>
-                        <controls:Label Text="{controls:Loc 'shuttle-console-orientation'}"/>
-                        <controls:Label Name="GridOrientation"
+                        <Label Text="{Loc 'shuttle-console-orientation'}"/>
+                        <Label Name="GridOrientation"
                                Text="0.0"
                                HorizontalExpand="True"
                                Align="Right"/>
-                        <controls:Label Text="{controls:Loc 'shuttle-console-linear-velocity'}"/>
-                        <controls:Label Name="GridLinearVelocity"
+                        <Label Text="{Loc 'shuttle-console-linear-velocity'}"/>
+                        <Label Name="GridLinearVelocity"
                                Text="0.0, 0.0"
                                HorizontalExpand="True"
                                Align="Right"/>
-                        <controls:Label Text="{controls:Loc 'shuttle-console-angular-velocity'}"/>
-                        <controls:Label Name="GridAngularVelocity"
+                        <Label Text="{Loc 'shuttle-console-angular-velocity'}"/>
+                        <Label Name="GridAngularVelocity"
                                Text="0.0"
                                HorizontalExpand="True"
                                Align="Right"/>
-                    </controls:GridContainer>
-                    <controls1:StripeBack
+                    </GridContainer>
+                    <StripeBack
                         MinSize="48 48">
-                        <controls:Label Name="NavSettingsLabel" Text="{controls:Loc 'shuttle-console-nav-settings'}"
+                        <Label Name="NavSettingsLabel" Text="{Loc 'shuttle-console-nav-settings'}"
                                VerticalExpand="True"
                                HorizontalAlignment="Center"/>
-                    </controls1:StripeBack>
-                    <controls:Button Name="IFFToggle"
-                            Text="{controls:Loc 'shuttle-console-iff-toggle'}"
+                    </StripeBack>
+                    <Button Name="IFFToggle"
+                            Text="{Loc 'shuttle-console-iff-toggle'}"
                             TextAlign="Center"
                             ToggleMode="True"/>
-                    <controls:Button Name="DockToggle"
-                            Text="{controls:Loc 'shuttle-console-dock-toggle'}"
+                    <Button Name="DockToggle"
+                            Text="{Loc 'shuttle-console-dock-toggle'}"
                             TextAlign="Center"
                             ToggleMode="True"/>
-                </controls:BoxContainer>
-            </controls:BoxContainer>
+                </BoxContainer>
+            </BoxContainer>

--- a/Content.Client/Shuttles/UI/RadarConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/RadarConsoleWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:ui="clr-namespace:Content.Client.Shuttles.UI"
                       Title="{Loc 'radar-console-window-title'}"
                       SetSize="648 648"
@@ -8,4 +7,4 @@
                      Margin="4"
                      HorizontalExpand = "True"
                      VerticalExpand = "True"/>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:ui="clr-namespace:Content.Client.Shuttles.UI"
                       Title="{Loc 'shuttle-console-window-title'}"
                       SetSize="960 762"
@@ -40,4 +39,4 @@
             <ui:DockingScreen Name="DockContainer" Visible="False"/>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Silicons/Borgs/BorgMenu.xaml
+++ b/Content.Client/Silicons/Borgs/BorgMenu.xaml
@@ -1,6 +1,5 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
                       Title="{Loc 'borg-ui-menu-title'}"
                       MinSize="600 350"
@@ -55,4 +54,4 @@
             </PanelContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Silicons/Borgs/BorgSelectTypeMenu.xaml
+++ b/Content.Client/Silicons/Borgs/BorgSelectTypeMenu.xaml
@@ -1,5 +1,4 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+﻿<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
                       Title="{Loc 'borg-select-type-menu-title'}"
                       SetSize="550 300">
@@ -19,7 +18,7 @@
             <BoxContainer Orientation="Vertical" HorizontalExpand="True" Margin="2 0">
                 <Label Text="{Loc 'borg-select-type-menu-information'}" StyleClasses="LabelHeading" />
                 <Control VerticalExpand="True">
-                    <controls:Placeholder Name="InfoPlaceholder" PlaceholderText="{Loc 'borg-select-type-menu-select-type'}" />
+                    <Placeholder Name="InfoPlaceholder" PlaceholderText="{Loc 'borg-select-type-menu-select-type'}" />
                     <BoxContainer Name="InfoContents" Orientation="Vertical" Visible="False">
                         <BoxContainer Orientation="Horizontal" Margin="0 0 0 4">
                             <EntityPrototypeView Name="ChassisView" Scale="2,2" />
@@ -29,15 +28,15 @@
                         <RichTextLabel Name="DescriptionLabel" VerticalExpand="True" VerticalAlignment="Top" />
                     </BoxContainer>
                 </Control>
-                <controls:ConfirmButton Name="ConfirmTypeButton" Text="{Loc 'borg-select-type-menu-confirm'}"
+                <ConfirmButton Name="ConfirmTypeButton" Text="{Loc 'borg-select-type-menu-confirm'}"
                                         Disabled="True" HorizontalAlignment="Right"
                                         MinWidth="200" />
             </BoxContainer>
         </BoxContainer>
 
-        <controls:StripeBack Margin="0 0 0 4">
+        <StripeBack Margin="0 0 0 4">
             <Label Text="{Loc 'borg-select-type-menu-bottom-text'}" HorizontalAlignment="Center" StyleClasses="LabelSubText" Margin="4 4 0 4"/>
-        </controls:StripeBack>
+        </StripeBack>
     </BoxContainer>
 
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Silicons/Laws/SiliconLawEditUi/SiliconLawUi.xaml
+++ b/Content.Client/Silicons/Laws/SiliconLawEditUi/SiliconLawUi.xaml
@@ -1,6 +1,5 @@
-﻿<controls:FancyWindow
+﻿<FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     Title="{Loc silicon-law-ui-title}"
     MinSize="560 400"
 >
@@ -19,4 +18,4 @@
             <BoxContainer Orientation="Vertical" Name="LawContainer" Access="Public" VerticalExpand="True" />
         </ScrollContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Silicons/Laws/Ui/SiliconLawMenu.xaml
+++ b/Content.Client/Silicons/Laws/Ui/SiliconLawMenu.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                      xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                      Title="{Loc 'laws-ui-menu-title'}"
                      MinSize="200 100"
@@ -24,4 +23,4 @@
             </ScrollContainer>
         </PanelContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Silicons/StationAi/StationAiCustomizationMenu.xaml
+++ b/Content.Client/Silicons/StationAi/StationAiCustomizationMenu.xaml
@@ -1,23 +1,21 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-         xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
          xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
          SetSize="600 600"
          MinSize="600 220">
     <BoxContainer Orientation="Vertical" VerticalExpand="True">
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="10 5 10 -5">
-            <controls:StripeBack HorizontalExpand="True">
+            <StripeBack HorizontalExpand="True">
                 <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
                     <Control SetWidth="200">
                         <Label Text="{Loc 'station-ai-customization-categories'}" Margin="0 5 0 5" HorizontalExpand="True" HorizontalAlignment="Center"  />
                     </Control>
                     <Label Text="{Loc 'station-ai-customization-options'}" Margin="0 5 0 5" HorizontalExpand="True" HorizontalAlignment="Center"/>
                 </BoxContainer>
-            </controls:StripeBack>
+            </StripeBack>
         </BoxContainer>
         <VerticalTabContainer Name="CustomizationGroupsContainer"
                               VerticalExpand="True"
                               HorizontalExpand="True">
         </VerticalTabContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Silicons/StationAi/StationAiFixerConsoleConfirmationDialog.xaml
+++ b/Content.Client/Silicons/StationAi/StationAiFixerConsoleConfirmationDialog.xaml
@@ -1,6 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       Title="{Loc 'station-ai-fixer-console-window-purge-warning-title'}"
                       Resizable="False">
     <BoxContainer Orientation="Vertical" VerticalExpand="True" SetWidth="400">
@@ -19,4 +17,4 @@
                     Margin="0 10 20 10"/>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Silicons/StationAi/StationAiFixerConsoleWindow.xaml
+++ b/Content.Client/Silicons/StationAi/StationAiFixerConsoleWindow.xaml
@@ -1,6 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       Title="{Loc 'station-ai-fixer-console-window'}"
                       Resizable="False">
@@ -54,7 +52,7 @@
                               Orientation="Vertical"
                               ReservesSpace="False">
 
-                    <controls:StripeBack VerticalExpand="True" HorizontalExpand="True" Margin="0 0 0 5">
+                    <StripeBack VerticalExpand="True" HorizontalExpand="True" Margin="0 0 0 5">
                     <PanelContainer VerticalExpand="True" HorizontalExpand="True">
                         <BoxContainer VerticalExpand="True" HorizontalExpand="True" Orientation="Vertical">
                             <Control VerticalExpand="True"/>
@@ -71,7 +69,7 @@
                             <Control VerticalExpand="True"/>
                         </BoxContainer>
                     </PanelContainer>
-                    </controls:StripeBack>
+                    </StripeBack>
                 </BoxContainer>
 
                 <!-- Action progress screen -->
@@ -112,13 +110,13 @@
                               ReservesSpace="False"
                               Visible="False">
 
-                    <controls:StripeBack>
+                    <StripeBack>
                         <PanelContainer>
                             <Label Text="{Loc 'Controls'}"
                                    HorizontalExpand="True"
                                    HorizontalAlignment="Center"/>
                         </PanelContainer>
-                    </controls:StripeBack>
+                    </StripeBack>
 
                     <!-- Eject button -->
                     <Button Name="EjectButton" HorizontalExpand="True" Margin="0 10 0 0" SetHeight="40"
@@ -169,4 +167,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/SmartFridge/SmartFridgeMenu.xaml
+++ b/Content.Client/SmartFridge/SmartFridgeMenu.xaml
@@ -1,14 +1,11 @@
-<controls:FancyWindow
+<FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-    xmlns:co="clr-namespace:Content.Client.UserInterface.Controls"
     MinHeight="450"
     MinWidth="350"
     Title="{Loc 'smart-fridge-component-title'}">
     <BoxContainer Name="MainContainer" Orientation="Vertical">
         <LineEdit Name="SearchBar" PlaceHolder="{Loc 'smart-fridge-component-search-filter'}" HorizontalExpand="True"  Margin ="4 4"/>
-        <co:SearchListContainer Name="VendingContents" VerticalExpand="True" Margin="4 4"/>
+        <SearchListContainer Name="VendingContents" VerticalExpand="True" Margin="4 4"/>
          <!-- Footer -->
         <BoxContainer Orientation="Vertical">
             <PanelContainer StyleClasses="LowDivider" />
@@ -21,4 +18,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/SprayPainter/UI/SprayPainterGroup.xaml
+++ b/Content.Client/SprayPainter/UI/SprayPainterGroup.xaml
@@ -1,12 +1,11 @@
 <BoxContainer
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     Orientation="Vertical">
     <Label Text="{Loc 'spray-painter-selected-style'}" />
-    <controls:ListContainer
+    <ListContainer
         Name="StyleList"
         Toggle="True"
         Group="True">
         <!-- populated by code -->
-    </controls:ListContainer>
+    </ListContainer>
 </BoxContainer>

--- a/Content.Client/Thief/ThiefBackpackMenu.xaml
+++ b/Content.Client/Thief/ThiefBackpackMenu.xaml
@@ -1,11 +1,10 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-						xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
 						xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
 						MinSize="700 700">
 	<BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
 		<!-- First Informational panel -->
 		<Label Name="Description" Margin="5 5"/>
-		<controls:HLine Color="#404040" Thickness="2" Margin="0 5"/>
+		<HLine Color="#404040" Thickness="2" Margin="0 5"/>
 		<Label Name="SelectedSets" Text="{Loc 'thief-backpack-window-selected'}" Margin="5 5"/>
 
 		<!-- Second sets panel -->
@@ -34,4 +33,4 @@
 					StyleClasses="OpenRight"/>
 		</PanelContainer>
 	</BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Thief/ThiefBackpackSet.xaml
+++ b/Content.Client/Thief/ThiefBackpackSet.xaml
@@ -1,5 +1,4 @@
 <Control xmlns="https://spacestation14.io"
-		xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
 		xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client">
 	<!-- Name and button -->
 	<PanelContainer Margin="5 5 0 5">
@@ -11,7 +10,7 @@
 				<Label Name="SetName" Text="Set" StyleClasses="highlight"></Label>
 				<Button Margin="0 10" Name="SetButton" Text="Select" StyleClasses="OpenRight" Access="Public" HorizontalAlignment="Right"/>
 			</GridContainer>
-			<controls:HLine Color="#404040" Thickness="1" Margin="0 5"/>
+			<HLine Color="#404040" Thickness="1" Margin="0 5"/>
 			<!-- Icon and Description -->
 			<GridContainer Margin="0 5" Columns="2">
 				<TextureRect Name="Icon" Margin="10" Stretch="KeepAspectCentered"

--- a/Content.Client/TurretController/TurretControllerWindow.xaml
+++ b/Content.Client/TurretController/TurretControllerWindow.xaml
@@ -1,7 +1,6 @@
 <ui:TurretControllerWindow xmlns="https://spacestation14.io"
                         xmlns:ui="clr-namespace:Content.Client.TurretController"
                         xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-                        xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                         xmlns:access="clr-namespace:Content.Client.Access.UI"
                         SetWidth="550"
                         Resizable="False"
@@ -78,11 +77,11 @@
                             </PanelContainer>
 
                             <BoxContainer Orientation="Horizontal" Margin="10 10 10 10">
-                                <controls:MonotoneButton Name="SafeButton" Text="{Loc 'turret-controls-window-safe'}"
+                                <MonotoneButton Name="SafeButton" Text="{Loc 'turret-controls-window-safe'}"
                                                    StyleClasses="OpenRight" Pressed="False" ToggleMode="True" HorizontalExpand="True"/>
-                                <controls:MonotoneButton Name="StunButton" Text="{Loc 'turret-controls-window-stun'}"
+                                <MonotoneButton Name="StunButton" Text="{Loc 'turret-controls-window-stun'}"
                                                    StyleClasses="OpenBoth" Pressed="False" ToggleMode="True" HorizontalExpand="True"/>
-                                <controls:MonotoneButton Name="LethalButton" Text="{Loc 'turret-controls-window-lethal'}"
+                                <MonotoneButton Name="LethalButton" Text="{Loc 'turret-controls-window-lethal'}"
                                                    StyleClasses="OpenLeft" Pressed="False" ToggleMode="True" HorizontalExpand="True"/>
                             </BoxContainer>
 

--- a/Content.Client/UserInterface/Controls/ContentTableContainer.cs
+++ b/Content.Client/UserInterface/Controls/ContentTableContainer.cs
@@ -20,7 +20,7 @@ namespace Content.Client.UserInterface.Controls;
 /// The first control is in the top left, laid out per row from there.
 /// </remarks>
 [Virtual]
-public class TableContainer : Container
+public class ContentTableContainer : Container
 {
     private int _columns = 1;
 

--- a/Content.Client/UserInterface/Controls/DialogWindow.xaml
+++ b/Content.Client/UserInterface/Controls/DialogWindow.xaml
@@ -1,4 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io" xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls">
+<FancyWindow xmlns="https://spacestation14.io">
     <BoxContainer Orientation="Vertical" Margin="8">
         <BoxContainer Name="Prompts" Orientation="Vertical"/> <!-- Populated in constructor -->
         <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center">
@@ -6,4 +6,4 @@
         <Button Name="CancelButton" Text="{Loc 'quick-dialog-ui-cancel'}"/>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/UserInterface/Controls/FancyTree/FancyTree.xaml
+++ b/Content.Client/UserInterface/Controls/FancyTree/FancyTree.xaml
@@ -1,6 +1,5 @@
-<controls:FancyTree xmlns="https://spacestation14.io"
-                    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls.FancyTree">
+<FancyTree xmlns="https://spacestation14.io">
     <ScrollContainer ReturnMeasure="True">
         <BoxContainer Orientation="Vertical" Name="Body" Access="Public" Margin="2"/>
     </ScrollContainer>
-</controls:FancyTree>
+</FancyTree>

--- a/Content.Client/UserInterface/Controls/FancyTree/TreeItem.xaml
+++ b/Content.Client/UserInterface/Controls/FancyTree/TreeItem.xaml
@@ -1,5 +1,4 @@
-<controls:TreeItem xmlns="https://spacestation14.io"
-                   xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls.FancyTree">
+<TreeItem xmlns="https://spacestation14.io">
     <BoxContainer Orientation="Vertical">
         <ContainerButton Name="Button" Access="Public">
             <BoxContainer Orientation="Horizontal">
@@ -10,5 +9,5 @@
         </ContainerButton>
         <BoxContainer Name="Body" Access="Public" Orientation="Vertical" Visible="False"/>
     </BoxContainer>
-    <controls:TreeLine/>
-</controls:TreeItem>
+    <TreeLine/>
+</TreeItem>

--- a/Content.Client/UserInterface/Controls/FancyWindow.xaml
+++ b/Content.Client/UserInterface/Controls/FancyWindow.xaml
@@ -1,6 +1,5 @@
 
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       MouseFilter="Stop"
                       MinWidth="200" MinHeight="150">
     <PanelContainer StyleClasses="BackgroundPanel" />
@@ -19,4 +18,4 @@
         <PanelContainer StyleClasses="LowDivider" />
         <Control Access="Public" Name="ContentsContainer" StyleClasses="WindowContentsContainer" RectClipContent="True" VerticalExpand="true" />
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/UserInterface/Controls/SimpleRadialMenu.xaml
+++ b/Content.Client/UserInterface/Controls/SimpleRadialMenu.xaml
@@ -1,8 +1,6 @@
-<ui:SimpleRadialMenu xmlns="https://spacestation14.io"
-                     xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
+<SimpleRadialMenu xmlns="https://spacestation14.io"
                      BackButtonStyleClass="RadialMenuBackButton"
                      CloseButtonStyleClass="RadialMenuCloseButton"
                      VerticalExpand="True"
                      HorizontalExpand="True"
-                     MinSize="450 450">
-</ui:SimpleRadialMenu>
+                     MinSize="450 450" />

--- a/Content.Client/UserInterface/Controls/SplitBar.xaml
+++ b/Content.Client/UserInterface/Controls/SplitBar.xaml
@@ -1,7 +1,5 @@
-<controls:SplitBar xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<SplitBar xmlns="https://spacestation14.io"
                       MouseFilter="Stop"
                       Orientation="Horizontal"
                       HorizontalExpand="True"
-                      MinSize="0 30">
-</controls:SplitBar>
+                      MinSize="0 30" />

--- a/Content.Client/UserInterface/Namespaces.cs
+++ b/Content.Client/UserInterface/Namespaces.cs
@@ -1,0 +1,5 @@
+using Avalonia.Metadata;
+
+[assembly: XmlnsDefinition("https://spacestation14.io", "Content.Client.UserInterface.Controls")]
+[assembly: XmlnsDefinition("https://spacestation14.io", "Content.Client.UserInterface.Controls.FancyTree")]
+[assembly: XmlnsDefinition("https://spacestation14.io", "Content.Client.UserInterface.XamlExtensions")]

--- a/Content.Client/UserInterface/Screens/DefaultGameScreen.xaml
+++ b/Content.Client/UserInterface/Screens/DefaultGameScreen.xaml
@@ -7,14 +7,13 @@
     xmlns:alerts="clr-namespace:Content.Client.UserInterface.Systems.Alerts.Widgets"
     xmlns:widgets="clr-namespace:Content.Client.UserInterface.Systems.Ghost.Widgets"
     xmlns:hotbar="clr-namespace:Content.Client.UserInterface.Systems.Hotbar.Widgets"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:inventory="clr-namespace:Content.Client.UserInterface.Systems.Inventory.Widgets"
     Name="DefaultHud"
     VerticalExpand="False"
     VerticalAlignment="Bottom"
     HorizontalAlignment="Center">
     <LayoutContainer Name="ViewportContainer" HorizontalExpand="True" VerticalExpand="True">
-        <controls:MainViewport Name="MainViewport"/>
+        <MainViewport Name="MainViewport"/>
     </LayoutContainer>
     <BoxContainer Name="TopLeft" Access="Protected" Orientation="Vertical">
         <BoxContainer Orientation="Horizontal">

--- a/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml
+++ b/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml
@@ -7,7 +7,6 @@
     xmlns:alerts="clr-namespace:Content.Client.UserInterface.Systems.Alerts.Widgets"
     xmlns:hotbar="clr-namespace:Content.Client.UserInterface.Systems.Hotbar.Widgets"
     xmlns:widgets="clr-namespace:Content.Client.UserInterface.Systems.Ghost.Widgets"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     xmlns:inventory="clr-namespace:Content.Client.UserInterface.Systems.Inventory.Widgets"
     Name="SeparatedChatHud"
@@ -16,7 +15,7 @@
     HorizontalAlignment="Center">
     <SplitContainer Name="ScreenContainer" HorizontalExpand="True" VerticalExpand="True" SplitWidth="0" StretchDirection="TopLeft">
         <LayoutContainer Name="ViewportContainer" HorizontalExpand="True" VerticalExpand="True">
-            <controls:MainViewport Name="MainViewport"/>
+            <MainViewport Name="MainViewport"/>
             <widgets:GhostGui Name="Ghost" Access="Protected" />
             <inventory:InventoryGui Name="Inventory" Access="Protected"/>
             <hotbar:HotbarGui Name="Hotbar" Access="Protected"/>

--- a/Content.Client/UserInterface/Systems/Chat/ChatWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Chat/ChatWindow.xaml
@@ -1,7 +1,6 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                       xmlns:widgets="clr-namespace:Content.Client.UserInterface.Systems.Chat.Widgets"
                       Title="{Loc chat-window-title}"
                       MinSize="465 265">
     <widgets:ChatBox Name="Chatbox"/>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/UserInterface/Systems/Inventory/Widgets/InventoryGui.xaml
+++ b/Content.Client/UserInterface/Systems/Inventory/Widgets/InventoryGui.xaml
@@ -2,7 +2,6 @@
     xmlns="https://spacestation14.io"
     xmlns:inventory="clr-namespace:Content.Client.UserInterface.Systems.Inventory.Controls"
     xmlns:widgets="clr-namespace:Content.Client.UserInterface.Systems.Inventory.Widgets"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     Name="InventoryInterface"
     VerticalExpand="True"
     VerticalAlignment="Bottom"
@@ -10,7 +9,7 @@
     HorizontalAlignment="Center">
     <Control HorizontalAlignment="Center">
         <!-- Needs to default to invisible because if we attach to a non-slots entity this will never get unset -->
-        <controls:SlotButton
+        <SlotButton
             Name="InventoryButton"
             Access="Public"
             Visible="False"

--- a/Content.Client/UserInterface/Systems/MenuBar/Widgets/GameTopMenuBar.xaml
+++ b/Content.Client/UserInterface/Systems/MenuBar/Widgets/GameTopMenuBar.xaml
@@ -3,8 +3,6 @@
            xmlns:style="clr-namespace:Content.Client.Stylesheets"
            xmlns:ic="clr-namespace:Robust.Shared.Input;assembly=Robust.Shared"
            xmlns:is="clr-namespace:Content.Shared.Input;assembly=Content.Shared"
-           xmlns:xe="clr-namespace:Content.Client.UserInterface.XamlExtensions"
-           xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
            xmlns:widgets="clr-namespace:Content.Client.UserInterface.Systems.MenuBar.Widgets"
            Name = "MenuButtons"
            VerticalExpand="False"
@@ -13,90 +11,90 @@
            VerticalAlignment="Top"
            SeparationOverride="5"
 >
-    <ui:MenuButton
+    <MenuButton
         Name="EscapeButton"
         Access="Internal"
-        Icon="{xe:Tex '/Textures/Interface/hamburger.svg.192dpi.png'}"
+        Icon="{Tex '/Textures/Interface/hamburger.svg.192dpi.png'}"
         BoundKey = "{x:Static ic:EngineKeyFunctions.EscapeMenu}"
         ToolTip="{Loc 'game-hud-open-escape-menu-button-tooltip'}"
         MinSize="70 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleClass.ButtonOpenRight}"
         />
-    <ui:MenuButton
+    <MenuButton
         Name="GuidebookButton"
         Access="Internal"
-        Icon="{xe:Tex '/Textures/Interface/VerbIcons/information.svg.192dpi.png'}"
+        Icon="{Tex '/Textures/Interface/VerbIcons/information.svg.192dpi.png'}"
         ToolTip="{Loc 'game-hud-open-guide-menu-button-tooltip'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenGuidebook}"
         MinSize="42 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleClass.ButtonSquare}"
         />
-    <ui:MenuButton
+    <MenuButton
         Name="CharacterButton"
         Access="Internal"
-        Icon="{xe:Tex '/Textures/Interface/character.svg.192dpi.png'}"
+        Icon="{Tex '/Textures/Interface/character.svg.192dpi.png'}"
         ToolTip="{Loc 'game-hud-open-character-menu-button-tooltip'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenCharacterMenu}"
         MinSize="42 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleClass.ButtonSquare}"
         />
-    <ui:MenuButton
+    <MenuButton
         Name="EmotesButton"
         Access="Internal"
-        Icon="{xe:Tex '/Textures/Interface/emotes.svg.192dpi.png'}"
+        Icon="{Tex '/Textures/Interface/emotes.svg.192dpi.png'}"
         ToolTip="{Loc 'game-hud-open-emotes-menu-button-tooltip'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenEmotesMenu}"
         MinSize="42 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleClass.ButtonSquare}"
         />
-    <ui:MenuButton
+    <MenuButton
         Name="CraftingButton"
         Access="Internal"
-        Icon="{xe:Tex '/Textures/Interface/hammer.svg.192dpi.png'}"
+        Icon="{Tex '/Textures/Interface/hammer.svg.192dpi.png'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenCraftingMenu}"
         ToolTip="{Loc 'game-hud-open-crafting-menu-button-tooltip'}"
         MinSize="42 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleClass.ButtonSquare}"
         />
-    <ui:MenuButton
+    <MenuButton
         Name="ActionButton"
         Access="Internal"
-        Icon="{xe:Tex '/Textures/Interface/fist.svg.192dpi.png'}"
+        Icon="{Tex '/Textures/Interface/fist.svg.192dpi.png'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenActionsMenu}"
         ToolTip="{Loc 'game-hud-open-actions-menu-button-tooltip'}"
         MinSize="42 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleClass.ButtonSquare}"
         />
-    <ui:MenuButton
+    <MenuButton
         Name="AdminButton"
         Access="Internal"
-        Icon="{xe:Tex '/Textures/Interface/gavel.svg.192dpi.png'}"
+        Icon="{Tex '/Textures/Interface/gavel.svg.192dpi.png'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenAdminMenu}"
         ToolTip="{Loc 'game-hud-open-admin-menu-button-tooltip'}"
         MinSize="42 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleClass.ButtonSquare}"
         />
-    <ui:MenuButton
+    <MenuButton
         Name="SandboxButton"
         Access="Internal"
-        Icon="{xe:Tex '/Textures/Interface/sandbox.svg.192dpi.png'}"
+        Icon="{Tex '/Textures/Interface/sandbox.svg.192dpi.png'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenSandboxWindow}"
         ToolTip="{Loc 'game-hud-open-sandbox-menu-button-tooltip'}"
         MinSize="42 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleClass.ButtonSquare}"
         />
-    <ui:MenuButton
+    <MenuButton
         Name="AHelpButton"
         Access="Internal"
-        Icon="{xe:Tex '/Textures/Interface/info.svg.192dpi.png'}"
+        Icon="{Tex '/Textures/Interface/info.svg.192dpi.png'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenAHelp}"
         ToolTip="{Loc 'ui-options-function-open-a-help'}"
         MinSize="42 64"

--- a/Content.Client/UserInterface/Systems/Objectives/Controls/ObjectiveConditionsControl.xaml
+++ b/Content.Client/UserInterface/Systems/Objectives/Controls/ObjectiveConditionsControl.xaml
@@ -1,9 +1,8 @@
 <controls:ObjectiveConditionsControl
     xmlns="https://spacestation14.io"
-    xmlns:cc="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Systems.Objectives.Controls"
     Orientation="Horizontal">
-    <cc:ProgressTextureRect Name="ProgressTexture" VerticalAlignment="Top" Access="Public" Margin="0 8 0 0"/>
+    <ProgressTextureRect Name="ProgressTexture" VerticalAlignment="Top" Access="Public" Margin="0 8 0 0"/>
     <Control MinSize="10 0"/>
     <BoxContainer Orientation="Vertical">
         <RichTextLabel Name="Title" Access="Public" SetWidth="325" HorizontalAlignment="Left"/>

--- a/Content.Client/VendingMachines/UI/VendingMachineMenu.xaml
+++ b/Content.Client/VendingMachines/UI/VendingMachineMenu.xaml
@@ -1,12 +1,9 @@
-<controls:FancyWindow
+<FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-    xmlns:co="clr-namespace:Content.Client.UserInterface.Controls"
     MinHeight="210">
     <BoxContainer Name="MainContainer" Orientation="Vertical">
         <LineEdit Name="SearchBar" PlaceHolder="{Loc 'vending-machine-component-search-filter'}" HorizontalExpand="True"  Margin ="4 4"/>
-        <co:SearchListContainer Name="VendingContents" VerticalExpand="True" Margin="4 4"/>
+        <SearchListContainer Name="VendingContents" VerticalExpand="True" Margin="4 4"/>
          <!-- Footer -->
         <BoxContainer Orientation="Vertical">
             <PanelContainer StyleClasses="LowDivider" />
@@ -19,4 +16,4 @@
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/VoiceMask/VoiceMaskNameChangeWindow.xaml
+++ b/Content.Client/VoiceMask/VoiceMaskNameChangeWindow.xaml
@@ -1,5 +1,4 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
                Title="{Loc 'voice-mask-name-change-window'}"
                MinSize="5 30">
     <BoxContainer Orientation="Vertical" Margin="5">
@@ -15,4 +14,4 @@
         <Button Name="ToggleAccentButton" Text="{Loc 'voice-mask-name-change-accent-toggle'}" HorizontalExpand="True" ToggleMode="True" Margin="5"/>
         <Button Name="ToggleButton" Text="{Loc 'voice-mask-name-change-toggle'}" HorizontalExpand="True" ToggleMode="True" Margin="5"/>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Voting/UI/VoteCallMenu.xaml
+++ b/Content.Client/Voting/UI/VoteCallMenu.xaml
@@ -1,6 +1,5 @@
 <ui:VoteCallMenu xmlns="https://spacestation14.io"
                  xmlns:ui="clr-namespace:Content.Client.Voting.UI"
-                 xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                  MouseFilter="Stop" MinSize="350 200">
     <PanelContainer StyleClasses="BackgroundPanel" />
     <BoxContainer Orientation="Vertical">
@@ -10,7 +9,7 @@
             <TextureButton Name="CloseButton" StyleClasses="windowCloseButton"
                            VerticalAlignment="Center" />
         </BoxContainer>
-        <controls:HighDivider />
+        <HighDivider />
 
         <BoxContainer Orientation="Vertical" Margin="8 2 8 0" VerticalExpand="True" VerticalAlignment="Top">
             <BoxContainer Orientation="Vertical">

--- a/Content.Client/Xenoarchaeology/Ui/AnalysisConsoleMenu.xaml
+++ b/Content.Client/Xenoarchaeology/Ui/AnalysisConsoleMenu.xaml
@@ -1,6 +1,5 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
+<FancyWindow xmlns="https://spacestation14.io"
     xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
     xmlns:ui="clr-namespace:Content.Client.Xenoarchaeology.Ui"
     Title="{Loc 'analysis-console-menu-title'}"
@@ -88,4 +87,4 @@
             </PanelContainer>
         </BoxContainer>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Client/Xenoarchaeology/Ui/NodeScannerDisplay.xaml
+++ b/Content.Client/Xenoarchaeology/Ui/NodeScannerDisplay.xaml
@@ -1,20 +1,19 @@
-<controls:FancyWindow xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+<FancyWindow xmlns="https://spacestation14.io"
     Title="{Loc 'node-scan-display-title'}"
     MinSize="305 180"
     SetSize="305 180"
     Resizable="False"
     >
     <BoxContainer Orientation="Vertical" >
-        <controls:StripeBack>
+        <StripeBack>
             <Label Name="NodeScannerState" HorizontalAlignment="Center" StyleClasses="LabelSubText" Margin="4 0 0 4" />
-        </controls:StripeBack>
+        </StripeBack>
         <BoxContainer Orientation="Horizontal">
             <Label Name="NoActiveNodeDataLabel" Text="{Loc 'node-scan-no-data'}" Margin="45 25 0 0" MinHeight="47" />
             <GridContainer Name="ActiveNodesList" Columns="4" Rows="2" Visible="True" MinHeight="72" />
         </BoxContainer>
-        <controls:StripeBack>
+        <StripeBack>
             <Label Name="ArtifactStateLabel" HorizontalAlignment="Center" StyleClasses="LabelSubText" Margin="4 0 0 4" />
-        </controls:StripeBack>
+        </StripeBack>
     </BoxContainer>
-</controls:FancyWindow>
+</FancyWindow>

--- a/Content.Replay/Menu/ReplayMainMenuControl.xaml
+++ b/Content.Replay/Menu/ReplayMainMenuControl.xaml
@@ -1,8 +1,5 @@
 <Control xmlns="https://spacestation14.io"
-         xmlns:pllax="clr-namespace:Content.Client.Parallax;assembly=Content.Client"
-         xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls;assembly=Content.Client"
-         xmlns:style="clr-namespace:Content.Client.Stylesheets;assembly=Content.Client"
-         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+         xmlns:pllax="clr-namespace:Content.Client.Parallax;assembly=Content.Client">
     <pllax:ParallaxControl SpeedX="20"/>
     <LayoutContainer>
         <BoxContainer Name="VBox" Orientation="Vertical" StyleIdentifier="mainMenuVBox">
@@ -44,7 +41,7 @@
                         MinSize="300 150">
             <BoxContainer Orientation="Vertical" Align="Begin" Margin="8">
                 <Label Text="{Loc 'replay-info-title'}" Margin="4" HorizontalAlignment="Center"/>
-                <controls:HLine StyleClasses="highlight" Thickness="4"/>
+                <HLine StyleClasses="highlight" Thickness="4"/>
                 <RichTextLabel Access="Public" Name="Info"/>
             </BoxContainer>
         </PanelContainer>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This puts Content.Client.UserInterface.* into the SS14 xmlns for XAML.
This makes it easier to reuse standard controls instead of every file needing to have the same verbose import & namespacing syntax.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`TableContainer` has been renamed to `ContentTableContainer` to avoid a name conflict with the same control in Robust Toolbox.
