### PR TITLE
Add FleetingClothingComponent

### DIFF
--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -223,7 +223,7 @@ public sealed class ClientClothingSystem : ClothingSystem
     {
         base.OnGotEquipped(uid, component, args);
 
-        RenderEquipment(args.Equipee, uid, args.Slot, clothingComponent: component);
+        RenderEquipment(args.EquipTarget, uid, args.Slot, clothingComponent: component);
     }
 
     private void RenderEquipment(EntityUid equipee, EntityUid equipment, string slot,

--- a/Content.Client/Inventory/ClientInventorySystem.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.cs
@@ -73,8 +73,8 @@ namespace Content.Client.Inventory
 
         private void OnDidUnequip(InventorySlotsComponent component, DidUnequipEvent args)
         {
-            UpdateSlot(args.Equipee, component, args.Slot);
-            if (args.Equipee != _playerManager.LocalEntity)
+            UpdateSlot(args.EquipTarget, component, args.Slot);
+            if (args.EquipTarget != _playerManager.LocalEntity)
                 return;
             var update = new SlotSpriteUpdate(null, args.SlotGroup, args.Slot, false);
             OnSpriteUpdate?.Invoke(update);
@@ -82,8 +82,8 @@ namespace Content.Client.Inventory
 
         private void OnDidEquip(InventorySlotsComponent component, DidEquipEvent args)
         {
-            UpdateSlot(args.Equipee, component, args.Slot);
-            if (args.Equipee != _playerManager.LocalEntity)
+            UpdateSlot(args.EquipTarget, component, args.Slot);
+            if (args.EquipTarget != _playerManager.LocalEntity)
                 return;
             var update = new SlotSpriteUpdate(args.Equipment, args.SlotGroup, args.Slot,
                 HasComp<StorageComponent>(args.Equipment));

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -64,17 +64,17 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnPressureProtectionEquipped(EntityUid uid, PressureProtectionComponent pressureProtection, GotEquippedEvent args)
         {
-            if (TryComp<BarotraumaComponent>(args.Equipee, out var barotrauma) && barotrauma.ProtectionSlots.Contains(args.Slot))
+            if (TryComp<BarotraumaComponent>(args.EquipTarget, out var barotrauma) && barotrauma.ProtectionSlots.Contains(args.Slot))
             {
-                UpdateCachedResistances(args.Equipee, barotrauma);
+                UpdateCachedResistances(args.EquipTarget, barotrauma);
             }
         }
 
         private void OnPressureProtectionUnequipped(EntityUid uid, PressureProtectionComponent pressureProtection, GotUnequippedEvent args)
         {
-            if (TryComp<BarotraumaComponent>(args.Equipee, out var barotrauma) && barotrauma.ProtectionSlots.Contains(args.Slot))
+            if (TryComp<BarotraumaComponent>(args.EquipTarget, out var barotrauma) && barotrauma.ProtectionSlots.Contains(args.Slot))
             {
-                UpdateCachedResistances(args.Equipee, barotrauma);
+                UpdateCachedResistances(args.EquipTarget, barotrauma);
             }
         }
 

--- a/Content.Server/Nutrition/EntitySystems/SmokingSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SmokingSystem.cs
@@ -106,7 +106,7 @@ namespace Content.Server.Nutrition.EntitySystems
         {
             if (args.Slot == "mask")
             {
-                _forensics.TransferDna(entity.Owner, args.Equipee, false);
+                _forensics.TransferDna(entity.Owner, args.EquipTarget, false);
             }
         }
 

--- a/Content.Server/Radiation/Systems/GeigerSystem.cs
+++ b/Content.Server/Radiation/Systems/GeigerSystem.cs
@@ -47,7 +47,7 @@ public sealed class GeigerSystem : SharedGeigerSystem
     {
         if (geiger.Comp.AttachedToSuit)
             SetEnabled(geiger, true);
-        SetUser(geiger, args.Equipee);
+        SetUser(geiger, args.EquipTarget);
     }
 
     private void OnEquippedHand(Entity<GeigerComponent> geiger, ref GotEquippedHandEvent args)

--- a/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
+++ b/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
@@ -58,7 +58,7 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
         base.OnGotEquipped(uid, component, args);
         if (component.IsEquipped && component.Enabled)
         {
-            EnsureComp<WearingHeadsetComponent>(args.Equipee).Headset = uid;
+            EnsureComp<WearingHeadsetComponent>(args.EquipTarget).Headset = uid;
             UpdateRadioChannels(uid, component);
         }
     }
@@ -67,7 +67,7 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
     {
         base.OnGotUnequipped(uid, component, args);
         RemComp<ActiveRadioComponent>(uid);
-        RemComp<WearingHeadsetComponent>(args.Equipee);
+        RemComp<WearingHeadsetComponent>(args.EquipTarget);
     }
 
     public void SetEnabled(EntityUid uid, bool value, HeadsetComponent? component = null)

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -927,7 +927,7 @@ public abstract partial class SharedActionsSystem : EntitySystem
         if (GameTiming.ApplyingState)
             return;
 
-        var ev = new GetItemActionsEvent(_actionContainer, args.Equipee, args.Equipment, args.SlotFlags);
+        var ev = new GetItemActionsEvent(_actionContainer, args.EquipTarget, args.Equipment, args.SlotFlags);
         RaiseLocalEvent(args.Equipment, ev);
 
         if (ev.Actions.Count == 0)

--- a/Content.Shared/Body/Systems/LungSystem.cs
+++ b/Content.Shared/Body/Systems/LungSystem.cs
@@ -37,10 +37,10 @@ public sealed class LungSystem : EntitySystem
             return;
         }
 
-        if (TryComp(args.Equipee, out InternalsComponent? internals))
+        if (TryComp(args.EquipTarget, out InternalsComponent? internals))
         {
-            ent.Comp.ConnectedInternalsEntity = args.Equipee;
-            _internals.ConnectBreathTool((args.Equipee, internals), ent);
+            ent.Comp.ConnectedInternalsEntity = args.EquipTarget;
+            _internals.ConnectBreathTool((args.EquipTarget, internals), ent);
         }
     }
 

--- a/Content.Shared/Clothing/Components/ChameleonClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ChameleonClothingComponent.cs
@@ -29,7 +29,7 @@ public sealed partial class ChameleonClothingComponent : Component
     /// <summary>
     ///     Current user that wears chameleon clothing.
     /// </summary>
-    [ViewVariables]
+    [DataField, AutoNetworkedField]
     public EntityUid? User;
 
     /// <summary>

--- a/Content.Shared/Clothing/Components/FleetingClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/FleetingClothingComponent.cs
@@ -53,4 +53,12 @@ public sealed partial class FleetingClothingComponent : Component
     /// </summary>
     [DataField]
     public LocId? ExamineOthers = "fleeting-clothing-component-default-examine";
