### PR TITLE
Traitor Syndicate Reinforcement rebalance

### DIFF
--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -59,7 +59,7 @@
     head: ClothingHeadHatSurgcapPurple
     id: VisitorPDA
     belt: ClothingBeltMedicalFilled
-    back: ClothingBackpackMedical
+    back: ClothingBackpackDuffelMedical
     ears: ClothingHeadsetMedical
     eyes: ClothingEyesHudMedical
     pocket1: HandheldHealthAnalyzer
@@ -80,12 +80,13 @@
   id: SyndicateReinforcementSpy
   equipment:
     jumpsuit: ClothingUniformJumpsuitOperative
-    back: ClothingBackpackChameleonFillAgent
+    back: ClothingBackpack
     shoes: ClothingShoesColorBlack
     gloves: ClothingHandsGlovesColorBlack
     pocket1: WeaponPistolViper
     pocket2: VoiceMaskImplanter
-
+  inhand:
+    - ClothingBackpackChameleonFillAgent
 - type: startingGear
   id: SyndicateReinforcementThief
   parent: SyndicateOperativeClothing

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -90,7 +90,6 @@
   id: SyndicateReinforcementThief
   parent: SyndicateOperativeClothing
   equipment:
-    id: SyndiOperativeIDCard
     pocket1: WeaponPistolViper
     pocket2: MagazinePistolHighCapacity
   inhand:
@@ -98,6 +97,7 @@
   storage:
     back:
     - SyndicateJawsOfLife
+    - CameraBug
 
 #Syndicate Operative Outfit - Basic
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -52,25 +52,47 @@
 
 - type: startingGear
   id: SyndicateReinforcementMedic
-  parent: SyndicateOperativeClothing
   equipment:
-    pocket1: WeaponPistolViper
+    jumpsuit: ClothingUniformJumpsuitOperative
+    shoes: ClothingShoesColorRed
+    gloves: ClothingHandsGlovesLatex
+    head: ClothingHeadHatSurgcapPurple
+    id: VisitorPDA
+    belt: ClothingBeltMedicalFilled
+    back: ClothingBackpackMedical
+    ears: ClothingHeadsetMedical
+    eyes: ClothingEyesHudMedical
+    pocket1: HandheldHealthAnalyzer
+    pocket2: PillCanisterBicaridine
   inhand:
     - MedkitCombatFilled
-
+  storage:
+    back:
+    - Defibrillator
+    - CigPackSyndicate
+    - UniformScrubsColorPurple
+    - ChemistryBottleToxin
+    - ChemistryBottleNecrosol
+    - Syringe
+    - Syringe
+    
 - type: startingGear
   id: SyndicateReinforcementSpy
-  parent: SyndicateOperativeClothing
   equipment:
-    id: AgentIDCard
-    mask: ClothingMaskGasVoiceChameleon
+    jumpsuit: ClothingUniformJumpsuitOperative
+    back: ClothingBackpackChameleonFillAgent
+    shoes: ClothingShoesColorBlack
+    gloves: ClothingHandsGlovesColorBlack
     pocket1: WeaponPistolViper
+    pocket2: VoiceMaskImplanter
 
 - type: startingGear
   id: SyndicateReinforcementThief
   parent: SyndicateOperativeClothing
   equipment:
+    id: SyndiOperativeIDCard
     pocket1: WeaponPistolViper
+    pocket2: MagazinePistolHighCapacity
   inhand:
     - ToolboxSyndicateFilled
   storage:

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -72,7 +72,7 @@
     - CigPackSyndicate
     - UniformScrubsColorPurple
     - ChemistryBottleToxin
-    - ChemistryBottleNecrosol
+    - WeaponPistolViper
     - Syringe
     - Syringe
     


### PR DESCRIPTION
## About the PR
Reworked the Syndicate Reinforcement kits for the Medic, Spy, and Thief specializations to make them better at their respective niches. Full inventories of each specialization listed here: 

Medic: 
    jumpsuit: Operative Jumpsuit
    shoes: Red Shoes
    gloves: Latex Gloves
    head: Purple Surgical Cap
    id: VisitorPDA w/ visitor ID
    belt: filled medical belt
    back: Medical Duffel
    ears: Medical Headset
    eyes: Medhud
    pocket1: Health Analyzer
    pocket2: Bicaridine Pill Canister
  inhand:
    - Combat Medkit
  Backpack items: 
    - Defibrillator (has med battery)
    - Interdyne pack of smokes
    - Purple Scrubs jumpsuit (completes the outfit)
    - Toxin bottle
    - Necrosol bottle
    - Syringe x2
    - standard syndicate survival box

Spy:
    jumpsuit: Operative Jumpsuit
    back: regular backpack (needed to prevent an error)
    shoes: Black shoes
    gloves: Black gloves
    pocket1: Viper
    pocket2: VoiceMask Implanter
  inhand:
    - Chameleon backpack (syndicate version so has ID too)
  Backpack items: 
   - standard syndicate survival box
 
Thief: 
    jumpsuit: Operative Jumpsuit
    back: Syndicate Backpack
    shoes: Combat Boots w/ Throwing knife (tot reinforcements got this instead of combat knife for some reason)
    gloves: Black gloves
    pocket1: Viper
    pocket2: .35 viper mag (the 15 shot uplink one)
  inhand:
    - Filled Suspicious Toolbox
   Backpack items;
    - Syndicate Jaws
    - Camera Bug
    - standard syndicate survival box

