### PR TITLE
Prevent changelings from repeated devourings take 2

### DIFF
--- a/Content.Client/Changeling/UI/ChangelingTransformBoundUserInterface.cs
+++ b/Content.Client/Changeling/UI/ChangelingTransformBoundUserInterface.cs
@@ -23,7 +23,6 @@ public sealed partial class ChangelingTransformBoundUserInterface(EntityUid owne
         _menu.OpenOverMouseScreenPosition();
     }
 
-
     public override void Update()
     {
         if (_menu == null)
@@ -32,7 +31,7 @@ public sealed partial class ChangelingTransformBoundUserInterface(EntityUid owne
         if (!EntMan.TryGetComponent<ChangelingIdentityComponent>(Owner, out var lingIdentity))
             return;
 
-        var models = ConvertToButtons(lingIdentity.ConsumedIdentities, lingIdentity?.CurrentIdentity);
+        var models = ConvertToButtons(lingIdentity.ConsumedIdentities.Keys, lingIdentity?.CurrentIdentity);
 
         _menu.SetButtons(models);
     }

--- a/Content.Shared/Changeling/Components/ChangelingDevouredComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingDevouredComponent.cs
@@ -1,0 +1,21 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Changeling.Components;
+
+/// <summary>
+/// Component used for marking entities devoured by a changeling.
+/// Used to prevent granting the identity several times.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ChangelingDevouredComponent : Component
+{
+    /// <summary>
+    /// List of all changelings that have devoured this entity.
+    /// </summary>
+    // TODO: This should be using some sort of relation system in the future.
+    [DataField, AutoNetworkedField]
+    public List<EntityUid> DevouredBy = new();
+
+    // Prevent other clients from knowing whos identity has been stolen.
+    public override bool SendOnlyToOwner => true;
+}

--- a/Content.Shared/Changeling/Components/ChangelingDevouredComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingDevouredComponent.cs
@@ -10,12 +10,9 @@ namespace Content.Shared.Changeling.Components;
 public sealed partial class ChangelingDevouredComponent : Component
 {
     /// <summary>
-    /// List of all changelings that have devoured this entity.
+    /// HashSet of all changelings that have devoured this entity.
     /// </summary>
     // TODO: This should be using some sort of relation system in the future.
     [DataField, AutoNetworkedField]
-    public List<EntityUid> DevouredBy = new();
-
-    // Prevent other clients from knowing whos identity has been stolen.
-    public override bool SendOnlyToOwner => true;
+    public HashSet<EntityUid> DevouredBy = new();
 }

--- a/Content.Shared/Changeling/Components/ChangelingIdentityComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingIdentityComponent.cs
@@ -13,11 +13,11 @@ public sealed partial class ChangelingIdentityComponent : Component
 {
     /// <summary>
     /// The list of entities that exist on a paused map. They are paused clones of the victims that the ling has consumed, with all relevant components copied from the original.
+    /// First is the Uid of the stored identity, second is the original entity the identity came from.
     /// </summary>
-    // TODO: Store a reference to the original entity as well so you cannot infinitely devour somebody. Currently very tricky due the inability to send over EntityUid if the original is ever deleted. Can be fixed by something like WeakEntityReference.
+    // TODO: This should be handled via a relation system in the future.
     [DataField, AutoNetworkedField]
-    public List<EntityUid> ConsumedIdentities = new();
-
+    public Dictionary<EntityUid, EntityUid?> ConsumedIdentities = new();
 
     /// <summary>
     /// The currently assumed identity.

--- a/Content.Shared/Changeling/Components/ChangelingIdentityComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingIdentityComponent.cs
@@ -13,7 +13,8 @@ public sealed partial class ChangelingIdentityComponent : Component
 {
     /// <summary>
     /// The list of entities that exist on a paused map. They are paused clones of the victims that the ling has consumed, with all relevant components copied from the original.
-    /// First is the Uid of the stored identity, second is the original entity the identity came from.
+    /// The key is the EntityUid of the stored identity, the value is the original entity the identity came from.
+    /// The value will be set to null if that entity is deleted.
     /// </summary>
     // TODO: This should be handled via a relation system in the future.
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -59,29 +59,6 @@ public sealed class ChangelingDevourSystem : EntitySystem
         }
     }
 
-    /// <summary>
-    /// Checkes if the targets outerclothing is beyond a DamageCoefficientThreshold to protect them from being devoured.
-    /// </summary>
-    /// <param name="target">The Targeted entity</param>
-    /// <param name="ent">Changelings Devour Component</param>
-    /// <returns>Is the target Protected from the attack</returns>
-    private bool IsTargetProtected(EntityUid target, Entity<ChangelingDevourComponent> ent)
-    {
-        var ev = new CoefficientQueryEvent(SlotFlags.OUTERCLOTHING);
-
-        RaiseLocalEvent(target, ev);
-
-        foreach (var compProtectiveDamageType in ent.Comp.ProtectiveDamageTypes)
-        {
-            if (!ev.DamageModifiers.Coefficients.TryGetValue(compProtectiveDamageType, out var coefficient))
-                continue;
-            if (coefficient < 1f - ent.Comp.DevourPreventionPercentageThreshold)
-                return true;
-        }
-
-        return false;
-    }
-
     // The action was used.
     // Start the first doafter for the windup.
     private void OnDevourAction(Entity<ChangelingDevourComponent> ent, ref ChangelingDevourActionEvent args)
@@ -94,33 +71,13 @@ public sealed class ChangelingDevourSystem : EntitySystem
         args.Handled = true;
         var target = args.Target;
 
-        if (target == ent.Owner)
-            return; // don't eat yourself
-
-        if (!_mobState.IsDead(target))
-        {
-            _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-not-dead"), args.Performer, args.Performer, PopupType.Medium);
+        if (!CanDevour(ent.AsNullable(), target))
             return;
-        }
-
-        if (HasComp<RottingComponent>(target))
-        {
-            _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-rotting"), args.Performer, args.Performer, PopupType.Medium);
-            return;
-        }
-
-        if (IsTargetProtected(target, ent))
-        {
-            _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-protected"), ent, ent, PopupType.Medium);
-            return;
-        }
 
         if (_net.IsServer)
         {
             ent.Comp.CurrentDevourSound = _audio.Stop(ent.Comp.CurrentDevourSound);
-            var pvsSound = _audio.PlayPvs(ent.Comp.DevourWindupNoise, ent);
-            if (pvsSound != null)
-                ent.Comp.CurrentDevourSound = pvsSound.Value.Entity;
+            ent.Comp.CurrentDevourSound = _audio.PlayPvs(ent.Comp.DevourWindupNoise, ent)?.Entity;
         }
 
         _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ent:player} started changeling devour windup against {target:player}");
