### PR TITLE
Expanded Tile Recipes for Cutter Machine

### DIFF
--- a/Resources/Locale/en-US/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/lathe/lathe-categories.ftl
@@ -31,8 +31,12 @@ lathe-category-faux-tile = Faux
 lathe-category-maints-tile = Maints
 lathe-category-marble = Marble
 lathe-category-steel-tile = Steel
+lathe-category-shuttle-tile = Shuttle
 lathe-category-white-tile = White
 lathe-category-wood-tile = Wood
+lathe-category-plastic-tile = Plastic
+lathe-category-precious-tile = Precious
+lathe-category-industrial-tile = Industrial
 
 # Science
 lathe-category-mechs = Mechs

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -690,10 +690,15 @@
     - FloorSteelTilesStatic
     - FloorWhiteTilesStatic
     - FloorMaintsTilesStatic
+    - FloorIndustrialTilesStatic
     - FloorWoodTilesStatic
     - FloorConcreteTilesStatic
     - CircuitFloorsStatic
     - FloorMarbleTilesStatic
+    - FloorShuttleTilesStatic
+    - PlasticTilesStatic
+    - CarpetTilesStatic
+    - PreciousTilesStatic
     dynamicPacks:
     - FauxTiles
   - type: MaterialStorage

--- a/Resources/Prototypes/Recipes/Lathes/Packs/tiles.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/tiles.yml
@@ -15,6 +15,7 @@
   - FloorTileItemDarkPavement
   - FloorTileItemDarkPavementVertical
   - FloorTileItemDarkOffset
+  - FloorTileItemDarkSquiggly
 
 - type: latheRecipePack
   id: FloorSteelTilesStatic
@@ -59,6 +60,18 @@
   - FloorTileItemTechmaintDark
 
 - type: latheRecipePack
+  id: FloorIndustrialTilesStatic
+  recipes:
+  - FloorTileItemMining
+  - FloorTileItemMiningDark
+  - FloorTileItemMiningLight
+  - FloorTileItemElevatorShaft
+  - FloorTileItemRockVault
+  - FloorTileItemMetalDiamond
+  - FloorTileItemFreezer
+  - FloorTileItemShowroom
+
+- type: latheRecipePack
   id: FloorWoodTilesStatic
   recipes:
   - FloorTileItemWood
@@ -93,6 +106,42 @@
   recipes:
   - FloorTileItemWhiteMarble
   - FloorTileItemDarkMarble
+  - FloorTileItemUraniumMarble
+  - FloorTileItemPlasmaMarble
+
+- type: latheRecipePack
+  id: FloorShuttleTilesStatic
+  recipes:
+  - FloorTileItemShuttleWhite
+  - FloorTileItemShuttleBlue
+  - FloorTileItemShuttleOrange
+  - FloorTileItemShuttlePurple
+  - FloorTileItemShuttleRed
+  - FloorTileItemShuttleGrey
+  - FloorTileItemShuttleBlack
+
+- type: latheRecipePack
+  id: PlasticTilesStatic
+  recipes:
+  - FloorTileItemLino
+  - FloorTileItemBoxing
+  - FloorTileItemGym
+
+- type: latheRecipePack
+  id: CarpetTilesStatic
+  recipes:
+  - FloorTileItemArcadeBlue
+  - FloorTileItemArcadeBlue2
+  - FloorTileItemArcadeRed
+  - FloorTileItemEighties
+  - FloorTileItemCarpetClown
+  - FloorTileItemCarpetOffice
+
+- type: latheRecipePack
+  id: PreciousTilesStatic
+  recipes:
+  - FloorTileItemGold
+  - FloorTileItemSilver
 
 ## Dynamic
 
@@ -107,6 +156,7 @@
   - FauxTileAstroIce
   - FauxTileAstroSnow
   - FauxTileAstroAsteroidSand
+  - FauxTileAstroAsteroidSandBorderless
   - FauxTileDesertAstroSand
   - FauxTileAstroIronsand
   - FauxTileAstroIronsandBorderless

--- a/Resources/Prototypes/Recipes/Lathes/categories.yml
+++ b/Resources/Prototypes/Recipes/Lathes/categories.yml
@@ -114,6 +114,22 @@
   id: Marble
   name: lathe-category-marble
 
