### PR TITLE
allow changelings to drop stored disguises

### DIFF
--- a/Content.Client/Changeling/UI/ChangelingTransformBoundUserInterface.cs
+++ b/Content.Client/Changeling/UI/ChangelingTransformBoundUserInterface.cs
@@ -4,6 +4,7 @@ using Content.Shared.Changeling.Components;
 using Content.Shared.Changeling.Systems;
 using JetBrains.Annotations;
 using Robust.Client.UserInterface;
+using Robust.Shared.Utility;
 
 namespace Content.Client.Changeling.UI;
 
@@ -12,7 +13,9 @@ public sealed partial class ChangelingTransformBoundUserInterface(EntityUid owne
 {
     private SimpleRadialMenu? _menu;
     private static readonly Color SelectedOptionBackground = Palettes.Green.Element.WithAlpha(128);
+    private static readonly Color DisabledOptionBackground = Palettes.Slate.Element.WithAlpha(128);
     private static readonly Color SelectedOptionHoverBackground = Palettes.Green.HoveredElement.WithAlpha(128);
+    private static readonly Color DisabledOptionHoverBackground = Palettes.Slate.HoveredElement.WithAlpha(128);
 
     protected override void Open()
     {
@@ -42,20 +45,40 @@ public sealed partial class ChangelingTransformBoundUserInterface(EntityUid owne
     )
     {
         var buttons = new List<RadialMenuOptionBase>();
+        var dropButtons = new List<RadialMenuOptionBase>();
+
         foreach (var identity in identities)
         {
-            if (!EntMan.TryGetComponent<MetaDataComponent>(identity, out var metadata))
-                continue;
-
+            // Options for selecting identities.
             var option = new RadialMenuActionOption<NetEntity>(SendIdentitySelect, EntMan.GetNetEntity(identity))
             {
                 IconSpecifier = RadialMenuIconSpecifier.With(identity),
-                ToolTip = metadata.EntityName,
-                BackgroundColor = (currentIdentity == identity) ? SelectedOptionBackground : null,
+                ToolTip = Loc.GetString("changeling-transform-bui-select-entity", ("entity", identity)),
+                BackgroundColor = (currentIdentity == identity) ? SelectedOptionBackground : null, // mark as selected
                 HoverBackgroundColor = (currentIdentity == identity) ? SelectedOptionHoverBackground : null
             };
             buttons.Add(option);
+
+            // Options for dropping identities.
+            var dropOption = new RadialMenuActionOption<NetEntity>(SendIdentityDrop, EntMan.GetNetEntity(identity))
+            {
+                IconSpecifier = RadialMenuIconSpecifier.With(identity),
+                ToolTip = (currentIdentity == identity)
+                    ? Loc.GetString("changeling-transform-bui-drop-identity-cannot-drop")
+                    : Loc.GetString("changeling-transform-bui-drop-identity-entity", ("entity", identity)),
+                BackgroundColor = (currentIdentity == identity) ? DisabledOptionBackground : null, // cannot drop your current identity
+                HoverBackgroundColor = (currentIdentity == identity) ? DisabledOptionHoverBackground : null
+            };
+            dropButtons.Add(dropOption);
         }
+
+        // Menu category for dropping identities.
+        var dropMenuButton = new RadialMenuNestedLayerOption(dropButtons)
+        {
+            IconSpecifier = RadialMenuIconSpecifier.With(new SpriteSpecifier.Rsi(new("/Textures/Markers/cross.rsi"), "red")),
+            ToolTip = Loc.GetString("changeling-transform-bui-drop-identity-menu")
+        };
+        buttons.Add(dropMenuButton);
 
         return buttons;
     }
@@ -63,5 +86,10 @@ public sealed partial class ChangelingTransformBoundUserInterface(EntityUid owne
     private void SendIdentitySelect(NetEntity identityId)
     {
         SendPredictedMessage(new ChangelingTransformIdentitySelectMessage(identityId));
+    }
+
+    private void SendIdentityDrop(NetEntity identityId)
+    {
+        SendPredictedMessage(new ChangelingTransformIdentityDropMessage(identityId));
     }
 }

--- a/Content.Client/Changeling/UI/ChangelingTransformBoundUserInterface.cs
+++ b/Content.Client/Changeling/UI/ChangelingTransformBoundUserInterface.cs
@@ -75,7 +75,7 @@ public sealed partial class ChangelingTransformBoundUserInterface(EntityUid owne
         // Menu category for dropping identities.
         var dropMenuButton = new RadialMenuNestedLayerOption(dropButtons)
         {
-            IconSpecifier = RadialMenuIconSpecifier.With(new SpriteSpecifier.Rsi(new("/Textures/Markers/cross.rsi"), "red")),
+            IconSpecifier = RadialMenuIconSpecifier.With(new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/delete.svg.192dpi.png"))),
             ToolTip = Loc.GetString("changeling-transform-bui-drop-identity-menu")
         };
         buttons.Add(dropMenuButton);

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.UI.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.UI.cs
@@ -3,13 +3,25 @@
 namespace Content.Shared.Changeling.Systems;
 
 /// <summary>
-/// Send when a player selects an intentity to transform into in the radial menu.
+/// Send when a player selects an identity to transform into in the radial menu.
 /// </summary>
 [Serializable, NetSerializable]
 public sealed class ChangelingTransformIdentitySelectMessage(NetEntity targetIdentity) : BoundUserInterfaceMessage
 {
     /// <summary>
-    /// The uid of the cloned identity.
+    /// The uid of the stored identity.
+    /// </summary>
+    public readonly NetEntity TargetIdentity = targetIdentity;
+}
+
+/// <summary>
+/// Send when a player selects an identity to drop from their storage.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class ChangelingTransformIdentityDropMessage(NetEntity targetIdentity) : BoundUserInterfaceMessage
+{
+    /// <summary>
+    /// The uid of the stored identity.
     /// </summary>
     public readonly NetEntity TargetIdentity = targetIdentity;
 }

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
@@ -39,9 +39,9 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
 
         SubscribeLocalEvent<ChangelingTransformComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<ChangelingTransformComponent, ChangelingTransformActionEvent>(OnTransformAction);
-        SubscribeLocalEvent<ChangelingTransformComponent, ChangelingTransformDoAfterEvent>(OnSuccessfulTransform);
         SubscribeLocalEvent<ChangelingTransformComponent, ChangelingTransformIdentitySelectMessage>(OnTransformSelected);
         SubscribeLocalEvent<ChangelingTransformComponent, ChangelingTransformIdentityDropMessage>(OnTransformDrop);
+        SubscribeLocalEvent<ChangelingTransformComponent, ChangelingTransformDoAfterEvent>(OnSuccessfulTransform);
         SubscribeLocalEvent<ChangelingTransformComponent, ComponentShutdown>(OnShutdown);
 
         // Components that need special handling outside of cloning.
@@ -79,6 +79,43 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
         } //TODO: Can add a Else here with TransformInto and CloseUI to make a quick switch,
           // issue right now is that Radials cover the Action buttons so clicking the action closes the UI (due to clicking off a radial causing it to close, even with UI)
           // but pressing the number does.
+    }
+
+    private void OnTransformSelected(Entity<ChangelingTransformComponent> ent,
+        ref ChangelingTransformIdentitySelectMessage args)
+    {
+        if (!TryGetEntity(args.TargetIdentity, out var targetIdentity))
+            return;
+
+        if (!TryComp<ChangelingIdentityComponent>(ent, out var identity))
+            return;
+
+        if (identity.CurrentIdentity == targetIdentity)
+            return; // don't transform into ourselves
+
+        if (!identity.ConsumedIdentities.ContainsKey(targetIdentity.Value))
+            return; // this identity does not belong to this player
+
+        TransformInto(ent.AsNullable(), targetIdentity.Value);
+    }
+
+    private void OnTransformDrop(Entity<ChangelingTransformComponent> ent,
+        ref ChangelingTransformIdentityDropMessage args)
+    {
+        if (!TryGetEntity(args.TargetIdentity, out var targetIdentity))
+            return;
+
+        if (!TryComp<ChangelingIdentityComponent>(ent, out var identity))
+            return;
+
+        if (identity.CurrentIdentity == targetIdentity)
+            return; // don't drop our current identity
+
+        if (!identity.ConsumedIdentities.ContainsKey(targetIdentity.Value))
+            return; // this identity does not belong to this player
+
+        _popup.PopupClient(Loc.GetString("changeling-transform-bui-drop-identity-entity-popup", ("entity", targetIdentity.Value)), ent.Owner, PopupType.Large);
+        _changelingIdentity.DropStoredIdentity(ent.Owner, targetIdentity.Value);
     }
 
     /// <summary>
@@ -125,42 +162,6 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
             RequireCanInteract = false,
             DistanceThreshold = null,
         });
-    }
-
-    private void OnTransformSelected(Entity<ChangelingTransformComponent> ent,
-        ref ChangelingTransformIdentitySelectMessage args)
-    {
-        if (!TryGetEntity(args.TargetIdentity, out var targetIdentity))
-            return;
-
-        if (!TryComp<ChangelingIdentityComponent>(ent, out var identity))
-            return;
-
-        if (identity.CurrentIdentity == targetIdentity)
-            return; // don't transform into ourselves
-
-        if (!identity.ConsumedIdentities.ContainsKey(targetIdentity.Value))
-            return; // this identity does not belong to this player
-
-        TransformInto(ent.AsNullable(), targetIdentity.Value);
-    }
-
-    private void OnTransformDrop(Entity<ChangelingTransformComponent> ent,
-        ref ChangelingTransformIdentityDropMessage args)
-    {
-        if (!TryGetEntity(args.TargetIdentity, out var targetIdentity))
-            return;
-
-        if (!TryComp<ChangelingIdentityComponent>(ent, out var identity))
-            return;
-
-        if (identity.CurrentIdentity == targetIdentity)
-            return; // don't drop our current identity
-
-        if (!identity.ConsumedIdentities.ContainsKey(targetIdentity.Value))
-            return; // this identity does not belong to this player
-
-        _changelingIdentity.DropStoredIdentity(ent.Owner, targetIdentity.Value);
     }
 
     private void OnSuccessfulTransform(Entity<ChangelingTransformComponent> ent,

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
@@ -30,6 +30,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly IdentitySystem _identity = default!;
+    [Dependency] private readonly SharedChangelingIdentitySystem _changelingIdentity = default!;
 
     private const string ChangelingBuiXmlGeneratedName = "ChangelingTransformBoundUserInterface";
     public override void Initialize()
@@ -40,6 +41,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
         SubscribeLocalEvent<ChangelingTransformComponent, ChangelingTransformActionEvent>(OnTransformAction);
         SubscribeLocalEvent<ChangelingTransformComponent, ChangelingTransformDoAfterEvent>(OnSuccessfulTransform);
         SubscribeLocalEvent<ChangelingTransformComponent, ChangelingTransformIdentitySelectMessage>(OnTransformSelected);
+        SubscribeLocalEvent<ChangelingTransformComponent, ChangelingTransformIdentityDropMessage>(OnTransformDrop);
         SubscribeLocalEvent<ChangelingTransformComponent, ComponentShutdown>(OnShutdown);
 
         // Components that need special handling outside of cloning.
@@ -128,8 +130,6 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
     private void OnTransformSelected(Entity<ChangelingTransformComponent> ent,
         ref ChangelingTransformIdentitySelectMessage args)
     {
-        _ui.CloseUi(ent.Owner, ChangelingTransformUiKey.Key, ent);
-
         if (!TryGetEntity(args.TargetIdentity, out var targetIdentity))
             return;
 
@@ -143,6 +143,24 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
             return; // this identity does not belong to this player
 
         TransformInto(ent.AsNullable(), targetIdentity.Value);
+    }
+
+    private void OnTransformDrop(Entity<ChangelingTransformComponent> ent,
+        ref ChangelingTransformIdentityDropMessage args)
+    {
+        if (!TryGetEntity(args.TargetIdentity, out var targetIdentity))
+            return;
+
+        if (!TryComp<ChangelingIdentityComponent>(ent, out var identity))
+            return;
+
+        if (identity.CurrentIdentity == targetIdentity)
+            return; // don't drop our current identity
+
+        if (!identity.ConsumedIdentities.ContainsKey(targetIdentity.Value))
+            return; // this identity does not belong to this player
+
+        _changelingIdentity.DropStoredIdentity(ent.Owner, targetIdentity.Value);
     }
 
     private void OnSuccessfulTransform(Entity<ChangelingTransformComponent> ent,

--- a/Content.Shared/Changeling/Systems/SharedChangelingIdentitySystem.cs
+++ b/Content.Shared/Changeling/Systems/SharedChangelingIdentitySystem.cs
@@ -185,6 +185,22 @@ public abstract class SharedChangelingIdentitySystem : EntitySystem
     }
 
     /// <summary>
+    /// Drop a stored identity from the changeling's storage.
+    /// </summary>
+    public void DropStoredIdentity(Entity<ChangelingIdentityComponent?> ent, EntityUid identity)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return;
+
+        if (!HasComp<ChangelingStoredIdentityComponent>(identity))
+            return; // Not a stored identity.
+
+        PredictedQueueDel(identity);
+        if (ent.Comp.ConsumedIdentities.Remove(identity))
+            Dirty(ent);
+    }
+
+    /// <summary>
     /// Simple helper to add a PVS override to a nullspace identity.
     /// </summary>
     /// <param name="uid">The actor that should get the override.</param>

