### PR TITLE
Complete reviews for #16556 - Cargo gifts adjustments.

### DIFF
--- a/Content.Server/StationEvents/Components/CargoGiftsRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/CargoGiftsRuleComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Server.StationEvents.Components;
 /// <summary>
 /// Used an event that gifts the station with certain cargo
 /// </summary>
-[RegisterComponent, Access(typeof(CargoGiftsRule))]
+[RegisterComponent, Access(typeof(CargoGiftsRule)), AutoGenerateComponentPause]
 public sealed partial class CargoGiftsRuleComponent : Component
 {
     /// <summary>
@@ -55,8 +55,8 @@ public sealed partial class CargoGiftsRuleComponent : Component
     public int OrderSpaceToLeave = 5;
 
     /// <summary>
-    /// Time until we consider next lot of gifts (if supply is overflowing with orders)
+    /// Time we consider next lot of gifts at (if supply is overflowing with orders)
     /// </summary>
-    [DataField(customTypeSerializer:typeof(TimeOffsetSerializer))]
+    [DataField(customTypeSerializer:typeof(TimeOffsetSerializer)), AutoPausedField]
     public TimeSpan ConsiderNextGiftsAt;
 }

--- a/Content.Server/StationEvents/Components/CargoGiftsRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/CargoGiftsRuleComponent.cs
@@ -1,11 +1,12 @@
 ﻿using Content.Server.StationEvents.Events;
 using Content.Shared.Cargo.Prototypes;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.StationEvents.Components;
 
 /// <summary>
-/// Used an event that gifts the station with certian cargo
+/// Used an event that gifts the station with certain cargo
 /// </summary>
 [RegisterComponent, Access(typeof(CargoGiftsRule))]
 public sealed partial class CargoGiftsRuleComponent : Component
@@ -13,25 +14,25 @@ public sealed partial class CargoGiftsRuleComponent : Component
     /// <summary>
     /// The base announcement string (which then incorporates the strings below)
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public LocId Announce = "cargo-gifts-event-announcement";
 
     /// <summary>
     /// What is being sent
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public LocId Description = "cargo-gift-default-description";
 
     /// <summary>
     /// Sender of the gifts
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public LocId Sender = "cargo-gift-default-sender";
 
     /// <summary>
     /// Destination of the gifts (who they get sent to on the station)
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public LocId Dest = "cargo-gift-default-dest";
 
     /// <summary>
@@ -44,18 +45,18 @@ public sealed partial class CargoGiftsRuleComponent : Component
     /// Cargo that you would like gifted to the station, with the quantity for each
     /// Use Ids from cargoProduct Prototypes
     /// </summary>
-    [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
+    [DataField(required: true)]
     public Dictionary<ProtoId<CargoProductPrototype>, int> Gifts = new();
 
     /// <summary>
     /// How much space (minimum) you want to leave in the order database for supply to actually do their work
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public int OrderSpaceToLeave = 5;
 
     /// <summary>
     /// Time until we consider next lot of gifts (if supply is overflowing with orders)
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float TimeUntilNextGifts = 10.0f;
+    [DataField(customTypeSerializer:typeof(TimeOffsetSerializer))]
+    public TimeSpan ConsiderNextGiftsAt;
 }

--- a/Content.Server/StationEvents/Events/CargoGiftsRule.cs
+++ b/Content.Server/StationEvents/Events/CargoGiftsRule.cs
@@ -1,19 +1,19 @@
 using System.Linq;
 using Content.Server.Cargo.Components;
 using Content.Server.Cargo.Systems;
