### PR TITLE
Fix `SharedCrayonSystem` being both `[Virtual]` and `abstract`

### DIFF
--- a/Content.Shared/Crayon/SharedCrayonSystem.cs
+++ b/Content.Shared/Crayon/SharedCrayonSystem.cs
@@ -1,4 +1,3 @@
 ﻿namespace Content.Shared.Crayon;
 
-[Virtual]
 public abstract class SharedCrayonSystem : EntitySystem { }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`SharedCrayonSystem` is no longer marked as both `[Virtual]` and `abstract`. It's just `abstract` now.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
`[Virtual]` is meant to be mutually exclusive with `abstract`, `sealed`, and `static`. This may be enforced by an analyzer in the future.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed `[Virtual]` from `SharedCrayonSystem`

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->