### PR TITLE
fix tailwag action for changelings

### DIFF
--- a/Content.Server/Cloning/CloningSystem.Subscriptions.cs
+++ b/Content.Server/Cloning/CloningSystem.Subscriptions.cs
@@ -53,7 +53,7 @@ public sealed partial class CloningSystem
         SubscribeLocalEvent<VocalComponent, CloningEvent>(OnCloneVocal);
         SubscribeLocalEvent<StorageComponent, CloningEvent>(OnCloneStorage);
         SubscribeLocalEvent<InventoryComponent, CloningEvent>(OnCloneInventory);
-        SubscribeLocalEvent<MovementSpeedModifierComponent, CloningEvent>(OnCloneInventory);
+        SubscribeLocalEvent<MovementSpeedModifierComponent, CloningEvent>(OnCloneMovementSpeedModifier);
     }
 
     private void OnCloneItemStack(Entity<StackComponent> ent, ref CloningItemEvent args)
@@ -120,7 +120,7 @@ public sealed partial class CloningSystem
         _inventory.CopyComponent(ent.AsNullable(), args.CloneUid);
     }
 
-    private void OnCloneInventory(Entity<MovementSpeedModifierComponent> ent, ref CloningEvent args)
+    private void OnCloneMovementSpeedModifier(Entity<MovementSpeedModifierComponent> ent, ref CloningEvent args)
     {
         if (!args.Settings.EventComponents.Contains(Factory.GetRegistration(ent.Comp.GetType()).Name))
             return;

--- a/Content.Server/Wagging/WaggingSystem.cs
+++ b/Content.Server/Wagging/WaggingSystem.cs
@@ -35,7 +35,13 @@ public sealed class WaggingSystem : EntitySystem
         if (!args.Settings.EventComponents.Contains(Factory.GetRegistration(ent.Comp.GetType()).Name))
             return;
 
-        EnsureComp<WaggingComponent>(args.CloneUid);
+        // Make sure to set the datafields before adding the component so that the correct action gets spawned on map init.
+        var cloneComp = Factory.GetComponent<WaggingComponent>();
+        cloneComp.Action = ent.Comp.Action;
+        cloneComp.Layer = ent.Comp.Layer;
+        cloneComp.Organ = ent.Comp.Organ;
+        cloneComp.Suffix = ent.Comp.Suffix;
+        AddComp(args.CloneUid, cloneComp, true);
     }
 
     private void OnWaggingMapInit(Entity<WaggingComponent> ent, ref MapInitEvent args)

--- a/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
@@ -99,13 +99,15 @@ public sealed partial class SharedJumpAbilitySystem : EntitySystem
         if (!args.Settings.EventComponents.Contains(Factory.GetRegistration(ent.Comp.GetType()).Name))
             return;
 
+        // Make sure to set the datafields before adding the component so that the correct action gets spawned on map init.
         var targetComp = Factory.GetComponent<JumpAbilityComponent>();
         targetComp.Action = ent.Comp.Action;
-        targetComp.CanCollide = ent.Comp.CanCollide;
-        targetComp.JumpSound = ent.Comp.JumpSound;
-        targetComp.CollideKnockdown = ent.Comp.CollideKnockdown;
         targetComp.JumpDistance = ent.Comp.JumpDistance;
         targetComp.JumpThrowSpeed = ent.Comp.JumpThrowSpeed;
+        targetComp.CanCollide = ent.Comp.CanCollide;
+        targetComp.CollideKnockdown = ent.Comp.CollideKnockdown;
+        targetComp.JumpSound = ent.Comp.JumpSound;
+        targetComp.JumpFailedPopup = ent.Comp.JumpFailedPopup;
         AddComp(args.CloneUid, targetComp, true);
     }
 }

--- a/Content.Shared/Rootable/RootableSystem.cs
+++ b/Content.Shared/Rootable/RootableSystem.cs
@@ -121,12 +121,15 @@ public sealed class RootableSystem : EntitySystem
         if (!args.Settings.EventComponents.Contains(Factory.GetRegistration(ent.Comp.GetType()).Name))
             return;
 
-        var cloneComp = EnsureComp<RootableComponent>(args.CloneUid);
+        // Make sure to set the datafields before adding the component so that the correct action gets spawned on map init.
+        var cloneComp = Factory.GetComponent<RootableComponent>();
+        cloneComp.Action = ent.Comp.Action;
+        cloneComp.RootedAlert = ent.Comp.RootedAlert;
         cloneComp.TransferRate = ent.Comp.TransferRate;
         cloneComp.TransferFrequency = ent.Comp.TransferFrequency;
         cloneComp.SpeedModifier = ent.Comp.SpeedModifier;
         cloneComp.RootSound = ent.Comp.RootSound;
-        Dirty(args.CloneUid, cloneComp);
+        AddComp(args.CloneUid, cloneComp, true);
     }
 
     private void OnRootableMapInit(Entity<RootableComponent> ent, ref MapInitEvent args)

--- a/Content.Shared/Sericulture/SericultureSystem.cs
+++ b/Content.Shared/Sericulture/SericultureSystem.cs
@@ -41,13 +41,15 @@ public abstract partial class SharedSericultureSystem : EntitySystem
         if (!args.Settings.EventComponents.Contains(Factory.GetRegistration(ent.Comp.GetType()).Name))
             return;
 
-        var comp = EnsureComp<SericultureComponent>(args.CloneUid);
-        comp.PopupText = ent.Comp.PopupText;
-        comp.ProductionLength = ent.Comp.ProductionLength;
-        comp.HungerCost = ent.Comp.HungerCost;
-        comp.EntityProduced = ent.Comp.EntityProduced;
-        comp.MinHungerThreshold = ent.Comp.MinHungerThreshold;
-        Dirty(args.CloneUid, comp);
+        // Make sure to set the datafields before adding the component so that the correct action gets spawned on map init.
+        var cloneComp = Factory.GetComponent<SericultureComponent>();
+        cloneComp.PopupText = ent.Comp.PopupText;
+        cloneComp.EntityProduced = ent.Comp.EntityProduced;
+        cloneComp.Action = ent.Comp.Action;
+        cloneComp.ProductionLength = ent.Comp.ProductionLength;
+        cloneComp.HungerCost = ent.Comp.HungerCost;
+        cloneComp.MinHungerThreshold = ent.Comp.MinHungerThreshold;
+        AddComp(args.CloneUid, cloneComp, true);
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
It was not updating the action icon when transforming

## Why / Balance
See #39439

## Technical details
We set the datafields for the component before adding it, because the action gets spawned on map init.
Did the same for a few other subscriptions. Those only have one species using them, but this might be different on forks.

## Media
![ss14](https://github.com/user-attachments/assets/22e11950-494c-4f6f-a158-cbdd586b98b5)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
not player facing yet