+
+    /// <summary>
+    /// If true this entity will use <see cref="SharedDestructibleSystem.DestroyEntity"/> rather than simply be deleted.
+    /// Use this if you need to do stuff before deleting it, for example emptying storage containers so that the contents don't get deleted with with.
+    /// If false the clothing item will just be deleted instead.
+    /// </summary>
+    [DataField]
+    public bool DestroyOnUnequip = true;
 }

--- a/Content.Shared/Clothing/Components/FleetingClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/FleetingClothingComponent.cs
@@ -1,0 +1,56 @@
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Clothing.Components;
+
+/// <summary>
+/// Makes a clothing item despawn when unequipped, stripped or removed in any other way.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class FleetingClothingComponent : Component
+{
+    /// <summary>
+    /// The sound to play when unequipping.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? RemovedSound;
+
+    /// <summary>
+    /// Should the sound also be played when the player wearing the item unequips it themselves?
+    /// </summary>
+    [DataField]
+    public bool PlaySoundOnSelfUnequip = true;
+
+    /// <summary>
+    /// The popup to show to the wearer if they unequip this item themselves.
+    /// </summary>
+    [DataField]
+    public LocId? SelfUnquipPopupWearer = "fleeting-clothing-component-default-popup";
+
+    /// <summary>
+    /// The popup to show to others if the wearer unequips this item themselves.
+    /// </summary>
+    [DataField]
+    public LocId? SelfUnquipPopupOthers = "fleeting-clothing-component-default-popup";
+
+    /// <summary>
+    /// The popup to show to everone if this item was removed by any other means.
+    /// </summary>
+    /// <remarks>
+    /// We can't split this one up into wearer/others popups because EntGotRemovedFromContainerEvent does not have the user passed in.
+    /// </remarks>
+    [DataField]
+    public LocId? RemovedPopup = "fleeting-clothing-component-default-popup";
+
+    /// <summary>
+    /// Examine text shown to the wearer.
+    /// </summary>
+    [DataField]
+    public LocId? ExamineWearer = "fleeting-clothing-component-default-examine";
+
+    /// <summary>
+    /// Examine text shown to others.
+    /// </summary>
+    [DataField]
+    public LocId? ExamineOthers = "fleeting-clothing-component-default-examine";
+}

--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -88,22 +88,22 @@ public abstract class ClothingSystem : EntitySystem
         if ((component.Slots & args.SlotFlags) == SlotFlags.NONE)
             return;
 
-        var gotEquippedEvent = new ClothingGotEquippedEvent(args.Equipee, component);
+        var gotEquippedEvent = new ClothingGotEquippedEvent(args.EquipTarget, component);
         RaiseLocalEvent(uid, ref gotEquippedEvent);
 
         var didEquippedEvent = new ClothingDidEquippedEvent((uid, component));
-        RaiseLocalEvent(args.Equipee, ref didEquippedEvent);
+        RaiseLocalEvent(args.EquipTarget, ref didEquippedEvent);
     }
 
     protected virtual void OnGotUnequipped(EntityUid uid, ClothingComponent component, GotUnequippedEvent args)
     {
         if ((component.Slots & args.SlotFlags) != SlotFlags.NONE)
         {
-            var gotUnequippedEvent = new ClothingGotUnequippedEvent(args.Equipee, component);
+            var gotUnequippedEvent = new ClothingGotUnequippedEvent(args.EquipTarget, component);
             RaiseLocalEvent(uid, ref gotUnequippedEvent);
 
             var didUnequippedEvent = new ClothingDidUnequippedEvent((uid, component));
-            RaiseLocalEvent(args.Equipee, ref didUnequippedEvent);
+            RaiseLocalEvent(args.EquipTarget, ref didUnequippedEvent);
         }
 
         component.InSlot = null;
@@ -138,6 +138,21 @@ public abstract class ClothingSystem : EntitySystem
     }
 
     #region Public API
+
+    /// <summary>
+    /// Returns true if this clothing item is currently inside an inventory slot AND that slot is considered valid for equipping.
+    /// For example putting shoes into your pockets does not count as being equipped.
+    /// </summary>
+    public bool IsEquipped(Entity<ClothingComponent?> item)
+    {
+        if (!Resolve(item, ref item.Comp, false))
+            return false;
+
+        if ((item.Comp.Slots & item.Comp.InSlotFlag) != SlotFlags.NONE)
+            return true;
+
+        return false;
+    }
 
     public void SetEquippedPrefix(EntityUid uid, string? prefix, ClothingComponent? clothing = null)
     {

--- a/Content.Shared/Clothing/EntitySystems/FactionClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/FactionClothingSystem.cs
@@ -22,8 +22,8 @@ public sealed class FactionClothingSystem : EntitySystem
 
     private void OnEquipped(Entity<FactionClothingComponent> ent, ref GotEquippedEvent args)
     {
-        TryComp<NpcFactionMemberComponent>(args.Equipee, out var factionComp);
-        var faction = (args.Equipee, factionComp);
+        TryComp<NpcFactionMemberComponent>(args.EquipTarget, out var factionComp);
+        var faction = (args.EquipTarget, factionComp);
         ent.Comp.AlreadyMember = _faction.IsMember(faction, ent.Comp.Faction);
 
         _faction.AddFaction(faction, ent.Comp.Faction);
@@ -37,6 +37,6 @@ public sealed class FactionClothingSystem : EntitySystem
             return;
         }
 
-        _faction.RemoveFaction(args.Equipee, ent.Comp.Faction);
+        _faction.RemoveFaction(args.EquipTarget, ent.Comp.Faction);
     }
 }

