### PR TITLE
Fix automatic whitelist condition being reversed

### DIFF
--- a/Resources/Prototypes/wizardsDenWhitelists.yml
+++ b/Resources/Prototypes/wizardsDenWhitelists.yml
@@ -34,6 +34,6 @@
     action: Allow
   - !type:ConditionPlaytime
     minimumPlaytime: 1200 # 20 hours to be whitelisted
-    action: Deny
+    action: Allow
   - !type:ConditionAlwaysMatch
     action: Deny


### PR DESCRIPTION
The automatic whitelisting is currently set to _deny_ players with at least 20 hours, while it's meant to _allow_ players with at least 20 hours. Oops.