### PR TITLE
Examination verb for items that enable suit storage.

### DIFF
--- a/Content.Shared/Armor/AllowSuitStorageComponent.cs
+++ b/Content.Shared/Armor/AllowSuitStorageComponent.cs
@@ -16,4 +16,10 @@ public sealed partial class AllowSuitStorageComponent : Component
     {
         Components = new[] {"Item"}
     };
+
+    /// <summary>
+    /// Examine string for enabling suit storage
+    /// </summary>
+    [DataField]
+    public LocId Examine = "examine-enable-suit-storage-base";
 }

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Clothing.Components;
+using Content.Shared.Clothing.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Examine;
@@ -24,6 +24,7 @@ public abstract class SharedArmorSystem : EntitySystem
         SubscribeLocalEvent<ArmorComponent, InventoryRelayedEvent<CoefficientQueryEvent>>(OnCoefficientQuery);
         SubscribeLocalEvent<ArmorComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnDamageModify);
         SubscribeLocalEvent<ArmorComponent, BorgModuleRelayedEvent<DamageModifyEvent>>(OnBorgDamageModify);
+        SubscribeLocalEvent<AllowSuitStorageComponent, GetVerbsEvent<ExamineVerb>>(OnArmorStorageVerbExamine);
         SubscribeLocalEvent<ArmorComponent, GetVerbsEvent<ExamineVerb>>(OnArmorVerbExamine);
     }
 
@@ -58,6 +59,17 @@ public abstract class SharedArmorSystem : EntitySystem
             return;
 
         args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, component.Modifiers);
+    }
+
+    private void OnArmorStorageVerbExamine(Entity<AllowSuitStorageComponent> ent, ref GetVerbsEvent<ExamineVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        var msg = new FormattedMessage();
+        msg.AddMarkupOrThrow(Loc.GetString(ent.Comp.Examine));
+
+        _examine.AddDetailedExamineVerb(args, ent.Comp, msg, Loc.GetString("suit-storage-examinable-verb-text"), "/Textures/Interface/VerbIcons/outfit.svg.192dpi.png", Loc.GetString("suit-storage-examinable-verb-message"));
     }
 
     private void OnArmorVerbExamine(EntityUid uid, ArmorComponent component, GetVerbsEvent<ExamineVerb> args)

--- a/Content.Shared/Examine/GroupExamineComponent.cs
+++ b/Content.Shared/Examine/GroupExamineComponent.cs
@@ -22,6 +22,7 @@ namespace Content.Shared.Examine
                 {
                     "Armor",
                     "ClothingSpeedModifier",
+                    "AllowSuitStorage"
                 },
             },
         };
@@ -67,7 +68,7 @@ namespace Content.Shared.Examine
         ///     Details shown when hovering over the button.
         /// </summary>
         [DataField]
-        public string HoverMessage = string.Empty;
+        public string HoverMessage = "verb-examine-group-other-message";
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/components/allow-suit-storage-component.ftl
+++ b/Resources/Locale/en-US/components/allow-suit-storage-component.ftl
@@ -1,0 +1,4 @@
+suit-storage-examinable-verb-text = Clothing
+suit-storage-examinable-verb-message = Examine this clothing's additional storage.
+examine-enable-suit-storage-base = This has a harness on the back to hold an air tank, weapon, or other equipment.
+examine-enable-suit-storage-tank-only = This has a harness on the back to hold an air tank.

--- a/Resources/Locale/en-US/verbs/verbs.ftl
+++ b/Resources/Locale/en-US/verbs/verbs.ftl
@@ -1,2 +1,3 @@
 # Default text that gets shown in the context menu for examining something with a GroupExamineComponent
 verb-examine-group-other = Other
+verb-examine-group-other-message = Examine this item's attributes.

--- a/Resources/Prototypes/Entities/Clothing/base_clothing.yml
+++ b/Resources/Prototypes/Entities/Clothing/base_clothing.yml
@@ -33,6 +33,7 @@
   id: AllowSuitStorageClothingGasTanks
   components:
   - type: AllowSuitStorage
+    examine: "examine-enable-suit-storage-tank-only"
     whitelist:
       components:
       - GasTank


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds an examination verb to the clothes that enable suit storage when worn. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's hard to tell that suit storage is only enabled while wearing certain items. This should make that more clear for new players.

## Technical details
<!-- Summary of code changes for easier review. -->
AllowSuitStorageComponent now has examine verb, which is included in GroupExamineComponent
Added a hover message to GroupExamineComponent, was empty before

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="283" height="161" alt="storage_message" src="https://github.com/user-attachments/assets/bf29eb61-18f7-4a4e-9adf-48f096ae74d8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Clothing that enables suit storage now tells you it does when examined
