### PR TITLE
fix: small typo in the restart alert V2

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -313,7 +313,7 @@ namespace Content.Server.RoundEnd
                 Loc.GetString(
                     "round-end-system-round-restart-eta-announcement",
                     ("time", time),
-                    ("units", Loc.GetString(unitsLocString))));
+                    ("units", Loc.GetString(unitsLocString, ("amount", time)))));
             Timer.Spawn(countdownTime.Value, AfterEndRoundRestart, _countdownTokenSource.Token);
         }
 

--- a/Resources/Locale/en-US/round-end/round-end-system.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-system.ftl
@@ -7,5 +7,11 @@ round-end-system-shuttle-recalled-announcement = The emergency shuttle has been 
 round-end-system-shuttle-sender-announcement = Station
 round-end-system-round-restart-eta-announcement = Restarting the round in {$time} {$units}...
 
-eta-units-minutes = minutes
-eta-units-seconds = seconds
+eta-units-minutes = {$amount ->
+    [one] minute
+    *[other] minutes
+}
+eta-units-seconds = {$amount ->
+    [one] second
+    *[other] seconds
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
No typo in the end round alert.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
close: #9797 

## Technical details
<!-- Summary of code changes for easier review. -->
I stole code from #33304 written by @freeagent1384, but with the fixes suggested by @SaphireLattice and @VerinSenpai.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="486" height="156" alt="image" src="https://github.com/user-attachments/assets/f7eb81ab-556b-4d4b-a78e-a11279350fee" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
no cl
