### PR TITLE
Add logic to Debug/Set Outfit command to also fill storage containers

### DIFF
--- a/Content.Server/Clothing/Systems/OutfitSystem.cs
+++ b/Content.Server/Clothing/Systems/OutfitSystem.cs
@@ -102,7 +102,6 @@ public sealed class OutfitSystem : EntitySystem
 
         if (TryComp(target, out HandsComponent? handsComponent))
         {
-            coords = Comp<TransformComponent>(target).Coordinates;
             foreach (var prototype in startingGear.Inhand)
             {
                 var inhandEntity = Spawn(prototype, coords);

--- a/Content.Server/Clothing/Systems/OutfitSystem.cs
+++ b/Content.Server/Clothing/Systems/OutfitSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.Hands.Systems;
 using Content.Server.Preferences.Managers;
+using Content.Server.Storage.EntitySystems;
 using Content.Shared.Access.Components;
 using Content.Shared.Clothing;
 using Content.Shared.Hands.Components;
@@ -11,11 +12,10 @@ using Content.Shared.Preferences;
 using Content.Shared.Preferences.Loadouts;
 using Content.Shared.Roles;
 using Content.Shared.Station;
-using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Storage;
-using Content.Server.Storage.EntitySystems;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Clothing.Systems;
 
@@ -81,7 +81,10 @@ public sealed class OutfitSystem : EntitySystem
                 if (storageContainers.Count == 0)
                     continue;
 
-                if (_invSystem.TryGetSlotEntity(target, slotName, out var slotEnt) && TryComp(slotEnt, out StorageComponent? storage))
+                if (!_invSystem.TryGetSlotEntity(target, slotName, out var slotEnt))
+                    continue;
+
+                if (TryComp<StorageComponent>(slotEnt, out var storage))
                 {
                     foreach (var storageContainer in storageContainers)
                     {
@@ -89,12 +92,12 @@ public sealed class OutfitSystem : EntitySystem
                         _storageSystem.Insert(slotEnt.Value, spawnedEntity, out _, user: null, storageComp: storage, playSound: false);
                     }
                 }
-                else if (_invSystem.TryGetSlotEntity(target, slotName, out var slotEnt2) && TryComp(slotEnt2, out ItemSlotsComponent? itemSlots))
+                else if (TryComp<ItemSlotsComponent>(slotEnt, out var itemSlots))
                 {
                     foreach (var storageContainer in storageContainers)
                     {
                         var spawnedEntity = Spawn(storageContainer, coords);
-                        _itemSlotsSystem.TryInsertEmpty((slotEnt2.Value, itemSlots), spawnedEntity, null, excludeUserAudio: true);
+                        _itemSlotsSystem.TryInsertEmpty((slotEnt.Value, itemSlots), spawnedEntity, null, excludeUserAudio: true);
                     }
                 }
             }

--- a/Content.Server/Clothing/Systems/OutfitSystem.cs
+++ b/Content.Server/Clothing/Systems/OutfitSystem.cs
@@ -73,39 +73,36 @@ public sealed class OutfitSystem : EntitySystem
             }
         }
 
