### PR TITLE
Clown spider rework/rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2861,7 +2861,22 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        180: Dead
+        120: Dead
+    - type: SolutionContainerManager
+      solutions:
+        melee:
+          maxVol: 60
+    - type: MeleeChemicalInjector
+      transferAmount: 4
+      solution: melee
+    - type: SolutionRegeneration
+      solution: melee
+      generated:
+        reagents:
+        - ReagentId: Mechanotoxin
+          Quantity: 0.5
+        - ReagentId: Laughter
+          Quantity: 3.5
     - type: Spider
       webPrototype: SpiderWebClown
     - type: MeleeWeapon
@@ -2869,10 +2884,11 @@
       angle: 0
       animation: WeaponArcBite
       soundHit:
-        path: /Audio/Effects/bite.ogg
+        path: /Audio/Items/bikehorn.ogg
       damage:
         types:
-          Piercing: 8
+          Blunt: 2
+          Piercing: 4
     - type: FootstepModifier
       footstepSoundCollection:
         collection: FootstepClownFast


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reworks clown spiders to be a more comedic threat than their current lethality incurs, via the following:
Lowers their health from 180 -> 120
Fixes their passive healing to allow for their new health limit (previously clown spiders would not heal passively past 90 damage)
Replaces their bite sounds with the bikehorn sfx
Lowers their injected mechanotoxin from 0.75 -> 0.5 (6 -> 4 poison per bite)
Added laughter injected on biting (3.5u)
Modifies their melee damage from 8 pierce -> 4 pierce + 2 blunt

## Why / Balance
Clown spiders along with slimes typically are the highest threat vent mob event, their 180hp and 14dmg melee (8 pierce and 6 poison from resultant mechanotoxin) means they can stat check anyone attempting to melee them (including a captains carapace + captains sabre) leaving them at bad or worse even when fought optimally.

These new values bring their overall durability more in line with regular spiders and make their damage more forgiving for first aid to treat (split blunt/pierce and less poison), with the new values their overall damage-trade in a melee situation is about the same as a regular spiders but a bit higher (expectantly with their now 30 additional health).
This should let player controlled clown spiders be more comedic akin to jonk/honk bots which overall is a better fit for the mob than being another piece of cannon fodder to KOS.

The choice of 3.5u of laughter / 0.5u of mechanotoxin works out to make each bite on average make the player laugh once.

## Technical details
all yaml.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Archee
- add: Clown spiders now honk when biting you.
- tweak: Clown spiders are now less lethal, less durable, and also inject laughter with their bites.