@@ -162,17 +119,12 @@ public sealed class ChangelingDevourSystem : EntitySystem
         _popupSystem.PopupPredicted(
             selfMessage,
             othersMessage,
-            args.User,
-            args.User,
+            ent.Owner,
+            ent.Owner,
             PopupType.LargeCaution);
 
         if (_net.IsServer)
-        {
-            var pvsSound = _audio.PlayPvs(ent.Comp.ConsumeNoise, ent);
-
-            if (pvsSound != null)
-                ent.Comp.CurrentDevourSound = pvsSound.Value.Entity;
-        }
+            ent.Comp.CurrentDevourSound = _audio.PlayPvs(ent.Comp.ConsumeNoise, ent)?.Entity;
 
         _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ent.Owner):player} began to devour {ToPrettyString(target):player}'s identity");
 
@@ -203,52 +155,120 @@ public sealed class ChangelingDevourSystem : EntitySystem
         if (args.Target is not { } target)
             return;
 
+        // Damage first before the CanDevour check to make sure they don't gib in-between and to kill them again in case they somehow revived.
         _damageable.ChangeDamage(target, ent.Comp.DevourDamage, true, true, ent.Owner);
 
-        if (!_mobState.IsDead(target))
-        {
-            _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-not-dead"), args.User, args.User, PopupType.Medium);
-            _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ent.Owner):player} unsuccessfully devoured {ToPrettyString(args.Target):player}'s identity");
+        if (!CanDevour(ent.AsNullable(), target)) // Check again if the conditions are still met.
             return;
-        }
 
-        var selfMessage = Loc.GetString("changeling-devour-consume-complete-self", ("user", Identity.Entity(args.User, EntityManager)));
-        var othersMessage = Loc.GetString("changeling-devour-consume-complete-others", ("user", Identity.Entity(args.User, EntityManager)));
+        var selfMessage = Loc.GetString("changeling-devour-consume-complete-self", ("user", Identity.Entity(ent.Owner, EntityManager)));
+        var othersMessage = Loc.GetString("changeling-devour-consume-complete-others", ("user", Identity.Entity(ent.Owner, EntityManager)));
         _popupSystem.PopupPredicted(
             selfMessage,
             othersMessage,
-            args.User,
-            args.User,
+            ent.Owner,
+            ent.Owner,
             PopupType.LargeCaution);
 
