### PR TITLE
Make locked machines deconstruction consistent

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/machine.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/machine.yml
@@ -101,6 +101,8 @@
           conditions:
             - !type:EntityAnchored
             - !type:WirePanel
+            - !type:Locked
+              locked: false
           steps:
             - tool: Prying
               doAfter: 2


### PR DESCRIPTION




## About the PR
Machines now need to be unlocked before allowing deconstruction.
## Why / Balance
Cause it's frankly absurd that emitters can just be deconstructed even when they're locked. It kinda defeats the whole purpose of locking in the first place.
## Technical details
It's just a single yaml update to the machine construction graph adding the locked condition.  

## Media
<img width="635" height="522" alt="image" src="https://github.com/user-attachments/assets/7619719b-3bf2-4ec9-9dcc-8b4c27f1dd8c" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None, I'm only adding not changing things. 

**Changelog**
-
:cl:
- tweak: Lockable machines (such as emitters) must now be unlocked before being deconstructed
