### PR TITLE
Reduce speso value of tech disks

### DIFF
--- a/Content.Shared/Research/TechnologyDisk/Components/TechnologyDiskComponent.cs
+++ b/Content.Shared/Research/TechnologyDisk/Components/TechnologyDiskComponent.cs
@@ -39,8 +39,8 @@ public sealed partial class TechnologyDiskComponent : Component
     [DataField]
     public Dictionary<int, int> DiskPricePerTier = new()
     {
-        [1] = 100,
-        [2] = 500,
-        [3] = 1500
+        [1] = 50,
+        [2] = 135,
+        [3] = 1000,
     };
 }

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
@@ -31,6 +31,8 @@
     energy: 0.5
     color: "#b53ca1"
 
+# The value per-disk equate to an average of 1000 research points -> 100 spesos
+# Average is calculated from this table, default speso value in TechnologyDiskComponent, and default point cost in DiskConsoleComponent
 - type: weightedRandom
   id: TechDiskTierWeights
   weights:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Reduced the speso value of tech disks to an average of 100 spesos per 1000 research points.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Maintainer meeting on 28/03/2026 determined that while printing tech disks for money is acceptable, it's not something we want to encourage more than already possible. The 2.5x increase to the average value of tech disks in #37719 was considered too much, and this PR brings it back to status quo (while retaining the varied prices). For transparency I was the one who brought up the topic in the meeting.

## Technical details
<!-- Summary of code changes for easier review. -->
`TechDiskTierWeights` is used for the distribution, which looks like `[1:25, 2:10, 3:1]`. 100 is the desired average, so:

```math
( 25x + 10y + z ) / 36 = 100
```
- Tier 1 (x) = 50
- Tier 2 (y) = 135
- Tier 3 (z) = 1000

With the value of Tier 1 being lowered, casual usage of the tech disk terminal for spesos will result in typically worse outcomes but an added chance to win a jackpot. The tech disk terminal is now even more of a slot machine than before (this is good).


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: aada
- tweak: The value of tier 1 tech disks has been lowered.