### PR TITLE
Borg chargers no longer rotate

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -304,6 +304,9 @@
       entity_storage: !type:Container
       machine_board: !type:Container
       machine_parts: !type:Container
+  - type: Transform
+    anchored: true
+    noRot: true
 
 - type: entity
   parent: BorgCharger


### PR DESCRIPTION
## About the PR
Made so borg chargers no longer rotate when dragging

## Why / Balance
Every time i try to relocate a borg charger it ALWAYS gets stuck in a 1 tile doors because its so easy to rotate it on accident and only consistent way to fix that is to achor it and unachor to fix the rotation.
sooo... basically a massive QOL for borgs i must say

## Technical details
yml

## Media

Before:
<img width="243" height="239" alt="image" src="https://github.com/user-attachments/assets/7237ff66-800c-465a-9601-0d6ecedcdb7f" />

After: 
<img width="405" height="288" alt="image" src="https://github.com/user-attachments/assets/9830889f-28e9-4920-badb-3d2d01e1423c" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**

:cl:
- tweak: Borg chargers no longer rotate, so they don't get stuck on doors no more
