### PR TITLE
[Fix] Correct derelict borg module count

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -206,7 +206,7 @@
       map: ["light"]
       visible: false
   - type: BorgChassis
-    maxModules: 5 # One less module slot than the regular module to reflect this being a "broken" cyborg.
+    maxModules: 6 # One less module slot than the regular module to reflect this being a "broken" cyborg.
     moduleWhitelist:
       tags:
       - BorgModuleGeneric
@@ -242,7 +242,7 @@
       map: ["light"]
       visible: false
   - type: BorgChassis
-    maxModules: 5 # One less module slot than the regular module to reflect this being a "broken" cyborg.
+    maxModules: 7 # One less module slot than the regular module to reflect this being a "broken" cyborg.
     moduleWhitelist:
       tags:
       - BorgModuleGeneric
@@ -351,7 +351,7 @@
       movement:
         state: miner_derelict
   - type: BorgChassis
-    maxModules: 6 # One less module slot than the regular module to reflect this being a "broken" cyborg.
+    maxModules: 7 # One less module slot than the regular module to reflect this being a "broken" cyborg.
     moduleWhitelist:
       tags:
       - BorgModuleGeneric


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Reviewed and corrected the maximum total number of modules for each derelict borg.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With the addition of https://github.com/space-wizards/space-station-14/pull/41812 , cyborgs were given a prying module, allowing them to open doors without the explicit need for a crowbar. While this is a good change, Derelict borgs currently do not have dynamic counts for their total module slots, and as a result changes to their base modules require manual intervention for their expected module totals.

As a general rule, derelict borgs are intended to have n-1 total slots compared to their non-derelict counterparts, though these extra slots may be pre-filled (such as with the thruster module that most derelicts come equipped with).

Here are our list of cyborgs:
- Generic Cyborg: 5 spare module slots
- Derelict Generic Cyborg: ```5``` -> ```6``` total module slots. With the prying and tool modules being our baseline inclusions, that gives us 2 + (5-1) for a total of 6 slots expected.

- Engineering Cyborg: 3 spare module slots
- Derelict Engineering Cyborg: ```5``` -> ```7``` total module slots. With the prying, tool, construction, engineering, and cable module being our baseline inclusions, that gives us 5 + (3-1) for a total of 7 slots expected.

- Janitorial Cyborg: 3 spare module slots
- Derelict Janitorial Cyborg: No change. With prying, cleaning, and custodial modules being our baseline inclusions, that gives us 3 + (3-1) for a total of 5 slots, which is currently reflected.

- Medical Cyborg: 3 spare module slots
- Derelict Medical Cyborg: No change. With prying, chemical, first aid, and rescue modules being our baseline inclusions, that gives us 4 + (3-1) for a total of 6 slots, which is currently reflected.

- Salvage Cyborg: 3 spare module slots
- Derelict Salvage Cyborg: ```6``` -> ```7``` total module slots. With prying, tool, mining, traversal, and appraisal modules being our baseline inclusions, that gives us 5 + (3-1) for a total of 7 slots expected.

- Syndicate Assault Cyborg: 0 spare module slots
- Derelict Syndicate Assault Cyborg: C-C-Combo breaker! Syndicate assault borg is a special case as we can't go negative in respect to spare module slots, so no change.

## Technical details
<!-- Summary of code changes for easier review. -->
simple yml change.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="1292" height="443" alt="image" src="https://github.com/user-attachments/assets/b9b2882b-c35c-4e1c-8067-a06b09987b4c" />

_Derelict engineering cyborg possessing a whole extra module greater than it should physically be able to hold, a result of the recent prying module addition._

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- fix: Derelict cyborg module numbers have been corrected.