### PR TITLE
avoiding cyclic recursive evaluation in the SpawnItemsOnUseSystem

### DIFF
--- a/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
+++ b/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
@@ -21,6 +21,8 @@ namespace Content.Server.Storage.EntitySystems
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
 
+        [ThreadStatic] private static HashSet<string>? _processingPrototypes;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -31,30 +33,53 @@ namespace Content.Server.Storage.EntitySystems
 
         private void CalculatePrice(EntityUid uid, SpawnItemsOnUseComponent component, ref PriceCalculationEvent args)
         {
+            if (_processingPrototypes == null)
+                _processingPrototypes = new HashSet<string>();
+
+            var processing = _processingPrototypes;
+
             var ungrouped = CollectOrGroups(component.Items, out var orGroups);
 
             foreach (var entry in ungrouped)
             {
-                var protUid = Spawn(entry.PrototypeId, MapCoordinates.Nullspace);
+                if (entry.PrototypeId == null)
+                    continue;
+                if (!processing.Add(entry.PrototypeId))
+                    continue;
 
-                // Calculate the average price of the possible spawned items
-                args.Price += _pricing.GetPrice(protUid) * entry.SpawnProbability * entry.GetAmount(getAverage: true);
-
-                Del(protUid);
+                try
+                {
+                    var protUid = Spawn(entry.PrototypeId, MapCoordinates.Nullspace);
+                    args.Price += _pricing.GetPrice(protUid) * entry.SpawnProbability * entry.GetAmount(getAverage: true);
+                    Del(protUid);
+                }
+                finally
+                {
+                    processing.Remove(entry.PrototypeId);
+                }
             }
 
             foreach (var group in orGroups)
             {
                 foreach (var entry in group.Entries)
                 {
-                    var protUid = Spawn(entry.PrototypeId, MapCoordinates.Nullspace);
+                    if (entry.PrototypeId == null)
+                        continue;
+                    if (!processing.Add(entry.PrototypeId))
+                        continue;
 
-                    // Calculate the average price of the possible spawned items
-                    args.Price += _pricing.GetPrice(protUid) *
-                                  (entry.SpawnProbability / group.CumulativeProbability) *
-                                  entry.GetAmount(getAverage: true);
-
-                    Del(protUid);
+                    try
+                    {
+                        var protUid = Spawn(entry.PrototypeId, MapCoordinates.Nullspace);
+                        args.Price += _pricing.GetPrice(protUid) *
+                                      (entry.SpawnProbability / group.CumulativeProbability) *
+                                      entry.GetAmount(getAverage: true);
+                        Del(protUid);
+                    }
+                    finally
+                    {
+                        processing.Remove(entry.PrototypeId);
+                    }
                 }
             }
 

--- a/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
+++ b/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
@@ -38,8 +38,9 @@ namespace Content.Server.Storage.EntitySystems
 
             var processing = _processingPrototypes;
 
-            var ungrouped = CollectOrGroups(component.Items, out var orGroups);
+            var priced = false;
 
+            var ungrouped = CollectOrGroups(component.Items, out var orGroups);
             foreach (var entry in ungrouped)
             {
                 if (entry.PrototypeId == null)
@@ -52,6 +53,7 @@ namespace Content.Server.Storage.EntitySystems
                     var protUid = Spawn(entry.PrototypeId, MapCoordinates.Nullspace);
                     args.Price += _pricing.GetPrice(protUid) * entry.SpawnProbability * entry.GetAmount(getAverage: true);
                     Del(protUid);
+                    priced = true;
                 }
                 finally
                 {
@@ -75,6 +77,7 @@ namespace Content.Server.Storage.EntitySystems
                                       (entry.SpawnProbability / group.CumulativeProbability) *
                                       entry.GetAmount(getAverage: true);
                         Del(protUid);
+                        priced = true;
                     }
                     finally
                     {
@@ -82,8 +85,8 @@ namespace Content.Server.Storage.EntitySystems
                     }
                 }
             }
-
-            args.Handled = true;
+            if (priced)
+                args.Handled = true;
         }
 
         private void OnUseInHand(EntityUid uid, SpawnItemsOnUseComponent component, UseInHandEvent args)


### PR DESCRIPTION

## About the PR
fix https://github.com/space-wizards/space-station-14/issues/34654

## Why / Balance
I think it's time. I like it when the server doesn't crash.

## Technical details
Now the CalculatePrice remembers the evaluated prototypes and does not allow them to re-evaluate itself to avoid cyclic recursion.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