--- a/Content.Shared/Clothing/EntitySystems/FleetingClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/FleetingClothingSystem.cs
@@ -1,0 +1,109 @@
+using Content.Shared.Clothing.Components;
+using Content.Shared.Examine;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Popups;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.Clothing.EntitySystems;
+
+public sealed class FleetingClothingSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ClothingSystem _clothing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<FleetingClothingComponent, ExaminedEvent>(OnExamine);
+        SubscribeLocalEvent<FleetingClothingComponent, BeforeGettingUnequippedEvent>(OnBeforeGettingUnequipped);
+        SubscribeLocalEvent<FleetingClothingComponent, GotUnequippedEvent>(OnGotUnequipped);
+    }
+
+    private void OnExamine(Entity<FleetingClothingComponent> ent, ref ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        string? examineText = null;
+        // check if the item is clothing, is currently equipped and if the wearer is the examiner
+        if (_clothing.IsEquipped(ent.Owner) && Transform(ent.Owner).ParentUid == args.Examiner)
+        {
+            // text to show to the wearer only
+            if (ent.Comp.ExamineWearer != null)
+                examineText = Loc.GetString(ent.Comp.ExamineWearer);
+        }
+        else
+        {
+            // text to show to everyone else
+            if (ent.Comp.ExamineOthers != null)
+                examineText = Loc.GetString(ent.Comp.ExamineOthers);
+        }
+
+        if (!string.IsNullOrEmpty(examineText))
+            args.PushMarkup(examineText);
+    }
+
+    // Raised before the item is being unequipped.
+    // We have to use QueueDel instead of Del because directly deleting the entity while an event is being raised on it will cause errors.
+    // We can't do this in.GotUnequippedEvent because container events don't include the user.
+    private void OnBeforeGettingUnequipped(Entity<FleetingClothingComponent> ent, ref BeforeGettingUnequippedEvent args)
+    {
+        PredictedQueueDel(ent.Owner); // Poof!
+
+        // Use coords because the entity will be deleted.
+        var coords = Transform(ent).Coordinates;
+        if (ent.Comp.PlaySoundOnSelfUnequip || args.User != args.EquipTarget)
+            _audio.PlayPredicted(ent.Comp.RemovedSound, coords, args.User);
+
+        if (args.User == args.EquipTarget)
+        {
+            // If the wearer removes the item themselves show specific messages to them and others.
+            string? selfMessage = null;
+            string? othersMessage = null;
+            if (ent.Comp.SelfUnquipPopupWearer != null)
+                selfMessage = Loc.GetString(ent.Comp.SelfUnquipPopupWearer, ("item", ent.Owner));
+            if (ent.Comp.SelfUnquipPopupOthers != null)
+                othersMessage = Loc.GetString(ent.Comp.SelfUnquipPopupOthers, ("item", ent.Owner));
+
+            // Use the wearer for the popup location because the item item itself will get deleted.
+            _popup.PopupPredicted(selfMessage, othersMessage, args.EquipTarget, args.User, PopupType.LargeCaution);
+        }
+        else
+        {
+            // Show the same popup message for everyone.
+            if (ent.Comp.RemovedPopup != null)
+                _popup.PopupPredicted(Loc.GetString(ent.Comp.RemovedPopup, ("item", ent.Owner)), args.EquipTarget, args.User, PopupType.LargeCaution);
+        }
+    }
+
+    // In case the item was somehow removed by any other means not using TryUnequip.
+    private void OnGotUnequipped(Entity<FleetingClothingComponent> ent, ref GotUnequippedEvent args)
+    {
+        if (_timing.ApplyingState)
+            return; // The results of the container change were already networked as part of the same game state.
+
+        if (Terminating(ent.Owner) || EntityManager.IsQueuedForDeletion(ent.Owner))
+            return; // Don't do the popups or sound twice.
+
+        if (Terminating(args.EquipTarget))
+            return; // Don't do anything if the item is removed due to the wearer getting deleted.
+
+        PredictedQueueDel(ent.Owner); // Poof!
+
+        // Can't predict the popup or sound without a user.
+        // TODO: Make the popup and sound API sane and remove this guard.
+        if (_net.IsClient)
+            return;
+
+        // Use the wearer for the popup location because the item item itself will get deleted.
+        _audio.PlayPvs(ent.Comp.RemovedSound, args.EquipTarget);
+        if (ent.Comp.RemovedPopup != null)
+            _popup.PopupEntity(Loc.GetString(ent.Comp.RemovedPopup, ("item", ent.Owner)), args.EquipTarget, PopupType.LargeCaution);
+    }
+}

--- a/Content.Shared/Clothing/EntitySystems/FleetingClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/FleetingClothingSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Clothing.Components;
+using Content.Shared.Destructible;
 using Content.Shared.Examine;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Popups;
@@ -15,6 +16,7 @@ public sealed class FleetingClothingSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly ClothingSystem _clothing = default!;
+    [Dependency] private readonly SharedDestructibleSystem _destructibleSystem = default!;
 
     public override void Initialize()
     {
@@ -54,7 +56,10 @@ public sealed class FleetingClothingSystem : EntitySystem
     // We can't do this in.GotUnequippedEvent because container events don't include the user.
     private void OnBeforeGettingUnequipped(Entity<FleetingClothingComponent> ent, ref BeforeGettingUnequippedEvent args)
     {
-        PredictedQueueDel(ent.Owner); // Poof!
+        if (ent.Comp.DestroyOnUnequip)
+            _destructibleSystem.DestroyEntity(ent.Owner); // Empty containers first.
+        else
+            PredictedQueueDel(ent.Owner); // Poof!
 
         // Use coords because the entity will be deleted.
         var coords = Transform(ent).Coordinates;
@@ -94,7 +99,10 @@ public sealed class FleetingClothingSystem : EntitySystem
         if (Terminating(args.EquipTarget))
             return; // Don't do anything if the item is removed due to the wearer getting deleted.
 
-        PredictedQueueDel(ent.Owner); // Poof!
+        if (ent.Comp.DestroyOnUnequip)
+            _destructibleSystem.DestroyEntity(ent.Owner); // Empty containers first.
+        else
+            PredictedQueueDel(ent.Owner); // Poof!
 
         // Can't predict the popup or sound without a user.
         // TODO: Make the popup and sound API sane and remove this guard.

--- a/Content.Shared/Clothing/EntitySystems/PilotedClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/PilotedClothingSystem.cs
@@ -63,7 +63,7 @@ public sealed partial class PilotedClothingSystem : EntitySystem
         if (!isCorrectSlot)
             return;
 
-        entity.Comp.Wearer = args.Equipee;
+        entity.Comp.Wearer = args.EquipTarget;
         Dirty(entity);
 
         // Attempt to setup control link, if Pilot and Wearer are both present.

--- a/Content.Shared/Clothing/EntitySystems/SelfUnremovableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/SelfUnremovableClothingSystem.cs
@@ -23,7 +23,7 @@ public sealed class SelfUnremovableClothingSystem : EntitySystem
         if (TryComp<ClothingComponent>(selfUnremovableClothing, out var clothing) && (clothing.Slots & args.SlotFlags) == SlotFlags.NONE)
             return;
 
-        if (args.UnEquipTarget == args.Unequipee)
+        if (args.UnEquipTarget == args.User)
         {
             args.Cancel();
         }

--- a/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
@@ -66,12 +66,20 @@ public abstract class SharedChameleonClothingSystem : EntitySystem
 
     private void OnGotEquipped(EntityUid uid, ChameleonClothingComponent component, GotEquippedEvent args)
     {
-        component.User = args.Equipee;
+        if (Timing.ApplyingState)
+            return; // Already networked as part of the same gamestate
+
+        component.User = args.EquipTarget;
+        Dirty(uid, component);
     }
 
     private void OnGotUnequipped(EntityUid uid, ChameleonClothingComponent component, GotUnequippedEvent args)
     {
+        if (Timing.ApplyingState)
+            return; // Already networked as part of the same gamestate
+
         component.User = null;
+        Dirty(uid, component);
     }
 
     // Updates chameleon visuals and meta information.

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -160,7 +160,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
         // This should maybe double check that the entity currently in the slot is actually the attached clothing, but
         // if its not, then something else has gone wrong already...
         if (component.Container != null && component.Container.ContainedEntity == null && component.ClothingUid != null)
-            _inventorySystem.TryUnequip(args.Equipee, component.Slot, force: true, triggerHandContact: true);
+            _inventorySystem.TryUnequip(args.EquipTarget, component.Slot, force: true, triggerHandContact: true);
     }
 
     private void OnRemoveToggleable(EntityUid uid, ToggleableClothingComponent component, ComponentRemove args)

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -795,14 +795,14 @@ namespace Content.Shared.Cuffs
         private void OnEquipAttempt(EntityUid uid, CuffableComponent component, IsEquippingAttemptEvent args)
         {
             // is this a self-equip, or are they being stripped?
-            if (args.Equipee == uid)
+            if (args.User == uid)
                 CheckAct(uid, component, args);
         }
 
         private void OnUnequipAttempt(EntityUid uid, CuffableComponent component, IsUnequippingAttemptEvent args)
         {
             // is this a self-equip, or are they being stripped?
-            if (args.Unequipee == uid)
+            if (args.User == uid)
                 CheckAct(uid, component, args);
         }
 

--- a/Content.Shared/Eye/Blinding/Systems/BlindfoldSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlindfoldSystem.cs
@@ -24,11 +24,11 @@ public sealed class BlindfoldSystem : EntitySystem
 
     private void OnEquipped(Entity<BlindfoldComponent> blindfold, ref GotEquippedEvent args)
     {
-        _blindableSystem.UpdateIsBlind(args.Equipee);
+        _blindableSystem.UpdateIsBlind(args.EquipTarget);
     }
 
     private void OnUnequipped(Entity<BlindfoldComponent> blindfold, ref GotUnequippedEvent args)
     {
-        _blindableSystem.UpdateIsBlind(args.Equipee);
+        _blindableSystem.UpdateIsBlind(args.EquipTarget);
     }
 }

