### PR TITLE
Mechs can pry firelocks

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -203,7 +203,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
     #region Interactions
     protected void OnActivate(EntityUid uid, DoorComponent door, ActivateInWorldEvent args)
     {
-        if (args.Handled || !args.Complex || !door.ClickOpen)
+        if (args.Handled || !(args.Complex || (TryComp<PryingComponent>(args.User, out var pry)) && pry.BypassVerb) || !door.ClickOpen)
             return;
 
         if (!TryToggleDoor(uid, door, args.User, predicted: true))

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -22,6 +22,13 @@ public sealed partial class PryingComponent : Component
     public bool Force;
 
     /// <summary>
+    /// Whether the entity should pry directly on click, instead of using an alternative verb
+    /// Only useful for mobs that can pry, such as mechs, cyborgs, and zombies
+    /// </summary>
+    [DataField]
+    public bool BypassVerb = false;
+
+    /// <summary>
     /// Modifier on the prying time.
     /// Lower values result in more time.
     /// </summary>

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -121,7 +121,7 @@ public sealed class PryingSystem : EntitySystem
 
         // hand-prying is much slower
         var modifier = CompOrNull<PryingComponent>(user)?.SpeedModifier ?? unpoweredComp.PryModifier;
-        return StartPry(target, user, null, modifier, out id);
+        return StartPry(target, user, HasComp<PryingComponent>(user) ? user : null, modifier, out id);
     }
 
     private bool CanPry(EntityUid target, EntityUid user, out string? message, PryingComponent? comp = null, PryUnpoweredComponent? unpoweredComp = null)

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -108,8 +108,19 @@
         acts: ["Destruction"]
 
 - type: entity
-  id: MechRipley
+  id: BaseMechCanPry
+  abstract: true
   parent: BaseMech
+  components:
+  - type: Prying
+    pryPowered: false
+    force: false
+    bypassVerb: true
+    useSound: /Audio/Items/jaws_pry.ogg
+
+- type: entity
+  id: MechRipley
+  parent: BaseMechCanPry
   name: Ripley APLU
   description: Versatile and lightly armored, the Ripley is useful for almost any heavy work scenario. The "APLU" stands for Autonomous Power Loading Unit.
   components:
@@ -140,6 +151,8 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
     baseSprintSpeed: 3.6
+  - type: Prying
+    speedModifier: 1.2 # little faster than usual since big mechs are stronk
 
 - type: entity
   id: MechRipleyBattery
@@ -153,7 +166,7 @@
 
 # TODO: have a whitelist for honker equipment
 - type: entity
-  parent: BaseMech
+  parent: BaseMechCanPry
   id: MechHonker
   name: H.O.N.K.
   description: "Produced by \"Tyranny of Honk, INC\", this exosuit is designed as heavy clown-support. Used to spread the fun and joy of life. HONK!"
@@ -178,6 +191,8 @@
     pilotWhitelist:
       components:
       - HumanoidProfile
+  - type: Prying
+    speedModifier: 1.2 # little faster than usual since big mechs are stronk
 
 - type: entity
   parent: MechHonker
@@ -190,7 +205,7 @@
       - PowerCellHigh
 
 - type: entity
-  parent: BaseMech
+  parent: BaseMechCanPry
   id: MechHamtr
   name: HAMTR
   description: "An experimental mech which uses a brain–computer interface to connect directly to a hamsters brain."
@@ -242,7 +257,7 @@
 # Vim!!!!!!!
 
 - type: entity
-  parent: BaseMech
+  parent: BaseMechCanPry
   id: MechVim
   name: Vim
   description: A miniature exosuit from Nanotrasen, developed to let the irreplaceable station pets live a little longer.
@@ -294,6 +309,9 @@
   - type: Access
     tags:
     - Maintenance
+  - type: Prying
+    speedModifier: 0.7 # slower than usual because the only thing the vim has to pry with are its legs
+    useSound: /Audio/Items/crowbar.ogg
   # TOOD: buzz / chime actions
   # TODO: builtin flashlight
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Mechs can now naturally pry open firelocks and unpowered doors as if they had a built-in crowbar. This happens automatically when you interact with a door or firelock you cannot open.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
At the moment, firelocks and mechs do not mix ... unless you're willing to get out of your mech every five seconds.

I don't think the big "Wizden Mech PR" is going to get merged any time soon, so for the time being, this PR makes mechs playable while spacing/atmos weirdness is happening.

The Vim is also allowed to pry, but since it must use its legs, prying is significantly slower.
## Technical details
<!-- Summary of code changes for easier review. -->
Minor modifications to SharedPryingSystem, PryingComponent, and DoorSystem.
YAML tweaks

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/edf41f73-8510-441e-b2b5-760b9e819ee8

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: All mechs can now pry open firelocks and unpowered doors.