### PR TITLE
Fix misinterpreting abstract in GDS + fix ignored prototypes not actually working.

### DIFF
--- a/Content.IntegrationTests/Tests/Utility/ScroungerTests.cs
+++ b/Content.IntegrationTests/Tests/Utility/ScroungerTests.cs
@@ -1,10 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
-using Content.Client.Parallax.Data;
 using Content.IntegrationTests.Pair;
 using Content.IntegrationTests.Utility;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Utility;
 
 namespace Content.IntegrationTests.Tests.Utility;
 

--- a/Content.IntegrationTests/Tests/Utility/ScroungerTests.cs
+++ b/Content.IntegrationTests/Tests/Utility/ScroungerTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using Content.IntegrationTests.Pair;
 using Content.IntegrationTests.Utility;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
@@ -7,6 +9,24 @@ namespace Content.IntegrationTests.Tests.Utility;
 [TestOf(typeof(GameDataScrounger))]
 public sealed class ScroungerTests
 {
+    private TestPair _pair;
+
+    // TODO: Implement scrounger support for types. Should be easier as we genuinely can just use ReflectionManager.
+    private static Type[] _prototypeTypes = [typeof(EntityPrototype)];
+
+    [OneTimeSetUp]
+    public async Task SetUp()
+    {
+        _pair = await PoolManager.GetServerClient();
+    }
+
+    [OneTimeTearDown]
+    public async Task TearDown()
+    {
+        // We never actually run anything on the pair, so we can just give it back always.
+        await _pair.CleanReturnAsync();
+    }
+
     [Test]
     [Description("Assert that the data scrounger finds prototypes by type successfully.")]
     public void ScroungeByType()
@@ -45,5 +65,20 @@ public sealed class ScroungerTests
         var items = GameDataScrounger.EntitiesWithComponent("Item");
 
         Assert.That(items, Is.Not.Empty);
+    }
+
+    [Test]
+    [Description("Assert that the discovered prototypes correspond precisely with the real set of prototypes, minus test suite prototypes.")]
+    [TestCaseSource(nameof(_prototypeTypes))]
+    public void Prototypes_gh43275(Type t)
+    {
+        var protoMan = _pair.Server.ProtoMan;
+
+        var scroungedProtos = GameDataScrounger.PrototypesOfKind(t);
+        var realProtos = protoMan.EnumeratePrototypes(t)
+            .Select(x => x.ID)
+            .Where(x => !_pair.IsTestPrototype(t, x));
+
+        Assert.That(scroungedProtos, Is.EquivalentTo(realProtos));
     }
 }

--- a/Content.IntegrationTests/Tests/Utility/ScroungerTests.cs
+++ b/Content.IntegrationTests/Tests/Utility/ScroungerTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Linq;
+using Content.Client.Parallax.Data;
 using Content.IntegrationTests.Pair;
 using Content.IntegrationTests.Utility;
 using Robust.Shared.Prototypes;
