### PR TITLE
Gametest Part 2: Preliminary refactor every test to use GameTest as the framework.

### DIFF
--- a/Content.Benchmarks/ComponentQueryBenchmark.cs
+++ b/Content.Benchmarks/ComponentQueryBenchmark.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
@@ -44,7 +45,7 @@ public class ComponentQueryBenchmark
         ProgramShared.PathOffset = "../../../../";
         PoolManager.Startup(typeof(QueryBenchSystem).Assembly);
 
-        _pair = PoolManager.GetServerClient().GetAwaiter().GetResult();
+        _pair = PoolManager.GetServerClient(testContext: new ExternalTestContext("Benchmark", StreamWriter.Null)).GetAwaiter().GetResult();
         _entMan = _pair.Server.ResolveDependency<IEntityManager>();
 
         _itemQuery = _entMan.GetEntityQuery<ItemComponent>();

--- a/Content.Benchmarks/DeltaPressureBenchmark.cs
+++ b/Content.Benchmarks/DeltaPressureBenchmark.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Content.IntegrationTests;
@@ -68,7 +69,7 @@ public class DeltaPressureBenchmark
     {
         ProgramShared.PathOffset = "../../../../";
         PoolManager.Startup();
-        _pair = await PoolManager.GetServerClient();
+        _pair = await PoolManager.GetServerClient(testContext: new ExternalTestContext("Benchmark", StreamWriter.Null));
         var server = _pair.Server;
 
         var mapdata = await _pair.CreateTestMap();

--- a/Content.Benchmarks/DestructibleBenchmark.cs
+++ b/Content.Benchmarks/DestructibleBenchmark.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Content.IntegrationTests;
@@ -69,7 +70,7 @@ public class DestructibleBenchmark
     {
         ProgramShared.PathOffset = "../../../../";
         PoolManager.Startup();
-        _pair = await PoolManager.GetServerClient();
+        _pair = await PoolManager.GetServerClient(testContext: new ExternalTestContext("Benchmark", StreamWriter.Null));
         var server = _pair.Server;
 
         _entMan = server.ResolveDependency<IEntityManager>();

--- a/Content.Benchmarks/DeviceNetworkingBenchmark.cs
+++ b/Content.Benchmarks/DeviceNetworkingBenchmark.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Content.IntegrationTests;
@@ -60,7 +61,7 @@ public class DeviceNetworkingBenchmark
     {
         ProgramShared.PathOffset = "../../../../";
         PoolManager.Startup(typeof(DeviceNetworkingBenchmark).Assembly);
-        _pair = await PoolManager.GetServerClient();
+        _pair = await PoolManager.GetServerClient(testContext: new ExternalTestContext("Benchmark", StreamWriter.Null));
         var server = _pair.Server;
 
         await server.WaitPost(() =>

--- a/Content.Benchmarks/GasReactionBenchmark.cs
+++ b/Content.Benchmarks/GasReactionBenchmark.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Content.IntegrationTests;
@@ -51,7 +52,7 @@ public class GasReactionBenchmark
     {
         ProgramShared.PathOffset = "../../../../";
         PoolManager.Startup();
-        _pair = await PoolManager.GetServerClient();
+        _pair = await PoolManager.GetServerClient(testContext: new ExternalTestContext("Benchmark", StreamWriter.Null));
         var server = _pair.Server;
 
         // Create test map and grid

--- a/Content.Benchmarks/HeatCapacityBenchmark.cs
+++ b/Content.Benchmarks/HeatCapacityBenchmark.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.IO;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Content.IntegrationTests;
 using Content.IntegrationTests.Pair;
@@ -27,7 +28,7 @@ public class HeatCapacityBenchmark
     {
         ProgramShared.PathOffset = "../../../../";
         PoolManager.Startup();
-        _pair = await PoolManager.GetServerClient();
+        _pair = await PoolManager.GetServerClient(testContext: new ExternalTestContext("Benchmark", StreamWriter.Null));
         await _pair.Connect();
         _cEntMan = _pair.Client.ResolveDependency<IEntityManager>();
         _sEntMan = _pair.Server.ResolveDependency<IEntityManager>();

--- a/Content.Benchmarks/MapLoadBenchmark.cs
+++ b/Content.Benchmarks/MapLoadBenchmark.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
@@ -29,7 +30,7 @@ public class MapLoadBenchmark
         ProgramShared.PathOffset = "../../../../";
         PoolManager.Startup();
 
-        _pair = PoolManager.GetServerClient().GetAwaiter().GetResult();
+        _pair = PoolManager.GetServerClient(testContext: new ExternalTestContext("Benchmark", StreamWriter.Null)).GetAwaiter().GetResult();
         var server = _pair.Server;
 
         Paths = server.ResolveDependency<IPrototypeManager>()

--- a/Content.Benchmarks/PvsBenchmark.cs
+++ b/Content.Benchmarks/PvsBenchmark.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
@@ -50,7 +51,7 @@ public class PvsBenchmark
 #endif
         PoolManager.Startup();
 
-        _pair = PoolManager.GetServerClient().GetAwaiter().GetResult();
+        _pair = PoolManager.GetServerClient(testContext: new ExternalTestContext("Benchmark", StreamWriter.Null)).GetAwaiter().GetResult();
         _entMan = _pair.Server.ResolveDependency<IEntityManager>();
         _pair.Server.CfgMan.SetCVar(CVars.NetPVS, true);
         _pair.Server.CfgMan.SetCVar(CVars.ThreadParallelCount, 0);

--- a/Content.Benchmarks/RaiseEventBenchmark.cs
+++ b/Content.Benchmarks/RaiseEventBenchmark.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
@@ -21,7 +22,7 @@ public class RaiseEventBenchmark
     {
         ProgramShared.PathOffset = "../../../../";
         PoolManager.Startup(typeof(BenchSystem).Assembly);
-        _pair = PoolManager.GetServerClient().GetAwaiter().GetResult();
+        _pair = PoolManager.GetServerClient(testContext: new ExternalTestContext("Benchmark", StreamWriter.Null)).GetAwaiter().GetResult();
         var entMan = _pair.Server.EntMan;
         var fact = _pair.Server.ResolveDependency<IComponentFactory>();
         var bus = (EntityEventBus)entMan.EventBus;

--- a/Content.Benchmarks/SpawnEquipDeleteBenchmark.cs
+++ b/Content.Benchmarks/SpawnEquipDeleteBenchmark.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.IO;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Content.IntegrationTests;
 using Content.IntegrationTests.Pair;
@@ -36,7 +37,7 @@ public class SpawnEquipDeleteBenchmark
     {
         ProgramShared.PathOffset = "../../../../";
         PoolManager.Startup();
-        _pair = await PoolManager.GetServerClient();
+        _pair = await PoolManager.GetServerClient(testContext: new ExternalTestContext("Benchmark", StreamWriter.Null));
         var server = _pair.Server;
 
         var mapData = await _pair.CreateTestMap();

--- a/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
+++ b/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
@@ -1,16 +1,17 @@
+#nullable enable
 using System.Collections.Generic;
+using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Shared.Access;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.Access
 {
-    [TestFixture]
     [TestOf(typeof(AccessReaderComponent))]
-    public sealed class AccessReaderTest
+    public sealed class AccessReaderTest : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -21,91 +22,85 @@ namespace Content.IntegrationTests.Tests.Access
   - type: AccessReader
 ";
 
+        [System(Side.Server)] private readonly AccessReaderSystem _system = null!;
+
         [Test]
+        [RunOnSide(Side.Server)]
         public async Task TestTags()
         {
-            await using var pair = await PoolManager.GetServerClient();
-            var server = pair.Server;
-            var entityManager = server.ResolveDependency<IEntityManager>();
+            var ent = SSpawn("TestAccessReader");
+            var reader = new Entity<AccessReaderComponent>(ent, SComp<AccessReaderComponent>(ent));
 
-            await server.WaitAssertion(() =>
+            // test empty
+            Assert.Multiple(() =>
             {
-                var system = entityManager.System<AccessReaderSystem>();
-                var ent = entityManager.SpawnEntity("TestAccessReader", MapCoordinates.Nullspace);
-                var reader = new Entity<AccessReaderComponent>(ent, entityManager.GetComponent<AccessReaderComponent>(ent));
-
-                // test empty
-                Assert.Multiple(() =>
-                {
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "Foo" }, reader), Is.True);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "Bar" }, reader), Is.True);
-                    Assert.That(system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.True);
-                });
-
-                // test deny
-                system.AddDenyTag(reader, "A");
-                Assert.Multiple(() =>
-                {
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "Foo" }, reader), Is.True);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.False);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "Foo" }, reader), Is.False);
-                    Assert.That(system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.True);
-                });
-                system.ClearDenyTags(reader);
-
-                // test one list
-                system.TryAddAccess(reader, "A");
-                Assert.Multiple(() =>
-                {
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.True);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "B" }, reader), Is.False);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "B" }, reader), Is.True);
-                    Assert.That(system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.False);
-                });
-                system.TryClearAccesses(reader);
-
-                // test one list - two items
-                system.TryAddAccess(reader, new HashSet<ProtoId<AccessLevelPrototype>> { "A", "B" });
-                Assert.Multiple(() =>
-                {
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.False);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "B" }, reader), Is.False);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "B" }, reader), Is.True);
-                    Assert.That(system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.False);
-                });
-                system.TryClearAccesses(reader);
-
-                // test two list
-                var accesses = new List<HashSet<ProtoId<AccessLevelPrototype>>>() {
-                    new HashSet<ProtoId<AccessLevelPrototype>> () { "A" },
-                    new HashSet<ProtoId<AccessLevelPrototype>> () { "B", "C" }
-                };
-                system.TryAddAccesses(reader, accesses);
-                Assert.Multiple(() =>
-                {
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.True);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "B" }, reader), Is.False);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "B" }, reader), Is.True);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "C", "B" }, reader), Is.True);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "C", "B", "A" }, reader), Is.True);
-                    Assert.That(system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.False);
-                });
-                system.TryClearAccesses(reader);
-
-                // test deny list
-                system.TryAddAccess(reader, new HashSet<ProtoId<AccessLevelPrototype>> { "A" });
-                system.AddDenyTag(reader, "B");
-                Assert.Multiple(() =>
-                {
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.True);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "B" }, reader), Is.False);
-                    Assert.That(system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "B" }, reader), Is.False);
-                    Assert.That(system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.False);
-                });
-                system.TryClearAccesses(reader);
-                system.ClearDenyTags(reader);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "Foo" }, reader), Is.True);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "Bar" }, reader), Is.True);
+                Assert.That(_system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.True);
             });
-            await pair.CleanReturnAsync();
+
+            // test deny
+            _system.AddDenyTag(reader, "A");
+            Assert.Multiple(() =>
+            {
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "Foo" }, reader), Is.True);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.False);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "Foo" }, reader), Is.False);
+                Assert.That(_system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.True);
+            });
+            _system.ClearDenyTags(reader);
+
+            // test one list
+            _system.TryAddAccess(reader, "A");
+            Assert.Multiple(() =>
+            {
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.True);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "B" }, reader), Is.False);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "B" }, reader), Is.True);
+                Assert.That(_system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.False);
+            });
+            _system.TryClearAccesses(reader);
+
+            // test one list - two items
+            _system.TryAddAccess(reader, new HashSet<ProtoId<AccessLevelPrototype>> { "A", "B" });
+            Assert.Multiple(() =>
+            {
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.False);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "B" }, reader), Is.False);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "B" }, reader), Is.True);
+                Assert.That(_system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.False);
+            });
+            _system.TryClearAccesses(reader);
+
+            // test two list
+            var accesses = new List<HashSet<ProtoId<AccessLevelPrototype>>>() {
+                new HashSet<ProtoId<AccessLevelPrototype>> () { "A" },
+                new HashSet<ProtoId<AccessLevelPrototype>> () { "B", "C" }
+            };
+            _system.TryAddAccesses(reader, accesses);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.True);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "B" }, reader), Is.False);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "B" }, reader), Is.True);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "C", "B" }, reader), Is.True);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "C", "B", "A" }, reader), Is.True);
+                Assert.That(_system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.False);
+            });
+            _system.TryClearAccesses(reader);
+
+            // test deny list
+            _system.TryAddAccess(reader, new HashSet<ProtoId<AccessLevelPrototype>> { "A" });
+            _system.AddDenyTag(reader, "B");
+            Assert.Multiple(() =>
+            {
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A" }, reader), Is.True);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "B" }, reader), Is.False);
+                Assert.That(_system.AreAccessTagsAllowed(new List<ProtoId<AccessLevelPrototype>> { "A", "B" }, reader), Is.False);
+                Assert.That(_system.AreAccessTagsAllowed(Array.Empty<ProtoId<AccessLevelPrototype>>(), reader), Is.False);
+            });
+            _system.TryClearAccesses(reader);
+            _system.ClearDenyTags(reader);
         }
 
     }

--- a/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
+++ b/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
@@ -22,7 +22,7 @@ namespace Content.IntegrationTests.Tests.Access
   - type: AccessReader
 ";
 
-        [System(Side.Server)] private readonly AccessReaderSystem _system = null!;
+        [SidedDependency(Side.Server)] private readonly AccessReaderSystem _system = null!;
 
         [Test]
         [RunOnSide(Side.Server)]

--- a/Content.IntegrationTests/Tests/Actions/ActionPvsDetachTest.cs
+++ b/Content.IntegrationTests/Tests/Actions/ActionPvsDetachTest.cs
@@ -1,4 +1,7 @@
+#nullable enable
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Shared.Actions;
 using Content.Shared.Eye;
 using Robust.Server.GameObjects;
@@ -7,15 +10,18 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests.Actions;
 
 [TestFixture]
-public sealed class ActionPvsDetachTest
+public sealed class ActionPvsDetachTest : GameTest
 {
+    [System(Side.Server)] private readonly SharedActionsSystem _sActionsSys = null!;
+    [System(Side.Client)] private readonly SharedActionsSystem _cActionsSys = null!;
+
     [Test]
     public async Task TestActionDetach()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-        var (server, client) = pair;
-        var sys = server.System<SharedActionsSystem>();
-        var cSys = client.System<SharedActionsSystem>();
+        var pair = Pair;
+        var (server, client) = (Server, Client);
+        var sys = _sActionsSys;
+        var cSys = _cActionsSys;
 
         // Spawn mob that has some actions
         EntityUid ent = default;
@@ -60,6 +66,5 @@ public sealed class ActionPvsDetachTest
         Assert.That(cSys.GetActions(cEnt).Count(), Is.EqualTo(initActions));
 
         await server.WaitPost(() => server.EntMan.DeleteEntity(map.MapUid));
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Actions/ActionPvsDetachTest.cs
+++ b/Content.IntegrationTests/Tests/Actions/ActionPvsDetachTest.cs
@@ -12,8 +12,8 @@ namespace Content.IntegrationTests.Tests.Actions;
 [TestFixture]
 public sealed class ActionPvsDetachTest : GameTest
 {
-    [System(Side.Server)] private readonly SharedActionsSystem _sActionsSys = null!;
-    [System(Side.Client)] private readonly SharedActionsSystem _cActionsSys = null!;
+    [SidedDependency(Side.Server)] private readonly SharedActionsSystem _sActionsSys = null!;
+    [SidedDependency(Side.Client)] private readonly SharedActionsSystem _cActionsSys = null!;
 
     [Test]
     public async Task TestActionDetach()

--- a/Content.IntegrationTests/Tests/Actions/ActionsAddedTest.cs
+++ b/Content.IntegrationTests/Tests/Actions/ActionsAddedTest.cs
@@ -1,4 +1,6 @@
+#nullable enable
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.CombatMode;
@@ -11,15 +13,17 @@ namespace Content.IntegrationTests.Tests.Actions;
 /// This tests checks that actions properly get added to an entity's actions component..
 /// </summary>
 [TestFixture]
-public sealed class ActionsAddedTest
+public sealed class ActionsAddedTest : GameTest
 {
+    public override PoolSettings PoolSettings => new PoolSettings { Connected = true, DummyTicker = false };
+
     // TODO add magboot test (inventory action)
     // TODO add ghost toggle-fov test (client-side action)
 
     [Test]
     public async Task TestCombatActionsAdded()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true, DummyTicker = false });
+        var pair = Pair;
         var server = pair.Server;
         var client = pair.Client;
         var sEntMan = server.ResolveDependency<IEntityManager>();
@@ -67,7 +71,5 @@ public sealed class ActionsAddedTest
         // required, because integration tests do not respect the [NonSerialized] attribute and will simply events by reference.
         Assert.That(ReferenceEquals(sAct.Comp, cAct.Comp), Is.False);
         Assert.That(ReferenceEquals(sQuery.GetComponent(sAct).Event, cQuery.GetComponent(cAct).Event), Is.False);
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -225,9 +225,6 @@ public sealed class AddTests : GameTest
 
             return true;
         });
-
-        await pair.CleanReturnAsync();
-        Assert.Pass();
     }
 
     [Test]
@@ -263,9 +260,6 @@ public sealed class AddTests : GameTest
 
             return true;
         });
-
-        await pair.CleanReturnAsync();
-        Assert.Pass();
     }
 }
 
@@ -335,7 +329,6 @@ public sealed class PreRoundAddTests : GameTest
 
             json.Dispose();
         }
-        await pair.CleanReturnAsync();
     }
 
 }

--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Administration.Logs;
 using Content.Server.Database;
 using Content.Server.GameTicking;
@@ -12,9 +14,9 @@ namespace Content.IntegrationTests.Tests.Administration.Logs;
 
 [TestFixture]
 [TestOf(typeof(AdminLogSystem))]
-public sealed class AddTests
+public sealed class AddTests : GameTest
 {
-    public static PoolSettings LogTestSettings = new()
+    public override PoolSettings PoolSettings => new()
     {
         AdminLogsEnabled = true,
         DummyTicker = false,
@@ -24,7 +26,7 @@ public sealed class AddTests
     [Test]
     public async Task AddAndGetSingleLog()
     {
-        await using var pair = await PoolManager.GetServerClient(LogTestSettings);
+        var pair = Pair;
         var server = pair.Server;
         var sEntities = server.ResolveDependency<IEntityManager>();
 
@@ -33,7 +35,7 @@ public sealed class AddTests
         var guid = Guid.NewGuid();
 
         await pair.CreateTestMap();
-        var coordinates = pair.TestMap.GridCoords;
+        var coordinates = pair.TestMap!.GridCoords;
         await server.WaitPost(() =>
         {
             var entity = sEntities.SpawnEntity(null, coordinates);
@@ -62,14 +64,12 @@ public sealed class AddTests
 
             return false;
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task AddAndGetUnformattedLog()
     {
-        await using var pair = await PoolManager.GetServerClient(LogTestSettings);
+        var pair = Pair;
         var server = pair.Server;
 
         var sDatabase = server.ResolveDependency<IServerDbManager>();
@@ -127,15 +127,13 @@ public sealed class AddTests
 
             json.Dispose();
         }
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     [TestCase(500)]
     public async Task BulkAddLogs(int amount)
     {
-        await using var pair = await PoolManager.GetServerClient(LogTestSettings);
+        var pair = Pair;
         var server = pair.Server;
 
         var sEntities = server.ResolveDependency<IEntityManager>();
@@ -158,14 +156,12 @@ public sealed class AddTests
             var messages = await sAdminLogSystem.CurrentRoundLogs();
             return messages.Count >= amount;
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task AddPlayerSessionLog()
     {
-        await using var pair = await PoolManager.GetServerClient(LogTestSettings);
+        var pair = Pair;
         var server = pair.Server;
 
         var sPlayers = server.ResolveDependency<IPlayerManager>();
@@ -195,20 +191,97 @@ public sealed class AddTests
             Assert.That(logs.First().Players, Does.Contain(playerGuid));
             return true;
         });
-        await pair.CleanReturnAsync();
     }
+
+    [Test]
+    public async Task DuplicatePlayerDoesNotThrowTest()
+    {
+        var pair = Pair;
+        var server = pair.Server;
+
+        var sPlayers = server.ResolveDependency<IPlayerManager>();
+        var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
+
+        var guid = Guid.NewGuid();
+
+        await server.WaitPost(() =>
+        {
+            var player = sPlayers.Sessions.Single();
+
+            sAdminLogSystem.Add(LogType.Unknown, $"{player} {player} test log: {guid}");
+        });
+
+        await PoolManager.WaitUntil(server, async () =>
+        {
+            var logs = await sAdminLogSystem.CurrentRoundLogs(new LogFilter
+            {
+                Search = guid.ToString()
+            });
+
+            if (logs.Count == 0)
+            {
+                return false;
+            }
+
+            return true;
+        });
+
+        await pair.CleanReturnAsync();
+        Assert.Pass();
+    }
+
+    [Test]
+    public async Task DuplicatePlayerIdDoesNotThrowTest()
+    {
+        var pair = Pair;
+        var server = pair.Server;
+
+        var sPlayers = server.ResolveDependency<IPlayerManager>();
+
+        var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
+
+        var guid = Guid.NewGuid();
+
+        await server.WaitPost(() =>
+        {
+            var player = sPlayers.Sessions.Single();
+
+            sAdminLogSystem.Add(LogType.Unknown, $"{player:first} {player:second} test log: {guid}");
+        });
+
+        await PoolManager.WaitUntil(server, async () =>
+        {
+            var logs = await sAdminLogSystem.CurrentRoundLogs(new LogFilter
+            {
+                Search = guid.ToString()
+            });
+
+            if (logs.Count == 0)
+            {
+                return false;
+            }
+
+            return true;
+        });
+
+        await pair.CleanReturnAsync();
+        Assert.Pass();
+    }
+}
+
+public sealed class PreRoundAddTests : GameTest
+{
+    public override PoolSettings PoolSettings => new PoolSettings
+    {
+        Dirty = true,
+        InLobby = true,
+        AdminLogsEnabled = true
+    };
 
     [Test]
     public async Task PreRoundAddAndGetSingle()
     {
-        var setting = new PoolSettings
-        {
-            Dirty = true,
-            InLobby = true,
-            AdminLogsEnabled = true
-        };
-
-        await using var pair = await PoolManager.GetServerClient(setting);
+        var pair = Pair;
         var server = pair.Server;
 
         var sDatabase = server.ResolveDependency<IServerDbManager>();
@@ -265,78 +338,4 @@ public sealed class AddTests
         await pair.CleanReturnAsync();
     }
 
-    [Test]
-    public async Task DuplicatePlayerDoesNotThrowTest()
-    {
-        await using var pair = await PoolManager.GetServerClient(LogTestSettings);
-        var server = pair.Server;
-
-        var sPlayers = server.ResolveDependency<IPlayerManager>();
-        var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
-
-        var guid = Guid.NewGuid();
-
-        await server.WaitPost(() =>
-        {
-            var player = sPlayers.Sessions.Single();
-
-            sAdminLogSystem.Add(LogType.Unknown, $"{player} {player} test log: {guid}");
-        });
-
-        await PoolManager.WaitUntil(server, async () =>
-        {
-            var logs = await sAdminLogSystem.CurrentRoundLogs(new LogFilter
-            {
-                Search = guid.ToString()
-            });
-
-            if (logs.Count == 0)
-            {
-                return false;
-            }
-
-            return true;
-        });
-
-        await pair.CleanReturnAsync();
-        Assert.Pass();
-    }
-
-    [Test]
-    public async Task DuplicatePlayerIdDoesNotThrowTest()
-    {
-        await using var pair = await PoolManager.GetServerClient(LogTestSettings);
-        var server = pair.Server;
-
-        var sPlayers = server.ResolveDependency<IPlayerManager>();
-
-        var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
-
-        var guid = Guid.NewGuid();
-
-        await server.WaitPost(() =>
-        {
-            var player = sPlayers.Sessions.Single();
-
-            sAdminLogSystem.Add(LogType.Unknown, $"{player:first} {player:second} test log: {guid}");
-        });
-
-        await PoolManager.WaitUntil(server, async () =>
-        {
-            var logs = await sAdminLogSystem.CurrentRoundLogs(new LogFilter
-            {
-                Search = guid.ToString()
-            });
-
-            if (logs.Count == 0)
-            {
-                return false;
-            }
-
-            return true;
-        });
-
-        await pair.CleanReturnAsync();
-        Assert.Pass();
-    }
 }

--- a/Content.IntegrationTests/Tests/Administration/Logs/FilterTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/FilterTests.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Administration.Logs;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
@@ -7,14 +8,21 @@ namespace Content.IntegrationTests.Tests.Administration.Logs;
 
 [TestFixture]
 [TestOf(typeof(AdminLogSystem))]
-public sealed class FilterTests
+public sealed class FilterTests : GameTest
 {
+    public override PoolSettings PoolSettings => new()
+    {
+        AdminLogsEnabled = true,
+        DummyTicker = false,
+        Connected = true
+    };
+
     [Test]
     [TestCase(DateOrder.Ascending)]
     [TestCase(DateOrder.Descending)]
     public async Task Date(DateOrder order)
     {
-        await using var pair = await PoolManager.GetServerClient(AddTests.LogTestSettings);
+        var pair = Pair;
         var server = pair.Server;
 
         var sEntities = server.ResolveDependency<IEntityManager>();
@@ -96,6 +104,5 @@ public sealed class FilterTests
 
             return firstFound && secondFound;
         });
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Administration/Logs/QueryTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/QueryTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Administration.Logs;
 using Content.Server.GameTicking;
 using Content.Shared.Database;
@@ -11,12 +12,19 @@ namespace Content.IntegrationTests.Tests.Administration.Logs;
 
 [TestFixture]
 [TestOf(typeof(AdminLogSystem))]
-public sealed class QueryTests
+public sealed class QueryTests : GameTest
 {
+    public override PoolSettings PoolSettings => new()
+    {
+        AdminLogsEnabled = true,
+        DummyTicker = false,
+        Connected = true
+    };
+
     [Test]
     public async Task QuerySingleLog()
     {
-        await using var pair = await PoolManager.GetServerClient(AddTests.LogTestSettings);
+        var pair = Pair;
         var server = pair.Server;
 
         var sSystems = server.ResolveDependency<IEntitySystemManager>();
@@ -55,7 +63,5 @@ public sealed class QueryTests
 
             return false;
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Atmos/AlarmThresholdTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/AlarmThresholdTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Atmos.Monitor;
 using Robust.Shared.Prototypes;
 
@@ -5,7 +6,7 @@ namespace Content.IntegrationTests.Tests.Atmos
 {
     [TestFixture]
     [TestOf(typeof(AtmosAlarmThreshold))]
-    public sealed class AlarmThresholdTest
+    public sealed class AlarmThresholdTest : GameTest
     {
         private const string AlarmThresholdTestDummyId = "AlarmThresholdTestDummy";
 
@@ -26,7 +27,7 @@ namespace Content.IntegrationTests.Tests.Atmos
         [Test]
         public async Task TestAlarmThreshold()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var prototypeManager = server.ResolveDependency<IPrototypeManager>();
@@ -136,7 +137,6 @@ namespace Content.IntegrationTests.Tests.Atmos
                     Assert.That(alarmType, Is.EqualTo(AtmosAlarmType.Normal));
                 }
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Atmos/ConstantsTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/ConstantsTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Prototypes;
@@ -6,12 +7,12 @@ using Content.Shared.Atmos.Prototypes;
 namespace Content.IntegrationTests.Tests.Atmos;
 
 [TestOf(typeof(Atmospherics))]
-public sealed class ConstantsTest
+public sealed class ConstantsTest : GameTest
 {
     [Test]
     public async Task TotalGasesTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var entityManager = server.EntMan;
         var protoManager = server.ProtoMan;
@@ -45,7 +46,6 @@ public sealed class ConstantsTest
                 }
             });
         });
-        await pair.CleanReturnAsync();
     }
 }
 

