### PR TITLE
Fix Human HeadTop

### DIFF
--- a/Resources/Prototypes/Body/Species/human.yml
+++ b/Resources/Prototypes/Body/Species/human.yml
@@ -2,6 +2,9 @@
   parent: Undergarments
   id: Human
   limits:
+    enum.HumanoidVisualLayers.HeadTop:
+      limit: 1
+      required: false
     enum.HumanoidVisualLayers.Hair:
       limit: 1
       required: false


### PR DESCRIPTION
## About the PR
Added a missing `limit: 1` constraint to the `HeadTop` visual layer for humans. Prevents stacking multiple ear visual variants on the same character.

## Why / Balance
Fixes an oversight that allowed players to equip multiple conflicting head-top visuals simultaneously. This should not have been possible and leads to "gremlin" characters.

## Technical details
Added `limit: 1` to `enum.HumanoidVisualLayers.HeadTop` in human limits configuration.

## Media
### Before:
<img width="184" height="317" alt="image" src="https://github.com/user-attachments/assets/1756d35e-980f-4e8d-9fa2-6d580ca8aeea" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed being able to set multiple conflicting head-top visuals on humans at the same time.
