### PR TITLE
Split command checks into a helper system. Chunk 1

### DIFF
--- a/Content.Server/Administration/Commands/AnnounceUiCommand.cs
+++ b/Content.Server/Administration/Commands/AnnounceUiCommand.cs
@@ -1,28 +1,21 @@
 using Content.Server.Administration.UI;
+using Content.Server.Commands;
 using Content.Server.EUI;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
 
-namespace Content.Server.Administration.Commands
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Moderator)]
+public sealed class AnnounceUiCommand : LocalizedEntityCommands
 {
-    [AdminCommand(AdminFlags.Moderator)]
-    public sealed class AnnounceUiCommand : LocalizedEntityCommands
+    [Dependency] private readonly EuiManager _euiManager = default!;
+
+    public override string Command => "announceui";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly EuiManager _euiManager = default!;
-
-        public override string Command => "announceui";
-
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
-        {
-            var player = shell.Player;
-            if (player == null)
-            {
-                shell.WriteLine(Loc.GetString($"shell-cannot-run-command-from-server"));
-                return;
-            }
-
-            var ui = new AdminAnnounceEui();
-            _euiManager.OpenEui(ui, player);
-        }
+        if (CommandChecks.MustNotBeServer(shell, out var player))
+            _euiManager.OpenEui(new AdminAnnounceEui(), player);
     }
 }

--- a/Content.Server/Administration/Commands/DSay.cs
+++ b/Content.Server/Administration/Commands/DSay.cs
@@ -1,4 +1,5 @@
 using Content.Server.Chat.Systems;
+using Content.Server.Commands;
 using Content.Shared.Administration;
 using Content.Shared.Chat;
 using Robust.Shared.Console;
@@ -14,25 +15,14 @@ public sealed class DsayCommand : LocalizedEntityCommands
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        if (shell.Player is not { } player)
-        {
-            shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
-            return;
-        }
-
-        if (player.AttachedEntity is not { Valid: true } entity)
-        {
-            shell.WriteError(Loc.GetString("shell-must-be-attached-to-entity"));
-            return;
-        }
-
-        if (args.Length < 1)
+        if (!CommandChecks.MustBeAttachedToEntity(shell, out var player, out var entity) ||
+            !CommandChecks.NeedExactlyOneArgument(shell, args))
             return;
 
         var message = string.Join(" ", args).Trim();
         if (string.IsNullOrEmpty(message))
             return;
 
-        _chatSystem.TrySendInGameOOCMessage(entity, message, InGameOOCChatType.Dead, false, shell, player);
+        _chatSystem.TrySendInGameOOCMessage(entity.Value, message, InGameOOCChatType.Dead, false, shell, player);
     }
 }

--- a/Content.Server/Administration/Commands/DeAdminCommand.cs
+++ b/Content.Server/Administration/Commands/DeAdminCommand.cs
@@ -4,20 +4,19 @@ using Content.Shared.Administration;
 using JetBrains.Annotations;
 using Robust.Shared.Console;
 
-namespace Content.Server.Administration.Commands
+namespace Content.Server.Administration.Commands;
+
+[UsedImplicitly]
+[AdminCommand(AdminFlags.None)]
+public sealed class DeAdminCommand : LocalizedCommands
 {
-    [UsedImplicitly]
-    [AdminCommand(AdminFlags.None)]
-    public sealed class DeAdminCommand : LocalizedCommands
+    [Dependency] private readonly IAdminManager _admin = default!;
+
+    public override string Command => "deadmin";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IAdminManager _admin = default!;
-
-        public override string Command => "deadmin";
-
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
-        {
-            if (CommandChecks.MustNotBeServer(shell, out var player))
-                _admin.DeAdmin(player);
-        }
+        if (CommandChecks.MustNotBeServer(shell, out var player))
+            _admin.DeAdmin(player);
     }
 }

