### PR TITLE
Fix GeneralRecords "unknown messageId" warning

### DIFF
--- a/Content.Client/StationRecords/GeneralRecord.xaml.cs
+++ b/Content.Client/StationRecords/GeneralRecord.xaml.cs
@@ -17,7 +17,7 @@ public sealed partial class GeneralRecord : Control
         RecordName.Text = record.Name;
         Age.Text = Loc.GetString("general-station-record-console-record-age", ("age", record.Age.ToString()));
         Title.Text = Loc.GetString("general-station-record-console-record-title",
-            ("job", Loc.GetString(record.JobTitle)));
+            ("job", record.JobTitle));
         var species = Loc.GetString(prototypeManager.Index<SpeciesPrototype>(record.Species).Name);
         Species.Text = Loc.GetString("general-station-record-console-record-species", ("species", species));
         Gender.Text = Loc.GetString("general-station-record-console-record-gender",


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed the localization warning in GeneralRecords. I don't know who did it, but they clearly weren't thinking about the consequences.
<!-- What did you change? -->

## Why / Balance
I'm tired of putting up with this bug in my fork.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
In GeneralRecord.xaml.cs I replaced `Loc.GetString(record.JobTitle)` with `record.JobTitle` since JobTitle is already localized and doesn't need to try to get the locale from it again.
<!-- Summary of code changes for easier review. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

no cl, no fun