--- a/Content.IntegrationTests/Tests/Atmos/GasArrayTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/GasArrayTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Robust.Shared.GameObjects;
@@ -8,7 +9,7 @@ namespace Content.IntegrationTests.Tests.Atmos;
 
 [TestFixture]
 [TestOf(typeof(Atmospherics))]
-public sealed class GasArrayTest
+public sealed class GasArrayTest : GameTest
 {
     private const string GasTankTestDummyId = "GasTankTestDummy";
 
@@ -42,7 +43,7 @@ public sealed class GasArrayTest
     [Test]
     public async Task TestGasArrayDeserialization()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var compFactory = server.ResolveDependency<IComponentFactory>();
@@ -80,6 +81,5 @@ public sealed class GasArrayTest
                 }
             });
         });
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Atmos/GasMixtureTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/GasMixtureTest.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server.Atmos;
+﻿using Content.IntegrationTests.Fixtures;
+using Content.Server.Atmos;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Atmos;
 using Robust.Shared.GameObjects;
@@ -7,12 +8,12 @@ namespace Content.IntegrationTests.Tests.Atmos
 {
     [TestFixture]
     [TestOf(typeof(GasMixture))]
-    public sealed class GasMixtureTest
+    public sealed class GasMixtureTest : GameTest
     {
         [Test]
         public async Task TestMerge()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var atmosphereSystem = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<AtmosphereSystem>();
@@ -56,8 +57,6 @@ namespace Content.IntegrationTests.Tests.Atmos
                     Assert.That(a.GetMoles(Gas.Oxygen), Is.EqualTo(50));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
@@ -69,7 +68,7 @@ namespace Content.IntegrationTests.Tests.Atmos
         [TestCase(Atmospherics.BreathPercentage)]
         public async Task RemoveRatio(float ratio)
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             await server.WaitAssertion(() =>
@@ -103,8 +102,6 @@ namespace Content.IntegrationTests.Tests.Atmos
                     Assert.That(a.GetMoles(Gas.Nitrogen), Is.EqualTo(100 - b.GetMoles(Gas.Nitrogen)));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Atmos/GridJoinTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/GridJoinTest.cs
@@ -1,4 +1,5 @@
 using Content.Server.Atmos.EntitySystems;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Atmos.Piping.EntitySystems;
 using Content.Shared.Atmos.Components;
 using Robust.Shared.GameObjects;
@@ -6,14 +7,14 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests.Atmos;
 
 [TestFixture]
-public sealed class GridJoinTest
+public sealed class GridJoinTest : GameTest
 {
     private const string CanisterProtoId = "AirCanister";
 
     [Test]
     public async Task TestGridJoinAtmosphere()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.EntMan;
@@ -46,7 +47,5 @@ public sealed class GridJoinTest
             // Make sure that the canister is now properly tracked as on-grid
             Assert.That(atmosDeviceSystem.IsJoinedOffGrid(canisterEnt), Is.False);
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Atmos/SharedGasSpecificHeatsTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/SharedGasSpecificHeatsTest.cs
@@ -37,7 +37,7 @@ public sealed class SharedGasSpecificHeatsTest
         {
             Connected = true,
         };
-        _pair = await PoolManager.GetServerClient(poolSettings);
+        _pair = await PoolManager.GetServerClient(poolSettings, new NUnitTestContextWrap(TestContext.CurrentContext, TestContext.Out));
 
         _sEntMan = Server.ResolveDependency<IEntityManager>();
         _cEntMan = Client.ResolveDependency<IEntityManager>();

--- a/Content.IntegrationTests/Tests/Body/GibbingTest.cs
+++ b/Content.IntegrationTests/Tests/Body/GibbingTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Body;
 using Content.Shared.Gibbing;
 using Robust.Shared.GameObjects;
@@ -6,7 +7,7 @@ namespace Content.IntegrationTests.Tests.Body;
 
 [TestFixture]
 [TestOf(typeof(GibbableOrganSystem))]
-public sealed class GibletTest
+public sealed class GibletTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -33,7 +34,7 @@ public sealed class GibletTest
     [Test]
     public async Task GibletCountTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         await server.WaitIdleAsync();
@@ -54,7 +55,5 @@ public sealed class GibletTest
                 Assert.That(entityManager.HasComponent<GibbableOrganComponent>(giblet), Is.True);
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Body/HandOrganTest.cs
+++ b/Content.IntegrationTests/Tests/Body/HandOrganTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Body;
 using Content.Shared.Hands.Components;
 using Robust.Shared.Containers;
@@ -9,7 +10,7 @@ namespace Content.IntegrationTests.Tests.Body;
 
 [TestFixture]
 [TestOf(typeof(HandOrganSystem))]
-public sealed class HandOrganTest
+public sealed class HandOrganTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -46,7 +47,7 @@ public sealed class HandOrganTest
     [Test]
     public async Task HandInsertionAndRemovalTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         await server.WaitIdleAsync();
@@ -81,7 +82,5 @@ public sealed class HandOrganTest
                 Assert.That(hands.Count, Is.EqualTo(expectedCount));
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Buckle/BuckleTest.Interact.cs
+++ b/Content.IntegrationTests/Tests/Buckle/BuckleTest.Interact.cs
@@ -12,7 +12,7 @@ public sealed partial class BuckleTest
     [Test]
     public async Task BuckleInteractUnbuckleOther()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -55,14 +55,12 @@ public sealed partial class BuckleTest
                 Assert.That(strap.BuckledEntities, Does.Not.Contain(victim));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task BuckleInteractBuckleUnbuckleSelf()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -102,7 +100,5 @@ public sealed partial class BuckleTest
                 Assert.That(strap.BuckledEntities, Does.Not.Contain(user));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
+++ b/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Buckle;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Buckle.Components;
@@ -12,7 +13,7 @@ namespace Content.IntegrationTests.Tests.Buckle
     [TestFixture]
     [TestOf(typeof(BuckleComponent))]
     [TestOf(typeof(StrapComponent))]
-    public sealed partial class BuckleTest
+    public sealed partial class BuckleTest : GameTest
     {
         private const string BuckleDummyId = "BuckleDummy";
         private const string StrapDummyId = "StrapDummy";
@@ -50,7 +51,7 @@ namespace Content.IntegrationTests.Tests.Buckle
         [Test]
         public async Task BuckleUnbuckleCooldownRangeTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var testMap = await pair.CreateTestMap();
@@ -228,14 +229,12 @@ namespace Content.IntegrationTests.Tests.Buckle
                     Assert.That(strap.BuckledEntities, Is.Empty);
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task BuckledDyingDropItemsTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var testMap = await pair.CreateTestMap();
@@ -298,14 +297,12 @@ namespace Content.IntegrationTests.Tests.Buckle
                 buckleSystem.Unbuckle(human, human);
                 Assert.That(buckle.Buckled, Is.False);
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task ForceUnbuckleBuckleTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var testMap = await pair.CreateTestMap();
@@ -373,7 +370,6 @@ namespace Content.IntegrationTests.Tests.Buckle
                     Assert.That(buckle.Buckled);
                 });
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Cargo.Components;
 using Content.Server.Cargo.Systems;
 using Content.Server.Nutrition.Components;
@@ -17,7 +18,7 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests;
 
 [TestFixture]
-public sealed class CargoTest
+public sealed class CargoTest : GameTest
 {
     private static readonly HashSet<ProtoId<CargoProductPrototype>> Ignored =
     [
@@ -28,7 +29,7 @@ public sealed class CargoTest
     [Test]
     public async Task NoCargoOrderArbitrage()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var testMap = await pair.CreateTestMap();
@@ -54,13 +55,11 @@ public sealed class CargoTest
                 }
             });
         });
-
-        await pair.CleanReturnAsync();
     }
     [Test]
     public async Task NoCargoBountyArbitrageTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var testMap = await pair.CreateTestMap();
@@ -94,14 +93,12 @@ public sealed class CargoTest
 
             mapSystem.DeleteMap(mapId);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task NoStaticPriceAndStackPrice()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var protoManager = server.ProtoMan;
@@ -133,8 +130,6 @@ public sealed class CargoTest
                 }
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -144,7 +139,7 @@ public sealed class CargoTest
     [Test]
     public async Task NoSliceableBountyArbitrageTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var testMap = await pair.CreateTestMap();
@@ -209,8 +204,6 @@ public sealed class CargoTest
             }
             mapSystem.DeleteMap(mapId);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [TestPrototypes]
@@ -233,7 +226,7 @@ public sealed class CargoTest
     [Test]
     public async Task StackPrice()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var entManager = server.ResolveDependency<IEntityManager>();
 
@@ -245,14 +238,12 @@ public sealed class CargoTest
             var price = priceSystem.GetPrice(ent);
             Assert.That(price, Is.EqualTo(100.0));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task MobPrice()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
 
         var componentFactory = pair.Server.ResolveDependency<IComponentFactory>();
 
@@ -266,7 +257,5 @@ public sealed class CargoTest
                 }
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Chemistry/ReagentDataTest.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/ReagentDataTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Tests.Interaction;
 using Content.Shared.Chemistry.Reagent;
 using Robust.Shared.Reflection;
@@ -8,12 +9,12 @@ namespace Content.IntegrationTests.Tests.Chemistry;
 
 [TestFixture]
 [TestOf(typeof(ReagentData))]
-public sealed class ReagentDataTest
+public sealed class ReagentDataTest : GameTest
 {
     [Test]
     public async Task ReagentDataIsSerializable()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var reflection = pair.Server.ResolveDependency<IReflectionManager>();
 
         Assert.Multiple(() =>
@@ -24,7 +25,5 @@ public sealed class ReagentDataTest
                 Assert.That(instance.HasCustomAttribute<SerializableAttribute>(), $"{instance} must have the serializable attribute.");
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Chemistry/SolutionRoundingTest.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/SolutionRoundingTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reaction;
@@ -9,7 +10,7 @@ namespace Content.IntegrationTests.Tests.Chemistry;
 
 [TestFixture]
 [TestOf(typeof(ChemicalReactionSystem))]
-public sealed class SolutionRoundingTest
+public sealed class SolutionRoundingTest : GameTest
 {
     // This test tests two things:
     // * A rounding error in reaction code while I was making chloral hydrate
@@ -72,7 +73,7 @@ public sealed class SolutionRoundingTest
     [Test]
     public async Task Test()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var testMap = await pair.CreateTestMap();
 
@@ -121,7 +122,5 @@ public sealed class SolutionRoundingTest
                     Is.EqualTo((FixedPoint2) 30));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Chemistry/SolutionSystemTests.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/SolutionSystemTests.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.FixedPoint;
@@ -12,7 +13,7 @@ namespace Content.IntegrationTests.Tests.Chemistry;
 // reactions can change this assumption
 [TestFixture]
 [TestOf(typeof(SharedSolutionContainerSystem))]
-public sealed class SolutionSystemTests
+public sealed class SolutionSystemTests : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -53,7 +54,7 @@ public sealed class SolutionSystemTests
     [Test]
     public async Task TryAddTwoNonReactiveReagent()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
@@ -88,8 +89,6 @@ public sealed class SolutionSystemTests
                 Assert.That(oil, Is.EqualTo(oilQuantity));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     // This test mimics current behavior
@@ -97,7 +96,7 @@ public sealed class SolutionSystemTests
     [Test]
     public async Task TryAddTooMuchNonReactiveReagent()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var testMap = await pair.CreateTestMap();
@@ -133,15 +132,13 @@ public sealed class SolutionSystemTests
                 Assert.That(oil, Is.EqualTo(FixedPoint2.Zero));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     // Unlike TryAddSolution this adds and two solution without then splits leaving only threshold in original
     [Test]
     public async Task TryMixAndOverflowTooMuchReagent()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
 
@@ -188,15 +185,13 @@ public sealed class SolutionSystemTests
                 Assert.That(oilOverFlow, Is.EqualTo(oilQuantity - oilMix));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     // TryMixAndOverflow will fail if Threshold larger than MaxVolume
     [Test]
     public async Task TryMixAndOverflowTooBigOverflow()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
@@ -226,14 +221,12 @@ public sealed class SolutionSystemTests
                 .TryMixAndOverflow(solutionEnt.Value, oilAdded, threshold, out _),
                 Is.False);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestTemperatureCalculations()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
         const float temp = 100.0f;
@@ -264,7 +257,5 @@ public sealed class SolutionSystemTests
             solutionOne.AddSolution(solutionTwo, protoMan);
             Assert.That(solutionOne.GetHeatCapacity(protoMan) * solutionOne.Temperature, Is.EqualTo(thermalEnergyOne + thermalEnergyTwo));
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Chemistry/TryAllReactionsTest.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/TryAllReactionsTest.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Utility;
 using Content.Shared.Chemistry.EntitySystems;
 
@@ -12,7 +13,7 @@ namespace Content.IntegrationTests.Tests.Chemistry
 {
     [TestFixture]
     [TestOf(typeof(ReactionPrototype))]
-    public sealed class TryAllReactionsTest
+    public sealed class TryAllReactionsTest : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -33,7 +34,7 @@ namespace Content.IntegrationTests.Tests.Chemistry
         [Description("Tries an individual reaction to see if it succeeds.")]
         public async Task TryReaction(string reaction)
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -134,8 +135,6 @@ namespace Content.IntegrationTests.Tests.Chemistry
 
                 server.EntMan.DeleteEntity(beaker);
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Cleanup/EuiManagerTest.cs
+++ b/Content.IntegrationTests/Tests/Cleanup/EuiManagerTest.cs
@@ -1,35 +1,37 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Administration.UI;
 using Content.Server.EUI;
 using Robust.Server.Player;
 
 namespace Content.IntegrationTests.Tests.Cleanup;
 
-public sealed class EuiManagerTest
+public sealed class EuiManagerTest : GameTest
 {
+    public override PoolSettings PoolSettings => new PoolSettings
+    {
+        Connected = true,
+        Dirty = true
+    };
+
     [Test]
+    [Retry(2)]
+    // Even though we are using the server EUI here, we actually want to see if the client EUIManager crashes
     public async Task EuiManagerRecycleWithOpenWindowTest()
     {
-        // Even though we are using the server EUI here, we actually want to see if the client EUIManager crashes
-        for (var i = 0; i < 2; i++)
+        var pair = Pair;
+        var server = pair.Server;
+
+        var sPlayerManager = server.ResolveDependency<IPlayerManager>();
+        var eui = server.ResolveDependency<EuiManager>();
+
+        await server.WaitAssertion(() =>
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings
-            {
-                Connected = true,
-                Dirty = true
-            });
-            var server = pair.Server;
+            var clientSession = sPlayerManager.Sessions.Single();
+            var ui = new AdminAnnounceEui();
+            eui.OpenEui(ui, clientSession);
+        });
 
-            var sPlayerManager = server.ResolveDependency<IPlayerManager>();
-            var eui = server.ResolveDependency<EuiManager>();
-
-            await server.WaitAssertion(() =>
-            {
-                var clientSession = sPlayerManager.Sessions.Single();
-                var ui = new AdminAnnounceEui();
-                eui.OpenEui(ui, clientSession);
-            });
-            await pair.CleanReturnAsync();
-        }
+        await RunUntilSynced();
     }
 }

--- a/Content.IntegrationTests/Tests/ClickableTest.cs
+++ b/Content.IntegrationTests/Tests/ClickableTest.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Client.Clickable;
+using Content.IntegrationTests.Fixtures;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.GameObjects;
@@ -7,7 +8,7 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
-    public sealed class ClickableTest
+    public sealed class ClickableTest : GameTest
     {
         private const double DirSouth = 0;
         private const double DirNorth = Math.PI;
@@ -44,7 +45,7 @@ namespace Content.IntegrationTests.Tests
         [TestCase("ClickTestRotatingCornerInvisibleNoRot", 0.25f, 0.25f, DirSouthEastJustShy, 1, ExpectedResult = true)]
         public async Task<bool> Test(string prototype, float clickPosX, float clickPosY, double angle, float scale)
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var pair = Pair;
             var server = pair.Server;
             var client = pair.Client;
 
@@ -66,7 +67,7 @@ namespace Content.IntegrationTests.Tests
             });
 
             // Let client sync up.
-            await pair.RunTicksSync(5);
+            await RunUntilSynced();
 
             var hit = false;
             var clientEnt = clientEntManager.GetEntity(serverEntManager.GetNetEntity(serverEnt));
@@ -88,8 +89,6 @@ namespace Content.IntegrationTests.Tests
             {
                 serverEntManager.DeleteEntity(serverEnt);
             });
-
-            await pair.CleanReturnAsync();
 
             return hit;
         }

--- a/Content.IntegrationTests/Tests/Cloning/CloningSettingsPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Cloning/CloningSettingsPrototypeTest.cs
@@ -1,8 +1,9 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Cloning;
 
 namespace Content.IntegrationTests.Tests.Cloning;
 
-public sealed class CloningSettingsPrototypeTest
+public sealed class CloningSettingsPrototypeTest : GameTest
 {
     /// <summary>
     /// Checks that the components named in every <see cref="CloningSettingsPrototype"/> are valid components known to the server.
@@ -12,7 +13,7 @@ public sealed class CloningSettingsPrototypeTest
     [Test]
     public async Task ValidatePrototypes()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var protoMan = server.ProtoMan;
         var compFactory = server.EntMan.ComponentFactory;
@@ -40,7 +41,5 @@ public sealed class CloningSettingsPrototypeTest
                 }
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Commands/ForceMapTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/ForceMapTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Maps;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
@@ -6,7 +7,7 @@ using Robust.Shared.Console;
 namespace Content.IntegrationTests.Tests.Commands;
 
 [TestFixture]