--- a/Content.Server/Administration/Commands/DeAdminCommand.cs
+++ b/Content.Server/Administration/Commands/DeAdminCommand.cs
@@ -1,4 +1,5 @@
 using Content.Server.Administration.Managers;
+using Content.Server.Commands;
 using Content.Shared.Administration;
 using JetBrains.Annotations;
 using Robust.Shared.Console;
@@ -15,14 +16,8 @@ namespace Content.Server.Administration.Commands
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            var player = shell.Player;
-            if (player == null)
-            {
-                shell.WriteLine(Loc.GetString($"shell-cannot-run-command-from-server"));
-                return;
-            }
-
-            _admin.DeAdmin(player);
+            if (CommandChecks.MustNotBeServer(shell, out var player))
+                _admin.DeAdmin(player);
         }
     }
 }

--- a/Content.Server/Administration/Commands/ExplosionCommand.cs
+++ b/Content.Server/Administration/Commands/ExplosionCommand.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using System.Linq;
 using System.Numerics;
+using Content.Server.Commands;
 using Robust.Server.GameObjects;
 
 namespace Content.Server.Administration.Commands;
@@ -21,15 +22,8 @@ public sealed class OpenExplosionEui : LocalizedEntityCommands
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        var player = shell.Player;
-        if (player == null)
-        {
-            shell.WriteError(Loc.GetString($"shell-cannot-run-command-from-server"));
-            return;
-        }
-
-        var ui = new SpawnExplosionEui();
-        _euiManager.OpenEui(ui, player);
+        if (CommandChecks.MustNotBeServer(shell, out var player))
+            _euiManager.OpenEui(new SpawnExplosionEui(), player);
     }
 }
 

--- a/Content.Server/Administration/Commands/FaxUiCommand.cs
+++ b/Content.Server/Administration/Commands/FaxUiCommand.cs
@@ -1,3 +1,4 @@
+using Content.Server.Commands;
 using Content.Server.EUI;
 using Content.Server.Fax.AdminUI;
 using Content.Shared.Administration;
@@ -14,13 +15,7 @@ public sealed class FaxUiCommand : LocalizedEntityCommands
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        if (shell.Player is not { } player)
-        {
-            shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
-            return;
-        }
-
-        var ui = new AdminFaxEui();
-        _euiManager.OpenEui(ui, player);
+        if (CommandChecks.MustNotBeServer(shell, out var player))
+            _euiManager.OpenEui(new AdminFaxEui(), player);
     }
 }

--- a/Content.Server/Administration/Commands/FollowCommand.cs
+++ b/Content.Server/Administration/Commands/FollowCommand.cs
@@ -1,7 +1,7 @@
+using Content.Server.Commands;
 using Content.Shared.Administration;
 using Content.Shared.Follower;
 using Robust.Shared.Console;
-using Robust.Shared.Enums;
 
 namespace Content.Server.Administration.Commands;
 
@@ -14,25 +14,11 @@ public sealed class FollowCommand : LocalizedEntityCommands
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        if (shell.Player is not { } player)
-        {
-            shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
+        if (!CommandChecks.MustBeAttachedToEntity(shell, out _, out var entity) ||
+            !CommandChecks.NeedExactlyOneArgument(shell, args))
             return;
-        }
-
-        if (args.Length != 1)
-        {
-            shell.WriteError(Loc.GetString("shell-need-exactly-one-argument"));
-            return;
-        }
-
-        if (player.Status != SessionStatus.InGame || player.AttachedEntity is not { Valid: true } playerEntity)
-        {
-            shell.WriteError(Loc.GetString("shell-must-be-attached-to-entity"));
-            return;
-        }
 
         if (NetEntity.TryParse(args[0], out var uidNet) && EntityManager.TryGetEntity(uidNet, out var uid))
-            _followerSystem.StartFollowingEntity(playerEntity, uid.Value);
+            _followerSystem.StartFollowingEntity(entity.Value, uid.Value);
     }
 }

