### PR TITLE
[Mald pr] Allow to wear pda without jumpsuit

### DIFF
--- a/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
+++ b/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
@@ -85,7 +85,6 @@ namespace Content.IntegrationTests.Tests
                     Assert.That(invSystem.CanEquip(human, uniform, "jumpsuit", out _));
 
                     // Can't equip any of these since no uniform!
-                    Assert.That(invSystem.CanEquip(human, idCard, "id", out _), Is.False);
                     Assert.That(invSystem.CanEquip(human, pocketItem, "pocket1", out _), Is.False);
                     Assert.That(invSystem.CanEquip(human, tooBigItem, "pocket2", out _), Is.False); // This one fails either way.
                 });

--- a/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
@@ -101,7 +101,6 @@
       stripTime: 6
       uiWindowPos: 2,1
       strippingWindowPos: 2,4
-      dependsOn: jumpsuit
       displayName: ID
     - name: belt
       slotTexture: belt


### PR DESCRIPTION
## About the PR
Continuation of the #43389

## Why / Balance
This is a logical extension of the previous point; I’ve seen it happen many times (and experienced it myself a couple of times early in the game) - people simply losing their PDAs when changing their jumpsuits. Unlike with pockets, losing access to the PDA slot is illogical, because when you’re naked, you obviously don’t have any pockets. But in the case of the PDA, it’s separate - I can easily imagine something like a belt or something similar on the back of the PDA. Even if we stick to logic, the PDA can still be worn in a belt slot without any clothing.
From a balance standpoint, this changes absolutely nothing (have you ever seen someone have their jumpsuit taken away and be left naked just to deprive them of access to a PDA, which can be picked up or hung on a belt anyway?).

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
human's `id` slot no longer depends on the jumpsuit

**Changelog**
:cl:
- tweak: You can now wear pda without jumpsuit