### PR TITLE
Fix speedloader reload

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -151,7 +151,7 @@ public partial class SharedGunSystem
 
                 ent.Comp.AmmoSlots[index] = ammoEnt.Value;
                 Containers.Insert(ammoEnt.Value, ent.Comp.AmmoContainer);
-                SetChamber(ent, insertEnt, index);
+                SetChamber(ent, ammoEnt.Value, index);
 
                 if (ev.Ammo.Count == 0)
                     break;


### PR DESCRIPTION
## About the PR
Fixed incorrect revolver GUI update on using speedloaders.

## Why / Balance
Fixes https://github.com/space-wizards/space-station-14/issues/43214

## Technical details
Passed correct entity to `SetChamber` so that resolving `CartridgeAmmoComponent` succeeds.

## Media
https://github.com/user-attachments/assets/aae84b9b-4abf-4613-8899-448456900a30

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- fix: Speedloaders now update revolver chambers correctly.
