### PR TITLE
Fix adduplink PDA lock initialization

### DIFF
--- a/Content.Server/Traitor/Uplink/Commands/AddUplinkCommand.cs
+++ b/Content.Server/Traitor/Uplink/Commands/AddUplinkCommand.cs
@@ -1,4 +1,5 @@
 using Content.Server.Administration;
+using Content.Server.Chat.Managers;
 using Content.Shared.Administration;
 using Robust.Server.Player;
 using Robust.Shared.Console;
@@ -9,6 +10,7 @@ namespace Content.Server.Traitor.Uplink.Commands;
 [AdminCommand(AdminFlags.Admin)]
 public sealed class AddUplinkCommand : LocalizedEntityCommands
 {
+    [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly UplinkSystem _uplinkSystem = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
 
@@ -74,7 +76,22 @@ public sealed class AddUplinkCommand : LocalizedEntityCommands
 
         // Finally add uplink
         if (!_uplinkSystem.AddUplink(user, 20, uplinkEntity: uplinkEntity, giveDiscounts: isDiscounted))
+        {
             shell.WriteLine(Loc.GetString("add-uplink-command-error-2"));
+            return;
+        }
+
+        uplinkEntity ??= _uplinkSystem.FindUplinkTarget(user);
+        var generatedCode = uplinkEntity is { } uplink
+            ? _uplinkSystem.GenerateUplinkCode(uplink)
+            : null;
+
+        if (generatedCode != null)
+        {
+            _chatManager.DispatchServerMessage(session,
+                Loc.GetString("add-uplink-command-uplink-code",
+                    ("code", string.Join("-", generatedCode).Replace("sharp", "#"))));
+        }
     }
 
     public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)

--- a/Content.Server/Traitor/Uplink/UplinkSystem.cs
+++ b/Content.Server/Traitor/Uplink/UplinkSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.Store.Systems;
 using Content.Server.StoreDiscount.Systems;
+using Content.Server.PDA.Ringer;
 using Content.Shared.FixedPoint;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Implants;
@@ -9,6 +10,7 @@ using Content.Shared.Mind;
 using Content.Shared.PDA;
 using Content.Shared.Store;
 using Content.Shared.Store.Components;
+using Content.Shared.PDA.Ringer;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.Traitor.Uplink;
@@ -21,7 +23,7 @@ public sealed class UplinkSystem : EntitySystem
     [Dependency] private readonly StoreSystem _store = default!;
     [Dependency] private readonly SharedSubdermalImplantSystem _subdermalImplant = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
-
+    
     public static readonly ProtoId<CurrencyPrototype> TelecrystalCurrencyPrototype = "Telecrystal";
     private static readonly EntProtoId FallbackUplinkImplant = "UplinkImplant";
     private static readonly ProtoId<ListingPrototype> FallbackUplinkCatalog = "UplinkUplinkImplanter";
@@ -81,6 +83,18 @@ public sealed class UplinkSystem : EntitySystem
             Listings: _store.GetAvailableListings(mind, uplink, store)
                 .ToArray());
         RaiseLocalEvent(ref uplinkInitializedEvent);
+    }
+
+    public Note[]? GenerateUplinkCode(EntityUid uplink)
+    {
+        if (!HasComp<PdaComponent>(uplink))
+            return null;
+
+        EnsureComp<RingerUplinkComponent>(uplink);
+
+        var ev = new GenerateUplinkCodeEvent();
+        RaiseLocalEvent(uplink, ref ev);
+        return ev.Code;
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/administration/commands/add-uplink-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/add-uplink-command.ftl
@@ -6,3 +6,4 @@ add-uplink-command-completion-2 = Uplink uid (default to PDA)
 add-uplink-command-completion-3 = Is uplink discount enabled
 add-uplink-command-error-1 = Selected player doesn't control any entity
 add-uplink-command-error-2 = Failed to add uplink to the player
+add-uplink-command-uplink-code = Your uplink code is {$code}. Set it as your PDA ringtone to access your store.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes PDA uplinks created with adduplink actually usable by generating an uplink code and sending it to the target player.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #17425.

adduplink was giving players access to the store, but PDA uplinks didn’t behave like normal ones because the player never got the code needed to unlock them.

## Technical details
<!-- Summary of code changes for easier review. -->
This adds PDA specific uplink code generation to the adduplink flow and sends the generated code to the target player as a server message.

I kept this scoped to admin created uplinks instead of trying to reuse the full roundstart traitor briefing flow.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1270" height="712" alt="Screenshot 2026-03-31 at 10 51 23" src="https://github.com/user-attachments/assets/0ebfb416-8e63-4b12-9893-b9f63b891f00" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
ADMIN
- fix: Fixed PDA uplinks created with adduplink not giving the code needed to unlock them.