--- a/Content.Server/Administration/Commands/OpenPermissionsCommand.cs
+++ b/Content.Server/Administration/Commands/OpenPermissionsCommand.cs
@@ -1,28 +1,21 @@
 using Content.Server.Administration.UI;
+using Content.Server.Commands;
 using Content.Server.EUI;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
 
-namespace Content.Server.Administration.Commands
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Permissions)]
+public sealed class OpenPermissionsCommand : LocalizedEntityCommands
 {
-    [AdminCommand(AdminFlags.Permissions)]
-    public sealed class OpenPermissionsCommand : LocalizedEntityCommands
+    [Dependency] private readonly EuiManager _euiManager = default!;
+
+    public override string Command => "permissions";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly EuiManager _euiManager = default!;
-
-        public override string Command => "permissions";
-
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
-        {
-            var player = shell.Player;
-            if (player == null)
-            {
-                shell.WriteLine(Loc.GetString($"shell-cannot-run-command-from-server"));
-                return;
-            }
-
-            var ui = new PermissionsEui();
-            _euiManager.OpenEui(ui, player);
-        }
+        if (CommandChecks.MustNotBeServer(shell, out var player))
+            _euiManager.OpenEui(new PermissionsEui(), player);
     }
 }

--- a/Content.Server/Chat/Commands/AdminChatCommand.cs
+++ b/Content.Server/Chat/Commands/AdminChatCommand.cs
@@ -1,35 +1,28 @@
 using Content.Server.Administration;
 using Content.Server.Chat.Managers;
+using Content.Server.Commands;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
 
-namespace Content.Server.Chat.Commands
+namespace Content.Server.Chat.Commands;
+
+[AdminCommand(AdminFlags.Adminchat)]
+public sealed class AdminChatCommand : LocalizedCommands
 {
-    [AdminCommand(AdminFlags.Adminchat)]
-    internal sealed class AdminChatCommand : LocalizedCommands
+    [Dependency] private readonly IChatManager _chatManager = default!;
+
+    public override string Command => "asay";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IChatManager _chatManager = default!;
+        if (!CommandChecks.MustNotBeServer(shell, out var player) ||
+            !CommandChecks.NeedExactlyOneArgument(shell, args))
+            return;
 
-        public override string Command => "asay";
+        var message = string.Join(" ", args).Trim();
+        if (string.IsNullOrEmpty(message))
+            return;
 
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
-        {
-            var player = shell.Player;
-
-            if (player == null)
-            {
-                shell.WriteError(Loc.GetString($"shell-cannot-run-command-from-server"));
-                return;
-            }
-
-            if (args.Length < 1)
-                return;
-
-            var message = string.Join(" ", args).Trim();
-            if (string.IsNullOrEmpty(message))
-                return;
-
-            _chatManager.TrySendOOCMessage(player, message, OOCChatType.Admin);
-        }
+        _chatManager.TrySendOOCMessage(player, message, OOCChatType.Admin);
     }
 }

--- a/Content.Server/Chat/Commands/LOOCCommand.cs
+++ b/Content.Server/Chat/Commands/LOOCCommand.cs
@@ -1,42 +1,27 @@
 using Content.Server.Chat.Systems;
+using Content.Server.Commands;
 using Content.Shared.Administration;
 using Content.Shared.Chat;
 using Robust.Shared.Console;
-using Robust.Shared.Enums;
 
