### PR TITLE
Add a holy light effect to bible healing

### DIFF
--- a/Content.Server/Bible/BibleSystem.cs
+++ b/Content.Server/Bible/BibleSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Popups;
 using Content.Shared.Timing;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 
@@ -145,6 +146,9 @@ namespace Content.Server.Bible
 
                 _audio.PlayPvs(component.HealSoundPath, args.User);
                 _delay.TryResetDelay((uid, useDelay));
+
+                if (component.HealingLightEffect.HasValue)
+                    Spawn(component.HealingLightEffect.Value, new EntityCoordinates(args.Target.Value, default));
             }
             else
             {

--- a/Content.Server/Bible/Components/BibleComponent.cs
+++ b/Content.Server/Bible/Components/BibleComponent.cs
@@ -53,5 +53,11 @@ namespace Content.Server.Bible.Components
 
         [DataField("locPrefix")]
         public string LocPrefix = "bible";
+
+        /// <summary>
+        /// A short light effect to display when successfully healing someone
+        /// </summary>
+        [DataField]
+        public EntProtoId? HealingLightEffect = "HolyLightEffect";
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -83,6 +83,7 @@
     failChance: 0
     locPrefix: "necro"
     healSound: "/Audio/Effects/lightburn.ogg"
+    healingLightEffect: EvilLightEffect
   - type: Summonable
     specialItem: SpawnPointGhostCerberus
     respawnTime: 300
@@ -168,3 +169,26 @@
     sprite: Objects/Specific/Chapel/ratvartablet.rsi
   - type: Item
     sprite: Objects/Specific/Chapel/ratvartablet.rsi
+
+- type: entity
+  id: HolyLightEffect
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: PointLight
+      enabled: true
+      radius: 1.5
+      energy: 20
+      color: lightgoldenrodyellow
+      netsync: false
+    - type: LightFade
+      duration: 0.7
+    - type: TimedDespawn
+      lifetime: 0.7
+
+- type: entity
+  id: EvilLightEffect
+  categories: [ HideSpawnMenu ]
+  parent: HolyLightEffect
+  components:
+    - type: PointLight
+      color: red


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds a flash of holy light when healing someone with the chaplain's holy book. Harming with the Necronomicon contraband will how have an evil light effect.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I feel like this gives more direct feedback as to whom has been healed.
The popup text references a flash of light, so it would be cool to see it.
It would also make playing as the chaplain a little more immersive and fun.

## Technical details
<!-- Summary of code changes for easier review. -->

This works similarly to the light added by a flashbang grenade. It fades out and is deleted by a basic TimedDespawn component.

I've also tested with simultaneous blessings, since chaplains can get multiple holy books #33081

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/2b11fef6-1cdd-42d1-bdfd-c8bae0de8b45

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Healing with a holy book now gives off a holy light.
