### PR TITLE
Throwing Croissant Incorrect Inhand Removed

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/croissant.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/croissant.yml
@@ -4,7 +4,7 @@
   suffix: Weapon
   components:
   - type: Item
-    sprite: null
+    sprite: null # Should be removed if croissant receives an inhand sprite
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The throwing croissant used the throwing knife inhand. This corrects that to an empty hand.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Showing a throwing knife in your hand reduces the stealth aspect of a throwing croissant. 
Ideally the contraband and slicing components would also be removed, but this is more difficult.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Throwing croissants no longer have a throwing knife in-hand sprite.