### PR TITLE
Chat tip color is now server color

### DIFF
--- a/Content.Server/Tips/TipsSystem.cs
+++ b/Content.Server/Tips/TipsSystem.cs
@@ -134,7 +134,7 @@ public sealed class TipsSystem : SharedTipsSystem
                 EntityUid.Invalid,
                 false,
                 false,
-                Color.MediumPurple);
+                ChatChannel.Server.TextColor());
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Chat tip color is now server color (orange, changed from purple).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Every time I see one while dead, I lose one second realising it's actually not a message from a ghost. Also it's a message from the server, so makes more sense than dead chat color.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="618" height="249" alt="image" src="https://github.com/user-attachments/assets/bf6dd4d7-5395-443c-bcfd-113fcd02728d" />


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Chat tip color is now same as server message color (orange).