### PR TITLE
LaunchOnTrigger should launch based off the launcher's direction, not the target

### DIFF
--- a/Content.Shared/Trigger/Components/Effects/LaunchOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/LaunchOnTriggerComponent.cs
@@ -18,6 +18,7 @@ public sealed partial class LaunchOnTriggerComponent : BaseXOnTriggerComponent
     /// <summary>
     /// Set to true to speed the target up in the direction that it itself is moving.
     /// Set to false to move the target in the direction the launcher is moving.
+    /// No effect if targetUser is false (the launcher will be the target)
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool UseTargetDirection = false;

--- a/Content.Shared/Trigger/Components/Effects/LaunchOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/LaunchOnTriggerComponent.cs
@@ -14,4 +14,11 @@ public sealed partial class LaunchOnTriggerComponent : BaseXOnTriggerComponent
     /// </summary>
     [DataField, AutoNetworkedField]
     public float Impulse = 10.0f;
+
+    /// <summary>
+    /// Set to true to speed the target up in the direction that it itself is moving.
+    /// Set to false to move the target in the direction the launcher is moving.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool UseTargetDirection = false;
 }

--- a/Content.Shared/Trigger/Systems/LaunchOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/LaunchOnTriggerSystem.cs
@@ -15,7 +15,7 @@ public sealed class LaunchOnTriggerSystem : XOnTriggerSystem<LaunchOnTriggerComp
         if (!TryComp(target, out PhysicsComponent? phys))
             return;
 
-        var linearVelocity = _physics.GetMapLinearVelocity(target);
+        var linearVelocity = _physics.GetMapLinearVelocity(ent);
         // If the linear velocity is length 0, this means it's not moving. Given we want to move it in some direction...
         if (linearVelocity.IsLengthZero())
             // An object that isn't moving is launched in the direction its facing, not the direction it's rotated (objects face away from their rotation).

--- a/Content.Shared/Trigger/Systems/LaunchOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/LaunchOnTriggerSystem.cs
@@ -15,7 +15,7 @@ public sealed class LaunchOnTriggerSystem : XOnTriggerSystem<LaunchOnTriggerComp
         if (!TryComp(target, out PhysicsComponent? phys))
             return;
 
-        var linearVelocity = _physics.GetMapLinearVelocity(ent);
+        var linearVelocity = _physics.GetMapLinearVelocity(ent.Comp.UseTargetDirection ? target : ent);
         // If the linear velocity is length 0, this means it's not moving. Given we want to move it in some direction...
         if (linearVelocity.IsLengthZero())
             // An object that isn't moving is launched in the direction its facing, not the direction it's rotated (objects face away from their rotation).

--- a/Resources/Prototypes/Entities/Objects/Fun/sports.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/sports.yml
@@ -141,6 +141,9 @@
         - ThrownItem
         restitution: 0.5 # very bouncy
         friction: 0.2
+  - type: TriggerOnCollide
+    fixtureID: fix1
+    keyOut: OnCollide
   - type: LaunchOnTrigger
     impulse: 100.0
     keysIn:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes the behavior of LaunchOnTrigger to allow the "launching" entity (the owner of the LaunchOnTriggerComponent) to move the target that it is interacting [e.g. colliding] with in a way that is informed by the "launching" entity's direction. Previously, the trigger would only "accelerate" the target because it would move target using the target's own velocity vector. If "targetUser" is false, this behavior has no effect (the launcher is the target).

Notably, nothing in this repository actually used LaunchOnTrigger at the moment as it is relatively new (this PR also fixes that for the currently broken "evil beach ball", which is currently just a regular beach ball).

## Why / Balance
This makes LaunchOnTrigger more useful, as generally a "launcher" entity will want to move the "target" entity as if it is imparting its own momentum to it.

## Technical details
* LaunchOnTriggerComponent now has a field for using the old behavior, though the new behavior is the default. This only is impactful when targetUser is true
* Added the TriggerOnCollide functionality to the admeme "evil beach ball" as it appeared to have been intended to function

## Media
For demonstration, using bullets that impart impulse (and no damage):

https://github.com/user-attachments/assets/2710c34e-6a47-46c4-94de-4b04336c8af4

**The old behavior** was unintuitive when `targetUser: true`, and would move things in the direction they were already going, as demonstrated here:

https://github.com/user-attachments/assets/27201dff-7e74-4abe-be42-e604e02da812


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Will change the behavior of prototypes using LaunchOnTrigger - those will need to set `useTargetDirection: true`. There are no prototypes in Wizden that used LaunchOnTrigger before.

**Changelog**
:cl:
- tweak: LaunchOnTrigger now (by default) moves the target in the launcher's direction instead of the target's