-public sealed class ForceMapTest
+public sealed class ForceMapTest : GameTest
 {
     private const string DefaultMapName = "Empty";
     private const string BadMapName = "asdf_asd-fa__sdfAsd_f"; // Hopefully no one ever names a map this...
@@ -44,7 +45,7 @@ public sealed class ForceMapTest
     [Test]
     public async Task TestForceMapCommand()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.EntMan;
@@ -82,7 +83,5 @@ public sealed class ForceMapTest
 
         // Cleanup
         configManager.SetCVar(CCVars.GameMap, DefaultMapName);
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Commands/ObjectiveCommandsTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/ObjectiveCommandsTest.cs
@@ -28,6 +28,11 @@ public sealed class ObjectiveCommandsTest : GameTest
   - type: DieCondition
 """;
 
+    public override PoolSettings PoolSettings => new ()
+    {
+        Connected = false
+    };
+
     /// <summary>
     /// Creates a dummy session, and assigns it a mind, then
     /// tests using <c>addobjective</c>, <c>lsobjectives</c>,

--- a/Content.IntegrationTests/Tests/Commands/ObjectiveCommandsTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/ObjectiveCommandsTest.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Objectives;
 using Content.Shared.Mind;
 using Robust.Shared.GameObjects;
@@ -7,7 +8,7 @@ using Robust.Shared.Player;
 
 namespace Content.IntegrationTests.Tests.Commands;
 
-public sealed class ObjectiveCommandsTest
+public sealed class ObjectiveCommandsTest : GameTest
 {
 
     private const string ObjectiveProtoId = "MindCommandsTestObjective";
@@ -35,7 +36,7 @@ public sealed class ObjectiveCommandsTest
     [Test]
     public async Task AddListRemoveObjectiveTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var entMan = server.EntMan;
         var playerMan = server.ResolveDependency<ISharedPlayerManager>();
@@ -66,7 +67,5 @@ public sealed class ObjectiveCommandsTest
         await pair.WaitCommand($"rmobjective {playerSession.Name} 0");
 
         Assert.That(mindComp.Objectives, Is.Empty, "rmobjective failed to remove objective");
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Commands/PardonCommand.cs
+++ b/Content.IntegrationTests/Tests/Commands/PardonCommand.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Database;
 using Robust.Server.Console;
 using Robust.Server.Player;
@@ -8,14 +9,14 @@ namespace Content.IntegrationTests.Tests.Commands
 {
     [TestFixture]
     [TestOf(typeof(PardonCommand))]
-    public sealed class PardonCommand
+    public sealed class PardonCommand : GameTest
     {
         private static readonly TimeSpan MarginOfError = TimeSpan.FromMinutes(1);
 
         [Test]
         public async Task PardonTest()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var pair = Pair;
             var server = pair.Server;
             var client = pair.Client;
 
@@ -148,8 +149,6 @@ namespace Content.IntegrationTests.Tests.Commands
             await client.WaitPost(() => netMan.ClientConnect(null!, 0, null!));
             await pair.RunTicksSync(5);
             Assert.That(sPlayerManager.Sessions, Has.Length.EqualTo(1));
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Commands/RejuvenateTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/RejuvenateTest.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Administration.Systems;
+﻿using Content.IntegrationTests.Fixtures;
+using Content.Shared.Administration.Systems;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
@@ -14,7 +15,7 @@ namespace Content.IntegrationTests.Tests.Commands
 {
     [TestFixture]
     [TestOf(typeof(RejuvenateSystem))]
-    public sealed class RejuvenateTest
+    public sealed class RejuvenateTest : GameTest
     {
         private static readonly ProtoId<DamageGroupPrototype> TestDamageGroup = "Toxin";
 
@@ -36,7 +37,7 @@ namespace Content.IntegrationTests.Tests.Commands
         [Test]
         public async Task RejuvenateDeadTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var entManager = server.ResolveDependency<IEntityManager>();
             var prototypeManager = server.ResolveDependency<IPrototypeManager>();
@@ -92,7 +93,6 @@ namespace Content.IntegrationTests.Tests.Commands
                     Assert.That(damSystem.GetTotalDamage((human, damageable)), Is.EqualTo(FixedPoint2.Zero));
                 });
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Commands/RestartRoundTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/RestartRoundTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Commands;
 using Content.Shared.CCVar;
@@ -10,25 +11,27 @@ namespace Content.IntegrationTests.Tests.Commands
 {
     [TestFixture]
     [TestOf(typeof(RestartRoundNowCommand))]
-    public sealed class RestartRoundNowTest
+    public sealed class RestartRoundNowTest : GameTest
     {
+        public override PoolSettings PoolSettings => new PoolSettings
+        {
+            DummyTicker = false,
+            Dirty = true
+        };
+
         [Test]
         [TestCase(true)]
         [TestCase(false)]
         public async Task RestartRoundAfterStart(bool lobbyEnabled)
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings
-            {
-                DummyTicker = false,
-                Dirty = true
-            });
+            var pair = Pair;
             var server = pair.Server;
 
             var configManager = server.ResolveDependency<IConfigurationManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var gameTicker = entityManager.System<GameTicker>();
 
-            await pair.RunTicksSync(5);
+            await pair.RunUntilSynced();
 
             GameTick tickBeforeRestart = default;
 
@@ -58,8 +61,7 @@ namespace Content.IntegrationTests.Tests.Commands
                 Assert.That(tickBeforeRestart, Is.LessThan(tickAfterRestart));
             });
 
-            await pair.RunTicksSync(5);
-            await pair.CleanReturnAsync();
+            await pair.RunUntilSynced();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
+++ b/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
@@ -21,7 +22,7 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Commands;
 
 [TestFixture]
-public sealed class SuicideCommandTests
+public sealed class SuicideCommandTests : GameTest
 {
 
     [TestPrototypes]
@@ -57,6 +58,13 @@ public sealed class SuicideCommandTests
     private static readonly ProtoId<TagPrototype> CannotSuicideTag = "CannotSuicide";
     private static readonly ProtoId<DamageTypePrototype> DamageType = "Slash";
 
+    public override PoolSettings PoolSettings => new PoolSettings
+    {
+        Connected = true,
+        Dirty = true,
+        DummyTicker = false
+    };
+
     /// <summary>
     /// Run the suicide command in the console
     /// Should successfully kill the player and ghost them
@@ -64,12 +72,7 @@ public sealed class SuicideCommandTests
     [Test]
     public async Task TestSuicide()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Connected = true,
-            Dirty = true,
-            DummyTicker = false
-        });
+        var pair = Pair;
         var server = pair.Server;
         var consoleHost = server.ResolveDependency<IConsoleHost>();
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -104,8 +107,6 @@ public sealed class SuicideCommandTests
                             !ghostComp.CanReturnToBody);
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -115,12 +116,7 @@ public sealed class SuicideCommandTests
     [Test]
     public async Task TestSuicideWhileDamaged()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Connected = true,
-            Dirty = true,
-            DummyTicker = false
-        });
+        var pair = Pair;
         var server = pair.Server;
         var consoleHost = server.ResolveDependency<IConsoleHost>();
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -166,8 +162,6 @@ public sealed class SuicideCommandTests
                 Assert.That(damageableSystem.GetTotalDamage(player), Is.EqualTo(lethalDamageThreshold));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -177,12 +171,7 @@ public sealed class SuicideCommandTests
     [Test]
     public async Task TestSuicideWhenCannotSuicide()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Connected = true,
-            Dirty = true,
-            DummyTicker = false
-        });
+        var pair = Pair;
         var server = pair.Server;
         var consoleHost = server.ResolveDependency<IConsoleHost>();
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -217,8 +206,6 @@ public sealed class SuicideCommandTests
                             !ghostComp.CanReturnToBody);
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
 
@@ -228,12 +215,7 @@ public sealed class SuicideCommandTests
     [Test]
     public async Task TestSuicideByHeldItem()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Connected = true,
-            Dirty = true,
-            DummyTicker = false
-        });
+        var pair = Pair;
         var server = pair.Server;
         var consoleHost = server.ResolveDependency<IConsoleHost>();
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -292,8 +274,6 @@ public sealed class SuicideCommandTests
                 Assert.That(damageableSystem.GetAllDamage((player, damageableComp)).DamageDict["Slash"], Is.EqualTo(lethalDamageThreshold));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -303,12 +283,7 @@ public sealed class SuicideCommandTests
     [Test]
     public async Task TestSuicideByHeldItemSpreadDamage()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Connected = true,
-            Dirty = true,
-            DummyTicker = false
-        });
+        var pair = Pair;
         var server = pair.Server;
         var consoleHost = server.ResolveDependency<IConsoleHost>();
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -367,7 +342,5 @@ public sealed class SuicideCommandTests
                 Assert.That(damageableSystem.GetAllDamage((player, damageableComp)).DamageDict["Slash"], Is.EqualTo(lethalDamageThreshold / 2));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/ConfigPresetTests.cs
+++ b/Content.IntegrationTests/Tests/ConfigPresetTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Entry;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
@@ -7,12 +8,12 @@ using Robust.Shared.ContentPack;
 namespace Content.IntegrationTests.Tests;
 
 [TestFixture]
-public sealed class ConfigPresetTests
+public sealed class ConfigPresetTests : GameTest
 {
     [Test]
     public async Task TestLoadAll()
     {
-        var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var resources = server.ResolveDependency<IResourceManager>();
@@ -70,7 +71,5 @@ public sealed class ConfigPresetTests
                     Assert.Fail($"CVar {name} was not reset to its original value.");
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Construction/ConstructionActionValid.cs
+++ b/Content.IntegrationTests/Tests/Construction/ConstructionActionValid.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Construction.Completions;
 using Content.Shared.Construction;
 using Content.Shared.Construction.Prototypes;
@@ -7,7 +8,7 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Construction
 {
     [TestFixture]
-    public sealed class ConstructionActionValid
+    public sealed class ConstructionActionValid : GameTest
     {
         private bool IsValid(IGraphAction action, IPrototypeManager protoMan, out string prototype)
         {
@@ -47,7 +48,7 @@ namespace Content.IntegrationTests.Tests.Construction
         [Test]
         public async Task ConstructionGraphSpawnPrototypeValid()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var protoMan = server.ResolveDependency<IPrototypeManager>();
@@ -84,13 +85,12 @@ namespace Content.IntegrationTests.Tests.Construction
             });
 
             Assert.That(valid, Is.True, $"One or more SpawnPrototype actions specified invalid entity prototypes!\n{message}");
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task ConstructionGraphEdgeValid()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var protoMan = server.ResolveDependency<IPrototypeManager>();
@@ -118,7 +118,6 @@ namespace Content.IntegrationTests.Tests.Construction
             });
 
             Assert.That(valid, Is.True, $"One or more edges specified invalid node targets!\n{message}");
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Utility;
 using Content.Server.Construction.Components;
 using Content.Shared.Construction.Prototypes;
@@ -7,7 +8,7 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Construction
 {
     [TestFixture]
-    public sealed class ConstructionPrototypeTest
+    public sealed class ConstructionPrototypeTest : GameTest
     {
         // discount linter for construction graphs
         // TODO: Create serialization validators for these?
@@ -25,7 +26,7 @@ namespace Content.IntegrationTests.Tests.Construction
         [Description("Tests that a given entity specifies a valid node for construction, and optionally a valid one for deconstruction.")]
         public async Task ConstructionComponentValid(string protoKey)
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var protoMan = server.ResolveDependency<IPrototypeManager>();
@@ -49,8 +50,6 @@ namespace Content.IntegrationTests.Tests.Construction
                         $"Invalid deconstruction node \"{target}\" on graph \"{graph.ID}\" for construction entity \"{proto.ID}\"!");
                 }
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
@@ -59,7 +58,7 @@ namespace Content.IntegrationTests.Tests.Construction
         [Description("Tests that a given construction prototype has a valid starting and target node, and a valid path between them.")]
         public async Task ConstructionFormsValidGraph(string protoKey)
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var protoMan = server.ResolveDependency<IPrototypeManager>();
@@ -95,7 +94,6 @@ namespace Content.IntegrationTests.Tests.Construction
                     $"The next node ({next.Name}) in the path from the start node ({start}) to the target node ({target}) specified an entity prototype ({next.Entity}) without a ConstructionComponent.");
 #pragma warning restore NUnit2045
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/ContainerOcclusionTest.cs
+++ b/Content.IntegrationTests/Tests/ContainerOcclusionTest.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Storage.EntitySystems;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
@@ -7,7 +8,7 @@ using Robust.Shared.Maths;
 
 namespace Content.IntegrationTests.Tests
 {
-    public sealed class ContainerOcclusionTest
+    public sealed class ContainerOcclusionTest : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -34,7 +35,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task TestA()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var pair = Pair;
             var server = pair.Server;
             var client = pair.Client;
 
@@ -69,14 +70,12 @@ namespace Content.IntegrationTests.Tests
                     Assert.That(light.ContainerOccluded);
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestB()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var pair = Pair;
             var server = pair.Server;
             var client = pair.Client;
 
@@ -112,14 +111,12 @@ namespace Content.IntegrationTests.Tests
                     Assert.That(light.ContainerOccluded, Is.False);
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestAb()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var pair = Pair;
             var server = pair.Server;
             var client = pair.Client;
 
@@ -157,8 +154,6 @@ namespace Content.IntegrationTests.Tests
                     Assert.That(light.ContainerOccluded);
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/ContrabandTest.cs
+++ b/Content.IntegrationTests/Tests/ContrabandTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Contraband;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
@@ -5,12 +6,12 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests;
 
 [TestFixture]
-public sealed class ContrabandTest
+public sealed class ContrabandTest : GameTest
 {
     [Test]
     public async Task EntityShowDepartmentsAndJobs()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var client = pair.Client;
         var protoMan = client.ResolveDependency<IPrototypeManager>();
         var componentFactory = client.ResolveDependency<IComponentFactory>();
@@ -41,7 +42,5 @@ public sealed class ContrabandTest
                 }
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
@@ -12,7 +13,7 @@ namespace Content.IntegrationTests.Tests.Damageable
     [TestFixture]
     [TestOf(typeof(DamageableComponent))]
     [TestOf(typeof(DamageableSystem))]
-    public sealed class DamageableTest
+    public sealed class DamageableTest : GameTest
     {
         private const string TestDamageableEntityId = "TestDamageableEntityId";
         private const string TestGroup1 = "TestGroup1";
@@ -95,7 +96,7 @@ namespace Content.IntegrationTests.Tests.Damageable
         [Test]
         public async Task TestDamageableComponents()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var sEntityManager = server.ResolveDependency<IEntityManager>();
@@ -254,7 +255,6 @@ namespace Content.IntegrationTests.Tests.Damageable
                 sDamageableSystem.ChangeDamage(uid, new DamageSpecifier(group3, -100));
                 Assert.That(sDamageableSystem.GetTotalDamage(ent), Is.EqualTo(FixedPoint2.Zero));
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Damageable/MobThresholdsTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/MobThresholdsTest.cs
@@ -1,10 +1,11 @@
+using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Utility;
 using Content.Shared.Alert;
 using Content.Shared.Mobs.Components;
 
 namespace Content.IntegrationTests.Tests.Damageable;
 
-public sealed class MobThresholdsTest
+public sealed class MobThresholdsTest : GameTest
 {
     private static string[] _entitiesWithThresholds = GameDataScrounger.EntitiesWithComponent("MobThresholds");
 
@@ -14,7 +15,7 @@ public sealed class MobThresholdsTest
     [Description("Ensures every entity with mob thresholds has valid mob state configuration corresponding to some AlertPrototype.")]
     public async Task ValidateMobThresholds(string protoKey)
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var protoMan = server.ProtoMan;
@@ -33,7 +34,5 @@ public sealed class MobThresholdsTest
                 Assert.That(alertStates, Does.Contain(state), $"{proto.ID} does not have an alert state for mob state {state}");
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Damageable/StaminaComponentTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/StaminaComponentTest.cs
@@ -1,11 +1,12 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Utility;
 using Content.Shared.Damage.Components;
 using Content.Shared.FixedPoint;
 
 namespace Content.IntegrationTests.Tests.Damageable;
 
-public sealed class StaminaComponentTest
+public sealed class StaminaComponentTest : GameTest
 {
     private static string[] _entitiesWithStamina = GameDataScrounger.EntitiesWithComponent("Stamina");
 
@@ -15,7 +16,7 @@ public sealed class StaminaComponentTest
     [Description("Ensures every entity with Stamina has a valid stamina configuration.")]
     public async Task ValidateStamina(string protoKey)
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var protoMan = server.ProtoMan;
 
@@ -46,7 +47,5 @@ public sealed class StaminaComponentTest
 #pragma warning restore NUnit2041
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/DeleteInventoryTest.cs
+++ b/Content.IntegrationTests/Tests/DeleteInventoryTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Inventory;
@@ -7,14 +8,14 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
-    public sealed class DeleteInventoryTest
+    public sealed class DeleteInventoryTest : GameTest
     {
         // Test that when deleting an entity with an InventoryComponent,
         // any equipped items also get deleted.
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var testMap = await pair.CreateTestMap();
             var entMgr = server.ResolveDependency<IEntityManager>();
@@ -44,7 +45,6 @@ namespace Content.IntegrationTests.Tests
                 // Assert that child item was also deleted.
                 Assert.That(item.Deleted, Is.True);
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDamageGroupTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDamageGroupTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
@@ -13,12 +14,12 @@ namespace Content.IntegrationTests.Tests.Destructible
     [TestFixture]
     [TestOf(typeof(DamageGroupTrigger))]
     [TestOf(typeof(AndTrigger))]
-    public sealed class DestructibleDamageGroupTest
+    public sealed class DestructibleDamageGroupTest : GameTest
     {
         [Test]
         public async Task AndTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var testMap = await pair.CreateTestMap();
@@ -193,7 +194,6 @@ namespace Content.IntegrationTests.Tests.Destructible
                 // No new thresholds reached as triggers once is set to true and it already triggered before
                 Assert.That(sTestThresholdListenerSystem.ThresholdsReached, Is.Empty);
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDamageTypeTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDamageTypeTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
@@ -12,12 +13,12 @@ namespace Content.IntegrationTests.Tests.Destructible
     [TestFixture]
     [TestOf(typeof(DamageTypeTrigger))]
     [TestOf(typeof(AndTrigger))]
-    public sealed class DestructibleDamageTypeTest
+    public sealed class DestructibleDamageTypeTest : GameTest
     {
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var testMap = await pair.CreateTestMap();
@@ -188,7 +189,6 @@ namespace Content.IntegrationTests.Tests.Destructible
                 // No new thresholds reached as triggers once is set to true and it already triggered before
                 Assert.That(sTestThresholdListenerSystem.ThresholdsReached, Is.Empty);
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDestructionTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDestructionTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Destructible.Thresholds.Behaviors;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
@@ -10,12 +11,12 @@ using static Content.IntegrationTests.Tests.Destructible.DestructibleTestPrototy
 
 namespace Content.IntegrationTests.Tests.Destructible
 {
-    public sealed class DestructibleDestructionTest
+    public sealed class DestructibleDestructionTest : GameTest
     {
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var testMap = await pair.CreateTestMap();
@@ -89,7 +90,6 @@ namespace Content.IntegrationTests.Tests.Destructible
 
                 Assert.That(found, Is.True, $"Unable to find {SpawnedEntityId} nearby for destructible test; found {entitiesInRange.Count} entities.");
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleThresholdActivationTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleThresholdActivationTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Destructible;
 using Content.Server.Destructible.Thresholds;
 using Content.Server.Destructible.Thresholds.Behaviors;
@@ -19,12 +20,12 @@ namespace Content.IntegrationTests.Tests.Destructible
     [TestFixture]
     [TestOf(typeof(DestructibleComponent))]
     [TestOf(typeof(DamageThreshold))]
-    public sealed class DestructibleThresholdActivationTest
+    public sealed class DestructibleThresholdActivationTest : GameTest
     {
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var sEntityManager = server.ResolveDependency<IEntityManager>();
@@ -289,7 +290,6 @@ namespace Content.IntegrationTests.Tests.Destructible
                     Assert.That(sTestThresholdListenerSystem.ThresholdsReached, Is.Empty);
                 });
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/DeviceLinking/DeviceLinkingTest.cs
+++ b/Content.IntegrationTests/Tests/DeviceLinking/DeviceLinkingTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Utility;
 using Content.Server.DeviceLinking.Systems;
 using Content.Shared.DeviceLinking;
@@ -7,7 +8,7 @@ using Robust.Shared.Maths;
 
 namespace Content.IntegrationTests.Tests.DeviceLinking;
 
-public sealed class DeviceLinkingTest
+public sealed class DeviceLinkingTest : GameTest
 {
     private const string PortTesterProtoId = "DeviceLinkingSinkPortTester";
 
@@ -29,7 +30,7 @@ public sealed class DeviceLinkingTest
     [Description("Ensures all devices that can sink signals will not cause exceptions when signaled.")]
     public async Task DeviceLinkSinkAllPortsTest(string protoKey)
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var protoMan = server.ProtoMan;
         var compFact = server.ResolveDependency<IComponentFactory>();
@@ -77,7 +78,5 @@ public sealed class DeviceLinkingTest
                 }
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/DeviceNetwork/DeviceNetworkTest.cs
+++ b/Content.IntegrationTests/Tests/DeviceNetwork/DeviceNetworkTest.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.DeviceNetwork.Components;
 using Content.Server.DeviceNetwork.Systems;
 using Content.Shared.DeviceNetwork;
@@ -12,7 +13,7 @@ namespace Content.IntegrationTests.Tests.DeviceNetwork
     [TestOf(typeof(DeviceNetworkComponent))]
     [TestOf(typeof(WiredNetworkComponent))]
     [TestOf(typeof(WirelessNetworkComponent))]
-    public sealed class DeviceNetworkTest
+    public sealed class DeviceNetworkTest : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -50,7 +51,7 @@ namespace Content.IntegrationTests.Tests.DeviceNetwork
         [Test]
         public async Task NetworkDeviceSendAndReceive()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -104,13 +105,12 @@ namespace Content.IntegrationTests.Tests.DeviceNetwork
             {
                 Assert.That(payload, Is.EquivalentTo(deviceNetTestSystem.LastPayload));
             });
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task WirelessNetworkDeviceSendAndReceive()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var testMap = await pair.CreateTestMap();
             var coordinates = testMap.GridCoords;
@@ -188,14 +188,12 @@ namespace Content.IntegrationTests.Tests.DeviceNetwork
             {
                 Assert.That(payload, Is.Not.EqualTo(deviceNetTestSystem.LastPayload).AsCollection);
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task WiredNetworkDeviceSendAndReceive()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var testMap = await pair.CreateTestMap();
             var coordinates = testMap.GridCoords;
@@ -271,8 +269,6 @@ namespace Content.IntegrationTests.Tests.DeviceNetwork
             {
                 Assert.That(payload, Is.EqualTo(deviceNetTestSystem.LastPayload).AsCollection);
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
+++ b/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
@@ -1,6 +1,7 @@
 #nullable enable annotations
 using System.Linq;
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Disposal.Unit;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
@@ -16,7 +17,7 @@ namespace Content.IntegrationTests.Tests.Disposal
     [TestOf(typeof(DisposalHolderComponent))]
     [TestOf(typeof(DisposalEntryComponent))]
     [TestOf(typeof(DisposalUnitComponent))]
-    public sealed class DisposalUnitTest
+    public sealed class DisposalUnitTest : GameTest
     {
         [Reflect(false)]
         private sealed class DisposalUnitTestSystem : EntitySystem
@@ -145,7 +146,7 @@ namespace Content.IntegrationTests.Tests.Disposal
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var testMap = await pair.CreateTestMap();
@@ -240,8 +241,6 @@ namespace Content.IntegrationTests.Tests.Disposal
                 // Re-pressurizing
                 Flush(disposalUnit, unitComponent, false, disposalSystem);
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/DoAfter/DoAfterServerTest.cs
+++ b/Content.IntegrationTests/Tests/DoAfter/DoAfterServerTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Robust.Shared.GameObjects;
@@ -12,7 +13,7 @@ namespace Content.IntegrationTests.Tests.DoAfter
 {
     [TestFixture]
     [TestOf(typeof(DoAfterComponent))]
-    public sealed partial class DoAfterServerTest
+    public sealed partial class DoAfterServerTest : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -35,7 +36,7 @@ namespace Content.IntegrationTests.Tests.DoAfter
         [Test]
         public async Task TestSerializable()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             await server.WaitIdleAsync();
             var refMan = server.ResolveDependency<IReflectionManager>();
@@ -55,14 +56,12 @@ namespace Content.IntegrationTests.Tests.DoAfter
                     }
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestFinished()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             await server.WaitIdleAsync();
 
@@ -84,14 +83,12 @@ namespace Content.IntegrationTests.Tests.DoAfter
 
             await server.WaitRunTicks(1);
             Assert.That(ev.Cancelled, Is.False);
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestCancelled()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var entityManager = server.EntMan;
             var timing = server.ResolveDependency<IGameTiming>();
@@ -113,8 +110,6 @@ namespace Content.IntegrationTests.Tests.DoAfter
 
             await server.WaitRunTicks(3);
             Assert.That(ev.Cancelled);
-
-            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -124,7 +119,7 @@ namespace Content.IntegrationTests.Tests.DoAfter
         [Test]
         public async Task TestGetInteractingEntities()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var entityManager = server.EntMan;
             var timing = server.ResolveDependency<IGameTiming>();
@@ -175,8 +170,6 @@ namespace Content.IntegrationTests.Tests.DoAfter
                 entityManager.DeleteEntity(target);
                 entityManager.DeleteEntity(target2);
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
+++ b/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Doors.Systems;
 using Content.Shared.Doors.Components;
 using Robust.Shared.GameObjects;
@@ -11,7 +12,7 @@ namespace Content.IntegrationTests.Tests.Doors
 {
     [TestFixture]
     [TestOf(typeof(AirlockComponent))]
-    public sealed class AirlockTest
+    public sealed class AirlockTest : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -54,7 +55,7 @@ namespace Content.IntegrationTests.Tests.Doors
         [Test]
         public async Task OpenCloseDestroyTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -104,16 +105,12 @@ namespace Content.IntegrationTests.Tests.Doors
                     entityManager.DeleteEntity(airlock);
                 });
             });
-
-            server.RunTicks(5);
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task AirlockBlockTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             await server.WaitIdleAsync();
@@ -179,7 +176,6 @@ namespace Content.IntegrationTests.Tests.Doors
             {
                 Assert.That(Math.Abs(xformSystem.GetWorldPosition(airlockPhysicsDummy).X - 1), Is.GreaterThan(0.01f));
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/DummyIconTest.cs
+++ b/Content.IntegrationTests/Tests/DummyIconTest.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Robust.Client.GameObjects;
 using Robust.Client.ResourceManagement;
 using Robust.Shared.Prototypes;
@@ -7,12 +8,12 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
-    public sealed class DummyIconTest
+    public sealed class DummyIconTest : GameTest
     {
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var pair = Pair;
             var client = pair.Client;
             var prototypeManager = client.ResolveDependency<IPrototypeManager>();
             var resourceCache = client.ResolveDependency<IResourceCache>();
@@ -32,7 +33,6 @@ namespace Content.IntegrationTests.Tests
                         proto.ID);
                 }
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -23,6 +23,7 @@ namespace Content.IntegrationTests.Tests
 
         public override PoolSettings PoolSettings => new()
         {
+            Connected = true,
             Dirty = true
         };
 
@@ -177,7 +178,7 @@ namespace Content.IntegrationTests.Tests
                 }
             });
 
-            await pair.RunTicksSync(15);
+            await pair.RunUntilSynced();
 
             // Make sure the client actually received the entities
             // 500 is completely arbitrary. Note that the client & sever entity counts aren't expected to match.

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Text;
+using Content.IntegrationTests.Fixtures;
 using Robust.Shared;
 using Robust.Shared.Audio.Components;
 using Robust.Shared.Configuration;
@@ -16,17 +17,21 @@ namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
     [TestOf(typeof(EntityUid))]
-    public sealed class EntityTest
+    public sealed class EntityTest : GameTest
     {
         private static readonly ProtoId<EntityCategoryPrototype> SpawnerCategory = "Spawner";
+
+        public override PoolSettings PoolSettings => new()
+        {
+            Dirty = true
+        };
 
         [Test]
         public async Task SpawnAndDeleteAllEntitiesOnDifferentMaps()
         {
             // This test dirties the pair as it simply deletes ALL entities when done. Overhead of restarting the round
             // is minimal relative to the rest of the test.
-            var settings = new PoolSettings { Dirty = true };
-            await using var pair = await PoolManager.GetServerClient(settings);
+            var pair = Pair;
             var server = pair.Server;
 
             var entityMan = server.ResolveDependency<IEntityManager>();
@@ -79,17 +84,12 @@ namespace Content.IntegrationTests.Tests
 
                 Assert.That(entityMan.EntityCount, Is.Zero);
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task SpawnAndDeleteAllEntitiesInTheSameSpot()
         {
-            // This test dirties the pair as it simply deletes ALL entities when done. Overhead of restarting the round
-            // is minimal relative to the rest of the test.
-            var settings = new PoolSettings { Dirty = true };
-            await using var pair = await PoolManager.GetServerClient(settings);
+            var pair = Pair;
             var server = pair.Server;
             var map = await pair.CreateTestMap();
 
@@ -134,8 +134,6 @@ namespace Content.IntegrationTests.Tests
 
                 Assert.That(entityMan.EntityCount, Is.Zero);
             });
-
-            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -145,10 +143,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task SpawnAndDirtyAllEntities()
         {
-            // This test dirties the pair as it simply deletes ALL entities when done. Overhead of restarting the round
-            // is minimal relative to the rest of the test.
-            var settings = new PoolSettings { Connected = true, Dirty = true };
-            await using var pair = await PoolManager.GetServerClient(settings);
+            var pair = Pair;
             var server = pair.Server;
             var client = pair.Client;
 
@@ -209,8 +204,6 @@ namespace Content.IntegrationTests.Tests
 
                 Assert.That(sEntMan.EntityCount, Is.Zero);
             });
-
-            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -230,8 +223,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task SpawnAndDeleteEntityCountTest()
         {
-            var settings = new PoolSettings { Connected = true, Dirty = true };
-            await using var pair = await PoolManager.GetServerClient(settings);
+            var pair = Pair;
             var mapSys = pair.Server.System<SharedMapSystem>();
             var server = pair.Server;
             var client = pair.Client;
@@ -317,8 +309,6 @@ namespace Content.IntegrationTests.Tests
                         BuildDiffString(clientEntities, Entities(client.EntMan), client.EntMan));
                 }
             });
-
-            await pair.CleanReturnAsync();
         }
 
         private static string BuildDiffString(IEnumerable<EntityUid> oldEnts, IEnumerable<EntityUid> newEnts, IEntityManager entMan)
@@ -392,7 +382,7 @@ namespace Content.IntegrationTests.Tests
                 "ActivatableUI", // Requires enum key
             };
 
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var entityManager = server.ResolveDependency<IEntityManager>();
             var componentFactory = server.ResolveDependency<IComponentFactory>();
@@ -445,8 +435,6 @@ namespace Content.IntegrationTests.Tests
                     }
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Numerics;
 using System.Text;
 using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Robust.Shared;
 using Robust.Shared.Audio.Components;
 using Robust.Shared.Configuration;
@@ -27,7 +28,13 @@ namespace Content.IntegrationTests.Tests
             Dirty = true
         };
 
+        public static PoolSettings Disconnected => new()
+        {
+            Dirty = true,
+        };
+
         [Test]
+        [PairConfig(nameof(Disconnected))]
         public async Task SpawnAndDeleteAllEntitiesOnDifferentMaps()
         {
             // This test dirties the pair as it simply deletes ALL entities when done. Overhead of restarting the round
@@ -88,9 +95,11 @@ namespace Content.IntegrationTests.Tests
         }
 
         [Test]
+        [PairConfig(nameof(Disconnected))]
         public async Task SpawnAndDeleteAllEntitiesInTheSameSpot()
         {
             var pair = Pair;
+            Assert.That(pair.Client.Session, Is.Null);
             var server = pair.Server;
             var map = await pair.CreateTestMap();
 

--- a/Content.IntegrationTests/Tests/Explosion/ExplosionPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Explosion/ExplosionPrototypeTest.cs
@@ -1,9 +1,10 @@
+using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Utility;
 using Content.Shared.Explosion;
 
 namespace Content.IntegrationTests.Tests.Explosion;
 
-public sealed class ExplosionPrototypeTest
+public sealed class ExplosionPrototypeTest : GameTest
 {
     private static string[] _explosionKinds = GameDataScrounger.PrototypesOfKind<ExplosionPrototype>();
 
@@ -13,7 +14,7 @@ public sealed class ExplosionPrototypeTest
     [Description("Ensures various properties of ExplosionPrototype are correctly configured.")]
     public async Task Validate(string protoKey)
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var protoMan = server.ProtoMan;
 
@@ -40,7 +41,5 @@ public sealed class ExplosionPrototypeTest
             Assert.That(proto.IntensityPerState, Is.Positive);
             Assert.That(proto.FireStates, Is.Positive);
         }
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/FillLevelSpriteTest.cs
+++ b/Content.IntegrationTests/Tests/FillLevelSpriteTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Prototypes;
@@ -12,7 +13,7 @@ namespace Content.IntegrationTests.Tests;
 /// Tests to see if any entity prototypes specify solution fill level sprites that don't exist.
 /// </summary>
 [TestFixture]
-public sealed class FillLevelSpriteTest
+public sealed class FillLevelSpriteTest : GameTest
 {
     private static readonly string[] HandStateNames = ["left", "right"];
     private static readonly string[] EquipStateNames = ["back", "suitstorage"];
@@ -20,7 +21,7 @@ public sealed class FillLevelSpriteTest
     [Test]
     public async Task FillLevelSpritesExist()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        var pair = Pair;
         var client = pair.Client;
         var protoMan = client.ResolveDependency<IPrototypeManager>();
         var componentFactory = client.ResolveDependency<IComponentFactory>();
@@ -101,7 +102,5 @@ public sealed class FillLevelSpriteTest
                 }
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Fluids/AbsorbentTest.cs
+++ b/Content.IntegrationTests/Tests/Fluids/AbsorbentTest.cs
@@ -7,12 +7,13 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 
 namespace Content.IntegrationTests.Tests.Fluids;
 
 [TestFixture]
 [TestOf(typeof(AbsorbentComponent))]
-public sealed class AbsorbentTest
+public sealed class AbsorbentTest : GameTest
 {
     private const string UserDummyId = "UserDummy";
     private const string AbsorbentDummyId = "AbsorbentDummy";
@@ -73,7 +74,7 @@ public sealed class AbsorbentTest
     [TestCaseSource(nameof(TestCasesToRun))]
     public async Task AbsorbentOnRefillableTest(TestSolutionCase testCase)
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var testMap = await pair.CreateTestMap();
@@ -123,15 +124,12 @@ public sealed class AbsorbentTest
                 Assert.That(VolumeOfPrototypeInComposition(refillableComposition, NonEvaporablePrototypeId), Is.EqualTo(testCase.ExpectedRefillableSolution.VolumeOfNonEvaporable));
             });
         });
-        await pair.RunTicksSync(5);
-
-        await pair.CleanReturnAsync();
     }
 
     [TestCaseSource(nameof(TestCasesToRunOnSmallRefillable))]
     public async Task AbsorbentOnSmallRefillableTest(TestSolutionCase testCase)
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var testMap = await pair.CreateTestMap();
@@ -180,9 +178,6 @@ public sealed class AbsorbentTest
                 Assert.That(VolumeOfPrototypeInComposition(refillableComposition, NonEvaporablePrototypeId), Is.EqualTo(testCase.ExpectedRefillableSolution.VolumeOfNonEvaporable));
             });
         });
-        await pair.RunTicksSync(5);
-
-        await pair.CleanReturnAsync();
     }
 
     private static FixedPoint2 VolumeOfPrototypeInComposition(Dictionary<string, FixedPoint2> composition, string prototypeId)

--- a/Content.IntegrationTests/Tests/Fluids/FluidSpillTest.cs
+++ b/Content.IntegrationTests/Tests/Fluids/FluidSpillTest.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Fluids.EntitySystems;
 using Content.Server.Spreader;
 using Content.Shared.Chemistry.Components;
@@ -14,7 +15,7 @@ namespace Content.IntegrationTests.Tests.Fluids;
 
 [TestFixture]
 [TestOf(typeof(SpreaderSystem))]
-public sealed class FluidSpill
+public sealed class FluidSpill : GameTest
 {
     private static PuddleComponent? GetPuddle(IEntityManager entityManager, Entity<MapGridComponent> mapGrid, Vector2i pos)
     {
@@ -36,7 +37,7 @@ public sealed class FluidSpill
     [Test]
     public async Task SpillCorner()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var mapManager = server.ResolveDependency<IMapManager>();
         var entityManager = server.ResolveDependency<IEntityManager>();
@@ -110,7 +111,5 @@ public sealed class FluidSpill
                 }
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
+++ b/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Fluids.EntitySystems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Coordinates;
@@ -10,12 +11,12 @@ namespace Content.IntegrationTests.Tests.Fluids
 {
     [TestFixture]
     [TestOf(typeof(PuddleComponent))]
-    public sealed class PuddleTest
+    public sealed class PuddleTest : GameTest
     {
         [Test]
         public async Task TilePuddleTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var testMap = await pair.CreateTestMap();
@@ -32,15 +33,12 @@ namespace Content.IntegrationTests.Tests.Fluids
 
                 Assert.That(spillSystem.TrySpillAt(coordinates, solution, out _), Is.True);
             });
-            await pair.RunTicksSync(5);
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task SpaceNoPuddleTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var testMap = await pair.CreateTestMap();
@@ -69,8 +67,6 @@ namespace Content.IntegrationTests.Tests.Fluids
 
                 Assert.That(spillSystem.TrySpillAt(coordinates, solution, out _), Is.False);
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/FollowerSystemTest.cs
+++ b/Content.IntegrationTests/Tests/FollowerSystemTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.GameTicking;
 using Content.Shared.Follower;
 using Robust.Shared.GameObjects;
@@ -7,7 +8,7 @@ using Robust.Shared.Map;
 namespace Content.IntegrationTests.Tests;
 
 [TestFixture, TestOf(typeof(FollowerSystem))]
-public sealed class FollowerSystemTest
+public sealed class FollowerSystemTest : GameTest
 {
     /// <summary>
     ///     This test ensures that deleting a map while an entity follows another doesn't throw any exceptions.
@@ -15,7 +16,7 @@ public sealed class FollowerSystemTest
     [Test]
     public async Task FollowerMapDeleteTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
@@ -44,6 +45,5 @@ public sealed class FollowerSystemTest
 
             entMan.DeleteEntity(mapSys.GetMap(map));
         });
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/GameObjects/Components/ActionBlocking/HandCuffTest.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/ActionBlocking/HandCuffTest.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Cuffs;
 using Content.Shared.Cuffs.Components;
 using Content.Shared.Hands.Components;
@@ -10,7 +11,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.ActionBlocking
     [TestFixture]
     [TestOf(typeof(CuffableComponent))]
     [TestOf(typeof(HandcuffComponent))]
-    public sealed class HandCuffTest
+    public sealed class HandCuffTest : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -40,7 +41,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.ActionBlocking
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             EntityUid human;
@@ -98,8 +99,6 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.ActionBlocking
                 cuffableSys.TryAddNewCuffs(human, human, secondCuffs, cuffed);
                 Assert.That(cuffed.CuffedHandCount, Is.EqualTo(4), "Player doesn't have correct amount of hands cuffed");
             });
-
-            await pair.CleanReturnAsync();
         }
 
         private static void AddHand(NetEntity to, IServerConsoleHost host)

--- a/Content.IntegrationTests/Tests/GameObjects/Components/EntityPrototypeComponentsTest.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/EntityPrototypeComponentsTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Content.IntegrationTests.Fixtures;
 using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Utility;
@@ -11,12 +12,12 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components
 {
     [TestFixture]
     [TestOf(typeof(Server.Entry.IgnoredComponents))]
-    public sealed class EntityPrototypeComponentsTest
+    public sealed class EntityPrototypeComponentsTest : GameTest
     {
         [Test]
         public async Task PrototypesHaveKnownComponents()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var client = pair.Client;
 
@@ -100,7 +101,6 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components
 
             if (unknownComponentsClient.Count + unknownComponentsServer.Count + doubleIgnoredComponents.Count == 0)
             {
-                await pair.CleanReturnAsync();
                 Assert.Pass($"Validated {entitiesValidated} entities with {componentsValidated} components in {paths.Length} files.");
                 return;
             }
@@ -131,11 +131,11 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components
         [Test]
         public async Task IgnoredComponentsExistInTheCorrectPlaces()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var client = pair.Client;
             var serverComponents = server.ResolveDependency<IComponentFactory>();
-            var ignoredServerNames = Server.Entry.IgnoredComponents.List;
+            var ignoredServerNames = Content.Server.Entry.IgnoredComponents.List;
             var clientComponents = client.ResolveDependency<IComponentFactory>();
 
             var failureMessages = "";
@@ -151,7 +151,6 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components
                 }
             }
             Assert.That(failureMessages, Is.Empty);
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/GameObjects/Components/Mobs/AlertsComponentTests.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/Mobs/AlertsComponentTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Client.UserInterface.Systems.Alerts.Controls;
 using Content.Client.UserInterface.Systems.Alerts.Widgets;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Alert;
 using Robust.Client.UserInterface;
 using Robust.Server.Player;
@@ -10,16 +11,18 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
 {
     [TestFixture]
     [TestOf(typeof(AlertsComponent))]
-    public sealed class AlertsComponentTests
+    public sealed class AlertsComponentTests : GameTest
     {
+        public override PoolSettings PoolSettings => new()
+        {
+            Connected = true,
+            DummyTicker = false
+        };
+
         [Test]
         public async Task AlertsTest()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings
-            {
-                Connected = true,
-                DummyTicker = false
-            });
+            var pair = Pair;
             var server = pair.Server;
             var client = pair.Client;
 
@@ -107,8 +110,6 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
                 var expectedIDs = new[] { "HumanHealth", "Debug2" };
                 Assert.That(alertIDs, Is.SupersetOf(expectedIDs));
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/GameRules/AntagPreferenceTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/AntagPreferenceTest.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Antag;
 using Content.Server.Antag.Components;
 using Content.Server.GameTicking;
@@ -14,17 +15,19 @@ namespace Content.IntegrationTests.Tests.GameRules;
 // Once upon a time, players in the lobby weren't ever considered eligible for antag roles.
 // Lets not let that happen again.
 [TestFixture]
-public sealed class AntagPreferenceTest
+public sealed class AntagPreferenceTest : GameTest
 {
+    public override PoolSettings PoolSettings => new PoolSettings
+    {
+        DummyTicker = false,
+        Connected = true,
+        InLobby = true
+    };
+
     [Test]
     public async Task TestLobbyPlayersValid()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true
-        });
+        var pair = Pair;
 
         var server = pair.Server;
         var client = pair.Client;
@@ -71,6 +74,5 @@ public sealed class AntagPreferenceTest
         Assert.That(pool.Count, Is.EqualTo(0));
 
         await server.WaitPost(() => server.EntMan.DeleteEntity(uid));
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/GameRules/FailAndStartPresetTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/FailAndStartPresetTest.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Content.IntegrationTests.Fixtures;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Presets;
 using Content.Shared.CCVar;
@@ -9,7 +10,7 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests.GameRules;
 
 [TestFixture]
-public sealed class FailAndStartPresetTest
+public sealed class FailAndStartPresetTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -52,19 +53,21 @@ public sealed class FailAndStartPresetTest
   - type: TestRule
 ";
 
+    public override PoolSettings PoolSettings => new()
+    {
+        Dirty = true,
+        DummyTicker = false,
+        Connected = true,
+        InLobby = true
+    };
+
     /// <summary>
     ///     Test that a nuke ops gamemode can start after failing to start once.
     /// </summary>
     [Test]
     public async Task FailAndStartTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Dirty = true,
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true
-        });
+        var pair = Pair;
 
         var server = pair.Server;
         var client = pair.Client;
@@ -115,7 +118,6 @@ public sealed class FailAndStartPresetTest
         server.CfgMan.SetCVar(CCVars.GameLobbyFallbackEnabled, true);
         server.CfgMan.SetCVar(CCVars.GameLobbyDefaultPreset, "secret");
         server.System<TestRuleSystem>().Run = false;
-        await pair.CleanReturnAsync();
     }
 }
 

--- a/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Body.Components;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Presets;
@@ -30,10 +31,19 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.GameRules;
 
 [TestFixture]
-public sealed class NukeOpsTest
+public sealed class NukeOpsTest : GameTest
 {
     private static readonly ProtoId<NpcFactionPrototype> SyndicateFaction = "Syndicate";
     private static readonly ProtoId<NpcFactionPrototype> NanotrasenFaction = "NanoTrasen";
+
+    public override PoolSettings PoolSettings => new()
+    {
+        Dirty = true,
+        DummyTicker = false,
+        Connected = true,
+        InLobby = true
+    };
+
 
     /// <summary>
     /// Check that a nuke ops game mode can start without issue. I.e., that the nuke station and such all get loaded.
@@ -41,13 +51,7 @@ public sealed class NukeOpsTest
     [Test]
     public async Task TryStopNukeOpsFromConstantlyFailing()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Dirty = true,
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true
-        });
+        var pair = Pair;
 
         var server = pair.Server;
         var client = pair.Client;
@@ -260,6 +264,5 @@ public sealed class NukeOpsTest
         });
 
         ticker.SetGamePreset((GamePresetPrototype?) null);
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/GameRules/RuleMaxTimeRestartTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/RuleMaxTimeRestartTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
 using Content.Server.GameTicking.Rules.Components;
@@ -9,12 +10,14 @@ namespace Content.IntegrationTests.Tests.GameRules
 {
     [TestFixture]
     [TestOf(typeof(MaxTimeRestartRuleSystem))]
-    public sealed class RuleMaxTimeRestartTest
+    public sealed class RuleMaxTimeRestartTest : GameTest
     {
+        public override PoolSettings PoolSettings => new() { InLobby = true };
+
         [Test]
         public async Task RestartTest()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
+            var pair = Pair;
             var server = pair.Server;
 
             Assert.That(server.EntMan.Count<GameRuleComponent>(), Is.Zero);
@@ -64,8 +67,6 @@ namespace Content.IntegrationTests.Tests.GameRules
             {
                 Assert.That(sGameTicker.RunLevel, Is.EqualTo(GameRunLevel.PreRoundLobby));
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/GameRules/SecretStartsTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/SecretStartsTest.cs
@@ -1,19 +1,22 @@
 ﻿using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.GameTicking;
 using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.GameRules;
 
 [TestFixture]
-public sealed class SecretStartsTest
+public sealed class SecretStartsTest : GameTest
 {
+    public override PoolSettings PoolSettings => new PoolSettings { Dirty = true };
+
     /// <summary>
     ///     Tests that when secret is started, all of the game rules it successfully adds are also started.
     /// </summary>
     [Test]
     public async Task TestSecretStarts()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Dirty = true });
+        var pair = Pair;
 
         var server = pair.Server;
         await server.WaitIdleAsync();
@@ -38,7 +41,5 @@ public sealed class SecretStartsTest
             // End all rules
             gameTicker.ClearGameRules();
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/GameRules/StartEndGameRulesTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/StartEndGameRulesTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.GameTicking;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
@@ -7,19 +8,21 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests.GameRules;
 
 [TestFixture]
-public sealed class StartEndGameRulesTest
+public sealed class StartEndGameRulesTest : GameTest
 {
+    public override PoolSettings PoolSettings => new PoolSettings
+    {
+        Dirty = true,
+        DummyTicker = false
+    };
+
     /// <summary>
     ///     Tests that all game rules can be added/started/ended at the same time without exceptions.
     /// </summary>
     [Test]
     public async Task TestAllConcurrent()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Dirty = true,
-            DummyTicker = false
-        });
+        var pair = Pair;
         var server = pair.Server;
         await server.WaitIdleAsync();
         var gameTicker = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<GameTicker>();
@@ -47,7 +50,5 @@ public sealed class StartEndGameRulesTest
             gameTicker.ClearGameRules();
             Assert.That(!gameTicker.GetAddedGameRules().Any());
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/GameRules/TraitorRuleTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/TraitorRuleTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Antag.Components;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
@@ -17,23 +18,25 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.GameRules;
 
 [TestFixture]
-public sealed class TraitorRuleTest
+public sealed class TraitorRuleTest : GameTest
 {
     private const string TraitorGameRuleProtoId = "Traitor";
     private const string TraitorAntagRoleName = "Traitor";
     private static readonly ProtoId<NpcFactionPrototype> SyndicateFaction = "Syndicate";
     private static readonly ProtoId<NpcFactionPrototype> NanotrasenFaction = "NanoTrasen";
 
+    public override PoolSettings PoolSettings => new()
+    {
+        Dirty = true,
+        DummyTicker = false,
+        Connected = true,
+        InLobby = true,
+    };
+
     [Test]
     public async Task TestTraitorObjectives()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings()
-        {
-            Dirty = true,
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true,
-        });
+        var pair = Pair;
         var server = pair.Server;
         var client = pair.Client;
         var entMan = server.EntMan;
@@ -123,9 +126,6 @@ public sealed class TraitorRuleTest
             $"MaxDifficulty exceeded! Objectives: {string.Join(", ", mindComp.Objectives.Select(o => FormatObjective(o, entMan)))}");
         Assert.That(mindComp.Objectives, Is.Not.Empty,
             $"No objectives assigned!");
-
-
-        await pair.CleanReturnAsync();
     }
 
     private static string FormatObjective(Entity<ObjectiveComponent> entity, IEntityManager entMan)

--- a/Content.IntegrationTests/Tests/Gibbing/GibTest.cs
+++ b/Content.IntegrationTests/Tests/Gibbing/GibTest.cs
@@ -1,16 +1,17 @@
 ﻿#nullable enable
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Gibbing;
 using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.Body;
 
 [TestFixture]
-public sealed class GibTest
+public sealed class GibTest : GameTest
 {
     [Test]
     public async Task TestGib()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        var pair = Pair;
         var (server, client) = (pair.Server, pair.Client);
         var map = await pair.CreateTestMap();
 
@@ -30,7 +31,5 @@ public sealed class GibTest
         await pair.RunTicksSync(5);
 
         Assert.That(!client.EntMan.EntityExists(nuid));
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Gravity/WeightlessStatusTests.cs
+++ b/Content.IntegrationTests/Tests/Gravity/WeightlessStatusTests.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Gravity;
 using Content.Shared.Alert;
 using Content.Shared.Gravity;
@@ -8,7 +9,7 @@ namespace Content.IntegrationTests.Tests.Gravity
     [TestFixture]
     [TestOf(typeof(GravitySystem))]
     [TestOf(typeof(GravityGeneratorComponent))]
-    public sealed class WeightlessStatusTests
+    public sealed class WeightlessStatusTests : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -38,7 +39,7 @@ namespace Content.IntegrationTests.Tests.Gravity
         [Test]
         public async Task WeightlessStatusTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -86,8 +87,6 @@ namespace Content.IntegrationTests.Tests.Gravity
             });
 
             await pair.RunTicksSync(10);
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/GravityGridTest.cs
+++ b/Content.IntegrationTests/Tests/GravityGridTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Power.Components;
 using Content.Shared.Gravity;
 using Robust.Shared.GameObjects;
@@ -11,7 +12,7 @@ namespace Content.IntegrationTests.Tests
     /// making sure that gravity is applied to the correct grids.
     [TestFixture]
     [TestOf(typeof(GravityGeneratorComponent))]
-    public sealed class GravityGridTest
+    public sealed class GravityGridTest : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -31,7 +32,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var testMap = await pair.CreateTestMap();
@@ -96,8 +97,6 @@ namespace Content.IntegrationTests.Tests
                     Assert.That(entityMan.GetComponent<GravityComponent>(grid2).Enabled, Is.False);
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Guidebook/DocumentParsingTest.cs
+++ b/Content.IntegrationTests/Tests/Guidebook/DocumentParsingTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Content.Client.Guidebook;
 using Content.Client.Guidebook.Richtext;
+using Content.IntegrationTests.Fixtures;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
@@ -13,7 +14,7 @@ namespace Content.IntegrationTests.Tests.Guidebook;
 /// </summary>
 [TestFixture]
 [TestOf(typeof(DocumentParsingManager))]
-public sealed class DocumentParsingTest
+public sealed class DocumentParsingTest : GameTest
 {
 
     public string TestDocument = @"multiple
@@ -45,7 +46,7 @@ whitespace before newlines are ignored.
     [Test]
     public async Task ParseTestDocument()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var client = pair.Client;
         await client.WaitIdleAsync();
         var parser = client.ResolveDependency<DocumentParsingManager>();
@@ -133,8 +134,6 @@ whitespace before newlines are ignored.
 
         subTest2.Params.TryGetValue("k", out val);
         Assert.That(val, Is.EqualTo(@"<>\>=""=<-_?*3.0//"));
-
-        await pair.CleanReturnAsync();
     }
 
     public sealed class TestControl : Control, IDocumentTag

--- a/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
+++ b/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
@@ -1,5 +1,6 @@
 using Content.Client.Guidebook;
 using Content.Client.Guidebook.Richtext;
+using Content.IntegrationTests.Fixtures;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Prototypes;
 using Content.IntegrationTests.Utility;
@@ -12,7 +13,7 @@ namespace Content.IntegrationTests.Tests.Guidebook;
 [TestOf(typeof(GuidebookSystem))]
 [TestOf(typeof(GuideEntryPrototype))]
 [TestOf(typeof(DocumentParsingManager))]
-public sealed class GuideEntryPrototypeTests
+public sealed class GuideEntryPrototypeTests : GameTest
 {
     private static string[] _guideEntries = GameDataScrounger.PrototypesOfKind<GuideEntryPrototype>();
 
@@ -21,7 +22,7 @@ public sealed class GuideEntryPrototypeTests
     [Description("Ensures a given guidebook entry is valid, checking the document/etc.")]
     public async Task Validate(string protoKey)
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        var pair = Pair;
         var client = pair.Client;
         await client.WaitIdleAsync();
         var protoMan = client.ResolveDependency<IPrototypeManager>();
@@ -36,7 +37,5 @@ public sealed class GuideEntryPrototypeTests
 
             Assert.That(parser.TryAddMarkup(new Document(), text), $"Failed to parse the guide entry's document.");
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Hands/HandTests.cs
+++ b/Content.IntegrationTests/Tests/Hands/HandTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Storage.EntitySystems;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
@@ -10,7 +11,7 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests.Hands;
 
 [TestFixture]
-public sealed class HandTests
+public sealed class HandTests : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -25,14 +26,16 @@ public sealed class HandTests
 ";
 
 
+    public override PoolSettings PoolSettings => new()
+    {
+        Connected = true,
+        DummyTicker = false
+    };
+
     [Test]
     public async Task TestPickupDrop()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Connected = true,
-            DummyTicker = false
-        });
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
@@ -69,17 +72,12 @@ public sealed class HandTests
         Assert.That(sys.GetActiveItem((player, hands)), Is.Null);
 
         await server.WaitPost(() => mapSystem.DeleteMap(data.MapId));
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestPickUpThenDropInContainer()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Connected = true,
-            DummyTicker = false
-        });
+        var pair = Pair;
         var server = pair.Server;
         var map = await pair.CreateTestMap();
         await pair.RunTicksSync(5);
@@ -134,6 +132,5 @@ public sealed class HandTests
         Assert.That(containerSystem.IsInSameOrNoContainer((player, xform), (item, itemXform)));
 
         await server.WaitPost(() => mapSystem.DeleteMap(map.MapId));
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
+++ b/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Inventory;
 using Robust.Shared.GameObjects;
 
@@ -7,7 +8,7 @@ namespace Content.IntegrationTests.Tests
     // i.e. the interaction between uniforms and the pocket/ID slots.
     // and also how big items don't fit in pockets.
     [TestFixture]
-    public sealed class HumanInventoryUniformSlotsTest
+    public sealed class HumanInventoryUniformSlotsTest : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -55,7 +56,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var testMap = await pair.CreateTestMap();
             var coordinates = testMap.GridCoords;
@@ -130,8 +131,6 @@ namespace Content.IntegrationTests.Tests
 
                 mapSystem.DeleteMap(testMap.MapId);
             });
-
-            await pair.CleanReturnAsync();
         }
 
         private static bool IsDescendant(EntityUid descendant, EntityUid parent, IEntityManager entManager)

--- a/Content.IntegrationTests/Tests/Humanoid/HideablePrototypeValidation.cs
+++ b/Content.IntegrationTests/Tests/Humanoid/HideablePrototypeValidation.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Body;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Humanoid;
@@ -8,13 +9,12 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Humanoid;
 
 [TestFixture]
-public sealed class HideablePrototypeValidation
+public sealed class HideablePrototypeValidation : GameTest
 {
     [Test]
     public async Task NoOrgansWithoutClothing()
     {
-        await using var pair = await PoolManager.GetServerClient();
-
+        var pair = Pair;
         var requirements = new Dictionary<Enum, HashSet<EntProtoId>>();
         foreach (var (proto, component) in pair.GetPrototypesWithComponent<VisualOrganMarkingsComponent>())
         {
@@ -42,14 +42,12 @@ public sealed class HideablePrototypeValidation
         {
             Assert.That(provided, Does.Contain(key), $"No clothing will hide {key} that can be hidden on {string.Join(", ", requirement.Select(it => it.Id))}");
         }
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task NoClothingWithoutOrgans()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
 
         var requirements = new Dictionary<Enum, HashSet<EntProtoId>>();
         foreach (var (proto, component) in pair.GetPrototypesWithComponent<HideLayerClothingComponent>())
@@ -74,7 +72,5 @@ public sealed class HideablePrototypeValidation
         {
             Assert.That(provided, Does.Contain(key), $"No organ will hide {key} that can be hidden by {string.Join(", ", requirement.Select(it => it.Id))}");
         }
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Humanoid/HumanoidProfileTests.cs
+++ b/Content.IntegrationTests/Tests/Humanoid/HumanoidProfileTests.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Preferences;
@@ -10,14 +11,14 @@ namespace Content.IntegrationTests.Tests.Humanoid;
 
 [TestFixture]
 [TestOf(typeof(HumanoidProfileSystem))]
-public sealed class HumanoidProfileTests
+public sealed class HumanoidProfileTests : GameTest
 {
     private static readonly ProtoId<SpeciesPrototype> Vox = "Vox";
 
     [Test]
     public async Task EnsureValidLoading()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         await server.WaitIdleAsync();
@@ -43,7 +44,5 @@ public sealed class HumanoidProfileTests
             Assert.That(voiceComponent.Sounds, Is.Not.Null, message: "the MobHuman spawned by this test needs to have sex-specific sound set");
             Assert.That(voiceComponent.Sounds![Sex.Female], Is.EqualTo(voiceComponent.EmoteSounds));
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
+++ b/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
@@ -1,5 +1,6 @@
 #nullable enable annotations
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Interaction;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
@@ -16,7 +17,7 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
 {
     [TestFixture]
     [TestOf(typeof(InteractionSystem))]
-    public sealed class InteractionSystemTests
+    public sealed class InteractionSystemTests : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -40,7 +41,7 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
         [Test]
         public async Task InteractionTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
@@ -101,13 +102,12 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             });
 
             testInteractionSystem.ClearHandlers();
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task InteractionObstructionTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
@@ -168,13 +168,12 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             });
 
             testInteractionSystem.ClearHandlers();
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task InteractionInRangeTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
@@ -234,14 +233,13 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             });
 
             testInteractionSystem.ClearHandlers();
-            await pair.CleanReturnAsync();
         }
 
 
         [Test]
         public async Task InteractionOutOfRangeTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
@@ -300,13 +298,12 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             });
 
             testInteractionSystem.ClearHandlers();
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task InsideContainerInteractionBlockTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
@@ -388,7 +385,6 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             });
 
             testInteractionSystem.ClearHandlers();
-            await pair.CleanReturnAsync();
         }
 
         public sealed class TestInteractionSystem : EntitySystem

--- a/Content.IntegrationTests/Tests/Interaction/InRangeUnobstructed.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InRangeUnobstructed.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Interaction;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
@@ -10,7 +11,7 @@ namespace Content.IntegrationTests.Tests.Interaction
 {
     [TestFixture]
     [TestOf(typeof(SharedInteractionSystem))]
-    public sealed class InRangeUnobstructed
+    public sealed class InRangeUnobstructed : GameTest
     {
         private const string HumanId = "MobHuman";
 
@@ -27,7 +28,7 @@ namespace Content.IntegrationTests.Tests.Interaction
         [Test]
         public async Task EntityEntityTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
@@ -109,8 +110,6 @@ namespace Content.IntegrationTests.Tests.Interaction
                     Assert.That(interactionSys.InRangeUnobstructed(mapCoordinates, origin, InteractionRangeDivided15Times3));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
@@ -175,7 +175,7 @@ public abstract partial class InteractionTest
     [SetUp]
     public virtual async Task Setup()
     {
-        Pair = await PoolManager.GetServerClient(Settings);
+        Pair = await PoolManager.GetServerClient(Settings, new NUnitTestContextWrap(TestContext.CurrentContext, TestContext.Out));
 
         // server dependencies
         SEntMan = Server.ResolveDependency<IEntityManager>();

--- a/Content.IntegrationTests/Tests/Internals/AutoInternalsTests.cs
+++ b/Content.IntegrationTests/Tests/Internals/AutoInternalsTests.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Systems;
 using Content.Server.Station.Systems;
@@ -7,12 +8,12 @@ namespace Content.IntegrationTests.Tests.Internals;
 
 [TestFixture]
 [TestOf(typeof(InternalsSystem))]
-public sealed class AutoInternalsTests
+public sealed class AutoInternalsTests : GameTest
 {
     [Test]
     public async Task TestInternalsAutoActivateInSpaceForStationSpawn()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var testMap = await pair.CreateTestMap();
@@ -31,14 +32,12 @@ public sealed class AutoInternalsTests
 
             server.EntMan.DeleteEntity(dummy);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestInternalsAutoActivateInSpaceForEntitySpawn()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var testMap = await pair.CreateTestMap();
@@ -55,8 +54,6 @@ public sealed class AutoInternalsTests
 
             server.EntMan.DeleteEntity(dummy);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [TestPrototypes]

--- a/Content.IntegrationTests/Tests/InventoryHelpersTest.cs
+++ b/Content.IntegrationTests/Tests/InventoryHelpersTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Stunnable;
 using Content.Shared.Inventory;
 using Robust.Shared.GameObjects;
@@ -7,7 +8,7 @@ using Robust.Shared.Map;
 namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
-    public sealed class InventoryHelpersTest
+    public sealed class InventoryHelpersTest : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -39,7 +40,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task SpawnItemInSlotTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
@@ -87,8 +88,6 @@ namespace Content.IntegrationTests.Tests
 #pragma warning restore NUnit2045
                 sEntities.DeleteEntity(human);
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Lathe/LatheTest.cs
+++ b/Content.IntegrationTests/Tests/Lathe/LatheTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Lathe;
 using Content.Shared.Materials;
 using Content.Shared.Prototypes;
@@ -11,12 +12,12 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Lathe;
 
 [TestFixture]
-public sealed class LatheTest
+public sealed class LatheTest : GameTest
 {
     [Test]
     public async Task TestLatheRecipeIngredientsFitLathe()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var mapData = await pair.CreateTestMap();
@@ -111,14 +112,12 @@ public sealed class LatheTest
                 }
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task AllLatheRecipesValidTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
 
         var server = pair.Server;
         var proto = server.ProtoMan;
@@ -131,7 +130,5 @@ public sealed class LatheTest
                     Assert.That(recipe.ResultReagents, Is.Not.Null, $"Recipe '{recipe.ID}' has no result or result reagents.");
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Linter/StaticFieldValidationTest.cs
+++ b/Content.IntegrationTests/Tests/Linter/StaticFieldValidationTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Tag;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
@@ -11,12 +12,12 @@ namespace Content.IntegrationTests.Tests.Linter;
 /// Verify that the yaml linter successfully validates static fields
 /// </summary>
 [TestFixture]
-public sealed class StaticFieldValidationTest
+public sealed class StaticFieldValidationTest : GameTest
 {
     [Test]
     public async Task TestStaticFieldValidation()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var protoMan = pair.Server.ProtoMan;
 
         var protos = new Dictionary<Type, HashSet<string>>();
@@ -49,8 +50,6 @@ public sealed class StaticFieldValidationTest
         Assert.That(protoMan.ValidateStaticFields(typeof(ProtoIdListInvalid), protos), Has.Count.EqualTo(2));
         Assert.That(protoMan.ValidateStaticFields(typeof(ProtoIdSetInvalid), protos), Has.Count.EqualTo(2));
         Assert.That(protoMan.ValidateStaticFields(typeof(PrivateProtoIdArrayInvalid), protos), Has.Count.EqualTo(2));
-
-        await pair.CleanReturnAsync();
     }
 
     [TestPrototypes]

--- a/Content.IntegrationTests/Tests/Lobby/CharacterCreationTest.cs
+++ b/Content.IntegrationTests/Tests/Lobby/CharacterCreationTest.cs
@@ -1,4 +1,5 @@
 using Content.Client.Lobby;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Preferences.Managers;
 using Content.Shared.Humanoid;
 using Content.Shared.Preferences;
@@ -9,12 +10,14 @@ namespace Content.IntegrationTests.Tests.Lobby;
 [TestFixture]
 [TestOf(typeof(ClientPreferencesManager))]
 [TestOf(typeof(ServerPreferencesManager))]
-public sealed class CharacterCreationTest
+public sealed class CharacterCreationTest : GameTest
 {
+    public override PoolSettings PoolSettings => new() { InLobby = true };
+
     [Test]
     public async Task CreateDeleteCreateTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
+        var pair = Pair;
         var server = pair.Server;
         var client = pair.Client;
         var user = pair.Client.User!.Value;
@@ -72,7 +75,6 @@ public sealed class CharacterCreationTest
         serverCharacters = serverPrefManager.GetPreferences(user).Characters;
         Assert.That(serverCharacters, Has.Count.EqualTo(2));
         AssertEqual(serverCharacters[1], profile);
-        await pair.CleanReturnAsync();
     }
 
     private void AssertEqual(HumanoidCharacterProfile a, HumanoidCharacterProfile b)

--- a/Content.IntegrationTests/Tests/Lobby/ServerReloginTest.cs
+++ b/Content.IntegrationTests/Tests/Lobby/ServerReloginTest.cs
@@ -1,20 +1,23 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.CCVar;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
 namespace Content.IntegrationTests.Tests.Lobby;
 
-public sealed class ServerReloginTest
+public sealed class ServerReloginTest : GameTest
 {
+    public override PoolSettings PoolSettings => new PoolSettings
+    {
+        Connected = true,
+        DummyTicker = false
+    };
+
     [Test]
     public async Task Relogin()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Connected = true,
-            DummyTicker = false
-        });
+        var pair = Pair;
         var server = pair.Server;
         var client = pair.Client;
         var originalMaxPlayers = 0;
@@ -62,7 +65,5 @@ public sealed class ServerReloginTest
             //Put the cvar back, so other tests can still use this server
             serverConfig.SetCVar(CCVars.SoftMaxPlayers, originalMaxPlayers);
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Localization/EntityPrototypeLocalizationTest.cs
+++ b/Content.IntegrationTests/Tests/Localization/EntityPrototypeLocalizationTest.cs
@@ -1,9 +1,10 @@
+using Content.IntegrationTests.Fixtures;
 using Robust.Shared.Localization;
 using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.Localization;
 
-public sealed class EntityPrototypeLocalizationTest
+public sealed class EntityPrototypeLocalizationTest : GameTest
 {
     /// <summary>
     /// An explanation of why LocIds should not be used for entity prototype names/descriptions.
@@ -18,7 +19,7 @@ public sealed class EntityPrototypeLocalizationTest
     [Test]
     public async Task TestNoManualEntityLocStrings()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var protoMan = server.ProtoMan;
         var locMan = server.ResolveDependency<ILocalizationManager>();
@@ -44,7 +45,5 @@ public sealed class EntityPrototypeLocalizationTest
                 }
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Localization/LocalizedDatasetPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Localization/LocalizedDatasetPrototypeTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Dataset;
 using Robust.Shared.Localization;
 using Robust.Shared.Prototypes;
@@ -6,12 +7,12 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Localization;
 
 [TestFixture]
-public sealed class LocalizedDatasetPrototypeTest
+public sealed class LocalizedDatasetPrototypeTest : GameTest
 {
     [Test]
     public async Task ValidProtoIdsTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
 
         var server = pair.Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
@@ -36,7 +37,5 @@ public sealed class LocalizedDatasetPrototypeTest
                 Assert.That(localizationMan.HasString(nextId), Is.False, $"LocalizedDataset {proto.ID} with prefix \"{proto.Values.Prefix}\" specifies {proto.Values.Count} entries, but a localized string exists with ID {nextId}! Does count need to be raised?");
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/MachineBoardTest.cs
+++ b/Content.IntegrationTests/Tests/MachineBoardTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Construction.Components;
 using Content.Shared.Construction.Components;
 using Robust.Shared.GameObjects;
@@ -7,7 +8,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests;
 
-public sealed class MachineBoardTest
+public sealed class MachineBoardTest : GameTest
 {
     /// <summary>
     /// A list of machine boards that can be ignored by this test.
@@ -32,7 +33,7 @@ public sealed class MachineBoardTest
     [Test]
     public async Task TestMachineBoardHasValidMachine()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var protoMan = server.ResolveDependency<IPrototypeManager>();
@@ -60,8 +61,6 @@ public sealed class MachineBoardTest
                 });
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -71,7 +70,7 @@ public sealed class MachineBoardTest
     [Test]
     public async Task TestComputerBoardHasValidComputer()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var protoMan = server.ResolveDependency<IPrototypeManager>();
@@ -100,8 +99,6 @@ public sealed class MachineBoardTest
                 });
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -111,7 +108,7 @@ public sealed class MachineBoardTest
     [Test]
     public async Task TestValidateBoardComponentRequirements()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
@@ -136,7 +133,5 @@ public sealed class MachineBoardTest
                 });
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/MagazineVisualsSpriteTest.cs
+++ b/Content.IntegrationTests/Tests/MagazineVisualsSpriteTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Content.Client.Weapons.Ranged.Components;
+using Content.IntegrationTests.Fixtures;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 
@@ -9,12 +10,12 @@ namespace Content.IntegrationTests.Tests;
 /// Tests all entity prototypes with the MagazineVisualsComponent.
 /// </summary>
 [TestFixture]
-public sealed class MagazineVisualsSpriteTest
+public sealed class MagazineVisualsSpriteTest : GameTest
 {
     [Test]
     public async Task MagazineVisualsSpritesExist()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        var pair = Pair;
         var client = pair.Client;
         var toTest = new List<(int, string)>();
         var protos = pair.GetPrototypesWithComponent<MagazineVisualsComponent>();
@@ -67,7 +68,5 @@ public sealed class MagazineVisualsSpriteTest
                 }
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Mapping/MappingTests.cs
+++ b/Content.IntegrationTests/Tests/Mapping/MappingTests.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
@@ -5,15 +6,18 @@ using Robust.Shared.Map;
 namespace Content.IntegrationTests.Tests.Mapping;
 
 [TestFixture]
-public sealed class MappingTests
+public sealed class MappingTests : GameTest
 {
+    public override PoolSettings PoolSettings =>
+        new() { Dirty = true, Connected = true, DummyTicker = false };
+
     /// <summary>
     /// Checks that the mapping command creates paused & uninitialized maps.
     /// </summary>
     [Test]
     public async Task MappingTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Dirty = true, Connected = true, DummyTicker = false });
+        var pair = Pair;
 
         var server = pair.Server;
         var entMan = server.EntMan;
@@ -97,6 +101,5 @@ public sealed class MappingTests
         Assert.That(server.MetaData(ent).EntityPaused, Is.True);
 
         await server.WaitPost(() => entMan.DeleteEntity(map));
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/MappingEditorTest.cs
+++ b/Content.IntegrationTests/Tests/MappingEditorTest.cs
@@ -1,19 +1,17 @@
 ﻿using Content.Client.Gameplay;
 using Content.Client.Mapping;
+using Content.IntegrationTests.Fixtures;
 using Robust.Client.State;
 
 namespace Content.IntegrationTests.Tests;
 
 [TestFixture]
-public sealed class MappingEditorTest
+public sealed class MappingEditorTest : GameTest
 {
     [Test]
     public async Task StopHardCodingWidgetsJesusChristTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Connected = true
-        });
+        var pair = Pair;
         var client = pair.Client;
         var state = client.ResolveDependency<IStateManager>();
 
@@ -35,7 +33,5 @@ public sealed class MappingEditorTest
                 state.RequestStateChange<GameplayState>();
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Markings/MarkingManagerTests.cs
+++ b/Content.IntegrationTests/Tests/Markings/MarkingManagerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Body;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
@@ -9,7 +10,7 @@ namespace Content.IntegrationTests.Tests.Markings;
 
 [TestFixture]
 [TestOf(typeof(MarkingManager))]
-public sealed class MarkingManagerTests
+public sealed class MarkingManagerTests : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -76,7 +77,7 @@ public sealed class MarkingManagerTests
     [Test]
     public async Task HairConvesion()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         await server.WaitIdleAsync();
@@ -96,14 +97,12 @@ public sealed class MarkingManagerTests
             Assert.That(hairMarkings[0].MarkingId, Is.EqualTo("HumanHairLongBedhead2"));
             Assert.That(hairMarkings[0].MarkingColors[0], Is.EqualTo(Color.Red));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task LimitsFilling()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         await server.WaitIdleAsync();
@@ -118,14 +117,12 @@ public sealed class MarkingManagerTests
             Assert.That(dict[HumanoidVisualLayers.Eyes], Has.Count.EqualTo(1));
             Assert.That(dict[HumanoidVisualLayers.Eyes][0].MarkingId, Is.EqualTo("EyesMarking"));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task LimitsTruncations()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         await server.WaitIdleAsync();
@@ -146,14 +143,12 @@ public sealed class MarkingManagerTests
             Assert.That(dict[HumanoidVisualLayers.Eyes], Has.Count.EqualTo(1));
             Assert.That(dict[HumanoidVisualLayers.Eyes][0].MarkingId, Is.EqualTo("MenOnlyMarking"));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task EnsureValidGroupAndSex()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         await server.WaitIdleAsync();
@@ -191,14 +186,12 @@ public sealed class MarkingManagerTests
             Assert.That(testingMenMarkings[HumanoidVisualLayers.Eyes][1].MarkingId, Is.EqualTo("TestingOnlyMarking"));
             Assert.That(testingMenMarkings[HumanoidVisualLayers.Eyes][2].MarkingId, Is.EqualTo("TestingMenOnlyMarking"));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task EnsureValidColors()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         await server.WaitIdleAsync();
@@ -232,7 +225,5 @@ public sealed class MarkingManagerTests
             Assert.That(eyeMarkings[1].MarkingColors[0], Is.EqualTo(Color.Red));
             Assert.That(eyeMarkings[3].MarkingColors[0], Is.EqualTo(Color.Green));
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Markings/MarkingsViewModelTests.cs
+++ b/Content.IntegrationTests/Tests/Markings/MarkingsViewModelTests.cs
@@ -59,7 +59,7 @@ public sealed class MarkingsViewModelTests
     [SetUp]
     public async Task SetUp()
     {
-        Pair = await PoolManager.GetServerClient();
+        Pair = await PoolManager.GetServerClient(testContext: new NUnitTestContextWrap(TestContext.CurrentContext, TestContext.Out));
         await Client.WaitPost(() =>
         {
             Model = new MarkingsViewModel();

--- a/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
+++ b/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Cargo.Systems;
 using Content.Server.Construction.Completions;
 using Content.Server.Construction.Components;
@@ -26,7 +27,7 @@ namespace Content.IntegrationTests.Tests;
 /// create them.
 /// </summary>
 [TestFixture]
-public sealed class MaterialArbitrageTest
+public sealed class MaterialArbitrageTest : GameTest
 {
     // These sets are for selectively excluding recipes from arbitrage.
     // You should NOT be adding to these. They exist here for downstreams and potential future issues.
@@ -36,7 +37,7 @@ public sealed class MaterialArbitrageTest
     [Test]
     public async Task NoMaterialArbitrage()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var testMap = await pair.CreateTestMap();
@@ -439,7 +440,6 @@ public sealed class MaterialArbitrageTest
         });
 
         await server.WaitPost(() => mapSystem.DeleteMap(testMap.MapId));
-        await pair.CleanReturnAsync();
 
         async Task<double> GetSpawnedPrice(Dictionary<string, float> ents)
         {

--- a/Content.IntegrationTests/Tests/Materials/MaterialTests.cs
+++ b/Content.IntegrationTests/Tests/Materials/MaterialTests.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Stack;
 using Content.Shared.Stacks;
 using Content.Shared.Materials;
@@ -14,12 +15,12 @@ namespace Content.IntegrationTests.Tests.Materials
     [TestFixture]
     [TestOf(typeof(StackSystem))]
     [TestOf(typeof(MaterialPrototype))]
-    public sealed class MaterialPrototypeSpawnsStackMaterialTest
+    public sealed class MaterialPrototypeSpawnsStackMaterialTest : GameTest
     {
         [Test]
         public async Task MaterialPrototypeSpawnsStackMaterial()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             await server.WaitIdleAsync();
 
@@ -60,8 +61,6 @@ namespace Content.IntegrationTests.Tests.Materials
 
                 mapSystem.DeleteMap(testMap.MapId);
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Minds/GhostRoleTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/GhostRoleTests.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Shared.Ghost;
@@ -12,7 +13,7 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Minds;
 
 [TestFixture]
-public sealed class GhostRoleTests
+public sealed class GhostRoleTests : GameTest
 {
     private const string GhostRoleProtoId = "GhostRoleTestEntity";
     private const string TestMobProtoId = "GhostRoleTestMob";
@@ -33,6 +34,13 @@ public sealed class GhostRoleTests
           - type: MobState # MobState is required for correct determination of if the player can return to body or not
         """;
 
+    public override PoolSettings PoolSettings => new()
+    {
+        Dirty = true,
+        DummyTicker = false,
+        Connected = true
+    };
+
     /// <summary>
     /// This is a simple test that just checks if a player can take a ghost role and then regain control of their
     /// original entity without encountering errors.
@@ -43,12 +51,7 @@ public sealed class GhostRoleTests
     {
         var ghostCommand = adminGhost ? "aghost" : "ghost";
 
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Dirty = true,
-            DummyTicker = false,
-            Connected = true
-        });
+        var pair = Pair;
         var server = pair.Server;
         var client = pair.Client;
 