-        if (startingGear.Storage.Count > 0)
+        var coords = Transform(target).Coordinates;
+        foreach (var (slotName, storageContainers) in startingGear.Storage)
         {
-            var coords = Comp<TransformComponent>(target).Coordinates;
-            foreach (var (slotName, storageContainers) in startingGear.Storage)
+            if (storageContainers.Count == 0)
+                continue;
+
+            if (!_invSystem.TryGetSlotEntity(target, slotName, out var slotEnt))
+                continue;
+
+            if (TryComp<StorageComponent>(slotEnt, out var storage))
             {
-                if (storageContainers.Count == 0)
-                    continue;
-
-                if (!_invSystem.TryGetSlotEntity(target, slotName, out var slotEnt))
-                    continue;
-
-                if (TryComp<StorageComponent>(slotEnt, out var storage))
+                foreach (var entProto in storageContainers)
                 {
-                    foreach (var entProto in storageContainers)
-                    {
-                        var spawnedEntity = SpawnAtPosition(entProto, coords);
-                        _storageSystem.Insert(slotEnt.Value, spawnedEntity, out _, user: null, storageComp: storage, playSound: false);
-                    }
+                    var spawnedEntity = SpawnAtPosition(entProto, coords);
+                    _storageSystem.Insert(slotEnt.Value, spawnedEntity, out _, user: null, storageComp: storage, playSound: false);
                 }
-                else if (TryComp<ItemSlotsComponent>(slotEnt, out var itemSlots))
+            }
+            else if (TryComp<ItemSlotsComponent>(slotEnt, out var itemSlots))
+            {
+                foreach (var entProto in storageContainers)
                 {
-                    foreach (var entProto in storageContainers)
-                    {
-                        var spawnedEntity = Spawn(entProto, coords);
-                        _itemSlotsSystem.TryInsertEmpty((slotEnt.Value, itemSlots), spawnedEntity, null, excludeUserAudio: true);
-                    }
+                    var spawnedEntity = Spawn(entProto, coords);
+                    _itemSlotsSystem.TryInsertEmpty((slotEnt.Value, itemSlots), spawnedEntity, null, excludeUserAudio: true);
                 }
             }
         }
 
         if (TryComp(target, out HandsComponent? handsComponent))
         {
-            var coords = Comp<TransformComponent>(target).Coordinates;
+            coords = Comp<TransformComponent>(target).Coordinates;
             foreach (var prototype in startingGear.Inhand)
             {
                 var inhandEntity = Spawn(prototype, coords);

--- a/Content.Server/Clothing/Systems/OutfitSystem.cs
+++ b/Content.Server/Clothing/Systems/OutfitSystem.cs
@@ -94,7 +94,7 @@ public sealed class OutfitSystem : EntitySystem
             {
                 foreach (var entProto in storageContainers)
                 {
-                    var spawnedEntity = Spawn(entProto, coords);
+                    var spawnedEntity = SpawnAtPosition(entProto, coords);
                     _itemSlotsSystem.TryInsertEmpty((slotEnt.Value, itemSlots), spawnedEntity, null, excludeUserAudio: true);
                 }
             }

--- a/Content.Server/Clothing/Systems/OutfitSystem.cs
+++ b/Content.Server/Clothing/Systems/OutfitSystem.cs
@@ -13,6 +13,9 @@ using Content.Shared.Roles;
 using Content.Shared.Station;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Storage;
+using Content.Server.Storage.EntitySystems;
 
 namespace Content.Server.Clothing.Systems;
 
@@ -23,6 +26,8 @@ public sealed class OutfitSystem : EntitySystem
     [Dependency] private readonly HandsSystem _handSystem = default!;
     [Dependency] private readonly InventorySystem _invSystem = default!;
     [Dependency] private readonly SharedStationSpawningSystem _spawningSystem = default!;
+    [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;
+    [Dependency] private readonly StorageSystem _storageSystem = default!;
 
     public bool SetOutfit(EntityUid target, string gear, Action<EntityUid, EntityUid>? onEquipped = null, bool unremovable = false)
     {
@@ -65,6 +70,33 @@ public sealed class OutfitSystem : EntitySystem
                     EnsureComp<UnremoveableComponent>(equipmentEntity);
 
                 onEquipped?.Invoke(target, equipmentEntity);
+            }
+        }
+
+        if (startingGear.Storage.Count > 0)
+        {
+            var coords = Comp<TransformComponent>(target).Coordinates;
+            foreach (var (slotName, storageContainers) in startingGear.Storage)
+            {
+                if (storageContainers.Count == 0)
+                    continue;
+
+                if (_invSystem.TryGetSlotEntity(target, slotName, out var slotEnt) && TryComp(slotEnt, out StorageComponent? storage))
+                {
+                    foreach (var storageContainer in storageContainers)
+                    {
+                        var spawnedEntity = Spawn(storageContainer, coords);
+                        _storageSystem.Insert(slotEnt.Value, spawnedEntity, out _, user: null, storageComp: storage, playSound: false);
+                    }
+                }
+                else if (_invSystem.TryGetSlotEntity(target, slotName, out var slotEnt2) && TryComp(slotEnt2, out ItemSlotsComponent? itemSlots))
+                {
+                    foreach (var storageContainer in storageContainers)
+                    {
+                        var spawnedEntity = Spawn(storageContainer, coords);
+                        _itemSlotsSystem.TryInsertEmpty((slotEnt2.Value, itemSlots), spawnedEntity, null, excludeUserAudio: true);
+                    }
+                }
             }
         }
 

--- a/Content.Server/Clothing/Systems/OutfitSystem.cs
+++ b/Content.Server/Clothing/Systems/OutfitSystem.cs
@@ -86,17 +86,17 @@ public sealed class OutfitSystem : EntitySystem
 
                 if (TryComp<StorageComponent>(slotEnt, out var storage))
                 {
-                    foreach (var storageContainer in storageContainers)
+                    foreach (var entProto in storageContainers)
                     {
-                        var spawnedEntity = Spawn(storageContainer, coords);
+                        var spawnedEntity = SpawnAtPosition(entProto, coords);
                         _storageSystem.Insert(slotEnt.Value, spawnedEntity, out _, user: null, storageComp: storage, playSound: false);
                     }
                 }
                 else if (TryComp<ItemSlotsComponent>(slotEnt, out var itemSlots))
                 {
-                    foreach (var storageContainer in storageContainers)
+                    foreach (var entProto in storageContainers)
                     {
-                        var spawnedEntity = Spawn(storageContainer, coords);
+                        var spawnedEntity = Spawn(entProto, coords);
                         _itemSlotsSystem.TryInsertEmpty((slotEnt.Value, itemSlots), spawnedEntity, null, excludeUserAudio: true);
                     }
                 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gives Admin's some quality of life with the SetOutfit debug command by having it also fill the storage containers associated with the prototype - backpacks, jackets, etc. This should help save time :)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Requested by several admins downstream on Starlight.

## Technical details
<!-- Summary of code changes for easier review. -->
Iterates through storage containers within the startingGear prototype to properly fill their inventory contents.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

### Without the storage filling:
https://github.com/user-attachments/assets/f58d046f-40f2-46e3-8e71-2828d8737f46

### With the storage filling:
https://github.com/user-attachments/assets/6fce05fd-7115-4eff-a690-3b6dfc78fa15

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
ADMIN:
- tweak: The debug SetOutfit command now also fills target's storage containers based on the gear preset.
