### PR TITLE
Correct attribution for /Textures/Objects/mre.rsi

### DIFF
--- a/Resources/Textures/Objects/Consumable/Food/mre.rsi/meta.json
+++ b/Resources/Textures/Objects/Consumable/Food/mre.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-3.0",
-  "copyright": "Taken from cev-eris at https://github.com/discordia-space/CEV-Eris/raw/9c980cb9bc84d07b1c210c5447798af525185f80/icons/obj/food.dmi",
+  "copyright": "Taken from cev-eris at https://github.com/discordia-space/CEV-Eris/blob/633736637f35321062f723752cb9e5d797c532aa/icons/obj/food.dmi",
   "size": {
     "x": 32,
     "y": 32


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Resolves #12999 

The copyright line was incorrectly pointing to an on older version of the dmi that did not include any sprites from mre.rsi.

As the latest dmi still contains the images necessary, I've just pointed to the most recent commit to it. Also, pointed to the blob because I'll download the image on my own thanks.

https://github.com/discordia-space/CEV-Eris/blob/633736637f35321062f723752cb9e5d797c532aa/icons/obj/food.dmi

<img width="704" height="672" alt="food (8)" src="https://github.com/user-attachments/assets/e32a6c65-27a1-4e73-b38c-6565dd0290ee" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->