### PR TITLE
Change Bad Chembottle Suffixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-bottles.yml
@@ -711,7 +711,7 @@
 
 - type: entity
   id: ChemistryBottlePotassiumIodide
-  suffix: iodide
+  suffix: potassium iodide
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
@@ -741,7 +741,7 @@
 
 - type: entity
   id: ChemistryBottlePulpedBananaPeel
-  suffix: pulped-banana-peel
+  suffix: pulped banana peel
   parent: BaseChemistryBottleFilled
   components:
   - type: Label


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Improved chem bottle suffixes.
Potassium Iodide and Pulped Banana Peel.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Potassium Iodide was listed as simply "Iodide"
Pulped banana peel has extraneous dashes.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No player facing changes.