### PR TITLE
Disable LOOC by default on Wizard's Den

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -13,6 +13,10 @@ panic_bunker.enable_without_admins = true
 panic_bunker.show_reason = true
 panic_bunker.custom_reason = "You have not played on a Wizard's Den server long enough to connect to this server. Please play on Wizard's Den Lizard or Wizard's Den Leviathan until you have more playtime."
 
+[looc]
+enabled = false
+
+
 # IPIntel stuff
 ipintel_enabled = true
 ipintel_contact_email = "support@spacestation14.com"

--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -7,7 +7,7 @@ game-ticker-unknown-role = Unknown
 game-ticker-delay-start = Round start has been delayed for {$seconds} seconds.
 game-ticker-pause-start = Round start has been paused.
 game-ticker-pause-start-resumed = Round start countdown is now resumed.
-game-ticker-player-join-game-message = Welcome to Space Station 14! If this is your first time playing, be sure to read the game rules, and don't be afraid to ask for help in LOOC (local OOC) or OOC (usually available only between rounds).
+game-ticker-player-join-game-message = Welcome to Space Station 14! If this is your first time playing, be sure to read the game rules, and don't be afraid to ask your co-workers for help or in OOC between rounds.
 game-ticker-get-info-text = Hi and welcome to [color=white]Space Station 14![/color]
                             The current round is: [color=white]#{$roundId}[/color]
                             The current player count is: [color=white]{$playerCount}[/color]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Requires https://github.com/space-wizards/space-station-14/issues/43244 to be fixed.

Disables LOOC by default. Only affects servers that use `wizardsDen.toml`
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Often times you will see players saying something in LOOC that should be said IC. Most of the time, LOOC things can and should be said IC. Also prevents telepaths from gathering in the bar and talking about something completely unrelated to the game.

In terms of teaching new players how to play the game, players can get creative with being IC and getting the point across.

"How do I switch hands?"
"Flex your X muscle."

"How do I bolt my pistol?"
"Flip the Z switch."
## Technical details
<!-- Summary of code changes for easier review. -->
Modifies server's default configs and changes one cvar.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Minemoder
- remove: LOOC has been disabled by default on Wizard's Den servers.