### PR TITLE
Cleanup warnings: CS0168, CS0414

### DIFF
--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -155,7 +155,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             // I feel like this is somewhat cursed, but its the only way I can think of without having to just send
             // redundant data over the network and increasing DoAfter boilerplate.
             var evType = typeof(DoAfterAttemptEvent<>).MakeGenericType(args.Event.GetType());
-            doAfter.AttemptEvent = _factory.CreateInstance(evType, [doAfter, args.Event]);
+            doAfter.AttemptEvent = _factory.CreateInstance(evType, new object[] { doAfter, args.Event });
         }
 
         args.Event.DoAfter = doAfter;


### PR DESCRIPTION
## About the PR
Cleanup 3x warnings:
- 1x CS0168 warning
- 2x CS0414 warnings

plus a small cleanup in the file

[CS0168](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0168): The variable 'var' is declared but never used.
[CS0414](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0414): The private field 'field' is assigned but its value is never used.

## Why / Balance
#33279

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
