### PR TITLE
Logical Hand Sorting

### DIFF
--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -71,7 +71,7 @@ namespace Content.Client.Hands.Systems
             {
                 AddHand(ent.AsNullable(), handId, state.Hands[handId]);
             }
-            ent.Comp.SortedHands = new (state.SortedHands);
+            ent.Comp.SortedHands = new(state.SortedHands);
 
             SetActiveHand(ent.AsNullable(), state.ActiveHandId);
 

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -62,8 +62,16 @@ public abstract partial class SharedHandsSystem
 
     private void OnMapInit(Entity<HandsComponent> ent, ref MapInitEvent args)
     {
+        foreach (var (key, _) in ent.Comp.Hands)
+        {
+            if (!ent.Comp.SortedHands.Contains(key))
+                ent.Comp.SortedHands.Add(key);
+        }
+
         if (ent.Comp.ActiveHandId == null)
             SetActiveHand(ent.AsNullable(), ent.Comp.SortedHands.FirstOrDefault());
+
+        Dirty(ent);
     }
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -28,9 +28,6 @@
         location: Right
       hand_left:
         location: Left
-    sortedHands:
-    - hand_right
-    - hand_left
   - type: ComplexInteraction
   - type: Puller
     needsHands: false


### PR DESCRIPTION
## About the PR
Automatically populates `SortedHands` for entities with a `HandsComponent` during `MapInit` if the list is missing or incomplete. Also ensures client synchronization via `Dirty()`.

## Why / Balance
Fixes a regression caused by #42419. That PR made the hands system ignore entities without a `InitialBody` with `HandOrgan` parts, which broke hand sorting for creatures like `MobCorgiSmart` that have hands but no body.

Previously, entities without an explicitly defined `sortedHands` list in YAML would have an empty list, causing client-side crashes when trying to swap hands. This change removes the need to manually specify `sortedHands` in prototypes for every hand-equipped entity and handles it automatically at map init.

_P.S. Sorry that a smart corgi was chosen for the test, it's just the first one I found of this kind._

Error:
```
[ERRO] clyde.win: Error dispatching window event DEventKeyDown:
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at Content.Shared.Hands.EntitySystems.SharedHandsSystem.SwapHands(ICommonSession session, Boolean reverse) in C:\SpaceStation\Working\wiz-station-14\Content.Shared\Hands\EntitySystems\SharedHandsSystem.Interactions.cs:line 105
   at Content.Shared.Hands.EntitySystems.SharedHandsSystem.SwapHandsPressed(ICommonSession session) in C:\SpaceStation\Working\wiz-station-14\Content.Shared\Hands\EntitySystems\SharedHandsSystem.Interactions.cs:line 84
   at Robust.Shared.Input.Binding.InputCmdHandler.StateInputCmdHandler.Enabled(ICommonSession session) in C:\SpaceStation\Working\wiz-station-14\RobustToolbox\Robust.Shared\Input\Binding\InputCmdHandler.cs:line 53
   at Robust.Shared.Input.Binding.InputCmdHandler.StateInputCmdHandler.HandleCmdMessage(IEntityManager entManager, ICommonSession session, IFullInputCmdMessage message) in C:\SpaceStation\Working\wiz-station-14\RobustToolbox\Robust.Shared\Input\Binding\InputCmdHandler.cs:line 68
   at Robust.Client.GameObjects.InputSystem.HandleInputCommand(ICommonSession session, BoundKeyFunction function, IFullInputCmdMessage message, Boolean replay) in C:\SpaceStation\Working\wiz-station-14\RobustToolbox\Robust.Client\GameObjects\EntitySystems\InputSystem.cs:line 79
   at Content.Client.Gameplay.GameplayStateBase.OnKeyBindStateChanged(ViewportBoundKeyEventArgs args) in C:\SpaceStation\Working\wiz-station-14\Content.Client\Gameplay\GameplayStateBase.cs:line 264
   at Content.Client.Gameplay.GameplayState.OnKeyBindStateChanged(ViewportBoundKeyEventArgs args) in C:\SpaceStation\Working\wiz-station-14\Content.Client\Gameplay\GameplayState.cs:line 138
   at Robust.Client.Input.InputManager.SetBindState(KeyBinding binding, BoundKeyState state, Boolean uiOnly, Boolean isRepeat) in C:\SpaceStation\Working\wiz-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 441
   at Robust.Client.Input.InputManager.DownBind(KeyBinding binding, Boolean uiOnly, Boolean isRepeat) in C:\SpaceStation\Working\wiz-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 373
   at Robust.Client.Input.InputManager.KeyDown(KeyEventArgs args) in C:\SpaceStation\Working\wiz-station-14\RobustToolbox\Robust.Client\Input\InputManager.cs:line 293
   at Robust.Client.GameController.KeyDown(KeyEventArgs keyEvent) in C:\SpaceStation\Working\wiz-station-14\RobustToolbox\Robust.Client\GameController\GameController.Input.cs:line 12
   at Robust.Client.Graphics.Clyde.Clyde.DispatchSingleEvent(DEventBase ev) in C:\SpaceStation\Working\wiz-station-14\RobustToolbox\Robust.Client\Graphics\Clyde\Clyde.Events.cs:line 47
   at Robust.Client.Graphics.Clyde.Clyde.DispatchEvents() in C:\SpaceStation\Working\wiz-station-14\RobustToolbox\Robust.Client\Graphics\Clyde\Clyde.Events.cs:line 31
```

## Technical details
Added automatic population of `SortedHands` based on existing hands from the `Hands` dictionary in `OnMapInit`. This solves the issue where an entity has hands but `SortedHands` is empty (e.g., `MobCorgiSmart`). Also added a `Dirty` call to synchronize changes with the client.

### Testing steps:
1. Spawn any humanoid - verify that `SortedHands` contains both hands (no duplicates) and hand swapping works with the hotkey
2. Spawn `MobCorgiSmart` - verify that `SortedHands` is properly populated, hand swapping works, and no errors appear in the console
3. Enter `aghost` mode - verify that hand functionality still works correctly for aghost

## Media
<img width="1284" height="842" alt="image" src="https://github.com/user-attachments/assets/db4fe017-3b9b-4fd7-875f-37aa49b5932e" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed hand swapping causing crashes on entities without manually defined sorted hands (e.g., smart corgi)
- tweak: Hands component now automatically populates sorted hand list on map init