### PR TITLE
Janitor Borg Modules changes

### DIFF
--- a/Resources/Locale/en-US/robotics/borg_modules.ftl
+++ b/Resources/Locale/en-US/robotics/borg_modules.ftl
@@ -9,6 +9,7 @@ borg-slot-small-containers-empty = Small containers
 borg-slot-chemical-containers-empty = Chemical containers
 borg-slot-documents-empty = Books and papers
 borg-slot-soap-empty = Soap
+borg-slot-cleanade-empty = Cleanade
 borg-slot-instruments-empty = Instruments
 borg-slot-beakers-empty = Beakers
 borg-slot-brains-empty = Brains and MMIs

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -169,7 +169,7 @@
     generated:
       reagents:
       - ReagentId: SpaceCleaner
-        Quantity: 1
+        Quantity: 2
 
 # Vapor
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -856,7 +856,7 @@
     hands:
     - item: AdvMopItem
     - item: BorgMegaSprayBottle
-    - item: CleanerGrenade
+    - item: CleanerGrenade # Please remove if cleanade gun gets added to the module
       hand:
         emptyLabel: borg-slot-cleanade-empty
         emptyRepresentative: CleanerGrenade

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -828,10 +828,17 @@
   - type: ItemBorgModule
     hands:
     - item: MopItem
-    - item: WireBrush
     - item: BorgBucket
     - item: BorgSprayBottle
+    - item: CleanerGrenade
+      hand:
+        emptyLabel: borg-slot-cleanade-empty
+        emptyRepresentative: CleanerGrenade
+        whitelist:
+          tags:
+          -  Cleanade
     - item: HoloprojectorBorg
+    - item: WireBrush
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: cleaning-module }
 
@@ -848,11 +855,18 @@
   - type: ItemBorgModule
     hands:
     - item: AdvMopItem
-    - item: WireBrushElectrical
     - item: BorgMegaSprayBottle
+    - item: CleanerGrenade
+      hand:
+        emptyLabel: borg-slot-cleanade-empty
+        emptyRepresentative: CleanerGrenade
+        whitelist:
+          tags:
+          -  Cleanade
     - item: HoloprojectorBorg
     - item: BorgDropper
     - item: Beaker
+    - item: WireBrushElectrical
       hand:
         emptyLabel: borg-slot-beakers-empty
         emptyRepresentative: Beaker

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/canister_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/canister_grenades.yml
@@ -31,6 +31,9 @@
   components:
   - type: Sprite
     sprite: Objects/Weapons/Grenades/janitor.rsi
+  - type: Tag
+    tags:
+    - Cleanade
   - type: SmokeOnTrigger
     keysIn:
     - timer

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -316,6 +316,9 @@
   id: CigPack # Storage whitelist: BaseClothingBeltEngineering, ClothingBeltAssault, ClothingBeltChef, ClothingBeltMedical, ClothingBeltJanitor
 
 - type: Tag
+  id: Cleanade # Storage whitelist: BorgModuleCleaning, BorgModuleAdvancedCleaning
+
+- type: Tag
   id: Cleaver # Storage whitelist: ClothingBeltChef. ItemMapper: ClothingBeltChef
 
 - type: Tag


### PR DESCRIPTION
## About the PR
( Split of this PR https://github.com/space-wizards/space-station-14/pull/43179 ) (PS: I dont know how to work on a closed PR)
Added cleanade hand for janitor borg modules, normal and advanced
Advanced internal spray bottle for jani borgs regenerate 2 times faster now
Wire brush was moved further in to the module

## Why / Balance
Janitor Borgs don't have a hand for holding clenades when they were introduced, but it would be nice for them to have a possibility to actually use it now. Humanoid janis usually can just horde cleanades in their backpack or belt and throw them if needed, so having one cleanade for jani borg isn't that bad i would say.
For the big internal spray bottle, i thought that the regeneration was too slow if you were to spam it on a pool of liquid. 
Moving the wire brush to further in to the modules saves you a click, the wirebrush isn't that useful

## Technical details
yml stuff
added a tag for cleanades

## Media
Regular jani borg module:
<img width="682" height="86" alt="image" src="https://github.com/user-attachments/assets/dc1f5a11-8fa4-44d2-a2c2-8aca9e3d32a7" />

Advanced Jani Borg Module:
<img width="669" height="174" alt="image" src="https://github.com/user-attachments/assets/fa8fe4f1-c247-47e4-a026-23a91fd7a35b" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added Cleanade hand for Jani Borg modules.
- tweak: Tweaked position of wire brush in jani borg modules