### PR TITLE
Hue based skin color clamping

### DIFF
--- a/Content.Shared/Humanoid/SkinColorationPrototype.cs
+++ b/Content.Shared/Humanoid/SkinColorationPrototype.cs
@@ -318,17 +318,22 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
     /// List of valid nodes in this coloration.
     /// </summary>
     [DataField]
-    public List<HueNodeClampedHsvColorationNode>? Nodes;
+    public List<HueNodeClampedHsvColorationNode> Nodes;
 
     public SkinColorationStrategyInput InputType => SkinColorationStrategyInput.Color;
 
     public bool VerifySkinColor(Color color)
     {
         var hsv = Color.ToHsv(color);
-        var range = GetNodeValuesForHue(hsv.X);
+
+        // Clamp the hue between the first and last node.
+        // We don't want anything going outside of these values.
+        var hue = SkinColorationUtils.ClampHue(hsv.X, Nodes.First().Hue,  Nodes.Last().Hue);
+
+        var range = GetNodeValuesForHue(hue);
 
         // If no range was found, this color is invalid.
-        if (!VerifyNodeOrder() || range is null)
+        if (range is null)
             return false;
 
         // If a range is found, check if the saturation is within the provided ranges.
@@ -344,10 +349,11 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
 
     public Color ClosestSkinColor(Color color)
     {
-        if (Nodes is null)
-            return color;
-
         var hsv = Color.ToHsv(color);
+
+        // Clamp within specified nodes.
+        hsv.X = SkinColorationUtils.ClampHue(hsv.X, Nodes.First().Hue,  Nodes.Last().Hue);
+
         var range = GetNodeValuesForHue(hsv.X);
         if (range == null)
             return color;
@@ -365,7 +371,7 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
     /// <returns>The nodes taking effect at the specified hue.</returns>
     private (HueNodeClampedHsvColorationNode, HueNodeClampedHsvColorationNode)? GetAffectingNodes(float hue)
     {
-        if (Nodes is null || Nodes.Count == 0)
+        if (Nodes.Count == 0)
             return null;
 
         // If only one node is provided we just consider it to control all values.
@@ -378,13 +384,12 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
             // There has to be at least one element here because we check the count above.
             var current = Nodes[i];
 
-            // If there is no element after this one, we just get the last element and give it full control of the color.
-            // Basically a node list of [0, 0.5] will fall back to node at 0.5 if the hue is ever higher.
-            // This could just set the next to current as well, but I don't think there is any difference.
-            var next = Nodes.ElementAtOrDefault(i + 1) ?? Nodes.Last();
+            // If there is no element after this one, we just loop back to the first element.
+            // Basically a node list of [0, 0.5] will fall back to node at 0 if the hue is ever higher.
+            var next = Nodes.ElementAtOrDefault(i + 1) ?? Nodes.First();
 
             // Is the hue within the range of the nodes we're considering?
-            if (current.Hue > hue || next.Hue < hue)
+            if (!SkinColorationUtils.IsHueInRange(hue, current.Hue, next.Hue))
                 continue;
 
             return (current, next);
@@ -400,7 +405,7 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
     /// <returns>Node containing the value and saturation clamping.</returns>
     private HueNodeClampedHsvColorationNode? GetNodeValuesForHue(float hue)
     {
-        if (Nodes is null || Nodes.Count == 0)
+        if (Nodes.Count == 0)
             return null;
 
         // No node is actually affecting this coloring, so it's invalid.
@@ -426,27 +431,6 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
         finalNode.Value.Item2 = MathHelper.Lerp(firstNode.Value.Item2, secondNode.Value.Item2, weight);
 
         return finalNode;
-    }
-
-    /// <summary>
-    /// Verifies whether the nodes are ordered correctly with ascending hue.
-    /// </summary>
-    /// <returns>True if nodes have correct hue, otherwise False.</returns>
-    private bool VerifyNodeOrder()
-    {
-        if (Nodes is null || Nodes.Count == 0)
-            return false;
-
-        float hue = 0f;
-        for (int i = 0; i < Nodes.Count; i++)
-        {
-            if (Nodes[i].Hue < hue)
-                return false;
-
-            hue = Nodes[i].Hue;
-        }
-
-        return true;
     }
 }
 

--- a/Content.Shared/Humanoid/SkinColorationPrototype.cs
+++ b/Content.Shared/Humanoid/SkinColorationPrototype.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Linq;
 using System.Numerics;
-using Content.Shared.EntityEffects.Effects;
-using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 

--- a/Content.Shared/Humanoid/SkinColorationPrototype.cs
+++ b/Content.Shared/Humanoid/SkinColorationPrototype.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using System.Numerics;
+using Content.Shared.EntityEffects.Effects;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -303,29 +305,32 @@ public sealed partial class ClampedHslColoration : ISkinColorationStrategy
 }
 
 /// <summary>
-/// Coloration strategy that clamps the color within the HSV colorspace.
-/// Clamped color depends on specified hue ranges.
+/// Coloration strategy that clamps the color between nodes within the HSV colorspace.
+/// Clamped values depend on the nodes and are linearly interpolated between them.
 /// </summary>
+/// <remarks>
+/// For example:
+/// A node at hue 0 with a saturation of [0,1] and a node at hue 1 with a staturation of [0.1,0.8]
+/// At hue 0.5, the saturation would be clamped within [0.05,0.9]
+/// </remarks>
 [DataDefinition]
 [Serializable, NetSerializable]
-public sealed partial class HueRangedClampedHsvColoration : ISkinColorationStrategy
+public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrategy
 {
     /// <summary>
-    /// List of valid ranges this coloration covers.
-    /// Colors outside of all ranges are considered invalid.
+    /// List of valid nodes in this coloration.
     /// </summary>
     [DataField]
-    public List<HueRangedClampedHsvColorationRange>? Ranges;
+    public List<HueNodeClampedHsvColorationNode>? Nodes;
 
     public SkinColorationStrategyInput InputType => SkinColorationStrategyInput.Color;
 
     public bool VerifySkinColor(Color color)
     {
         var hsv =  Color.ToHsv(color);
-        var range = GetHueRange(hsv.X);
+        var range = GetNodeValuesForHue(hsv.X);
 
         // If no range was found, this color is invalid.
-        // We don't care for clamping the hue here, but it must be within a specified range.
         if (range == null)
             return false;
 
@@ -342,11 +347,11 @@ public sealed partial class HueRangedClampedHsvColoration : ISkinColorationStrat
 
     public Color ClosestSkinColor(Color color)
     {
-        if (Ranges is null)
+        if (Nodes is null)
             return color;
 
         var hsv = Color.ToHsv(color);
-        var range = GetHueRange(hsv.X);
+        var range = GetNodeValuesForHue(hsv.X);
         if (range == null)
             return color;
 
@@ -356,41 +361,86 @@ public sealed partial class HueRangedClampedHsvColoration : ISkinColorationStrat
         return Color.FromHsv(hsv);
     }
 
-    private HueRangedClampedHsvColorationRange? GetHueRange(float hue)
+    private (HueNodeClampedHsvColorationNode, HueNodeClampedHsvColorationNode)? GetAffectingNodes(float hue)
     {
-        if (Ranges is null)
+        if (Nodes is null || Nodes.Count == 0)
             return null;
 
-        foreach (var hueRange in Ranges)
+        // If only one node is provided we just consider it to control all values.
+        if (Nodes.Count == 1)
+            return (Nodes.First(), Nodes.Last());
+
+        for (int i = 0; i < Nodes.Count; i++)
         {
-            if (hue >= hueRange.HueRange.Item1 && hue <= hueRange.HueRange.Item2)
-            {
-                return hueRange;
-            }
+            // We get the currently iterated element. If for WHATEVER reason it doesn't exist, we fall back to the first element.
+            // There has to be at least one element here because we check the count above.
+            var current = Nodes.ElementAtOrDefault(i) ?? Nodes.First();
+
+            // If there is no element after this one, we just get the last element and give it full control of the color.
+            // Basically a node list of [0, 0.5] will fall back to node at 0.5 if the hue is ever higher.
+            // This could just set the next to current as well, but I don't think there is any differance.
+            var next = Nodes.ElementAtOrDefault(i+1) ?? Nodes.Last();
+
+            // Is the hue within the range of the nodes we're considering?
+            if (current.Hue > hue || next.Hue < hue)
+                continue;
+
+            return  (current, next);
         }
 
         return null;
+    }
+
+    private HueNodeClampedHsvColorationNode? GetNodeValuesForHue(float hue)
+    {
+        if (Nodes is null || Nodes.Count == 0)
+            return null;
+
+        // No node is actually affecting this coloring, so it's invalid.
+        if (GetAffectingNodes(hue) is not { } affectingNodes)
+            return null;
+
+        var firstNode = affectingNodes.Item1;
+        var secondNode = affectingNodes.Item2;
+
+        // If both values are equal we just return 0f.
+        // This is to prevent dividing by 0.
+        var weight = MathHelper.CloseTo(firstNode.Hue, secondNode.Hue) ? 0f : (hue - firstNode.Hue)/(secondNode.Hue - firstNode.Hue);
+
+        // I know this is also used to define the nodes, however it contains all the data necessary
+        // And I don't think creating a new DataDefinition is worth it just to get rid of the hue from this one.
+        var finalNode = new HueNodeClampedHsvColorationNode();
+        finalNode.Hue = hue;
+
+        finalNode.Saturation.Item1 = MathHelper.Lerp(firstNode.Saturation.Item1, secondNode.Saturation.Item1, weight);
+        finalNode.Saturation.Item2 = MathHelper.Lerp(firstNode.Saturation.Item2, secondNode.Saturation.Item2, weight);
+
+        finalNode.Value.Item1 = MathHelper.Lerp(firstNode.Value.Item1, secondNode.Value.Item1, weight);
+        finalNode.Value.Item2 = MathHelper.Lerp(firstNode.Value.Item2, secondNode.Value.Item2, weight);
+
+        return finalNode;
     }
 }
 
 [DataDefinition]
 [Serializable, NetSerializable]
-public sealed partial class HueRangedClampedHsvColorationRange
+public sealed partial class HueNodeClampedHsvColorationNode
 {
     /// <summary>
-    /// Defines the range within which the saturation and value ranges will apply.
+    /// The point on the hue spectrum where this node is placed.
+    /// 0 is 0, 1 is 360
     /// </summary>
     [DataField]
-    public (float, float) HueRange;
+    public float Hue;
 
     /// <summary>
-    /// Defines the (min, max) saturation within the provided range.
+    /// Defines the (min, max) saturation on the provided node.
     /// </summary>
     [DataField]
     public (float, float) Saturation;
 
     /// <summary>
-    /// Defines the (min, max) value within the provided range.
+    /// Defines the (min, max) value on the provided node.
     /// </summary>
     [DataField]
     public (float, float) Value;

--- a/Content.Shared/Humanoid/SkinColorationPrototype.cs
+++ b/Content.Shared/Humanoid/SkinColorationPrototype.cs
@@ -328,7 +328,7 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
         var range = GetNodeValuesForHue(hsv.X);
 
         // If no range was found, this color is invalid.
-        if (range == null)
+        if (!VerifyNodeOrder() || range is null)
             return false;
 
         // If a range is found, check if the saturation is within the provided ranges.
@@ -376,7 +376,7 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
         {
             // We get the currently iterated element. If for WHATEVER reason it doesn't exist, we fall back to the first element.
             // There has to be at least one element here because we check the count above.
-            var current = Nodes.ElementAtOrDefault(i) ?? Nodes.First();
+            var current = Nodes[i];
 
             // If there is no element after this one, we just get the last element and give it full control of the color.
             // Basically a node list of [0, 0.5] will fall back to node at 0.5 if the hue is ever higher.
@@ -426,6 +426,27 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
         finalNode.Value.Item2 = MathHelper.Lerp(firstNode.Value.Item2, secondNode.Value.Item2, weight);
 
         return finalNode;
+    }
+
+    /// <summary>
+    /// Verifies whether the nodes are ordered correctly with ascending hue.
+    /// </summary>
+    /// <returns>True if nodes have correct hue, otherwise False.</returns>
+    private bool VerifyNodeOrder()
+    {
+        if (Nodes is null || Nodes.Count == 0)
+            return false;
+
+        float hue = 0f;
+        for (int i = 0; i < Nodes.Count; i++)
+        {
+            if (Nodes[i].Hue < hue)
+                return false;
+
+            hue = Nodes[i].Hue;
+        }
+
+        return true;
     }
 }
 

--- a/Content.Shared/Humanoid/SkinColorationPrototype.cs
+++ b/Content.Shared/Humanoid/SkinColorationPrototype.cs
@@ -317,7 +317,7 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
     /// <summary>
     /// List of valid nodes in this coloration.
     /// </summary>
-    [DataField]
+    [DataField(required: true)]
     public List<HueNodeClampedHsvColorationNode> Nodes;
 
     public SkinColorationStrategyInput InputType => SkinColorationStrategyInput.Color;

--- a/Content.Shared/Humanoid/SkinColorationPrototype.cs
+++ b/Content.Shared/Humanoid/SkinColorationPrototype.cs
@@ -303,6 +303,100 @@ public sealed partial class ClampedHslColoration : ISkinColorationStrategy
 }
 
 /// <summary>
+/// Coloration strategy that clamps the color within the HSV colorspace.
+/// Clamped color depends on specified hue ranges.
+/// </summary>
+[DataDefinition]
+[Serializable, NetSerializable]
+public sealed partial class HueRangedClampedHsvColoration : ISkinColorationStrategy
+{
+    /// <summary>
+    /// List of valid ranges this coloration covers.
+    /// Colors outside of all ranges are considered invalid.
+    /// </summary>
+    [DataField]
+    public List<HueRangedClampedHsvColorationRange>? Ranges;
+
+    public SkinColorationStrategyInput InputType => SkinColorationStrategyInput.Color;
+
+    public bool VerifySkinColor(Color color)
+    {
+        var hsv =  Color.ToHsv(color);
+        var range = GetHueRange(hsv.X);
+
+        // If no range was found, this color is invalid.
+        // We don't care for clamping the hue here, but it must be within a specified range.
+        if (range == null)
+            return false;
+
+        // If a range is found, check if the saturation is within the provided ranges.
+        if (hsv.Y < range.Saturation.Item1 || hsv.Y > range.Saturation.Item2)
+            return false;
+
+        // Check if the value is within provided ranges.
+        if (hsv.Z < range.Value.Item1 || hsv.Y > range.Value.Item2)
+            return false;
+
+        return true;
+    }
+
+    public Color ClosestSkinColor(Color color)
+    {
+        if (Ranges is null)
+            return color;
+
+        var hsv = Color.ToHsv(color);
+        var range = GetHueRange(hsv.X);
+        if (range == null)
+            return color;
+
+        hsv.Y = Math.Clamp(hsv.Y, range.Saturation.Item1, range.Saturation.Item2);
+        hsv.Z = Math.Clamp(hsv.Z, range.Value.Item1, range.Value.Item2);
+
+        return Color.FromHsv(hsv);
+    }
+
+    private HueRangedClampedHsvColorationRange? GetHueRange(float hue)
+    {
+        if (Ranges is null)
+            return null;
+
+        foreach (var hueRange in Ranges)
+        {
+            if (hue >= hueRange.HueRange.Item1 && hue <= hueRange.HueRange.Item2)
+            {
+                return hueRange;
+            }
+        }
+
+        return null;
+    }
+}
+
+[DataDefinition]
+[Serializable, NetSerializable]
+public sealed partial class HueRangedClampedHsvColorationRange
+{
+    /// <summary>
+    /// Defines the range within which the saturation and value ranges will apply.
+    /// </summary>
+    [DataField]
+    public (float, float) HueRange;
+
+    /// <summary>
+    /// Defines the (min, max) saturation within the provided range.
+    /// </summary>
+    [DataField]
+    public (float, float) Saturation;
+
+    /// <summary>
+    /// Defines the (min, max) value within the provided range.
+    /// </summary>
+    [DataField]
+    public (float, float) Value;
+}
+
+/// <summary>
 /// Contains shared utility methods for handling color manipulations in skin coloration strategies.
 /// </summary>
 internal static class SkinColorationUtils

--- a/Content.Shared/Humanoid/SkinColorationPrototype.cs
+++ b/Content.Shared/Humanoid/SkinColorationPrototype.cs
@@ -324,7 +324,7 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
 
     public bool VerifySkinColor(Color color)
     {
-        var hsv =  Color.ToHsv(color);
+        var hsv = Color.ToHsv(color);
         var range = GetNodeValuesForHue(hsv.X);
 
         // If no range was found, this color is invalid.
@@ -375,14 +375,14 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
 
             // If there is no element after this one, we just get the last element and give it full control of the color.
             // Basically a node list of [0, 0.5] will fall back to node at 0.5 if the hue is ever higher.
-            // This could just set the next to current as well, but I don't think there is any differance.
-            var next = Nodes.ElementAtOrDefault(i+1) ?? Nodes.Last();
+            // This could just set the next to current as well, but I don't think there is any difference.
+            var next = Nodes.ElementAtOrDefault(i + 1) ?? Nodes.Last();
 
             // Is the hue within the range of the nodes we're considering?
             if (current.Hue > hue || next.Hue < hue)
                 continue;
 
-            return  (current, next);
+            return (current, next);
         }
 
         return null;
@@ -402,7 +402,7 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
 
         // If both values are equal we just return 0f.
         // This is to prevent dividing by 0.
-        var weight = MathHelper.CloseTo(firstNode.Hue, secondNode.Hue) ? 0f : (hue - firstNode.Hue)/(secondNode.Hue - firstNode.Hue);
+        var weight = MathHelper.CloseTo(firstNode.Hue, secondNode.Hue) ? 0f : (hue - firstNode.Hue) / (secondNode.Hue - firstNode.Hue);
 
         // I know this is also used to define the nodes, however it contains all the data necessary
         // And I don't think creating a new DataDefinition is worth it just to get rid of the hue from this one.
@@ -419,13 +419,17 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
     }
 }
 