@@ -11,8 +13,7 @@ public sealed class ScroungerTests
 {
     private TestPair _pair;
 
-    // TODO: Implement scrounger support for types. Should be easier as we genuinely can just use ReflectionManager.
-    private static Type[] _prototypeTypes = [typeof(EntityPrototype)];
+    private static IEnumerable<Type> PrototypeTypes => GameDataScrounger.FindTypesWithAttribute<PrototypeAttribute>();
 
     [OneTimeSetUp]
     public async Task SetUp()
@@ -69,10 +70,13 @@ public sealed class ScroungerTests
 
     [Test]
     [Description("Assert that the discovered prototypes correspond precisely with the real set of prototypes, minus test suite prototypes.")]
-    [TestCaseSource(nameof(_prototypeTypes))]
+    [TestCaseSource(nameof(PrototypeTypes))]
     public void Prototypes_gh43275(Type t)
     {
-        var protoMan = _pair.Server.ProtoMan;
+        // TODO: EntryPoint based check for this, in another PR.
+        var clientSided = t.FullName!.StartsWith("Robust.Client") || t.FullName.StartsWith("Content.Client");
+
+        var protoMan = clientSided ? _pair.Client.ProtoMan : _pair.Server.ProtoMan;
 
         var scroungedProtos = GameDataScrounger.PrototypesOfKind(t);
         var realProtos = protoMan.EnumeratePrototypes(t)

--- a/Content.IntegrationTests/Utility/GameDataScrounger.Reflection.cs
+++ b/Content.IntegrationTests/Utility/GameDataScrounger.Reflection.cs
@@ -1,0 +1,121 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Robust.Shared.IoC;
+using Robust.Shared.Log;
+using Robust.Shared.Reflection;
+
+namespace Content.IntegrationTests.Utility;
+
+public static partial class GameDataScrounger
+{
+    /// <inheritdoc cref="M:Robust.Shared.Reflection.ReflectionManager.GetAllChildren``1(System.Boolean)"/>
+    public static IEnumerable<Type> GetAllChildren<T>(bool inclusive = false)
+    {
+        return ReflectionManager.GetAllChildren<T>(inclusive);
+    }
+
+    /// <inheritdoc cref="M:Robust.Shared.Reflection.ReflectionManager.GetAllChildren(System.Type,System.Boolean)"/>
+    public static IEnumerable<Type> GetAllChildren(Type baseType, bool inclusive = false)
+    {
+        return ReflectionManager.GetAllChildren(baseType, inclusive);
+    }
+
+    /// <inheritdoc cref="M:Robust.Shared.Reflection.ReflectionManager.GetType(System.String)"/>
+    public static Type? GetType(string name)
+    {
+        return ReflectionManager.GetType(name);
+    }
+
+    /// <inheritdoc cref="M:Robust.Shared.Reflection.ReflectionManager.LooseGetType(System.String)"/>
+    public static Type LooseGetType(string name)
+    {
+        return ReflectionManager.LooseGetType(name);
+    }
+
+    /// <inheritdoc cref="M:Content.IntegrationTests.Utility.GameDataScrounger.TryLooseGetType(System.String,System.Type@)"/>
+    public static bool TryLooseGetType(string name, out Type? type)
+    {
+        return ReflectionManager.TryLooseGetType(name, out type);
+    }
+
+    /// <inheritdoc cref="M:Robust.Shared.Reflection.ReflectionManager.FindTypesWithAttribute``1"/>
+    public static IEnumerable<Type> FindTypesWithAttribute<T>() where T : Attribute
+    {
+        return ReflectionManager.FindTypesWithAttribute<T>();
+    }
+
+    /// <inheritdoc cref="M:Robust.Shared.Reflection.ReflectionManager.FindTypesWithAttribute(System.Type)"/>
+    public static IEnumerable<Type> FindTypesWithAttribute(Type attributeType)
+    {
+        return ReflectionManager.FindTypesWithAttribute(attributeType);
+    }
+
+    /// <inheritdoc cref="M:Robust.Shared.Reflection.ReflectionManager.FindAllTypes"/>
+    public static IEnumerable<Type> FindAllTypes()
+    {
+        return ReflectionManager.FindAllTypes();
+    }
+
+    /// <inheritdoc cref="M:Robust.Shared.Reflection.ReflectionManager.GetEnumReference(System.Enum)"/>
+    public static string GetEnumReference(Enum @enum)
+    {
+        return ReflectionManager.GetEnumReference(@enum);
+    }
+
+    /// <inheritdoc cref="M:Robust.Shared.Reflection.ReflectionManager.TryParseEnumReference(System.String,System.Enum@,System.Boolean)"/>
+    public static bool TryParseEnumReference(string reference, out Enum? @enum, bool shouldThrow = true)
+    {
+        return ReflectionManager.TryParseEnumReference(reference, out @enum, shouldThrow);
+    }
+
+    /// <inheritdoc cref="M:Robust.Shared.Reflection.ReflectionManager.YamlTypeTagLookup(System.Type,System.String)"/>
+    public static Type? YamlTypeTagLookup(Type baseType, string typeName)
+    {
+        return ReflectionManager.YamlTypeTagLookup(baseType, typeName);
+    }
+
+    private sealed class TestReflectionManager : ReflectionManager
+    {
+        // We don't support shorthands for the client or server as they conflict often.
+        // But you can do, say, `Shared.MyStuff.MyComponent` and it'll work.
+        protected override IEnumerable<string> TypePrefixes =>
+        [
+            "",
+            "Robust.Shared.",
+            "Robust.",
+            "Content.Shared.",
+            "Content.IntegrationTests.",
+            "Content."
+        ];
+    }
+
+    private static TestReflectionManager ConstructTestReflectionManager()
+    {
+        TestReflectionManager? result = null;
+
+        // Jank pending engine change. I need to make IDependencyCollection have a static constructor.
+        var t = new Thread(() =>
+        {
+            IoCManager.InitThread(); // Create a dep collection
+
+            IoCManager.Register<ILogManager, LogManager>();
+            IoCManager.Register<TestReflectionManager>();
+
+            IoCManager.BuildGraph();
+
+            result = IoCManager.Resolve<TestReflectionManager>();
+            result.Initialize();
+            result.LoadAssemblies(AppDomain.CurrentDomain.GetAssemblies().Where(x => x.FullName?.StartsWith("Robust.") ?? false));
+            result.LoadAssemblies(AppDomain.CurrentDomain.GetAssemblies().Where(x => x.FullName?.StartsWith("Content.") ?? false));
+        });
+
+        t.Start();
+        t.Join();
+
+        return result!;
+    }
+
+
+}

--- a/Content.IntegrationTests/Utility/GameDataScrounger.cs
+++ b/Content.IntegrationTests/Utility/GameDataScrounger.cs
@@ -175,13 +175,13 @@ public static partial class GameDataScrounger
             return;
 
         var resDir = ContentResources();
-        Assert.That(Directory.Exists($"{resDir}/Prototypes"));
-        Assert.That(Directory.Exists($"{resDir}/../RobustToolbox/Resources/EnginePrototypes"));
+        Assert.That(Directory.Exists($"{resDir}{ResPath.SystemSeparator}Prototypes"));
+        Assert.That(Directory.Exists($"{resDir}{ResPath.SystemSeparator}..{ResPath.SystemSeparator}RobustToolbox{ResPath.SystemSeparator}Resources{ResPath.SystemSeparator}EnginePrototypes"));
 
         var ignoreList = GetIgnoredPrototypes(resDir);
 
         // Start with our root directory. We use this as a stack of directories to traverse.
-        var explorationStack = new List<string>() { $"{resDir}/Prototypes", $"{resDir}/../RobustToolbox/Resources/EnginePrototypes" };
+        var explorationStack = new List<string>() { $"{resDir}{ResPath.SystemSeparator}Prototypes", $"{resDir}{ResPath.SystemSeparator}..{ResPath.SystemSeparator}RobustToolbox{ResPath.SystemSeparator}Resources{ResPath.SystemSeparator}EnginePrototypes" };
 
         while (explorationStack.Count > 0)
         {
@@ -377,7 +377,7 @@ public static partial class GameDataScrounger
                     if (entry is not YamlScalarNode { Value: {} value })
                         throw new Exception($"An entry in {path} is not a valid YAML scalar/string literal. Entry: {entry}");
 
-                    ignores.Add(value);
+                    ignores.Add($"{resDir}{value.Replace(ResPath.Separator, ResPath.SystemSeparator)}");
                 }
             }
         }

