### PR TITLE
Add "failed to load crew manifest" message

### DIFF
--- a/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Station.Systems;
 using Content.Shared.CartridgeLoader;
 using Content.Shared.CartridgeLoader.Cartridges;
 using Content.Shared.CCVar;
+using Content.Shared.CrewManifest;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
@@ -60,7 +61,13 @@ public sealed class CrewManifestCartridgeSystem : EntitySystem
         var owningStation = _stationSystem.GetOwningStation(uid);
 
         if (owningStation is null)
+        {
+            // Display "loading failed" message
+            var failureMessage = Loc.GetString("crew-manifest-cartridge-loading-failed");
+            var failureState = new CrewManifestUiState(failureMessage, new CrewManifestEntries());
+            _cartridgeLoader.UpdateCartridgeUiState(loaderUid, failureState);
             return;
+        }
 
         var (stationName, entries) = _crewManifest.GetCrewManifest(owningStation.Value);
 

--- a/Resources/Locale/en-US/cartridge-loader/cartridges.ftl
+++ b/Resources/Locale/en-US/cartridge-loader/cartridges.ftl
@@ -7,6 +7,7 @@ news-read-program-name = Station news
 
 crew-manifest-program-name = Crew manifest
 crew-manifest-cartridge-loading = Loading ...
+crew-manifest-cartridge-loading-failed = Failed to load crew manifest!
 
 net-probe-program-name = NetProbe
 net-probe-scan = Scanned {$device}!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
**Currently**, if you open the crew manifest when you're not on a station, it just says "Loading ..." forever.

**After this PR**, it will say "Failed to load crew manifest!" when you're not on a station.

## Why / Balance
It's confusing to see "loading" even when the crew manifest gave up loading a long time ago. This should make it more clear.

## Technical details
Changes `CrewManifestCartridgeSystem.UpdateUiState` so that it displays a failure message instead of just returning early.

Instead of passing a `null` crew manifest when loading fails, I pass an *empty* one. This is because if I passed a `null` one it would display nothing at all! Reason: `CrewManifestUi.Populate`

https://github.com/space-wizards/space-station-14/blob/e27f51762b5e0476c7d8f9041bb7db4bfaaa4070/Content.Client/CrewManifest/CrewManifestUi.xaml.cs#L19-L24

## Media

Before:

https://github.com/user-attachments/assets/658ce37f-7b09-469e-a7bb-d1122b46ace7

After:

https://github.com/user-attachments/assets/9db80eeb-871f-43de-817a-773ca450fb68

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Crew Manifest PDA program now displays a message when it fails to load.
