### PR TITLE
Use dependencies for EntityQueries in Systems (Part 1: Client)

### DIFF
--- a/Content.Client/Audio/AmbientSoundSystem.cs
+++ b/Content.Client/Audio/AmbientSoundSystem.cs
@@ -30,6 +30,8 @@ public sealed class AmbientSoundSystem : SharedAmbientSoundSystem
     [Dependency] private readonly IOverlayManager _overlayManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] EntityQuery<TransformComponent> _transformQuery = default!;
+    [Dependency] EntityQuery<MetaDataComponent> _metaQuery = default!;
 
     protected override void QueueUpdate(EntityUid uid, AmbientSoundComponent ambience)
         => _treeSys.QueueTreeUpdate(uid, ambience);
@@ -235,8 +237,6 @@ public sealed class AmbientSoundSystem : SharedAmbientSoundSystem
     /// </summary>
     private void ProcessNearbyAmbience(TransformComponent playerXform)
     {
-        var query = GetEntityQuery<TransformComponent>();
-        var metaQuery = GetEntityQuery<MetaDataComponent>();
         var mapPos = _xformSystem.GetMapCoordinates(playerXform);
 
         // Remove out-of-range ambiences
@@ -249,9 +249,9 @@ public sealed class AmbientSoundSystem : SharedAmbientSoundSystem
             if (comp.Enabled &&
                 // Don't keep playing sounds that have changed since.
                 sound.Sound == comp.Sound &&
-                query.TryGetComponent(owner, out var xform) &&
+                _transformQuery.TryGetComponent(owner, out var xform) &&
                 xform.MapID == playerXform.MapID &&
-                !metaQuery.GetComponent(owner).EntityPaused)
+                !_metaQuery.GetComponent(owner).EntityPaused)
             {
                 // TODO: This is just trydistance for coordinates.
                 var distance = (xform.ParentUid == playerXform.ParentUid)
@@ -294,7 +294,7 @@ public sealed class AmbientSoundSystem : SharedAmbientSoundSystem
                 var comp = sourceEntity.Comp;
 
                 if (_playingSounds.ContainsKey(sourceEntity) ||
-                    metaQuery.GetComponent(uid).EntityPaused)
+                    _metaQuery.GetComponent(uid).EntityPaused)
                     continue;
 
                 var audioParams = _params

--- a/Content.Client/Audio/AmbientSoundSystem.cs
+++ b/Content.Client/Audio/AmbientSoundSystem.cs
@@ -30,8 +30,8 @@ public sealed class AmbientSoundSystem : SharedAmbientSoundSystem
     [Dependency] private readonly IOverlayManager _overlayManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] EntityQuery<TransformComponent> _transformQuery = default!;
-    [Dependency] EntityQuery<MetaDataComponent> _metaQuery = default!;
+    [Dependency] private readonly EntityQuery<TransformComponent> _transformQuery = default!;
+    [Dependency] private readonly EntityQuery<MetaDataComponent> _metaQuery = default!;
 
     protected override void QueueUpdate(EntityUid uid, AmbientSoundComponent ambience)
         => _treeSys.QueueTreeUpdate(uid, ambience);

--- a/Content.Client/Audio/AmbientSoundSystem.cs
+++ b/Content.Client/Audio/AmbientSoundSystem.cs
@@ -30,8 +30,6 @@ public sealed class AmbientSoundSystem : SharedAmbientSoundSystem
     [Dependency] private readonly IOverlayManager _overlayManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly EntityQuery<TransformComponent> _transformQuery = default!;
-    [Dependency] private readonly EntityQuery<MetaDataComponent> _metaQuery = default!;
 
     protected override void QueueUpdate(EntityUid uid, AmbientSoundComponent ambience)
         => _treeSys.QueueTreeUpdate(uid, ambience);
@@ -249,9 +247,9 @@ public sealed class AmbientSoundSystem : SharedAmbientSoundSystem
             if (comp.Enabled &&
                 // Don't keep playing sounds that have changed since.
                 sound.Sound == comp.Sound &&
-                _transformQuery.TryGetComponent(owner, out var xform) &&
+                TryComp(owner, out TransformComponent? xform) &&
                 xform.MapID == playerXform.MapID &&
-                !_metaQuery.GetComponent(owner).EntityPaused)
+                !Paused(owner))
             {
                 // TODO: This is just trydistance for coordinates.
                 var distance = (xform.ParentUid == playerXform.ParentUid)
@@ -294,7 +292,7 @@ public sealed class AmbientSoundSystem : SharedAmbientSoundSystem
                 var comp = sourceEntity.Comp;
 
                 if (_playingSounds.ContainsKey(sourceEntity) ||
-                    _metaQuery.GetComponent(uid).EntityPaused)
+                    Paused(uid))
                     continue;
 
                 var audioParams = _params

--- a/Content.Client/Audio/AmbientSoundTreeSystem.cs
+++ b/Content.Client/Audio/AmbientSoundTreeSystem.cs
@@ -23,8 +23,7 @@ public sealed class AmbientSoundTreeSystem : ComponentTreeSystem<AmbientSoundTre
 
         var pos = XformSystem.GetRelativePosition(
             entry.Transform,
-            entry.Component.TreeUid.Value,
-            GetEntityQuery<TransformComponent>());
+            entry.Component.TreeUid.Value);
 
         return ExtractAabb(in entry, pos, default);
     }

--- a/Content.Client/CardboardBox/CardboardBoxSystem.cs
+++ b/Content.Client/CardboardBox/CardboardBoxSystem.cs
@@ -14,14 +14,12 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
-
-    private EntityQuery<MobStateComponent> _mobStateQuery;
+    [Dependency] private readonly EntityQuery<MobStateComponent> _mobStateQuery = default!;
+    [Dependency] private readonly EntityQuery<TransformComponent> _transformQuery = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-
-        _mobStateQuery = GetEntityQuery<MobStateComponent>();
 
         SubscribeNetworkEvent<PlayBoxEffectMessage>(OnBoxEffect);
     }
@@ -33,9 +31,7 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         if (!TryComp<CardboardBoxComponent>(source, out var box))
             return;
 
