### PR TITLE
Make DamageableComponent manually networked again

### DIFF
--- a/Content.Shared/Damage/Components/DamageableComponent.cs
+++ b/Content.Shared/Damage/Components/DamageableComponent.cs
@@ -17,7 +17,7 @@ namespace Content.Shared.Damage.Components;
 ///     may also have resistances to certain damage types, defined via a <see cref="DamageModifierSetPrototype"/>.
 /// </remarks>
 [RegisterComponent]
-[NetworkedComponent, AutoGenerateComponentState(true)]
+[NetworkedComponent]
 [Access(typeof(DamageableSystem), Other = AccessPermissions.ReadExecute)]
 public sealed partial class DamageableComponent : Component
 {
@@ -25,7 +25,7 @@ public sealed partial class DamageableComponent : Component
     ///     This <see cref="DamageContainerPrototype"/> specifies what damage types are supported by this component.
     ///     If null, all damage types will be supported.
     /// </summary>
-    [DataField("damageContainer"), AutoNetworkedField]
+    [DataField("damageContainer")]
     // ReSharper disable once InconsistentNaming - This is wrong but fixing it is potentially annoying for downstreams.
     public ProtoId<DamageContainerPrototype>? DamageContainerID;
 
@@ -37,7 +37,7 @@ public sealed partial class DamageableComponent : Component
     ///     Though DamageModifierSets can be deserialized directly, we only want to use the prototype version here
     ///     to reduce duplication.
     /// </remarks>
-    [DataField("damageModifierSet"), AutoNetworkedField]
+    [DataField("damageModifierSet")]
     public ProtoId<DamageModifierSetPrototype>? DamageModifierSetId;
 
     /// <summary>
@@ -46,7 +46,7 @@ public sealed partial class DamageableComponent : Component
     /// <remarks>
     ///     If this data-field is specified, this allows damageable components to be initialized with non-zero damage.
     /// </remarks>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public DamageSpecifier Damage = new();
 
     /// <summary>
@@ -87,6 +87,20 @@ public sealed partial class DamageableComponent : Component
     [DataField]
     public ProtoId<HealthIconPrototype> RottingIcon = "HealthIconRotting";
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public FixedPoint2? HealthBarThreshold;
+}
+
+[Serializable, NetSerializable]
+public sealed class DamageableComponentState(
+    DamageSpecifier damage,
+    ProtoId<DamageContainerPrototype>? damageContainerId,
+    ProtoId<DamageModifierSetPrototype>? modifierSetId,
+    FixedPoint2? healthBarThreshold)
+    : ComponentState
+{
+    public readonly DamageSpecifier Damage = damage;
+    public readonly ProtoId<DamageContainerPrototype>? DamageContainerId = damageContainerId;
+    public readonly ProtoId<DamageModifierSetPrototype>? ModifierSetId = modifierSetId;
+    public readonly FixedPoint2? HealthBarThreshold = healthBarThreshold;
 }

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -17,6 +17,7 @@ public sealed partial class DamageableSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly INetManager _netMan = default!;
     [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly SharedChemistryGuideDataSystem _chemistryGuideData = default!;


### PR DESCRIPTION
Closes https://github.com/space-wizards/space-station-14/issues/43052

## About the PR
- DamageableComponent is manually networked once more
- uses a DamageSpecifier verbatim instead of its dictionary at least

## Why / Balance
- @slarticodefast raised concerns over delta being missing in client cases where damage was changed by the server, as well as the performance concerns of raising an event on every network

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
