### PR TITLE
Fix Foolbox Hiesen

### DIFF
--- a/Content.Shared/Containers/ContainerFillSystem.cs
+++ b/Content.Shared/Containers/ContainerFillSystem.cs
@@ -81,13 +81,13 @@ public sealed class ContainerFillSystem : EntitySystem
                 return itemSizeProto?.Weight;
             });
 
-            foreach (var item in sortedItems)
+            foreach (var spawn in sortedItems)
             {
-                if (!_containerSystem.Insert(item, container, containerXform: xform))
+                if (!_containerSystem.Insert(spawn, container, containerXform: xform))
                 {
                     var alreadyContained = container.ContainedEntities.Count > 0 ? string.Join("\n", container.ContainedEntities.Select(e => $"\t - {ToPrettyString(e)}")) : "< empty >";
-                    Log.Error($"Entity {ToPrettyString(ent)} with a {nameof(EntityTableContainerFillComponent)} failed to insert an entity: {ToPrettyString(item)}.\nCurrent contents:\n{alreadyContained}");
-                    _transform.AttachToGridOrMap(item);
+                    Log.Error($"Entity {ToPrettyString(ent)} with a {nameof(EntityTableContainerFillComponent)} failed to insert an entity: {ToPrettyString(spawn)}.\nCurrent contents:\n{alreadyContained}");
+                    _transform.AttachToGridOrMap(spawn);
                     break;
                 }
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Resolves #43354

By the magic of debugging, I identified that in some circumstances, an item may spawn at the end of the table that would be too large to fit into the haphazardly filled container. The solution to this was quite stupid but appears to be effective. Sort the items going in by size. This takes some of the random out and perhaps that is not desired, but I figured I'd put this up and see what happens.

## Technical details
I am still incredibly bad with anything iterable in C#. I have no idea what I'm doing in this regard and have to rely on looking up concepts I'd understand in python. This could potentially use cleanup.

I've modified OnTableMapInit to first spawn all the items that get selected into a list that is then sorted by size, coming from the size weight from the item component.

Then iterate again through the spawned items and put em in the box. I've opted for orderbydescending so it starts with bigger items first as I felt this would make it unlikely to encounter an item that wouldn't fit.

A brief splint with an auto clicker and 42000 items spawned later, I did not hit my breakpoint after making this change.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="428" height="84" alt="image" src="https://github.com/user-attachments/assets/c18c0909-7e40-4f12-88ce-e354d83e18e5" />

<img width="662" height="326" alt="image" src="https://github.com/user-attachments/assets/106b3d38-d122-447c-909e-b63b57efaf4f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->