### PR TITLE
Fix #25112 - Random Borg Blindness/Dark Vision

### DIFF
--- a/Content.Client/UserInterface/Systems/DamageOverlays/DamageOverlayUiController.cs
+++ b/Content.Client/UserInterface/Systems/DamageOverlays/DamageOverlayUiController.cs
@@ -69,6 +69,7 @@ public sealed class DamageOverlayUiController : UIController
 
     private void ClearOverlay()
     {
+        _overlay.State = MobState.Alive;
         _overlay.DeadLevel = 0f;
         _overlay.CritLevel = 0f;
         _overlay.PainLevel = 0f;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes #25112

## Technical details
<!-- Summary of code changes for easier review. -->
Borgs have overlays disabled. During comp startup, ClearOverlay is called twice (maybe some cleanup that can be done here? I didn't study it too intently).
In each time, it sets the damage values of the overlay to zero. The problem, the overlay itself reapplies damage because its internal MobState is never changed from MobState.Dead. I can think of a few ways to fix this. First is what I've done here. Hard set the mob state to alive when the overlay is cleared. This works because the mobstate will be reapplied below if for some reason it must be different immediately after clearoverlay is called. The second was to reinit a new DamageOverlay when the player is attached as appose to when the UIController is inited. I personally think this is probably better but I wasn't sure so I figured I'd shoot this out there and see what happens.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

I was going too but between me connecting to dev, acidifying, restarting the round, changing the map, and spawning as a borg, the video file is "tOo BiG". BLEH

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->