### PR TITLE
Brings Estoc DMR accuracy to standard rifle accuracy, lowers movement speed debuff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -265,7 +265,7 @@
   - type: EyeCursorOffset
     maxOffset: 2
     pvsIncrease: 0.2
-  - type: SpeedModifiedonWield
+  - type: SpeedModifiedOnWield
     walkModifier: 0.9
     sprintModifier: 0.9
   - type: ContainerContainer


### PR DESCRIPTION
## About the PR
Changes the Estoc DMR accuracy to match the accuracy model of all other rifles; removes the move speed debuff from the Estoc when wielding.

## Why / Balance
While the Estoc's long-range visibility has been its upside, the downsides of having a slightly degraded accuracy and slowdown have made it an underwhelming weapon, particularly for nukies. This change makes the Estoc much more on par with the weapons available to nukies.

## Technical details


## Media


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes


**Changelog**

:cl:

- tweak: The Estoc DMR now has less slowdown when wielding and the same accuracy as other rifles.