+- type: latheCategory
+  id: Shuttle
+  name: lathe-category-shuttle-tile
+
+- type: latheCategory
+  id: Plastic
+  name: lathe-category-plastic-tile
+
+- type: latheCategory
+  id: Precious
+  name: lathe-category-precious-tile
+
+- type: latheCategory
+  id: Industrial
+  name: lathe-category-industrial-tile
+
 # Science
 - type: latheCategory
   id: Mech

--- a/Resources/Prototypes/Recipes/Lathes/tiles.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tiles.yml
@@ -45,6 +45,16 @@
 - type: latheRecipe
   abstract: true
   parent: BaseSteelTileRecipe
+  id: BaseIndustrialTileRecipe
+  categories:
+  - Tiles
+  - Industrial
+  materials:
+    Steel: 50
+
+- type: latheRecipe
+  abstract: true
+  parent: BaseSteelTileRecipe
   id: BaseCircuitTileRecipe
   categories:
   - Tiles
@@ -91,6 +101,46 @@
   materials:
     Steel: 25
     Glass: 25
+
+- type: latheRecipe
+  abstract: true
+  parent: BaseTileRecipe
+  id: BaseShuttleTileRecipe
+  categories:
+  - Tiles
+  - Shuttle
+  completetime: 1
+  materials:
+    Plasteel: 25
+
+- type: latheRecipe
+  abstract: true
+  parent: BaseTileRecipe
+  id: BasePlasticTileRecipe
+  categories:
+  - Tiles
+  - Plastic
+  materials:
+    Plastic: 25
+
+- type: latheRecipe
+  abstract: true
+  parent: BaseTileRecipe
+  id: BaseCarpetTileRecipe
+  categories:
+  - Tiles
+  - Carpets
+  materials:
+    Cloth: 25
+
+- type: latheRecipe
+  abstract: true
+  parent: BaseTileRecipe
+  id: BasePreciousTileRecipe
+  applyMaterialDiscount: false
+  categories:
+  - Tiles
+  - Precious
 
 ## Recipes
 
@@ -313,6 +363,47 @@
   id: FloorTileItemTechmaintDark
   result: FloorTileItemTechmaintDark
 
+# Industrial
+- type: latheRecipe
+  parent: BaseIndustrialTileRecipe
+  id: FloorTileItemMining
+  result: FloorTileItemMining
+
+- type: latheRecipe
+  parent: BaseIndustrialTileRecipe
+  id: FloorTileItemMiningDark
+  result: FloorTileItemMiningDark
+
+- type: latheRecipe
+  parent: BaseIndustrialTileRecipe
+  id: FloorTileItemMiningLight
+  result: FloorTileItemMiningLight
+
+- type: latheRecipe
+  parent: BaseIndustrialTileRecipe
+  id: FloorTileItemElevatorShaft
+  result: FloorTileItemElevatorShaft
+
+- type: latheRecipe
+  parent: BaseIndustrialTileRecipe
+  id: FloorTileItemRockVault
+  result: FloorTileItemRockVault
+
+- type: latheRecipe
+  parent: BaseIndustrialTileRecipe
+  id: FloorTileItemMetalDiamond
+  result: FloorTileItemMetalDiamond
+
+- type: latheRecipe
+  parent: BaseIndustrialTileRecipe
+  id: FloorTileItemShowroom
+  result: FloorTileItemShowroom
+
+- type: latheRecipe
+  parent: BaseIndustrialTileRecipe
+  id: FloorTileItemFreezer
+  result: FloorTileItemFreezer
+
 # Circuit
 - type: latheRecipe
   parent: BaseCircuitTileRecipe
@@ -477,3 +568,119 @@
   parent: BaseMarbleTileRecipe
   id: FloorTileItemDarkMarble
   result: FloorTileItemDarkMarble
