### PR TITLE
Fix melee attack sprite rotations

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
@@ -94,6 +94,10 @@ public sealed partial class MeleeWeaponSystem
         }
     }
 
+    /// <summary>
+    /// Makes the sprite move in a slash motion around the player.
+    /// For example for wide swing animations.
+    /// </summary>
     private Animation GetSlashAnimation(Entity<SpriteComponent> sprite, Angle arc, Angle spriteRotation, float length, float offset)
     {
         var startRotation = sprite.Comp.Rotation + (arc * 0.5f);
@@ -105,7 +109,6 @@ public sealed partial class MeleeWeaponSystem
 
         startRotation += spriteRotation;
         endRotation += spriteRotation;
-        sprite.Comp.NoRotation = true;
 
         return new Animation()
         {
@@ -141,6 +144,10 @@ public sealed partial class MeleeWeaponSystem
         };
     }
 
+    /// <summary>
+    /// Makes the sprite move in a thrust motion from the player towards the target, then slightly pulls back.
+    /// For example for spears.
+    /// </summary>
     private Animation GetThrustAnimation(Entity<SpriteComponent> sprite, float offset, Angle spriteRotation, float length)
     {
         var startOffset = sprite.Comp.Rotation.RotateVec(new Vector2(0f, 0f));
@@ -170,6 +177,10 @@ public sealed partial class MeleeWeaponSystem
         };
     }
 
+    /// <summary>
+    /// Makes the sprite slowly fade by gradually reducing its alpha value.
+    /// Used at the end of attack animations so that the weapon sprite does not abruptly disappears.
+    /// </summary>
     private Animation GetFadeAnimation(SpriteComponent sprite, float start, float end)
     {
         return new Animation
@@ -193,6 +204,7 @@ public sealed partial class MeleeWeaponSystem
 
     /// <summary>
     /// Get the sprite offset animation to use for mob lunges.
+    /// This is applied to the attacker to show who is attacking.
     /// </summary>
     private Animation GetLungeAnimation(Vector2 direction)
     {
@@ -230,7 +242,7 @@ public sealed partial class MeleeWeaponSystem
             if (arcComponent.User == null || EntityManager.Deleted(arcComponent.User))
                 continue;
 
-            Vector2 targetPos = TransformSystem.GetWorldPosition(arcComponent.User.Value);
+            var targetPos = TransformSystem.GetWorldPosition(arcComponent.User.Value);
 
             if (arcComponent.Offset != Vector2.Zero)
             {


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

## Why / Balance
Resolves #42528

## Technical details
This was introduced in #41425 which added `noRot` to the client-side weapon sprite entity for no reason.
We just remove that line again.
If you look closely the lunge animation (the small offset applied to the player when attacking) still has the same problem, but that was already like that before the PR linked above.
I did not find a good way to fix it for the lunge because mobs are always have `SpriteComponent.NoRot` set to true, which will then also apply to the offset when the camera is rotated. This might need an engine change to fix.

## Media
![ss14](https://github.com/user-attachments/assets/d8e6429a-965a-4d91-92f7-dbc7391c8c11)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed melee attack animations being rotated wrong if your camera is rotated.
