### PR TITLE
Predict IngestionBlockerComponent

### DIFF
--- a/Content.Shared/Nutrition/Components/IngestionBlockerComponent.cs
+++ b/Content.Shared/Nutrition/Components/IngestionBlockerComponent.cs
@@ -14,8 +14,8 @@ namespace Content.Shared.Nutrition.Components;
 public sealed partial class IngestionBlockerComponent : Component
 {
     /// <summary>
-    ///     Is this component currently blocking consumption.
+    ///     Whether this item currently blocks consuming something.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public bool Enabled { get; set; } = true;
+    public bool Enabled = true;
 }

--- a/Content.Shared/Nutrition/Components/IngestionBlockerComponent.cs
+++ b/Content.Shared/Nutrition/Components/IngestionBlockerComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Nutrition.EntitySystems;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Nutrition.Components;
 
@@ -9,12 +10,12 @@ namespace Content.Shared.Nutrition.Components;
 ///     In the event that more head-wear & mask functionality is added (like identity systems, or raising/lowering of
 ///     masks), then this component might become redundant.
 /// </remarks>
-[RegisterComponent, Access(typeof(IngestionSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(IngestionSystem))]
 public sealed partial class IngestionBlockerComponent : Component
 {
     /// <summary>
     ///     Is this component currently blocking consumption.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool Enabled { get; set; } = true;
 }

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
@@ -43,27 +43,28 @@ public sealed partial class IngestionSystem
         args.Cancelled = true;
     }
 
-    private void OnBlockerMaskToggled(Entity<IngestionBlockerComponent> ent, ref ItemMaskToggledEvent args)
+    private void OnBlockerMaskToggled(Entity<IngestionBlockerComponent> mask, ref ItemMaskToggledEvent args)
     {
-        ent.Comp.Enabled = !args.Mask.Comp.IsToggled;
+        mask.Comp.Enabled = !args.Mask.Comp.IsToggled;
+        Dirty(mask);
     }
 
-    private void OnIngestionBlockerAttempt(Entity<IngestionBlockerComponent> entity, ref IngestionAttemptEvent args)
+    private void OnIngestionBlockerAttempt(Entity<IngestionBlockerComponent> mask, ref IngestionAttemptEvent args)
     {
-        if (!args.Cancelled && entity.Comp.Enabled)
+        if (!args.Cancelled && mask.Comp.Enabled)
             args.Cancelled = true;
     }
 
     /// <summary>
     ///     Block ingestion attempts based on the equipped mask or head-wear
     /// </summary>
-    private void OnIngestionBlockerAttempt(Entity<IngestionBlockerComponent> entity, ref InventoryRelayedEvent<IngestionAttemptEvent> args)
+    private void OnIngestionBlockerAttempt(Entity<IngestionBlockerComponent> mask, ref InventoryRelayedEvent<IngestionAttemptEvent> args)
     {
-        if (args.Args.Cancelled || !entity.Comp.Enabled)
+        if (args.Args.Cancelled || !mask.Comp.Enabled)
             return;
 
         args.Args.Cancelled = true;
-        args.Args.Blocker = entity;
+        args.Args.Blocker = mask;
     }
 
     private void OnEdible(Entity<EdibleComponent> entity, ref EdibleEvent args)

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
@@ -43,28 +43,28 @@ public sealed partial class IngestionSystem
         args.Cancelled = true;
     }
 
-    private void OnBlockerMaskToggled(Entity<IngestionBlockerComponent> mask, ref ItemMaskToggledEvent args)
+    private void OnBlockerMaskToggled(Entity<IngestionBlockerComponent> entity, ref ItemMaskToggledEvent args)
     {
-        mask.Comp.Enabled = !args.Mask.Comp.IsToggled;
-        Dirty(mask);
+        entity.Comp.Enabled = !args.Mask.Comp.IsToggled;
+        Dirty(entity);
     }
 
-    private void OnIngestionBlockerAttempt(Entity<IngestionBlockerComponent> mask, ref IngestionAttemptEvent args)
+    private void OnIngestionBlockerAttempt(Entity<IngestionBlockerComponent> entity, ref IngestionAttemptEvent args)
     {
-        if (!args.Cancelled && mask.Comp.Enabled)
+        if (!args.Cancelled && entity.Comp.Enabled)
             args.Cancelled = true;
     }
 
     /// <summary>
     ///     Block ingestion attempts based on the equipped mask or head-wear
     /// </summary>
-    private void OnIngestionBlockerAttempt(Entity<IngestionBlockerComponent> mask, ref InventoryRelayedEvent<IngestionAttemptEvent> args)
+    private void OnIngestionBlockerAttempt(Entity<IngestionBlockerComponent> entity, ref InventoryRelayedEvent<IngestionAttemptEvent> args)
     {
-        if (args.Args.Cancelled || !mask.Comp.Enabled)
+        if (args.Args.Cancelled || !entity.Comp.Enabled)
             return;
 
         args.Args.Cancelled = true;
-        args.Args.Blocker = mask;
+        args.Args.Blocker = entity;
     }
 
     private void OnEdible(Entity<EdibleComponent> entity, ref EdibleEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Predicted IngestionBlockerComponent.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Prediction good. I found out about in #42377 when I used Soap on someone.
Somehow, this only affects when you attempt to feed other people.
If you pull down your mask and attempt to eat something, even though it's not predicted, it has no prediction issues.
However, if someone else pulls down their mask and you attempt to feed them, your client will think it's still blocking your food.
## Technical details
<!-- Summary of code changes for easier review. -->
Small c# changes.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before followed up by after
https://github.com/user-attachments/assets/1ec965f1-013d-43ed-869a-10256ef172af


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the Prediction Issue when trying to forcefeed someone with a pulled-down mask!
