### PR TITLE
Fix magnet storages playing animation twice

### DIFF
--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -88,9 +88,9 @@ public sealed class MagnetPickupSystem : EntitySystem
 
                 // Play pickup animation for either the stack entity or the original entity.
                 if (stacked != null)
-                    _storage.PlayPickupAnimation(stacked.Value, nearCoords, finalCoords, nearXform.LocalRotation);
+                    _storage.PlayPickupAnimation(stacked.Value, nearCoords, finalCoords, nearXform.LocalRotation, parentUid);
                 else
-                    _storage.PlayPickupAnimation(near, nearCoords, finalCoords, nearXform.LocalRotation);
+                    _storage.PlayPickupAnimation(near, nearCoords, finalCoords, nearXform.LocalRotation, parentUid);
 
                 playedSound = true;
             }


### PR DESCRIPTION
## About the PR
Magnet animation now doesn't play on either client and server

## Media
https://github.com/user-attachments/assets/c72a21d2-2b60-40bf-8f87-0a5fca757d09

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: Fixed ore bags animation playing twice