### PR TITLE
Department ordering consoles directly order again

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -930,7 +930,6 @@
     account: Engineering
     announcementChannel: Engineering
     removeLimitAccess: [ "ChiefEngineer" ]
-    mode: SendToPrimary
   - type: ActiveRadio
     channels:
     - Engineering
@@ -963,7 +962,6 @@
     account: Medical
     announcementChannel: Medical
     removeLimitAccess: [ "ChiefMedicalOfficer" ]
-    mode: SendToPrimary
   - type: ActiveRadio
     channels:
     - Medical
@@ -996,7 +994,6 @@
     account: Science
     announcementChannel: Science
     removeLimitAccess: [ "ResearchDirector" ]
-    mode: SendToPrimary
   - type: ActiveRadio
     channels:
     - Science
@@ -1029,7 +1026,6 @@
     account: Security
     announcementChannel: Security
     removeLimitAccess: [ "HeadOfSecurity" ]
-    mode: SendToPrimary
   - type: ActiveRadio
     channels:
     - Security
@@ -1062,7 +1058,6 @@
     account: Service
     announcementChannel: Service
     removeLimitAccess: [ "HeadOfPersonnel" ]
-    mode: SendToPrimary
   - type: ActiveRadio
     channels:
     - Service


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Department ordering consoles now directly place orders with the Trade Station, exactly like they did when departmental economy first released

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This PR restores direct departmental ordering because the current cargo-approval workflow reintroduces the exact friction that the departmental economy system was designed to eliminate.
This also more closely aligns with the [departmental economy doc](https://docs.spacestation14.com/en/space-station-14/round-flow/proposals/departmental-economy.html).

Departmental economy was intended to increase departmental autonomy, reduce redundant cargo mediation, and improve round pacing. The current system undermines all three by requiring cargo to both approve and deliver orders.

Under the original design, departments could place orders independently, and cargo’s role was focused on logistics. The current workflow instead combines direct ordering with a mandatory approval step, effectively recreating the pre-economy bottleneck. A step-by-step breakdown of the pre- and post-departmental economy ordering flow can be found in [this discussion post](https://forum.spacestation14.com/t/departmental-budgets-and-acquisitions-slips/20437).

In practice, players must place an order and then manually coordinate with cargo to have it approved, duplicating effort, slowing delivery, and reducing department agency.

While cargo approval can support higher roleplay environments(one of the reasons for originally adding acquisition slips was due to MRP downstreams not liking the changes), this comes at the cost of gameplay flow. For upstream which is primarily LRP, this tradeoff is misaligned with the intended experience for most players.

Counterarguments:
**Orders requiring cargo approval moves agency/oversight back into cargo's hands**
Cargo approval does give cargo more control over purchases, but this control manifests more as a gatekeeping step rather than actual meaningful gameplay. Approving/denying orders is repetitive gameplay which is often arbitrary("yes unless we're broke"). This moves agency away from departments solving their own problems and into cargo techs passively doing routine approvals. It increases cargo authority, but not cargo gameplay depth.

**The current system is good for situations like "Science places an order for steel while we already have 1000 steel stored"**
This is a valid concern which the current system does solve. However, requiring that additional cargo approval for every order is a broad solution to a narrow problem. This is better solved by increasing visibility of what cargo currently has(e.g. some UI displaying cargo's lathe materials) rather than gating all orders behind manual approval. The current system prevents some inefficient orders, but at the cost of slowing down all orders and reintroducing the exact bottlenecks departmental economy aimed to remove. I don't believe this is a beneficial tradeoff.

**You can just tell cargo to approve orders over commons/a holopad call**
It's true that it reduces some or even most of the friction but it doesn't eliminate the underlying issue which is the dependency on cargo for a manual approval step. Even when using common, a request still requires someone in the department to notice the request, stop what they're doing, and respond, with a delay that varies based on how available or attentive cargo is. Sometimes cargo will respond immediately and other times orders will take several minutes to get approved if at all. More importantly it reduces departmental autonomy as departments are unable to order independently without cargo approval.
The issue isn't that just telling cargo to approve your order isn't impossible or inconvenient, it's that the manual approval step was explicitly supposed to be removed. Reintroducing it in the lessened form of orders being forwarded to cargo just reintroduces the bottleneck.

In conclusion, restoring direct departmental ordering removes the redundant approval step to improve the flow of gameplay and realigns orders with the original goals that departmental economy set out to achieve. Cargo remains relevant as a logistics role that delivers orders without unnecessarily gating routine department purchases.

## Technical details
<!-- Summary of code changes for easier review. -->
YML only

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Department ordering consoles now directly place orders with the Trade Station again.
