### PR TITLE
Uplink implants connect to the same store as the PDA, and also fix not giving stores to PDAs

### DIFF
--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -23,7 +23,7 @@ public sealed class StoreTests : GameTest
 - type: entity
   name: InventoryPdaDummy
   id: InventoryPdaDummy
-  parent: [BasePDA, StorePresetUplink]
+  parent: BasePDA
   components:
   - type: Clothing
     QuickEquip: false
@@ -144,7 +144,7 @@ public sealed class StoreTests : GameTest
 
 
                     var buyMsg = new StoreBuyListingMessage(discountedListingItem.ID, null){Actor = human};
-                    server.EntMan.EventBus.RaiseLocalEvent(pda, buyMsg);
+                    server.EntMan.EventBus.RaiseLocalEvent(storeEnt.Value, buyMsg);
 
                     var newBalance = storeComponent.Balance[UplinkSystem.TelecrystalCurrencyPrototype];
                     Assert.That(newBalance.Value, Is.EqualTo((originalBalance - plainDiscountedCost).Value), "Expected to have balance reduced by discounted cost");
@@ -157,7 +157,7 @@ public sealed class StoreTests : GameTest
                     Assert.That(costAfterBuy.Value, Is.EqualTo(prototypeCost.Value), "Expected cost after discount refund to be equal to prototype cost.");
 
                     var refundMsg = new StoreRequestRefundMessage { Actor = human };
-                    server.EntMan.EventBus.RaiseLocalEvent(pda, refundMsg);
+                    server.EntMan.EventBus.RaiseLocalEvent(storeEnt.Value, refundMsg);
 
                     // get refreshed item after refund re-generated items
                     discountedListingItem = storeComponent.FullListingsCatalog.First(x => x.ID == itemId);

--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Fixtures.Attributes;
+using Content.Server.PDA.Ringer;
 using Content.Server.Traitor.Uplink;
 using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;
@@ -68,6 +69,7 @@ public sealed class StoreTests : GameTest
         EntityUid pda = default;
 
         var uplinkSystem = entManager.System<UplinkSystem>();
+        var ringerSystem = entManager.System<RingerSystem>();
 
         var listingPrototypes = prototypeManager.EnumeratePrototypes<ListingPrototype>()
                                                 .ToArray();
@@ -89,10 +91,10 @@ public sealed class StoreTests : GameTest
             mindSystem.TransferTo(mind, human, mind: mind);
 
             FixedPoint2 originalBalance = 20;
-            uplinkSystem.AddUplink(human, originalBalance, out var notes, pda, null, true);
+            uplinkSystem.AddUplink(human, originalBalance, out var notes, pda, true);
 
-            var remote = entManager.GetComponent<RemoteStoreComponent>(pda);
-            var storeEnt = remote.Store;
+            Assert.That(notes != null);
+            ringerSystem.TryMatchRingtoneToStore(notes, out var storeEnt);
             Assert.That(storeEnt.HasValue);
             var storeComponent = entManager.GetComponent<StoreComponent>(storeEnt.Value);
             var discountComponent = entManager.GetComponent<StoreDiscountComponent>(storeEnt.Value);

--- a/Content.Server/PDA/PdaSystem.cs
+++ b/Content.Server/PDA/PdaSystem.cs
@@ -311,11 +311,11 @@ namespace Content.Server.PDA
         private bool TryGetUnlockedStore(EntityUid uid, [NotNullWhen(true)] out EntityUid? store)
         {
             store = null;
-            if (!TryComp<RingerUplinkComponent>(uid, out var uplink) || !uplink.Unlocked || uplink.TargetStore == null)
+            if (!TryComp<RingerUplinkComponent>(uid, out var uplink) || !uplink.Unlocked)
                 return false;
 
-            store = uplink.TargetStore;
-            return true;
+            store = _store.GetStore(uid);
+            return store != null;
         }
 
         private void UpdateStationName(EntityUid uid, PdaComponent pda)

--- a/Content.Server/PDA/Ringer/RingerSystem.cs
+++ b/Content.Server/PDA/Ringer/RingerSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Store.Systems;
 using Content.Shared.GameTicking;
 using Content.Shared.PDA;
 using Content.Shared.PDA.Ringer;
