### PR TITLE
Make test runnable on windows in debug config again

### DIFF
--- a/Content.IntegrationTests/Utility/GameDataScrounger.Files.cs
+++ b/Content.IntegrationTests/Utility/GameDataScrounger.Files.cs
@@ -39,7 +39,7 @@ public static partial class GameDataScrounger
         return Directory.EnumerateFiles(path,
                 pattern ?? "*",
                 recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
-            .Select(x => new ResPath(x.Remove(0, resBasePath.Length)))
+            .Select(x => ResPath.FromRelativeSystemPath(x.Remove(0, resBasePath.Length)))
             .ToArray();
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The title's kinda meaningless, sorry. There's one place in resource directory helper code (added by #42977 ) which directly instantiates a `ResPath` from a path from an OS-dependent call, and on Windows, that means you get a debug assertion as you end up with a path containing the dreaded `\`.
This just fixes that so that those enslaved by Micro$oft, like me, can still run the tests locally.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Not being able to run the tests discourages people from running the tests, which is bad.

## Technical details
<!-- Summary of code changes for easier review. -->
Strategic replacement of `new ResPath` with `ResPath.FromRelativeSystemPath`.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1321" height="231" alt="image" src="https://github.com/user-attachments/assets/5a38ac94-b641-431f-8abe-45368623cb18" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Shouldn't be any.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
n/a