--- a/Content.IntegrationTests/Utility/GameDataScrounger.cs
+++ b/Content.IntegrationTests/Utility/GameDataScrounger.cs
@@ -64,6 +64,11 @@ public static partial class GameDataScrounger
     /// </summary>
     private static Dictionary<string, EntityMetadata>? _entitiesMetaIndex = null;
 
+    /// <summary>
+    ///     Our personal reflection manager.
+    /// </summary>
+    private static readonly TestReflectionManager ReflectionManager = ConstructTestReflectionManager();
+
     private sealed class EntityMetadata
     {
         public required string Id;
@@ -111,7 +116,10 @@ public static partial class GameDataScrounger
         {
             Scrounge();
 
-            return _prototypeIndex[kind].ToArray();
+            if (_prototypeIndex.TryGetValue(kind, out var value))
+                return value.ToArray();
+
+            return Array.Empty<string>(); // Nothin'.
         }
     }
 

--- a/Content.IntegrationTests/Utility/GameDataScrounger.cs
+++ b/Content.IntegrationTests/Utility/GameDataScrounger.cs
@@ -17,7 +17,7 @@ namespace Content.IntegrationTests.Utility;
 /// </summary>
 /// <remarks>
 /// <para>
-///     This does not include engine prototypes, nor anything generated at runtime, as it's made to be simple and fast
+///     This does not include test-provided prototypes, nor anything generated at runtime, as it's made to be simple and fast
 ///     for usage during test framework startup where we cannot afford to initialize all of <see cref="ISerializationManager"/>.
 /// </para>
 /// <para>