--- a/Content.Shared/Eye/Blinding/Systems/BlurryVisionSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlurryVisionSystem.cs
@@ -44,12 +44,12 @@ public sealed class BlurryVisionSystem : EntitySystem
 
     private void OnGlassesEquipped(Entity<VisionCorrectionComponent> glasses, ref GotEquippedEvent args)
     {
-        UpdateBlurMagnitude(args.Equipee);
+        UpdateBlurMagnitude(args.EquipTarget);
     }
 
     private void OnGlassesUnequipped(Entity<VisionCorrectionComponent> glasses, ref GotUnequippedEvent args)
     {
-        UpdateBlurMagnitude(args.Equipee);
+        UpdateBlurMagnitude(args.EquipTarget);
     }
 }
 

--- a/Content.Shared/Hands/EntitySystems/ExtraHandsEquipmentSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/ExtraHandsEquipmentSystem.cs
@@ -17,27 +17,27 @@ public sealed class ExtraHandsEquipmentSystem : EntitySystem
 
     private void OnEquipped(Entity<ExtraHandsEquipmentComponent> ent, ref GotEquippedEvent args)
     {
-        if (!TryComp<HandsComponent>(args.Equipee, out var handsComp))
+        if (!TryComp<HandsComponent>(args.EquipTarget, out var handsComp))
             return;
 
         foreach (var (handName, hand) in ent.Comp.Hands)
         {
             // add the NetEntity id to the container name to prevent multiple items with this component from conflicting
             var handId = $"{GetNetEntity(ent.Owner).Id}-{handName}";
-            _hands.AddHand((args.Equipee, handsComp), handId, hand.Location);
+            _hands.AddHand((args.EquipTarget, handsComp), handId, hand.Location);
         }
     }
 
     private void OnUnequipped(Entity<ExtraHandsEquipmentComponent> ent, ref GotUnequippedEvent args)
     {
-        if (!TryComp<HandsComponent>(args.Equipee, out var handsComp))
+        if (!TryComp<HandsComponent>(args.EquipTarget, out var handsComp))
             return;
 
         foreach (var handName in ent.Comp.Hands.Keys)
         {
             // add the NetEntity id to the container name to prevent multiple items with this component from conflicting
             var handId = $"{GetNetEntity(ent.Owner).Id}-{handName}";
-            _hands.RemoveHand((args.Equipee, handsComp), handId);
+            _hands.RemoveHand((args.EquipTarget, handsComp), handId);
         }
     }
 }

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
@@ -80,6 +80,10 @@ public abstract partial class SharedHandsSystem
         if (handId == null)
             return false;
 
+        // don't try to pick up the item if it's being deleted anyways
+        if (TerminatingOrDeleted(entity) || EntityManager.IsQueuedForDeletion(entity))
+            return false;
+
         if (!Resolve(entity, ref item, false))
             return false;
 

--- a/Content.Shared/Inventory/Events/BeforeEquipEvents.cs
+++ b/Content.Shared/Inventory/Events/BeforeEquipEvents.cs
@@ -1,0 +1,50 @@
+﻿namespace Content.Shared.Inventory.Events;
+
+public abstract class BeforeEquipEventBase(EntityUid user, EntityUid equipTarget, EntityUid equipment, SlotDefinition slotDefinition) : EntityEventArgs
+{
+    /// <summary>
+    /// The entity performing the action.
+    /// NOT necessarily the one actually "receiving" the equipment.
+    /// </summary>
+    public readonly EntityUid User = user;
+
+    /// <summary>
+    /// The entity which got equipped to.
+    /// NOT necessarily the one who performed the interaction.
+    /// </summary>
+    public readonly EntityUid EquipTarget = equipTarget;
+
+    /// <summary>
+    /// The entity which got equipped.
+    /// </summary>
+    public readonly EntityUid Equipment = equipment;
+
+    /// <summary>
+    /// The slot the entity got equipped to.
+    /// </summary>
+    public readonly string Slot = slotDefinition.Name;
+
+    /// <summary>
+    /// The slot group the entity got equipped in.
+    /// </summary>
+    public readonly string SlotGroup = slotDefinition.SlotGroup;
+
+    /// <summary>
+    /// Slotflags of the slot the entity just got equipped to.
+    /// </summary>
+    public readonly SlotFlags SlotFlags = slotDefinition.SlotFlags;
+}
+
+/// <summary>
+/// Raised directed on an equipee before something is equipped to them.
+/// Note: This is only raised when equipped using TryEquip, not if the container is directly modified.
+/// </summary>
+public sealed class BeforeEquipEvent(EntityUid user, EntityUid equipTarget, EntityUid equipment, SlotDefinition slotDefinition)
+    : BeforeEquipEventBase(user, equipTarget, equipment, slotDefinition);
+
+/// <summary>
+/// Raised directed on equipment before it is equipped to an equipee.
+/// Note: This is only raised when equipped using TryEquip, not if the container is directly modified.
+/// </summary>
+public sealed class BeforeGettingEquippedEvent(EntityUid user, EntityUid equipTarget, EntityUid equipment, SlotDefinition slotDefinition)
+    : BeforeEquipEventBase(user, equipTarget, equipment, slotDefinition);