-namespace Content.Server.Chat.Commands
+namespace Content.Server.Chat.Commands;
+
+[AnyCommand]
+internal sealed class LoocCommand : LocalizedEntityCommands
 {
-    [AnyCommand]
-    internal sealed class LOOCCommand : IConsoleCommand
+    [Dependency] private readonly ChatSystem _chatSystem = default!;
+    public override string Command => "looc";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IEntityManager _e = default!;
+        if (!CommandChecks.MustBeAttachedToEntity(shell, out var player, out var entity) ||
+            !CommandChecks.NeedExactlyOneArgument(shell, args))
+            return;
 
-        public string Command => "looc";
-        public string Description => "Send Local Out Of Character chat messages.";
-        public string Help => "looc <text>";
+        var message = string.Join(" ", args).Trim();
+        if (string.IsNullOrEmpty(message))
+            return;
 
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
-        {
-            if (shell.Player is not { } player)
-            {
-                shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
-                return;
-            }
-
-            if (player.AttachedEntity is not { Valid: true } entity)
-                return;
-
-            if (player.Status != SessionStatus.InGame)
-                return;
-
-            if (args.Length < 1)
-                return;
-
-            var message = string.Join(" ", args).Trim();
-            if (string.IsNullOrEmpty(message))
-                return;
-
-            _e.System<ChatSystem>().TrySendInGameOOCMessage(entity, message, InGameOOCChatType.Looc, false, shell, player);
-        }
+        _chatSystem.TrySendInGameOOCMessage(entity.Value, message, InGameOOCChatType.Looc, false, shell, player);
     }
 }

--- a/Content.Server/Chat/Commands/MeCommand.cs
+++ b/Content.Server/Chat/Commands/MeCommand.cs
@@ -1,8 +1,8 @@
 using Content.Server.Chat.Systems;
+using Content.Server.Commands;
 using Content.Shared.Administration;
 using Content.Shared.Chat;
 using Robust.Shared.Console;
-using Robust.Shared.Enums;
 
 namespace Content.Server.Chat.Commands
 {
@@ -15,29 +15,15 @@ namespace Content.Server.Chat.Commands
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            if (shell.Player is not { } player)
-            {
-                shell.WriteError(Loc.GetString($"shell-cannot-run-command-from-server"));
-                return;
-            }
-
-            if (player.Status != SessionStatus.InGame)
-                return;
-
-            if (player.AttachedEntity is not {} playerEntity)
-            {
-                shell.WriteError(Loc.GetString($"shell-must-be-attached-to-entity"));
-                return;
-            }
-
-            if (args.Length < 1)
+            if (!CommandChecks.MustBeAttachedToEntity(shell, out var player, out var entity) ||
+                !CommandChecks.NeedExactlyOneArgument(shell, args))
                 return;
 
             var message = string.Join(" ", args).Trim();
             if (string.IsNullOrEmpty(message))
                 return;
 
-            _chatSystem.TrySendInGameICMessage(playerEntity, message, InGameICChatType.Emote, ChatTransmitRange.Normal, false, shell, player);
+            _chatSystem.TrySendInGameICMessage(entity.Value, message, InGameICChatType.Emote, ChatTransmitRange.Normal, false, shell, player);
         }
     }
 }

--- a/Content.Server/Chat/Commands/OOCCommand.cs
+++ b/Content.Server/Chat/Commands/OOCCommand.cs
@@ -1,32 +1,27 @@
 using Content.Server.Chat.Managers;
+using Content.Server.Commands;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
 
-namespace Content.Server.Chat.Commands
+namespace Content.Server.Chat.Commands;
+
+[AnyCommand]
+internal sealed class OOCCommand : LocalizedCommands
 {
-    [AnyCommand]
-    internal sealed class OOCCommand : LocalizedCommands
+    [Dependency] private readonly IChatManager _chatManager = default!;
+
+    public override string Command => "ooc";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IChatManager _chatManager = default!;
+        if (!CommandChecks.MustNotBeServer(shell, out var player) ||
+            !CommandChecks.NeedExactlyOneArgument(shell, args))
+            return;
 
-        public override string Command => "ooc";
+        var message = string.Join(" ", args).Trim();
+        if (string.IsNullOrEmpty(message))
+            return;
 
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
-        {
-            if (shell.Player is not { } player)
-            {
-                shell.WriteError(Loc.GetString($"shell-cannot-run-command-from-server"));
-                return;
-            }
-
-            if (args.Length < 1)
-                return;
-
-            var message = string.Join(" ", args).Trim();
-            if (string.IsNullOrEmpty(message))
-                return;
-
-            _chatManager.TrySendOOCMessage(player, message, OOCChatType.OOC);
-        }
+        _chatManager.TrySendOOCMessage(player, message, OOCChatType.OOC);
     }
 }