+using Content.Shared.Store.Components;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
@@ -95,18 +96,20 @@ public sealed class RingerSystem : SharedRingerSystem
     }
 
     /// <inheritdoc/>
-    public override bool TryToggleUplink(EntityUid uid, Note[] ringtone, EntityUid? user = null)
+    public override bool TryToggleUplink(Entity<RingerUplinkComponent?> entity, Note[] ringtone, EntityUid? user = null)
     {
-        if (!TryComp<RingerUplinkComponent>(uid, out var uplink))
+        if (!Resolve(entity, ref entity.Comp))
             return false;
 
         // On the server, we always check if the code matches
-        if (!TryMatchRingtoneToStore(ringtone, out var store, uid))
+        if (!TryMatchRingtoneToStore(ringtone, out var store, entity))
             return false;
 
-        uplink.TargetStore = store;
+        // If the store is not this entity, we make sure to properly set the remote store.
+        if (store != entity.Owner)
+            Store.SetRemoteStore(entity.Owner, store);
 
-        return ToggleUplinkInternal((uid, uplink));
+        return ToggleUplinkInternal((entity, entity.Comp));
     }
 
     /// <summary>

--- a/Content.Server/Store/Systems/StoreSystem.cs
+++ b/Content.Server/Store/Systems/StoreSystem.cs
@@ -33,8 +33,9 @@ public sealed partial class StoreSystem : SharedStoreSystem
         SubscribeLocalEvent<StoreComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<StoreComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<StoreComponent, ComponentShutdown>(OnShutdown);
-        SubscribeLocalEvent<StoreComponent, OpenUplinkImplantEvent>(OnImplantActivate);
         SubscribeLocalEvent<StoreComponent, IntrinsicStoreActionEvent>(OnIntrinsicStoreAction);
+
+        SubscribeLocalEvent<RemoteStoreComponent, OpenUplinkImplantEvent>(OnImplantActivate);
 
         InitializeUi();
         InitializeCommand();
@@ -110,9 +111,12 @@ public sealed partial class StoreSystem : SharedStoreSystem
         _popup.PopupEntity(msg, target, args.User);
     }
 
-    private void OnImplantActivate(EntityUid uid, StoreComponent component, OpenUplinkImplantEvent args)
+    private void OnImplantActivate(Entity<RemoteStoreComponent> entity, ref OpenUplinkImplantEvent args)
     {
-        ToggleUi(args.Performer, uid, component);
+        if (GetRemoteStore(entity.AsNullable()) is not { } store)
+            return;
+
+        ToggleUi(args.Performer, store, store.Comp, entity, entity.Comp);
     }
 
     /// <summary>

--- a/Content.Server/Traitor/Uplink/UplinkSystem.cs
+++ b/Content.Server/Traitor/Uplink/UplinkSystem.cs
@@ -52,6 +52,7 @@ public sealed class UplinkSystem : EntitySystem
             return;
         }
 
+        SetUplink(args.Implanted, Spawn(TraitorUplinkStore, MapCoordinates.Nullspace), 0, false);
         Log.Error($"{ToPrettyString(args.Implanted)} did not have an uplink when they were implanted.");
     }
 

--- a/Content.Server/Traitor/Uplink/UplinkSystem.cs
+++ b/Content.Server/Traitor/Uplink/UplinkSystem.cs
@@ -30,6 +30,31 @@ public sealed class UplinkSystem : EntitySystem
     private static readonly EntProtoId FallbackUplinkImplant = "UplinkImplant";
     private static readonly ProtoId<ListingPrototype> FallbackUplinkCatalog = "UplinkUplinkImplanter";
 
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RemoteStoreComponent, ImplantImplantedEvent>(OnRemoteStoreImplanted);
+    }
+
+    private void OnRemoteStoreImplanted(Entity<RemoteStoreComponent> entity, ref ImplantImplantedEvent args)
+    {
+        if (_mind.GetMind(args.Implanted) is not { } mind )
+            return;
+
+        var storeEnumerator = EntityQueryEnumerator<RingerAccessUplinkComponent, StoreComponent>();
+        while (storeEnumerator.MoveNext(out var uid, out _, out var store))
+        {
+            if (store.AccountOwner != mind)
+                continue;
+
+            entity.Comp.Store = uid;
+            return;
+        }
+
+        Log.Error($"{ToPrettyString(args.Implanted)} did not have an uplink when they were implanted.");
+    }
+
     /// <summary>
     /// Adds an uplink to the target
     /// </summary>