+/// <summary>
+/// A node to be used with <see cref="HueNodeClampedHsvColoration"/>.
+/// Represents a single point on the hue spectrum with corresponding clamping limits for saturation and value.
+/// </summary>
 [DataDefinition]
 [Serializable, NetSerializable]
 public sealed partial class HueNodeClampedHsvColorationNode
 {
     /// <summary>
     /// The point on the hue spectrum where this node is placed.
-    /// 0 is 0, 1 is 360
+    /// Between 0 and 1.
     /// </summary>
     [DataField]
     public float Hue;

--- a/Content.Shared/Humanoid/SkinColorationPrototype.cs
+++ b/Content.Shared/Humanoid/SkinColorationPrototype.cs
@@ -358,6 +358,11 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
         return Color.FromHsv(hsv);
     }
 
+    /// <summary>
+    /// Finds the nodes affecting value and saturation at a specified hue value.
+    /// </summary>
+    /// <param name="hue">The hue value at which to find the nodes. Between 0 and 1.</param>
+    /// <returns>The nodes taking effect at the specified hue.</returns>
     private (HueNodeClampedHsvColorationNode, HueNodeClampedHsvColorationNode)? GetAffectingNodes(float hue)
     {
         if (Nodes is null || Nodes.Count == 0)
@@ -388,6 +393,11 @@ public sealed partial class HueNodeClampedHsvColoration : ISkinColorationStrateg
         return null;
     }
 
