### PR TITLE
fix Changeling transformation making items in slime storage inaccessible

### DIFF
--- a/Content.Shared/Changeling/ChangelingTransformEvents.cs
+++ b/Content.Shared/Changeling/ChangelingTransformEvents.cs
@@ -14,3 +14,26 @@ public sealed partial class ChangelingTransformActionEvent : InstantActionEvent;
 /// </summary>
 [Serializable, NetSerializable]
 public sealed partial class ChangelingTransformDoAfterEvent : SimpleDoAfterEvent;
+
+/// <summary>
+/// Raised on a changeling before they transform into a stored identity.
+/// This is raised after the DoAfter finished.
+/// </summary>
+public readonly record struct BeforeChangelingTransformEvent(EntityUid StoredIdentity)
+{
+    /// <summary>
+    /// The stored identity the changeling will transform into.
+    /// </summary>
+    public readonly EntityUid StoredIdentity = StoredIdentity;
+};
+
+/// <summary>
+/// Raised on a changeling after they successfully transformed into a stored identity.
+/// </summary>
+public readonly record struct AfterChangelingTransformEvent(EntityUid StoredIdentity)
+{
+    /// <summary>
+    /// The stored identity the changeling transformed into.
+    /// </summary>
+    public readonly EntityUid StoredIdentity = StoredIdentity;
+};

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
@@ -5,10 +5,11 @@ using Content.Shared.Changeling.Components;
 using Content.Shared.Cloning;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
-using Content.Shared.Humanoid;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Popups;
+using Content.Shared.Storage;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 
@@ -27,6 +28,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
     [Dependency] private readonly SharedCloningSystem _cloningSystem = default!;
     [Dependency] private readonly SharedVisualBodySystem _visualBody = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
 
     private const string ChangelingBuiXmlGeneratedName = "ChangelingTransformBoundUserInterface";
     public override void Initialize()
@@ -38,6 +40,9 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
         SubscribeLocalEvent<ChangelingTransformComponent, ChangelingTransformDoAfterEvent>(OnSuccessfulTransform);
         SubscribeLocalEvent<ChangelingTransformComponent, ChangelingTransformIdentitySelectMessage>(OnTransformSelected);
         SubscribeLocalEvent<ChangelingTransformComponent, ComponentShutdown>(OnShutdown);
+
+        // Components that need special handling outside of cloning.
+        SubscribeLocalEvent<StorageComponent, BeforeChangelingTransformEvent>(StorageBeforeTransform);
     }
 
     private void OnMapInit(Entity<ChangelingTransformComponent> ent, ref MapInitEvent init)
@@ -153,6 +158,9 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
         if (args.Target is not { } targetIdentity)
             return;
 
+        var beforeTransformEvent = new BeforeChangelingTransformEvent(targetIdentity);
+        RaiseLocalEvent(args.User, beforeTransformEvent);
+
         _visualBody.CopyAppearanceFrom(targetIdentity, args.User);
         _cloningSystem.CloneComponents(targetIdentity, args.User, settings);
 
@@ -169,5 +177,17 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
             identity.CurrentIdentity = targetIdentity;
             Dirty(ent.Owner, identity);
         }