--- a/Content.Server/Chat/Commands/SayCommand.cs
+++ b/Content.Server/Chat/Commands/SayCommand.cs
@@ -1,42 +1,28 @@
 using Content.Server.Chat.Systems;
+using Content.Server.Commands;
 using Content.Shared.Administration;
 using Content.Shared.Chat;
 using Robust.Shared.Console;
-using Robust.Shared.Enums;
 
-namespace Content.Server.Chat.Commands
+namespace Content.Server.Chat.Commands;
+
+[AnyCommand]
+public sealed class SayCommand : LocalizedEntityCommands
 {
-    [AnyCommand]
-    internal sealed class SayCommand : LocalizedEntityCommands
+    [Dependency] private readonly ChatSystem _chatSystem = default!;
+
+    public override string Command => "say";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly ChatSystem _chatSystem = default!;
-        public override string Command => "say";
+        if (!CommandChecks.MustBeAttachedToEntity(shell, out var player, out var entity) ||
+            !CommandChecks.NeedExactlyOneArgument(shell, args))
+            return;
 
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
-        {
-            if (shell.Player is not { } player)
-            {
-                shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
-                return;
-            }
+        var message = string.Join(" ", args).Trim();
+        if (string.IsNullOrEmpty(message))
+            return;
 
-            if (player.Status != SessionStatus.InGame)
-                return;
-
-            if (player.AttachedEntity is not {} playerEntity)
-            {
-                shell.WriteError(Loc.GetString($"shell-must-be-attached-to-entity"));
-                return;
-            }
-
-            if (args.Length < 1)
-                return;
-
-            var message = string.Join(" ", args).Trim();
-            if (string.IsNullOrEmpty(message))
-                return;
-
-            _chatSystem.TrySendInGameICMessage(playerEntity, message, InGameICChatType.Speak, ChatTransmitRange.Normal, false, shell, player);
-        }
+        _chatSystem.TrySendInGameICMessage(entity.Value, message, InGameICChatType.Speak, ChatTransmitRange.Normal, false, shell, player);
     }
 }

--- a/Content.Server/Chat/Commands/SuicideCommand.cs
+++ b/Content.Server/Chat/Commands/SuicideCommand.cs
@@ -1,60 +1,44 @@
-using Content.Server.GameTicking;
+using Content.Server.Commands;
 using Content.Server.Popups;
 using Content.Shared.Administration;
-using Content.Shared.Chat;
 using Content.Shared.Mind;
 using Robust.Shared.Console;
-using Robust.Shared.Enums;
 
