### PR TITLE
Ensure client/server in SharedGasSpecificHeatsTest.cs are idle

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/SharedGasSpecificHeatsTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/SharedGasSpecificHeatsTest.cs
@@ -44,6 +44,9 @@ public sealed class SharedGasSpecificHeatsTest
 
         _sAtmos = _sEntMan.System<Content.Server.Atmos.EntitySystems.AtmosphereSystem>();
         _cAtmos = _cEntMan.System<AtmosphereSystem>();
+
+        // ensure that client and server atmos are fully inited otherwise arrays might not agree
+        await _pair.ReallyBeIdle();
     }
 
     [TearDown]

--- a/Content.IntegrationTests/Tests/Atmos/SharedGasSpecificHeatsTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/SharedGasSpecificHeatsTest.cs
@@ -46,7 +46,7 @@ public sealed class SharedGasSpecificHeatsTest
         _cAtmos = _cEntMan.System<AtmosphereSystem>();
 
         // ensure that client and server atmos are fully inited otherwise arrays might not agree
-        await _pair.ReallyBeIdle();
+        await _pair.ReallyBeIdle(1);
     }
 
     [TearDown]


### PR DESCRIPTION
## About the PR
Attempts to fix #42442 by waiting until client/server is idle before continuing.

## Why / Balance
Fixes #42442

## Technical details
The systems and thus arrays may not be fully initted before the test checks client/server to see if the arrays agree. As such, we wait until the instance goes idle so we know that client/server atmospherics are present and have populated instance data.

## Media
Hail mary.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
n/a