--- a/Resources/Locale/en-US/changeling/changeling.ftl
+++ b/Resources/Locale/en-US/changeling/changeling.ftl
@@ -1,6 +1,8 @@
-﻿roles-antag-changeling-name = Changeling
+﻿# antag selection
+roles-antag-changeling-name = Changeling
 roles-antag-changeling-objective = A intelligent predator that assumes the identities of its victims.
 
+# devour
 changeling-devour-attempt-failed-cannot-devour = We cannot devour this!
 changeling-devour-attempt-failed-already-devoured = We already consumed this body!
 changeling-devour-attempt-failed-not-dead = This body yet lives! We cannot consume it alive!
@@ -14,7 +16,15 @@ changeling-devour-begin-consume-others = { CAPITALIZE(POSS-ADJ($user)) } uncanny
 changeling-devour-consume-complete-self = Our uncanny mouth retreats, biomass consumed.
 changeling-devour-consume-complete-others = { CAPITALIZE(POSS-ADJ($user)) } uncanny mouth retreats.
 
+# transformation
 changeling-transform-attempt-self = Our bones snap, muscles tear, one flesh becomes another.
 changeling-transform-attempt-others = { CAPITALIZE(POSS-ADJ($user)) } bones snap, muscles tear, body shifts into another.
 
