### PR TITLE
Fix LINDA pressure delta nonsense and weighting

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -117,8 +117,11 @@ namespace Content.Server.Atmos.EntitySystems
         private void Archive(TileAtmosphere tile, int fireCount)
         {
             if (tile.Air != null)
+            {
+                // TODO ATMOS: This is an extremely large hotspot in LINDA, accounting for 1/5th of its time.
+                // Please make GasMixture a struct or use a FauxGasMixture with an InlineArray to handle copying this sanely.
                 tile.AirArchived = new GasMixture(tile.Air);
-
+            }
             tile.ArchivedCycle = fireCount;
         }
 
@@ -197,12 +200,25 @@ namespace Content.Server.Atmos.EntitySystems
         }
 
         /// <summary>
-        ///     Shares gas between two tiles. Part of LINDA.
+        /// Performs a share operation between two tiles, sharing both physical gas and temperature.
         /// </summary>
+        /// <param name="tileReceiver">The <see cref="TileAtmosphere"/> receiving the share.</param>
+        /// <param name="tileSharer">The <see cref="TileAtmosphere"/> sharing its air.</param>
+        /// <param name="atmosAdjacentTurfs">The number of <see cref="TileAtmosphere"/>s next to the receiver that air can flow to.</param>
+        /// <returns>The pressure difference between the two tiles after sharing.</returns>
+        /// <para>LINDA is an FEA-like solver and this method is basically the core of it.
+        /// In FEA we divide the problem into infinitesimal parts and try to step towards the desired end state:
+        /// a steady state where all air is equalized between tiles.</para>
+        /// <para>To do this we share the tiles air between other tiles over time (as well as the temperature).
+        /// Note that the timestep is actually a cyclestep, so running the cycles faster leads to a faster equalization.
+        /// Hilarious, I know.</para>
         public float Share(TileAtmosphere tileReceiver, TileAtmosphere tileSharer, int atmosAdjacentTurfs)
         {
-            if (tileReceiver.Air is not {} receiver || tileSharer.Air is not {} sharer ||
-                    tileReceiver.AirArchived == null || tileSharer.AirArchived == null)
+            // TODO ATMOS: Method needs to timestep over deltaTime instead of per cycle
+            // TODO ATMOS: Method needs to account for adjacent turfs in the situation where air is moving from receiver to sharer.
+            // See https://github.com/tgstation/tgstation/pull/63785
+            if (tileReceiver.Air is not { } receiver || tileSharer.Air is not { } sharer ||
+                tileReceiver.AirArchived == null || tileSharer.AirArchived == null)
                 return 0f;
 
             var temperatureDelta = tileReceiver.AirArchived.Temperature - tileSharer.AirArchived.Temperature;
@@ -221,12 +237,13 @@ namespace Content.Server.Atmos.EntitySystems
             var movedMoles = 0f;
             var absMovedMoles = 0f;
 
-            for(var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
+            for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
             {
                 var thisValue = receiver.Moles[i];
                 var sharerValue = sharer.Moles[i];
                 var delta = (thisValue - sharerValue) / (atmosAdjacentTurfs + 1);
-                if (!(MathF.Abs(delta) >= Atmospherics.GasMinMoles)) continue;
+                if (!(MathF.Abs(delta) >= Atmospherics.GasMinMoles))
+                    continue;
                 if (absTemperatureDelta > Atmospherics.MinimumTemperatureDeltaToConsider)
                 {
                     var gasHeatCapacity = delta * GasMolarHeatCapacities[i];
@@ -240,8 +257,10 @@ namespace Content.Server.Atmos.EntitySystems
                     }
                 }
 
-                if (!receiver.Immutable) receiver.Moles[i] -= delta;
-                if (!sharer.Immutable) sharer.Moles[i] += delta;
+                if (!receiver.Immutable)
+                    receiver.Moles[i] -= delta;
+                if (!sharer.Immutable)
+                    sharer.Moles[i] += delta;
                 movedMoles += delta;
                 absMovedMoles += MathF.Abs(delta);
             }
@@ -256,16 +275,21 @@ namespace Content.Server.Atmos.EntitySystems
                 // Transfer of thermal energy (via changed heat capacity) between self and sharer.
                 if (!receiver.Immutable && newHeatCapacity > Atmospherics.MinimumHeatCapacity)
                 {
-                    receiver.Temperature = ((oldHeatCapacity * receiver.Temperature) - (heatCapacityToSharer * tileReceiver.AirArchived.Temperature) + (heatCapacitySharerToThis * tileSharer.AirArchived.Temperature)) / newHeatCapacity;
+                    receiver.Temperature =
+                        (oldHeatCapacity * receiver.Temperature -
+                         heatCapacityToSharer * tileReceiver.AirArchived.Temperature +
+                         heatCapacitySharerToThis * tileSharer.AirArchived.Temperature) / newHeatCapacity;
                 }
 
                 if (!sharer.Immutable && newSharerHeatCapacity > Atmospherics.MinimumHeatCapacity)
                 {
-                    sharer.Temperature = ((oldSharerHeatCapacity * sharer.Temperature) - (heatCapacitySharerToThis * tileSharer.AirArchived.Temperature) + (heatCapacityToSharer * tileReceiver.AirArchived.Temperature)) / newSharerHeatCapacity;
+                    sharer.Temperature =
+                        (oldSharerHeatCapacity * sharer.Temperature -
+                         heatCapacitySharerToThis * tileSharer.AirArchived.Temperature +
+                         heatCapacityToSharer * tileReceiver.AirArchived.Temperature) / newSharerHeatCapacity;
                 }
 
                 // Thermal energy of the system (self and sharer) is unchanged.
-
                 if (MathF.Abs(oldSharerHeatCapacity) > Atmospherics.MinimumHeatCapacity)
                 {
                     if (MathF.Abs(newSharerHeatCapacity / oldSharerHeatCapacity - 1) < 0.1)
@@ -275,12 +299,25 @@ namespace Content.Server.Atmos.EntitySystems
                 }
             }
 
