### PR TITLE
Update DungeonSystem.Rooms to use IRobustRandom instead of Random

### DIFF
--- a/Content.Server/Procedural/DungeonSystem.Rooms.cs
+++ b/Content.Server/Procedural/DungeonSystem.Rooms.cs
@@ -7,6 +7,7 @@ using Content.Shared.Whitelist;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Utility;
+using Robust.Shared.Random;
 
 namespace Content.Server.Procedural;
 

--- a/Content.Server/Procedural/DungeonSystem.Rooms.cs
+++ b/Content.Server/Procedural/DungeonSystem.Rooms.cs
@@ -19,7 +19,7 @@ public sealed partial class DungeonSystem
     /// <summary>
     /// Gets a random dungeon room matching the specified area, whitelist and size.
     /// </summary>
-    public DungeonRoomPrototype? GetRoomPrototype(Vector2i size, Random random, EntityWhitelist? whitelist = null)
+    public DungeonRoomPrototype? GetRoomPrototype(Vector2i size, IRobustRandom random, EntityWhitelist? whitelist = null)
     {
         return GetRoomPrototype(random, whitelist, minSize: size, maxSize: size);
     }
@@ -27,7 +27,7 @@ public sealed partial class DungeonSystem
     /// <summary>
     /// Gets a random dungeon room matching the specified area and whitelist and size range
     /// </summary>
-    public DungeonRoomPrototype? GetRoomPrototype(Random random,
+    public DungeonRoomPrototype? GetRoomPrototype(IRobustRandom random,
         EntityWhitelist? whitelist = null,
         Vector2i? minSize = null,
         Vector2i? maxSize = null)
@@ -77,7 +77,7 @@ public sealed partial class DungeonSystem
         MapGridComponent grid,
         Vector2i origin,
         DungeonRoomPrototype room,
-        Random random,
+        IRobustRandom random,
         HashSet<Vector2i>? reservedTiles,
         bool clearExisting = false,
         bool rotation = false)
@@ -96,7 +96,7 @@ public sealed partial class DungeonSystem
         SpawnRoom(gridUid, grid, finalTransform, room, reservedTiles, clearExisting);
     }
 
-    public Angle GetRoomRotation(DungeonRoomPrototype room, Random random)
+    public Angle GetRoomRotation(DungeonRoomPrototype room, IRobustRandom random)
     {
         var roomRotation = Angle.Zero;
 

--- a/Content.Server/Procedural/RoomFillSystem.cs
+++ b/Content.Server/Procedural/RoomFillSystem.cs
@@ -6,6 +6,7 @@ public sealed class RoomFillSystem : EntitySystem
 {
     [Dependency] private readonly DungeonSystem _dungeon = default!;
     [Dependency] private readonly SharedMapSystem _maps = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()
     {
@@ -19,8 +20,7 @@ public sealed class RoomFillSystem : EntitySystem
 
         if (xform.GridUid != null)
         {
-            var random = new Random();
-            var room = _dungeon.GetRoomPrototype(random, component.RoomWhitelist, component.MinSize, component.MaxSize);
+            var room = _dungeon.GetRoomPrototype(_random, component.RoomWhitelist, component.MinSize, component.MaxSize);
 
             if (room != null)
             {
@@ -30,7 +30,7 @@ public sealed class RoomFillSystem : EntitySystem
                     mapGrid,
                     _maps.LocalToTile(xform.GridUid.Value, mapGrid, xform.Coordinates) - new Vector2i(room.Size.X/2,room.Size.Y/2),
                     room,
-                    random,
+                    _random,
                     null,
                     clearExisting: component.ClearExisting,
                     rotation: component.Rotation);

--- a/Content.Server/Procedural/RoomFillSystem.cs
+++ b/Content.Server/Procedural/RoomFillSystem.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.Map.Components;
+using Robust.Shared.Random;
 
 namespace Content.Server.Procedural;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Update `DungeonSystem.GetRoomPrototype` and `DungeonSystem.SpawnRoom` to use `IRobustRandom` instead of `System.Random`, fixes usages of these functions accordingly.

## Why / Balance
I'm intending to add functionality to these and noticed the usage of `Random`, brought it up in #development in the ss14 discord and they said it was a problem, so I fixed it.

## Technical details
A very trivial change since `IRobustRandom` replicates the functionality of `System.Random` closely.

I made sure all usages of these functions were not impacted or adjusted accordingly, `DungeonJob.DunGenPrefab` does use `SpawnRoom`, but it does not pass a Random object and is thusly unimpacted.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="861" height="629" alt="Screenshot 2026-04-03 195806" src="https://github.com/user-attachments/assets/fb70036c-7247-4f0e-a87f-e4fd30b54e0a" />
<img width="879" height="637" alt="image" src="https://github.com/user-attachments/assets/6497bc53-8834-4e7f-8cd5-46a86b5b0311" />

Here is the bagel theatre generating both of it's two random variants, since it is created using an entity with `RoomFillComponent` it would be impacted by this change; The bagel theatre has appeared as expected.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`DungeonSystem.GetRoomPrototype`'s `random` parameter is now of type `IRobustRandom` instead of `Random`
`DungeonSystem.SpawnRoom` `random` parameter now is of type `IRobustRandom` instead of `Random`

Updating code to align with this requires using `Robust.Shared.Random` and replacing usages of `Random` with `IRobustRandom`, 