### PR TITLE
Adjust flare fade-out flicker

### DIFF
--- a/Content.Client/Light/EntitySystems/LightBehaviorSystem.cs
+++ b/Content.Client/Light/EntitySystems/LightBehaviorSystem.cs
@@ -40,7 +40,9 @@ public sealed class LightBehaviorSystem : EntitySystem
         }
         else
         {
-            StopLightBehaviour((uid, component), container.LightBehaviour.ID);
+            // Only stop this specific behavior, not all siblings with the same id
+            if (TryComp(uid, out AnimationPlayerComponent? animPlayer))
+                _player.Stop(uid, animPlayer, container.FullKey);
         }
     }
 
@@ -74,7 +76,7 @@ public sealed class LightBehaviorSystem : EntitySystem
             var propertyValue = AnimationHelper.GetAnimatableProperty(light, property);
             if (propertyValue != null)
             {
-                entity.Comp.OriginalPropertyValues.Add(property, propertyValue);
+                entity.Comp.OriginalPropertyValues[property] = propertyValue;
             }
         }
         else

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -60,15 +60,21 @@
         maxDuration: 45.0
         startValue: 2.5
         endValue: 10.0
-      - !type:RandomizeBehaviour # weaker flicker as it fades out
+      - !type:RandomizeBehaviour # add flicker as it fizzles out
         id: fade_out
         interpolate: Nearest
-        minDuration: 0.001
-        maxDuration: 0.001
-        startValue: 4.0
-        endValue: 8.0
+        minDuration: 0.01
+        maxDuration: 0.01
+        startValue: 1.5
+        endValue: 3.5
         property: Energy
         isLooped: true
+      - !type:FadeBehaviour # fade out energy without flicker initially
+        id: fade_out
+        property: Energy
+        maxDuration: 12.0
+        startValue: 9.0
+        endValue: 3.0
       - !type:FadeBehaviour # fade out radius as it burns out
         id: fade_out
         maxDuration: 15.0


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Reduced the very heavy constant flicker when the flare starts to fade-out. Switched to smooth `Linear` radius / energy reduction animation for ~75% of the fade-out. The remainder swaps only energy fade-out back to the `Nearest` interpolation animation, as I thought it looks cool fizzling out, this should hopefully be a good balance between previous behavior and accessibility.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves https://github.com/space-wizards/space-station-14/issues/43367
Flare duration and fade-out duration itself is the same as before, so no balance changes. Only lighting animation changed for accessibility.

## Technical details
<!-- Summary of code changes for easier review. -->
Slight changes to `LightBehaviorSystem` to allow registering multiple animations for the same property (e.g. Energy). This also should allow animations affecting the same property to stop independently of each other.

`flare.yml` now has a two-stage fade-out so the flickering is only active when the radius & energy are both very low.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/cb27474d-9729-4b10-8114-d818b8e31a11

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Flares now flicker only towards the end of burning out.
