### PR TITLE
Refactor guide entry tests.

### DIFF
--- a/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
+++ b/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
@@ -26,7 +26,6 @@ public sealed class GuideEntryPrototypeTests
         await client.WaitIdleAsync();
         var protoMan = client.ResolveDependency<IPrototypeManager>();
         var resMan = client.ResolveDependency<IResourceManager>();
-        var locMan = client.ResolveDependency<ILocalizationManager>();
         var parser = client.ResolveDependency<DocumentParsingManager>();
         var proto = protoMan.Index<GuideEntryPrototype>(protoKey);
 
@@ -34,12 +33,8 @@ public sealed class GuideEntryPrototypeTests
         {
             using var reader = resMan.ContentFileReadText(proto.Text);
             var text = reader.ReadToEnd();
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(parser.TryAddMarkup(new Document(), text), $"Failed to parse the guide entry's document.");
 
-                Assert.That(locMan.TryGetString(proto.Name, out _), $"The entry's name, {proto.Name}, is missing a locale key.");
-            }
+            Assert.That(parser.TryAddMarkup(new Document(), text), $"Failed to parse the guide entry's document.");
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Shared/Guidebook/GuideEntry.cs
+++ b/Content.Shared/Guidebook/GuideEntry.cs
@@ -26,7 +26,7 @@ public class GuideEntry
     /// <summary>
     ///     The name of this guide. This gets localized.
     /// </summary>
-    [DataField(required: true)] public string Name = default!;
+    [DataField(required: true)] public LocId Name = default!;
 
     /// <summary>
     ///     The "children" of this guide for when guides are shown in a tree / table of contents.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Guide entries are now tested individually. Additionally, the `Name` field for guidebook entries was changed to explicitly be a localization key, as `Loc.GetString` is always used.

## Why / Balance
dev-ex

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->