--- a/Content.Shared/Inventory/Events/BeforeUnequipEvents.cs
+++ b/Content.Shared/Inventory/Events/BeforeUnequipEvents.cs
@@ -1,0 +1,50 @@
+﻿namespace Content.Shared.Inventory.Events;
+
+public abstract class BeforeUnequipEventBase(EntityUid user, EntityUid equipTarget, EntityUid equipment, SlotDefinition slotDefinition) : EntityEventArgs
+{
+    /// <summary>
+    /// The entity performing the action.
+    /// NOT necessarily the same as the entity whose equipment is being removed.
+    /// </summary>
+    public readonly EntityUid User = user;
+
+    /// <summary>
+    /// The entity which was unequipped from.
+    /// NOT necessarily the one who performed the interaction.
+    /// </summary>
+    public readonly EntityUid EquipTarget = equipTarget;
+
+    /// <summary>
+    /// The entity which got unequipped.
+    /// </summary>
+    public readonly EntityUid Equipment = equipment;
+
+    /// <summary>
+    /// The slot the entity got unequipped from.
+    /// </summary>
+    public readonly string Slot = slotDefinition.Name;
+
+    /// <summary>
+    /// The slot group the entity got unequipped from.
+    /// </summary>
+    public readonly string SlotGroup = slotDefinition.SlotGroup;
+
+    /// <summary>
+    /// Slotflags of the slot the entity just got unequipped from.
+    /// </summary>
+    public readonly SlotFlags SlotFlags = slotDefinition.SlotFlags;
+}
+
+/// <summary>
+/// Raised directed on an equipee before something is unequipped from them.
+/// Note: This is only raised when enequipped using TryUnequip, not if the container is directly modified or the item is deleted.
+/// </summary>
+public sealed class BeforeUnequipEvent(EntityUid user, EntityUid equipTarget, EntityUid equipment, SlotDefinition slotDefinition)
+    : BeforeUnequipEventBase(user, equipTarget, equipment, slotDefinition);
+
+/// <summary>
+/// Raised directed on equipment before it is unequipped from an equipee.
+/// Note: This is only raised when enequipped using TryUnequip, not if the container is directly modified or the item is deleted.
+/// </summary>
+public sealed class BeforeGettingUnequippedEvent(EntityUid user, EntityUid equipTarget, EntityUid equipment, SlotDefinition slotDefinition)
+    : BeforeUnequipEventBase(user, equipTarget, equipment, slotDefinition);

--- a/Content.Shared/Inventory/Events/EquipAttemptEvents.cs
+++ b/Content.Shared/Inventory/Events/EquipAttemptEvents.cs
@@ -1,14 +1,15 @@
 namespace Content.Shared.Inventory.Events;
 
