### PR TITLE
Fix reagent grinders on dev map

### DIFF
--- a/Resources/Maps/Test/dev_map.yml
+++ b/Resources/Maps/Test/dev_map.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 270.0.0
+  engineVersion: 273.0.0
   forkId: ""
   forkVersion: ""
-  time: 12/29/2025 08:52:17
-  entityCount: 3158
+  time: 03/15/2026 20:01:24
+  entityCount: 3155
 maps:
 - 23
 grids:
@@ -1621,6 +1621,8 @@ entities:
       id: Dev
     - type: ImplicitRoof
     - type: ExplosionAirtightGrid
+    - type: TileHistory
+      chunkHistory: {}
   - uid: 23
     components:
     - type: MetaData
@@ -1723,6 +1725,8 @@ entities:
     - type: RadiationGridResistance
     - type: ImplicitRoof
     - type: ExplosionAirtightGrid
+    - type: TileHistory
+      chunkHistory: {}
   - uid: 2869
     components:
     - type: MetaData
@@ -1765,6 +1769,8 @@ entities:
     - type: IFF
       flags: HideLabel
     - type: ImplicitRoof
+    - type: TileHistory
+      chunkHistory: {}
 - proto: AirAlarm
   entities:
   - uid: 1270
@@ -11607,77 +11613,23 @@ entities:
     - type: Transform
       pos: 28.5,41.5
       parent: 1
-- proto: KitchenReagentGrinder
+- proto: KitchenReagentGrinderBeakerLarge
   entities:
   - uid: 979
     components:
     - type: Transform
       pos: 31.5,41.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        beakerSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 980
-        inputContainer: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-  - uid: 1044
+  - uid: 980
     components:
     - type: Transform
       pos: 30.5,44.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        beakerSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 1045
-        inputContainer: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-  - uid: 1125
+  - uid: 1044
     components:
     - type: Transform
       pos: 52.5,42.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        beakerSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 1126
-        inputContainer: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
 - proto: KitchenSpike
   entities:
   - uid: 963
@@ -11685,26 +11637,6 @@ entities:
     - type: Transform
       pos: 25.5,40.5
       parent: 1
-- proto: LargeBeaker
-  entities:
-  - uid: 980
-    components:
-    - type: Transform
-      parent: 979
-    - type: Physics
-      canCollide: False
-  - uid: 1045
-    components:
-    - type: Transform
-      parent: 1044
-    - type: Physics
-      canCollide: False
-  - uid: 1126
-    components:
-    - type: Transform
-      parent: 1125
-    - type: Physics
-      canCollide: False
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
   - uid: 453
@@ -12416,8 +12348,8 @@ entities:
       text: Other
     - type: PointLight
       energy: 2
-      radius: 2
       offset: 0,1
+      radius: 2
   - uid: 610
     components:
     - type: Transform
@@ -12428,9 +12360,9 @@ entities:
       text: Weapons
     - type: PointLight
       energy: 5
+      offset: 0,1
       color: '#FF0000FF'
       radius: 2
-      offset: 0,1
   - uid: 611
     components:
     - type: Transform
@@ -12441,9 +12373,9 @@ entities:
       text: Service
     - type: PointLight
       energy: 5
+      offset: 0,1
       color: '#87EB87FF'
       radius: 2
-      offset: 0,1
   - uid: 612
     components:
     - type: Transform
@@ -12454,9 +12386,9 @@ entities:
       text: Medical
     - type: PointLight
       energy: 5
+      offset: 0,1
       color: '#87D1EBFF'
       radius: 2
-      offset: 0,1
   - uid: 613
     components:
     - type: Transform
@@ -12467,9 +12399,9 @@ entities:
       text: Engi & Atmos
     - type: PointLight
       energy: 5
+      offset: 0,1
       color: '#FFA500FF'
       radius: 2
-      offset: 0,1
   - uid: 614
     components:
     - type: Transform
@@ -12480,9 +12412,9 @@ entities:
       text: R&D
     - type: PointLight
       energy: 5
+      offset: 0,1
       color: '#EB87EBFF'
       radius: 2
-      offset: 0,1
 - proto: MaterialBiomass
   entities:
   - uid: 1186
@@ -16867,9 +16799,9 @@ entities:
       parent: 1
     - type: PointLight
       energy: 5
+      offset: 0,2
       color: '#EB87EBFF'
       radius: 2
-      offset: 0,2
   - uid: 101
     components:
     - type: Transform
@@ -17235,9 +17167,9 @@ entities:
       parent: 1
     - type: PointLight
       energy: 5
+      offset: 0,2
       color: '#87EB87FF'
       radius: 2
-      offset: 0,2
   - uid: 891
     components:
     - type: Transform
@@ -17589,9 +17521,9 @@ entities:
       parent: 1
     - type: PointLight
       energy: 5
+      offset: 0,2
       color: '#87D1EBFF'
       radius: 2
-      offset: 0,2
   - uid: 1095
     components:
     - type: Transform
@@ -18050,9 +17982,9 @@ entities:
       parent: 1
     - type: PointLight
       energy: 5
+      offset: 0,2
       color: '#FFA500FF'
       radius: 2
-      offset: 0,2
   - uid: 1315
     components:
     - type: Transform
@@ -18652,9 +18584,9 @@ entities:
       parent: 1
     - type: PointLight
       energy: 5
+      offset: -2,0
       color: '#FF0000FF'
       radius: 2
-      offset: -2,0
   - uid: 1942
     components:
     - type: Transform
@@ -19524,8 +19456,8 @@ entities:
       parent: 1
     - type: PointLight
       energy: 2
-      radius: 2
       offset: 0,-2
+      radius: 2
   - uid: 2522
     components:
     - type: Transform


### PR DESCRIPTION
## About the PR
Follow-up to #42815
The previous mapper directly inserted beakers into the grinders before map init.
This was causing the appearance data to get lost (apparently it is not serialized at all) when the map was saved and then loaded, and the sprite for the beaker inside the grinder would not show up as a result. Similarly the newly introduced `InsideReagentGrinderComponent` was missing on the beaker as it did not exist yet when the mapper inserted it, and it's not being added later as the beaker is already inside the grinder during map init and no further container events are being raised.
I solved this by adding custom prototypes for grinders that have beakers as containerfill.

I checked and the dev map is the only map with this problem.

## Why / Balance
bugfix

## Technical details
I just deleted the three grinders and spawned new ones with the new beaker prototype and saved the map again.

## Media
Sprites are visible again.
<img width="269" height="299" alt="grafik" src="https://github.com/user-attachments/assets/68cd66ae-ee4e-4941-a982-363a110c1ced" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
not player facing