-        var xformQuery = GetEntityQuery<TransformComponent>();
-
-        if (!xformQuery.TryGetComponent(source, out var xform))
+        if (!_transformQuery.TryGetComponent(source, out var xform))
             return;
 
         var sourcePos = _transform.GetMapCoordinates(source, xform);
@@ -72,7 +68,7 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
 
             var ent = Spawn(box.Effect, mapPos);
 
-            if (!xformQuery.TryGetComponent(ent, out var entTransform) || !TryComp<SpriteComponent>(ent, out var sprite))
+            if (!_transformQuery.TryGetComponent(ent, out var entTransform) || !TryComp<SpriteComponent>(ent, out var sprite))
                 continue;
 
             _sprite.SetOffset((ent, sprite), new Vector2(0, 1));

--- a/Content.Client/CardboardBox/CardboardBoxSystem.cs
+++ b/Content.Client/CardboardBox/CardboardBoxSystem.cs
@@ -15,7 +15,6 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
     [Dependency] private readonly ExamineSystemShared _examine = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
     [Dependency] private readonly EntityQuery<MobStateComponent> _mobStateQuery = default!;
-    [Dependency] private readonly EntityQuery<TransformComponent> _transformQuery = default!;
 
     public override void Initialize()
     {
@@ -31,9 +30,7 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         if (!TryComp<CardboardBoxComponent>(source, out var box))
             return;
 
-        if (!_transformQuery.TryGetComponent(source, out var xform))
-            return;
-
+        var xform = Transform(source);
         var sourcePos = _transform.GetMapCoordinates(source, xform);
 
         //Any mob that can move should be surprised?
@@ -68,7 +65,7 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
 
             var ent = Spawn(box.Effect, mapPos);
 
-            if (!_transformQuery.TryGetComponent(ent, out var entTransform) || !TryComp<SpriteComponent>(ent, out var sprite))
+            if (!TryComp(ent, out TransformComponent? entTransform) || !TryComp<SpriteComponent>(ent, out var sprite))
                 continue;
 
             _sprite.SetOffset((ent, sprite), new Vector2(0, 1));

--- a/Content.Client/Clickable/ClickableSystem.cs
+++ b/Content.Client/Clickable/ClickableSystem.cs
@@ -16,17 +16,9 @@ public sealed class ClickableSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transforms = default!;
     [Dependency] private readonly SpriteSystem _sprites = default!;
 
-    private EntityQuery<ClickableComponent> _clickableQuery;
-    private EntityQuery<TransformComponent> _xformQuery;
-    private EntityQuery<FadingSpriteComponent> _fadingSpriteQuery;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-        _clickableQuery = GetEntityQuery<ClickableComponent>();
-        _xformQuery = GetEntityQuery<TransformComponent>();
-        _fadingSpriteQuery = GetEntityQuery<FadingSpriteComponent>();
-    }
+    [Dependency] private readonly EntityQuery<ClickableComponent> _clickableQuery = default!;
+    [Dependency] private readonly EntityQuery<TransformComponent> _xformQuery = default!;
+    [Dependency] private readonly EntityQuery<FadingSpriteComponent> _fadingSpriteQuery = default!;
 
     /// <summary>
     /// Used to check whether a click worked. Will first check if the click falls inside of some explicit bounding

--- a/Content.Client/DoAfter/DoAfterSystem.cs
+++ b/Content.Client/DoAfter/DoAfterSystem.cs
@@ -50,9 +50,7 @@ public sealed class DoAfterSystem : SharedDoAfterSystem
 
         var time = GameTiming.CurTime;
         var comp = Comp<DoAfterComponent>(playerEntity.Value);
-        var xformQuery = GetEntityQuery<TransformComponent>();
-        var handsQuery = GetEntityQuery<HandsComponent>();
-        Update(playerEntity.Value, active, comp, time, xformQuery, handsQuery);
+        Update(playerEntity.Value, active, comp, time);
     }
 
     /// <summary>