+
+- type: latheRecipe
+  parent: BaseMarbleTileRecipe
+  id: FloorTileItemUraniumMarble
+  result: FloorTileItemUraniumMarble
+  materials:
+    Steel: 25
+    Glass: 25
+    Uranium: 25
+
+- type: latheRecipe
+  parent: BaseMarbleTileRecipe
+  id: FloorTileItemPlasmaMarble
+  result: FloorTileItemPlasmaMarble
+  materials:
+    Steel: 25
+    Glass: 25
+    Plasma: 25
+
+# Shuttle
+- type: latheRecipe
+  parent: BaseShuttleTileRecipe
+  id: FloorTileItemShuttleWhite
+  result: FloorTileItemShuttleWhite
+
+- type: latheRecipe
+  parent: BaseShuttleTileRecipe
+  id: FloorTileItemShuttleBlue
+  result: FloorTileItemShuttleBlue
+
+- type: latheRecipe
+  parent: BaseShuttleTileRecipe
+  id: FloorTileItemShuttleOrange
+  result: FloorTileItemShuttleOrange
+
+- type: latheRecipe
+  parent: BaseShuttleTileRecipe
+  id: FloorTileItemShuttlePurple
+  result: FloorTileItemShuttlePurple
+
+- type: latheRecipe
+  parent: BaseShuttleTileRecipe
+  id: FloorTileItemShuttleRed
+  result: FloorTileItemShuttleRed
+
+- type: latheRecipe
+  parent: BaseShuttleTileRecipe
+  id: FloorTileItemShuttleGrey
+  result: FloorTileItemShuttleGrey
+
+- type: latheRecipe
+  parent: BaseShuttleTileRecipe
+  id: FloorTileItemShuttleBlack
+  result: FloorTileItemShuttleBlack
+
+# Precious
+- type: latheRecipe
+  parent: BasePreciousTileRecipe
+  id: FloorTileItemGold
+  result: FloorTileItemGold
+  materials:
+    Gold: 50
+
+- type: latheRecipe
+  parent: BasePreciousTileRecipe
+  id: FloorTileItemSilver
+  result: FloorTileItemSilver
+  materials:
+    Silver: 50
+
+# Carpets
+- type: latheRecipe
+  parent: BaseCarpetTileRecipe
+  id: FloorTileItemArcadeBlue
+  result: FloorTileItemArcadeBlue
+
+- type: latheRecipe
+  parent: BaseCarpetTileRecipe
+  id: FloorTileItemArcadeBlue2
+  result: FloorTileItemArcadeBlue2
+
+- type: latheRecipe
+  parent: BaseCarpetTileRecipe
+  id: FloorTileItemArcadeRed
+  result: FloorTileItemArcadeRed
+
+- type: latheRecipe
+  parent: BaseCarpetTileRecipe
+  id: FloorTileItemEighties
+  result: FloorTileItemEighties
+
+- type: latheRecipe
+  parent: BaseCarpetTileRecipe
+  id: FloorTileItemCarpetClown
+  result: FloorTileItemCarpetClown
+
+- type: latheRecipe
+  parent: BaseCarpetTileRecipe
+  id: FloorTileItemCarpetOffice
+  result: FloorTileItemCarpetOffice
+
+# Plastic
+- type: latheRecipe
+  parent: BasePlasticTileRecipe
+  id: FloorTileItemLino
+  result: FloorTileItemLino
+
+- type: latheRecipe
+  parent: BasePlasticTileRecipe
+  id: FloorTileItemBoxing
+  result: FloorTileItemBoxing
+
+- type: latheRecipe
+  parent: BasePlasticTileRecipe
+  id: FloorTileItemGym
+  result: FloorTileItemGym

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -103,6 +103,7 @@
   - FauxTileAstroIce
   - FauxTileAstroSnow
   - FauxTileAstroAsteroidSand
+  - FauxTileAstroAsteroidSandBorderless
   - FauxTileDesertAstroSand
   - FauxTileAstroIronsand
   - FauxTileAstroIronsandBorderless


### PR DESCRIPTION
## About the PR
Adds recipes for many tiles to the Cutter Machine, including industrial, shuttle, plastic, carpet, and precious materials variants.

Note: I've excluded simple color variants (like bar, kitchen, or clown tiles) as exceptions, since they can be handled via the spray painter and don't need dedicated recipes. Also, if anyone thinks that plastic tiles and carpets should be merged into a single category for less clutter - let me know.

## Why / Balance
This makes various existing decorative tiles craftable, providing players with more options for station customization without relying solely on map-spawned items or admin intervention. Costs are balanced according to the materials used in the tiles.

## Technical details
- Added new lathe categories and localization.
- Created abstract base prototypes for each tile category to simplify material and category management.

## Media
<img width="941" height="559" alt="Content Client_wKtWPSSipG" src="https://github.com/user-attachments/assets/30c7b3a4-a36f-446b-934f-cf40468364b9" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

**Changelog**
:cl:
- add: Added a wide variety of new tile recipes to the Cutter Machine.
