### PR TITLE
Elk Evac Shuttle - 2 Fixes 

### DIFF
--- a/Resources/Maps/Shuttles/emergency_delta.yml
+++ b/Resources/Maps/Shuttles/emergency_delta.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 266.0.0
+  engineVersion: 275.2.0
   forkId: ""
   forkVersion: ""
-  time: 09/17/2025 04:14:52
-  entityCount: 957
+  time: 04/05/2026 13:24:37
+  entityCount: 959
 maps: []
 grids:
 - 1
@@ -516,6 +516,9 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: ImplicitRoof
+    - type: TileHistory
+      chunkHistory: {}
+    - type: ExplosionAirtightGrid
 - proto: AirCanister
   entities:
   - uid: 326
@@ -523,10 +526,10 @@ entities:
     - type: Transform
       pos: -13.5,-3.5
       parent: 1
-  - uid: 445
+  - uid: 643
     components:
     - type: Transform
-      pos: -1.5,-18.5
+      pos: 0.5,-20.5
       parent: 1
 - proto: AirlockBrigGlassLocked
   entities:
@@ -732,6 +735,14 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-17.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 795
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,0.5
       parent: 1
     - type: Fixtures
       fixtures: {}
@@ -1714,6 +1725,11 @@ entities:
     - type: Transform
       pos: -2.5,-22.5
       parent: 1
+  - uid: 802
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 1
 - proto: CableHV
   entities:
   - uid: 33
@@ -2222,6 +2238,16 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-17.5
+      parent: 1
+  - uid: 958
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 1
+  - uid: 959
+    components:
+    - type: Transform
+      pos: -8.5,0.5
       parent: 1
 - proto: CableTerminal
   entities:
@@ -3134,11 +3160,11 @@ entities:
       parent: 1
 - proto: GasOutletInjector
   entities:
-  - uid: 801
+  - uid: 687
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-18.5
+      pos: 1.5,-20.5
       parent: 1
 - proto: GasPassiveVent
   entities:
@@ -3146,10 +3172,16 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-20.5
+      pos: 1.5,-19.5
       parent: 1
 - proto: GasPipeBend
   entities:
+  - uid: 680
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-20.5
+      parent: 1
   - uid: 856
     components:
     - type: Transform
@@ -3181,7 +3213,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,-20.5
+      pos: -0.5,-19.5
       parent: 1
   - uid: 514
     components:
@@ -3189,44 +3221,27 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,-16.5
       parent: 1
-  - uid: 643
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-20.5
-      parent: 1
   - uid: 644
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-20.5
+      pos: -1.5,-19.5
       parent: 1
   - uid: 675
     components:
     - type: Transform
       pos: -2.5,-17.5
       parent: 1
-  - uid: 680
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-18.5
-      parent: 1
   - uid: 699
     components:
     - type: Transform
-      pos: -2.5,-19.5
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-19.5
       parent: 1
   - uid: 707
     components:
     - type: Transform
       pos: -2.5,-18.5
-      parent: 1
-  - uid: 802
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-18.5
       parent: 1
   - uid: 840
     components:
@@ -3627,11 +3642,11 @@ entities:
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 795
+  - uid: 445
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,-20.5
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-19.5
       parent: 1
   - uid: 841
     components:
@@ -3741,11 +3756,11 @@ entities:
       parent: 1
 - proto: GasPort
   entities:
-  - uid: 687
+  - uid: 460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,-18.5
+      pos: 0.5,-20.5
       parent: 1
 - proto: GasVentPump
   entities:
@@ -4270,32 +4285,24 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,-18.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 119
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-20.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 130
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-19.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 293
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-21.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
 - proto: PosterLegitEnlist
   entities:
   - uid: 788
@@ -4657,393 +4664,281 @@ entities:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 7
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 15
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 18
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 19
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 81
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 82
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 101
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 142
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 170
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 171
     components:
     - type: Transform
       pos: -10.5,6.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 173
     components:
     - type: Transform
       pos: -10.5,7.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 174
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 182
     components:
     - type: Transform
       pos: -8.5,9.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 183
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 184
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 185
     components:
     - type: Transform
       pos: -5.5,9.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 186
     components:
     - type: Transform
       pos: -6.5,9.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 187
     components:
     - type: Transform
       pos: -7.5,9.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 261
     components:
     - type: Transform
       pos: -14.5,-3.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 262
     components:
     - type: Transform
       pos: -14.5,-4.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 263
     components:
     - type: Transform
       pos: -14.5,-5.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 264
     components:
     - type: Transform
       pos: -14.5,-6.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 265
     components:
     - type: Transform
       pos: -14.5,-7.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 267
     components:
     - type: Transform
       pos: -1.5,-22.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 274
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 327
     components:
     - type: Transform
       pos: -2.5,-22.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 330
     components:
     - type: Transform
       pos: -9.5,-11.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 331
     components:
     - type: Transform
       pos: -9.5,-14.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 338
     components:
     - type: Transform
       pos: -11.5,-17.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 339
     components:
     - type: Transform
       pos: -12.5,-17.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 342
     components:
     - type: Transform
       pos: -14.5,-12.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 343
     components:
     - type: Transform
       pos: -14.5,-13.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 344
     components:
     - type: Transform
       pos: -14.5,-14.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 345
     components:
     - type: Transform
       pos: -14.5,-15.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 430
     components:
     - type: Transform
       pos: -8.5,-17.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 432
     components:
     - type: Transform
       pos: -6.5,-17.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 469
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 470
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 471
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 478
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 479
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 513
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 515
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 530
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 533
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 535
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 557
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 712
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 760
     components:
     - type: Transform
       pos: -9.5,-7.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 764
     components:
     - type: Transform
       pos: -9.5,-6.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 817
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 819
     components:
     - type: Transform
       pos: -5.5,-14.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 820
     components:
     - type: Transform
       pos: -5.5,-16.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 821
     components:
     - type: Transform
       pos: -1.5,-16.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 837
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
 - proto: SignBridge
   entities:
   - uid: 11
@@ -5064,10 +4959,10 @@ entities:
       fixtures: {}
 - proto: SignEVA
   entities:
-  - uid: 460
+  - uid: 801
     components:
     - type: Transform
-      pos: -9.5,0.5
+      pos: -9.5,2.5
       parent: 1
     - type: Fixtures
       fixtures: {}
@@ -5952,8 +5847,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,-20.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
 - proto: WindoorSecureSecurityLocked
   entities:
   - uid: 37
@@ -5962,8 +5855,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
 - proto: WindowReinforcedDirectional
   entities:
   - uid: 660
@@ -5972,30 +5863,22 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,-19.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 682
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-18.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 746
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-21.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
   - uid: 755
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,2.5
       parent: 1
-    - type: DeltaPressure
-      gridUid: 1
 ...


### PR DESCRIPTION
## About the PR
Added an APC to the upper left room (it was missing and the section was unpowered)
Moved the air canister connector (it was located directly on top of directional window which meant that you weren't able to achor it)

## Why / Balance
I wanted to fix it

## Technical details
shuttle edit

## Media
<img width="572" height="552" alt="image" src="https://github.com/user-attachments/assets/1a6d1d8e-79fe-4cb0-a4e3-01f6bcba3cf5" />
<img width="465" height="425" alt="image" src="https://github.com/user-attachments/assets/3bd279d5-10b4-4f35-a827-aeda07fc916f" />

(idk how to render a grid like that, so i just made screenshot of changes)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
MAPS:
- tweak: On Fland Evac shuttle (Delta) Added missing APC in the upper left room
- tweak: On Fland Evac shuttle (Delta) Moved air canister connector