### PR TITLE
fix topicals

### DIFF
--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -130,7 +130,7 @@ public sealed class HealingSystem : EntitySystem
         var healingDict = healing.Comp.Damage.DamageDict;
         foreach (var type in healingDict)
         {
-            if (damageableDict[type.Key].Value > 0)
+            if (damageableDict.TryGetValue(type.Key, out var amount) && amount > 0)
             {
                 return true;
             }


### PR DESCRIPTION
## About the PR
There were causing debug asserts and potentially bricking your client until reconnect.

## Why / Balance
bugfix

## Technical details
Introduced by #43049
See this breaking change in that PR
<img width="800" height="59" alt="grafik" src="https://github.com/user-attachments/assets/bd60252c-208a-452a-9f2b-ef3d50b19e18" />

To reproduce the bug on master:
- hit a Urist with a baseball bat
- fully heal them with topicals

get the following debug assert:

```
[FATL] unhandled: System.Collections.Generic.KeyNotFoundException: The given key 'Piercing' was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Content.Shared.Medical.Healing.HealingSystem.HasDamage(Entity`1 healing, Entity`1 target) in D:\Code\SS14\space-station-14\Content.Shared\Medical\Healing\HealingSystem.cs:line 133
   at Content.Shared.Medical.Healing.HealingSystem.OnDoAfter(Entity`1 target, HealingDoAfterEvent& args) in D:\Code\SS14\space-station-14\Content.Shared\Medical\Healing\HealingSystem.cs:line 113        
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass57_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, Unit& ev) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 305
   at Robust.Shared.GameObjects.EntityEventBus.EntDispatch(EntityUid euid, Type eventType, Unit& args) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 573
   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEventCore(EntityUid uid, Unit& unitRef, Type type, Boolean broadcast) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 235
   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent(EntityUid uid, Object args, Boolean broadcast) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 204
   at Robust.Shared.GameObjects.EntitySystem.RaiseLocalEvent(EntityUid uid, Object args, Boolean broadcast) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntitySystem.cs:line 
234
   at Content.Shared.DoAfter.SharedDoAfterSystem.RaiseDoAfterEvents(DoAfter doAfter, DoAfterComponent component) in D:\Code\SS14\space-station-14\Content.Shared\DoAfter\SharedDoAfterSystem.cs:line 88   
   at Content.Shared.DoAfter.SharedDoAfterSystem.TryComplete(DoAfter doAfter, DoAfterComponent component) in D:\Code\SS14\space-station-14\Content.Shared\DoAfter\SharedDoAfterSystem.Update.cs:line 138  
   at Content.Shared.DoAfter.SharedDoAfterSystem.Update(EntityUid uid, ActiveDoAfterComponent active, DoAfterComponent comp, TimeSpan time, EntityQuery`1 xformQuery, EntityQuery`1 handsQuery) in D:\Code\SS14\space-station-14\Content.Shared\DoAfter\SharedDoAfterSystem.Update.cs:line 82
   at Content.Shared.DoAfter.SharedDoAfterSystem.Update(Single frameTime) in D:\Code\SS14\space-station-14\Content.Shared\DoAfter\SharedDoAfterSystem.Update.cs:line 30
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntitySystemManager.cs:line 319
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.cs:line 280
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Server\GameObjects\ServerEntityManager.cs:line 170
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Server\BaseServer.cs:line 760
   at Robust.Server.BaseServer.<SetupMainLoop>b__69_1(Object sender, FrameEventArgs args) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Server\BaseServer.cs:line 560
   at Robust.Shared.Timing.GameLoop.Run() in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Shared\Timing\GameLoop.cs:line 243
   at Robust.Server.BaseServer.MainLoop() in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Server\BaseServer.cs:line 587
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Server\Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Server\Program.cs:line 42
   at Robust.Server.ContentStart.Start(String[] args) in D:\Code\SS14\space-station-14\RobustToolbox\Robust.Server\ContentStart.cs:line 10
   at Content.Server.Program.Main(String[] args) in D:\Code\SS14\space-station-14\Content.Server\Program.cs:line 9
```

## Media
I did not have time to fully test this yet, would be great if someone else could take this over check if everything work.
I won't be home the next few hours.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed topicals.
