### PR TITLE
Fix damagable mispredicts

### DIFF
--- a/Content.Shared/Damage/Systems/DamageableSystem.Events.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.Events.cs
@@ -207,13 +207,14 @@ public sealed partial class DamageableSystem
         ent.Comp.HealthBarThreshold = state.HealthBarThreshold;
 
         // Has the damage actually changed?
-        var delta = state.Damage - ent.Comp.Damage;
+        var newDamage = state.Damage.Clone();
+        var delta = newDamage - ent.Comp.Damage;
         delta.TrimZeros();
 
         if (delta.Empty)
             return;
 
-        ent.Comp.Damage = state.Damage;
+        ent.Comp.Damage = newDamage;
 
         OnEntityDamageChanged(ent, delta);
     }


### PR DESCRIPTION
## About the PR
Fixes a bug introduced in #43054

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Added back the missing dictionary clone that was originally removed in #43049 but not added back in #43054

## Media
before

![before](https://github.com/user-attachments/assets/ea543f19-eab3-4443-a031-3b4eb9635384)

after

![after](https://github.com/user-attachments/assets/e9cc6040-40a4-4af0-8328-0f4b28c356b9)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed damage mispredicting.