### PR TITLE
Fix incorrect DeltaPressure comparison

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/AtmosTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/AtmosTest.cs
@@ -122,4 +122,20 @@ public abstract class AtmosTest : InteractionTest
         Assert.That(MathHelper.CloseToPercent(mix1.TotalMoles, mix2.TotalMoles, tolerance),
             $"GasMixtures do not match. Got {mix1.TotalMoles} and {mix2.TotalMoles} moles");
     }
+
+    /// <summary>
+    /// Sets the tile's air mixture to have a certain pressure at a certain temperature.
+    /// </summary>
+    /// <param name="tile">Tile to set the air mixture of.</param>
+    /// <param name="pressure">The pressure to set the tile to.</param>
+    /// <param name="temp">The temperature to set the tile to.</param>
+    /// <param name="gas">The gas to fill the tile with.</param>
+    /// <remarks>Yeah, it could be a general atmospherics API, but the test assertion is desired.</remarks>
+    protected static void SetTilePressure(TileAtmosphere tile, float pressure, float temp = Atmospherics.T20C, Gas gas = Gas.Nitrogen)
+    {
+        Assert.That(tile.Air, Is.Not.Null, "Target tile should have an air mixture.");
+        tile.Air!.Clear();
+        var moles = pressure * tile.Air.Volume / (Atmospherics.R * temp);
+        tile.Air.AdjustMoles(gas, moles);
+    }
 }

--- a/Content.IntegrationTests/Tests/Atmos/DeltaPressureTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/DeltaPressureTest.cs
@@ -84,7 +84,19 @@ public sealed class DeltaPressureTest : AtmosTest
     baseDamage:
       types:
         Structural: 1000
-";
+
+- type: entity
+  parent: DeltaPressureSolidTest
+  id: DeltaPressureSolidTestDeltaOnly
+  components:
+  - type: DeltaPressure
+    minPressure: 100000
+    minPressureDelta: 10000
+    scalingType: Threshold
+    baseDamage:
+      types:
+        Structural: 1000
+ ";
 
     #endregion
 
@@ -337,5 +349,90 @@ public sealed class DeltaPressureTest : AtmosTest
 
             await Server.WaitRunTicks(30);
         }
+    }
+
+    /// <summary>
+    /// Asserts that diagonal pressure groupings do not trigger delta pressure damage.
+    /// </summary>
+    [Test]
+    public async Task ProcessingDeltaCardinalOnlyStandbyTest()
+    {
+        Entity<DeltaPressureComponent> dpEnt = default;
+
+        await Server.WaitPost(delegate
+        {
+            SAtmos.SetAtmosphereSimulation(ProcessEnt, false);
+            var uid = SEntMan.SpawnAtPosition("DeltaPressureSolidTestDeltaOnly", new EntityCoordinates(ProcessEnt.Owner, Vector2.Zero));
+            dpEnt = new Entity<DeltaPressureComponent>(uid, SEntMan.GetComponent<DeltaPressureComponent>(uid));
+            Assert.That(SAtmos.IsDeltaPressureEntityInList(ProcessEnt.Owner, dpEnt), "Entity was not in processing list when it should have been added!");
+
+            var indices = Transform.GetGridOrMapTilePosition(dpEnt);
+            var tiles = ProcessEnt.Comp1.Tiles;
+
+            // Same pressure on each opposing pair: N==S and E==W, so delta should be zero.
+            SetTilePressure(tiles[indices.Offset(AtmosDirection.North)], 12_000f);
+            SetTilePressure(tiles[indices.Offset(AtmosDirection.South)], 12_000f);
+            SetTilePressure(tiles[indices.Offset(AtmosDirection.East)], 100f);
+            SetTilePressure(tiles[indices.Offset(AtmosDirection.West)], 100f);
+        });
+
+        await Server.WaitPost(delegate
+        {
+            SAtmos.RunProcessingFull(ProcessEnt, ProcessEnt.Owner, SAtmos.AtmosTickRate);
+        });
+        await Server.WaitRunTicks(30);
+
+        await Server.WaitAssertion(delegate
+        {
+            Assert.That(!SEntMan.Deleted(dpEnt), $"{dpEnt} should not take damage when only diagonal comparisons would differ.");
+            foreach (var mix in SAtmos.GetAllMixtures(ProcessEnt))
+            {
+                mix.Clear();
+            }
+        });
+    }
+
+    /// <summary>
+    /// Asserts that opposing pressure groupings do trigger delta pressure damage.
+    /// </summary>
+    [Test]
+    public async Task ProcessingDeltaCardinalOnlyDamageTest()
+    {
+        Entity<DeltaPressureComponent> dpEnt = default;
+
+        await Server.WaitPost(delegate
+        {
+            SAtmos.SetAtmosphereSimulation(ProcessEnt, false);
+            var uid = SEntMan.SpawnAtPosition("DeltaPressureSolidTestDeltaOnly", new EntityCoordinates(ProcessEnt.Owner, Vector2.Zero));
+            dpEnt = new Entity<DeltaPressureComponent>(uid, SEntMan.GetComponent<DeltaPressureComponent>(uid));
+            Assert.That(SAtmos.IsDeltaPressureEntityInList(ProcessEnt.Owner, dpEnt), "Entity was not in processing list when it should have been added!");
+
+            var indices = Transform.GetGridOrMapTilePosition(dpEnt);
+            var tiles = ProcessEnt.Comp1.Tiles;
+
+            // There was a nasty bug where the indexing for comparisons was off and diagonals were
+            // being compared against instead of cardinals. This test basically
+            // stamps that out, so hopefully something silly doesn't happen again
+            // smile
+            SetTilePressure(tiles[indices.Offset(AtmosDirection.North)], 12_000f);
+            SetTilePressure(tiles[indices.Offset(AtmosDirection.South)], 100f);
+            SetTilePressure(tiles[indices.Offset(AtmosDirection.East)], 12_000f);
+            SetTilePressure(tiles[indices.Offset(AtmosDirection.West)], 100f);
+        });
+
+        await Server.WaitPost(delegate
+        {
+            SAtmos.RunProcessingFull(ProcessEnt, ProcessEnt.Owner, SAtmos.AtmosTickRate);
+        });
+        await Server.WaitRunTicks(30);
+
+        await Server.WaitAssertion(delegate
+        {
+            Assert.That(SEntMan.Deleted(dpEnt), $"{dpEnt} should take damage when opposing cardinals have threshold pressure differences.");
+            foreach (var mix in SAtmos.GetAllMixtures(ProcessEnt))
+            {
+                mix.Clear();
+            }
+        });
     }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.DeltaPressure.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.DeltaPressure.cs