+# transformation BUI
+changeling-transform-bui-select-entity = {$entity}
+changeling-transform-bui-drop-identity-menu = Drop a devoured identity from your memory.
+changeling-transform-bui-drop-identity-entity = Drop {$entity}
+changeling-transform-bui-drop-identity-cannot-drop = You cannot drop your current identity.
+
+# other
 changeling-paused-map-name = Changeling identity storage map

--- a/Resources/Locale/en-US/changeling/changeling.ftl
+++ b/Resources/Locale/en-US/changeling/changeling.ftl
@@ -1,4 +1,4 @@
-﻿# antag selection
+# antag selection
 roles-antag-changeling-name = Changeling
 roles-antag-changeling-objective = A intelligent predator that assumes the identities of its victims.
 
@@ -24,6 +24,7 @@ changeling-transform-attempt-others = { CAPITALIZE(POSS-ADJ($user)) } bones snap
 changeling-transform-bui-select-entity = {$entity}
 changeling-transform-bui-drop-identity-menu = Drop a devoured identity from your memory.
 changeling-transform-bui-drop-identity-entity = Drop {$entity}
+changeling-transform-bui-drop-identity-entity-popup = You dropped {$entity} from your memory.
 changeling-transform-bui-drop-identity-cannot-drop = You cannot drop your current identity.
 
 # other


### PR DESCRIPTION
## About the PR
Adds a new option to the transformation menu, allowing you to remove devoured identities.

## Why / Balance
We will introduce a disguise limit in a future PR. See #39439

## Technical details
Adds a new category button to the menu.
If pressed, it sends a message to the server that deletes the stored identity from the paused map and cleans up the reference to it in your identity storage.

## Media
![ss14](https://github.com/user-attachments/assets/bb030d90-16a6-424e-afed-7225a8e2adbf)


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
not released yet