-using Content.Server.GameTicking;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Station.Components;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Server.StationEvents.Events;
 
 public sealed class CargoGiftsRule : StationEventSystem<CargoGiftsRuleComponent>
 {
-    [Dependency] private readonly CargoSystem _cargoSystem = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-    [Dependency] private readonly GameTicker _ticker = default!;
+    [Dependency] private readonly CargoSystem _cargoSystem = default!;
 
     protected override void Added(EntityUid uid, CargoGiftsRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
     {
@@ -33,15 +33,15 @@ public sealed class CargoGiftsRule : StationEventSystem<CargoGiftsRuleComponent>
     protected override void ActiveTick(EntityUid uid, CargoGiftsRuleComponent component, GameRuleComponent gameRule, float frameTime)
     {
         if (component.Gifts.Count == 0)
-            return;
-
-        if (component.TimeUntilNextGifts > 0)
         {
-            component.TimeUntilNextGifts -= frameTime;
-            return;
+            // We're done here!
+            ForceEndSelf(uid, gameRule);
         }
 
-        component.TimeUntilNextGifts += 30f;
+        if (_timing.CurTime < component.ConsiderNextGiftsAt)
+            return;
+
+        component.ConsiderNextGiftsAt = _timing.CurTime + TimeSpan.FromSeconds(30.0f);
 
         if (!TryGetRandomStation(out var station, HasComp<StationCargoOrderDatabaseComponent>) ||
                 !TryComp<StationDataComponent>(station, out var stationData))
@@ -77,12 +77,5 @@ public sealed class CargoGiftsRule : StationEventSystem<CargoGiftsRuleComponent>
                 break;
             }
         }
-
-        if (component.Gifts.Count == 0)
-        {
-            // We're done here!
-            _ticker.EndGameRule(uid, gameRule);
-        }
     }
-
 }

--- a/Content.Server/StationEvents/Events/CargoGiftsRule.cs
+++ b/Content.Server/StationEvents/Events/CargoGiftsRule.cs
@@ -43,14 +43,14 @@ public sealed class CargoGiftsRule : StationEventSystem<CargoGiftsRuleComponent>
 
         component.ConsiderNextGiftsAt = _timing.CurTime + TimeSpan.FromSeconds(30.0f);
 
-        if (!TryGetRandomStation(out var station, HasComp<StationCargoOrderDatabaseComponent>) ||
-                !TryComp<StationDataComponent>(station, out var stationData))
+        StationCargoOrderDatabaseComponent? cargoDb = null;
+
+        if (!TryGetRandomStation(out var station, stationUid => TryComp(stationUid, out cargoDb))
+            || !TryComp<StationDataComponent>(station, out var stationData))
             return;
 
-        if (!TryComp<StationCargoOrderDatabaseComponent>(station, out var cargoDb))
-        {
+        if (cargoDb == null)
             return;
-        }
 
         // Add some presents
         var outstanding = _cargoSystem.GetOutstandingOrderCount((station.Value, cargoDb), component.Account);

--- a/Resources/Locale/en-US/station-events/events/cargo-gifts.ftl
+++ b/Resources/Locale/en-US/station-events/events/cargo-gifts.ftl
@@ -13,7 +13,7 @@ cargo-gift-dest-sec = security dept
 cargo-gift-pizza-small = a small pizza party
 cargo-gift-pizza-large = a large pizza party
 
-cargo-gift-eng = repair Materials
+cargo-gift-eng = repair materials
 cargo-gift-vending = vending machines refills
 cargo-gift-cleaning = cleaning equipment
 cargo-gift-medical-supply = medical supplies

--- a/Resources/Locale/en-US/station-events/events/cargo-gifts.ftl
+++ b/Resources/Locale/en-US/station-events/events/cargo-gifts.ftl
@@ -4,20 +4,28 @@ cargo-gift-default-sender = NanoTrasen
 cargo-gift-default-dest = Cargo Dept.
 
 cargo-gift-dest-bar = bar
-cargo-gift-dest-eng = Engineering Dept
-cargo-gift-dest-supp = Cargo Dept
-cargo-gift-dest-janitor = Service Dept
-cargo-gift-dest-med = Medical Dept
-cargo-gift-dest-sec = Security Dept
+cargo-gift-dest-eng = engineering dept
+cargo-gift-dest-supp = cargo dept
+cargo-gift-dest-janitor = service dept
+cargo-gift-dest-med = medical dept
+cargo-gift-dest-sec = security dept
 
-cargo-gift-pizza-small = A small pizza party
-cargo-gift-pizza-large = A large pizza party
+cargo-gift-pizza-small = a small pizza party
+cargo-gift-pizza-large = a large pizza party
 