-namespace Content.Server.Chat.Commands
+namespace Content.Server.Chat.Commands;
+
+[AnyCommand]
+internal sealed class SuicideCommand : LocalizedEntityCommands
 {
-    [AnyCommand]
-    internal sealed class SuicideCommand : IConsoleCommand
+    [Dependency] private readonly PopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedMindSystem _mindSystem = default!;
+    [Dependency] private readonly SuicideSystem _suicideSystem = default!;
+
+    public override string Command => "suicide";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IEntityManager _e = default!;
+        if (!CommandChecks.MustBeAttachedToEntity(shell, out var player, out _))
+            return;
 
-        public string Command => "suicide";
-
-        public string Description => Loc.GetString("suicide-command-description");
-
-        public string Help => Loc.GetString("suicide-command-help-text");
-
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        // This check also proves mind not-null for at the end when the mob is ghosted.
+        if (!_mindSystem.TryGetMind(player, out _, out var mindComp) ||
+            mindComp.OwnedEntity is not { Valid: true } victim)
         {
-            if (shell.Player is not { } player)
-            {
-                shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
-                return;
-            }
-
-            if (player.Status != SessionStatus.InGame || player.AttachedEntity == null)
-                return;
-
-            var minds = _e.System<SharedMindSystem>();
-
-            // This check also proves mind not-null for at the end when the mob is ghosted.
-            if (!minds.TryGetMind(player, out var mindId, out var mindComp) ||
-                mindComp.OwnedEntity is not { Valid: true } victim)
-            {
-                shell.WriteLine(Loc.GetString("suicide-command-no-mind"));
-                return;
-            }
-
-            var suicideSystem = _e.System<SuicideSystem>();
-
-            if (_e.HasComponent<AdminFrozenComponent>(victim))
-            {
-                var deniedMessage = Loc.GetString("suicide-command-denied");
-                shell.WriteLine(deniedMessage);
-                _e.System<PopupSystem>()
-                    .PopupEntity(deniedMessage, victim, victim);
-                return;
-            }
-
-            if (suicideSystem.Suicide(victim))
-                return;
-
-            shell.WriteLine(Loc.GetString("ghost-command-denied"));
+            shell.WriteLine(Loc.GetString("suicide-command-no-mind"));
+            return;
         }
+
+        if (EntityManager.HasComponent<AdminFrozenComponent>(victim))
+        {
+            var deniedMessage = Loc.GetString("suicide-command-denied");
+            shell.WriteLine(deniedMessage);
+            _popupSystem.PopupEntity(deniedMessage, victim, victim);
+            return;
+        }
+
+        if (_suicideSystem.Suicide(victim))
+            return;
+
+        shell.WriteLine(Loc.GetString("ghost-command-denied"));
     }
 }

--- a/Content.Server/Chat/Commands/WhisperCommand.cs
+++ b/Content.Server/Chat/Commands/WhisperCommand.cs
@@ -1,42 +1,28 @@
 using Content.Server.Chat.Systems;
+using Content.Server.Commands;
 using Content.Shared.Administration;
 using Content.Shared.Chat;
 using Robust.Shared.Console;
-using Robust.Shared.Enums;
 
-namespace Content.Server.Chat.Commands
+namespace Content.Server.Chat.Commands;
+
+[AnyCommand]
+internal sealed class WhisperCommand : LocalizedEntityCommands
 {
-    [AnyCommand]
-    internal sealed class WhisperCommand : LocalizedEntityCommands
+    [Dependency] private readonly ChatSystem _chatSystem = default!;
+
+    public override string Command => "whisper";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly ChatSystem _chatSystem = default!;
-        public override string Command => "whisper";
+        if (!CommandChecks.MustBeAttachedToEntity(shell, out var player, out var entity) ||
+            !CommandChecks.NeedExactlyOneArgument(shell, args))
+            return;
 
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
-        {
-            if (shell.Player is not { } player)
-            {
-                shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
-                return;
-            }
+        var message = string.Join(" ", args).Trim();
+        if (string.IsNullOrEmpty(message))
+            return;
 
-            if (player.Status != SessionStatus.InGame)
-                return;
-
-            if (player.AttachedEntity is not {} playerEntity)
-            {
-                shell.WriteError(Loc.GetString($"shell-must-be-attached-to-entity"));
-                return;
-            }
-
-            if (args.Length < 1)
-                return;
-
-            var message = string.Join(" ", args).Trim();
-            if (string.IsNullOrEmpty(message))
-                return;
-
-            _chatSystem.TrySendInGameICMessage(playerEntity, message, InGameICChatType.Whisper, ChatTransmitRange.Normal, false, shell, player);
-        }
+        _chatSystem.TrySendInGameICMessage(entity.Value, message, InGameICChatType.Whisper, ChatTransmitRange.Normal, false, shell, player);
     }
 }

