### PR TITLE
Add notification for AI core being damaged

### DIFF
--- a/Content.Server/Silicons/StationAi/StationAiSystem.cs
+++ b/Content.Server/Silicons/StationAi/StationAiSystem.cs
@@ -67,6 +67,7 @@ public sealed class StationAiSystem : SharedStationAiSystem
     private readonly ProtoId<ChatNotificationPrototype> _aiWireSnippedChatNotificationPrototype = "AiWireSnipped";
     private readonly ProtoId<ChatNotificationPrototype> _aiLosingPowerChatNotificationPrototype = "AiLosingPower";
     private readonly ProtoId<ChatNotificationPrototype> _aiCriticalPowerChatNotificationPrototype = "AiCriticalPower";
+    private readonly ProtoId<ChatNotificationPrototype> _aiTakingDamageChatNotificationPrototype = "AiTakingDamage";
 
     private readonly ProtoId<JobPrototype> _stationAiJob = "StationAi";
     private readonly EntProtoId _stationAiBrain = "StationAiBrain";
@@ -235,7 +236,7 @@ public sealed class StationAiSystem : SharedStationAiSystem
 
     private void OnDamageChanged(Entity<StationAiCoreComponent> entity, ref DamageChangedEvent args)
     {
-        UpdateCoreIntegrityAlert(entity);
+        UpdateCoreIntegrityAlert(entity, args.DamageIncreased);
         UpdateDamagedAccent(entity);
     }
 
@@ -285,7 +286,7 @@ public sealed class StationAiSystem : SharedStationAiSystem
         }
     }
 
-    private void UpdateCoreIntegrityAlert(Entity<StationAiCoreComponent> ent)
+    private void UpdateCoreIntegrityAlert(Entity<StationAiCoreComponent> ent, bool damageIncreased = false)
     {
         if (!TryComp<DamageableComponent>(ent, out var damageable))
             return;
@@ -303,6 +304,12 @@ public sealed class StationAiSystem : SharedStationAiSystem
         var damageLevel = Math.Round(damagePercent.Float() * proto.MaxSeverity);
 
         _alerts.ShowAlert(held.Value, _damageAlert, (short)Math.Clamp(damageLevel, 0, proto.MaxSeverity));
+
+        if (damageIncreased && damagePercent > 0)
+        {
+            var ev = new ChatNotificationEvent(_aiTakingDamageChatNotificationPrototype, ent);
+            RaiseLocalEvent(held.Value, ref ev);
+        }
     }
 
     private void OnDoAfterAttempt(Entity<StationAiCoreComponent> ent, ref DoAfterAttemptEvent<IntellicardDoAfterEvent> args)

--- a/Content.Server/Silicons/StationAi/StationAiSystem.cs
+++ b/Content.Server/Silicons/StationAi/StationAiSystem.cs
@@ -305,7 +305,7 @@ public sealed class StationAiSystem : SharedStationAiSystem
 
         _alerts.ShowAlert(held.Value, _damageAlert, (short)Math.Clamp(damageLevel, 0, proto.MaxSeverity));
 
-        if (damageIncreased && damagePercent > 0)
+        if (damageIncreased)
         {
             var ev = new ChatNotificationEvent(_aiTakingDamageChatNotificationPrototype, ent);
             RaiseLocalEvent(held.Value, ref ev);

--- a/Resources/Locale/en-US/silicons/station-ai.ftl
+++ b/Resources/Locale/en-US/silicons/station-ai.ftl
@@ -8,6 +8,7 @@ station-ai-has-no-power-for-upload = Upload failed - the AI core is unpowered.
 station-ai-is-too-damaged-for-upload = Upload failed - the AI core must be repaired.
 station-ai-core-losing-power = Your AI core is now running on reserve battery power.
 station-ai-core-critical-power = Your AI core is critically low on power. External power must be re-established or severe data corruption may occur!
+station-ai-core-taking-damage = Your AI core is sustaining physical damage.
 
 # Ghost role
 station-ai-ghost-role-name = Station AI

--- a/Resources/Prototypes/Chat/notifications.yml
+++ b/Resources/Prototypes/Chat/notifications.yml
@@ -33,3 +33,10 @@
   sound: /Audio/Effects/alert.ogg
   color: Red
   nextDelay: 120
+
+- type: chatNotification
+  id: AiTakingDamage
+  message: station-ai-core-taking-damage
+  sound: /Audio/Misc/notice2.ogg
+  color: Orange
+  nextDelay: 30


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds an audio and chat notification for the Station AI that is displayed upon their core taking physical damage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Discussed a bit in the Silicon workgroup on Discord, but essentially, right now, unless the AI is actively watching their core on cameras, it is very easy to miss the fact that they are taking damage, which doesn't really make sense in my opinion.

This _can_ technically be alleviated by having turrets on (which will then alert the player when they're shooting an intruder), but many MRP servers consider activating them on green alert to be powergaming, so it's still possible for the AI player to be round removed without even knowing something was wrong if done early enough in the shift, especially now that it's a traitor objective to kill the AI.

## Technical details
<!-- Summary of code changes for easier review. -->

I am aware that there is currently a freeze on Silicon-related code, but this PR does not touch any files that are also modified by the two refactor PRs, so hopefully it shouldn't cause merge conflicts.

**Content.Server/Silicons/StationAi/StationAiSystem.cs**

- New read-only field for the new chat notification prototype
- `UpdateCoreIntegrityAlert` now takes a bool (defaulting to false) specifying whether or not damage was increased as part of that invocation
  - If it was, and the AI core is damaged, then an event is raised sending a notification to the player
- `OnDamageChanged` now passes whether or not damage was increased from its event args to `UpdateCoreIntegrityAlert`

**Resources/Locale/en-US/silicons/station-ai.ftl**

Added one locstring for the new chat notification text.

**Resources/Prototypes/Chat/notifications.yml**

Added a new chat notification prototype with the message referenced above, that plays the same audio as when the AI core loses power, with the same delay as well. Note that in practice, this delay starts counting from when the core _stops_ taking damage, so if it's continuously being attacked over the course of e.g. a minute, only a single alert will be sent.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/b8d2fd5c-29c7-46c7-baae-0a9da2ab5472

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: The Station AI is now notified when their core is taking damage.