--- a/Content.Client/IconSmoothing/IconSmoothSystem.cs
+++ b/Content.Client/IconSmoothing/IconSmoothSystem.cs
@@ -18,10 +18,8 @@ namespace Content.Client.IconSmoothing
     {
         [Dependency] private readonly SharedMapSystem _mapSystem = default!;
         [Dependency] private readonly SpriteSystem _sprite = default!;
-        [Dependency] private readonly EntityQuery<TransformComponent> _transformQuery = default!;
         [Dependency] private readonly EntityQuery<IconSmoothComponent> _iconSmoothQuery = default!;
         [Dependency] private readonly EntityQuery<SpriteComponent> _spriteQuery = default!;
-
 
         private readonly Queue<EntityUid> _dirtyEntities = new();
         private readonly Queue<EntityUid> _anchorChangedEntities = new();
@@ -113,7 +111,7 @@ namespace Content.Client.IconSmoothing
             // first process anchor state changes.
             while (_anchorChangedEntities.TryDequeue(out var uid))
             {
-                if (!_transformQuery.TryGetComponent(uid, out var xform))
+                if (!TryComp(uid, out TransformComponent? xform))
                     continue;
 
                 if (xform.MapID == MapId.Nullspace)
@@ -220,7 +218,7 @@ namespace Content.Client.IconSmoothing
             {
                 if (smooth is { Enabled: true } &&
                     TryComp<SmoothEdgeComponent>(uid, out var edge) &&
-                    _transformQuery.TryGetComponent(uid, out xform))
+                    TryComp(uid, out xform))
                 {
                     var directions = DirectionFlag.None;
 
@@ -247,7 +245,7 @@ namespace Content.Client.IconSmoothing
                 return;
             }
 
-            xform = _transformQuery.GetComponent(uid);
+            xform = Transform(uid);
             smooth.UpdateGeneration = _generation;
 
             if (!_spriteQuery.TryGetComponent(uid, out var sprite))

--- a/Content.Client/IconSmoothing/IconSmoothSystem.cs
+++ b/Content.Client/IconSmoothing/IconSmoothSystem.cs
@@ -18,6 +18,10 @@ namespace Content.Client.IconSmoothing
     {
         [Dependency] private readonly SharedMapSystem _mapSystem = default!;
         [Dependency] private readonly SpriteSystem _sprite = default!;
+        [Dependency] private readonly EntityQuery<TransformComponent> _transformQuery = default!;
+        [Dependency] private readonly EntityQuery<IconSmoothComponent> _iconSmoothQuery = default!;
+        [Dependency] private readonly EntityQuery<SpriteComponent> _spriteQuery = default!;
+
 
         private readonly Queue<EntityUid> _dirtyEntities = new();
         private readonly Queue<EntityUid> _anchorChangedEntities = new();
@@ -106,13 +110,10 @@ namespace Content.Client.IconSmoothing
         {
             base.FrameUpdate(frameTime);
 
-            var xformQuery = GetEntityQuery<TransformComponent>();
-            var smoothQuery = GetEntityQuery<IconSmoothComponent>();
-
             // first process anchor state changes.
             while (_anchorChangedEntities.TryDequeue(out var uid))
             {
-                if (!xformQuery.TryGetComponent(uid, out var xform))
+                if (!_transformQuery.TryGetComponent(uid, out var xform))
                     continue;
 
                 if (xform.MapID == MapId.Nullspace)
@@ -123,7 +124,7 @@ namespace Content.Client.IconSmoothing
                     continue;
                 }
 
-                DirtyNeighbours(uid, comp: null, xform, smoothQuery);
+                DirtyNeighbours(uid, comp: null, xform);
             }
 
             // Next, update actual sprites.
@@ -132,19 +133,16 @@ namespace Content.Client.IconSmoothing
 
             _generation += 1;
 
-            var spriteQuery = GetEntityQuery<SpriteComponent>();
-
             // Performance: This could be spread over multiple updates, or made parallel.
             while (_dirtyEntities.TryDequeue(out var uid))
             {
-                CalculateNewSprite(uid, spriteQuery, smoothQuery, xformQuery);
+                CalculateNewSprite(uid);
             }
         }
 
-        public void DirtyNeighbours(EntityUid uid, IconSmoothComponent? comp = null, TransformComponent? transform = null, EntityQuery<IconSmoothComponent>? smoothQuery = null)
+        public void DirtyNeighbours(EntityUid uid, IconSmoothComponent? comp = null, TransformComponent? transform = null)
         {
-            smoothQuery ??= GetEntityQuery<IconSmoothComponent>();
-            if (!smoothQuery.Value.Resolve(uid, ref comp) || !comp.Running)
+            if (!_iconSmoothQuery.Resolve(uid, ref comp) || !comp.Running)
                 return;
 
             _dirtyEntities.Enqueue(uid);
@@ -206,11 +204,7 @@ namespace Content.Client.IconSmoothing
                 _anchorChangedEntities.Enqueue(uid);
         }
 
-        private void CalculateNewSprite(EntityUid uid,
-            EntityQuery<SpriteComponent> spriteQuery,
-            EntityQuery<IconSmoothComponent> smoothQuery,
-            EntityQuery<TransformComponent> xformQuery,
-            IconSmoothComponent? smooth = null)
+        private void CalculateNewSprite(EntityUid uid, IconSmoothComponent? smooth = null)
         {
             TransformComponent? xform;
             Entity<MapGridComponent>? gridEntity = null;
@@ -218,7 +212,7 @@ namespace Content.Client.IconSmoothing
             // The generation check prevents updating an entity multiple times per tick.
             // As it stands now, it's totally possible for something to get queued twice.
             // Generation on the component is set after an update so we can cull updates that happened this generation.
-            if (!smoothQuery.Resolve(uid, ref smooth, false)
+            if (!_iconSmoothQuery.Resolve(uid, ref smooth, false)
                 || smooth.Mode == IconSmoothingMode.NoSprite
                 || smooth.UpdateGeneration == _generation
                 || !smooth.Enabled
@@ -226,7 +220,7 @@ namespace Content.Client.IconSmoothing
             {
                 if (smooth is { Enabled: true } &&
                     TryComp<SmoothEdgeComponent>(uid, out var edge) &&
-                    xformQuery.TryGetComponent(uid, out xform))
+                    _transformQuery.TryGetComponent(uid, out xform))
                 {
                     var directions = DirectionFlag.None;
 
@@ -237,13 +231,13 @@ namespace Content.Client.IconSmoothing
 
                         gridEntity = (gridUid, grid);
 
-                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.North)), smoothQuery))
+                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.North))))
                             directions |= DirectionFlag.North;
-                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.South)), smoothQuery))
+                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.South))))
                             directions |= DirectionFlag.South;
-                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.East)), smoothQuery))
+                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.East))))
                             directions |= DirectionFlag.East;
-                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.West)), smoothQuery))
+                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.West))))
                             directions |= DirectionFlag.West;
                     }
 
@@ -253,10 +247,10 @@ namespace Content.Client.IconSmoothing
                 return;
             }
 
-            xform = xformQuery.GetComponent(uid);
+            xform = _transformQuery.GetComponent(uid);
             smooth.UpdateGeneration = _generation;
 
-            if (!spriteQuery.TryGetComponent(uid, out var sprite))
+            if (!_spriteQuery.TryGetComponent(uid, out var sprite))
             {
                 Log.Error($"Encountered a icon-smoothing entity without a sprite: {ToPrettyString(uid)}");
                 RemCompDeferred(uid, smooth);
@@ -281,13 +275,13 @@ namespace Content.Client.IconSmoothing
             switch (smooth.Mode)
             {
                 case IconSmoothingMode.Corners:
-                    CalculateNewSpriteCorners(gridEntity, smooth, spriteEnt, xform, smoothQuery);
+                    CalculateNewSpriteCorners(gridEntity, smooth, spriteEnt, xform);
                     break;
                 case IconSmoothingMode.CardinalFlags:
-                    CalculateNewSpriteCardinal(gridEntity, smooth, spriteEnt, xform, smoothQuery);
+                    CalculateNewSpriteCardinal(gridEntity, smooth, spriteEnt, xform);
                     break;
                 case IconSmoothingMode.Diagonal:
-                    CalculateNewSpriteDiagonal(gridEntity, smooth, spriteEnt, xform, smoothQuery);
+                    CalculateNewSpriteDiagonal(gridEntity, smooth, spriteEnt, xform);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -295,7 +289,7 @@ namespace Content.Client.IconSmoothing
         }
 
         private void CalculateNewSpriteDiagonal(Entity<MapGridComponent>? gridEntity, IconSmoothComponent smooth,
-            Entity<SpriteComponent> sprite, TransformComponent xform, EntityQuery<IconSmoothComponent> smoothQuery)
+            Entity<SpriteComponent> sprite, TransformComponent xform)
         {
             if (gridEntity == null)
             {
@@ -320,7 +314,7 @@ namespace Content.Client.IconSmoothing
             for (var i = 0; i < neighbors.Length; i++)
             {
                 var neighbor = (Vector2i)rotation.RotateVec(neighbors[i]);
-                matching = matching && MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos + neighbor), smoothQuery);
+                matching = matching && MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos + neighbor));
             }
 
             if (matching)
