### PR TITLE
Fix ghost time of death

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -205,7 +205,7 @@ namespace Content.Server.Ghost
             }
 
             _eye.RefreshVisibilityMask(uid);
-            var time = _gameTiming.CurTime;
+            var time = _gameTiming.RealTime;
             component.TimeOfDeath = time;
         }
 

--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Ghost;
 /// Handles limiting interactions, using ghost abilities, ghost visibility, and ghost warping.
 /// </summary>
 [RegisterComponent, NetworkedComponent, Access(typeof(SharedGhostSystem))]
-[AutoGenerateComponentState(true), AutoGenerateComponentPause]
+[AutoGenerateComponentState(true)]
 public sealed partial class GhostComponent : Component
 {
     // Actions

--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -54,7 +54,7 @@ public sealed partial class GhostComponent : Component
     /// May not reflect actual time of death if this entity has been paused,
     /// but will give an accurate length of time <i>since</i> death.
     /// </remarks>
-    [DataField, AutoPausedField]
+    [DataField]
     public TimeSpan TimeOfDeath = TimeSpan.Zero;
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The display of how long ago a ghost died should now be accurate. This should also fix voting eligibility based on time since death.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A silly mistake has kept this from working properly for _years_.

## Technical details
<!-- Summary of code changes for easier review. -->
On ghost startup, the `TimeOfDeath` field is set to `IGameTiming.CurTime`.
The calculations for how long ago that was (used in the examine message and the voting system) subtract `TimeOfDeath` from `IGameTiming.RealTime`.

`CurTime` and `RealTime` do not remain in sync - `CurTime` is affected by pausing, timescale, and lag, while `RealTime` is not. Subtracting one from the other will not give the desired result here - if the server has lagged or been paused for any reason (such as not having any players connected), the difference will be bigger than desired.

This has been changed so the `TimeOfDeath` field is now set to `RealTime` on ghost startup. Because `RealTime` is not affected by pausing, the `TimeOfDeath` field is no longer marked with `[AutoPausedField]`.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="450" height="200" alt="Screenshot 2026-03-30 at 4 36 14 PM" src="https://github.com/user-attachments/assets/ad8050ba-5081-410e-8530-e606fe94519e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Ghost time of death display is now accurate.