@@ -210,7 +213,6 @@ public sealed class GhostRoleTests
         if (!adminGhost)
         {
             // End of the normal player ghost role test
-            await pair.CleanReturnAsync();
             return;
         }
 
@@ -242,7 +244,5 @@ public sealed class GhostRoleTests
             // Check that there is are no lingereing ghosts
             Assert.That(entMan.Count<GhostComponent>(), Is.Zero);
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Minds/GhostTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/GhostTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Pair;
 using Content.Shared.Ghost;
 using Content.Shared.Mind;
@@ -12,7 +13,7 @@ using Robust.UnitTesting;
 namespace Content.IntegrationTests.Tests.Minds;
 
 [TestFixture]
-public sealed class GhostTests
+public sealed class GhostTests : GameTest
 {
     private struct GhostTestData
     {
@@ -45,17 +46,20 @@ public sealed class GhostTests
         }
     }
 
+    // Client is needed to create a session for the ghost system. Creating a dummy session was too difficult.
+    public override PoolSettings PoolSettings => new()
+    {
+        DummyTicker = false,
+        Connected = true,
+        Dirty = true
+    };
+
     private async Task<GhostTestData> SetupData()
     {
         var data = new GhostTestData
         {
-            // Client is needed to create a session for the ghost system. Creating a dummy session was too difficult.
-            Pair = await PoolManager.GetServerClient(new PoolSettings
-            {
-                DummyTicker = false,
-                Connected = true,
-                Dirty = true
-            })
+            // ..Just use the gametest pair, please.
+            Pair = Pair,
         };
 
         data.SEntMan = data.Pair.Server.ResolveDependency<IServerEntityManager>();
@@ -126,8 +130,6 @@ public sealed class GhostTests
         // Ensure the position is the same
         var ghostPosition = data.SEntMan.GetComponent<TransformComponent>(ghost).Coordinates;
         Assert.That(ghostPosition, Is.EqualTo(oldPosition));
-
-        await data.Pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -154,8 +156,6 @@ public sealed class GhostTests
         // Ensure the position is the same
         var ghostPosition = data.SEntMan.GetComponent<TransformComponent>(ghost).Coordinates;
         Assert.That(ghostPosition, Is.EqualTo(oldPosition));
-
-        await data.Pair.CleanReturnAsync();
     }
 
     [Test]