@@ -333,7 +327,7 @@ namespace Content.Client.IconSmoothing
             }
         }
 
-        private void CalculateNewSpriteCardinal(Entity<MapGridComponent>? gridEntity, IconSmoothComponent smooth, Entity<SpriteComponent> sprite, TransformComponent xform, EntityQuery<IconSmoothComponent> smoothQuery)
+        private void CalculateNewSpriteCardinal(Entity<MapGridComponent>? gridEntity, IconSmoothComponent smooth, Entity<SpriteComponent> sprite, TransformComponent xform)
         {
             var dirs = CardinalConnectDirs.None;
 
@@ -347,13 +341,13 @@ namespace Content.Client.IconSmoothing
             var grid = gridEntity.Value.Comp;
 
             var pos = _mapSystem.TileIndicesFor(gridUid, grid, xform.Coordinates);
-            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.North)), smoothQuery))
+            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.North))))
                 dirs |= CardinalConnectDirs.North;
-            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.South)), smoothQuery))
+            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.South))))
                 dirs |= CardinalConnectDirs.South;
-            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.East)), smoothQuery))
+            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.East))))
                 dirs |= CardinalConnectDirs.East;
-            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.West)), smoothQuery))
+            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.West))))
                 dirs |= CardinalConnectDirs.West;
 
             _sprite.LayerSetRsiState(sprite.AsNullable(), 0, $"{smooth.StateBase}{(int)dirs}");
@@ -372,11 +366,11 @@ namespace Content.Client.IconSmoothing
             CalculateEdge(sprite, directions, sprite);
         }
 
-        private bool MatchingEntity(IconSmoothComponent smooth, AnchoredEntitiesEnumerator candidates, EntityQuery<IconSmoothComponent> smoothQuery)
+        private bool MatchingEntity(IconSmoothComponent smooth, AnchoredEntitiesEnumerator candidates)
         {
             while (candidates.MoveNext(out var entity))
             {
-                if (smoothQuery.TryGetComponent(entity, out var other) &&
+                if (_iconSmoothQuery.TryGetComponent(entity, out var other) &&
                     other.SmoothKey != null &&
                     (other.SmoothKey == smooth.SmoothKey || smooth.AdditionalKeys.Contains(other.SmoothKey)) &&
                     other.Enabled)
@@ -388,11 +382,11 @@ namespace Content.Client.IconSmoothing
             return false;
         }
 
-        private void CalculateNewSpriteCorners(Entity<MapGridComponent>? gridEntity, IconSmoothComponent smooth, Entity<SpriteComponent> spriteEnt, TransformComponent xform, EntityQuery<IconSmoothComponent> smoothQuery)
+        private void CalculateNewSpriteCorners(Entity<MapGridComponent>? gridEntity, IconSmoothComponent smooth, Entity<SpriteComponent> spriteEnt, TransformComponent xform)
         {
             var (cornerNE, cornerNW, cornerSW, cornerSE) = gridEntity == null
                 ? (CornerFill.None, CornerFill.None, CornerFill.None, CornerFill.None)
-                : CalculateCornerFill(gridEntity.Value, smooth, xform, smoothQuery);
+                : CalculateCornerFill(gridEntity.Value, smooth, xform);
 
             // TODO figure out a better way to set multiple sprite layers.
             // This will currently re-calculate the sprite bounding box 4 times.
@@ -422,20 +416,20 @@ namespace Content.Client.IconSmoothing
             CalculateEdge(spriteEnt, directions, sprite);
         }
 
-        private (CornerFill ne, CornerFill nw, CornerFill sw, CornerFill se) CalculateCornerFill(Entity<MapGridComponent> gridEntity, IconSmoothComponent smooth, TransformComponent xform, EntityQuery<IconSmoothComponent> smoothQuery)
+        private (CornerFill ne, CornerFill nw, CornerFill sw, CornerFill se) CalculateCornerFill(Entity<MapGridComponent> gridEntity, IconSmoothComponent smooth, TransformComponent xform)
         {
             var gridUid = gridEntity.Owner;
             var grid = gridEntity.Comp;
 
             var pos = _mapSystem.TileIndicesFor(gridUid, grid, xform.Coordinates);
-            var n = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.North)), smoothQuery);
-            var ne = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.NorthEast)), smoothQuery);
-            var e = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.East)), smoothQuery);
-            var se = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.SouthEast)), smoothQuery);
-            var s = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.South)), smoothQuery);
-            var sw = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.SouthWest)), smoothQuery);
-            var w = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.West)), smoothQuery);
-            var nw = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.NorthWest)), smoothQuery);
+            var n = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.North)));
+            var ne = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.NorthEast)));
+            var e = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.East)));
+            var se = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.SouthEast)));
+            var s = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.South)));
+            var sw = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.SouthWest)));
+            var w = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.West)));
+            var nw = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.NorthWest)));
 
             // ReSharper disable InconsistentNaming
             var cornerNE = CornerFill.None;

--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -48,6 +48,7 @@ public sealed class DragDropSystem : SharedDragDropSystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
+    [Dependency] private readonly EntityQuery<SpriteComponent> _spriteQuery = default!;
 
     // how often to recheck possible targets (prevents calling expensive
     // check logic each update)
