### PR TITLE
helpful tip on map screen

### DIFF
--- a/Resources/Locale/en-US/navmap-beacons/station_map.ftl
+++ b/Resources/Locale/en-US/navmap-beacons/station_map.ftl
@@ -1,5 +1,5 @@
 station-map-window-title = Station map
-station-map-user-interface-flavor-left = Don't panic
+station-map-user-interface-flavor-left = For a portable station map, ask Cargo, Science, or Engineering.
 station-map-user-interface-flavor-right = v1.42
 station-map-filter-placeholder = Search by name
 station-map-unknown-station = Unknown station


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes the flavor text on the station map UI from "Don't Panic" to "For a portable station map, ask Cargo, Science, or Engineering."

## Why / Balance
The portable station map is an insanely useful tool for new players, available cheap at any department with a lathe. However, new players being new, they never know to even ask for it. This small bit of flavor text could help in that regard.

## Technical details
One line change

## Media

![Map text](https://github.com/user-attachments/assets/456039d0-0263-4441-8da5-e6566f9d7b00)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
:cl:
tweak: The station map UI now has a small text reminder about portable station maps
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