-        if (_mobState.IsDead(target)
-            && HasComp<HumanoidProfileComponent>(target)
-            && TryComp<ChangelingIdentityComponent>(args.User, out var identityStorage))
+        _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ent.Owner):player} successfully devoured {ToPrettyString(target):player}'s identity");
+
+        if (_inventorySystem.TryGetSlotEntity(target, "jumpsuit", out var item)
+            && TryComp<ButcherableComponent>(item, out var butcherable))
+            RipClothing(target, (item.Value, butcherable));
+
+        if (!TryComp<ChangelingIdentityComponent>(ent.Owner, out var identityStorage))
+            return;
+
+        _changelingIdentitySystem.CloneToPausedMap((ent, identityStorage), target);
+
+        // We add a reference to ourselves to prevent repeated identity gain.
+        var targetDevoured = EnsureComp<ChangelingDevouredComponent>(target);
+        targetDevoured.DevouredBy.Add(ent.Owner);
+        Dirty(target, targetDevoured);
+        Dirty(ent);
+    }
+
+    /// <summary>
+    /// Has the given victim been devoured by the given changeling before?
+    /// </summary>
+    public bool HasDevoured(EntityUid changeling, Entity<ChangelingDevouredComponent?> devoured)
+    {
+        if (!Resolve(devoured, ref devoured.Comp, false))
+            return false; // If they don't have the component they have never been devoured.
+
+        return devoured.Comp.DevouredBy.Contains(changeling);
+    }
+
+    /// <summary>
+    /// Can the given changeling devour the given victim?
+    /// </summary>
+    public bool CanDevour(Entity<ChangelingDevourComponent?> changeling, EntityUid victim, bool showPopup = true)
+    {
+        if (!Resolve(changeling, ref changeling.Comp))
+            return false;
+
+        if (changeling.Owner == victim)
+            return false; // Can't devour yourself.
+
+        if (!HasComp<HumanoidProfileComponent>(victim))
         {
-
-            // Has the NOT target been devoured?
-            // If so, were they NOT devoured by us?
-            // Do we NOT have a stored reference to them?
-            // Add them to our saved identities.
-            if (!TryComp<ChangelingDevouredComponent>(target, out var devoured)
-                || !devoured.DevouredBy.Contains(args.User)
-                || !identityStorage.ConsumedIdentities.ContainsValue(target))
-            {
-                _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ent.Owner):player} successfully devoured {ToPrettyString(target):player}'s identity");
-                _changelingIdentitySystem.CloneToPausedMap((ent, identityStorage), target);
-
-                // We add a reference to ourselves to prevent repeated identity gain.
-                EnsureComp<ChangelingDevouredComponent>(target, out var targetDevoured);
-                targetDevoured.DevouredBy.Add(args.User);
-                Dirty(target, targetDevoured);
-            }
-
-            if (_inventorySystem.TryGetSlotEntity(target, "jumpsuit", out var item)
-                && TryComp<ButcherableComponent>(item, out var butcherable))
-                RipClothing(target, (item.Value, butcherable));
+            if (showPopup)
+                _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-cannot-devour"), changeling.Owner, changeling.Owner, PopupType.Medium);
+            return false;
         }
 