@@ -37,7 +62,6 @@ public sealed class UplinkSystem : EntitySystem
     /// <param name="balance">The amount of currency on the uplink. If null, will just use the amount specified in the preset.</param>
     /// <param name="code">The code which was generated, if any.</param>
     /// <param name="uplinkEntity">The entity that will actually have the uplink functionality. Defaults to the PDA if null.</param>
-    /// <param name="storeEntity">The entity that will have the store in it.</param>
     /// <param name="giveDiscounts">Marker that enables discounts for uplink items.</param>
     /// <param name="bindToPda">Binds the uplink to the specific uplink entity.</param>
     /// <returns>Whether the uplink was added successfully to a PDA, implant or not at all.</returns>
@@ -46,23 +70,24 @@ public sealed class UplinkSystem : EntitySystem
         FixedPoint2 balance,
         out Note[]? code,
         EntityUid? uplinkEntity = null,
-        EntityUid? storeEntity = null,
         bool giveDiscounts = false,
         bool bindToPda = false)
     {
         code = null;
 
+        var storeEntity = Spawn(TraitorUplinkStore, MapCoordinates.Nullspace);
         if (TryAddEntityUplink(user, balance, out var generatedCode, uplinkEntity, storeEntity, giveDiscounts, bindToPda))
         {
             code = generatedCode;
             return AddUplinkResult.Pda;
         }
 
-        if (TryImplantUplink(user, balance, giveDiscounts))
+        if (TryImplantUplink(user, storeEntity, balance, giveDiscounts))
         {
             return AddUplinkResult.Implant;
         }
 
+        Del(storeEntity);
         return AddUplinkResult.Failure;
     }
 
@@ -71,20 +96,18 @@ public sealed class UplinkSystem : EntitySystem
         FixedPoint2 balance,
         out Note[]? code,
         EntityUid? uplinkEntity,