@@ -433,11 +434,9 @@ public sealed class DragDropSystem : SharedDragDropSystem
         var bounds = new Box2(mousePos.Position - expansion, mousePos.Position + expansion);
         var pvsEntities = _lookup.GetEntitiesIntersecting(mousePos.MapId, bounds);
 
-        var spriteQuery = GetEntityQuery<SpriteComponent>();
-
         foreach (var entity in pvsEntities)
         {
-            if (!spriteQuery.TryGetComponent(entity, out var inRangeSprite) ||
+            if (!_spriteQuery.TryGetComponent(entity, out var inRangeSprite) ||
                 !inRangeSprite.Visible ||
                 entity == _draggedEntity)
             {

--- a/Content.Client/Movement/Systems/ClientSpriteMovementSystem.cs
+++ b/Content.Client/Movement/Systems/ClientSpriteMovementSystem.cs
@@ -10,14 +10,11 @@ namespace Content.Client.Movement.Systems;
 public sealed class ClientSpriteMovementSystem : SharedSpriteMovementSystem
 {
     [Dependency] private readonly SpriteSystem _sprite = default!;
-
-    private EntityQuery<SpriteComponent> _spriteQuery;
+    [Dependency] private readonly EntityQuery<SpriteComponent> _spriteQuery = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-
-        _spriteQuery = GetEntityQuery<SpriteComponent>();
 
         SubscribeLocalEvent<SpriteMovementComponent, AfterAutoHandleStateEvent>(OnAfterAutoHandleState);
     }

--- a/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
+++ b/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
@@ -12,13 +12,11 @@ public sealed class FloorOcclusionSystem : SharedFloorOcclusionSystem
 
     [Dependency] private readonly IPrototypeManager _proto = default!;
 
-    private EntityQuery<SpriteComponent> _spriteQuery;
+    [Dependency] private readonly EntityQuery<SpriteComponent> _spriteQuery = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-
-        _spriteQuery = GetEntityQuery<SpriteComponent>();
 
         SubscribeLocalEvent<FloorOcclusionComponent, ComponentStartup>(OnOcclusionStartup);
         SubscribeLocalEvent<FloorOcclusionComponent, ComponentShutdown>(OnOcclusionShutdown);

--- a/Content.Client/Outline/TargetOutlineSystem.cs
+++ b/Content.Client/Outline/TargetOutlineSystem.cs
@@ -27,6 +27,7 @@ public sealed class TargetOutlineSystem : EntitySystem
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    [Dependency] private readonly EntityQuery<SpriteComponent> _spriteQuery = default!;
 
     private bool _enabled = false;
 
@@ -130,11 +131,10 @@ public sealed class TargetOutlineSystem : EntitySystem
         var mousePos = _eyeManager.PixelToMap(_inputManager.MouseScreenPosition).Position;
         var bounds = new Box2(mousePos - LookupVector, mousePos + LookupVector);
         var pvsEntities = _lookup.GetEntitiesIntersecting(_eyeManager.CurrentEye.Position.MapId, bounds, LookupFlags.Approximate | LookupFlags.Static);
-        var spriteQuery = GetEntityQuery<SpriteComponent>();
 
         foreach (var entity in pvsEntities)
         {
-            if (!spriteQuery.TryGetComponent(entity, out var sprite) || !sprite.Visible)
+            if (!_spriteQuery.TryGetComponent(entity, out var sprite) || !sprite.Visible)
                 continue;
 
             // Check the predicate

--- a/Content.Client/Polymorph/Systems/ChameleonProjectorSystem.cs
+++ b/Content.Client/Polymorph/Systems/ChameleonProjectorSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Polymorph.Components;
 using Content.Shared.Polymorph.Systems;
 using Robust.Client.GameObjects;
-using Robust.Shared.Player;
 
 namespace Content.Client.Polymorph.Systems;
 
@@ -13,15 +12,12 @@ public sealed class ChameleonProjectorSystem : SharedChameleonProjectorSystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
 
-    private EntityQuery<AppearanceComponent> _appearanceQuery;
-    private EntityQuery<SpriteComponent> _spriteQuery;
+    [Dependency] private readonly EntityQuery<AppearanceComponent> _appearanceQuery = default!;
+    [Dependency] private readonly EntityQuery<SpriteComponent> _spriteQuery = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-
-        _appearanceQuery = GetEntityQuery<AppearanceComponent>();
-        _spriteQuery = GetEntityQuery<SpriteComponent>();
 
         SubscribeLocalEvent<ChameleonDisguiseComponent, AfterAutoHandleStateEvent>(OnHandleState);
 

--- a/Content.Client/Replay/Spectator/ReplaySpectatorSystem.Movement.cs
+++ b/Content.Client/Replay/Spectator/ReplaySpectatorSystem.Movement.cs
@@ -74,8 +74,7 @@ public sealed partial class ReplaySpectatorSystem
         if ((Direction & DirectionFlag.East) != 0)
             effectiveDir &= ~DirectionFlag.West;
 
-        var query = GetEntityQuery<TransformComponent>();
-        var xform = query.GetComponent(player);
+        var xform = Transform(player);
         var pos = _transform.GetWorldPosition(xform);
 
         if (!xform.ParentUid.IsValid())

--- a/Content.Client/Silicons/Borgs/BorgSystem.Battery.cs
+++ b/Content.Client/Silicons/Borgs/BorgSystem.Battery.cs
@@ -13,16 +13,11 @@ public sealed partial class BorgSystem
     // Don't put this on the component because we only need to track the time for a single entity
     // and we don't want to TryComp it every single tick.
     private TimeSpan _nextAlertUpdate = TimeSpan.Zero;
-    private EntityQuery<BorgChassisComponent> _chassisQuery;
-    private EntityQuery<PowerCellSlotComponent> _slotQuery;
 
     public void InitializeBattery()
     {
         SubscribeLocalEvent<BorgChassisComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<BorgChassisComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
-
-        _chassisQuery = GetEntityQuery<BorgChassisComponent>();
-        _slotQuery = GetEntityQuery<PowerCellSlotComponent>();
     }
 
     private void OnPlayerAttached(Entity<BorgChassisComponent> ent, ref LocalPlayerAttachedEvent args)

--- a/Content.Client/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Client/Silicons/Borgs/BorgSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared.Mobs;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.PowerCell;
+using Content.Shared.PowerCell.Components;
 using Content.Shared.Silicons.Borgs;
 using Content.Shared.Silicons.Borgs.Components;
 using Robust.Client.GameObjects;
@@ -22,6 +23,8 @@ public sealed partial class BorgSystem : SharedBorgSystem
     [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly EntityQuery<BorgChassisComponent> _chassisQuery = default!;
+    [Dependency] private readonly EntityQuery<PowerCellSlotComponent> _slotQuery = default!;
 
     public override void Initialize()
     {

--- a/Content.Client/Sprite/SpriteFadeSystem.cs
+++ b/Content.Client/Sprite/SpriteFadeSystem.cs
@@ -27,15 +27,14 @@ public sealed class SpriteFadeSystem : EntitySystem
     [Dependency] private readonly IInputManager _inputManager = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
+    [Dependency] private readonly EntityQuery<SpriteComponent> _spriteQuery = default!;
+    [Dependency] private readonly EntityQuery<SpriteFadeComponent> _fadeQuery = default!;
+    [Dependency] private readonly EntityQuery<FadingSpriteComponent> _fadingQuery = default!;
+    [Dependency] private readonly EntityQuery<FixturesComponent> _fixturesQuery = default!;
 
     private List<(MapCoordinates Point, bool ExcludeBoundingBox)> _points = new();
 
     private readonly HashSet<FadingSpriteComponent> _comps = new();
-
-    private EntityQuery<SpriteComponent> _spriteQuery;
-    private EntityQuery<SpriteFadeComponent> _fadeQuery;
-    private EntityQuery<FadingSpriteComponent> _fadingQuery;
-    private EntityQuery<FixturesComponent> _fixturesQuery;
 
     private const float TargetAlpha = 0.4f;
     private const float ChangeRate = 1f;
@@ -43,11 +42,6 @@ public sealed class SpriteFadeSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-
-        _spriteQuery = GetEntityQuery<SpriteComponent>();
-        _fadeQuery = GetEntityQuery<SpriteFadeComponent>();
-        _fadingQuery = GetEntityQuery<FadingSpriteComponent>();
-        _fixturesQuery = GetEntityQuery<FixturesComponent>();
 
         SubscribeLocalEvent<FadingSpriteComponent, ComponentShutdown>(OnFadingShutdown);
     }

--- a/Content.Client/Sticky/Visualizers/StickyVisualizerSystem.cs
+++ b/Content.Client/Sticky/Visualizers/StickyVisualizerSystem.cs
@@ -5,13 +5,11 @@ namespace Content.Client.Sticky.Visualizers;
 
 public sealed class StickyVisualizerSystem : VisualizerSystem<StickyVisualizerComponent>
 {
-    private EntityQuery<SpriteComponent> _spriteQuery;
+    [Dependency] private readonly EntityQuery<SpriteComponent> _spriteQuery = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-
-        _spriteQuery = GetEntityQuery<SpriteComponent>();
 
         SubscribeLocalEvent<StickyVisualizerComponent, ComponentInit>(OnInit);
     }

--- a/Content.Client/SubFloor/TrayScannerSystem.cs
+++ b/Content.Client/SubFloor/TrayScannerSystem.cs
@@ -20,7 +20,6 @@ public sealed class TrayScannerSystem : SharedTrayScannerSystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
     [Dependency] private readonly TrayScanRevealSystem _trayScanReveal = default!;
-    [Dependency] private readonly EntityQuery<TransformComponent> _transformQuery = default!;
     [Dependency] private readonly EntityQuery<TrayScannerComponent> _trayScannerQuery = default!;
     [Dependency] private readonly EntityQuery<SubFloorHideComponent> _subFloorHideQuery = default!;
 
@@ -39,7 +38,7 @@ public sealed class TrayScannerSystem : SharedTrayScannerSystem
         // TODO: Multiple viewports or w/e
         var player = _player.LocalEntity;
 
-        if (!_transformQuery.TryGetComponent(player, out var playerXform))
+        if (!TryComp(player, out TransformComponent? playerXform))
             return;
 
         var playerPos = _transform.GetWorldPosition(playerXform);

--- a/Content.Client/SubFloor/TrayScannerSystem.cs
+++ b/Content.Client/SubFloor/TrayScannerSystem.cs
@@ -20,6 +20,9 @@ public sealed class TrayScannerSystem : SharedTrayScannerSystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
     [Dependency] private readonly TrayScanRevealSystem _trayScanReveal = default!;
+    [Dependency] private readonly EntityQuery<TransformComponent> _transformQuery = default!;
+    [Dependency] private readonly EntityQuery<TrayScannerComponent> _trayScannerQuery = default!;
+    [Dependency] private readonly EntityQuery<SubFloorHideComponent> _subFloorHideQuery = default!;
 
     private const string TRayAnimationKey = "trays";
     private const double AnimationLength = 0.3;
@@ -35,16 +38,14 @@ public sealed class TrayScannerSystem : SharedTrayScannerSystem
 
         // TODO: Multiple viewports or w/e
         var player = _player.LocalEntity;
-        var xformQuery = GetEntityQuery<TransformComponent>();
 
-        if (!xformQuery.TryGetComponent(player, out var playerXform))
+        if (!_transformQuery.TryGetComponent(player, out var playerXform))
             return;
 
-        var playerPos = _transform.GetWorldPosition(playerXform, xformQuery);
+        var playerPos = _transform.GetWorldPosition(playerXform);
         var playerMap = playerXform.MapID;
         var range = 0f;
         HashSet<Entity<SubFloorHideComponent>> inRange;
-        var scannerQuery = GetEntityQuery<TrayScannerComponent>();
 
         // TODO: Should probably sub to player attached changes / inventory changes but inventory's
         // API is extremely skrungly. If this ever shows up on dottrace ping me and laugh.
@@ -57,7 +58,7 @@ public sealed class TrayScannerSystem : SharedTrayScannerSystem
             {
                 foreach (var ent in slot.ContainedEntities)
                 {
-                    if (!scannerQuery.TryGetComponent(ent, out var sneakScanner) || !sneakScanner.Enabled)
+                    if (!_trayScannerQuery.TryGetComponent(ent, out var sneakScanner) || !sneakScanner.Enabled)
                         continue;
 
                     canSee = true;
@@ -71,7 +72,7 @@ public sealed class TrayScannerSystem : SharedTrayScannerSystem
             if (!_hands.TryGetHeldItem(player.Value, hand, out var heldEntity))
                 continue;
 
-            if (!scannerQuery.TryGetComponent(heldEntity, out var heldScanner) || !heldScanner.Enabled)
+            if (!_trayScannerQuery.TryGetComponent(heldEntity, out var heldScanner) || !heldScanner.Enabled)
                 continue;
 
             range = MathF.Max(heldScanner.Range, range);
@@ -93,13 +94,12 @@ public sealed class TrayScannerSystem : SharedTrayScannerSystem
         }
 
         var revealedQuery = AllEntityQuery<TrayRevealedComponent, SpriteComponent>();
-        var subfloorQuery = GetEntityQuery<SubFloorHideComponent>();
 
         while (revealedQuery.MoveNext(out var uid, out _, out var sprite))
         {
             // Revealing
             // Add buffer range to avoid flickers.
-            if (subfloorQuery.TryGetComponent(uid, out var subfloor) &&
+            if (_subFloorHideQuery.TryGetComponent(uid, out var subfloor) &&
                 inRange.Contains((uid, subfloor)))
             {
                 // Due to the fact client is predicting this server states will reset it constantly

--- a/Content.Client/UserInterface/BuiPreTickUpdateSystem.cs
+++ b/Content.Client/UserInterface/BuiPreTickUpdateSystem.cs
@@ -33,15 +33,7 @@ public sealed class BuiPreTickUpdateSystem : EntitySystem
     [Dependency] private readonly IPlayerManager _playerManager = null!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = null!;
     [Dependency] private readonly IGameTiming _gameTiming = null!;
-
-    private EntityQuery<UserInterfaceUserComponent> _userQuery;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        _userQuery = GetEntityQuery<UserInterfaceUserComponent>();
-    }
+    [Dependency] private readonly EntityQuery<UserInterfaceUserComponent> _userQuery = default!;
 
     public void RunUpdates()
     {

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -34,6 +34,7 @@ namespace Content.Client.Verbs
         [Dependency] private readonly SharedContainerSystem _containers = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
         [Dependency] private readonly EntityLookupSystem _lookup = default!;
+        [Dependency] private readonly EntityQuery<SpriteComponent> _spriteQuery = default!;
 
         private float _lookupSize;
 
@@ -159,10 +160,9 @@ namespace Content.Client.Verbs
             if (container == null && (visibility & MenuVisibility.InContainer) == 0)
                 return entities.Count != 0;
 
-            var spriteQuery = GetEntityQuery<SpriteComponent>();
             for (var i = entities.Count - 1; i >= 0; i--)
             {
-                if (!spriteQuery.TryGetComponent(entities[i], out var spriteComponent) || !spriteComponent.Visible)
+                if (!_spriteQuery.TryGetComponent(entities[i], out var spriteComponent) || !spriteComponent.Visible)
                     entities.RemoveSwap(i);
             }
 

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
@@ -32,7 +32,7 @@ public sealed partial class MeleeWeaponSystem
         if (localPos == Vector2.Zero || animation == null)
             return;
 
-        if (!_xformQuery.TryGetComponent(user, out var userXform) || userXform.MapID == MapId.Nullspace)
+        if (!TryComp(user, out TransformComponent? userXform) || userXform.MapID == MapId.Nullspace)
             return;
 
         var animationUid = Spawn(animation, userXform.Coordinates);
@@ -64,7 +64,7 @@ public sealed partial class MeleeWeaponSystem
         }
         _sprite.SetRotation((animationUid, sprite), localPos.ToWorldAngle());
 
-        var xform = _xformQuery.GetComponent(animationUid);
+        var xform = Transform(animationUid);
         TrackUserComponent track;
 
         switch (arcComponent.Animation)

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -34,15 +34,14 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
-
-    private EntityQuery<TransformComponent> _xformQuery;
+    [Dependency] private EntityQuery<TransformComponent> _xformQuery = default!;
 
     private const string MeleeLungeKey = "melee-lunge";
 
     public override void Initialize()
     {
         base.Initialize();
-        _xformQuery = GetEntityQuery<TransformComponent>();
+
         SubscribeNetworkEvent<MeleeLungeEvent>(OnMeleeLunge);
         UpdatesOutsidePrediction = true;
     }

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -34,7 +34,6 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
-    [Dependency] private EntityQuery<TransformComponent> _xformQuery = default!;
 
     private const string MeleeLungeKey = "melee-lunge";
 
@@ -176,7 +175,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     private void ClientHeavyAttack(EntityUid user, EntityCoordinates coordinates, EntityUid meleeUid, MeleeWeaponComponent component)
     {
         // Only run on first prediction to avoid the potential raycast entities changing.
-        if (!_xformQuery.TryGetComponent(user, out var userXform) ||
+        if (!TryComp(user, out TransformComponent? userXform) ||
             !Timing.IsFirstTimePredicted)
         {
             return;

--- a/Content.Client/Weather/WeatherSystem.cs
+++ b/Content.Client/Weather/WeatherSystem.cs
@@ -20,19 +20,15 @@ public sealed class WeatherSystem : SharedWeatherSystem
     [Dependency] private readonly MapSystem _mapSystem = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
-    private EntityQuery<AudioComponent> _audioQuery;
-    private EntityQuery<MapGridComponent> _gridQuery;
-    private EntityQuery<RoofComponent> _roofQuery;
+    [Dependency] private readonly EntityQuery<AudioComponent> _audioQuery = default!;
+    [Dependency] private readonly EntityQuery<MapGridComponent> _gridQuery = default!;
+    [Dependency] private readonly EntityQuery<RoofComponent> _roofQuery = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<WeatherStatusEffectComponent, ComponentShutdown>(OnComponentShutdown);
-
-        _audioQuery = GetEntityQuery<AudioComponent>();
-        _gridQuery = GetEntityQuery<MapGridComponent>();
-        _roofQuery = GetEntityQuery<RoofComponent>();
     }
 
     private void OnComponentShutdown(Entity<WeatherStatusEffectComponent> ent, ref ComponentShutdown args)

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -2,6 +2,8 @@ using Content.Shared.Gravity;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Robust.Shared.Exceptions;
+using Robust.Shared.Network;
 
 namespace Content.Shared.DoAfter;
 

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -2,8 +2,6 @@ using Content.Shared.Gravity;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
-using Robust.Shared.Exceptions;
-using Robust.Shared.Network;
 
 namespace Content.Shared.DoAfter;
 
@@ -17,6 +15,8 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
     [Dependency] private readonly SharedGravitySystem _gravity = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] EntityQuery<TransformComponent> _xformQuery = default!;
+    [Dependency] EntityQuery<HandsComponent> _handsQuery = default!;
 
     private DoAfter[] _doAfters = Array.Empty<DoAfter>();
 
@@ -34,7 +34,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
 
             try
             {
-                Update(uid, active, comp, time, xformQuery, handsQuery);
+                Update(uid, active, comp, time);
             }
             // ReSharper disable once RedundantCatchClause
 #if EXCEPTION_TOLERANCE
@@ -87,9 +87,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         EntityUid uid,
         ActiveDoAfterComponent active,
         DoAfterComponent comp,
-        TimeSpan time,
-        EntityQuery<TransformComponent> xformQuery,
-        EntityQuery<HandsComponent> handsQuery)
+        TimeSpan time)
     {
         var dirty = false;
 
@@ -122,7 +120,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
                 continue;
             }
 
-            if (ShouldCancel(doAfter, xformQuery, handsQuery))
+            if (ShouldCancel(doAfter))
             {
                 InternalCancel(doAfter, comp);
                 dirty = true;
@@ -196,27 +194,25 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         }
     }
 
-    private bool ShouldCancel(DoAfter doAfter,
-        EntityQuery<TransformComponent> xformQuery,
-        EntityQuery<HandsComponent> handsQuery)
+    private bool ShouldCancel(DoAfter doAfter)
     {
         var args = doAfter.Args;
 
         //re-using xformQuery for Exists() checks.
-        if (args.Used is { } used && !xformQuery.HasComponent(used))
+        if (args.Used is { } used && !_xformQuery.HasComponent(used))
             return true;
 
-        if (args.EventTarget is { Valid: true } eventTarget && !xformQuery.HasComponent(eventTarget))
+        if (args.EventTarget is { Valid: true } eventTarget && !_xformQuery.HasComponent(eventTarget))
             return true;
 
-        if (!xformQuery.TryGetComponent(args.User, out var userXform))
+        if (!_xformQuery.TryGetComponent(args.User, out var userXform))
             return true;
 
         TransformComponent? targetXform = null;
-        if (args.Target is { } target && !xformQuery.TryGetComponent(target, out targetXform))
+        if (args.Target is { } target && !_xformQuery.TryGetComponent(target, out targetXform))
             return true;
 
-        if (args.Used is { } @using && !xformQuery.HasComp(@using))
+        if (args.Used is { } @using && !_xformQuery.HasComp(@using))
             return true;
 
         // TODO: Re-use existing xform query for these calculations.
@@ -265,7 +261,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         // This does not mean their hand needs to be empty.
         if (args.NeedHand)
         {
-            if (!handsQuery.TryGetComponent(args.User, out var hands) || hands.Count == 0)
+            if (!_handsQuery.TryGetComponent(args.User, out var hands) || hands.Count == 0)
                 return true;
 
             // If an item was in the user's hand to begin with,

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -17,7 +17,6 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
     [Dependency] private readonly SharedGravitySystem _gravity = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
-    [Dependency] EntityQuery<TransformComponent> _xformQuery = default!;
     [Dependency] EntityQuery<HandsComponent> _handsQuery = default!;
 
     private DoAfter[] _doAfters = Array.Empty<DoAfter>();
@@ -200,21 +199,20 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
     {
         var args = doAfter.Args;
 
-        //re-using xformQuery for Exists() checks.
-        if (args.Used is { } used && !_xformQuery.HasComponent(used))
+        if (args.Used is { } used && !Exists(used))
             return true;
 
-        if (args.EventTarget is { Valid: true } eventTarget && !_xformQuery.HasComponent(eventTarget))
+        if (args.EventTarget is { Valid: true } eventTarget && !Exists(eventTarget))
             return true;
 
-        if (!_xformQuery.TryGetComponent(args.User, out var userXform))
+        if (!TryComp(args.User, out TransformComponent? userXform))
             return true;
 
         TransformComponent? targetXform = null;
-        if (args.Target is { } target && !_xformQuery.TryGetComponent(target, out targetXform))
+        if (args.Target is { } target && !TryComp(target, out targetXform))
             return true;
 
-        if (args.Used is { } @using && !_xformQuery.HasComp(@using))
+        if (args.Used is { } @using && !Exists(@using))
             return true;
 
         // TODO: Re-use existing xform query for these calculations.

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -251,7 +251,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         doAfter.NetInitialItem = GetNetEntity(doAfter.InitialItem);
 
         // Initial checks
-        if (ShouldCancel(doAfter, GetEntityQuery<TransformComponent>(), GetEntityQuery<HandsComponent>()))
+        if (ShouldCancel(doAfter))
             return false;
 
         if (args.AttemptFrequency == AttemptFrequency.StartAndEnd && !TryAttemptEvent(doAfter))


### PR DESCRIPTION
## About the PR
Gets rid of some boilerplate that is no longer needed.
I think it's better that we clean this up everywhere so that people stop copy pasting it.
See https://github.com/space-wizards/RobustToolbox/pull/6394

## Why / Balance
We have the technology

## Technical details
Just use `[Dependency]` instead of manually getting the query when initializing the system.
Some methods were repeatedly getting the query on each call, so I just made them use a single system-wide variable and removed any queries being passed along in parameters because that was redundant.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The following public system APIs no longer take `EntityQueries` as parameters:
`SharedDoAfterSystem.ShouldCancel`
`SharedDoAfterSystem.Update`

**Changelog**
not player facing