-        Dirty(ent);
+        if (HasDevoured(changeling, victim))
+        {
+            if (showPopup)
+                _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-already-devoured"), changeling.Owner, changeling.Owner, PopupType.Medium);
+            return false;
+        }
+
+        if (!_mobState.IsDead(victim))
+        {
+            if (showPopup)
+                _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-not-dead"), changeling.Owner, changeling.Owner, PopupType.Medium);
+            return false;
+        }
+
+        if (HasComp<RottingComponent>(victim))
+        {
+            if (showPopup)
+                _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-rotting"), changeling.Owner, changeling.Owner, PopupType.Medium);
+            return false;
+        }
+
+        if (IsTargetProtected(victim, changeling!))
+        {
+            if (showPopup)
+                _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-protected"), changeling.Owner, changeling.Owner, PopupType.Medium);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Checks if the target's outerclothing is beyond a DamageCoefficientThreshold to protect them from being devoured.
+    /// </summary>
+    /// <param name="target">The Targeted entity</param>
+    /// <param name="ent">Changelings Devour Component</param>
+    /// <returns>Is the target Protected from the attack</returns>
+    private bool IsTargetProtected(EntityUid target, Entity<ChangelingDevourComponent> ent)
+    {
+        var ev = new CoefficientQueryEvent(SlotFlags.OUTERCLOTHING);
+
+        RaiseLocalEvent(target, ev);
+
+        foreach (var compProtectiveDamageType in ent.Comp.ProtectiveDamageTypes)
+        {
+            if (!ev.DamageModifiers.Coefficients.TryGetValue(compProtectiveDamageType, out var coefficient))
+                continue;
+            if (coefficient < 1f - ent.Comp.DevourPreventionPercentageThreshold)
+                return true;
+        }
+
+        return false;
     }
 
     // TODO: This should just be an API method in the butcher system

--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -225,8 +225,23 @@ public sealed class ChangelingDevourSystem : EntitySystem
             && HasComp<HumanoidProfileComponent>(target)
             && TryComp<ChangelingIdentityComponent>(args.User, out var identityStorage))
         {
-            _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ent.Owner):player} successfully devoured {ToPrettyString(target):player}'s identity");
-            _changelingIdentitySystem.CloneToPausedMap((ent, identityStorage), target);
+
+            // Has the NOT target been devoured?
+            // If so, were they NOT devoured by us?
+            // Do we NOT have a stored reference to them?
+            // Add them to our saved identities.
+            if (!TryComp<ChangelingDevouredComponent>(target, out var devoured)
+                || !devoured.DevouredBy.Contains(args.User)
+                || !identityStorage.ConsumedIdentities.ContainsValue(target))
+            {
+                _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ent.Owner):player} successfully devoured {ToPrettyString(target):player}'s identity");
+                _changelingIdentitySystem.CloneToPausedMap((ent, identityStorage), target);
+
+                // We add a reference to ourselves to prevent repeated identity gain.
+                EnsureComp<ChangelingDevouredComponent>(target, out var targetDevoured);
+                targetDevoured.DevouredBy.Add(args.User);
+                Dirty(target, targetDevoured);
+            }
 
             if (_inventorySystem.TryGetSlotEntity(target, "jumpsuit", out var item)
                 && TryComp<ButcherableComponent>(item, out var butcherable))

--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -191,12 +191,12 @@ public sealed class ChangelingDevourSystem : EntitySystem
     /// <summary>
     /// Has the given victim been devoured by the given changeling before?
     /// </summary>
-    public bool HasDevoured(EntityUid changeling, Entity<ChangelingDevouredComponent?> devoured)
+    public bool HasDevoured(Entity<ChangelingIdentityComponent?> changeling, EntityUid devoured)
     {
-        if (!Resolve(devoured, ref devoured.Comp, false))
-            return false; // If they don't have the component they have never been devoured.
+        if (!Resolve(changeling, ref changeling.Comp, false))
+            return false;
 
-        return devoured.Comp.DevouredBy.Contains(changeling);
+        return changeling.Comp.ConsumedIdentities.ContainsValue(devoured);
     }
 
     /// <summary>
@@ -217,7 +217,7 @@ public sealed class ChangelingDevourSystem : EntitySystem
             return false;
         }
 