-cargo-gift-eng = Repair Materials
-cargo-gift-vending = Vending machines refills
-cargo-gift-cleaning = Cleaning equipment
-cargo-gift-medical-supply = Medical supplies
-cargo-gift-space-protection = Space Hazard Protection
-cargo-gift-fire-protection = Fire Protection
-cargo-gift-security-guns = Lethal Weapons
-cargo-gift-security-riot = Riot Gear
+cargo-gift-eng = repair Materials
+cargo-gift-vending = vending machines refills
+cargo-gift-cleaning = cleaning equipment
+cargo-gift-medical-supply = medical supplies
+cargo-gift-space-protection = space hazard protection
+cargo-gift-fire-protection = fire protection
+cargo-gift-security-guns = lethal weapons
+cargo-gift-security-riot = riot gear
+
+cargo-gift-pizza-small-announce = Well, this is embarrassing. It turns out that the NanoTrasen board is allergic to cheese. We've redirected some pizza to your supply department, please dispose of it. We suggest the bar.
+cargo-gift-pizza-large-announce = Our apologies for everything that's just happened. Here, have a lot of pizza. No need to evacuate, please just go to the bar and eat away your problems.
+cargo-gift-eng-announce = We've sent you a bunch of repair material for your engineers to use. No specific reason, we just think you might need it. If not now, soon.
+cargo-gift-vending-announce = You'll be glad to know that human interaction is down 15%! With all that saved time, we're VERY happy. So, some vending machine refills are incoming... for no reason.
+cargo-gift-cleaning-announce = We support the janitorial staff's effort to stem the tide of mess you're all creating. Especially since we plan to visit one day. Have some mops.
+cargo-gift-space-announce = Our space salvage team found an ominous empty derelict. It had useful emergency supplies in it! They don't need them, so we sent them to you.
+cargo-gift-security-riot-announce = Our quarterly report is looking great! Real Great! All your jobs are safe. In unrelated news, we've sent riot gear to your security team.

--- a/Resources/Locale/en-US/station-events/events/cargo-gifts.ftl
+++ b/Resources/Locale/en-US/station-events/events/cargo-gifts.ftl
@@ -21,11 +21,3 @@ cargo-gift-space-protection = space hazard protection
 cargo-gift-fire-protection = fire protection
 cargo-gift-security-guns = lethal weapons
 cargo-gift-security-riot = riot gear
-
-cargo-gift-pizza-small-announce = Well, this is embarrassing. It turns out that the NanoTrasen board is allergic to cheese. We've redirected some pizza to your supply department, please dispose of it. We suggest the bar.
-cargo-gift-pizza-large-announce = Our apologies for everything that's just happened. Here, have a lot of pizza. No need to evacuate, please just go to the bar and eat away your problems.
-cargo-gift-eng-announce = We've sent you a bunch of repair material for your engineers to use. No specific reason, we just think you might need it. If not now, soon.
-cargo-gift-vending-announce = You'll be glad to know that human interaction is down 15%! With all that saved time, we're VERY happy. So, some vending machine refills are incoming... for no reason.
-cargo-gift-cleaning-announce = We support the janitorial staff's effort to stem the tide of mess you're all creating. Especially since we plan to visit one day. Have some mops.
-cargo-gift-space-announce = Our space salvage team found an ominous empty derelict. It had useful emergency supplies in it! They don't need them, so we sent them to you.
-cargo-gift-security-riot-announce = Our quarterly report is looking great! Real Great! All your jobs are safe. In unrelated news, we've sent riot gear to your security team.

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -44,6 +44,7 @@
   - type: CargoGiftsRule
     description: cargo-gift-pizza-small
     dest: cargo-gift-dest-bar
+    announce: cargo-gift-pizza-small-announce
     gifts:
       FoodPizza: 1              # 4 pizzas
       FoodBarSupply: 1
@@ -62,6 +63,7 @@
   - type: CargoGiftsRule
     description: cargo-gift-pizza-large
     dest: cargo-gift-dest-bar
+    announce: cargo-gift-pizza-large-announce
     gifts:
       FoodPizza: 4              # 16 pizzas
       FoodBarSupply: 1
@@ -79,6 +81,7 @@
   - type: CargoGiftsRule
     description: cargo-gift-eng
     dest: cargo-gift-dest-eng
+    announce: cargo-gift-eng-announce
     gifts:
       EngineeringCableBulk: 1
       AirlockKit: 1
