### PR TITLE
Replace bad use of `SpriteSystem.CopyFrom` in `ChameleonClothingSystem`

### DIFF
--- a/Content.Client/Clothing/Systems/ChameleonClothingSystem.cs
+++ b/Content.Client/Clothing/Systems/ChameleonClothingSystem.cs
@@ -1,16 +1,17 @@
-﻿using System.Linq;
-using Content.Client.PDA;
+﻿using Content.Client.PDA;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
-using Content.Shared.Inventory;
 using Robust.Client.GameObjects;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.Manager;
 
 namespace Content.Client.Clothing.Systems;
 
 // All valid items for chameleon are calculated on client startup and stored in dictionary.
 public sealed class ChameleonClothingSystem : SharedChameleonClothingSystem
 {
+    [Dependency] private readonly ISerializationManager _serMan = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -37,7 +38,7 @@ public sealed class ChameleonClothingSystem : SharedChameleonClothingSystem
         if (TryComp(uid, out SpriteComponent? sprite)
             && proto.TryGetComponent(out SpriteComponent? otherSprite, Factory))
         {
-            sprite.CopyFrom(otherSprite);
+            _serMan.CopyTo(otherSprite, ref sprite, notNullableOverride: true);
         }
 
         // Edgecase for PDAs to include visuals when UI is open


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Replaced a misuse of `SpriteSystem.CopyFrom` in `ChameleonClothingSystem` with `ISerializationManager.CopyTo`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves https://github.com/space-wizards/space-station-14/issues/43290.

## Technical details
<!-- Summary of code changes for easier review. -->
Copying data from an uninitialized component (the one defined by the prototype) is not a good thing to do. Instead, the serialization manager is now used to copy data from the prototype to the component.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->