### PR TITLE
Fix pneumatic valve solution convergance

### DIFF
--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/PressureControlledValveSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/PressureControlledValveSystem.cs
@@ -8,86 +8,90 @@ using Content.Shared.Atmos.Piping.Components;
 using Content.Shared.Audio;
 using JetBrains.Annotations;
 
-namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
+namespace Content.Server.Atmos.Piping.Trinary.EntitySystems;
+
+[UsedImplicitly]
+public sealed class PressureControlledValveSystem : EntitySystem
 {
-    [UsedImplicitly]
-    public sealed class PressureControlledValveSystem : EntitySystem
+    [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
+    [Dependency] private readonly SharedAmbientSoundSystem _ambientSoundSystem = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
+
+    public override void Initialize()
     {
-        [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
-        [Dependency] private readonly SharedAmbientSoundSystem _ambientSoundSystem = default!;
-        [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-        [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
+        base.Initialize();
+        SubscribeLocalEvent<PressureControlledValveComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<PressureControlledValveComponent, AtmosDeviceUpdateEvent>(OnUpdate);
+        SubscribeLocalEvent<PressureControlledValveComponent, AtmosDeviceDisabledEvent>(OnFilterLeaveAtmosphere);
+    }
 
-        public override void Initialize()
+    private void OnInit(EntityUid uid, PressureControlledValveComponent comp, ComponentInit args)
+    {
+        UpdateAppearance(uid, comp);
+    }
+
+    private void OnUpdate(EntityUid uid, PressureControlledValveComponent comp, ref AtmosDeviceUpdateEvent args)
+    {
+        if (!_nodeContainer.TryGetNodes(uid, comp.InletName, comp.ControlName, comp.OutletName, out PipeNode? inletNode, out PipeNode? controlNode, out PipeNode? outletNode))
         {
-            base.Initialize();
-            SubscribeLocalEvent<PressureControlledValveComponent, ComponentInit>(OnInit);
-            SubscribeLocalEvent<PressureControlledValveComponent, AtmosDeviceUpdateEvent>(OnUpdate);
-            SubscribeLocalEvent<PressureControlledValveComponent, AtmosDeviceDisabledEvent>(OnFilterLeaveAtmosphere);
+            _ambientSoundSystem.SetAmbience(uid, false);
+            comp.Enabled = false;
+            return;
         }
 
-        private void OnInit(EntityUid uid, PressureControlledValveComponent comp, ComponentInit args)
+        // If output is higher than input, flip input/output to enable bidirectional flow.
+        if (outletNode.Air.Pressure > inletNode.Air.Pressure)
         {
-            UpdateAppearance(uid, comp);
+            PipeNode temp = outletNode;
+            outletNode = inletNode;
+            inletNode = temp;
         }
 
-        private void OnUpdate(EntityUid uid, PressureControlledValveComponent comp, ref AtmosDeviceUpdateEvent args)
-        {
-            if (!_nodeContainer.TryGetNodes(uid, comp.InletName, comp.ControlName, comp.OutletName, out PipeNode? inletNode, out PipeNode? controlNode, out PipeNode? outletNode))
-            {
-                _ambientSoundSystem.SetAmbience(uid, false);
-                comp.Enabled = false;
-                return;
-            }
-
-            // If output is higher than input, flip input/output to enable bidirectional flow.
-            if (outletNode.Air.Pressure > inletNode.Air.Pressure)
-            {
-                PipeNode temp = outletNode;
-                outletNode = inletNode;
-                inletNode = temp;
-            }
-
-            float control = (controlNode.Air.Pressure - outletNode.Air.Pressure) - comp.Threshold;
-            float transferRate;
-            if (control < 0)
-            {
-                comp.Enabled = false;
-                transferRate = 0;
-            }
-            else
-            {
-                comp.Enabled = true;
-                transferRate = Math.Min(control * comp.Gain, comp.MaxTransferRate * _atmosphereSystem.PumpSpeedup());
-            }
-            UpdateAppearance(uid, comp);
-
-            // We multiply the transfer rate in L/s by the seconds passed since the last process to get the liters.
-            var transferVolume = transferRate * args.dt;
-            if (transferVolume <= 0)
-            {
-                _ambientSoundSystem.SetAmbience(uid, false);
-                return;
-            }
-
-            _ambientSoundSystem.SetAmbience(uid, true);
-            var removed = inletNode.Air.RemoveVolume(transferVolume);
-            _atmosphereSystem.Merge(outletNode.Air, removed);
-        }
-
-        private void OnFilterLeaveAtmosphere(EntityUid uid, PressureControlledValveComponent comp, ref AtmosDeviceDisabledEvent args)
+        float control = (controlNode.Air.Pressure - outletNode.Air.Pressure) - comp.Threshold;
+        float transferRate;
+        if (control < 0)
         {
             comp.Enabled = false;
-            UpdateAppearance(uid, comp);
-            _ambientSoundSystem.SetAmbience(uid, false);
+            transferRate = 0;
         }
-
-        private void UpdateAppearance(EntityUid uid, PressureControlledValveComponent? comp = null, AppearanceComponent? appearance = null)
+        else
         {
-            if (!Resolve(uid, ref comp, ref appearance, false))
-                return;
-
-            _appearance.SetData(uid, FilterVisuals.Enabled, comp.Enabled, appearance);
+            comp.Enabled = true;
+            transferRate = Math.Min(control * comp.Gain, comp.MaxTransferRate * _atmosphereSystem.PumpSpeedup());
         }
+        UpdateAppearance(uid, comp);
+
+        // We multiply the transfer rate in L/s by the seconds passed since the last process to get the liters.
+        var transferVolume = transferRate * args.dt;
+        if (transferVolume <= 0)
+        {
+            _ambientSoundSystem.SetAmbience(uid, false);
+            return;
+        }
+
+        // clamp to equalization so we don't overshoot (happens with silly euler)
+        var maxFrac = _atmosphereSystem.FractionToEqualizePressure(inletNode.Air, outletNode.Air);
+        var maxVol = inletNode.Air.Volume * maxFrac;
+        var clampedVolume = Math.Min(transferVolume, maxVol);
+
+        _ambientSoundSystem.SetAmbience(uid, true);
+        var removed = inletNode.Air.RemoveVolume(clampedVolume);
+        _atmosphereSystem.Merge(outletNode.Air, removed);
+    }
+
+    private void OnFilterLeaveAtmosphere(EntityUid uid, PressureControlledValveComponent comp, ref AtmosDeviceDisabledEvent args)
+    {
+        comp.Enabled = false;
+        UpdateAppearance(uid, comp);
+        _ambientSoundSystem.SetAmbience(uid, false);
+    }
+
+    private void UpdateAppearance(EntityUid uid, PressureControlledValveComponent? comp = null, AppearanceComponent? appearance = null)
+    {
+        if (!Resolve(uid, ref comp, ref appearance, false))
+            return;
+
+        _appearance.SetData(uid, FilterVisuals.Enabled, comp.Enabled, appearance);
     }
 }


### PR DESCRIPTION
## About the PR
Fixes the pneumatic valve overshooting equalization.

## Why / Balance
Bug.

## Technical details
Anything that's multiplied by a $dt$ has an overshoot issue - luckily in this system we know the desired final state (effectively a passive valve, so sides should be equal in pressure minus whatever pressure offset we have, which is 1 atm).

## Media
b4

<img width="1266" height="549" alt="image" src="https://github.com/user-attachments/assets/4c9d22b8-21e1-4fb5-827c-8c8e0f33037b" />

after

<img width="1456" height="520" alt="overshootfixed" src="https://github.com/user-attachments/assets/f95d5aeb-1751-41da-8848-cee1e21f9acd" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed the pneumatic valve overshooting gas equalization between the two connected pipenets.