@@ -141,9 +141,13 @@ public sealed partial class AtmosphereSystem
 
             /*
              In order to perform SIMD ops we load the values into opposing pairs, where:
-             groupA: North, East, South, West
-             groupB: South, West, North, East
+             groupA: North, East
+             groupB: South, West
              That way NumericsHelpers can just do vectorized operations on them super easily.
+
+             In a sense this means that the arrays, per index, would look like:
+             0, 1 - 0, 2
+             0, 1 - 1, 3
              */
             for (var i = 0; i < len; i++)
             {
@@ -151,8 +155,9 @@ public sealed partial class AtmosphereSystem
                 var pairBase = i * DeltaPressurePairCount;
                 for (var j = 0; j < DeltaPressurePairCount; j++)
                 {
-                    groupA[pairBase + j] = pressures[presBase + j];
-                    groupB[pairBase + j] = pressures[presBase + j + DeltaPressurePairCount];
+                    var pressurePairBase = DeltaPressurePairCount * j;
+                    groupA[pairBase + j] = pressures[presBase + pressurePairBase];
+                    groupB[pairBase + j] = pressures[presBase + pressurePairBase + 1];
                 }
             }
 


### PR DESCRIPTION
## About the PR
Fixed an incorrect comparison in DeltaPressure from incorrectly loading data into arrays for SIMD.
Fixes #43506

## Why / Balance
Bug.

## Technical details
When DeltaPressure was loading data into arrays for SIMD, it was accidentally:
- Overwriting previously loaded data due to an incorrect offset
- Loading data in the wrong place due to an incorrect offset

When data is loaded into SIMD, data should be loaded like so:

```mermaid
flowchart TD;
G11[North]
G21[South]
G12[East]
G22[West]

subgraph 1 [Group 1]
G11
G12
end

subgraph 2 [Group 2]
G21
G22
end

G11 -- SIMD --> G21
G12 -- SIMD --> G22
```

With the following indexes in their respective pair arrays and pressure arrays:

```mermaid
flowchart TD;
G11[North, 0]
G21[South, 0]
G12[East, 1]
G22[West, 1]

subgraph p [Pressures]
dir1[North, 0]
dir2[South, 1]
dir3[East, 2]
dir4[West, 3]
end

subgraph 1 [groupA]
G11
G12
end

subgraph 2 [groupB]
G21
G22
end

dir1 --> G11
dir2 --> G12
dir3 --> G21
dir4 --> G22

```

(In HL scientist voice) This should work.

I've been doing MATLAB for the past few weeks so I'm still shaking off the horrors of the first element in an array being index 1 instead of 0.

## Media
it works smile

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- fix: Fixed Delta-Pressure computing the pressure differential for a structure incorrectly.
