### PR TITLE
Fix `TrackingIssueAttribute` blocking orgs/repos containing numbers

### DIFF
--- a/Content.IntegrationTests/Fixtures/Attributes/TrackingIssueAttribute.cs
+++ b/Content.IntegrationTests/Fixtures/Attributes/TrackingIssueAttribute.cs
@@ -28,7 +28,7 @@ public sealed class TrackingIssueAttribute : PropertyAttribute
         "github.com"
     ];
 
-    private static readonly Regex GithubStyleIssueMatch = new(@"^\/[a-z\-\$\#]*\/[a-z\-\$\#]*\/(issues|pulls)\/\d*$",
+    private static readonly Regex GithubStyleIssueMatch = new(@"^\/[a-z\d\-\$\#]*\/[a-z\d\-\$\#]*\/(issues|pulls)\/\d*$",
         RegexOptions.Compiled | RegexOptions.NonBacktracking | RegexOptions.IgnoreCase);
 
     public TrackingIssueAttribute([StringSyntax(StringSyntaxAttribute.Uri)] string url) : base(url)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The regex in `TrackingIssueAttribute` no longer considers an issue URL invalid due to the org or repo name containing numbers.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is kind of important for a repo named `space-station-14`.

## Technical details
<!-- Summary of code changes for easier review. -->
Added `\d` into the org and repo name portions of the regex.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

@moonheart08 