### PR TITLE
Fixed ConfirmButton not disabling after being pressed + confirmed

### DIFF
--- a/Content.Client/UserInterface/Controls/ConfirmButton.cs
+++ b/Content.Client/UserInterface/Controls/ConfirmButton.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Timing;
 
 namespace Content.Client.UserInterface.Controls;
@@ -131,6 +131,8 @@ public sealed class ConfirmButton : Button
                 Disabled = true;
                 break;
             case true:
+                _nextCooldown = null;
+                _nextReset = null;
                 OnPressed?.Invoke(buttonEvent);
                 break;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Bugfix for #43009 

Changed ConfirmButton so it can be disabled after its been pressed + confirmed. A bug in the FrameUpdate code was stopping the button from being disabled after its pressed + confirmed. FrameUpdate would check the `_nextCooldown` time and reenable the button even when its not waiting to confirm. This PR fixes that behavior by resetting the `_nextCooldown` timer, therefore allowing the button to be disabled again.

## Why / Balance
Bugfix

## Technical details
Reset _nextCooldown and _nextReset to null on ConfirmButton after being confirmation press. This stops FrameUpdate from re-enabling the button after its been used.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
[before fix](https://booru.cactus.vg/data/posts/603_271707752419a7ff.mp4)

[after fix](https://booru.cactus.vg/data/posts/604_319e6f6088e0af3d.mp4)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None I hope. The changes are all internal to ConfirmButton

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed ConfirmButton not disabling after being pressed + confirmed
