### PR TITLE
Improvments to Advanced Mop and Jani Borg modules

### DIFF
--- a/Resources/Locale/en-US/robotics/borg_modules.ftl
+++ b/Resources/Locale/en-US/robotics/borg_modules.ftl
@@ -9,6 +9,7 @@ borg-slot-small-containers-empty = Small containers
 borg-slot-chemical-containers-empty = Chemical containers
 borg-slot-documents-empty = Books and papers
 borg-slot-soap-empty = Soap
+borg-slot-cleanade-empty = Cleanade
 borg-slot-instruments-empty = Instruments
 borg-slot-beakers-empty = Beakers
 borg-slot-brains-empty = Brains and MMIs

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -76,17 +76,21 @@
       sprite: Objects/Specific/Janitorial/advmop.rsi
     - type: Absorbent
       pickupAmount: 100
+    - type: SolutionContainerManager
+      solutions:
+        absorbed:
+          maxVol: 500
     - type: SolutionRegeneration
       solution: absorbed
       generated:
         reagents:
         - ReagentId: Water
-          Quantity: 5
+          Quantity: 25
     - type: SolutionPurge
       solution: absorbed
       preserve:
       - Water
-      quantity: 10
+      quantity: 50
     - type: Tag
       tags:
         - Mop

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -169,7 +169,7 @@
     generated:
       reagents:
       - ReagentId: SpaceCleaner
-        Quantity: 1
+        Quantity: 2
 
 # Vapor
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -828,10 +828,17 @@
   - type: ItemBorgModule
     hands:
     - item: MopItem
-    - item: WireBrush
     - item: BorgBucket
     - item: BorgSprayBottle
+    - item: CleanerGrenade
+      hand:
+        emptyLabel: borg-slot-cleanade-empty
+        emptyRepresentative: CleanerGrenade
+        whitelist:
+          tags:
+          -  Cleanade
     - item: HoloprojectorBorg
+    - item: WireBrush
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: cleaning-module }
 
@@ -848,11 +855,18 @@
   - type: ItemBorgModule
     hands:
     - item: AdvMopItem
-    - item: WireBrushElectrical
     - item: BorgMegaSprayBottle
+    - item: CleanerGrenade
+      hand:
+        emptyLabel: borg-slot-cleanade-empty
+        emptyRepresentative: CleanerGrenade
+        whitelist:
+          tags:
+          -  Cleanade
     - item: HoloprojectorBorg
     - item: BorgDropper
     - item: Beaker
+    - item: WireBrushElectrical
       hand:
         emptyLabel: borg-slot-beakers-empty
         emptyRepresentative: Beaker

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/canister_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/canister_grenades.yml
@@ -29,6 +29,9 @@
   name: cleanade
   description: Special grenade for janitors, releasing large cloud of space cleaner foam.
   components:
+  - type: Tag
+    tags:
+    - Cleanade
   - type: Sprite
     sprite: Objects/Weapons/Grenades/janitor.rsi
   - type: SmokeOnTrigger

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -316,6 +316,9 @@
   id: CigPack # Storage whitelist: BaseClothingBeltEngineering, ClothingBeltAssault, ClothingBeltChef, ClothingBeltMedical, ClothingBeltJanitor
 
 - type: Tag
+  id: Cleanade # Storage whitelist: BorgModuleCleaning, BorgModuleAdvancedCleaning
+
+- type: Tag
   id: Cleaver # Storage whitelist: ClothingBeltChef. ItemMapper: ClothingBeltChef
 
 - type: Tag


### PR DESCRIPTION
## About the PR
Buffed Advanced mop - it's 5 times better now
Added cleanade hand for janitor borg modules, normal and advanced
Advanced internal spray bottle for jani borgs regenerate 2 times faster now

## Why / Balance
I always felt that advanced version of janitor items kind of... sucked. 
Advanced mop in the current form is really bad, generating only 5 units of water every second with the same amount of internal storage which is 100. Basically, regular mop with a trolley surpasses the capabilities of it. Also there are cleanades that basically stumps the effectiveness of adv mop in to the ground.

I'm not sure what the initial balancing of it was, but i assume it was supposed to be a alternative for regular mop that would make the trolley cart last a little bit longer. For me tho i think it should be used as a mop that doesn't require a trolley at all and actually counters cleanade's scarcity nature (you need to buy more if you run out) even tho they are better for area cleaning.

For janitor borgs, they didn't get a hand for holding clenades when they were introduced, but it would be nice for them to have a possibility to actually use it now. Humanoid janis usually can just horde cleanades in their backpack or belt and throw them if needed, so having one cleanade for jani borg isn't that bad i would say.
For the big internal spray bottle, i thought that the regeneration was too slow if you were to spam it on a pool of liquid. 

I'm hoping this will make researching the jani tech more worth it and more enjoyable to use adv mop.

## Technical details
yml stuff
added a tag for cleanades

## Media

So for a current comparison, current adv mop to clean a 1000u of solution it takes around 3-4min to clean with 5u of water regeneration. (you can see how slow it takes clean this stuff, i gave up showing the whole thing)

https://github.com/user-attachments/assets/d934d137-ea1d-4837-8c0a-2cd73d75f7fc

For regular mop, the only downside is the travel time back to the jani closet

https://github.com/user-attachments/assets/d6ba5c6d-9083-4c68-b2cf-0155412b43ab

And just for show, the cleanade:

https://github.com/user-attachments/assets/83d3bf2e-1546-4a9a-bfe3-6accc4239c36

Here is the improved version of adv mop:

https://github.com/user-attachments/assets/b7ca3650-edd9-4ce3-a145-d5eaf0c4da70


Regular jani borg module:
<img width="682" height="86" alt="image" src="https://github.com/user-attachments/assets/dc1f5a11-8fa4-44d2-a2c2-8aca9e3d32a7" />

Advanced Jani Borg Module:
<img width="669" height="174" alt="image" src="https://github.com/user-attachments/assets/fa8fe4f1-c247-47e4-a026-23a91fd7a35b" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added Cleanade hand for Jani Borg modules.
- tweak: Advanced Mop is now 5 times better.