@@ -168,10 +168,6 @@ public sealed class GhostTests
             // Delete the grid
             await data.Server.WaitPost(() => data.SEntMan.DeleteEntity(data.MapData.Grid.Owner));
         });
-
-        await data.Pair.RunTicksSync(5);
-
-        await data.Pair.CleanReturnAsync();
     }
 
 }

--- a/Content.IntegrationTests/Tests/Minds/MindTest.DeleteAllThenGhost.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTest.DeleteAllThenGhost.cs
@@ -11,13 +11,7 @@ public sealed partial class MindTests
     [Test]
     public async Task DeleteAllThenGhost()
     {
-        var settings = new PoolSettings
-        {
-            Dirty = true,
-            DummyTicker = false,
-            Connected = true
-        };
-        await using var pair = await PoolManager.GetServerClient(settings);
+        var pair = Pair;
 
         // Client is connected with a valid entity & mind
         Assert.That(pair.Client.EntMan.EntityExists(pair.Client.AttachedEntity));
@@ -56,7 +50,5 @@ public sealed partial class MindTests
         Assert.That(pair.Server.EntMan.EntityExists(pair.PlayerData?.Mind));
         var xform = pair.Client.Transform(pair.Client.AttachedEntity!.Value);
         Assert.That(xform.MapID, Is.EqualTo(mapId));
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Minds/MindTests.EntityDeletion.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.EntityDeletion.cs
@@ -23,7 +23,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestDeleteVisiting()
     {
-        await using var pair = await SetupPair();
+        var pair = await SetupPair();
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -67,15 +67,13 @@ public sealed partial class MindTests
         // This used to throw so make sure it doesn't.
         await server.WaitPost(() => entMan.DeleteEntity(mind.OwnedEntity!.Value));
         await pair.RunTicksSync(5);
-
-        await pair.CleanReturnAsync();
     }
 
     // this is a variant of TestGhostOnDelete that just deletes the whole map.
     [Test]
     public async Task TestGhostOnDeleteMap()
     {
-        await using var pair = await SetupPair(dirty: true);
+        var pair = await SetupPair(dirty: true);
         var server = pair.Server;
         var testMap = await pair.CreateTestMap();
         var testMap2 = await pair.CreateTestMap();
@@ -117,8 +115,6 @@ public sealed partial class MindTests
             Assert.That(transform.MapID, Is.Not.EqualTo(testMap.MapId));
 #pragma warning restore NUnit2045
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -130,7 +126,7 @@ public sealed partial class MindTests
     public async Task TestGhostOnDelete()
     {
         // Client is needed to spawn session
-        await using var pair = await SetupPair(dirty: true);
+        var pair = await SetupPair(dirty: true);
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -145,8 +141,6 @@ public sealed partial class MindTests
         await pair.RunTicksSync(5);
 
         Assert.That(entMan.HasComponent<GhostComponent>(player.AttachedEntity), "Player did not become a ghost");
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -162,7 +156,7 @@ public sealed partial class MindTests
     public async Task TestOriginalDeletedWhileGhostingKeepsGhost()
     {
         // Client is needed to spawn session
-        await using var pair = await SetupPair();
+        var pair = await SetupPair();
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -207,8 +201,6 @@ public sealed partial class MindTests
             Assert.That(mind.Comp.VisitingEntity, Is.Null);
             Assert.That(mind.Comp.OwnedEntity, Is.EqualTo(ghost));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -220,7 +212,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestGhostToAghost()
     {
-        await using var pair = await SetupPair();
+        var pair = await SetupPair();
         var server = pair.Server;
         var entMan = server.ResolveDependency<IServerEntityManager>();
         var playerMan = server.ResolveDependency<IPlayerManager>();
@@ -250,8 +242,6 @@ public sealed partial class MindTests
 
         var mind = entMan.GetComponent<MindComponent>(mindId!.Value);
         Assert.That(mind.VisitingEntity, Is.Null);
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -264,7 +254,7 @@ public sealed partial class MindTests
     public async Task TestGhostDeletedSpawnsNewGhost()
     {
         // Client is needed to spawn session
-        await using var pair = await SetupPair();
+        var pair = await SetupPair();
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -308,7 +298,5 @@ public sealed partial class MindTests
             Assert.That(entMan.HasComponent<GhostComponent>(player.AttachedEntity!.Value));
 #pragma warning restore NUnit2045
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Minds/MindTests.Helpers.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.Helpers.cs
@@ -18,6 +18,14 @@ namespace Content.IntegrationTests.Tests.Minds;
 // This partial class contains misc helper functions for other tests.
 public sealed partial class MindTests
 {
+    // TODO GAMETEST: Rewrite this test to use improved GameTest pair management when I have an API for that figured out.
+    public override PoolSettings PoolSettings => new()
+    {
+        DummyTicker = false,
+        Connected = true,
+        Dirty = true,
+    };
+
     /// <summary>
     /// Gets a server-client pair and ensures that the client is attached to a simple mind test entity.
     /// </summary>
@@ -26,15 +34,9 @@ public sealed partial class MindTests
     /// the player's mind's current entity, likely because some previous test directly changed the players attached
     /// entity.
     /// </remarks>
-    private static async Task<Pair.TestPair> SetupPair(bool dirty = false)
+    private async Task<Pair.TestPair> SetupPair(bool dirty = false)
     {
-        var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            DummyTicker = false,
-            Connected = true,
-            Dirty = dirty
-        });
-
+        var pair = Pair;
         var entMan = pair.Server.ResolveDependency<IServerEntityManager>();
         var playerMan = pair.Server.ResolveDependency<IPlayerManager>();
         var mindSys = entMan.System<SharedMindSystem>();

--- a/Content.IntegrationTests/Tests/Minds/MindTests.ReconnectTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.ReconnectTests.cs
@@ -17,7 +17,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestGhostsCanReconnect()
     {
-        await using var pair = await SetupPair();
+        var pair = await SetupPair();
         var entMan = pair.Server.ResolveDependency<IEntityManager>();
         var mind = GetMind(pair);
 
@@ -32,8 +32,6 @@ public sealed partial class MindTests
             Assert.That(entMan.HasComponent<GhostComponent>(mind.Comp.OwnedEntity));
             Assert.That(mind.Comp.VisitingEntity, Is.Null);
         });
-
-        await pair.CleanReturnAsync();
     }
 
     // This test will do the following:
@@ -44,7 +42,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestDeletedCanReconnect()
     {
-        await using var pair = await SetupPair();
+        var pair = await SetupPair();
         var entMan = pair.Server.ResolveDependency<IEntityManager>();
         var mind = GetMind(pair);
 
@@ -82,8 +80,6 @@ public sealed partial class MindTests
             Assert.That(mind.Comp.OwnedEntity, Is.Not.EqualTo(entity));
             Assert.That(entMan.HasComponent<GhostComponent>(mind.Comp.OwnedEntity));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     // This test will do the following:
@@ -94,7 +90,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestVisitingGhostReconnect()
     {
-        await using var pair = await SetupPair();
+        var pair = await SetupPair();
         var entMan = pair.Server.ResolveDependency<IEntityManager>();
         var mind = GetMind(pair);
 
@@ -110,8 +106,6 @@ public sealed partial class MindTests
             Assert.That(entMan.Deleted(original), Is.False);
             Assert.That(entMan.Deleted(ghost));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     // This test will do the following:
@@ -122,7 +116,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestVisitingReconnect()
     {
-        await using var pair = await SetupPair(true);
+        var pair = await SetupPair(true);
         var entMan = pair.Server.ResolveDependency<IEntityManager>();
         var mindSys = entMan.System<SharedMindSystem>();
         var mind = GetMind(pair);
@@ -150,8 +144,6 @@ public sealed partial class MindTests
             Assert.That(entMan.Deleted(visiting), Is.False);
             Assert.That(mind.Comp.CurrentEntity, Is.EqualTo(visiting));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     // This test will do the following
@@ -162,7 +154,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestReconnect()
     {
-        await using var pair = await SetupPair();
+        var pair = await SetupPair();
         var mind = GetMind(pair);
 
         Assert.That(mind.Comp.VisitingEntity, Is.Null);
@@ -178,7 +170,5 @@ public sealed partial class MindTests
         Assert.That(newMind.Comp.VisitingEntity, Is.Null);
         Assert.That(newMind.Comp.OwnedEntity, Is.EqualTo(entity));
         Assert.That(newMind.Id, Is.EqualTo(mind.Id));
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Minds/MindTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Mind;
@@ -23,7 +24,7 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Minds;
 
 [TestFixture]
-public sealed partial class MindTests
+public sealed partial class MindTests : GameTest
 {
     private static readonly ProtoId<DamageTypePrototype> BluntDamageType = "Blunt";
 
@@ -56,7 +57,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestCreateAndTransferMindToNewEntity()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -75,14 +76,12 @@ public sealed partial class MindTests
             mindSystem.TransferTo(mind, entity, mind: mind);
             Assert.That(mindSystem.GetMind(entity, mindComp), Is.EqualTo(mind.Owner));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestReplaceMind()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -107,14 +106,12 @@ public sealed partial class MindTests
                 Assert.That(mind.OwnedEntity, Is.Not.EqualTo(entity));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestEntityDeadWhenGibbed()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -160,14 +157,12 @@ public sealed partial class MindTests
             var mind = entMan.GetComponent<MindComponent>(mindId);
             Assert.That(mindSystem.IsCharacterDeadPhysically(mind));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestMindTransfersToOtherEntity()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -194,18 +189,12 @@ public sealed partial class MindTests
                 Assert.That(mindSystem.GetMind(targetEntity), Is.EqualTo(mind));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestOwningPlayerCanBeChanged()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Connected = true,
-            DummyTicker = false
-        });
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -253,14 +242,12 @@ public sealed partial class MindTests
         });
 
         await pair.RunTicksSync(5);
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestAddRemoveHasRoles()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -323,15 +310,13 @@ public sealed partial class MindTests
                 Assert.That(roleSystem.MindHasRole<JobRoleComponent>(mindId), Is.False);
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestPlayerCanGhost()
     {
         // Client is needed to spawn session
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true, DummyTicker = false });
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -399,19 +384,12 @@ public sealed partial class MindTests
                 Assert.That(mId, Is.Not.EqualTo(mindId));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestGhostDoesNotInfiniteLoop()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            DummyTicker = false,
-            Connected = true,
-            Dirty = true
-        });
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -482,7 +460,5 @@ public sealed partial class MindTests
             Assert.That(player.AttachedEntity, Is.Not.Null);
             Assert.That(player.AttachedEntity!.Value, Is.EqualTo(ghost));
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Minds/RoleTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/RoleTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Roles.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Reflection;
@@ -6,7 +7,7 @@ using Robust.Shared.Reflection;
 namespace Content.IntegrationTests.Tests.Minds;
 
 [TestFixture]
-public sealed class RoleTests
+public sealed class RoleTests : GameTest
 {
     /// <summary>
     /// Check that any prototype with a <see cref="MindRoleComponent"/> is properly configured
@@ -14,7 +15,7 @@ public sealed class RoleTests
     [Test]
     public async Task ValidateRolePrototypes()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
 
         var jobComp = pair.Server.ResolveDependency<IComponentFactory>().GetComponentName<JobRoleComponent>();
 
@@ -35,7 +36,6 @@ public sealed class RoleTests
             }
         });
 
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -45,7 +45,7 @@ public sealed class RoleTests
     [Test]
     public async Task ValidateJobPrototypes()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
 
         var mindCompId = pair.Server.ResolveDependency<IComponentFactory>().GetComponentName<MindRoleComponent>();
 
