### PR TITLE
Makes singularities respect reduced motion option

### DIFF
--- a/Content.Client/Singularity/SingularityOverlay.cs
+++ b/Content.Client/Singularity/SingularityOverlay.cs
@@ -1,5 +1,3 @@
-using Content.Shared.Singularity.Components;
-using Robust.Client.Graphics;
 using System.Numerics;
 using Content.Shared.CCVar;
 using Content.Shared.Singularity.Components;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR makes singularities and gravity anomalies (and probably everything else that does the distortion) respect the accessibility option "Reduce motion of visual effects"

## Why / Balance
I played an Engineering round with one and I want to throw up
(another engineer took over for me unprompted when hearing about it. I love you other engineer player)

If "I specifically opted out of seeing horribly nauseating visual effects and saw this anyway" isn't reason enough:
- It's a permanent kind-of-hard-to-avoid (in Engineering) visual effect I'd say is far worse than a flash's visual effect. If you're within 1.5 screens of a singularity you're probably going to be seeing it. Even through *walls* (with diminished intensity)
- SS13 (last I checked?) doesn't have this anyway. This is how they handle things
- It's somewhat of a tradeoff enabling this (silly as it is to say that in reference to an accessibility option). You don't get much of an early warning a singularity is near you
- You can see around singularities anyway. All the effect does is make it look cooler and make it slightly more unpleasant to see things

I really, really, really feel like balancing shouldn't be decided around a nauseating visual effect. I want to play Engineering without risking getting too close to the Bad Sphere that causes me actual OOC discomfort

## Technical details
I have no clue what I'm doing. I just used existing reduced motion code as reference

I just copied the line to another part of the code because it's just a two line if statement. It's not like I'm copying a 30 line thing twice

This *should* work to disable the visual effect and also the item placement thing intended to adjust item locations based on the visual effect

## Media
<img width="794" height="650" alt="image" src="https://github.com/user-attachments/assets/c836f895-0583-4024-a417-d5c57b5c1f9b" />

<img width="869" height="796" alt="image" src="https://github.com/user-attachments/assets/03cfae5a-af27-4436-b9e0-8e65d63b69b7" />

<img width="1070" height="871" alt="image" src="https://github.com/user-attachments/assets/4ddbbbf8-7ebe-41b1-992d-e42b7a0a5ed0" />

<img width="904" height="853" alt="image" src="https://github.com/user-attachments/assets/fbada7fd-d63f-498b-a748-c838304954e1" />
<img width="818" height="713" alt="image" src="https://github.com/user-attachments/assets/656c9c91-3192-4e76-b178-ba4b8a32ec46" />
<img width="984" height="839" alt="image" src="https://github.com/user-attachments/assets/b417ea37-6bdc-4bfc-8dda-3a7354fc2787" />


I couldn't take a screenshot of the weird item displacey thing due to its nature. If I were to drop an item, it'd just look like an item next to me and it wouldn't show the fact it's on my cursor as it normally should be

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- tweak: Singularity distortion effects now respect the reduced motion accessibility option.