--- a/Content.Server/Commands/CommandChecks.cs
+++ b/Content.Server/Commands/CommandChecks.cs
@@ -1,0 +1,48 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Console;
+using Robust.Shared.Enums;
+using Robust.Shared.Player;
+
+namespace Content.Server.Commands;
+
+public static class CommandChecks
+{
+    public static bool MustNotBeServer(IConsoleShell shell, [NotNullWhen(true)] out ICommonSession? player)
+    {
+        player = shell.Player;
+
+        if (player is not { Status: SessionStatus.InGame })
+            shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
+
+        return shell.Player != null;
+    }
+
+    public static bool MustBeAttachedToEntity(IConsoleShell shell,
+        [NotNullWhen(true)] out ICommonSession? player,
+        [NotNullWhen(true)] out EntityUid? entity)
+    {
+        MustNotBeServer(shell, out player);
+        entity = player?.AttachedEntity;
+
+        if (player != null && entity == null)
+            shell.WriteError(Loc.GetString("shell-must-be-attached-to-entity"));
+
+        return entity != null;
+    }
+
+    public static bool NeedExactlyZeroArguments(IConsoleShell shell, string[] args)
+    {
+        if (args.Length > 0)
+            shell.WriteError(Loc.GetString("shell-need-exactly-zero-arguments"));
+
+        return args.Length == 0;
+    }
+
+    public static bool NeedExactlyOneArgument(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 1)
+            shell.WriteError(Loc.GetString("shell-need-exactly-one-argument"));
+
+        return args.Length == 1;
+    }
+}

--- a/Content.Server/NPC/Commands/NPCCommand.cs
+++ b/Content.Server/NPC/Commands/NPCCommand.cs
@@ -1,4 +1,5 @@
 using Content.Server.Administration;
+using Content.Server.Commands;
 using Content.Server.EUI;
 using Content.Server.NPC.UI;
 using Content.Shared.Administration;
@@ -15,12 +16,7 @@ public sealed class NpcCommand : LocalizedEntityCommands
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        if (shell.Player is not { } playerSession)
-        {
-            shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
-            return;
-        }
-
-        _euiManager.OpenEui(new NPCEui(), playerSession);
+        if (CommandChecks.MustNotBeServer(shell, out var player))
+            _euiManager.OpenEui(new NPCEui(), player);
     }
 }

--- a/Content.Server/Salvage/SalvageRulerCommand.cs
+++ b/Content.Server/Salvage/SalvageRulerCommand.cs
@@ -1,4 +1,5 @@
 using Content.Server.Administration;
+using Content.Server.Commands;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
 using Robust.Shared.Map;
@@ -6,45 +7,25 @@ using Robust.Shared.Map;
 namespace Content.Server.Salvage;
 
 [AdminCommand(AdminFlags.Admin)]
