### PR TITLE
Fix welders running an additional time when no damage remains.

### DIFF
--- a/Content.Shared/Repairable/RepairableSystem.cs
+++ b/Content.Shared/Repairable/RepairableSystem.cs
@@ -42,6 +42,8 @@ public sealed partial class RepairableSystem : EntitySystem
         else
             RepairAllDamage((ent, damageable), args.User);
 
+        totalDamage = _damageableSystem.GetTotalDamage((ent.Owner, damageable));
+
         args.Repeat = ent.Comp.AutoDoAfter && totalDamage > 0;
         args.Args.Event.Repeat = args.Repeat;
         args.Handled = true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a call to GetTotalDamage to update the totalDamage value after a repair is completed.

Previously this wasn't occurring because we changed how we're accessing the total damage from the component.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:

https://github.com/user-attachments/assets/5e54ab7b-9f4d-4699-8f9c-bf5731030c6a

After:

https://github.com/user-attachments/assets/0b8c6104-eff0-4084-8e5d-efc5a8f1a726


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: SlartiBartFast, Verin
- fix: Welders no longer perform an extra pass after a repair has completed.