### PR TITLE
slightly enlarged Janibelt to reduce roundstart faff for new players

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/job.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/job.yml
@@ -123,6 +123,8 @@
     sprite: Clothing/Belt/janitor.rsi
   - type: Storage
     maxItemSize: Large
+    grid:
+      - 0,0,8,1
     whitelist:
       tags:
       - Wrench


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
* The Janibelt is now two slots wider (9x2, instead of 8x2)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
* This is intended to reduce some roundstart faff for new players (as 'janitor' is generally seen as a good role for new players whom are trying to get their bearings with the game).
* In ye olde days, before the wire brush was added, the Janibelt had a 2x2 empty space inside it at round start - perfect for allowing a new janitor to pick up a trashbag, stick it in their belt, and carry on with their day.
* However, nowadays, in order to do this, one has to first remove an item from their janibelt (and potentially rejig things in the janibelt) in order to make space for a trash bag. Whilst this is second nature to any experienced player, this may very easily confuse a new player, potentially leading them to do something silly like put the trashbag in their backpack instead or awkwardly carry it around in their hands instead.
* The simplest solution to this problem is probably to just enlarge the janibelt (to once again make it possible to shove the binbag into the belt at the start of the round) - or change the 'filled' janibelt entity to not have the wire brush and move that into one's bag instead at roundstart but that would still probably lead to some unwanted faff at roundstart for new players.

## Technical details
<!-- Summary of code changes for easier review. -->
* Manually defined grid size of janibelt as `0,0,8,1` to add extra space on the end for a trashbag.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="941" height="539" alt="image" src="https://github.com/user-attachments/assets/15e71766-64ba-4f01-a218-0246b254af9a" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
* Janibelt capacity is now 9x2 instead of 8x2


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The Janibelt is now 9x2.