@@ -99,6 +102,7 @@
   - type: CargoGiftsRule
     description: cargo-gift-vending
     dest: cargo-gift-dest-supp
+    announce: cargo-gift-vending-announce
     gifts:
       CrateVendingMachineRestockHotDrinks: 3
       CrateVendingMachineRestockBooze: 1
@@ -119,6 +123,7 @@
   - type: CargoGiftsRule
     description: cargo-gift-cleaning
     dest: cargo-gift-dest-janitor
+    announce: cargo-gift-cleaning-announce
     gifts:
       ServiceJanitorial: 2
       ServiceLightsReplacement: 2
@@ -155,6 +160,7 @@
   - type: CargoGiftsRule
     description: cargo-gift-space-protection
     dest: cargo-gift-dest-supp
+    announce: cargo-gift-space-announce
     gifts:
       EmergencyInternalsLarge: 2
       EmergencyInflatablewall: 1
@@ -210,6 +216,7 @@
   - type: CargoGiftsRule
     description: cargo-gift-security-riot
     dest: cargo-gift-dest-sec
+    announce: cargo-gift-security-riot-announce
     gifts:
       SecurityRiot: 2
       SecurityRestraints: 2

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -44,7 +44,6 @@
   - type: CargoGiftsRule
     description: cargo-gift-pizza-small
     dest: cargo-gift-dest-bar
-    announce: cargo-gift-pizza-small-announce
     gifts:
       FoodPizza: 1              # 4 pizzas
       FoodBarSupply: 1
@@ -63,7 +62,6 @@
   - type: CargoGiftsRule
     description: cargo-gift-pizza-large
     dest: cargo-gift-dest-bar
-    announce: cargo-gift-pizza-large-announce
     gifts:
       FoodPizza: 4              # 16 pizzas
       FoodBarSupply: 1
@@ -81,7 +79,6 @@
   - type: CargoGiftsRule
     description: cargo-gift-eng
     dest: cargo-gift-dest-eng
-    announce: cargo-gift-eng-announce
     gifts:
       EngineeringCableBulk: 1
       AirlockKit: 1
@@ -102,7 +99,6 @@
   - type: CargoGiftsRule
     description: cargo-gift-vending
     dest: cargo-gift-dest-supp
-    announce: cargo-gift-vending-announce
     gifts:
       CrateVendingMachineRestockHotDrinks: 3
       CrateVendingMachineRestockBooze: 1
@@ -123,7 +119,6 @@
   - type: CargoGiftsRule
     description: cargo-gift-cleaning
     dest: cargo-gift-dest-janitor
-    announce: cargo-gift-cleaning-announce
     gifts:
       ServiceJanitorial: 2
       ServiceLightsReplacement: 2
@@ -160,7 +155,6 @@
   - type: CargoGiftsRule
     description: cargo-gift-space-protection
     dest: cargo-gift-dest-supp
-    announce: cargo-gift-space-announce
     gifts:
       EmergencyInternalsLarge: 2
       EmergencyInflatablewall: 1
@@ -216,7 +210,6 @@
   - type: CargoGiftsRule
     description: cargo-gift-security-riot
     dest: cargo-gift-dest-sec
-    announce: cargo-gift-security-riot-announce
     gifts:
       SecurityRiot: 2
       SecurityRestraints: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Implement Sloths requested changes from #16556 and re-upload #16735

Resolves #16712

## Technical details
<!-- Summary of code changes for easier review. -->

Most of the requested changes were already implemented, so this just finishes it out by re-opening 16735.

The most notable changes here are:
- Fixing an issue where it would be possible for the game rule to not end if Gifts count was 0 at the start of a tick.
- Replacing the accumulator with a TimeSpan.

I did not bring over any balance or monetary value changes.

Note, I was not entirely sure what Sloth meant with this:

<img width="810" height="281" alt="image" src="https://github.com/user-attachments/assets/522be573-0813-4aea-b518-228fd3c48fc3" />

He's referring to the HasComp here as this component check is performed twice here. The issue is we need that component but TryGetRandomStation doesn't enable us to return it. Perhaps that should be changed so it outputs it?

I wasn't entirely sure how to test this. The game rules do still run manually.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->