@@ -57,8 +57,6 @@ public sealed class RoleTests
                     Assert.That(((MindRoleComponent)mindComp).JobPrototype, Is.Not.Null);
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -68,7 +66,7 @@ public sealed class RoleTests
     [Test]
     public async Task ValidateRolesHaveMindRoleComp()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
 
         var refMan = pair.Server.ResolveDependency<IReflectionManager>();
         var mindCompId = pair.Server.ResolveDependency<IComponentFactory>().GetComponentName<MindRoleComponent>();
@@ -87,7 +85,5 @@ public sealed class RoleTests
                 }
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/NPC/NPCTest.cs
+++ b/Content.IntegrationTests/Tests/NPC/NPCTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.NPC.HTN;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
@@ -7,12 +8,12 @@ using Robust.Shared.Utility;
 namespace Content.IntegrationTests.Tests.NPC;
 
 [TestFixture]
-public sealed class NPCTest
+public sealed class NPCTest : GameTest
 {
     [Test]
     public async Task CompoundRecursion()
     {
-        var pool = await PoolManager.GetServerClient();
+        var pool = Pair;
         var server = pool.Server;
 
         await server.WaitIdleAsync();
@@ -30,8 +31,6 @@ public sealed class NPCTest
                 counts.Clear();
             }
         });
-
-        await pool.CleanReturnAsync();
     }
 
     private static void Count(HTNCompoundPrototype compound, Dictionary<string, int> counts, HTNSystem htnSystem, IPrototypeManager protoManager)

--- a/Content.IntegrationTests/Tests/Networking/NetworkIdsMatchTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/NetworkIdsMatchTest.cs
@@ -1,14 +1,15 @@
+using Content.IntegrationTests.Fixtures;
 using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.Networking
 {
     [TestFixture]
-    public sealed class NetworkIdsMatchTest
+    public sealed class NetworkIdsMatchTest : GameTest
     {
         [Test]
         public async Task TestConnect()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var pair = Pair;
             var server = pair.Server;
             var client = pair.Client;
 
@@ -38,7 +39,6 @@ namespace Content.IntegrationTests.Tests.Networking
                     Assert.That(clientNetComps[netId].Name, Is.EqualTo(serverNetComps[netId].Name));
                 }
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Networking/PvsCommandTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/PvsCommandTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
@@ -5,16 +6,17 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Networking;
 
 [TestFixture]
-public sealed class PvsCommandTest
+public sealed class PvsCommandTest : GameTest
 {
     private static readonly EntProtoId TestEnt = "MobHuman";
+
+    public override PoolSettings PoolSettings => new() { Connected = true, DummyTicker = false };
 
     [Test]
     public async Task TestPvsCommands()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true, DummyTicker = false });
+        var pair = Pair;
         var (server, client) = pair;
-        await pair.RunTicksSync(5);
 
         // Spawn a complex entity.
         EntityUid entity = default;
@@ -46,6 +48,5 @@ public sealed class PvsCommandTest
         Assert.That(meta.LastStateApplied, Is.GreaterThan(lastApplied));
 
         await server.WaitPost(() => server.EntMan.DeleteEntity(entity));
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Networking/ReconnectTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/ReconnectTest.cs
@@ -1,15 +1,16 @@
+using Content.IntegrationTests.Fixtures;
 using Robust.Client.Console;
 using Robust.Shared.Network;
 
 namespace Content.IntegrationTests.Tests.Networking
 {
     [TestFixture]
-    public sealed class ReconnectTest
+    public sealed class ReconnectTest : GameTest
     {
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var pair = Pair;
             var server = pair.Server;
             var client = pair.Client;
 
@@ -32,7 +33,6 @@ namespace Content.IntegrationTests.Tests.Networking
             await pair.RunTicksSync(10);
 
             await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Networking/SimplePredictReconcileTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/SimplePredictReconcileTest.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Robust.Client.GameStates;
 using Robust.Client.Timing;
 using Robust.Shared;
@@ -27,12 +28,12 @@ namespace Content.IntegrationTests.Tests.Networking
     // the tick where the server *should* have, but did not, acknowledge the state change.
     // Finally, we run two events inside the prediction area to ensure reconciling does for incremental stuff.
     [TestFixture]
-    public sealed class SimplePredictReconcileTest
+    public sealed class SimplePredictReconcileTest : GameTest
     {
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var pair = Pair;
             var server = pair.Server;
             var client = pair.Client;
 
@@ -386,7 +387,6 @@ namespace Content.IntegrationTests.Tests.Networking
             }
 
             cfg.SetCVar(CVars.NetLogging, log);
-            await pair.CleanReturnAsync();
         }
 
         public sealed class PredictionTestEntitySystem : EntitySystem

--- a/Content.IntegrationTests/Tests/Physics/AnchorPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Physics/AnchorPrototypeTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
@@ -6,7 +7,7 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Physics;
 
 [TestFixture]
-public sealed class AnchorPrototypeTest
+public sealed class AnchorPrototypeTest : GameTest
 {
     /// <summary>
     /// Asserts that entityprototypes marked as anchored are also static physics bodies.
@@ -14,7 +15,7 @@ public sealed class AnchorPrototypeTest
     [Test]
     public async Task TestStaticAnchorPrototypes()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
 
         var protoManager = pair.Server.ResolveDependency<IPrototypeManager>();
 
@@ -37,7 +38,5 @@ public sealed class AnchorPrototypeTest
                 Assert.That(physics.BodyType, Is.EqualTo(BodyType.Static), $"Found entity prototype {ent} marked as anchored but not static for physics.");
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Content.IntegrationTests.Utility;
 using YamlDotNet.RepresentationModel;
 using Content.Server.Administration.Systems;
@@ -28,8 +30,14 @@ using Robust.Shared.Utility;
 namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
-    public sealed class PostMapInitTest
+    public sealed class PostMapInitTest : GameTest
     {
+        public override PoolSettings PoolSettings => new PoolSettings()
+        {
+            Connected = true,
+            Dirty = true,
+        };
+
         private const bool SkipTestMaps = true;
         private const string TestMapsPath = "/Maps/Test/";
 
@@ -93,16 +101,16 @@ namespace Content.IntegrationTests.Tests
         /// Asserts that specific files have been saved as grids and not maps.
         /// </summary>
         [Test, TestCaseSource(nameof(Grids))]
+        [EnsureCVar(Side.Server, typeof(CCVars), nameof(CCVars.GridFill), false)]
         public async Task GridsLoadableTest(string mapFile)
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var entManager = server.ResolveDependency<IEntityManager>();
             var mapLoader = entManager.System<MapLoaderSystem>();
             var mapSystem = entManager.System<SharedMapSystem>();
             var cfg = server.ResolveDependency<IConfigurationManager>();
-            Assert.That(cfg.GetCVar(CCVars.GridFill), Is.False);
             var path = new ResPath(mapFile);
 
             await server.WaitPost(() =>
@@ -119,9 +127,6 @@ namespace Content.IntegrationTests.Tests
 
                 mapSystem.DeleteMap(mapId);
             });
-            await server.WaitRunTicks(1);
-
-            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -129,16 +134,16 @@ namespace Content.IntegrationTests.Tests
         /// </summary>
         [Test]
         [TestCaseSource(nameof(ShuttleMapFiles))]
+        [EnsureCVar(Side.Server, typeof(CCVars), nameof(CCVars.GridFill), false)]
         public async Task ShuttlesLoadableTest(ResPath path)
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var entManager = server.ResolveDependency<IEntityManager>();
             var mapLoader = entManager.System<MapLoaderSystem>();
             var mapSystem = entManager.System<SharedMapSystem>();
             var cfg = server.ResolveDependency<IConfigurationManager>();
-            Assert.That(cfg.GetCVar(CCVars.GridFill), Is.False);
 
             await server.WaitPost(() =>
             {
@@ -158,17 +163,13 @@ namespace Content.IntegrationTests.Tests
                     mapSystem.DeleteMap(mapId);
                 });
             });
-
-            await server.WaitRunTicks(1);
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         [TestCaseSource(nameof(AllMapFiles))]
         public async Task NoSavedPostMapInitTest(ResPath map)
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var resourceManager = server.ResolveDependency<IResourceManager>();
@@ -182,7 +183,6 @@ namespace Content.IntegrationTests.Tests
             // ReSharper disable once RedundantLogicalConditionalExpressionOperand
             if (SkipTestMaps && rootedPath.ToString().StartsWith(TestMapsPath, StringComparison.Ordinal))
             {
-                await pair.CleanReturnAsync();
                 return; // We just pass immediately.
             }
 
@@ -239,8 +239,6 @@ namespace Content.IntegrationTests.Tests
             await server.WaitPost(() => mapSys.InitializeMap(id));
             Assert.That(loader.TrySaveMap(id, path));
             Assert.That(IsPreInit(path, loader, deps, ev.RenamedPrototypes, ev.DeletedPrototypes), Is.False);
-
-            await pair.CleanReturnAsync();
         }
 
         private bool IsWhitelistedForMap(EntProtoId protoId, ResPath map)
@@ -325,12 +323,10 @@ namespace Content.IntegrationTests.Tests
         }
 
         [Test, TestCaseSource(nameof(GameMaps))]
+        [EnsureCVar(Side.Server, typeof(CCVars), nameof(CCVars.GridFill), false)]
         public async Task GameMapsLoadableTest(string mapProto)
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings
-            {
-                Dirty = true // Stations spawn a bunch of nullspace entities and maps like centcomm.
-            });
+            var pair = Pair;
             var server = pair.Server;
 
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -341,7 +337,6 @@ namespace Content.IntegrationTests.Tests
             var ticker = entManager.EntitySysManager.GetEntitySystem<GameTicker>();
             var shuttleSystem = entManager.EntitySysManager.GetEntitySystem<ShuttleSystem>();
             var cfg = server.ResolveDependency<IConfigurationManager>();
-            Assert.That(cfg.GetCVar(CCVars.GridFill), Is.False);
 
             await server.WaitPost(() =>
             {
@@ -440,9 +435,6 @@ namespace Content.IntegrationTests.Tests
                     throw new Exception($"Failed to delete map {mapProto}", ex);
                 }
             });
-            await server.WaitRunTicks(1);
-
-            await pair.CleanReturnAsync();
         }
 
 
@@ -472,36 +464,17 @@ namespace Content.IntegrationTests.Tests
         }
 
         [Test]
-        public async Task AllMapsTested()
-        {
-            await using var pair = await PoolManager.GetServerClient();
-            var server = pair.Server;
-            var protoMan = server.ResolveDependency<IPrototypeManager>();
-
-            var gameMaps = protoMan.EnumeratePrototypes<GameMapPrototype>()
-                .Where(x => !pair.IsTestPrototype(x))
-                .Select(x => x.ID)
-                .ToHashSet();
-
-            Assert.That(gameMaps.Remove(PoolManager.TestMap));
-
-            Assert.That(gameMaps, Is.EquivalentTo(GameMaps.ToHashSet()), "Game map prototype missing from test cases.");
-
-            await pair.CleanReturnAsync();
-        }
-
-        [Test]
         [TestCaseSource(nameof(AllMapFiles))]
+        [EnsureCVar(Side.Server, typeof(CCVars), nameof(CCVars.GridFill), false)]
         public async Task NonGameMapsLoadableTest(ResPath mapPath)
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var mapLoader = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<MapLoaderSystem>();
             var resourceManager = server.ResolveDependency<IResourceManager>();
             var protoManager = server.ResolveDependency<IPrototypeManager>();
             var cfg = server.ResolveDependency<IConfigurationManager>();
-            Assert.That(cfg.GetCVar(CCVars.GridFill), Is.False);
 
             var gameMaps = protoManager.EnumeratePrototypes<GameMapPrototype>().Select(o => o.MapPath).ToHashSet();
 
@@ -510,7 +483,6 @@ namespace Content.IntegrationTests.Tests
             {
                 // TODO: You might be able to save like, 1-2 seconds of test time if you eliminate these before
                 //       actually needing a pair.
-                await pair.CleanReturnAsync();
                 return;
             }
 
@@ -518,7 +490,6 @@ namespace Content.IntegrationTests.Tests
 
             if (SkipTestMaps && rootedPath.ToString().StartsWith(TestMapsPath, StringComparison.Ordinal))
             {
-                await pair.CleanReturnAsync();
                 return;
             }
 
@@ -561,9 +532,6 @@ namespace Content.IntegrationTests.Tests
                     }
                 });
             });
-
-            await server.WaitRunTicks(1);
-            await pair.CleanReturnAsync();
         }
 
         /// <summary>

--- a/Content.IntegrationTests/Tests/Power/PowerStatePrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Power/PowerStatePrototypeTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Power.Components;
 using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
@@ -8,7 +9,7 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Power;
 
 [TestFixture, TestOf(typeof(SharedPowerStateSystem))]
-public sealed class PowerStatePrototypeTest
+public sealed class PowerStatePrototypeTest : GameTest
 {
     /// <summary>
     /// Asserts that the <see cref="SharedApcPowerReceiverComponent"/>'s load is the same
@@ -18,7 +19,7 @@ public sealed class PowerStatePrototypeTest
     [Test]
     public async Task AssertApcPowerMatchesPowerState()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var protoMan = server.ResolveDependency<IPrototypeManager>();
@@ -53,7 +54,5 @@ public sealed class PowerStatePrototypeTest
                 }
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Power/PowerStateTest.cs
+++ b/Content.IntegrationTests/Tests/Power/PowerStateTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Coordinates;
 using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
@@ -8,7 +9,7 @@ using Robust.Shared.Maths;
 namespace Content.IntegrationTests.Tests.Power;
 
 [TestFixture]
-public sealed class PowerStateTest
+public sealed class PowerStateTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -31,7 +32,7 @@ public sealed class PowerStateTest
     [Test]
     public async Task SetWorkingState_IdleToWorking_UpdatesLoad()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var mapManager = server.ResolveDependency<IMapManager>();
@@ -65,8 +66,6 @@ public sealed class PowerStateTest
                 Assert.That(receiver.Load, Is.EqualTo(powerState.WorkingPowerDraw).Within(0.01f));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -75,7 +74,7 @@ public sealed class PowerStateTest
     [Test]
     public async Task SetWorkingState_WorkingToIdle_UpdatesLoad()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var mapManager = server.ResolveDependency<IMapManager>();
@@ -118,8 +117,6 @@ public sealed class PowerStateTest
                 Assert.That(receiver.Load, Is.EqualTo(powerState.IdlePowerDraw).Within(0.01f));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -128,7 +125,7 @@ public sealed class PowerStateTest
     [Test]
     public async Task SetWorkingState_AlreadyInState_NoChange()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var mapManager = server.ResolveDependency<IMapManager>();
@@ -179,8 +176,6 @@ public sealed class PowerStateTest
                 Assert.That(receiver.Load, Is.EqualTo(powerState.WorkingPowerDraw).Within(0.01f));
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }
 

--- a/Content.IntegrationTests/Tests/Power/PowerTest.cs
+++ b/Content.IntegrationTests/Tests/Power/PowerTest.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Content.IntegrationTests.Fixtures;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
@@ -14,7 +15,7 @@ using Robust.Shared.Timing;
 namespace Content.IntegrationTests.Tests.Power
 {
     [TestFixture]
-    public sealed class PowerTest
+    public sealed class PowerTest : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -167,7 +168,7 @@ namespace Content.IntegrationTests.Tests.Power
         [Test]
         public async Task TestSimpleSurplus()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -218,8 +219,6 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(supplier.CurrentSupply, Is.EqualTo(loadPower * 2).Within(0.1));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
 
@@ -229,7 +228,7 @@ namespace Content.IntegrationTests.Tests.Power
         [Test]
         public async Task TestSimpleDeficit()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -280,14 +279,12 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(supplier.CurrentSupply, Is.EqualTo(supplier.MaxSupply).Within(0.1));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestSupplyRamp()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -368,14 +365,12 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(consumer.ReceivedPower, Is.EqualTo(400).Within(tickDev));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestBatteryRamp()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -472,8 +467,6 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(currentCharge, Is.EqualTo(startingCharge - spentExpected).Within(tickDev));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
@@ -481,7 +474,7 @@ namespace Content.IntegrationTests.Tests.Power
         {
             // checks that batteries and supplies properly ramp down if the load is disconnected/disabled.
 
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -571,14 +564,12 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(consumer.ReceivedPower, Is.EqualTo(0).Within(0.1));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestSimpleBatteryChargeDeficit()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var gameTiming = server.ResolveDependency<IGameTiming>();
@@ -631,14 +622,12 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(supplier.CurrentSupply, Is.EqualTo(500).Within(0.1));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestFullBattery()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -713,14 +702,12 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(currentCharge, Is.EqualTo(battery.MaxCharge - expectedSpent).Within(tickDev));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestFullBatteryEfficiencyPassThrough()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -795,14 +782,12 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(currentCharge, Is.EqualTo(battery.MaxCharge - expectedSpent).Within(tickDev));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestFullBatteryEfficiencyDemandPassThrough()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -888,8 +873,6 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(supplier.CurrentSupply, Is.EqualTo(supplier.MaxSupply).Within(0.1));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -899,7 +882,7 @@ namespace Content.IntegrationTests.Tests.Power
         [Test]
         public async Task TestSupplyPrioritized()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -988,8 +971,6 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(netBattery2.SupplyRampPosition, Is.EqualTo(500).Within(0.1));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -998,7 +979,7 @@ namespace Content.IntegrationTests.Tests.Power
         [Test]
         public async Task TestBatteriesProportional()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -1079,14 +1060,12 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(supplier.CurrentSupply, Is.EqualTo(supplier.MaxSupply).Within(0.1));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestBatteryEngineCut()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -1161,8 +1140,6 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(netBattery.CurrentSupply, Is.GreaterThan(0));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -1171,7 +1148,7 @@ namespace Content.IntegrationTests.Tests.Power
         [Test]
         public async Task TestTerminalNodeGroups()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -1230,14 +1207,12 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(leftNode.NodeGroup, Is.Not.EqualTo(rightNode.NodeGroup));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task ApcChargingTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -1290,14 +1265,12 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(currentCharge, Is.GreaterThan(0)); //apc battery should have gained charge
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task ApcNetTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -1355,8 +1328,6 @@ namespace Content.IntegrationTests.Tests.Power
                     Assert.That(apcNetBattery.CurrentSupply, Is.EqualTo(1).Within(0.1));
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
     }

--- a/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
+++ b/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.GameTicking;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
@@ -13,7 +14,7 @@ using Robust.Shared.EntitySerialization;
 
 namespace Content.IntegrationTests.Tests.Power;
 
-public sealed class StationPowerTests
+public sealed class StationPowerTests : GameTest
 {
     /// <summary>
     /// How long the station should be able to survive on stored power if nothing is changed from round start.
@@ -36,14 +37,16 @@ public sealed class StationPowerTests
         "Exo",
     ];
 
+    public override PoolSettings PoolSettings => new ()
+    {
+        Dirty = true,
+    };
+
     [Explicit]
     [Test, TestCaseSource(nameof(GameMaps))]
     public async Task TestStationStartingPowerWindow(string mapProtoId)
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Dirty = true,
-        });
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.EntMan;
@@ -96,17 +99,12 @@ public sealed class StationPowerTests
             Assert.That(totalStartingCharge, Is.GreaterThanOrEqualTo(requiredStoredPower),
                 $"Needs at least {requiredStoredPower - totalStartingCharge} more stored power!");
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test, TestCaseSource(nameof(GameMaps))]
     public async Task TestApcLoad(string mapProtoId)
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Dirty = true,
-        });
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.EntMan;
@@ -145,7 +143,5 @@ public sealed class StationPowerTests
                 }
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Preferences/LoadoutTests.cs
+++ b/Content.IntegrationTests/Tests/Preferences/LoadoutTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Station.Systems;
 using Content.Shared.Inventory;
 using Content.Shared.Preferences;