-        EntityUid? storeEntity,
+        EntityUid storeEntity,
         bool giveDiscounts = false,
         bool bindToPda = false)
     {
         code = null;
-
-        storeEntity ??= Spawn(TraitorUplinkStore, MapCoordinates.Nullspace);
         uplinkEntity ??= FindUplinkTarget(user);
 
         if (uplinkEntity == null)
             return false;
 
         var ev = new GenerateUplinkCodeEvent();
-        RaiseLocalEvent(storeEntity.Value, ref ev);
+        RaiseLocalEvent(storeEntity, ref ev);
 
         if (ev.Code == null)
         {
@@ -96,23 +119,13 @@ public sealed class UplinkSystem : EntitySystem
 
         if (bindToPda)
         {
-            var accessComp = EnsureComp<RingerAccessUplinkComponent>(storeEntity.Value);
-            _ringer.SetBoundUplinkEntity((storeEntity.Value, accessComp), uplinkEntity.Value);
+            var accessComp = EnsureComp<RingerAccessUplinkComponent>(storeEntity);
+            _ringer.SetBoundUplinkEntity((storeEntity, accessComp), uplinkEntity.Value);
         }
 
-        SetUplink(user, storeEntity.Value, uplinkEntity.Value, balance, giveDiscounts);
+        SetUplink(user, storeEntity, balance, giveDiscounts);
 
         return true;
-    }
-
-    /// <summary>
-    /// Configure TC for the uplink
-    /// </summary>
-    private void SetUplink(EntityUid user, EntityUid store, EntityUid uplink, FixedPoint2 balance, bool giveDiscounts)
-    {
-        SetUplink(user, store, balance, giveDiscounts);
-        var remote = EnsureComp<RemoteStoreComponent>(uplink);
-        remote.Store = store;
     }
 
     /// <summary>
@@ -144,9 +157,9 @@ public sealed class UplinkSystem : EntitySystem
     /// <summary>
     /// Implant an uplink as a fallback measure if the traitor had no PDA
     /// </summary>
-    public bool TryImplantUplink(EntityUid user, FixedPoint2 balance, bool giveDiscounts)
+    public bool TryImplantUplink(EntityUid user, EntityUid storeEntity, FixedPoint2 balance, bool giveDiscounts)
     {
-        if (!_proto.Resolve<ListingPrototype>(FallbackUplinkCatalog, out var catalog))
+        if (!_proto.Resolve(FallbackUplinkCatalog, out var catalog))
             return false;
 
         if (!catalog.Cost.TryGetValue(TelecrystalCurrencyPrototype, out var cost))
@@ -157,15 +170,15 @@ public sealed class UplinkSystem : EntitySystem
         else
             balance = balance - cost;
 
+        SetUplink(user, storeEntity, balance, giveDiscounts);
         var implant = _subdermalImplant.AddImplant(user, FallbackUplinkImplant);
 
-        if (!HasComp<StoreComponent>(implant))
+        if (!HasComp<RemoteStoreComponent>(implant))
         {
             Log.Error($"Implant does not have the store component {implant}");
             return false;
         }
 
-        SetUplink(user, implant.Value, balance, giveDiscounts);
         return true;
     }
 
@@ -173,7 +186,7 @@ public sealed class UplinkSystem : EntitySystem
     /// Finds the entity that can hold an uplink for a user.
     /// Usually this is a pda in their pda slot, but can also be in their hands. (but not pockets or inside bag, etc.)
     /// </summary>
-    public Entity<RemoteStoreComponent>? FindUplinkTarget(EntityUid user)
+    public EntityUid? FindUplinkTarget(EntityUid user)
     {
         // Try to find PDA in inventory
         if (_inventorySystem.TryGetContainerSlotEnumerator(user, out var containerSlotEnumerator))
@@ -182,16 +195,16 @@ public sealed class UplinkSystem : EntitySystem
             {
                 var pdaUid = containerSlot.ContainedEntity;
 
-                if (HasComp<StoreComponent>(pdaUid) && TryComp<RemoteStoreComponent>(pdaUid, out var remote))
-                    return (pdaUid.Value, remote);
+                if (HasComp<PdaComponent>(pdaUid) && HasComp<RemoteStoreComponent>(pdaUid))
+                    return pdaUid.Value;
             }
         }
 
         // Also check hands
         foreach (var item in _handsSystem.EnumerateHeld(user))
         {
-            if (HasComp<StoreComponent>(item) && TryComp<RemoteStoreComponent>(item, out var remote))
-                return (item, remote);
+            if (HasComp<PdaComponent>(item) && HasComp<RemoteStoreComponent>(item))
+                return item;
         }
 
         return null;

--- a/Content.Server/Traitor/Uplink/UplinkSystem.cs
+++ b/Content.Server/Traitor/Uplink/UplinkSystem.cs
@@ -52,6 +52,7 @@ public sealed class UplinkSystem : EntitySystem
             return;
         }
 
+        // If we didn't have an uplink, make an empty one.
         SetUplink(args.Implanted, Spawn(TraitorUplinkStore, MapCoordinates.Nullspace), 0, false);
         Log.Error($"{ToPrettyString(args.Implanted)} did not have an uplink when they were implanted.");
     }

--- a/Content.Shared/PDA/Ringer/RingerUplinkComponent.cs
+++ b/Content.Shared/PDA/Ringer/RingerUplinkComponent.cs
@@ -14,10 +14,4 @@ public sealed partial class RingerUplinkComponent : Component
     /// </summary>
     [DataField]
     public bool Unlocked;
-
-    /// <summary>
-    /// The store which the ringer is targetting.
-    /// </summary>
-    [DataField]
-    public EntityUid? TargetStore;
 }

--- a/Content.Shared/PDA/SharedRingerSystem.cs
+++ b/Content.Shared/PDA/SharedRingerSystem.cs
@@ -27,6 +27,7 @@ public abstract class SharedRingerSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedPdaSystem _pda = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] protected readonly SharedStoreSystem Store = default!;
     [Dependency] private readonly SharedTransformSystem _xform = default!;
     [Dependency] protected readonly SharedUserInterfaceSystem UI = default!;
 
@@ -137,7 +138,6 @@ public abstract class SharedRingerSystem : EntitySystem
             return;
 
         ent.Comp.Unlocked = false;
-        ent.Comp.TargetStore = null;
         UI.CloseUi(ent.Owner, StoreUiKey.Key);
     }
 
