### PR TITLE
Remove syndie bomb restock time

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -483,7 +483,6 @@
     Telecrystal: 11
   categories:
     - UplinkExplosives
-  restockTime: 1800
   conditions:
   - !type:StoreWhitelistCondition
     blacklist:
@@ -934,7 +933,6 @@
     Telecrystal: 4
   categories:
   - UplinkDeception
-  restockTime: 1800
   conditions:
   - !type:StoreWhitelistCondition
     blacklist:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Removes 30-minute purchase delay for Syndicate Bomb.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Since the destructive scale of Syndicate Bombs got reduced by https://github.com/space-wizards/space-station-14/pull/42477 and https://github.com/space-wizards/space-station-14/pull/42474, there is less of a need to delay purchases for traitors.  

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![dotnet_LtVOnaCCUv](https://github.com/user-attachments/assets/60ffe09e-2bc0-469a-8c76-03b1731ca99c)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Removed restock time on Syndicate Bombs.