### PR TITLE
Check collision filter when unpacking flatpack

### DIFF
--- a/Content.Shared/Construction/SharedFlatpackSystem.cs
+++ b/Content.Shared/Construction/SharedFlatpackSystem.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Construction;
@@ -22,7 +23,6 @@ public abstract class SharedFlatpackSystem : EntitySystem
 {
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly INetManager _net = default!;
-    [Dependency] private readonly IComponentFactory _componentFactory = default!;
     [Dependency] protected readonly IPrototypeManager PrototypeManager = default!;
     [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -34,6 +34,7 @@ public abstract class SharedFlatpackSystem : EntitySystem
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedToolSystem _tool = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -177,21 +178,15 @@ public abstract class SharedFlatpackSystem : EntitySystem
     private bool HasRoomToConstruct(EntProtoId protoId, EntityCoordinates coords)
     {
         var entWithPhysics = new EntProtoId<FixturesComponent>(protoId);
-        if (!entWithPhysics.TryGet(out var flatpackFixtures, PrototypeManager, _componentFactory))
+        if (!entWithPhysics.TryGet(out var flatpackFixtures, PrototypeManager, Factory))
         {
             // The entity we're constructing has no fixtures, so can't overlap anything
             return true;
         }
 
-        // Sum up the collision mask of all the fixtures of the entity we're trying to create
-        int collisionMask = 0;
-        foreach (var fixture in flatpackFixtures.Fixtures.Values)
-        {
-            if (fixture.Hard)
-            {
-                collisionMask |= fixture.CollisionMask;
-            }
-        }
+        // Have to call the static version of this method, as we don't
+        // have an EntityId for the item contained in the flatpack:
+        var (flatpackedLayer, flatpackedMask) = SharedPhysicsSystem.GetHardCollision(flatpackFixtures);
 
         // Find all the overlaps at the coordinates and see if they have a collision
         // layer which collides with any of the flatpacked entity's collision mask
@@ -200,20 +195,12 @@ public abstract class SharedFlatpackSystem : EntitySystem
         var overlaps = _entityLookup.GetEntitiesIntersecting(coords, LookupFlags.Static | LookupFlags.Dynamic);
         foreach (var overlap in overlaps)
         {
-            if (!TryComp<FixturesComponent>(overlap, out var overlapFixtures))
+            var (overlapLayer, overlapMask) = _physics.GetHardCollision(overlap);
+            if ((overlapLayer & flatpackedMask) != 0 || (overlapMask & flatpackedLayer) != 0)
             {
-                // This overlap has no fixtures. Can't collide.
-                continue;
-            }
-
-            foreach (var fixture in overlapFixtures.Fixtures.Values)
-            {
-                if (fixture.Hard && (fixture.CollisionLayer & collisionMask) != 0)
-                {
-                    // Found an overlap which collides with at least one of the
-                    // flatpacked entity's fixtures.
-                    return false;
-                }
+                // Found an overlap containing fixtures which would collide with
+                // at least one of the flatpacked entity's fixtures.
+                return false;
             }
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Improves unpacking flatpack experience - uses collision filter of item contained inside the flatpack to determine if the flatpack can be unpacked. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Sometimes a flatpack wouldn't behave as expected. If you placed -say- a microwave or reagent grinder flatpack on a table and attempted to unpack it, you'd get a "no room" popup. To place the item on the table, you'd have to put the flatpack on an empty tile, unpack it, unanchor the item, drag it on top of the table and then anchor it down again.

Also fixes a bug where ghost players could troll living players by hovering over the flatpack, which would prevent the living player from unpacking the flatpack (TIL). Fixes #24588 

Fixes one (1) TODO in the code.


## Technical details
<!-- Summary of code changes for easier review. -->

Look at collision filter of contained item, use that to determine if there would be a collision in the location being unpacked.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


https://github.com/user-attachments/assets/a621a7c3-296c-46d7-90d0-f466bde3f6bb



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: Small flatpacked appliances such as microwaves can now be unpacked directly onto tables and counters
