### PR TITLE
Fix diagonal grilles laser blocking

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -195,8 +195,6 @@
             - "-0.5,-0.5"
             - "0.5,0.5"
             - "0.5,-0.5"
-        mask:
-        - FullTileMask
         layer:
         - GlassLayer
   - type: Construction
@@ -233,8 +231,6 @@
             - "-0.5,-0.5"
             - "0.5,0.5"
             - "0.5,-0.5"
-        mask:
-        - FullTileMask
         layer:
         - GlassLayer
   - type: Construction


### PR DESCRIPTION
## About the PR
Removed redundant collision mask from diagonal grilles to match standard grille behavior.

## Why / Balance
Diagonal grilles were inconsistent with full-tile grilles, causing them to block hitscan (lasers) where they shouldn't. This change aligns their collision with the standard versions.

## Technical details
Cleaned up mask section in grille.yml for diagonal prototypes.

## Media
Small fix.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed diagonal grille collision to correctly allow hitscan/lasers to pass through.