### PR TITLE
On Exo, fixed power for AI North and South external cameras

### DIFF
--- a/Resources/Maps/exo.yml
+++ b/Resources/Maps/exo.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/08/2026 05:26:54
-  entityCount: 20049
+  time: 03/08/2026 15:02:53
+  entityCount: 20047
 maps:
 - 1
 grids:
@@ -10166,7 +10166,7 @@ entities:
       pos: 11.5,-30.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -260246.27
+      secondsUntilStateChange: -260311.42
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10522,7 +10522,7 @@ entities:
       pos: 34.5,-36.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -35743.953
+      secondsUntilStateChange: -35809.105
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -27613,11 +27613,6 @@ entities:
     - type: Transform
       pos: 2.5,-62.5
       parent: 2
-  - uid: 19378
-    components:
-    - type: Transform
-      pos: 92.5,-52.5
-      parent: 2
   - uid: 19379
     components:
     - type: Transform
@@ -27627,11 +27622,6 @@ entities:
     components:
     - type: Transform
       pos: 92.5,-39.5
-      parent: 2
-  - uid: 19391
-    components:
-    - type: Transform
-      pos: 92.5,-38.5
       parent: 2
   - uid: 19392
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I added some LV cables to Exo's AI core, connecting the previously unpowered north and south external cameras.

## Why / Balance
Doesn't really affect AI's vision either way, but it's important to have them powered for consistency reasons.

## Technical details
Just a small mapping change.

## Media
<img width="762" height="695" alt="image" src="https://github.com/user-attachments/assets/d0e0be42-5919-44f2-8284-2d940a7303a3" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Sapphic_bee
Maps:
- fix: On Exo, the AI north and south external cameras are now connected to power.


