### PR TITLE
Minor fixes to server api ban endpoint

### DIFF
--- a/Content.Server/Administration/ServerApi.cs
+++ b/Content.Server/Administration/ServerApi.cs
@@ -340,7 +340,7 @@ public sealed partial class ServerApi : IPostInjectInit
             var bans = await _db.GetBansAsync(userId: located.UserId,
                 address: null,
                 hwId: null,
-                modernHWIds: located.LastModernHWIds,
+                modernHWIds: null,
                 includeUnbanned: false);
             if (bans.Count > 0)
             {
@@ -369,6 +369,11 @@ public sealed partial class ServerApi : IPostInjectInit
             if (_playerManager.TryGetSessionById(new NetUserId(body.Guid), out var player))
             {
                 info.AddAddress(player.Channel.RemoteEndPoint.Address);
+            }
+            else
+            {
+                // We fallback into using the located player ip.
+                info.AddAddress(located.LastAddress);
             }
 
             _bans.CreateServerBan(info);


### PR DESCRIPTION
The ban endpoint now has a fallback for the IP Address. The ban check now only checks the user ID instead of also matching hardware ID (reason being, there may not be a ban placed on the user, but a hwid match may happen).