@@ -96,7 +96,7 @@ public static partial class GameDataScrounger
     /// </summary>
     public static string[] PrototypesOfKind(Type t)
     {
-        Assert.That(t.IsAssignableTo(t));
+        Assert.That(t.IsAssignableTo(typeof(IPrototype)));
 
         if (t.GetCustomAttribute<PrototypeAttribute>() is { Type: { } ty })
             return PrototypesOfKind(ty);

--- a/Content.IntegrationTests/Utility/GameDataScrounger.cs
+++ b/Content.IntegrationTests/Utility/GameDataScrounger.cs
@@ -231,7 +231,7 @@ public static partial class GameDataScrounger
                     //       this is mildly nontrivial.
 
                     // We use exact equality to match what serialization does.
-                    if (abstractNode.Value == "true")
+                    if (abstractNode.Value?.Equals("true", StringComparison.InvariantCultureIgnoreCase) ?? false)
                         @abstract = true;
                 }
 

--- a/Content.IntegrationTests/Utility/GameDataScrounger.cs
+++ b/Content.IntegrationTests/Utility/GameDataScrounger.cs
@@ -250,7 +250,7 @@ public static partial class GameDataScrounger
                     //       this is mildly nontrivial.
 
                     // We use exact equality to match what serialization does.
-                    if (abstractNode.Value?.Equals("true", StringComparison.InvariantCultureIgnoreCase) ?? false)
+                    if (bool.TryParse(abstractNode.Value, out var res) && res)
                         @abstract = true;
                 }
 

--- a/Content.IntegrationTests/Utility/GameDataScrounger.cs
+++ b/Content.IntegrationTests/Utility/GameDataScrounger.cs
@@ -249,7 +249,6 @@ public static partial class GameDataScrounger
                     //       and not for parenting. However no such prototype exists in the game as of writing and solving
                     //       this is mildly nontrivial.
 
-                    // We use exact equality to match what serialization does.
                     if (bool.TryParse(abstractNode.Value, out var res) && res)
                         @abstract = true;
                 }

--- a/Content.IntegrationTests/Utility/GameDataScrounger.cs
+++ b/Content.IntegrationTests/Utility/GameDataScrounger.cs
@@ -83,10 +83,20 @@ public static partial class GameDataScrounger
     public static string[] PrototypesOfKind<T>()
         where T : IPrototype
     {
-        if (typeof(T).GetCustomAttribute<PrototypeAttribute>() is { Type: { } ty })
+        return PrototypesOfKind(typeof(T));
+    }
+
+    /// <summary>
+    ///     Gets all prototypes of the given type kind.
+    /// </summary>
+    public static string[] PrototypesOfKind(Type t)
+    {
+        Assert.That(t.IsAssignableTo(t));
+
+        if (t.GetCustomAttribute<PrototypeAttribute>() is { Type: { } ty })
             return PrototypesOfKind(ty);
 
-        return PrototypesOfKind(PrototypeUtility.CalculatePrototypeName(typeof(T).Name));
+        return PrototypesOfKind(PrototypeUtility.CalculatePrototypeName(t.Name));
     }
 
     /// <summary>
@@ -158,11 +168,12 @@ public static partial class GameDataScrounger
 
         var resDir = ContentResources();
         Assert.That(Directory.Exists($"{resDir}/Prototypes"));
+        Assert.That(Directory.Exists($"{resDir}/../RobustToolbox/Resources/EnginePrototypes"));
 
         var ignoreList = GetIgnoredPrototypes(resDir);
 
         // Start with our root directory. We use this as a stack of directories to traverse.
-        var explorationStack = new List<string>() { $"{resDir}/Prototypes" };
+        var explorationStack = new List<string>() { $"{resDir}/Prototypes", $"{resDir}/../RobustToolbox/Resources/EnginePrototypes" };
 
         while (explorationStack.Count > 0)
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Check for `true` case insensitively.
- Enumerate the engine prototypes folder too, not just the content one.

## Why
Better matches BooleanParser behavior, I was reading the wrong parser when implementing this. Issue discovered by `ClothingOuterBaseToggleable` which has `abstract: True` instead of `abstract: true`.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->