-            if (!(temperatureDelta > Atmospherics.MinimumTemperatureToMove) &&
-                !(MathF.Abs(movedMoles) > Atmospherics.MinimumMolesDeltaToMove)) return 0f;
+            // If we didn't move enough air or if the temperature difference is too small,
+            // we don't consider there to be a pressure difference.
+            // TODO ATMOS: This is a very weird early return, please figure out why this exists because this logic seems to be double checked
+            // in a lot of other places (ex. HighPressureDelta).
+            if (!(absTemperatureDelta > Atmospherics.MinimumTemperatureToMove) &&
+                !(MathF.Abs(movedMoles) > Atmospherics.MinimumMolesDeltaToMove))
+                return 0f;
+
             var moles = receiver.TotalMoles;
             var theirMoles = sharer.TotalMoles;
 
-            return (tileReceiver.AirArchived.Temperature * (moles + movedMoles)) - (tileSharer.AirArchived.Temperature * (theirMoles - movedMoles)) * Atmospherics.R / receiver.Volume;
+            /*
+             To get the pressure delta:
+             PV = nRT
+             P = nRT / V
+             \Delta P = ((n_1 * T_1) - (n_2 * T_2)) * R / V
+             */
+            return (tileReceiver.AirArchived.Temperature * (moles + movedMoles) -
+                    tileSharer.AirArchived.Temperature * (theirMoles - movedMoles)) * Atmospherics.R / receiver.Volume;
         }
 
         /// <summary>

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -138,8 +138,18 @@ namespace Content.Shared.Atmos
         /// </summary>
         public const float MinimumAirToSuspend = (MolesCellStandard * MinimumAirRatioToSuspend);
 
-        public const float MinimumTemperatureToMove = (T20C + 100f);
+        /// <summary>
+        /// The minimum difference in temperature between <see cref="GasMixture"/>s
+        /// (<see cref="TileAtmosphere"/>s) required
+        /// for LINDA to report a pressure difference between them for space wind.
+        /// </summary>
+        public const float MinimumTemperatureToMove = 5f;
 
+        /// <summary>
+        /// The minimum difference in moles between <see cref="GasMixture"/>s
+        /// (<see cref="TileAtmosphere"/>s) required for LINDA to
+        /// report a pressure difference between them for space wind.
+        /// </summary>
         public const float MinimumMolesDeltaToMove = (MolesCellStandard * MinimumAirRatioToMove);
 
         /// <summary>

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -142,6 +142,7 @@ namespace Content.Shared.Atmos
         /// The minimum difference in temperature between <see cref="GasMixture"/>s
         /// (<see cref="TileAtmosphere"/>s) required
         /// for LINDA to report a pressure difference between them for space wind.
+        /// In Kelvin.
         /// </summary>
         public const float MinimumTemperatureToMove = 5f;
 


### PR DESCRIPTION
## About the PR
This PR fixes a LINDA math error that caused one gas tile to be incorrectly weighted when considering pressure deltas (a constant was not multiplied over).
This also fixes a missing `abs` in an early return check causing high temperature deltas to not report a share to `HighPressureDelta`.

Since the error pretty much only propegates down the `HighPressureDelta`	section of Atmospherics, only space wind and any other system that kept track of pressure deltas was affected. This also sometimes wasn't an issue if Monstermos is your primary equalization method. 

Thanks to @AppalachianHooch for figuring it out.

## Why / Balance
So, a pressure delta in only one direction is pretty bad...

## Technical details
LINDA's primary method, `Share`, returns a `float` representing the pressure difference between the tiles after equalization:
```C#
return (tileReceiver.AirArchived.Temperature * (moles + movedMoles)) - (tileSharer.AirArchived.Temperature * (theirMoles - movedMoles)) * Atmospherics.R / receiver.Volume;
```
This is actually being evaluated as:
```math
\Delta P =  \frac{(T_1 \cdot n_1) - (T_2 \cdot n_2) \cdot R}{V}
```
Instead of the correct derivation for pressure delta:
```math
\Delta P =  \frac{((T_1 \cdot n_1) - ((T_2 \cdot n_2)) \cdot R}{V}
```

In addition, some early return logic is incorrectly using the signed variant of the temperature delta instead of the absolute variant. Since the absolute variant when compared to the new limiter is a bit crazy, I changed it to be a little bit more lenient on what constitutes a minimum transfer.

## Media
No reversed flow directions (from the perspective of `HighPressureDelta`).
<img width="906" height="844" alt="image" src="https://github.com/user-attachments/assets/a134edcb-8608-42ee-85fc-eeedef913aa0" />

<img width="823" height="699" alt="image" src="https://github.com/user-attachments/assets/1e69c9d7-b1d6-45f5-8148-1b9efd595990" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The `Atmospherics.MinimumTemperatureToMove` shared `const` has been changed from `T20C + 100f` to `5f`.

**Changelog**
No CL unfortunately since space wind is disabled on upstream. For now. Smile.
