### PR TITLE
Wire brush can scrub away webs and posters

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Decoration/cobwebs.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/cobwebs.yml
@@ -28,10 +28,13 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: Construction
+    graph: CobwebsGraph
+    node: cobwebs
 
 - type: entity
-  id: Cobweb2
   parent: Cobweb1
+  id: Cobweb2
   components:
   - type: Sprite
     sprite: Structures/Decoration/cobweb.rsi

--- a/Resources/Prototypes/Entities/Structures/Decoration/cobwebs.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/cobwebs.yml
@@ -30,7 +30,7 @@
         acts: [ "Destruction" ]
   - type: Construction
     graph: CobwebsGraph
-    node: cobwebs
+    node: start
 
 - type: entity
   parent: Cobweb1

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -36,7 +36,7 @@
         offset: 0
   - type: Construction
     graph: PosterGraph
-    node: poster
+    node: start
 
 - type: entity
   parent: BaseSign

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -1,7 +1,7 @@
 - type: entity
+  abstract: true
   parent: BaseSign
   id: PosterBase
-  abstract: true
   components:
   - type: Sprite
     sprite: Structures/Wallmounts/posters.rsi
@@ -34,6 +34,9 @@
             min: 1
             max: 1
         offset: 0
+  - type: Construction
+    graph: PosterGraph
+    node: poster
 
 - type: entity
   parent: BaseSign
@@ -56,6 +59,9 @@
           path: /Audio/Effects/poster_broken.ogg
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: Construction
+    graph: PosterGraph
+    node: tornPoster
 
 # Contraband
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -48,6 +48,8 @@
     drawdepth: WallTops
     sprite: Structures/Wallmounts/posters.rsi
     state: poster_broken
+  - type: Damageable
+    damageModifierSet: Card
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/spider_web.yml
+++ b/Resources/Prototypes/Entities/Structures/spider_web.yml
@@ -1,6 +1,6 @@
 - type: entity
-  id: SpiderWebBase
   abstract: true
+  id: SpiderWebBase
   placement:
     mode: SnapgridCenter
     snap:
@@ -45,6 +45,9 @@
     additionalKeys:
     - walls
     base: web_
+  - type: Construction
+    graph: CobwebsGraph
+    node: cobwebs
 
 - type: entity
   id: SpiderWeb

--- a/Resources/Prototypes/Entities/Structures/spider_web.yml
+++ b/Resources/Prototypes/Entities/Structures/spider_web.yml
@@ -47,7 +47,7 @@
     base: web_
   - type: Construction
     graph: CobwebsGraph
-    node: cobwebs
+    node: start
 
 - type: entity
   id: SpiderWeb

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/posters.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/posters.yml
@@ -1,8 +1,8 @@
 - type: constructionGraph
   id: PosterGraph
-  start: poster
+  start: start
   graph:
-  - node: poster
+  - node: start
     edges:
     - to: tornPoster
       steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/posters.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/posters.yml
@@ -1,0 +1,26 @@
+- type: constructionGraph
+  id: PosterGraph
+  start: poster
+  graph:
+  - node: poster
+    edges:
+    - to: tornPoster
+      steps:
+      - tool: Brushing
+        doAfter: 2
+      completed:
+      - !type:PlaySound
+        sound:
+          path: /Audio/Effects/poster_broken.ogg
+
+  - node: tornPoster
+    entity: PosterBroken
+    edges:
+    - to: removed
+      steps:
+      - tool: Brushing
+        doAfter: 2
+
+  - node: removed
+    actions:
+    - !type:DestroyEntity {}

--- a/Resources/Prototypes/Recipes/Construction/Graphs/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/web.yml
@@ -1,8 +1,8 @@
 - type: constructionGraph
   id: CobwebsGraph
-  start: cobwebs
+  start: start
   graph:
-  - node: cobwebs
+  - node: start
     edges:
     - to: removed
       steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/web.yml
@@ -1,4 +1,19 @@
 - type: constructionGraph
+  id: CobwebsGraph
+  start: cobwebs
+  graph:
+  - node: cobwebs
+    edges:
+    - to: removed
+      steps:
+      - tool: Brushing
+        doAfter: 2
+
+  - node: removed
+    actions:
+    - !type:DestroyEntity {}
+
+- type: constructionGraph
   id: WebStructures
   start: start
   graph:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The wire brush can now be used to quickly clean cobwebs (the map decoration), spiderwebs (the mob spawn), posters, and torn posters. Torn posters were given cardboard for their damage modifier (from StructrualMetallic).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Suggestion taken from [discourse](https://forum.spacestation14.com/t/the-many-requests-of-a-humble-janitor-main/26731).

Cobwebs and posters are objects that carry associations with dirt and vandalism (enemies of cleanliness). Janitors want to be able to clean them, and a variety of things to clean is a natural expansion for the Janitor gameloop. The wire brush was chosen for verisimilitude and because it doesn't have a lot of uses right now.

While not an ideal fix, spiderwebs placed over walls can now be removed using the wirebrush. See #43338.

## Technical details
<!-- Summary of code changes for easier review. -->
Uses construction graphs to tie tool usage to entity destruction.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/2f6a4e05-4b67-49db-b908-1472fa10c3f4


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: aada
- add: The wire brush can now scrub away spiderwebs and posters.