## Why / Balance
As per discussion with traitor workgroup, there was consensus that the reinforcements felt extremely underwhelming to use. They're all comically valid and require the buyer to go out of their way to collect items to prop up the reinforcement, which makes it feel more like an inconvenience to get one than the significantly less expensive but self-sufficient monkey / kobold. This also ignores that some (medic especially) were also really awful at doing their intended job. I was given the shot to rebalance these all in one go and I took a stab at reworking their kits to make them all feel more unique, specialized into their respective niche, and FUNCTIONAL in that niche. Thoughts on each individual specialization and their respective changes below.

Medic was a reinforcement that basically had no current place. Outside of the basic reinforcement blueprint you got a combat medkit, and that was it. In raw TC value it fell short compared to the other options, and it completely lacked the pieces necessary for a traitor to actually avoid medbay, whether that be reviving an ally dragged away from a firefight or covering anything more than the most rudimentary damage.
The goal of Medic for this rework was to make a reinforcement that felt very functional outside of the medbay, losing the viper, syndie backpack, and filled combat boots for a more dedicated support niche that doesn't really have tools to advance a traitor's goals but also can't be immediately killed and RR'd as a foreign invader. I noticed how similar the reinforcement medic's gear was to the (now-removed) doctor visitor and thought that it sounded like a perfectly flimsy but functional alibi for the reinforcement while giving a healthy supply of medicine to cover basically every instance of damage a traitor might get. Doctor visitor gear, a defibrillator, a pack of Interdynes, a health analyzer, a bottle of Bic pills and a few syringes and a bottle each of Toxin and Necrosol rounds out the loadout with a combat kit. The toxin and necrosol are easy removals if these seem out of place, but poison on a syndicate doctor felt like it could lead to interesting strategies / actions due to the slow TTK while also serving as a reminder that YOU ARE EVIL to the reinforcement and to maybe not get too into being a good doctor. The necrosol serves to save any syndicate that find themselves either horribly maimed or RR'd by poison. Omnizine felt like too much, this was the middle ground. Again, easy removals but could be used creatively or with more investment by the purchaser, and worth discussing. 

Spy was nearly there but just had a lot of outdated equipment due to the equipment rebalance. In exchange for losing the syndie backpack and the filled combat boots, the voice mask was updated to instead be the voice mask implanter, and the agent ID was replaced with a filled chameleon backpack (syndicate version, so also has an ID). This is a net loss in terms of TC value but should feel way, way more functional as a reinforcement that can immediately back you up and act in a bunch of creative ways. 

Thief is in a weird place because syndicate objectives don't really fit pure thieving; breaking and entering without any obfuscation like a chameleon kit is more an immediate loud thing because you need to kill a guy or steal something (off a corpse). On paper the TC value of the thief kit is actually pretty great, being functionally cheaper than a monkey by a large margin (backpack + viper + jaws + susbox is, functionally, 9tc plus a free syndie gasmask on top!!) but the unpopularity of the choice and the evident, massive downsides of a lack of disguise show that this option clearly isn't effective despite the sheer value.
The way I decided to improve on this specialization was to lean even further into a hybridized loud / steal function. The Thief gets an additional viper mag and a camera bug, to help with planning breaking into a department to assassinate a target or making sure the coast is clear before sneaking in some place they shouldn't be. Compared to other specializations you get big TC value but are also way less able to traverse the station and way more reliant on support, which either forces your purchaser to go out of their way to cover these weaknesses / buy solutions, or accept the downsides and work more aggressively with the reinforcement.

Ultimately the vision was to make each reinforcement good in specific but generic scenarios. Examples of the kind of things I was aiming for below: 
- I'm working with another traitor and they get shot / killed / executed, but I'm able to pull their body into maints and hide. A medical reinforcement is able to get them on their feet and continue helping us after the fact, so it feels like a great option. 
- I complete my objectives without using much TC and am waiting for evac. A medical reinforcement is suspicious but protected by space law, will help me stay alive, and may have fun objectives to give me something to do, so it feels like a decent thing to buy instead of hoarding TC doing nothing.
- I want a reinforcement that can just help me with what I'm working on immediately without having to spend a lot of time getting it up to speed while also wanting more capability than a monkey / kobold, a Spy seems good. 
- I want to give my reinforcement my second objective while I work on my plan alone for my first. Spy would be great. 
- I am ready to commit to killing my target but am not confident on doing it by myself. The Thief is great, because I get another pair of hands to help and can better time the right moment to break in.
- I want value and I'm willing to spend time to prop up a reinforcement. Thief gives great value and are items that would be helpful for what I'm trying to do, so Thief seems great. 
- I want to go loud. Medical could be nice because we get plenty of healing value. Spy could be nice to make use of the IDs and accesses we get. Thief gives me plenty of tools to do so, if I'm willing to work around how valid they are.


## Technical details
yaml warrior.

## Media
<img width="330" height="258" alt="syndiop1" src="https://github.com/user-attachments/assets/cd86e375-a34d-4322-92dc-ce72d810cefd" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
**Changelog**
:cl:
- tweak: Rebalanced the syndicate reinforcement specializations to be more effective at their roles. 