-        if (HasDevoured(changeling, victim))
+        if (HasDevoured(changeling.Owner, victim))
         {
             if (showPopup)
                 _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-already-devoured"), changeling.Owner, changeling.Owner, PopupType.Medium);

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
@@ -139,7 +139,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
         if (identity.CurrentIdentity == targetIdentity)
             return; // don't transform into ourselves
 
-        if (!identity.ConsumedIdentities.Contains(targetIdentity.Value))
+        if (!identity.ConsumedIdentities.ContainsKey(targetIdentity.Value))
             return; // this identity does not belong to this player
 
         TransformInto(ent.AsNullable(), targetIdentity.Value);
@@ -170,6 +170,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
             _adminLogger.Add(LogType.Action, LogImpact.High, $"{ToPrettyString(ent.Owner):player} successfully transformed into \"{Name(targetIdentity)}\" ({storedIdentity.OriginalSession:player})");
         else
             _adminLogger.Add(LogType.Action, LogImpact.High, $"{ToPrettyString(ent.Owner):player} successfully transformed into \"{Name(targetIdentity)}\"");
+
         _metaData.SetEntityName(ent, Name(targetIdentity), raiseEvents: false); // Don't raise events because we don't want to rename the ID card.
         _identity.QueueIdentityUpdate(ent); // We have to manually refresh the identity because we did not raise events.
 

--- a/Content.Shared/Changeling/Systems/SharedChangelingIdentitySystem.cs
+++ b/Content.Shared/Changeling/Systems/SharedChangelingIdentitySystem.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System.Linq;
+using System.Numerics;
 using Content.Shared.Body;
 using Content.Shared.Changeling.Components;
 using Content.Shared.Cloning;
@@ -34,6 +35,8 @@ public abstract class SharedChangelingIdentitySystem : EntitySystem
         SubscribeLocalEvent<ChangelingIdentityComponent, PlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<ChangelingIdentityComponent, PlayerDetachedEvent>(OnPlayerDetached);
         SubscribeLocalEvent<ChangelingStoredIdentityComponent, ComponentRemove>(OnStoredRemove);
+
+        SubscribeLocalEvent<ChangelingDevouredComponent, ComponentShutdown>(OnDevouredShutdown);
     }
 
     private void OnPlayerAttached(Entity<ChangelingIdentityComponent> ent, ref PlayerAttachedEvent args)
@@ -57,7 +60,24 @@ public abstract class SharedChangelingIdentitySystem : EntitySystem
     {
         if (TryComp<ActorComponent>(ent, out var actor))
             CleanupPvsOverride(ent, actor.PlayerSession);
+
         CleanupChangelingNullspaceIdentities(ent);
+        CleanupDevouredReferences(ent);
+    }
+
+    private void OnDevouredShutdown(Entity<ChangelingDevouredComponent> ent, ref ComponentShutdown args)
+    {
+        // We remove all references to this entity for all changelings that devoured it.
+        foreach (var ling in ent.Comp.DevouredBy)
+        {
+            if (!TryComp<ChangelingIdentityComponent>(ling, out var identityComp))
+                continue;
+
+            var key = identityComp.ConsumedIdentities.FirstOrDefault(x => x.Value == ent.Owner).Key;
+            identityComp.ConsumedIdentities[key] = null;
+
+            Dirty(ling, identityComp);
+        }
     }
 
     private void OnStoredRemove(Entity<ChangelingStoredIdentityComponent> ent, ref ComponentRemove args)
@@ -78,7 +98,26 @@ public abstract class SharedChangelingIdentitySystem : EntitySystem
 
         foreach (var consumedIdentity in ent.Comp.ConsumedIdentities)
         {
-            QueueDel(consumedIdentity);
+            QueueDel(consumedIdentity.Key);
+        }
+    }
+
+    /// <summary>
+    /// Removes all references to the owning changeling from ChangelingDevouredComponents.
+    /// </summary>
+    /// <param name="ent">The changeling entity</param>
+    private void CleanupDevouredReferences(Entity<ChangelingIdentityComponent> ent)
+    {
+        foreach (var entity in ent.Comp.ConsumedIdentities)
+        {
+            if (!TryComp<ChangelingDevouredComponent>(entity.Value, out var devoured))
+                continue;
+
+            if (!devoured.DevouredBy.Contains(ent.Owner))
+                continue;
+
+            devoured.DevouredBy.Remove(ent.Owner);
+            Dirty(entity.Value.Value, devoured);
         }
     }
 
@@ -132,7 +171,7 @@ public abstract class SharedChangelingIdentitySystem : EntitySystem
         if (clone == null)
             return null;
 
-        ent.Comp.ConsumedIdentities.Add(clone.Value);
+        ent.Comp.ConsumedIdentities.Add(clone.Value, target);
 
         Dirty(ent);
         HandlePvsOverride(ent, clone.Value);
@@ -157,12 +196,12 @@ public abstract class SharedChangelingIdentitySystem : EntitySystem
     /// Cleanup all PVS overrides for the owner of the ChangelingIdentity
     /// </summary>
     /// <param name="ent">The changeling storing the identities.</param>
