### PR TITLE
Convert a few simple LEC commands to Toolshed.

### DIFF
--- a/Content.Server/Administration/Commands/AnnounceUiCommand.cs
+++ b/Content.Server/Administration/Commands/AnnounceUiCommand.cs
@@ -1,28 +1,25 @@
 using Content.Server.Administration.UI;
 using Content.Server.EUI;
 using Content.Shared.Administration;
-using Robust.Shared.Console;
+using Robust.Shared.Toolshed;
+using Robust.Shared.Toolshed.Errors;
 
-namespace Content.Server.Administration.Commands
+namespace Content.Server.Administration.Commands;
+
+[ToolshedCommand, AdminCommand(AdminFlags.Moderator)]
+public sealed class AnnounceUiCommand : ToolshedCommand
 {
-    [AdminCommand(AdminFlags.Moderator)]
-    public sealed class AnnounceUiCommand : LocalizedEntityCommands
+    [Dependency] private readonly EuiManager _euiManager = default!;
+
+    [CommandImplementation]
+    public void AnnounceUi(IInvocationContext ctx)
     {
-        [Dependency] private readonly EuiManager _euiManager = default!;
-
-        public override string Command => "announceui";
-
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (ctx.Session is null)
         {
-            var player = shell.Player;
-            if (player == null)
-            {
-                shell.WriteLine(Loc.GetString($"shell-cannot-run-command-from-server"));
-                return;
-            }
-
-            var ui = new AdminAnnounceEui();
-            _euiManager.OpenEui(ui, player);
+            ctx.ReportError(new NotForServerConsoleError());
+            return;
         }
+
+        _euiManager.OpenEui(new AdminAnnounceEui(), ctx.Session);
     }
 }

--- a/Content.Server/Administration/Commands/FaxUiCommand.cs
+++ b/Content.Server/Administration/Commands/FaxUiCommand.cs
@@ -1,26 +1,25 @@
 using Content.Server.EUI;
 using Content.Server.Fax.AdminUI;
 using Content.Shared.Administration;
-using Robust.Shared.Console;
+using Robust.Shared.Toolshed;
+using Robust.Shared.Toolshed.Errors;
 
 namespace Content.Server.Administration.Commands;
 
-[AdminCommand(AdminFlags.Fun)]
-public sealed class FaxUiCommand : LocalizedEntityCommands
+[ToolshedCommand, AdminCommand(AdminFlags.Fun)]
+public sealed class FaxUiCommand : ToolshedCommand
 {
     [Dependency] private readonly EuiManager _euiManager = default!;
 
-    public override string Command => "faxui";
-
-    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    [CommandImplementation]
+    public void FaxUi(IInvocationContext ctx)
     {
-        if (shell.Player is not { } player)
+        if (ctx.Session is null)
         {
-            shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
+            ctx.ReportError(new NotForServerConsoleError());
             return;
         }
 
-        var ui = new AdminFaxEui();
-        _euiManager.OpenEui(ui, player);
+        _euiManager.OpenEui(new AdminFaxEui(), ctx.Session);
     }
 }

