### PR TITLE
Ghost AI overlay toggle

### DIFF
--- a/Content.Client/Ghost/GhostSystem.cs
+++ b/Content.Client/Ghost/GhostSystem.cs
@@ -1,4 +1,5 @@
 using Content.Client.Movement.Systems;
+using Content.Client.Silicons.StationAi;
 using Content.Shared.Actions;
 using Content.Shared.Ghost;
 using Robust.Client.Console;
@@ -16,6 +17,7 @@ namespace Content.Client.Ghost
         [Dependency] private readonly PointLightSystem _pointLightSystem = default!;
         [Dependency] private readonly ContentEyeSystem _contentEye = default!;
         [Dependency] private readonly SpriteSystem _sprite = default!;
+        [Dependency] private readonly StationAiSystem _stationAi = default!;
 
         public int AvailableGhostRoleCount { get; private set; }
 
@@ -68,6 +70,7 @@ namespace Content.Client.Ghost
             SubscribeLocalEvent<EyeComponent, ToggleLightingActionEvent>(OnToggleLighting);
             SubscribeLocalEvent<EyeComponent, ToggleFoVActionEvent>(OnToggleFoV);
             SubscribeLocalEvent<GhostComponent, ToggleGhostsActionEvent>(OnToggleGhosts);
+            SubscribeLocalEvent<GhostComponent, ToggleGhostAiOverlayActionEvent>(OnToggleGhostAiOverlay);
         }
 
         private void OnStartup(EntityUid uid, GhostComponent component, ComponentStartup args)
@@ -128,13 +131,21 @@ namespace Content.Client.Ghost
             args.Handled = true;
         }
 
+        private void OnToggleGhostAiOverlay(EntityUid uid, GhostComponent component, ToggleGhostAiOverlayActionEvent args)
+        {
+            if (args.Handled)
+                return;
+            _stationAi.ToggleOverlay();
+            args.Handled = true;
+        }
+
         private void OnGhostRemove(EntityUid uid, GhostComponent component, ComponentRemove args)
         {
             _actions.RemoveAction(uid, component.ToggleLightingActionEntity);
             _actions.RemoveAction(uid, component.ToggleFoVActionEntity);
             _actions.RemoveAction(uid, component.ToggleGhostsActionEntity);
             _actions.RemoveAction(uid, component.ToggleGhostHearingActionEntity);
-
+            _actions.RemoveAction(uid, component.ToggleGhostAiOverlayActionEntity);
             if (uid != _playerManager.LocalEntity)
                 return;
 
@@ -162,7 +173,8 @@ namespace Content.Client.Ghost
         private void OnGhostPlayerDetach(EntityUid uid, GhostComponent component, LocalPlayerDetachedEvent args)
         {
             GhostVisibility = false;
-            PlayerDetached?.Invoke();
+            _stationAi.DisableOverlay();
+            PlayerDetached?.Invoke(); 
         }
 
         private void OnGhostWarpsResponse(GhostWarpsResponseEvent msg)

--- a/Content.Client/Silicons/StationAi/StationAiSystem.cs
+++ b/Content.Client/Silicons/StationAi/StationAiSystem.cs
@@ -66,6 +66,20 @@ public sealed partial class StationAiSystem : SharedStationAiSystem
         _overlay = null;
     }
 
+    public void ToggleOverlay()
+    {
+        if (_overlay == null)
+            AddOverlay();
+        else
+            RemoveOverlay();
+    }
+
+    public void DisableOverlay()
+    {
+        RemoveOverlay();
+    }
+
+
     private void OnAiAttached(Entity<StationAiOverlayComponent> ent, ref LocalPlayerAttachedEvent args)
     {
         AddOverlay();

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -235,6 +235,7 @@ namespace Content.Server.Ghost
             _actions.AddAction(uid, ref component.ToggleLightingActionEntity, component.ToggleLightingAction);
             _actions.AddAction(uid, ref component.ToggleFoVActionEntity, component.ToggleFoVAction);
             _actions.AddAction(uid, ref component.ToggleGhostsActionEntity, component.ToggleGhostsAction);
+            _actions.AddAction(uid, ref component.ToggleGhostAiOverlayActionEntity, component.ToggleGhostAiOverlayAction);
         }
 
         private void OnGhostExamine(EntityUid uid, GhostComponent component, ExaminedEvent args)

--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -44,6 +44,12 @@ public sealed partial class GhostComponent : Component
     [DataField, AutoNetworkedField]
     public EntityUid? BooActionEntity;
 
+    [DataField]
+    public EntProtoId ToggleGhostAiOverlayAction = "ActionToggleGhostAiOverlay";
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? ToggleGhostAiOverlayActionEntity;
+
     // End actions
 
     /// <summary>
@@ -117,3 +123,5 @@ public sealed partial class ToggleGhostHearingActionEvent : InstantActionEvent {
 public sealed partial class ToggleGhostVisibilityToAllEvent : InstantActionEvent { }
 
 public sealed partial class BooActionEvent : InstantActionEvent { }
+
+public sealed partial class ToggleGhostAiOverlayActionEvent : InstantActionEvent { }

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -180,3 +180,17 @@
     iconOn: Interface/Actions/ghostHearingToggled.png
   - type: InstantAction
     event: !type:ToggleGhostHearingActionEvent
+
+- type: entity
+  parent: BaseMentalAction
+  id: ActionToggleGhostAiOverlay
+  name: Toggle AI Overlay
+  description: Toggle the station AI overlay while observing.
+  components:
+  - type: Action
+    icon:
+      sprite: Interface/Actions/actions_ai.rsi
+      state: ai_core
+    clientExclusive: true
+  - type: InstantAction
+    event: !type:ToggleGhostAiOverlayActionEvent


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a ghost action that toggles the existing station AI overlay.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #31544.

This lets ghosts view what the station AI sees, including camera static and inaccessible areas, without affecting normal ghosting behavior.
## Technical details
<!-- Summary of code changes for easier review. -->
Adds a new client-exclusive ghost action that toggles the existing station AI overlay through `StationAiSystem`.

The overlay is explicitly disabled when the player leaves ghost state so it does not persist after respawning or returning to their body.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.
**Changelog**
:cl: 
- add: Ghosts can now toggle the AI overlay.