-    /// <param name="entityUid"The session you wish to remove the overrides from.</param>
+    /// <param name="session">The session you wish to remove the overrides from.</param>
     private void CleanupPvsOverride(Entity<ChangelingIdentityComponent> ent, ICommonSession session)
     {
         foreach (var identity in ent.Comp.ConsumedIdentities)
         {
-            _pvsOverrideSystem.RemoveSessionOverride(identity, session);
+            _pvsOverrideSystem.RemoveSessionOverride(identity.Key, session);
         }
     }
 
@@ -175,7 +214,7 @@ public abstract class SharedChangelingIdentitySystem : EntitySystem
     {
         foreach (var identity in ent.Comp.ConsumedIdentities)
         {
-            _pvsOverrideSystem.AddSessionOverride(identity, session);
+            _pvsOverrideSystem.AddSessionOverride(identity.Key, session);
         }
     }
 

--- a/Content.Shared/Changeling/Systems/SharedChangelingIdentitySystem.cs
+++ b/Content.Shared/Changeling/Systems/SharedChangelingIdentitySystem.cs
@@ -65,16 +65,24 @@ public abstract class SharedChangelingIdentitySystem : EntitySystem
         CleanupDevouredReferences(ent);
     }
 
+    // Set all references to this entity to null to prevent PVS errors when networking.
     private void OnDevouredShutdown(Entity<ChangelingDevouredComponent> ent, ref ComponentShutdown args)
     {
-        // We remove all references to this entity for all changelings that devoured it.
         foreach (var ling in ent.Comp.DevouredBy)
         {
             if (!TryComp<ChangelingIdentityComponent>(ling, out var identityComp))
                 continue;
 
-            var key = identityComp.ConsumedIdentities.FirstOrDefault(x => x.Value == ent.Owner).Key;
-            identityComp.ConsumedIdentities[key] = null;
+            var keysToUpdate = identityComp.ConsumedIdentities
+                .Where(kvp => kvp.Value == ent.Owner)
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            if (keysToUpdate.Count == 0)
+                continue; // No need to dirty.
+
+            foreach (var key in keysToUpdate)
+                identityComp.ConsumedIdentities[key] = null;
 
             Dirty(ling, identityComp);
         }
@@ -108,16 +116,13 @@ public abstract class SharedChangelingIdentitySystem : EntitySystem
     /// <param name="ent">The changeling entity</param>
     private void CleanupDevouredReferences(Entity<ChangelingIdentityComponent> ent)
     {
-        foreach (var entity in ent.Comp.ConsumedIdentities)
+        foreach (var devouredUid in ent.Comp.ConsumedIdentities.Values)
         {
-            if (!TryComp<ChangelingDevouredComponent>(entity.Value, out var devoured))
+            if (!TryComp<ChangelingDevouredComponent>(devouredUid, out var devouredComp))
                 continue;
 
-            if (!devoured.DevouredBy.Contains(ent.Owner))
-                continue;
-
-            devoured.DevouredBy.Remove(ent.Owner);
-            Dirty(entity.Value.Value, devoured);
+            if (devouredComp.DevouredBy.Remove(ent.Owner))
+                Dirty(devouredUid.Value, devouredComp);
         }
     }
 

--- a/Resources/Locale/en-US/changeling/changeling.ftl
+++ b/Resources/Locale/en-US/changeling/changeling.ftl
@@ -1,6 +1,8 @@
 ﻿roles-antag-changeling-name = Changeling
 roles-antag-changeling-objective = A intelligent predator that assumes the identities of its victims.
 
+changeling-devour-attempt-failed-cannot-devour = We cannot devour this!
+changeling-devour-attempt-failed-already-devoured = We already consumed this body!
 changeling-devour-attempt-failed-not-dead = This body yet lives! We cannot consume it alive!
 changeling-devour-attempt-failed-rotting = This corpse has only rotted biomass.
 changeling-devour-attempt-failed-protected = This victim's biomass is protected by armor!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed changelings being able to gain the same identity several times.
Will need updating to a relation system in the future.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
See https://github.com/space-wizards/space-station-14/issues/39439

## Technical details
<!-- Summary of code changes for easier review. -->
Added a marker component. ChangelingIdentity and ChangelingDevoured mutually clean up on shutdown.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/7991789e-7b7c-4d27-a413-9ad1d761d8db


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`ChangelingIdentityComponent.ConsumedIdentities` is now a `Dictionary<EntityUid, EntityUid?>` instead of `List<EntityUid>`.
All usages of values from the list will need to be updated to use the Key instead.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
I wish changeling was out already.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