-sealed class SalvageRulerCommand : IConsoleCommand
+public sealed class SalvageRulerCommand : LocalizedEntityCommands
 {
-    [Dependency] private readonly IEntityManager _entities = default!;
     [Dependency] private readonly IMapManager _maps = default!;
+    [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
 
-    public string Command => "salvageruler";
+    public override string Command => "salvageruler";
 
-    public string Description => Loc.GetString("salvage-ruler-command-description");
-
-    public string Help => Loc.GetString("salvage-ruler-command-help-text", ("command",Command));
-
-    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        if (args.Length != 0)
-        {
-            shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+        if (!CommandChecks.MustBeAttachedToEntity(shell, out _, out var entity) ||
+            !CommandChecks.NeedExactlyZeroArguments(shell, args))
             return;
-        }
 
-        if (shell.Player is not { } player)
-        {
-            shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
-            return;
-        }
-
-        var entity = player.AttachedEntity;
-
-        if (entity == null)
-        {
-            shell.WriteError(Loc.GetString("shell-must-be-attached-to-entity"));
-            return;
-        }
-
-        var entityTransform = _entities.GetComponent<TransformComponent>(entity.Value);
+        var entityTransform = EntityManager.GetComponent<TransformComponent>(entity.Value);
         var total = Box2.UnitCentered;
         var first = true;
         foreach (var mapGrid in _maps.GetAllGrids(entityTransform.MapID))
         {
-            var aabb = _entities.System<SharedTransformSystem>().GetWorldMatrix(mapGrid).TransformBox(mapGrid.Comp.LocalAABB);
+            var aabb = _xformSystem.GetWorldMatrix(mapGrid).TransformBox(mapGrid.Comp.LocalAABB);
             if (first)
             {
                 total = aabb;

--- a/Resources/Locale/en-US/chat/commands/suicide-command.ftl
+++ b/Resources/Locale/en-US/chat/commands/suicide-command.ftl
@@ -1,8 +1,8 @@
-suicide-command-description = Commits suicide
-suicide-command-help-text = The suicide command gives you a quick way out of a round while remaining in-character.
-                            The method varies, first it will attempt to use the held item in your active hand.
-                            If that fails, it will attempt to use an object in the environment.
-                            Finally, if neither of the above worked, you will die by biting your tongue.
+cmd-suicide-desc = The suicide command gives you a quick way out of a round while remaining in-character.
+                   The method varies, first it will attempt to use the held item in your active hand.
+                   If that fails, it will attempt to use an object in the environment.
+                   Finally, if neither of the above worked, you will die by biting your tongue.
+cmd-suicide-help = Usage: {$command}
 suicide-command-default-text-others = {CAPITALIZE(THE($name))} is attempting to bite {POSS-ADJ($name)} own tongue!
 suicide-command-default-text-self = You attempt to bite your own tongue!
 suicide-command-already-dead = You can't suicide. You're dead.

--- a/Resources/Locale/en-US/commands/cmd-looc.ftl
+++ b/Resources/Locale/en-US/commands/cmd-looc.ftl
@@ -1,0 +1,2 @@
+﻿cmd-looc-desc = Send Local Out Of Character chat messages.
+cmd-looc-help = Usage: {$command}

--- a/Resources/Locale/en-US/salvage/salvage-ruler-command.ftl
+++ b/Resources/Locale/en-US/salvage/salvage-ruler-command.ftl
@@ -1,2 +1,2 @@
-salvage-ruler-command-description = Measures grids on this map to get a total world AABB. Use for salvage bounds specifications.
-salvage-ruler-command-help-text = Usage: {$command}
+cmd-salvageruler-desc = Measures grids on this map to get a total world AABB. Use for salvage bounds specifications.
+cmd-salvageruler-help = Usage: {$command}

--- a/Resources/Locale/en-US/shell.ftl
+++ b/Resources/Locale/en-US/shell.ftl
@@ -28,6 +28,7 @@ shell-argument-uid = EntityUid
 
 ## Guards
 
+shell-invalid-string = The argument you passed could not be parsed as a string!
 shell-missing-required-permission = You need {$perm} for this command!
 shell-entity-is-not-mob = Target entity is not a mob!
 shell-invalid-entity-id = Invalid entity ID.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
See https://github.com/space-wizards/space-station-14/pull/38652#pullrequestreview-3302064068

Per the above, I've begun to deduplicate command checks where possible. My plan for this is to have the static class included in this PR for checks that don't involve entity systems, and a separate entity system itself for those that do.

## Technical details
<!-- Summary of code changes for easier review. -->
Simply put, the intent here is to take common command checks and move em off in a separate file so they don't need to be duplicated everywhere, and better yet, are consistent among all commands.

Included here is a few small IConsoleCommand -> LocalizedEntityCommand transitions and relevant cleanup.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->