### PR TITLE
Borg charger hitbox changes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -237,6 +237,7 @@
   components:
   - type: Sprite
     sprite: Structures/Power/borg_charger.rsi
+    noRot: True
     layers:
       - state: borgcharger-u1
         map: ["base"]
@@ -304,9 +305,17 @@
       entity_storage: !type:Container
       machine_board: !type:Container
       machine_parts: !type:Container
-  - type: Transform
-    anchored: true
-    noRot: true
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.48
+        density: 190
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
 
 - type: entity
   parent: BorgCharger

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -304,6 +304,9 @@
       entity_storage: !type:Container
       machine_board: !type:Container
       machine_parts: !type:Container
+  - type: Transform
+    anchored: true
+    noRot: true
 
 - type: entity
   parent: BorgCharger


### PR DESCRIPTION
## About the PR
Changed the hitbox of borg rechargers to a circle and made the sprite no longer rotate

## Why / Balance
Borg chargers are quite common machine to move around by borgs and most annoying thing about it is that when transporting is when the charger gets stuck on the doors because of a square hitbox and rotation. Now that should be a problem of the past and a quite welcome change to borg players. Good QOL overall.

## Technical details
Added a circle fixture to the charger and made the sprite no longer rotate (looked weird when dragging againts the wall i doesn't seems that rotating the spirte is that much needed anymore)

I tried doing this before with a different method in this PR #43287 as well as someone else in #39258 , but it caused build problems. I hope this is much better solution than that

## Media
Before:
<img width="404" height="235" alt="image" src="https://github.com/user-attachments/assets/491fff6a-8676-4e3b-b39d-712e73c3ff95" />

After:
<img width="390" height="314" alt="image" src="https://github.com/user-attachments/assets/0cde5d88-3f76-4a26-89bd-82387faaad82" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Changed the hitbox of borg chargers, so they no longer get stuck in doorways.