+    /// <summary>
+    /// Gets the values at which to clamp the value and saturation based on the given hue.
+    /// </summary>
+    /// <param name="hue">The hue for which to get the clamping values. Between 0 and 1.</param>
+    /// <returns>Node containing the value and saturation clamping.</returns>
     private HueNodeClampedHsvColorationNode? GetNodeValuesForHue(float hue)
     {
         if (Nodes is null || Nodes.Count == 0)

--- a/Resources/Prototypes/Species/skin_colorations.yml
+++ b/Resources/Prototypes/Species/skin_colorations.yml
@@ -28,7 +28,7 @@
     - hue: 0.55
       saturation: [ 0.2, 0.5 ]
       value: [ 0.36, 0.55 ]
-    - hue: 1 # Red
+    - hue: 1
       saturation: [ 0.2, 0.5 ]
       value: [ 0.36, 0.5 ]
 

--- a/Resources/Prototypes/Species/skin_colorations.yml
+++ b/Resources/Prototypes/Species/skin_colorations.yml
@@ -19,9 +19,6 @@
     - hue: 0.045
       saturation: [ 0.2, 0.8 ]
       value: [ 0.36, 0.55 ]
-    - hue: 0.1666
-      saturation: [ 0.2, 0.8 ]
-      value: [ 0.36, 0.55 ]
     - hue: 0.44
       saturation: [ 0.2, 0.8 ]
       value: [ 0.36, 0.55 ]

--- a/Resources/Prototypes/Species/skin_colorations.yml
+++ b/Resources/Prototypes/Species/skin_colorations.yml
@@ -11,10 +11,26 @@
 
 - type: skinColoration
   id: VoxFeathers
-  strategy: !type:ClampedHsvColoration
-    hue: [0.081, 0.48]
-    saturation: [0.2, 0.8]
-    value: [0.36, 0.55]
+  strategy: !type:HueNodeClampedHsvColoration
+    nodes:
+    - hue: 0
+      saturation: [ 0.2, 0.5 ]
+      value: [ 0.36, 0.55 ]
+    - hue: 0.045
+      saturation: [ 0.2, 0.8 ]
+      value: [ 0.36, 0.55 ]
+    - hue: 0.1666
+      saturation: [ 0.2, 0.8 ]
+      value: [ 0.36, 0.55 ]
+    - hue: 0.44
+      saturation: [ 0.2, 0.8 ]
+      value: [ 0.36, 0.55 ]
+    - hue: 0.55
+      saturation: [ 0.2, 0.5 ]
+      value: [ 0.36, 0.55 ]
+    - hue: 1 # Red
+      saturation: [ 0.2, 0.5 ]
+      value: [ 0.36, 0.5 ]
 
 - type: skinColoration
   id: HumanToned

--- a/Resources/Prototypes/Species/skin_colorations.yml
+++ b/Resources/Prototypes/Species/skin_colorations.yml
@@ -51,10 +51,10 @@
       value: [ 0.2, 0.9 ]
     - hue: 0.33 # From green to pink keep it the same. (0.65 -> 0.65)
       saturation: [ 0, 0.65 ]
-      value: [ 0.2, 0.90 ]
+      value: [ 0.2, 0.9 ]
     - hue: 0.94 # From pink, increase saturation for red. (0.65 -> 0.75)
       saturation: [ 0, 0.65 ]
-      value: [ 0.2, 0.90 ]
+      value: [ 0.2, 0.9 ]
     - hue: 1 # Red
       saturation: [ 0, 0.75 ]
-      value: [ 0.2, 0.90 ]
+      value: [ 0.2, 0.9 ]

--- a/Resources/Prototypes/Species/skin_colorations.yml
+++ b/Resources/Prototypes/Species/skin_colorations.yml
@@ -22,17 +22,23 @@
 
 - type: skinColoration
   id: VulpkaninColors
-  strategy: !type:HueRangedClampedHsvColoration
-    ranges:
-    # Red(0) to Greenish(90)
-    - hueRange: [0, 0.25]
-      saturation: [0, 0.9]
-      value: [0.2, 0.9]
-    # Greenish(90) to Pink(340)
-    - hueRange: [ 0.25, 0.97 ]
-      saturation: [ 0, 0.6 ]
+  strategy: !type:HueNodeClampedHsvColoration
+    nodes:
+    - hue: 0 # From red to orange slowly increase saturation. (0.75 -> 0.9)
+      saturation: [ 0, 0.75 ]
       value: [ 0.2, 0.9 ]
-    # Pink(340) to Red(360)
-    - hueRange: [ 0.97, 1 ]
+    - hue: 0.05 # From orange to yellow, keep it the same. (0.9 -> 0.8)
       saturation: [ 0, 0.9 ]
       value: [ 0.2, 0.9 ]
+    - hue: 0.1666 # From yellow to green, slowly decrease it. (0.8 -> 0.65)
+      saturation: [ 0, 0.8 ]
+      value: [ 0.2, 0.9 ]
+    - hue: 0.33 # From green to pink keep it the same. (0.65 -> 0.65)
+      saturation: [ 0, 0.65 ]
+      value: [ 0.2, 0.90 ]
+    - hue: 0.94 # From pink, increase saturation for red. (0.65 -> 0.75)
+      saturation: [ 0, 0.65 ]
+      value: [ 0.2, 0.90 ]
+    - hue: 1 # Red
+      saturation: [ 0, 0.75 ]
+      value: [ 0.2, 0.90 ]

--- a/Resources/Prototypes/Species/skin_colorations.yml
+++ b/Resources/Prototypes/Species/skin_colorations.yml
@@ -22,6 +22,17 @@
 
 - type: skinColoration
   id: VulpkaninColors
-  strategy: !type:ClampedHslColoration
-    saturation: [0.0, 0.60]
-    lightness: [0.2, 0.9]
+  strategy: !type:HueRangedClampedHsvColoration
+    ranges:
+    # Red(0) to Greenish(90)
+    - hueRange: [0, 0.25]
+      saturation: [0, 0.9]
+      value: [0.2, 0.9]
+    # Greenish(90) to Pink(340)
+    - hueRange: [ 0.25, 0.97 ]
+      saturation: [ 0, 0.6 ]
+      value: [ 0.2, 0.9 ]
+    # Pink(340) to Red(360)
+    - hueRange: [ 0.97, 1 ]
+      saturation: [ 0, 0.9 ]
+      value: [ 0.2, 0.9 ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a way to define skin color based on nodes on the Hue spectrum.
Vulps now can access more saturated colors in the red-orange-yellow color range.

Also increased the minimum from 0.6 to 0.65 because the colors overall look dead in that range. But this is a simple tweak if not desired.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Blocker for things like voxes and vulps being able to have prettier colors.
This PR also allows vulps to access more saturated tones in the red-orange-yellow range while keeping similiar restrictions in the other colors.

Have you ever tried to use actual orange while making a vulpkanin fox? Yeah it's difficult. This basically solves that.

## Technical details
<!-- Summary of code changes for easier review. -->
When selecting the skin color, we grab the nodes as shown in the YAML file.
While the hue is between two nodes, we interpolate between values from the previous node to the values on the next node.
This allows to smoothly control the saturation/value clamping.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
### The calmping values here are subject to change based on arttainer discretion.

https://github.com/user-attachments/assets/2ad1bdbf-27ef-4023-98d3-c26515c6c19f

### More aggressive values to show properly that it works

https://github.com/user-attachments/assets/5f2e532e-160e-44d3-93e0-a26194a8aab2

### Voxes after

https://github.com/user-attachments/assets/71db7bca-fc9e-4244-bb89-15cfaf292a37

### Voxes before

https://github.com/user-attachments/assets/f2d887a3-6483-47f4-8dbf-a7908a686121

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Vulpkanin can now use more saturated colors in the red-orange-yellow range.
- tweak: Vox are no longer hue restricted, but have decreased allowed saturation in the red-pink colors.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