+
+        var afterTransformEvent = new AfterChangelingTransformEvent(targetIdentity);
+        RaiseLocalEvent(args.User, afterTransformEvent);
+    }
+
+    private void StorageBeforeTransform(Entity<StorageComponent> ent, ref BeforeChangelingTransformEvent args)
+    {
+        if (HasComp<StorageComponent>(args.StoredIdentity))
+            return; // If we have a storage component and the target has one as well, then do nothing.
+
+        // If the target identity does not have a storage anymore, drop all items inside our storage so that they don't become unreachable.
+        _container.EmptyContainer(ent.Comp.Container);
     }
 }

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
@@ -18,17 +18,18 @@ namespace Content.Shared.Changeling.Systems;
 public sealed partial class ChangelingTransformSystem : EntitySystem
 {
     [Dependency] private readonly INetManager _net = default!;
-    [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
-    [Dependency] private readonly SharedUserInterfaceSystem _uiSystem = default!;
-    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
-    [Dependency] private readonly MetaDataSystem _metaSystem = default!;
-    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly MetaDataSystem _metaData = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly SharedCloningSystem _cloningSystem = default!;
+    [Dependency] private readonly SharedCloningSystem _cloning = default!;
     [Dependency] private readonly SharedVisualBodySystem _visualBody = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly IdentitySystem _identity = default!;
 
     private const string ChangelingBuiXmlGeneratedName = "ChangelingTransformBoundUserInterface";
     public override void Initialize()
@@ -47,17 +48,17 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
 
     private void OnMapInit(Entity<ChangelingTransformComponent> ent, ref MapInitEvent init)
     {
-        _actionsSystem.AddAction(ent, ref ent.Comp.ChangelingTransformActionEntity, ent.Comp.ChangelingTransformAction);
+        _actions.AddAction(ent, ref ent.Comp.ChangelingTransformActionEntity, ent.Comp.ChangelingTransformAction);
 
         var userInterfaceComp = EnsureComp<UserInterfaceComponent>(ent);
-        _uiSystem.SetUi((ent, userInterfaceComp), ChangelingTransformUiKey.Key, new InterfaceData(ChangelingBuiXmlGeneratedName));
+        _ui.SetUi((ent, userInterfaceComp), ChangelingTransformUiKey.Key, new InterfaceData(ChangelingBuiXmlGeneratedName));
     }
 
     private void OnShutdown(Entity<ChangelingTransformComponent> ent, ref ComponentShutdown args)
     {
         if (ent.Comp.ChangelingTransformActionEntity != null)
         {
-            _actionsSystem.RemoveAction(ent.Owner, ent.Comp.ChangelingTransformActionEntity);
+            _actions.RemoveAction(ent.Owner, ent.Comp.ChangelingTransformActionEntity);
         }
     }
 
@@ -70,9 +71,9 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
         if (!TryComp<ChangelingIdentityComponent>(ent, out var userIdentity))
             return;
 
-        if (!_uiSystem.IsUiOpen((ent, userInterfaceComp), ChangelingTransformUiKey.Key, args.Performer))
+        if (!_ui.IsUiOpen((ent, userInterfaceComp), ChangelingTransformUiKey.Key, args.Performer))
         {
-            _uiSystem.OpenUi((ent, userInterfaceComp), ChangelingTransformUiKey.Key, args.Performer);
+            _ui.OpenUi((ent, userInterfaceComp), ChangelingTransformUiKey.Key, args.Performer);
         } //TODO: Can add a Else here with TransformInto and CloseUI to make a quick switch,
           // issue right now is that Radials cover the Action buttons so clicking the action closes the UI (due to clicking off a radial causing it to close, even with UI)
           // but pressing the number does.
@@ -80,7 +81,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
 
     /// <summary>
     /// Transform the changeling into another identity.
-    /// This can be any cloneable humanoid and doesn't have to be stored in the ChangelingIdentiyComponent,
+    /// This can be any cloneable humanoid and doesn't have to be stored in the ChangelingIdentityComponent,
     /// so make sure to validate the target before.
     /// </summary>
     public void TransformInto(Entity<ChangelingTransformComponent?> ent, EntityUid targetIdentity)
@@ -90,7 +91,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
 
         var selfMessage = Loc.GetString("changeling-transform-attempt-self", ("user", Identity.Entity(ent.Owner, EntityManager)));
         var othersMessage = Loc.GetString("changeling-transform-attempt-others", ("user", Identity.Entity(ent.Owner, EntityManager)));
-        _popupSystem.PopupPredicted(
+        _popup.PopupPredicted(
             selfMessage,
             othersMessage,
             ent,
@@ -105,7 +106,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
         else
             _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ent.Owner):player} begun an attempt to transform into \"{Name(targetIdentity)}\"");
 
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(
+        _doAfter.TryStartDoAfter(new DoAfterArgs(
             EntityManager,
             ent,
             ent.Comp.TransformWindup,
@@ -124,7 +125,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
     private void OnTransformSelected(Entity<ChangelingTransformComponent> ent,
         ref ChangelingTransformIdentitySelectMessage args)
     {
-        _uiSystem.CloseUi(ent.Owner, ChangelingTransformUiKey.Key, ent);
+        _ui.CloseUi(ent.Owner, ChangelingTransformUiKey.Key, ent);
 
         if (!TryGetEntity(args.TargetIdentity, out var targetIdentity))
             return;
@@ -162,13 +163,14 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
         RaiseLocalEvent(args.User, beforeTransformEvent);
 
         _visualBody.CopyAppearanceFrom(targetIdentity, args.User);
-        _cloningSystem.CloneComponents(targetIdentity, args.User, settings);
+        _cloning.CloneComponents(targetIdentity, args.User, settings);
 
         if (TryComp<ChangelingStoredIdentityComponent>(targetIdentity, out var storedIdentity) && storedIdentity.OriginalSession != null)
             _adminLogger.Add(LogType.Action, LogImpact.High, $"{ToPrettyString(ent.Owner):player} successfully transformed into \"{Name(targetIdentity)}\" ({storedIdentity.OriginalSession:player})");
         else
             _adminLogger.Add(LogType.Action, LogImpact.High, $"{ToPrettyString(ent.Owner):player} successfully transformed into \"{Name(targetIdentity)}\"");
-        _metaSystem.SetEntityName(ent, Name(targetIdentity), raiseEvents: false);
+        _metaData.SetEntityName(ent, Name(targetIdentity), raiseEvents: false); // Don't raise events because we don't want to rename the ID card.
+        _identity.QueueIdentityUpdate(ent); // We have to manually refresh the identity because we did not raise events.
 
         Dirty(ent);
 


### PR DESCRIPTION
## About the PR
Fixes #42118
The items in your slime storage now drop onto the ground when tranforming from a slime to a non-slime species-

## Why / Balance
bugfix

## Technical details
The problem occurred because `StorageComponent` tracks the list of entities inside the container, along with their location in the grid. If the component is removed and added again those references are lost, but the entity is still in the container.

To fix this I added two new events and use one of them to empty out the container before transforming if the target identity we are transforming into does not have the StorageComponent. This also prevents changelings from effectively making items inaccessible to other players.

Also fixed a missing identity update that sometimes made you keep your old name until putting on a mask.

## Media
![ling](https://github.com/user-attachments/assets/8da86f14-e29e-4791-8f6f-807f1cbb0ff8)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
changeling is not released yet
