### PR TITLE
APC building doAfter fix

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/APC.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/APC.yml
@@ -8,6 +8,7 @@
           steps:
             - material: Steel
               amount: 3
+              doAfter: 2
 
     - node: apcFrame
       entity: APCFrame


### PR DESCRIPTION

<img width="888" height="499" alt="PRAPCdoAfter" src="https://github.com/user-attachments/assets/8c30868b-50dc-4ea4-a652-102334927576" />

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I've added a doAfter to the construction of the APC it now matches most other things like air alarms with a 2 second of a building doAfter.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Seems like an oversight with many almost all objects having a crafting time but the APC just appearing.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: APCs take 2 seconds to build instead of instantly appearing.