### PR TITLE
trico no longer heals when mob is crit, and no longer heals rad

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -819,16 +819,14 @@
       - !type:EvenHealthChange
         conditions:
         - !type:MobStateCondition # no healing in crit so that dedicated single damage type meds can still have a niche.
-          mobstate: Critical
-          inverted: true
+          mobstate: Alive
         damage:
           Brute: -1
           Burn: -1
       - !type:HealthChange
         conditions:
         - !type:MobStateCondition
-          mobstate: Critical
-          inverted: true
+          mobstate: Alive
         damage:
           types:
             Poison: -0.5 # Same as what it was before the second coming of offmed


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Tricordrazine no longer heals when mob is crit and no longer heals radiation damage.

## Why / Balance
Radiation damage is supposed to be a somewhat hard to heal, and trico was supposed to be a fairly limited med. I see no reason why that should change any more than it already has, what with trico now healing even when damage is greater than 50.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
does this need media?

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Tricordrazine no longer heals radiation
- tweak:. Tricordrazine no longer works on mobs in crit
