### PR TITLE
Add unsafe unanchor for gas heaters

### DIFF
--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosUnsafeUnanchorSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosUnsafeUnanchorSystem.cs
@@ -18,138 +18,139 @@ using Content.Shared.Tools.Systems;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 
-namespace Content.Server.Atmos.Piping.EntitySystems;
-
-[UsedImplicitly]
-public sealed class AtmosUnsafeUnanchorSystem : EntitySystem
+namespace Content.Server.Atmos.Piping.EntitySystems
 {
-    [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
-    [Dependency] private readonly NodeGroupSystem _group = default!;
-    [Dependency] private readonly PopupSystem _popup = default!;
-    [Dependency] private readonly SharedToolSystem _toolSystem = default!;
-
-    private static readonly ProtoId<ToolQualityPrototype> PryingQuality = "Prying";
-    private static readonly ProtoId<ConstructionGraphPrototype> MachineGraph = "Machine";
-
-    public override void Initialize()
+    [UsedImplicitly]
+    public sealed class AtmosUnsafeUnanchorSystem : EntitySystem
     {
-        SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, UserUnanchoredEvent>(OnUserUnanchored);
-        SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
-        SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, BreakageEventArgs>(OnBreak);
-        SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, MachineDeconstructedEvent>(OnMachineDeconstructed);
-        SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, InteractUsingEvent>(OnInteractUsing, after: [typeof(ConstructionSystem)]);
-    }
+        [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
+        [Dependency] private readonly NodeGroupSystem _group = default!;
+        [Dependency] private readonly PopupSystem _popup = default!;
+        [Dependency] private readonly SharedToolSystem _toolSystem = default!;
 
-    private bool IsUnsafe(Entity<AtmosUnsafeUnanchorComponent> ent)
-    {
-        if (!ent.Comp.Enabled || !TryComp(ent, out NodeContainerComponent? nodes))
-            return false;
+        private static readonly ProtoId<ToolQualityPrototype> PryingQuality = "Prying";
+        private static readonly ProtoId<ConstructionGraphPrototype> MachineGraph = "Machine";
 
-        if (_atmosphere.GetContainingMixture(ent.Owner, true) is not { } environment)
-            return false;
-
-        foreach (var node in nodes.Nodes.Values)
+        public override void Initialize()
         {
-            if (node is not PipeNode pipe)
-                continue;
-
-            if (pipe.Air.Pressure - environment.Pressure > 2 * Atmospherics.OneAtmosphere)
-            {
-                return true;
-            }
+            SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, UserUnanchoredEvent>(OnUserUnanchored);
+            SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
+            SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, BreakageEventArgs>(OnBreak);
+            SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, MachineDeconstructedEvent>(OnMachineDeconstructed);
+            SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, InteractUsingEvent>(OnInteractUsing, after: [typeof(ConstructionSystem)]);
         }
 
-        return false;
-    }
-
-    // Handle unsafe machine deconstruction. Currently applies to gas heaters.
-    private void OnInteractUsing(Entity<AtmosUnsafeUnanchorComponent> ent, ref InteractUsingEvent args)
-    {
-        if (!IsMachineDeconstructInteraction(ent, args) || !IsUnsafe(ent))
-            return;
-
-        _popup.PopupEntity(Loc.GetString("comp-atmos-unsafe-deconstruction-warning"), ent,
-            args.User, PopupType.MediumCaution);
-    }
-
-    // Check if we're about to deconstruct the machine.
-    private bool IsMachineDeconstructInteraction(Entity<AtmosUnsafeUnanchorComponent> ent, InteractUsingEvent args)
-    {
-        if (!args.Handled || !_toolSystem.HasQuality(args.Used, PryingQuality))
-            return false;
-
-        if (!TryComp(ent, out ConstructionComponent? construction) || construction.Graph != MachineGraph)
-            return false;
-
-        return true;
-    }
-
-    private void OnUnanchorAttempt(Entity<AtmosUnsafeUnanchorComponent> ent, ref UnanchorAttemptEvent args)
-    {
-        if (IsUnsafe(ent))
+        private bool IsUnsafe(Entity<AtmosUnsafeUnanchorComponent> ent)
         {
-            args.Delay += 2f;
-            _popup.PopupEntity(Loc.GetString("comp-atmos-unsafe-unanchor-warning"), ent,
+            if (!ent.Comp.Enabled || !TryComp(ent, out NodeContainerComponent? nodes))
+                return false;
+
+            if (_atmosphere.GetContainingMixture(ent.Owner, true) is not { } environment)
+                return false;
+
+            foreach (var node in nodes.Nodes.Values)
+            {
+                if (node is not PipeNode pipe)
+                    continue;
+
+                if (pipe.Air.Pressure - environment.Pressure > 2 * Atmospherics.OneAtmosphere)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // Handle unsafe machine deconstruction. Currently applies to gas heaters.
+        private void OnInteractUsing(Entity<AtmosUnsafeUnanchorComponent> ent, ref InteractUsingEvent args)
+        {
+            if (!IsMachineDeconstructInteraction(ent, args) || !IsUnsafe(ent))
+                return;
+
+            _popup.PopupEntity(Loc.GetString("comp-atmos-unsafe-deconstruction-warning"), ent,
                 args.User, PopupType.MediumCaution);
-            return; // Show the warning only once.
         }
-    }
 
-    // When unanchoring a pipe, leak the gas that was inside the pipe element.
-    // At this point the pipe has been scheduled to be removed from the group, but that won't happen until the next Update() call in NodeGroupSystem,
-    // so we have to force an update.
-    // This way the gas inside other connected pipes stays unchanged, while the removed pipe is completely emptied.
-    private void OnUserUnanchored(Entity<AtmosUnsafeUnanchorComponent> ent, ref UserUnanchoredEvent args)
-    {
-        if (ent.Comp.Enabled)
+        // Check if we're about to deconstruct the machine.
+        private bool IsMachineDeconstructInteraction(Entity<AtmosUnsafeUnanchorComponent> ent, InteractUsingEvent args)
         {
-            _group.ForceUpdate();
-            LeakGas(ent);
+            if (!args.Handled || !_toolSystem.HasQuality(args.Used, PryingQuality))
+                return false;
+
+            if (!TryComp(ent, out ConstructionComponent? construction) || construction.Graph != MachineGraph)
+                return false;
+
+            return true;
         }
-    }
 
-    private void OnBreak(Entity<AtmosUnsafeUnanchorComponent> ent, ref BreakageEventArgs args)
-    {
-        LeakGas(ent, false);
-        // Can't use DoActsBehavior["Destruction"] in the same trigger because that would prevent us
-        // from leaking. So we make up for this by queueing deletion here.
-        QueueDel(ent);
-    }
-
-    private void OnMachineDeconstructed(Entity<AtmosUnsafeUnanchorComponent> ent, ref MachineDeconstructedEvent args)
-    {
-        LeakGas(ent, false);
-    }
-
-    /// <summary>
-    /// Leak gas from the uid's NodeContainer into the tile atmosphere.
-    /// Setting removeFromPipe to false will duplicate the gas inside the pipe intead of moving it.
-    /// This is needed to properly handle the gas in the pipe getting deleted with the pipe.
-    /// </summary>
-    public void LeakGas(Entity<AtmosUnsafeUnanchorComponent> ent, bool removeFromPipe = true)
-    {
-        if (!TryComp(ent, out NodeContainerComponent? nodes))
-            return;
-
-        if (_atmosphere.GetContainingMixture(ent.Owner, true, true) is not { } environment)
-            environment = GasMixture.SpaceGas;
-
-        var buffer = new GasMixture();
-
-        foreach (var node in nodes.Nodes.Values)
+        private void OnUnanchorAttempt(Entity<AtmosUnsafeUnanchorComponent> ent, ref UnanchorAttemptEvent args)
         {
-            if (node is not PipeNode pipe)
-                continue;
-
-            if (removeFromPipe)
-                _atmosphere.Merge(buffer, pipe.Air.RemoveVolume(pipe.Volume));
-            else
+            if (IsUnsafe(ent))
             {
-                var copy = new GasMixture(pipe.Air); //clone, then remove to keep the original untouched
-                _atmosphere.Merge(buffer, copy.RemoveVolume(pipe.Volume));
+                args.Delay += 2f;
+                _popup.PopupEntity(Loc.GetString("comp-atmos-unsafe-unanchor-warning"), ent,
+                    args.User, PopupType.MediumCaution);
+                return; // Show the warning only once.
             }
         }
 
-        _atmosphere.Merge(environment, buffer);
+        // When unanchoring a pipe, leak the gas that was inside the pipe element.
+        // At this point the pipe has been scheduled to be removed from the group, but that won't happen until the next Update() call in NodeGroupSystem,
+        // so we have to force an update.
+        // This way the gas inside other connected pipes stays unchanged, while the removed pipe is completely emptied.
+        private void OnUserUnanchored(Entity<AtmosUnsafeUnanchorComponent> ent, ref UserUnanchoredEvent args)
+        {
+            if (ent.Comp.Enabled)
+            {
+                _group.ForceUpdate();
+                LeakGas(ent);
+            }
+        }
+
+        private void OnBreak(Entity<AtmosUnsafeUnanchorComponent> ent, ref BreakageEventArgs args)
+        {
+            LeakGas(ent, false);
+            // Can't use DoActsBehavior["Destruction"] in the same trigger because that would prevent us
+            // from leaking. So we make up for this by queueing deletion here.
+            QueueDel(ent);
+        }
+
+        private void OnMachineDeconstructed(Entity<AtmosUnsafeUnanchorComponent> ent, ref MachineDeconstructedEvent args)
+        {
+            LeakGas(ent, false);
+        }
+
+        /// <summary>
+        /// Leak gas from the uid's NodeContainer into the tile atmosphere.
+        /// Setting removeFromPipe to false will duplicate the gas inside the pipe intead of moving it.
+        /// This is needed to properly handle the gas in the pipe getting deleted with the pipe.
+        /// </summary>
+        public void LeakGas(Entity<AtmosUnsafeUnanchorComponent> ent, bool removeFromPipe = true)
+        {
+            if (!TryComp(ent, out NodeContainerComponent? nodes))
+                return;
+
+            if (_atmosphere.GetContainingMixture(ent.Owner, true, true) is not { } environment)
+                environment = GasMixture.SpaceGas;
+
+            var buffer = new GasMixture();
+
+            foreach (var node in nodes.Nodes.Values)
+            {
+                if (node is not PipeNode pipe)
+                    continue;
+
+                if (removeFromPipe)
+                    _atmosphere.Merge(buffer, pipe.Air.RemoveVolume(pipe.Volume));
+                else
+                {
+                    var copy = new GasMixture(pipe.Air); //clone, then remove to keep the original untouched
+                    _atmosphere.Merge(buffer, copy.RemoveVolume(pipe.Volume));
+                }
+            }
+
+            _atmosphere.Merge(environment, buffer);
+        }
     }
 }

--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosUnsafeUnanchorSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosUnsafeUnanchorSystem.cs
@@ -1,112 +1,155 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
+using Content.Server.Construction;
+using Content.Server.Construction.Components;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.Popups;
 using Content.Shared.Atmos;
 using Content.Shared.Construction;
 using Content.Shared.Construction.Components;
+using Content.Shared.Construction.Prototypes;
 using Content.Shared.Destructible;
+using Content.Shared.Interaction;
 using Content.Shared.NodeContainer;
 using Content.Shared.Popups;
+using Content.Shared.Tools;
+using Content.Shared.Tools.Systems;
 using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
 
-namespace Content.Server.Atmos.Piping.EntitySystems
+namespace Content.Server.Atmos.Piping.EntitySystems;
+
+[UsedImplicitly]
+public sealed class AtmosUnsafeUnanchorSystem : EntitySystem
 {
-    [UsedImplicitly]
-    public sealed class AtmosUnsafeUnanchorSystem : EntitySystem
+    [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
+    [Dependency] private readonly NodeGroupSystem _group = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly SharedToolSystem _toolSystem = default!;
+
+    private static readonly ProtoId<ToolQualityPrototype> PryingQuality = "Prying";
+    private static readonly ProtoId<ConstructionGraphPrototype> MachineGraph = "Machine";
+
+    public override void Initialize()
     {
-        [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
-        [Dependency] private readonly NodeGroupSystem _group = default!;
-        [Dependency] private readonly PopupSystem _popup = default!;
+        SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, UserUnanchoredEvent>(OnUserUnanchored);
+        SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
+        SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, BreakageEventArgs>(OnBreak);
+        SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, MachineDeconstructedEvent>(OnMachineDeconstructed);
+        SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, InteractUsingEvent>(OnInteractUsing, after: [typeof(ConstructionSystem)]);
+    }
 
-        public override void Initialize()
+    private bool IsUnsafe(Entity<AtmosUnsafeUnanchorComponent> ent)
+    {
+        if (!ent.Comp.Enabled || !TryComp(ent, out NodeContainerComponent? nodes))
+            return false;
+
+        if (_atmosphere.GetContainingMixture(ent.Owner, true) is not { } environment)
+            return false;
+
+        foreach (var node in nodes.Nodes.Values)
         {
-            SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, UserUnanchoredEvent>(OnUserUnanchored);
-            SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
-            SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, BreakageEventArgs>(OnBreak);
-            SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, MachineDeconstructedEvent>(OnMachineDeconstructed);
-        }
+            if (node is not PipeNode pipe)
+                continue;
 
-        private void OnUnanchorAttempt(EntityUid uid, AtmosUnsafeUnanchorComponent component, UnanchorAttemptEvent args)
-        {
-            if (!component.Enabled || !TryComp(uid, out NodeContainerComponent? nodes))
-                return;
-
-            if (_atmosphere.GetContainingMixture(uid, true) is not {} environment)
-                return;
-
-            foreach (var node in nodes.Nodes.Values)
+            if (pipe.Air.Pressure - environment.Pressure > 2 * Atmospherics.OneAtmosphere)
             {
-                if (node is not PipeNode pipe)
-                    continue;
-
-                if (pipe.Air.Pressure - environment.Pressure > 2 * Atmospherics.OneAtmosphere)
-                {
-                    args.Delay += 2f;
-                    _popup.PopupEntity(Loc.GetString("comp-atmos-unsafe-unanchor-warning"), pipe.Owner,
-                        args.User, PopupType.MediumCaution);
-                    return; // Show the warning only once.
-                }
+                return true;
             }
         }
 
-        // When unanchoring a pipe, leak the gas that was inside the pipe element.
-        // At this point the pipe has been scheduled to be removed from the group, but that won't happen until the next Update() call in NodeGroupSystem,
-        // so we have to force an update.
-        // This way the gas inside other connected pipes stays unchanged, while the removed pipe is completely emptied.
-        private void OnUserUnanchored(EntityUid uid, AtmosUnsafeUnanchorComponent component, UserUnanchoredEvent args)
+        return false;
+    }
+
+    // Handle unsafe machine deconstruction. Currently applies to gas heaters.
+    private void OnInteractUsing(Entity<AtmosUnsafeUnanchorComponent> ent, ref InteractUsingEvent args)
+    {
+        if (!IsMachineDeconstructInteraction(ent, args) || !IsUnsafe(ent))
+            return;
+
+        _popup.PopupEntity(Loc.GetString("comp-atmos-unsafe-deconstruction-warning"), ent,
+            args.User, PopupType.MediumCaution);
+    }
+
+    // Check if we're about to deconstruct the machine.
+    private bool IsMachineDeconstructInteraction(Entity<AtmosUnsafeUnanchorComponent> ent, InteractUsingEvent args)
+    {
+        if (!args.Handled || !_toolSystem.HasQuality(args.Used, PryingQuality))
+            return false;
+
+        if (!TryComp(ent, out ConstructionComponent? construction) || construction.Graph != MachineGraph)
+            return false;
+
+        return true;
+    }
+
+    private void OnUnanchorAttempt(Entity<AtmosUnsafeUnanchorComponent> ent, ref UnanchorAttemptEvent args)
+    {
+        if (IsUnsafe(ent))
         {
-            if (component.Enabled)
+            args.Delay += 2f;
+            _popup.PopupEntity(Loc.GetString("comp-atmos-unsafe-unanchor-warning"), ent,
+                args.User, PopupType.MediumCaution);
+            return; // Show the warning only once.
+        }
+    }
+
+    // When unanchoring a pipe, leak the gas that was inside the pipe element.
+    // At this point the pipe has been scheduled to be removed from the group, but that won't happen until the next Update() call in NodeGroupSystem,
+    // so we have to force an update.
+    // This way the gas inside other connected pipes stays unchanged, while the removed pipe is completely emptied.
+    private void OnUserUnanchored(Entity<AtmosUnsafeUnanchorComponent> ent, ref UserUnanchoredEvent args)
+    {
+        if (ent.Comp.Enabled)
+        {
+            _group.ForceUpdate();
+            LeakGas(ent);
+        }
+    }
+
+    private void OnBreak(Entity<AtmosUnsafeUnanchorComponent> ent, ref BreakageEventArgs args)
+    {
+        LeakGas(ent, false);
+        // Can't use DoActsBehavior["Destruction"] in the same trigger because that would prevent us
+        // from leaking. So we make up for this by queueing deletion here.
+        QueueDel(ent);
+    }
+
+    private void OnMachineDeconstructed(Entity<AtmosUnsafeUnanchorComponent> ent, ref MachineDeconstructedEvent args)
+    {
+        LeakGas(ent, false);
+    }
+
+    /// <summary>
+    /// Leak gas from the uid's NodeContainer into the tile atmosphere.
+    /// Setting removeFromPipe to false will duplicate the gas inside the pipe intead of moving it.
+    /// This is needed to properly handle the gas in the pipe getting deleted with the pipe.
+    /// </summary>
+    public void LeakGas(Entity<AtmosUnsafeUnanchorComponent> ent, bool removeFromPipe = true)
+    {
+        if (!TryComp(ent, out NodeContainerComponent? nodes))
+            return;
+
+        if (_atmosphere.GetContainingMixture(ent.Owner, true, true) is not { } environment)
+            environment = GasMixture.SpaceGas;
+
+        var buffer = new GasMixture();
+
+        foreach (var node in nodes.Nodes.Values)
+        {
+            if (node is not PipeNode pipe)
+                continue;
+
+            if (removeFromPipe)
+                _atmosphere.Merge(buffer, pipe.Air.RemoveVolume(pipe.Volume));
+            else
             {
-                _group.ForceUpdate();
-                LeakGas(uid);
+                var copy = new GasMixture(pipe.Air); //clone, then remove to keep the original untouched
+                _atmosphere.Merge(buffer, copy.RemoveVolume(pipe.Volume));
             }
         }
 
-        private void OnBreak(EntityUid uid, AtmosUnsafeUnanchorComponent component, BreakageEventArgs args)
-        {
-            LeakGas(uid, false);
-            // Can't use DoActsBehavior["Destruction"] in the same trigger because that would prevent us
-            // from leaking. So we make up for this by queueing deletion here.
-            QueueDel(uid);
-        }
-
-        private void OnMachineDeconstructed(Entity<AtmosUnsafeUnanchorComponent> uid, ref MachineDeconstructedEvent args)
-        {
-            LeakGas(uid, false);
-        }
-
-        /// <summary>
-        /// Leak gas from the uid's NodeContainer into the tile atmosphere.
-        /// Setting removeFromPipe to false will duplicate the gas inside the pipe intead of moving it.
-        /// This is needed to properly handle the gas in the pipe getting deleted with the pipe.
-        /// </summary>
-        public void LeakGas(EntityUid uid, bool removeFromPipe = true)
-        {
-            if (!TryComp(uid, out NodeContainerComponent? nodes))
-                return;
-
-            if (_atmosphere.GetContainingMixture(uid, true, true) is not { } environment)
-                environment = GasMixture.SpaceGas;
-
-            var buffer = new GasMixture();
-
-            foreach (var node in nodes.Nodes.Values)
-            {
-                if (node is not PipeNode pipe)
-                    continue;
-
-                if (removeFromPipe)
-                    _atmosphere.Merge(buffer, pipe.Air.RemoveVolume(pipe.Volume));
-                else
-                {
-                    var copy = new GasMixture(pipe.Air); //clone, then remove to keep the original untouched
-                    _atmosphere.Merge(buffer, copy.RemoveVolume(pipe.Volume));
-                }
-            }
-
-            _atmosphere.Merge(environment, buffer);
-        }
+        _atmosphere.Merge(environment, buffer);
     }
 }

--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosUnsafeUnanchorSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosUnsafeUnanchorSystem.cs
@@ -1,10 +1,10 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
-using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.Popups;
 using Content.Shared.Atmos;
+using Content.Shared.Construction;
 using Content.Shared.Construction.Components;
 using Content.Shared.Destructible;
 using Content.Shared.NodeContainer;
@@ -25,6 +25,7 @@ namespace Content.Server.Atmos.Piping.EntitySystems
             SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, UserUnanchoredEvent>(OnUserUnanchored);
             SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
             SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, BreakageEventArgs>(OnBreak);
+            SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, MachineDeconstructedEvent>(OnMachineDeconstructed);
         }
 
         private void OnUnanchorAttempt(EntityUid uid, AtmosUnsafeUnanchorComponent component, UnanchorAttemptEvent args)
@@ -69,6 +70,11 @@ namespace Content.Server.Atmos.Piping.EntitySystems
             // Can't use DoActsBehavior["Destruction"] in the same trigger because that would prevent us
             // from leaking. So we make up for this by queueing deletion here.
             QueueDel(uid);
+        }
+
+        private void OnMachineDeconstructed(Entity<AtmosUnsafeUnanchorComponent> uid, ref MachineDeconstructedEvent args)
+        {
+            LeakGas(uid, false);
         }
 
         /// <summary>

--- a/Resources/Locale/en-US/components/atmos-unsafe-unanchor-component.ftl
+++ b/Resources/Locale/en-US/components/atmos-unsafe-unanchor-component.ftl
@@ -1,4 +1,7 @@
 ### AtmosUnsafeUnanchorComponent
 
-# Examine text showing pressure in tank.
+# Device unanchor popup
 comp-atmos-unsafe-unanchor-warning = A gush of air blows in your face... Maybe you should reconsider?
+
+# Machine deconstruction attempt popup
+comp-atmos-unsafe-deconstruction-warning = The pressure gauge reads red... Maybe you should reconsider?

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -266,6 +266,7 @@
     - type: GuideHelp
       guides:
       - Thermomachines
+    - type: AtmosUnsafeUnanchor
 
 - type: entity
   parent: BaseGasThermoMachine


### PR DESCRIPTION
## About the PR
Heaters and freezers now leak their contents on deconstruction.

## Why / Balance
Heaters/coolers having an internal gas storage is not very well communicated in-game, which led to accidental pipeline contamination. This is frustrating.
Their contents, however, could be purged by deconstructing the machine. Destroying matter is not the atmos way.

## Technical details
Added `AtmosUnsafeUnanchorComponent` to `BaseGasThermoMachine`.
Added `MachineDeconstructedEvent` handling to `AtmosUnsafeUnanchorComponent`.
Does not affect SpaceHeater. Affects TEG.
Minor system refactor.

## Media
https://github.com/user-attachments/assets/43bb2fb2-8831-4873-832d-43ae78b7772f

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- fix: Heaters/coolers now leak their contents on deconstruction/unanchor.