@@ -9,7 +10,7 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Preferences;
 
 [TestFixture]
-public sealed class LoadoutTests
+public sealed class LoadoutTests : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -42,16 +43,18 @@ public sealed class LoadoutTests
         ["jumpsuit"] = "ClothingUniformJumpsuitColorGrey"
     };
 
+    public override PoolSettings PoolSettings => new()
+    {
+        Dirty = true,
+    };
+
     /// <summary>
     /// Checks that an empty loadout still spawns with default gear and not naked.
     /// </summary>
     [Test]
     public async Task TestEmptyLoadout()
     {
-        var pair = await PoolManager.GetServerClient(new PoolSettings()
-        {
-            Dirty = true,
-        });
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -87,7 +90,5 @@ public sealed class LoadoutTests
 
             entManager.DeleteEntity(tester);
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Preferences/ServerDbSqliteTests.cs
+++ b/Content.IntegrationTests/Tests/Preferences/ServerDbSqliteTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Database;
 using Content.Server.Preferences.Managers;
 using Content.Shared.Body;
@@ -20,7 +21,7 @@ using Robust.UnitTesting;
 namespace Content.IntegrationTests.Tests.Preferences
 {
     [TestFixture]
-    public sealed class ServerDbSqliteTests
+    public sealed class ServerDbSqliteTests : GameTest
     {
         [TestPrototypes]
         private const string Prototypes = @"
@@ -69,12 +70,10 @@ namespace Content.IntegrationTests.Tests.Preferences
         [Test]
         public async Task TestUserDoesNotExist()
         {
-            var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var db = GetDb(pair.Server);
             // Database should be empty so a new GUID should do it.
             Assert.That(await db.GetPlayerPreferencesAsync(NewUserId()), Is.Null);
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
@@ -113,7 +112,7 @@ namespace Content.IntegrationTests.Tests.Preferences
         [Test]
         public async Task TestInitPrefs()
         {
-            var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var db = GetDb(pair.Server);
             var preferences = (ServerPreferencesManager)pair.Server.ResolveDependency<IServerPreferencesManager>();
             var username = new NetUserId(new Guid("640bd619-fc8d-4fe2-bf3c-4a5fb17d6ddd"));
@@ -123,13 +122,12 @@ namespace Content.IntegrationTests.Tests.Preferences
             var prefs = await db.GetPlayerPreferencesAsync(username);
             var profile = preferences.ConvertProfiles(prefs!.Profiles.Find(p => p.Slot == slot));
             Assert.That(profile.MemberwiseEquals(originalProfile));
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestDeleteCharacter()
         {
-            var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var db = GetDb(server);
             var username = new NetUserId(new Guid("640bd619-fc8d-4fe2-bf3c-4a5fb17d6ddd"));
@@ -139,18 +137,16 @@ namespace Content.IntegrationTests.Tests.Preferences
             await db.SaveCharacterSlotAsync(username, null, 1);
             var prefs = await db.GetPlayerPreferencesAsync(username);
             Assert.That(prefs!.Profiles, Has.Count.EqualTo(1));
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestNoPendingDatabaseChanges()
         {
-            var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var db = GetDb(server);
             Assert.That(async () => await db.HasPendingModelChanges(), Is.False,
                 "The database has pending model changes. Add a new migration to apply them. See https://learn.microsoft.com/en-us/ef/core/managing-schemas/migrations");
-            await pair.CleanReturnAsync();
         }
 
         private static NetUserId NewUserId()
@@ -166,7 +162,7 @@ namespace Content.IntegrationTests.Tests.Preferences
         [TestCaseSource(nameof(_trueFalse))]
         public async Task InvalidSpeciesConversion(bool legacy)
         {
-            var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var db = GetDb(pair.Server);
             var preferences = (ServerPreferencesManager)pair.Server.ResolveDependency<IServerPreferencesManager>();
@@ -198,8 +194,6 @@ namespace Content.IntegrationTests.Tests.Preferences
                 Assert.That(converted.Characters[0].Species, Is.Not.EqualTo(InvalidSpecies));
                 Assert.That(converted.Characters[0].Species, Is.EqualTo(HumanoidCharacterProfile.DefaultSpecies));
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Procedural/DungeonTests.cs
+++ b/Content.IntegrationTests/Tests/Procedural/DungeonTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Procedural;
 using Content.Shared.Procedural;
 using Robust.Shared.Maths;
@@ -7,12 +8,12 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Procedural;
 
 [TestOf(typeof(DungeonSystem))]
-public sealed class DungeonTests
+public sealed class DungeonTests : GameTest
 {
     [Test]
     public async Task TestDungeonRoomPackBounds()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var protoManager = pair.Server.ResolveDependency<IPrototypeManager>();
 
         await pair.Server.WaitAssertion(() =>
@@ -55,14 +56,12 @@ public sealed class DungeonTests
                 }
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestDungeonPresets()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var protoManager = pair.Server.ResolveDependency<IPrototypeManager>();
 
         await pair.Server.WaitAssertion(() =>
@@ -92,7 +91,5 @@ public sealed class DungeonTests
                 }
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Coordinates;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -27,12 +28,12 @@ namespace Content.IntegrationTests.Tests;
 ///     spawn it into a new empty map and seeing what the map yml looks like.
 /// </remarks>
 [TestFixture]
-public sealed class PrototypeSaveTest
+public sealed class PrototypeSaveTest : GameTest
 {
     [Test]
     public async Task UninitializedSaveTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entityMan = server.ResolveDependency<IEntityManager>();
@@ -156,7 +157,6 @@ public sealed class PrototypeSaveTest
                 }
             });
         });
-        await pair.CleanReturnAsync();
     }
 
     public sealed class TestEntityUidContext : ISerializationContext,

--- a/Content.IntegrationTests/Tests/PrototypeTests/PrototypeTests.cs
+++ b/Content.IntegrationTests/Tests/PrototypeTests/PrototypeTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
+using Content.IntegrationTests.Fixtures;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown;
@@ -8,7 +9,7 @@ using Robust.UnitTesting;
 
 namespace Content.IntegrationTests.Tests.PrototypeTests;
 
-public sealed class PrototypeTests
+public sealed class PrototypeTests : GameTest
 {
     /// <summary>
     /// This test writes all known server prototypes as yaml files, then validates that the result is valid yaml.
@@ -17,10 +18,9 @@ public sealed class PrototypeTests
     [Test]
     public async Task TestAllServerPrototypesAreSerializable()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var context = new PrototypeSaveTest.TestEntityUidContext();
         await SaveThenValidatePrototype(pair.Server, "server", context);
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -30,10 +30,9 @@ public sealed class PrototypeTests
     [Test]
     public async Task TestAllClientPrototypesAreSerializable()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var context = new PrototypeSaveTest.TestEntityUidContext();
         await SaveThenValidatePrototype(pair.Client, "client", context);
-        await pair.CleanReturnAsync();
     }
 
     public async Task SaveThenValidatePrototype(RobustIntegrationTest.IntegrationInstance instance, string instanceId,
@@ -69,10 +68,9 @@ public sealed class PrototypeTests
     [Test]
     public async Task ServerPrototypeSaveLoadSaveTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var context = new PrototypeSaveTest.TestEntityUidContext();
         await SaveLoadSavePrototype(pair.Server, context);
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -81,10 +79,9 @@ public sealed class PrototypeTests
     [Test]
     public async Task ClientPrototypeSaveLoadSaveTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var context = new PrototypeSaveTest.TestEntityUidContext();
         await SaveLoadSavePrototype(pair.Client, context);
-        await pair.CleanReturnAsync();
     }
 
     private async Task SaveLoadSavePrototype(

--- a/Content.IntegrationTests/Tests/PrototypeTests/PrototypeUploadTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeTests/PrototypeUploadTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Tag;
 using Robust.Client.Upload.Commands;
 using Robust.Shared.GameObjects;
@@ -6,7 +7,7 @@ using Robust.Shared.Upload;
 
 namespace Content.IntegrationTests.Tests.PrototypeTests;
 
-public sealed class PrototypeUploadTest
+public sealed class PrototypeUploadTest : GameTest
 {
     public const string IdA = "UploadTestPrototype";
     public const string IdB = $"{IdA}NoParent";
@@ -36,7 +37,7 @@ public sealed class PrototypeUploadTest
     [TestOf(typeof(LoadPrototypeCommand))]
     public async Task TestFileUpload()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings {Connected = true});
+        var pair = Pair;
         var sCompFact = pair.Server.ResolveDependency<IComponentFactory>();
         var cCompFact = pair.Client.ResolveDependency<IComponentFactory>();
 
@@ -79,7 +80,5 @@ public sealed class PrototypeUploadTest
             Assert.That(cProtoB!.TryGetComponent<TagComponent>(out _, cCompFact), Is.False);
             Assert.That(cProtoD!.TryGetComponent<TagComponent>(out _, cCompFact), Is.True);
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Puller/PullerTest.cs
+++ b/Content.IntegrationTests/Tests/Puller/PullerTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Hands.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Prototypes;
@@ -9,7 +10,7 @@ namespace Content.IntegrationTests.Tests.Puller;
 #nullable enable
 
 [TestFixture]
-public sealed class PullerTest
+public sealed class PullerTest : GameTest
 {
     /// <summary>
     /// Checks that needsHands on PullerComponent is not set on mobs that don't even have hands.
@@ -17,7 +18,7 @@ public sealed class PullerTest
     [Test]
     public async Task PullerSanityTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var compFactory = server.ResolveDependency<IComponentFactory>();
@@ -39,7 +40,5 @@ public sealed class PullerTest
                 }
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
+++ b/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.GameTicking;
 using Content.Shared.CCVar;
 using Robust.Shared;
@@ -6,20 +7,21 @@ using Robust.Shared.Replays;
 namespace Content.IntegrationTests.Tests.Replays;
 
 [TestFixture]
-public sealed class ReplayTests
+public sealed class ReplayTests : GameTest
 {
+    public override PoolSettings PoolSettings => new()
+    {
+        DummyTicker = false,
+        Dirty = true
+    };
+
     /// <summary>
     /// Simple test that just makes sure that automatic replay recording on round restarts works without any issues.
     /// </summary>
     [Test]
     public async Task AutoRecordReplayTest()
     {
-        var settings = new PoolSettings
-        {
-            DummyTicker = false,
-            Dirty = true
-        };
-        await using var pair = await PoolManager.GetServerClient(settings);
+        var pair = Pair;
         var server = pair.Server;
 
         Assert.That(server.CfgMan.GetCVar(CVars.ReplayServerRecordingEnabled), Is.False);
@@ -54,7 +56,5 @@ public sealed class ReplayTests
         await server.WaitPost(() => ticker.RestartRound());
         await pair.RunTicksSync(25);
         Assert.That(recordMan.IsRecording, Is.False);
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/ResearchTest.cs
+++ b/Content.IntegrationTests/Tests/ResearchTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Lathe;
 using Content.Shared.Research.Prototypes;
 using Robust.Shared.GameObjects;
@@ -8,12 +9,12 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests;
 
 [TestFixture]
-public sealed class ResearchTest
+public sealed class ResearchTest : GameTest
 {
     [Test]
     public async Task DisciplineValidTierPrerequesitesTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var protoManager = server.ResolveDependency<IPrototypeManager>();
@@ -42,14 +43,12 @@ public sealed class ResearchTest
                 }
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task AllTechPrintableTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
@@ -99,7 +98,5 @@ public sealed class ResearchTest
                 }
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/ResettingEntitySystemTests.cs
+++ b/Content.IntegrationTests/Tests/ResettingEntitySystemTests.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server.GameTicking;
+﻿using Content.IntegrationTests.Fixtures;
+using Content.Server.GameTicking;
 using Content.Shared.GameTicking;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Reflection;
@@ -7,7 +8,7 @@ namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
     [TestOf(typeof(RoundRestartCleanupEvent))]
-    public sealed class ResettingEntitySystemTests
+    public sealed class ResettingEntitySystemTests : GameTest
     {
         public sealed class TestRoundRestartCleanupEvent : EntitySystem
         {
@@ -26,15 +27,17 @@ namespace Content.IntegrationTests.Tests
             }
         }
 
+        public override PoolSettings PoolSettings => new PoolSettings
+        {
+            DummyTicker = false,
+            Connected = true,
+            Dirty = true
+        };
+
         [Test]
         public async Task ResettingEntitySystemResetTest()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings
-            {
-                DummyTicker = false,
-                Connected = true,
-                Dirty = true
-            });
+            var pair = Pair;
             var server = pair.Server;
 
             var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
@@ -52,7 +55,6 @@ namespace Content.IntegrationTests.Tests
 
                 Assert.That(system.HasBeenReset);
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Respirator/LungTest.cs
+++ b/Content.IntegrationTests/Tests/Respirator/LungTest.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Atmos.Components;
 using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.Utility;
@@ -14,7 +15,7 @@ namespace Content.IntegrationTests.Tests.Respirator;
 
 [TestFixture]
 [TestOf(typeof(LungSystem))]
-public sealed class LungTest
+public sealed class LungTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -54,7 +55,7 @@ public sealed class LungTest
     public async Task AirConsistencyTest()
     {
         // --- Setup
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         await server.WaitIdleAsync();
@@ -123,14 +124,12 @@ public sealed class LungTest
                 "Did not exhale as much gas as was inhaled"
             );
         }
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task NoSuffocationTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var mapManager = server.ResolveDependency<IMapManager>();
@@ -183,7 +182,5 @@ public sealed class LungTest
                     $"Entity {entityManager.GetComponent<MetaDataComponent>(human).EntityName} is suffocating on tick {tick}");
             });
         }
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RestartRoundTest.cs
+++ b/Content.IntegrationTests/Tests/RestartRoundTest.cs
@@ -1,20 +1,23 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.GameTicking;
 using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
-    public sealed class RestartRoundTest
+    public sealed class RestartRoundTest : GameTest
     {
+        public override PoolSettings PoolSettings => new PoolSettings
+        {
+            DummyTicker = false,
+            Connected = true,
+            Dirty = true
+        };
+
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings
-            {
-                DummyTicker = false,
-                Connected = true,
-                Dirty = true
-            });
+            var pair = Pair;
             var server = pair.Server;
             var sysManager = server.ResolveDependency<IEntitySystemManager>();
 
@@ -23,8 +26,7 @@ namespace Content.IntegrationTests.Tests
                 sysManager.GetEntitySystem<GameTicker>().RestartRound();
             });
 
-            await pair.RunTicksSync(10);
-            await pair.CleanReturnAsync();
+            await pair.RunUntilSynced();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Roles/StartingGearStorageTests.cs
+++ b/Content.IntegrationTests/Tests/Roles/StartingGearStorageTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Roles;
 using Content.Server.Storage.EntitySystems;
 using Robust.Shared.GameObjects;
@@ -7,16 +8,17 @@ using Robust.Shared.Collections;
 namespace Content.IntegrationTests.Tests.Roles;
 
 [TestFixture]
-public sealed class StartingGearPrototypeStorageTest
+public sealed class StartingGearPrototypeStorageTest : GameTest
 {
+    public override PoolSettings PoolSettings => new() { Connected = true, Dirty = true };
+
     /// <summary>
     /// Checks that a storage fill on a StartingGearPrototype will properly fill
     /// </summary>
     [Test]
     public async Task TestStartingGearStorage()
     {
-        var settings = new PoolSettings { Connected = true, Dirty = true };
-        await using var pair = await PoolManager.GetServerClient(settings);
+        var pair = Pair;
         var server = pair.Server;
         var mapSystem = server.System<SharedMapSystem>();
         var storageSystem = server.System<StorageSystem>();
@@ -65,7 +67,5 @@ public sealed class StartingGearPrototypeStorageTest
 
             mapSystem.DeleteMap(testMap.MapId);
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Pair;
 using Content.Server.GameTicking;
 using Content.Server.Mind;
@@ -16,7 +17,7 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Round;
 
 [TestFixture]
-public sealed class JobTest
+public sealed class JobTest : GameTest
 {
     private static readonly ProtoId<JobPrototype> Passenger = "Passenger";
     private static readonly ProtoId<JobPrototype> Engineer = "StationEngineer";
@@ -43,6 +44,13 @@ public sealed class JobTest
             {Engineer}: [ -1, -1 ]
             {Captain}: [ 1, 1 ]
 ";
+
+    public override PoolSettings PoolSettings => new()
+    {
+        DummyTicker = false,
+        Connected = true,
+        InLobby = true
+    };
 
     private void AssertJob(TestPair pair, ProtoId<JobPrototype> job, NetUserId? user = null, bool isAntag = false)
     {
@@ -71,12 +79,7 @@ public sealed class JobTest
     [Test]
     public async Task StartRoundTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true
-        });
+        var pair = Pair;
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
         var ticker = pair.Server.System<GameTicker>();
@@ -95,7 +98,6 @@ public sealed class JobTest
         AssertJob(pair, Passenger);
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -104,12 +106,7 @@ public sealed class JobTest
     [Test]
     public async Task JobPreferenceTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true
-        });
+        var pair = Pair;
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
         var ticker = pair.Server.System<GameTicker>();
@@ -133,7 +130,6 @@ public sealed class JobTest
         AssertJob(pair, Passenger);
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -143,12 +139,7 @@ public sealed class JobTest
     [Test]
     public async Task JobWeightTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true
-        });
+        var pair = Pair;
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
         var ticker = pair.Server.System<GameTicker>();
@@ -169,7 +160,6 @@ public sealed class JobTest
         AssertJob(pair, Captain);
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -178,12 +168,7 @@ public sealed class JobTest
     [Test]
     public async Task JobPriorityTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true
-        });
+        var pair = Pair;
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
         var ticker = pair.Server.System<GameTicker>();
@@ -217,6 +202,5 @@ public sealed class JobTest
         });
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/RoundEndTest.cs
+++ b/Content.IntegrationTests/Tests/RoundEndTest.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.GameTicking;
 using Content.Server.RoundEnd;
 using Content.Shared.CCVar;
@@ -7,7 +8,7 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
-    public sealed class RoundEndTest
+    public sealed class RoundEndTest : GameTest
     {
         private sealed class RoundEndTestSystem : EntitySystem
         {
@@ -25,15 +26,18 @@ namespace Content.IntegrationTests.Tests
             }
         }
 
+
+        public override PoolSettings PoolSettings => new PoolSettings
+        {
+            DummyTicker = false,
+            Connected = true,
+            Dirty = true
+        };
+
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings
-            {
-                DummyTicker = false,
-                Connected = true,
-                Dirty = true
-            });
+            var pair = Pair;
 
             var server = pair.Server;
 
@@ -151,7 +155,6 @@ namespace Content.IntegrationTests.Tests
                 roundEndSystem.DefaultCountdownDuration = TimeSpan.FromMinutes(4);
                 ticker.RestartRound();
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/SalvageTest.cs
+++ b/Content.IntegrationTests/Tests/SalvageTest.cs
@@ -1,4 +1,6 @@
-﻿using Content.Shared.CCVar;
+﻿using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
+using Content.Shared.CCVar;
 using Content.Shared.Salvage;
 using Robust.Shared.Configuration;
 using Robust.Shared.EntitySerialization.Systems;
@@ -8,15 +10,16 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests;
 
 [TestFixture]
-public sealed class SalvageTest
+public sealed class SalvageTest : GameTest
 {
     /// <summary>
     /// Asserts that all salvage maps have been saved as grids and are loadable.
     /// </summary>
     [Test]
+    [EnsureCVar(Side.Server, typeof(CCVars), nameof(CCVars.GridFill), false)]
     public async Task AllSalvageMapsLoadableTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -24,7 +27,6 @@ public sealed class SalvageTest
         var prototypeManager = server.ResolveDependency<IPrototypeManager>();
         var cfg = server.ResolveDependency<IConfigurationManager>();
         var mapSystem = entManager.System<SharedMapSystem>();
-        Assert.That(cfg.GetCVar(CCVars.GridFill), Is.False);
 
         await server.WaitPost(() =>
         {
@@ -50,8 +52,6 @@ public sealed class SalvageTest
                 }
             }
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
+        await RunUntilSynced();
     }
 }

--- a/Content.IntegrationTests/Tests/SaveLoadMapTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadMapTest.cs
@@ -1,4 +1,6 @@
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Shared.CCVar;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
@@ -12,14 +14,15 @@ using Robust.Shared.Utility;
 namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
-    public sealed class SaveLoadMapTest
+    public sealed class SaveLoadMapTest : GameTest
     {
         [Test]
+        [EnsureCVar(Side.Server, typeof(CCVars), nameof(CCVars.GridFill), false)]
         public async Task SaveLoadMultiGridMap()
         {
             var mapPath = new ResPath("/Maps/Test/TestMap.yml");
 
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var sEntities = server.ResolveDependency<IEntityManager>();
@@ -27,8 +30,6 @@ namespace Content.IntegrationTests.Tests
             var mapSystem = sEntities.System<SharedMapSystem>();
             var xformSystem = sEntities.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
             var resManager = server.ResolveDependency<IResourceManager>();
-            var cfg = server.ResolveDependency<IConfigurationManager>();
-            Assert.That(cfg.GetCVar(CCVars.GridFill), Is.False);
 
             await server.WaitAssertion(() =>
             {
@@ -94,8 +95,6 @@ namespace Content.IntegrationTests.Tests
                     });
                 }
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
@@ -16,12 +17,12 @@ namespace Content.IntegrationTests.Tests
     ///     Tests that a grid's yaml does not change when saved consecutively.
     /// </summary>
     [TestFixture]
-    public sealed class SaveLoadSaveTest
+    public sealed class SaveLoadSaveTest : GameTest
     {
         [Test]
         public async Task CreateSaveLoadSaveGrid()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var entManager = server.ResolveDependency<IEntityManager>();
             var mapLoader = entManager.System<MapLoaderSystem>();
@@ -85,7 +86,6 @@ namespace Content.IntegrationTests.Tests
                 }
             });
             testSystem.Enabled = false;
-            await pair.CleanReturnAsync();
         }
 
         private const string TestMap = "Maps/bagel.yml";
@@ -96,7 +96,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task LoadSaveTicksSaveBagel()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             var mapLoader = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<MapLoaderSystem>();
             var mapSys = server.System<SharedMapSystem>();
@@ -167,7 +167,6 @@ namespace Content.IntegrationTests.Tests
 
             testSystem.Enabled = false;
             await server.WaitPost(() => mapSys.DeleteMap(mapId));
-            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -183,7 +182,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task LoadTickLoadBagel()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var mapLoader = server.System<MapLoaderSystem>();
@@ -241,7 +240,6 @@ namespace Content.IntegrationTests.Tests
             testSystem.Enabled = false;
             await server.WaitPost(() => mapSys.DeleteMap(mapId1));
             await server.WaitPost(() => mapSys.DeleteMap(mapId2));
-            await pair.CleanReturnAsync();
         }
 
         /// <summary>

--- a/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
@@ -88,7 +88,7 @@ namespace Content.IntegrationTests.Tests
             testSystem.Enabled = false;
         }
 
-        private const string TestMap = "Maps/bagel.yml";
+        private new const string TestMap = "Maps/bagel.yml";
 
         /// <summary>
         ///     Loads the default map, runs it for 5 ticks, then assert that it did not change.

--- a/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
+++ b/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Robust.Shared.Reflection;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -8,7 +9,7 @@ using Robust.Shared.Serialization.Markdown.Value;
 namespace Content.IntegrationTests.Tests.Serialization;
 
 [TestFixture]
-public sealed partial class SerializationTest
+public sealed partial class SerializationTest : GameTest
 {
     /// <summary>
     /// Check that serializing generic enums works as intended. This should really be in engine, but engine
@@ -17,7 +18,7 @@ public sealed partial class SerializationTest
     [Test]
     public async Task SerializeGenericEnums()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var seriMan = server.ResolveDependency<ISerializationManager>();
         var refMan = server.ResolveDependency<IReflectionManager>();
@@ -67,8 +68,6 @@ public sealed partial class SerializationTest
         Assert.That(seriMan.ValidateNode<TestEnum>(genericNode).GetErrors().Any(), Is.True);
         Assert.That(seriMan.ValidateNode<Enum>(typedNode).GetErrors().Any(), Is.True);
         Assert.That(seriMan.ValidateNode<TestEnum>(typedNode).GetErrors().Any(), Is.False);
-
-        await pair.CleanReturnAsync();
     }
 
     private enum TestEnum : byte { Aa, Bb, Cc, Dd }