-public abstract class EquipAttemptBase(EntityUid equipee, EntityUid equipTarget, EntityUid equipment,
+public abstract class EquipAttemptBase(EntityUid user, EntityUid equipTarget, EntityUid equipment,
     SlotDefinition slotDefinition) : CancellableEntityEventArgs, IInventoryRelayEvent
 {
     public SlotFlags TargetSlots { get; } = SlotFlags.WITHOUT_POCKET;
 
     /// <summary>
-    /// The entity performing the action. NOT necessarily the one actually "receiving" the equipment.
+    /// The entity performing the action.
+    /// NOT necessarily the one actually "receiving" the equipment.
     /// </summary>
-    public readonly EntityUid Equipee = equipee;
+    public readonly EntityUid User = user;
 
     /// <summary>
     /// The entity being equipped to.
@@ -39,17 +40,17 @@ public abstract class EquipAttemptBase(EntityUid equipee, EntityUid equipTarget,
 /// <summary>
 /// Raised on the item that is being equipped.
 /// </summary>
-public sealed class BeingEquippedAttemptEvent(EntityUid equipee, EntityUid equipTarget, EntityUid equipment,
-    SlotDefinition slotDefinition) : EquipAttemptBase(equipee, equipTarget, equipment, slotDefinition);
+public sealed class BeingEquippedAttemptEvent(EntityUid user, EntityUid equipTarget, EntityUid equipment,
+    SlotDefinition slotDefinition) : EquipAttemptBase(user, equipTarget, equipment, slotDefinition);
 
 /// <summary>
 /// Raised on the entity that is equipping an item.
 /// </summary>
-public sealed class IsEquippingAttemptEvent(EntityUid equipee, EntityUid equipTarget, EntityUid equipment,
-    SlotDefinition slotDefinition) : EquipAttemptBase(equipee, equipTarget, equipment, slotDefinition);
+public sealed class IsEquippingAttemptEvent(EntityUid user, EntityUid equipTarget, EntityUid equipment,
+    SlotDefinition slotDefinition) : EquipAttemptBase(user, equipTarget, equipment, slotDefinition);
 
 /// <summary>
 /// Raised on the entity on who item is being equipped.
 /// </summary>
-public sealed class IsEquippingTargetAttemptEvent(EntityUid equipee, EntityUid equipTarget, EntityUid equipment,
-    SlotDefinition slotDefinition) : EquipAttemptBase(equipee, equipTarget, equipment, slotDefinition);
+public sealed class IsEquippingTargetAttemptEvent(EntityUid user, EntityUid equipTarget, EntityUid equipment,
+    SlotDefinition slotDefinition) : EquipAttemptBase(user, equipTarget, equipment, slotDefinition);

--- a/Content.Shared/Inventory/Events/EquippedEvents.cs
+++ b/Content.Shared/Inventory/Events/EquippedEvents.cs
@@ -1,58 +1,42 @@
 ﻿namespace Content.Shared.Inventory.Events;
 
-public abstract class EquippedEventBase : EntityEventArgs
+public abstract class EquippedEventBase(EntityUid equipTarget, EntityUid equipment, SlotDefinition slotDefinition) : EntityEventArgs
 {
     /// <summary>
-    /// The entity equipping.
+    /// The entity which got equipped to.
+    /// NOT necessarily the one who performed the interaction.
     /// </summary>
-    public readonly EntityUid Equipee;
+    public readonly EntityUid EquipTarget = equipTarget;
 
     /// <summary>
     /// The entity which got equipped.
     /// </summary>
-    public readonly EntityUid Equipment;
+    public readonly EntityUid Equipment = equipment;
 
     /// <summary>
     /// The slot the entity got equipped to.
     /// </summary>
-    public readonly string Slot;
+    public readonly string Slot = slotDefinition.Name;
 
     /// <summary>
     /// The slot group the entity got equipped in.
     /// </summary>
-    public readonly string SlotGroup;
+    public readonly string SlotGroup = slotDefinition.SlotGroup;
 
     /// <summary>
     /// Slotflags of the slot the entity just got equipped to.
     /// </summary>
-    public readonly SlotFlags SlotFlags;
-
-    public EquippedEventBase(EntityUid equipee, EntityUid equipment, SlotDefinition slotDefinition)
-    {
-        Equipee = equipee;
-        Equipment = equipment;
-        Slot = slotDefinition.Name;
-        SlotGroup = slotDefinition.SlotGroup;
-        SlotFlags = slotDefinition.SlotFlags;
-    }
+    public readonly SlotFlags SlotFlags = slotDefinition.SlotFlags;
 }
 
 /// <summary>
-/// Raised directed on an equipee when something is equipped.
+/// Raised directed on an equipee when something was equipped.
 /// </summary>
-public sealed class DidEquipEvent : EquippedEventBase
-{
-    public DidEquipEvent(EntityUid equipee, EntityUid equipment, SlotDefinition slotDefinition) : base(equipee, equipment, slotDefinition)
-    {
-    }
-}
+public sealed class DidEquipEvent(EntityUid equipTarget, EntityUid equipment, SlotDefinition slotDefinition)
+    : EquippedEventBase(equipTarget, equipment, slotDefinition);
 
 /// <summary>
-/// Raised directed on equipment when it's equipped to an equipee
+/// Raised directed on equipment when it was equipped to an equipee.
 /// </summary>
-public sealed class GotEquippedEvent : EquippedEventBase
-{
-    public GotEquippedEvent(EntityUid equipee, EntityUid equipment, SlotDefinition slotDefinition) : base(equipee, equipment, slotDefinition)
-    {
-    }
-}
+public sealed class GotEquippedEvent(EntityUid equipTarget, EntityUid equipment, SlotDefinition slotDefinition)
+    : EquippedEventBase(equipTarget, equipment, slotDefinition);

--- a/Content.Shared/Inventory/Events/UnequipAttemptEvent.cs
+++ b/Content.Shared/Inventory/Events/UnequipAttemptEvent.cs
@@ -1,14 +1,15 @@
 namespace Content.Shared.Inventory.Events;
 
-public abstract class UnequipAttemptEventBase(EntityUid unequipee, EntityUid unEquipTarget, EntityUid equipment,
+public abstract class UnequipAttemptEventBase(EntityUid user, EntityUid unEquipTarget, EntityUid equipment,
     SlotDefinition slotDefinition) : CancellableEntityEventArgs, IInventoryRelayEvent
 {
     public SlotFlags TargetSlots { get; } = SlotFlags.WITHOUT_POCKET;
 
     /// <summary>
-    /// The entity performing the action. NOT necessarily the same as the entity whose equipment is being removed..
+    /// The entity performing the action.
+    /// NOT necessarily the same as the entity whose equipment is being removed.
     /// </summary>
-    public readonly EntityUid Unequipee = unequipee;
+    public readonly EntityUid User = user;
 
     /// <summary>
     /// The entity being unequipped from.
@@ -39,17 +40,17 @@ public abstract class UnequipAttemptEventBase(EntityUid unequipee, EntityUid unE
 /// <summary>
 /// Raised on the item that is being unequipped.
 /// </summary>
-public sealed class BeingUnequippedAttemptEvent(EntityUid unequipee, EntityUid unEquipTarget, EntityUid equipment,
-    SlotDefinition slotDefinition) : UnequipAttemptEventBase(unequipee, unEquipTarget, equipment, slotDefinition);
+public sealed class BeingUnequippedAttemptEvent(EntityUid user, EntityUid unEquipTarget, EntityUid equipment,
+    SlotDefinition slotDefinition) : UnequipAttemptEventBase(user, unEquipTarget, equipment, slotDefinition);
 
 /// <summary>
 /// Raised on the entity that is unequipping an item.
 /// </summary>
-public sealed class IsUnequippingAttemptEvent(EntityUid unequipee, EntityUid unEquipTarget, EntityUid equipment,
-    SlotDefinition slotDefinition) : UnequipAttemptEventBase(unequipee, unEquipTarget, equipment, slotDefinition);
+public sealed class IsUnequippingAttemptEvent(EntityUid user, EntityUid unEquipTarget, EntityUid equipment,
+    SlotDefinition slotDefinition) : UnequipAttemptEventBase(user, unEquipTarget, equipment, slotDefinition);
 
 /// <summary>
 /// Raised on the entity from who item is being unequipped.
 /// </summary>
-public sealed class IsUnequippingTargetAttemptEvent(EntityUid unequipee, EntityUid unEquipTarget, EntityUid equipment,
-    SlotDefinition slotDefinition) : UnequipAttemptEventBase(unequipee, unEquipTarget, equipment, slotDefinition);
+public sealed class IsUnequippingTargetAttemptEvent(EntityUid user, EntityUid unEquipTarget, EntityUid equipment,
+    SlotDefinition slotDefinition) : UnequipAttemptEventBase(user, unEquipTarget, equipment, slotDefinition);

--- a/Content.Shared/Inventory/Events/UnequippedEvents.cs
+++ b/Content.Shared/Inventory/Events/UnequippedEvents.cs
@@ -1,52 +1,42 @@
 ﻿namespace Content.Shared.Inventory.Events;
 
-public abstract class UnequippedEventBase : EntityEventArgs
+public abstract class UnequippedEventBase(EntityUid equipTarget, EntityUid equipment, SlotDefinition slotDefinition) : EntityEventArgs
 {
     /// <summary>
-    /// The entity unequipping.
+    /// The entity which was unequipped from.
+    /// NOT necessarily the one who performed the interaction.
     /// </summary>
-    public readonly EntityUid Equipee;
+    public readonly EntityUid EquipTarget = equipTarget;
 
     /// <summary>
     /// The entity which got unequipped.
     /// </summary>
-    public readonly EntityUid Equipment;
+    public readonly EntityUid Equipment = equipment;
 
     /// <summary>
     /// The slot the entity got unequipped from.
     /// </summary>
-    public readonly string Slot;
+    public readonly string Slot = slotDefinition.Name;
 
     /// <summary>
     /// The slot group the entity got unequipped from.
     /// </summary>
-    public readonly string SlotGroup;
+    public readonly string SlotGroup = slotDefinition.SlotGroup;
 
     /// <summary>
     /// Slotflags of the slot the entity just got unequipped from.
     /// </summary>
-    public readonly SlotFlags SlotFlags;
-
-    public UnequippedEventBase(EntityUid equipee, EntityUid equipment, SlotDefinition slotDefinition)
-    {
-        Equipee = equipee;
-        Equipment = equipment;
-        Slot = slotDefinition.Name;
-        SlotGroup = slotDefinition.SlotGroup;
-        SlotFlags = slotDefinition.SlotFlags;
-    }
+    public readonly SlotFlags SlotFlags = slotDefinition.SlotFlags;
 }
 
-public sealed class DidUnequipEvent : UnequippedEventBase
-{
-    public DidUnequipEvent(EntityUid equipee, EntityUid equipment, SlotDefinition slotDefinition) : base(equipee, equipment, slotDefinition)
-    {
-    }
-}
+/// <summary>
+/// Raised directed on an equipee when something was unequipped.
+/// </summary>
+public sealed class DidUnequipEvent(EntityUid equipTarget, EntityUid equipment, SlotDefinition slotDefinition)
+    : UnequippedEventBase(equipTarget, equipment, slotDefinition);
 
-public sealed class GotUnequippedEvent : UnequippedEventBase
-{
-    public GotUnequippedEvent(EntityUid equipee, EntityUid equipment, SlotDefinition slotDefinition) : base(equipee, equipment, slotDefinition)
-    {
-    }
-}
+/// <summary>
+/// Raised directed on equipment when it was unequipped from an equipee.
+/// </summary>
+public sealed class GotUnequippedEvent(EntityUid equipTarget, EntityUid equipment, SlotDefinition slotDefinition)
+    : UnequippedEventBase(equipTarget, equipment, slotDefinition);

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -133,7 +133,7 @@ public abstract partial class InventorySystem
     {
         if (!Resolve(target, ref inventory, false))
         {
-            if(!silent)
+            if (!silent)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-equip-cannot"));
             return false;
         }
@@ -144,14 +144,14 @@ public abstract partial class InventorySystem
 
         if (!TryGetSlotContainer(target, slot, out var slotContainer, out var slotDefinition, inventory))
         {
-            if(!silent)
+            if (!silent)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-equip-cannot"));
             return false;
         }
 
         if (!force && !CanEquip(actor, target, itemUid, slot, out var reason, slotDefinition, inventory, clothing))
         {
-            if(!silent)
+            if (!silent)
                 _popup.PopupCursor(Loc.GetString(reason));
             return false;
         }
@@ -179,9 +179,17 @@ public abstract partial class InventorySystem
             return false;
         }
 
+        // give other systems a chance to do stuff before equipping
+        var beforeGettingEquippedEvent = new BeforeGettingEquippedEvent(actor, target, itemUid, slotDefinition);
+        var beforeEquipEvent = new BeforeEquipEvent(actor, target, itemUid, slotDefinition);
+
+        RaiseLocalEvent(itemUid, beforeGettingEquippedEvent);
+        RaiseLocalEvent(target, beforeEquipEvent);
+
+        // actually equip the item
         if (!_containerSystem.Insert(itemUid, slotContainer))
         {
-            if(!silent)
+            if (!silent)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"));
             return false;
         }
@@ -400,14 +408,14 @@ public abstract partial class InventorySystem
 
         if (!Resolve(target, ref inventory, false))
         {
-            if(!silent)
+            if (!silent)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"));
             return false;
         }
 
         if (!TryGetSlotContainer(target, slot, out var slotContainer, out var slotDefinition, inventory))
         {
-            if(!silent)
+            if (!silent)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"));
             return false;
         }
@@ -419,7 +427,7 @@ public abstract partial class InventorySystem
 
         if (!force && !CanUnequip(actor, target, slot, out var reason, slotContainer, slotDefinition, inventory))
         {
-            if(!silent)
+            if (!silent)
                 _popup.PopupCursor(Loc.GetString(reason));
             return false;
         }
@@ -450,6 +458,14 @@ public abstract partial class InventorySystem
             return false;
         }
 
+        // give other systems a chance do stuff before unequipping
+        var beforeGettingUnequippedEvent = new BeforeGettingUnequippedEvent(actor, target, removedItem.Value, slotDefinition);
+        var beforeUnequipEvent = new BeforeUnequipEvent(actor, target, removedItem.Value, slotDefinition);
+
+        RaiseLocalEvent(removedItem.Value, beforeGettingUnequippedEvent);
+        RaiseLocalEvent(target, beforeUnequipEvent);
+
+        // actually unequip the item
         if (!_containerSystem.Remove(removedItem.Value, slotContainer, force: force, reparent: reparent))
             return false;
 
@@ -457,6 +473,8 @@ public abstract partial class InventorySystem
         var firstRun = itemsDropped == 0;
         ++itemsDropped;
 
+        // TODO: This is not being checked at the moment if we remove clothing by any other means than TryUnequip, for example when deleting the item or teleporting it away.
+        // But checking this in a EntGotRemovedFromContainerMessage subscription is fundamentally incompatible with the current prediction API for popups and audio since we don't have a user.
         foreach (var slotDef in inventory.Slots)
         {
             if (slotDef != slotDefinition && slotDef.DependsOn == slotDefinition.Name)

--- a/Content.Shared/Inventory/SelfEquipOnlySystem.cs
+++ b/Content.Shared/Inventory/SelfEquipOnlySystem.cs
@@ -23,7 +23,7 @@ public sealed class SelfEquipOnlySystem : EntitySystem
         if (TryComp<ClothingComponent>(ent, out var clothing) && (clothing.Slots & args.SlotFlags) == SlotFlags.NONE)
             return;
 
-        if (args.Equipee != args.EquipTarget)
+        if (args.User != args.EquipTarget)
             args.Cancel();
     }
 
@@ -32,7 +32,7 @@ public sealed class SelfEquipOnlySystem : EntitySystem
         if (args.Cancelled)
             return;
 
-        if (args.Unequipee == args.UnEquipTarget)
+        if (args.User == args.UnEquipTarget)
             return;
 
         if (TryComp<ClothingComponent>(ent, out var clothing) && (clothing.Slots & args.SlotFlags) == SlotFlags.NONE)

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -182,14 +182,14 @@ public partial class MobStateSystem
     private void OnEquipAttempt(EntityUid target, MobStateComponent component, IsEquippingAttemptEvent args)
     {
         // is this a self-equip, or are they being stripped?
-        if (args.Equipee == target)
+        if (args.User == target)
             CheckAct(target, component, args);
     }
 
     private void OnUnequipAttempt(EntityUid target, MobStateComponent component, IsUnequippingAttemptEvent args)
     {
         // is this a self-equip, or are they being stripped?
-        if (args.Unequipee == target)
+        if (args.User == target)
             CheckAct(target, component, args);
     }
 

--- a/Content.Shared/Ninja/Systems/EnergyKatanaSystem.cs
+++ b/Content.Shared/Ninja/Systems/EnergyKatanaSystem.cs
@@ -23,7 +23,7 @@ public sealed class EnergyKatanaSystem : EntitySystem
     /// </summary>
     private void OnEquipped(Entity<EnergyKatanaComponent> ent, ref GotEquippedEvent args)
     {
-        _ninja.BindKatana(args.Equipee, ent);
+        _ninja.BindKatana(args.EquipTarget, ent);
     }
 
     private void OnCheckDash(Entity<EnergyKatanaComponent> ent, ref CheckDashEvent args)

--- a/Content.Shared/Ninja/Systems/SharedNinjaSuitSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedNinjaSuitSystem.cs
@@ -98,7 +98,7 @@ public abstract class SharedNinjaSuitSystem : EntitySystem
     /// </summary>
     private void OnUnequipped(Entity<NinjaSuitComponent> ent, ref GotUnequippedEvent args)
     {
-        var user = args.Equipee;
+        var user = args.EquipTarget;
         if (_ninja.NinjaQuery.TryComp(user, out var ninja))
             UserUnequippedSuit(ent, (user, ninja));
     }

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -392,14 +392,14 @@ public abstract partial class SharedStunSystem : EntitySystem
     private void OnEquipAttempt(EntityUid uid, StunnedComponent stunned, IsEquippingAttemptEvent args)
     {
         // is this a self-equip, or are they being stripped?
-        if (args.Equipee == uid)
+        if (args.User == uid)
             args.Cancel();
     }
 
     private void OnUnequipAttempt(EntityUid uid, StunnedComponent stunned, IsUnequippingAttemptEvent args)
     {
         // is this a self-equip, or are they being stripped?
-        if (args.Unequipee == uid)
+        if (args.User == uid)
             args.Cancel();
     }
 

--- a/Content.Shared/SubFloor/SharedTrayScannerSystem.cs
+++ b/Content.Shared/SubFloor/SharedTrayScannerSystem.cs
@@ -80,12 +80,12 @@ public abstract class SharedTrayScannerSystem : EntitySystem
 
     private void OnTrayUnequipped(Entity<TrayScannerComponent> ent, ref GotUnequippedEvent args)
     {
-        OnUnequip(args.Equipee);
+        OnUnequip(args.EquipTarget);
     }
 
     private void OnTrayEquipped(Entity<TrayScannerComponent> ent, ref GotEquippedEvent args)
     {
-        OnEquip(args.Equipee);
+        OnEquip(args.EquipTarget);
     }
 
     private void OnTrayScannerActivate(EntityUid uid, TrayScannerComponent scanner, ActivateInWorldEvent args)

--- a/Content.Shared/Trigger/Systems/TriggerOnEquipmentSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerOnEquipmentSystem.cs
@@ -53,7 +53,7 @@ public sealed class TriggerOnEquipmentSystem : TriggerOnXSystem
         if ((ent.Comp.SlotFlags & args.SlotFlags) == 0)
             return;
 
-        Trigger.Trigger(ent.Owner, args.Equipee, ent.Comp.KeyOut);
+        Trigger.Trigger(ent.Owner, args.EquipTarget, ent.Comp.KeyOut);
     }
 
     private void OnGotUnequipped(Entity<TriggerOnGotUnequippedComponent> ent, ref GotUnequippedEvent args)
@@ -64,6 +64,6 @@ public sealed class TriggerOnEquipmentSystem : TriggerOnXSystem
         if ((ent.Comp.SlotFlags & args.SlotFlags) == 0)
             return;
 
-        Trigger.Trigger(ent.Owner, args.Equipee, ent.Comp.KeyOut);
+        Trigger.Trigger(ent.Owner, args.EquipTarget, ent.Comp.KeyOut);
     }
 }

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -209,7 +209,7 @@ public abstract class SharedWieldableSystem : EntitySystem
     private void OnBlockerEquipped(Entity<WieldingBlockerComponent> ent, ref GotEquippedEvent args)
     {
         if (ent.Comp.BlockEquipped)
-            UnwieldAll(args.Equipee, force: true);
+            UnwieldAll(args.EquipTarget, force: true);
     }
 
     private void OnBlockerEquippedHand(Entity<WieldingBlockerComponent> ent, ref GotEquippedHandEvent args)

--- a/Resources/Locale/en-US/clothing/components/fleeting-clothing-coponent.ftl
+++ b/Resources/Locale/en-US/clothing/components/fleeting-clothing-coponent.ftl
@@ -1,0 +1,2 @@
+fleeting-clothing-component-default-popup = {CAPITALIZE(THE($item))} crumbles into dust.
+fleeting-clothing-component-default-examine = This is a fleeting item. It will diseappear when unequipped.


### PR DESCRIPTION
## About the PR
Adds a component that makes an item despawn with a sound and popup when someone unequips it.

## Why / Balance
I need it for changeling flesh clothing, but it could also be useful for items like summoned magic armor, acidifying equipment etc

## Technical details
I renamed a bunch of fields in events so that they are more consistent, see the breaking changes below.
The name "Equipee" was either used as the player doing the interaction or the player being equipped to.
Added new `Before*Events` for (un)euipping since in the event raised after the item was (un)equipped we don't have the user available anymore, meaning we cannot predict the popup and audio nor can we make it different for self-removing.
There was an engine PR that tried to make this possible, but it was declined.
https://github.com/space-wizards/RobustToolbox/pull/6071
We cannot use attempt events either because these can also be raised if checking if we *can* do something (for example when showing a verb), without us actually trying to do it.
Also fixed missing networking for ChameleonClothingComponent

## Media
![ss14](https://github.com/user-attachments/assets/8c0cbda3-0a25-4aa0-8bff-5186f03319c5)

test prototype:
```
- type: entity
  parent: ClothingHandsGlovesColorYellow
  id: FleetingInsuls
  name: fleeting insulated gloves
  components:
  - type: FleetingClothing
    examineWearer: "This item will disappear if you remove it"
    selfUnquipPopupWearer: "You removed the item and it crumbles into dust"
    selfUnquipPopupOthers: "They removed the item and it crumbles into dust"
    playSoundOnSelfUnequip: false
    removedSound:
      path: /Audio/Items/Toys/weh.ogg

```

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Renamed some event fields to make them consistent with other events:
Renamed `BeingEquippedAttemptEvent.Equipee` to `User`
Renamed `IsEquippingAttemptEvent.Equipee` to `User`
Renamed `BeingUnequippedAttemptEvent.Equipee` to `User`
Renamed `IsUnequippingAttemptEvent.Equipee` to `User`
Renamed `DidEquipEvent.Equipee` to `EquipTarget`
Renamed `GotEquippedEvent.Equipee` to `EquipTarget`
Renamed `DidUnquipEvent.Equipee` to `EquipTarget`
Renamed `GotUnequippedEvent.Equipee` to `EquipTarget`

**Changelog**
not player facing