### PR TITLE
Atmos parens fixup and temp bias fix up

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -280,7 +280,12 @@ namespace Content.Server.Atmos.EntitySystems
             var moles = receiver.TotalMoles;
             var theirMoles = sharer.TotalMoles;
 
-            return (tileReceiver.AirArchived.Temperature * (moles + movedMoles)) - (tileSharer.AirArchived.Temperature * (theirMoles - movedMoles)) * Atmospherics.R / receiver.Volume;
+            // Pressure delta from ideal gas law: P = nRT / V.
+            // So, deltaP = ((n1 * T1) - (n2 * T2)) * R / V.
+            // Reference: https://en.wikipedia.org/wiki/Ideal_gas_law
+            return ((tileReceiver.AirArchived.Temperature * (moles + movedMoles)) -
+                    (tileSharer.AirArchived.Temperature * (theirMoles - movedMoles)))
+                   * Atmospherics.R / receiver.Volume;
         }
 
         /// <summary>

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -275,14 +275,13 @@ namespace Content.Server.Atmos.EntitySystems
                 }
             }
 
-            if (!(temperatureDelta > Atmospherics.MinimumTemperatureToMove) &&
+            if (!(MathF.Abs(temperatureDelta) > Atmospherics.MinimumTemperatureToMove) &&
                 !(MathF.Abs(movedMoles) > Atmospherics.MinimumMolesDeltaToMove)) return 0f;
             var moles = receiver.TotalMoles;
             var theirMoles = sharer.TotalMoles;
 
             // Pressure delta from ideal gas law: P = nRT / V.
             // So, deltaP = ((n1 * T1) - (n2 * T2)) * R / V.
-            // Reference: https://en.wikipedia.org/wiki/Ideal_gas_law
             return ((tileReceiver.AirArchived.Temperature * (moles + movedMoles)) -
                     (tileSharer.AirArchived.Temperature * (theirMoles - movedMoles)))
                    * Atmospherics.R / receiver.Volume;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
There was an error in the ideal gas law, and a temperature bias in share.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
wind shouldn't move backwards anymore, hopefully.
## Technical details
<!-- Summary of code changes for easier review. -->
I didn't do much testing, but everything seemed to work normally.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