--- a/Content.IntegrationTests/Tests/Shuttle/DockTest.cs
+++ b/Content.IntegrationTests/Tests/Shuttle/DockTest.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Shuttles.Systems;
 using Content.Tests;
 using Robust.Server.GameObjects;
@@ -13,7 +14,7 @@ using Robust.Shared.Utility;
 
 namespace Content.IntegrationTests.Tests.Shuttle;
 
-public sealed class DockTest : ContentUnitTest
+public sealed class DockTest : GameTest
 {
     private static IEnumerable<object[]> TestSource()
     {
@@ -26,7 +27,7 @@ public sealed class DockTest : ContentUnitTest
     [TestCaseSource(nameof(TestSource))]
     public async Task TestDockingConfig(Vector2 dock1Pos, Vector2 dock2Pos, Angle dock1Angle, Angle dock2Angle, bool result)
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var map = await pair.CreateTestMap();
@@ -83,14 +84,12 @@ public sealed class DockTest : ContentUnitTest
 
             Assert.That(result, Is.EqualTo(config != null));
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestPlanetDock()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var map = await pair.CreateTestMap();
@@ -126,7 +125,5 @@ public sealed class DockTest : ContentUnitTest
             var dockingConfig = dockingSystem.GetDockingConfig(shuttle, map.MapUid);
             Assert.That(dockingConfig, Is.Not.EqualTo(null));
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/ShuttleTest.cs
+++ b/Content.IntegrationTests/Tests/ShuttleTest.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Shuttles.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
@@ -9,12 +10,12 @@ using Robust.Shared.Physics.Systems;
 namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
-    public sealed class ShuttleTest
+    public sealed class ShuttleTest : GameTest
     {
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             await server.WaitIdleAsync();
 
@@ -50,7 +51,6 @@ namespace Content.IntegrationTests.Tests
             {
                 Assert.That(entManager.GetComponent<TransformComponent>(map.Grid).LocalPosition, Is.Not.EqualTo(Vector2.Zero));
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Sprite/ItemSpriteTest.cs
+++ b/Content.IntegrationTests/Tests/Sprite/ItemSpriteTest.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Item;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
@@ -22,7 +23,7 @@ namespace Content.IntegrationTests.Tests.Sprite;
 /// <see cref="Ignored"/>
 /// </remarks>
 [TestFixture]
-public sealed class PrototypeSaveTest
+public sealed class PrototypeSaveTest : GameTest
 {
     private static readonly HashSet<string> Ignored = new()
     {
@@ -34,8 +35,7 @@ public sealed class PrototypeSaveTest
     [Test]
     public async Task AllItemsHaveSpritesTest()
     {
-        var settings = new PoolSettings() { Connected = true }; // client needs to be in-game
-        await using var pair = await PoolManager.GetServerClient(settings);
+        var pair = Pair;
         List<EntityPrototype> badPrototypes = [];
 
         await pair.Client.WaitPost(() =>
@@ -58,7 +58,5 @@ public sealed class PrototypeSaveTest
                 Assert.Fail($"Item prototype has no sprite: {proto.ID}. It should probably either be marked as abstract, not be an item, or have a valid sprite");
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/StartTest.cs
+++ b/Content.IntegrationTests/Tests/StartTest.cs
@@ -1,9 +1,10 @@
+using Content.IntegrationTests.Fixtures;
 using Robust.Shared.Exceptions;
 
 namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
-    public sealed class StartTest
+    public sealed class StartTest : GameTest
     {
         /// <summary>
         ///     Test that the server, and client start, and stop.
@@ -11,7 +12,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task TestClientStart()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var client = pair.Client;
             Assert.That(client.IsAlive);
             await client.WaitRunTicks(5);
@@ -27,8 +28,6 @@ namespace Content.IntegrationTests.Tests
             Assert.That(sRuntimeLog.ExceptionCount, Is.EqualTo(0), "No exceptions must be logged on server.");
             await server.WaitIdleAsync();
             Assert.That(server.IsAlive);
-
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Station/EvacShuttleTest.cs
+++ b/Content.IntegrationTests/Tests/Station/EvacShuttleTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.GameTicking;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Systems;
@@ -12,15 +13,21 @@ namespace Content.IntegrationTests.Tests.Station;
 
 [TestFixture]
 [TestOf(typeof(EmergencyShuttleSystem))]
-public sealed class EvacShuttleTest
+public sealed class EvacShuttleTest : GameTest
 {
+    public override PoolSettings PoolSettings => new PoolSettings()
+    {
+        DummyTicker = true,
+        Dirty = true,
+    };
+
     /// <summary>
     /// Ensure that the emergency shuttle can be called, and that it will travel to centcomm
     /// </summary>
     [Test]
     public async Task EmergencyEvacTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { DummyTicker = true, Dirty = true });
+        var pair = Pair;
         var server = pair.Server;
         var entMan = server.EntMan;
         var ticker = server.System<GameTicker>();
@@ -122,6 +129,5 @@ public sealed class EvacShuttleTest
         server.CfgMan.SetCVar(CCVars.EmergencyShuttleDockTime, dockTime);
         pair.Server.CfgMan.SetCVar(CCVars.EmergencyShuttleEnabled, false);
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, gameMap);
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Station/JobTests.cs
+++ b/Content.IntegrationTests/Tests/Station/JobTests.cs
@@ -2,12 +2,13 @@ using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
 using Robust.Shared.Prototypes;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 
 namespace Content.IntegrationTests.Tests.Station;
 
 [TestFixture]
 [TestOf(typeof(SharedJobSystem))]
-public sealed class JobTest
+public sealed class JobTest : GameTest
 {
     /// <summary>
     /// Ensures that every job belongs to at most 1 primary department.
@@ -16,7 +17,7 @@ public sealed class JobTest
     [Test]
     public async Task PrimaryDepartmentsTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var prototypeManager = server.ResolveDependency<IPrototypeManager>();
@@ -43,6 +44,5 @@ public sealed class JobTest
                 }
             }
         });
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Station/StationJobsTest.cs
+++ b/Content.IntegrationTests/Tests/Station/StationJobsTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Shared.Maps;
@@ -15,7 +16,7 @@ namespace Content.IntegrationTests.Tests.Station;
 
 [TestFixture]
 [TestOf(typeof(StationJobsSystem))]
-public sealed class StationJobsTest
+public sealed class StationJobsTest : GameTest
 {
     private const string StationMapId = "FooStation";
 
@@ -85,7 +86,7 @@ public sealed class StationJobsTest
     [Test]
     public async Task AssignJobsTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var prototypeManager = server.ResolveDependency<IPrototypeManager>();
@@ -153,13 +154,12 @@ public sealed class StationJobsTest
                 Assert.That(assigned.Values.Select(x => x.Item1).ToList(), Does.Contain("TCaptain"));
             });
         });
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task AdjustJobsTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var prototypeManager = server.ResolveDependency<IPrototypeManager>();
@@ -203,13 +203,12 @@ public sealed class StationJobsTest
                 Assert.That(stationJobs.IsJobUnlimited(station, "TChaplain"), "Could not make TChaplain unlimited.");
             });
         });
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task InvalidRoundstartJobsTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var prototypeManager = server.ResolveDependency<IPrototypeManager>();
@@ -247,7 +246,6 @@ public sealed class StationJobsTest
                 }
             });
         });
-        await pair.CleanReturnAsync();
     }
 }
 

--- a/Content.IntegrationTests/Tests/Storage/EntityStorageTests.cs
+++ b/Content.IntegrationTests/Tests/Storage/EntityStorageTests.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Storage.EntitySystems;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
@@ -7,7 +8,7 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests.Storage;
 
 [TestFixture]
-public sealed class EntityStorageTests
+public sealed class EntityStorageTests : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -31,7 +32,7 @@ public sealed class EntityStorageTests
     [Test]
     public async Task TestContainerDestruction()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var map = await pair.CreateTestMap();
 
@@ -76,7 +77,5 @@ public sealed class EntityStorageTests
         await server.WaitRunTicks(5);
         Assert.That(server.EntMan.Deleted(box));
         Assert.That(server.EntMan.Deleted(crowbar), Is.False);
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Storage/StorageTest.cs
+++ b/Content.IntegrationTests/Tests/Storage/StorageTest.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Containers;
 using Content.Shared.Item;
 using Content.Shared.Prototypes;
@@ -12,7 +13,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.Storage;
 
-public sealed class StorageTest
+public sealed class StorageTest : GameTest
 {
     /// <summary>
     /// Can an item store more than itself weighs.
@@ -21,7 +22,7 @@ public sealed class StorageTest
     [Test]
     public async Task StorageSizeArbitrageTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var protoManager = server.ResolveDependency<IPrototypeManager>();
@@ -44,13 +45,12 @@ public sealed class StorageTest
                     $"Found storage arbitrage on {proto.ID}");
             }
         });
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestStorageFillPrototypes()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var protoManager = server.ResolveDependency<IPrototypeManager>();
@@ -72,13 +72,12 @@ public sealed class StorageTest
                 }
             });
         });
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestSufficientSpaceForFill()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
@@ -159,14 +158,12 @@ public sealed class StorageTest
                 }
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestSufficientSpaceForEntityStorageFill()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
@@ -194,7 +191,6 @@ public sealed class StorageTest
                     $"{proto.ID} storage fill is too large.");
             });
         }
-        await pair.CleanReturnAsync();
     }
 
     private int GetEntrySize(EntitySpawnEntry entry, bool getCount, IPrototypeManager protoMan, SharedItemSystem itemSystem)
@@ -242,7 +238,7 @@ public sealed class StorageTest
     [Test]
     public async Task NoMultipleContainerFillsTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var compFact = pair.Server.ResolveDependency<IComponentFactory>();
 
         Assert.Multiple(() =>
@@ -258,6 +254,5 @@ public sealed class StorageTest
                 Assert.That(!proto.HasComponent<StorageFillComponent>(compFact), $"Prototype {proto.ID} has both {nameof(ContainerFillComponent)} and {nameof(StorageFillComponent)}.");
             }
         });
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -33,6 +33,10 @@ public sealed class StoreTests : GameTest
     - idcard
   - type: Pda
 ";
+
+    // This test is broken and crashes the client if connected.
+    public override PoolSettings PoolSettings => new();
+
     [Test]
     public async Task StoreDiscountAndRefund()
     {

--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Store.Systems;
 using Content.Server.Traitor.Uplink;
 using Content.Shared.FixedPoint;
@@ -16,7 +17,7 @@ using Robust.Shared.Random;
 namespace Content.IntegrationTests.Tests;
 
 [TestFixture]
-public sealed class StoreTests
+public sealed class StoreTests : GameTest
 {
 
     [TestPrototypes]
@@ -35,7 +36,7 @@ public sealed class StoreTests
     [Test]
     public async Task StoreDiscountAndRefund()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var testMap = await pair.CreateTestMap();
@@ -168,7 +169,5 @@ public sealed class StoreTests
             }
 
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -1,8 +1,6 @@
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Content.IntegrationTests.Fixtures;
-using Content.Server.Store.Systems;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Server.Traitor.Uplink;
 using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;
@@ -11,7 +9,6 @@ using Content.Shared.Store;
 using Content.Shared.Store.Components;
 using Content.Shared.StoreDiscount.Components;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.IntegrationTests.Tests;
@@ -34,10 +31,19 @@ public sealed class StoreTests : GameTest
   - type: Pda
 ";
 
-    // This test is broken and crashes the client if connected.
-    public override PoolSettings PoolSettings => new();
+    [Test]
+    [Ignore("""
+        This currently causes the client to crash, failing the test.
+        When this is fixed, this test should be removed and StoreDiscountAndRefund
+        should just use the default pair config.
+    """)]
+    public async Task StoreDiscountAndRefundWithClient()
+    {
+        await StoreDiscountAndRefund();
+    }
 
     [Test]
+    [PairConfig(nameof(PsDisconnected))]
     public async Task StoreDiscountAndRefund()
     {
         var pair = Pair;

--- a/Content.IntegrationTests/Tests/Tag/TagTest.cs
+++ b/Content.IntegrationTests/Tests/Tag/TagTest.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Tag;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
@@ -10,7 +11,7 @@ namespace Content.IntegrationTests.Tests.Tag
 {
     [TestFixture]
     [TestOf(typeof(TagComponent))]
-    public sealed class TagTest
+    public sealed class TagTest : GameTest
     {
         private const string TagEntityId = "TagTestDummy";
 
@@ -44,7 +45,7 @@ namespace Content.IntegrationTests.Tests.Tag
         [Test]
         public async Task TagComponentTest()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var sEntityManager = server.ResolveDependency<IEntityManager>();
@@ -295,7 +296,6 @@ namespace Content.IntegrationTests.Tests.Tag
                 Assert.Throws<DebugAssertException>(() => { tagSystem.AddTags(sTagEntity, new HashSet<ProtoId<TagPrototype>> { UnregisteredTag }); });
 #endif
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Tiles/TileStackRecursionTest.cs
+++ b/Content.IntegrationTests/Tests/Tiles/TileStackRecursionTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.CCVar;
 using Content.Shared.Maps;
 using Robust.Shared.Configuration;
@@ -7,12 +8,12 @@ using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.Tiles;
 
-public sealed class TileStackRecursionTest
+public sealed class TileStackRecursionTest : GameTest
 {
     [Test]
     public async Task TestBaseTurfRecursion()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var protoMan = pair.Server.ResolveDependency<IPrototypeManager>();
         var cfg = pair.Server.ResolveDependency<IConfigurationManager>();
         var maxTileHistoryLength = cfg.GetCVar(CCVars.TileStackLimit);
@@ -40,7 +41,6 @@ public sealed class TileStackRecursionTest
                 (possibleTurf, new ProtoId<ContentTileDefinition>(ctdef.ID))));
         }
         Bfs(nodes, edges, maxTileHistoryLength);
-        await pair.CleanReturnAsync();
     }
 
     private void Bfs(List<(ProtoId<ContentTileDefinition>, int)> nodes, List<(ProtoId<ContentTileDefinition>, ProtoId<ContentTileDefinition>)> edges, int depthLimit)

--- a/Content.IntegrationTests/Tests/UserInterface/UiControlTest.cs
+++ b/Content.IntegrationTests/Tests/UserInterface/UiControlTest.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Client.LateJoin;
+using Content.IntegrationTests.Fixtures;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
@@ -8,7 +9,7 @@ using Robust.Shared.Reflection;
 namespace Content.IntegrationTests.Tests.UserInterface;
 
 [TestFixture]
-public sealed class UiControlTest
+public sealed class UiControlTest : GameTest
 {
     // You should not be adding to this.
     private Type[] _ignored = new Type[]
@@ -22,10 +23,7 @@ public sealed class UiControlTest
     [Test]
     public async Task TestWindows()
     {
-        var pair = await PoolManager.GetServerClient(new PoolSettings()
-        {
-            Connected = true,
-        });
+        var pair = Pair;
         var activator = pair.Client.ResolveDependency<IDynamicTypeFactory>();
         var refManager = pair.Client.ResolveDependency<IReflectionManager>();
         var loader = pair.Client.ResolveDependency<IModLoader>();
@@ -50,7 +48,5 @@ public sealed class UiControlTest
                 activator.CreateInstance(type, oneOff: true, inject: false);
             }
         });
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Utility/EntitySystemExtensionsTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/EntitySystemExtensionsTest.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Physics;
 using Content.Shared.Spawning;
 using Robust.Shared.GameObjects;
@@ -8,7 +9,7 @@ namespace Content.IntegrationTests.Tests.Utility
 {
     [TestFixture]
     [TestOf(typeof(EntitySystemExtensions))]
-    public sealed class EntitySystemExtensionsTest
+    public sealed class EntitySystemExtensionsTest : GameTest
     {
         private const string BlockerDummyId = "BlockerDummy";
 
@@ -32,7 +33,7 @@ namespace Content.IntegrationTests.Tests.Utility
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var testMap = await pair.CreateTestMap();
@@ -95,7 +96,6 @@ namespace Content.IntegrationTests.Tests.Utility
                     Assert.That(entity, Is.Not.Null);
                 });
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Utility/EntityWhitelistTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/EntityWhitelistTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Whitelist;
 using Robust.Shared.GameObjects;
@@ -7,7 +8,7 @@ namespace Content.IntegrationTests.Tests.Utility
 {
     [TestFixture]
     [TestOf(typeof(EntityWhitelist))]
-    public sealed class EntityWhitelistTest
+    public sealed class EntityWhitelistTest : GameTest
     {
         private const string InvalidComponent = "Sprite";
         private const string ValidComponent = "Physics";
@@ -58,7 +59,7 @@ namespace Content.IntegrationTests.Tests.Utility
         [Test]
         public async Task Test()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
 
             var testMap = await pair.CreateTestMap();
@@ -111,7 +112,6 @@ namespace Content.IntegrationTests.Tests.Utility
                     Assert.That(sys.IsValid(whitelistSer, WhitelistTestInvalidTag), Is.False);
                 });
             });
-            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs
+++ b/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.VendingMachines;
 using Content.Server.Wires;
 using Content.Shared.Cargo.Prototypes;
@@ -21,7 +22,7 @@ namespace Content.IntegrationTests.Tests
     [TestFixture]
     [TestOf(typeof(VendingMachineRestockComponent))]
     [TestOf(typeof(VendingMachineSystem))]
-    public sealed class VendingMachineRestockTest : EntitySystem
+    public sealed class VendingMachineRestockTest : GameTest
     {
         private static readonly ProtoId<DamageTypePrototype> TestDamageType = "Blunt";
 
@@ -111,7 +112,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task TestAllRestocksAreAvailableToBuy()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             await server.WaitIdleAsync();
 
@@ -194,14 +195,12 @@ namespace Content.IntegrationTests.Tests
                         $"Some entities with {restockCompName} are unavailable for purchase: \n - {string.Join("\n - ", restockEntities)}");
                 });
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestCompleteRestockProcess()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             await server.WaitIdleAsync();
 
@@ -280,14 +279,12 @@ namespace Content.IntegrationTests.Tests
 
                 mapSystem.DeleteMap(testMap.MapId);
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestRestockBreaksOpen()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             await server.WaitIdleAsync();
 
@@ -342,14 +339,12 @@ namespace Content.IntegrationTests.Tests
 
                 mapSystem.DeleteMap(testMap.MapId);
             });
-
-            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestRestockInventoryBounds()
         {
-            await using var pair = await PoolManager.GetServerClient();
+            var pair = Pair;
             var server = pair.Server;
             await server.WaitIdleAsync();
 
@@ -388,10 +383,6 @@ namespace Content.IntegrationTests.Tests
                 Assert.That(vendingMachineSystem.GetAvailableInventory(machine)[0].Amount, Is.EqualTo(3),
                     "Machine's available inventory did not stay the same after a third restock.");
             });
-
-            await pair.CleanReturnAsync();
         }
     }
 }
-
-#nullable disable

--- a/Content.IntegrationTests/Tests/Wires/WireLayoutTest.cs
+++ b/Content.IntegrationTests/Tests/Wires/WireLayoutTest.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server.Doors;
+﻿using Content.IntegrationTests.Fixtures;
+using Content.Server.Doors;
 using Content.Server.Power;
 using Content.Server.Wires;
 using Robust.Shared.GameObjects;
@@ -10,7 +11,7 @@ namespace Content.IntegrationTests.Tests.Wires;
 [TestFixture]
 [Parallelizable(ParallelScope.All)]
 [TestOf(typeof(WiresSystem))]
-public sealed class WireLayoutTest
+public sealed class WireLayoutTest : GameTest
 {
     [TestPrototypes]
     public const string Prototypes = """
@@ -53,7 +54,7 @@ public sealed class WireLayoutTest
     [Test]
     public async Task TestLayoutInheritance()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
         var testMap = await pair.CreateTestMap();
 
@@ -89,8 +90,6 @@ public sealed class WireLayoutTest
                 Assert.That(ent3.Comp.WiresList, Has.One.With.Property("Action").InstanceOf<DoorBoltWireAction>(), "1 door bolt wire");
             });
         });
-
-        await pair.CleanReturnAsync();
     }
 
     private static Entity<T> SpawnWithComp<T>(IEntityManager entityManager, string prototype, MapCoordinates coords)

--- a/Content.IntegrationTests/Tests/WizdenContentFreeze/WizdenContentFreeze.cs
+++ b/Content.IntegrationTests/Tests/WizdenContentFreeze/WizdenContentFreeze.cs
@@ -1,3 +1,4 @@
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Kitchen;
 
 namespace Content.IntegrationTests.Tests.WizdenContentFreeze;
@@ -5,7 +6,7 @@ namespace Content.IntegrationTests.Tests.WizdenContentFreeze;
 /// <summary>
 /// These tests are limited to adding a specific type of content, essentially freezing it. If you are a fork developer, you may want to disable these tests.
 /// </summary>
-public sealed class WizdenContentFreeze
+public sealed class WizdenContentFreeze : GameTest
 {
     /// <summary>
     /// This freeze prohibits the addition of new microwave recipes.
@@ -18,7 +19,7 @@ public sealed class WizdenContentFreeze
     [Test]
     public async Task MicrowaveRecipesFreezeTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var protoMan = server.ProtoMan;
@@ -35,7 +36,5 @@ public sealed class WizdenContentFreeze
         {
             Assert.Fail($"Oh, you deleted the microwave recipes? YOU ARE SO COOL! Please lower the number of recipes in MicrowaveRecipesFreezeTest from {recipesLimit} to {recipesCount} so that future contributors cannot add new recipes back.");
         }
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/XenoArtifactTest.cs
+++ b/Content.IntegrationTests/Tests/XenoArtifactTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Xenoarchaeology.Artifact;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 using Robust.Shared.GameObjects;
@@ -6,7 +7,7 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests;
 
 [TestFixture]
-public sealed class XenoArtifactTest
+public sealed class XenoArtifactTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -90,7 +91,7 @@ public sealed class XenoArtifactTest
     [Test]
     public async Task XenoArtifactAddNodeTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -133,9 +134,6 @@ public sealed class XenoArtifactTest
             Assert.That(artifactSystem.GetDirectPredecessorNodes(artifactEnt, node3!.Value), Has.Count.EqualTo(1));
             Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node3!.Value), Has.Count.EqualTo(2));
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -144,7 +142,7 @@ public sealed class XenoArtifactTest
     [Test]
     public async Task XenoArtifactRemoveNodeTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -182,9 +180,6 @@ public sealed class XenoArtifactTest
             Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node2!.Value), Is.Empty);
             Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node4!.Value), Is.Empty);
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -193,7 +188,7 @@ public sealed class XenoArtifactTest
     [Test]
     public async Task XenoArtifactResizeTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -245,9 +240,6 @@ public sealed class XenoArtifactTest
             Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node4!.Value), Is.Empty);
             Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node4!.Value), Is.Empty);
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -256,7 +248,7 @@ public sealed class XenoArtifactTest
     [Test]
     public async Task XenoArtifactReplaceTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -304,9 +296,6 @@ public sealed class XenoArtifactTest
             Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node4!.Value), Is.Empty);
 
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -315,7 +304,7 @@ public sealed class XenoArtifactTest
     [Test]
     public async Task XenoArtifactBuildActiveNodesTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -367,15 +356,12 @@ public sealed class XenoArtifactTest
             Assert.That(artifactEnt.Comp.CachedActiveNodes, Has.Count.EqualTo(expectedActiveNodes.Length));
 
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task XenoArtifactGenerateSegmentsTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -412,8 +398,5 @@ public sealed class XenoArtifactTest
             Assert.That(grouped[2].Count(), Is.LessThanOrEqualTo(2)); // maintain same width or, if we used 3 nodes on previous layer - we only have 1 left!
 
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.MapRenderer/Program.cs
+++ b/Content.MapRenderer/Program.cs
@@ -145,7 +145,7 @@ namespace Content.MapRenderer
                 {
                     Console.Write($"Following map files did not exist on disk directly, searching through prototypes: {string.Join(", ", lookupPrototypeFiles)}");
 
-                    await using var pair = await PoolManager.GetServerClient();
+                    await using var pair = await PoolManager.GetServerClient(testContext: testContext);
                     var mapPrototypes = pair.Server
                         .ResolveDependency<IPrototypeManager>()
                         .EnumeratePrototypes<GameMapPrototype>()

--- a/Content.Shared/Trigger/Systems/TriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.cs
@@ -90,6 +90,9 @@ public sealed partial class TriggerSystem : EntitySystem
         if (!Resolve(ent, ref ent.Comp))
             return false;
 
+        if (Terminating(ent))
+            return false; // Stop trying to resurrect a dead horse.
+
         if (HasComp<ActiveTimerTriggerComponent>(ent))
             return false; // already activated
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
this fixes the DisposeAsync test failures and also catches a bunch of other ways tests mismanaged pairs (like not properly returning them on failure),

Blocked on https://github.com/space-wizards/space-station-14/pull/43182/

Discovered https://github.com/space-wizards/space-station-14/issues/43223
Resolves https://github.com/space-wizards/space-station-14/issues/43239

## Why / Balance
~300 content tests all did resource management incorrectly, GameTest does it correctly.

## Technical details
Mostly just changes out pair usage within tests without significantly altering them. Minor alteration is done for things like CVar asserts. Full refactors come in part 3 (in many PRs, not one.)

This changes some tests to be more conservative with their pair configurations, I will get back to them eventually.

This changes a *lot* of tests that previously did not have a connected client to have a connected client. I consider this a plus for coverage, PVS is disabled so any shenanigans should sync with the client.

There is a little bit of wider rewrite-y-ness in here but I gave up on that pretty quick.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
