### PR TITLE
Add Flippo lighter to loadout

### DIFF
--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -12,6 +12,7 @@
   - PlushieSpaceLizard
   - ThreeCandles
   - Lighter
+  - FlippoLighter
   - CigPackGreen
   - CigPackRed
   - CigPackBlue

--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -59,6 +59,16 @@
   groupBy: "smokeables"
 
 - type: loadout
+  id: FlippoLighter
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: Command
+  storage:
+    back:
+    - FlippoLighter
+  groupBy: "smokeables"
+
+- type: loadout
   id: CigPackGreen
   storage:
     back:


### PR DESCRIPTION
## About the PR
Adds the Flippo Lighter to the loadout selection, grouped under "smokeables".

## Why / Balance
It's a nice flavor item for experienced players. To keep it somewhat exclusive, it requires 1 hour of Command experience to unlock, matching the requirements of the premium Havanian cigar and other command-tier trinkets.

## Technical details
Added FlippoLighter loadout prototype to trinkets.yml and loadout_groups.yml.

## Media
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/cbe7ac45-74f7-4f04-861a-3bf9cff9807d" />

## Requirements
- x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

**Changelog**
:cl:
- add: Added Flippo lighter to the loadouts (requires 1h in Command).