### PR TITLE
Put a cargo shuttle console on every cargo shuttle

### DIFF
--- a/Resources/Maps/Shuttles/cargo.yml
+++ b/Resources/Maps/Shuttles/cargo.yml
@@ -645,7 +645,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,7.5
       parent: 173
-- proto: ComputerShuttle
+- proto: ComputerShuttleCargo
   entities:
   - uid: 78
     components:

--- a/Resources/Maps/Shuttles/cargo_exo.yml
+++ b/Resources/Maps/Shuttles/cargo_exo.yml
@@ -762,7 +762,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5,8.5
       parent: 173
-- proto: ComputerShuttle
+- proto: ComputerShuttleCargo
   entities:
   - uid: 36
     components:

--- a/Resources/Maps/Shuttles/cargo_plasma.yml
+++ b/Resources/Maps/Shuttles/cargo_plasma.yml
@@ -571,7 +571,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
       parent: 1
-- proto: ComputerShuttle
+- proto: ComputerShuttleCargo
   entities:
   - uid: 52
     components:

--- a/Resources/Maps/Shuttles/cargo_syndicate.yml
+++ b/Resources/Maps/Shuttles/cargo_syndicate.yml
@@ -708,7 +708,7 @@ entities:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-- proto: ComputerShuttleSyndie
+- proto: ComputerShuttleCargo
   entities:
   - uid: 87
     components:


### PR DESCRIPTION
## About the PR
Replaces the shuttle console on every cargo shuttle that had one with a cargo shuttle console. 

This also replaces the syndicate shuttle console on serpentcrest's shuttle with a normal one, which might not be wanted, and can be reverted by request.

## Why / Balance
Removes the exploit where salvagers could get a free shuttle console board from cargo shuttles that used a normal shuttle console.

This is an oversight that was not accounted for whenever the salvager's originally had the reclaimer taken away in favor of building their own shuttle. This exploit currently allows them to replace the shuttle console with the spare cargo shuttle console board in the QM's locker, giving them a free shuttle console without the need of finding one or getting one from research.

Many of the cargo shuttles already had a cargo shuttle console on them, and only a select few had the normal shuttle console board.

## Media
<img width="592" height="339" alt="image" src="https://github.com/user-attachments/assets/95894a98-de0a-4441-ad17-969a43667373" />
<img width="683" height="519" alt="image" src="https://github.com/user-attachments/assets/8abff2c5-f150-4e68-a776-cbad2e88e2f6" />
<img width="567" height="430" alt="image" src="https://github.com/user-attachments/assets/e3d39aff-f8bd-437c-acb7-64e0830440ed" />
<img width="629" height="380" alt="image" src="https://github.com/user-attachments/assets/5393cb87-d5cb-4eec-a26c-c4d55def886d" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Changed every cargo shuttle to have a cargo shuttle console
-->
