### PR TITLE
Fix AtmosDebugOverlay being always active

### DIFF
--- a/Content.Client/Atmos/EntitySystems/AtmosDebugOverlaySystem.cs
+++ b/Content.Client/Atmos/EntitySystems/AtmosDebugOverlaySystem.cs
@@ -10,7 +10,9 @@ namespace Content.Client.Atmos.EntitySystems
     [UsedImplicitly]
     internal sealed class AtmosDebugOverlaySystem : SharedAtmosDebugOverlaySystem
     {
-        public readonly Dictionary<EntityUid, AtmosDebugOverlayMessage> TileData = new();
+        [Dependency] private readonly IOverlayManager _overlayManager = default!;
+
+        public readonly Dictionary<EntityUid, AtmosDebugOverlayMessage> TileData = [];
 
         // Configuration set by debug commands and used by AtmosDebugOverlay {
         /// <summary>Value source for display</summary>
@@ -54,8 +56,7 @@ namespace Content.Client.Atmos.EntitySystems
                 return;
 
             _overlay = new AtmosDebugOverlay(this);
-            var overlayManager = IoCManager.Resolve<IOverlayManager>();
-            overlayManager.AddOverlay(_overlay);
+            _overlayManager.AddOverlay(_overlay);
         }
 
         private void HandleAtmosDebugOverlayDisableMessage(AtmosDebugOverlayDisableMessage ev)
@@ -86,8 +87,7 @@ namespace Content.Client.Atmos.EntitySystems
             if (_overlay is null)
                 return;
 
-            var overlayManager = IoCManager.Resolve<IOverlayManager>();
-            overlayManager.RemoveOverlay(_overlay);
+            _overlayManager.RemoveOverlay(_overlay);
             _overlay = null;
         }
     }


### PR DESCRIPTION
## About the PR
`AtmosDebugOverlay` was previously created on initialization, even when not in use. Now, the overlay is only created when needed.

## Why / Balance
Resolves #35157
Regarding the last sentence in the issue, I did not find a similar problem in other debug overlays.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