@@ -146,12 +146,12 @@ public abstract class SharedRingerSystem : EntitySystem
     /// On the client side, it does nothing since the client cannot know the code in advance.
     /// On the server side, the code is verified.
     /// </summary>
-    /// <param name="uid">The entity with the RingerUplinkComponent.</param>
+    /// <param name="entity">The entity with the RingerUplinkComponent.</param>
     /// <param name="ringtone">The ringtone to check against the uplink code.</param>
     /// <param name="user">The entity attempting to toggle the uplink.</param>
     /// <returns>True if the uplink state was toggled, false otherwise.</returns>
     [PublicAPI]
-    public virtual bool TryToggleUplink(EntityUid uid, Note[] ringtone, EntityUid? user = null)
+    public virtual bool TryToggleUplink(Entity<RingerUplinkComponent?> entity, Note[] ringtone, EntityUid? user = null)
     {
         return false;
     }
@@ -178,7 +178,7 @@ public abstract class SharedRingerSystem : EntitySystem
             return;
 
         // Try to toggle the uplink first
-        if (TryToggleUplink(ent, args.Ringtone))
+        if (TryToggleUplink(ent.Owner, args.Ringtone))
             return; // Don't save the uplink code as the ringtone
 
         UpdateRingerRingtone(ent, args.Ringtone);
@@ -245,13 +245,11 @@ public abstract class SharedRingerSystem : EntitySystem
         ent.Comp.Unlocked = !ent.Comp.Unlocked;
 
         // Update PDA UI if needed
-        if (TryComp<PdaComponent>(ent, out var pda))
-            _pda.UpdatePdaUi(ent, pda);
+        _pda.UpdatePdaUi(ent.Owner);
 
         // Close store UI if we're locking
         if (!ent.Comp.Unlocked)
         {
-            ent.Comp.TargetStore = null;
             UI.CloseUi(ent.Owner, StoreUiKey.Key);
         }
 

--- a/Content.Shared/Store/SharedStoreSystem.cs
+++ b/Content.Shared/Store/SharedStoreSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Implants;
 using Content.Shared.Store.Components;
 
 namespace Content.Shared.Store;
@@ -49,11 +50,19 @@ public abstract partial class SharedStoreSystem : EntitySystem
     /// <returns>The store entity and component if found.</returns>
     public Entity<StoreComponent>? GetRemoteStore(Entity<RemoteStoreComponent?> entity)
     {
-        if (RemoteStoreQuery.Resolve(entity, ref entity.Comp, false)
+        if (RemoteStoreQuery.Resolve(entity, ref entity.Comp)
             && entity.Comp.Store != null
             && StoreQuery.TryComp(entity.Comp.Store, out var storeComp))
             return (entity.Comp.Store.Value, storeComp);
 
         return null;
+    }
+
+    public void SetRemoteStore(Entity<RemoteStoreComponent?> entity, EntityUid? store)
+    {
+        if (!RemoteStoreQuery.Resolve(entity, ref entity.Comp))
+            return;
+
+        entity.Comp.Store = store;
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -169,9 +169,7 @@
     whitelist:
       components:
       - Hands # prevent mouse buying grenade penguin since its not telepathic
-  - type: Store
-    balance:
-      Telecrystal: 0
+  - type: RemoteStore
   - type: UserInterface
     interfaces:
       enum.StoreUiKey.Key:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed a really bad bug I introduced last night whoops! I swapped the HasComp\<PDAComponent> for a HasComp\<StoreComponent>
Found it while testing uplink implants, while I was here I also made it so the uplink implant connects to the same store you're assigned roundstart. It would do this if it implanted into you cause it couldn't find a PDA before so this just makes the behavior consistent. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Consistent behavior, and this was easily the most common complaint about the uplink implant.
Should make it an overall better item.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed a HasComp to the correct component
Fixed some tests based on bad assumptions
Removed some unnecessary duplication of saved EntityUids and make some behavior better for finding and linking remote stores. 
Made it so uplink implant uses RemoteStore, instead of Store, and sets up the store. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1411" height="740" alt="image" src="https://github.com/user-attachments/assets/f3567ac2-802c-4488-b271-fe92270a5571" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
TryAddEntityUplink's store entity is no longer nullable and instead must take a store entity.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Uplink implant now links to the same store as your PDA ringtone.

