### PR TITLE
Fix Cutter Machine rotation

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -666,8 +666,6 @@
   name: cutter machine
   description: This is a cutter. It cuts. Add variety to your station floor with eye-pleasing patterns! Don't stick your fingers in.
   components:
-  - type: Transform
-    noRot: false
   - type: Sprite
     sprite: Structures/Machines/cuttermachine.rsi
     snapCardinals: true


### PR DESCRIPTION
## About the PR
Removed the Transform component with noRot: false from the Cutter Machine.

## Why / Balance
Standardizing the Cutter Machine with other lathes. It shouldn't have free rotation, as it's inconsistent and makes moving/placing the machine through narrow spaces more annoying than it should be.

## Technical details
Deleted the Transform component with noRot: false from the CutterMachine prototype in lathe.yml.

## Media
Small fix.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed Cutter Machine rotation to be consistent with other lathes.