### PR TITLE
Fix hitscan visual scaling

### DIFF
--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
@@ -124,10 +124,42 @@ public sealed class HitscanBasicRaycastSystem : EntitySystem
 
             if (vizComp.TravelFlash != null)
             {
-                var coords = fromCoordinates.Offset(shotAngle.ToVec() * (distance + 0.5f) / 2);
-                var netCoords = GetNetCoordinates(coords);
+                var muzzleFlashLength = vizComp.MuzzleFlash != null ? 1.0f : 0.0f;
+                // Impact is only 0.5 because you *want* the middle of the sprite to be centered (unlike the muzzle flash)
+                var impactFlashLength = vizComp.ImpactFlash != null ? 0.5f : 0.0f;
 
-                sprites.Add((netCoords, shotAngle, vizComp.TravelFlash, distance - 1.5f));
+                var actualDistance = distance - muzzleFlashLength - impactFlashLength;
+
+                var segments = (float) Math.Round(actualDistance);
+
+                // Amount to scale each segment by so it actually fits the entire distance.
+                var scaler = actualDistance / segments;
+
+                // Edge case, just have one segment scaled to the correct length.
+                if (segments == 0)
+                {
+                    scaler = actualDistance;
+                    segments = 1;
+                }
+
+                // The sprites are one unit distance, if that changes for some reason 1.0f should be changed to reflect that.
+                var segmentLength = 1.0f * scaler;
+
+                for (var i = 0; i < segments; i++)
+                {
+                    var coords = fromCoordinates;
+
+                    // If there is a muzzle flash, bring make it start at that offset.
+                    if (vizComp.MuzzleFlash != null)
+                        coords = coords.Offset(shotAngle.ToVec());
+
+                    // Offset by half of the (scaled) sprite length so it starts on the edge of the sprite not the middle
+                    coords = coords.Offset((shotAngle.ToVec() * segmentLength) / 2);
+
+                    coords = coords.Offset(shotAngle.ToVec() * i * segmentLength);
+
+                    sprites.Add((GetNetCoordinates(coords), shotAngle, vizComp.TravelFlash, scaler));
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Technical details
<!-- Summary of code changes for easier review. -->
Hitscan visuals were done in a kind of confusing way. The middle segment of the laser would just be stretched to fit the distance which could really weird on long distances:

<img width="702" height="228" alt="Screenshot from 2026-03-06 21-37-55" src="https://github.com/user-attachments/assets/885cd99d-54c4-44bd-908a-32b89c45bcf3" />

This new version will split up the distance into sections to minimize the amount of stretching necessary, this results in much more consistent looking sprites (see media) and also allows for complex laser sprites that aren't just lines!

Here is a quick example of what the difference changes

Old version (One sprite stretched to fit):
<img width="384" height="880" alt="image" src="https://github.com/user-attachments/assets/38c9ec5c-6068-4fe8-ae93-572b9f2cfad2" />

My version (multiple segments that are only slightly stretched ):
<img width="384" height="880" alt="image" src="https://github.com/user-attachments/assets/05543acf-8c13-4907-b85e-57b3979f0a36" />

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/0d428fd6-a592-4bad-9ed3-04350f85d45c

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

If you have hitscan sprites that depend on the current implementation you might need to update them to work. Most sprites should be fine, but depending on what your doing the new system might not work exactly for you.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Beck Thompson
- tweak: Laser sprites are now more consistent.