--- a/Content.Server/Administration/Commands/OpenPermissionsCommand.cs
+++ b/Content.Server/Administration/Commands/OpenPermissionsCommand.cs
@@ -11,7 +11,8 @@ public sealed class OpenPermissionsCommand : ToolshedCommand
 {
     [Dependency] private readonly EuiManager _euiManager = default!;
 
-    public void Permissions(IInvocationContext ctx)
+    [CommandImplementation]
+    public void OpenPermissions(IInvocationContext ctx)
     {
         if (ctx.Session is null)
         {

--- a/Content.Server/Administration/Commands/OpenPermissionsCommand.cs
+++ b/Content.Server/Administration/Commands/OpenPermissionsCommand.cs
@@ -1,28 +1,24 @@
 using Content.Server.Administration.UI;
 using Content.Server.EUI;
 using Content.Shared.Administration;
-using Robust.Shared.Console;
+using Robust.Shared.Toolshed;
+using Robust.Shared.Toolshed.Errors;
 
-namespace Content.Server.Administration.Commands
+namespace Content.Server.Administration.Commands;
+
+[ToolshedCommand, AdminCommand(AdminFlags.Permissions)]
+public sealed class OpenPermissionsCommand : ToolshedCommand
 {
-    [AdminCommand(AdminFlags.Permissions)]
-    public sealed class OpenPermissionsCommand : LocalizedEntityCommands
+    [Dependency] private readonly EuiManager _euiManager = default!;
+
+    public void Permissions(IInvocationContext ctx)
     {
-        [Dependency] private readonly EuiManager _euiManager = default!;
-
-        public override string Command => "permissions";
-
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (ctx.Session is null)
         {
-            var player = shell.Player;
-            if (player == null)
-            {
-                shell.WriteLine(Loc.GetString($"shell-cannot-run-command-from-server"));
-                return;
-            }
-
-            var ui = new PermissionsEui();
-            _euiManager.OpenEui(ui, player);
+            ctx.ReportError(new NotForServerConsoleError());
+            return;
         }
+
+        _euiManager.OpenEui(new PermissionsEui(), ctx.Session);
     }
 }

--- a/Content.Server/Administration/Commands/PermissionsCommand.cs
+++ b/Content.Server/Administration/Commands/PermissionsCommand.cs
@@ -7,12 +7,12 @@ using Robust.Shared.Toolshed.Errors;
 namespace Content.Server.Administration.Commands;
 
 [ToolshedCommand, AdminCommand(AdminFlags.Permissions)]
-public sealed class OpenPermissionsCommand : ToolshedCommand
+public sealed class PermissionsCommand : ToolshedCommand
 {
     [Dependency] private readonly EuiManager _euiManager = default!;
 
     [CommandImplementation]
-    public void OpenPermissions(IInvocationContext ctx)
+    public void Permissions(IInvocationContext ctx)
     {
         if (ctx.Session is null)
         {

--- a/Content.Server/Administration/Commands/StealthminCommand.cs
+++ b/Content.Server/Administration/Commands/StealthminCommand.cs
@@ -1,33 +1,32 @@
 using Content.Server.Administration.Managers;
 using Content.Shared.Administration;
-using Robust.Shared.Console;
+using Robust.Shared.Toolshed;
+using Robust.Shared.Toolshed.Errors;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Administration.Commands;
 
-[AdminCommand(AdminFlags.Stealth)]
-public sealed class StealthminCommand : LocalizedCommands
+[ToolshedCommand, AdminCommand(AdminFlags.Stealth)]
+public sealed class StealthminCommand : ToolshedCommand
 {
     [Dependency] private readonly IAdminManager _adminManager = default!;
 
-    public override string Command => "stealthmin";
-
-    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    [CommandImplementation]
+    public void Stealthmin(IInvocationContext ctx)
     {
-        var player = shell.Player;
-        if (player == null)
+        if (ctx.Session is not { } admin)
         {
-            shell.WriteLine(Loc.GetString("shell-cannot-run-command-from-server"));
+            ctx.ReportError(new NotForServerConsoleError());
             return;
         }
 
-        var adminData = _adminManager.GetAdminData(player);
+        var adminData = _adminManager.GetAdminData(admin);
 
         DebugTools.AssertNotNull(adminData);
 
         if (!adminData!.Stealth)
-            _adminManager.Stealth(player);
+            _adminManager.Stealth(admin);
         else
-            _adminManager.UnStealth(player);
+            _adminManager.UnStealth(admin);
     }
 }

--- a/Content.Server/Administration/Commands/StealthminCommand.cs
+++ b/Content.Server/Administration/Commands/StealthminCommand.cs
@@ -24,7 +24,7 @@ public sealed class StealthminCommand : ToolshedCommand
 
         DebugTools.AssertNotNull(adminData);
 
-        if (!adminData!.Stealth)
+        if (!adminData.Stealth)
             _adminManager.Stealth(admin);
         else
             _adminManager.UnStealth(admin);

--- a/Content.Server/NPC/Commands/NPCCommand.cs
+++ b/Content.Server/NPC/Commands/NPCCommand.cs
@@ -2,25 +2,25 @@ using Content.Server.Administration;
 using Content.Server.EUI;
 using Content.Server.NPC.UI;
 using Content.Shared.Administration;
-using Robust.Shared.Console;
+using Robust.Shared.Toolshed;
+using Robust.Shared.Toolshed.Errors;
 
 namespace Content.Server.NPC.Commands;
 
-[AdminCommand(AdminFlags.Debug)]
-public sealed class NpcCommand : LocalizedEntityCommands
+[ToolshedCommand, AdminCommand(AdminFlags.Debug)]
+public sealed class NpcCommand : ToolshedCommand
 {
     [Dependency] private readonly EuiManager _euiManager = default!;
 
-    public override string Command => "npc";
-
-    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    [CommandImplementation]
+    public void Npc(IInvocationContext ctx)
     {
-        if (shell.Player is not { } playerSession)
+        if (ctx.Session is null)
         {
-            shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
+            ctx.ReportError(new NotForServerConsoleError());
             return;
         }
 
-        _euiManager.OpenEui(new NPCEui(), playerSession);
+        _euiManager.OpenEui(new NPCEui(), ctx.Session);
     }
 }

--- a/Resources/Locale/en-US/administration/commands/stealthmin-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/stealthmin-command.ftl
@@ -1,2 +1,1 @@
-cmd-stealthmin-desc = Toggle whether others can see you in adminwho.
-cmd-stealthmin-help = Usage: stealthmin\nUse stealthmin to toggle whether you appear in the output of the adminwho command.
+command-description-stealthmin = Toggle whether others can see you in adminwho.

--- a/Resources/Locale/en-US/administration/ui/admin-announce-window.ftl
+++ b/Resources/Locale/en-US/administration/ui/admin-announce-window.ftl
@@ -7,5 +7,4 @@ admin-announce-type-station = Station
 admin-announce-type-server = Server
 admin-announce-keep-open = Keep open
 
-cmd-announceui-desc = Opens the announcement UI.
-cmd-announceui-help = Usage: announceui
+command-description-announceui = Opens the announcement UI.

--- a/Resources/Locale/en-US/administration/ui/permissions-eui.ftl
+++ b/Resources/Locale/en-US/administration/ui/permissions-eui.ftl
@@ -22,5 +22,4 @@ permissions-eui-edit-admin-rank-window-title = Edit Admin Rank
 permissions-eui-edit-admin-window-save-button = Save
 permissions-eui-edit-admin-window-remove-flag-button = Remove
 
-cmd-permissions-desc = Opens the admin permissions panel.
-cmd-permissions-help = Usage: permissions
+command-description-permissions = Opens the admin permissions panel.

--- a/Resources/Locale/en-US/commands/npc-command.ftl
+++ b/Resources/Locale/en-US/commands/npc-command.ftl
@@ -1,2 +1,1 @@
-﻿cmd-npc-desc = Opens the debug window for NPCs.
-cmd-npc-help = Usage: npc
+﻿command-description-npc = Opens the debug window for NPCs.

--- a/Resources/Locale/en-US/fax/fax-admin.ftl
+++ b/Resources/Locale/en-US/fax/fax-admin.ftl
@@ -1,6 +1,5 @@
 # Command
-cmd-faxui-desc = Open admin window for sending faxes
-cmd-faxui-help = Usage: faxui
+command-description-faxui = Open admin window for sending faxes
 
 # Window
 admin-fax-title = Admin Fax Manager


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Following Moonys input on my previous command PR, I've converted a chunk of simple to do LEC commands to toolshed.
Command invocation remains the same and most functionality is not lost. I say most because while working on this I noticed the engine NotForServerConsoleError class hardcodes its error message. A ding to my morale to be sure. This is on my todo list.

## Technical details
<!-- Summary of code changes for easier review. -->
Most of these are one for one. Removed the command name definition from the classes and added the CommandImplementation and ToolshedCommand attirbutes.
Updated locale files to reflect the change to toolshed. Removed help definitions.\
Permisisons command file was not following the naming scheme for commands and their files.
OpenPermissionsCommand -> PermissionsCommand

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->