### PR TITLE
Atmospherics AddHeatTileMixture API

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
@@ -291,6 +291,23 @@ public partial class AtmosphereSystem
     }
 
     /// <summary>
+    /// Adds heat to the tile mixture of a tile that an entity is on.
+    /// </summary>
+    /// <param name="entity">The entity that's on the tile to add heat to.</param>
+    /// <param name="dQ">The amount of heat to add, in joules.</param>
+    /// <param name="excite">Whether to mark the tile as active for atmosphere processing.
+    /// You pretty much always want this if you're changing the temperature.</param>
+    [PublicAPI]
+    public void AddHeatTileMixture(Entity<TransformComponent?> entity, float dQ, bool excite = true)
+    {
+        var mixture = GetTileMixture(entity, excite);
+        if (mixture == null)
+            return;
+
+        AddHeat(mixture, dQ);
+    }
+
+    /// <summary>
     /// Retrieves the pressures of all gas mixtures
     /// in the given array of <see cref="TileAtmosphere"/>s, and stores the results in the
     /// provided <paramref name="pressures"/> span.

--- a/Content.Server/Lathe/Components/LatheHeatProducingComponent.cs
+++ b/Content.Server/Lathe/Components/LatheHeatProducingComponent.cs
@@ -11,24 +11,11 @@ namespace Content.Server.Lathe.Components;
 public sealed partial class LatheHeatProducingComponent : Component
 {
     /// <summary>
-    /// The amount of heat produced from making an item, in Joules.
-    /// Dumped into the tile the entity is on at <see cref="NextUpdate"/>.
-    /// Can be negative.
+    /// The amount of energy produced each second when producing an item.
     /// </summary>
-    /// <remarks>Name is massively incorrect and I don't want to change it.
-    /// This is just watts if you dump heat every second.</remarks>
-    [DataField]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float EnergyPerSecond = 30000;
 
-    /// <summary>
-    /// How often the lathe should dump heat into the surroundings, in seconds.
-    /// </summary>
-    [DataField]
-    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(1);
-
-    /// <summary>
-    /// The next time the lathe should dump heat into the surroundings.
-    /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
-    public TimeSpan NextUpdate;
+    public TimeSpan NextSecond;
 }

--- a/Content.Server/Lathe/Components/LatheHeatProducingComponent.cs
+++ b/Content.Server/Lathe/Components/LatheHeatProducingComponent.cs
@@ -11,11 +11,24 @@ namespace Content.Server.Lathe.Components;
 public sealed partial class LatheHeatProducingComponent : Component
 {
     /// <summary>
-    /// The amount of energy produced each second when producing an item.
+    /// The amount of heat produced from making an item, in Joules.
+    /// Dumped into the tile the entity is on at <see cref="NextUpdate"/>.
+    /// Can be negative.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    /// <remarks>Name is massively incorrect and I don't want to change it.
+    /// This is just watts if you dump heat every second.</remarks>
+    [DataField]
     public float EnergyPerSecond = 30000;
 
+    /// <summary>
+    /// How often the lathe should dump heat into the surroundings, in seconds.
+    /// </summary>
+    [DataField]
+    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The next time the lathe should dump heat into the surroundings.
+    /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
-    public TimeSpan NextSecond;
+    public TimeSpan NextUpdate;
 }

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -54,7 +54,6 @@ namespace Content.Server.Lathe
         [Dependency] private readonly ReagentSpeedSystem _reagentSpeed = default!;
         [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
         [Dependency] private readonly StackSystem _stack = default!;
-        [Dependency] private readonly TransformSystem _transform = default!;
         [Dependency] private readonly RadioSystem _radio = default!;
 
         public override void Initialize()

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -57,6 +57,11 @@ namespace Content.Server.Lathe
         [Dependency] private readonly TransformSystem _transform = default!;
         [Dependency] private readonly RadioSystem _radio = default!;
 
+        /// <summary>
+        /// Per-tick cache
+        /// </summary>
+        private readonly List<GasMixture> _environments = new();
+
         public override void Initialize()
         {
             base.Initialize();
@@ -78,15 +83,7 @@ namespace Content.Server.Lathe
             SubscribeLocalEvent<TechnologyDatabaseComponent, LatheGetRecipesEvent>(OnGetRecipes);
             SubscribeLocalEvent<EmagLatheRecipesComponent, LatheGetRecipesEvent>(GetEmagLatheRecipes);
             SubscribeLocalEvent<LatheHeatProducingComponent, LatheStartPrintingEvent>(OnHeatStartPrinting);
-
-            SubscribeLocalEvent<LatheHeatProducingComponent, MapInitEvent>(HeatComponentMapInit);
         }
-
-        private void HeatComponentMapInit(Entity<LatheHeatProducingComponent> ent, ref MapInitEvent args)
-        {
-            ent.Comp.NextUpdate = _timing.CurTime + ent.Comp.UpdateInterval;
-        }
-
         public override void Update(float frameTime)
         {
             var query = EntityQueryEnumerator<LatheProducingComponent, LatheComponent>();
@@ -102,11 +99,33 @@ namespace Content.Server.Lathe
             var heatQuery = EntityQueryEnumerator<LatheHeatProducingComponent, LatheProducingComponent, TransformComponent>();
             while (heatQuery.MoveNext(out var uid, out var heatComp, out _, out var xform))
             {
-                if (_timing.CurTime < heatComp.NextUpdate)
+                if (_timing.CurTime < heatComp.NextSecond)
                     continue;
+                heatComp.NextSecond += TimeSpan.FromSeconds(1);
 
-                heatComp.NextUpdate += heatComp.UpdateInterval;
-                _atmosphere.AddHeatTileMixture((uid, xform), heatComp.EnergyPerSecond);
+                var position = _transform.GetGridTilePositionOrDefault((uid, xform));
+                _environments.Clear();
+
+                if (_atmosphere.GetTileMixture(xform.GridUid, xform.MapUid, position, true) is { } tileMix)
+                    _environments.Add(tileMix);
+
+                if (xform.GridUid != null)
+                {
+                    var enumerator = _atmosphere.GetAdjacentTileMixtures(xform.GridUid.Value, position, false, true);
+                    while (enumerator.MoveNext(out var mix))
+                    {
+                        _environments.Add(mix);
+                    }
+                }
+
+                if (_environments.Count > 0)
+                {
+                    var heatPerTile = heatComp.EnergyPerSecond / _environments.Count;
+                    foreach (var env in _environments)
+                    {
+                        _atmosphere.AddHeat(env, heatPerTile);
+                    }
+                }
             }
         }
 
@@ -305,7 +324,7 @@ namespace Content.Server.Lathe
 
         private void OnHeatStartPrinting(EntityUid uid, LatheHeatProducingComponent component, LatheStartPrintingEvent args)
         {
-            component.NextUpdate = _timing.CurTime;
+            component.NextSecond = _timing.CurTime;
         }
 
         private void OnMaterialAmountChanged(EntityUid uid, LatheComponent component, ref MaterialAmountChangedEvent args)

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -57,11 +57,6 @@ namespace Content.Server.Lathe
         [Dependency] private readonly TransformSystem _transform = default!;
         [Dependency] private readonly RadioSystem _radio = default!;
 
-        /// <summary>
-        /// Per-tick cache
-        /// </summary>
-        private readonly List<GasMixture> _environments = new();
-
         public override void Initialize()
         {
             base.Initialize();
@@ -83,7 +78,15 @@ namespace Content.Server.Lathe
             SubscribeLocalEvent<TechnologyDatabaseComponent, LatheGetRecipesEvent>(OnGetRecipes);
             SubscribeLocalEvent<EmagLatheRecipesComponent, LatheGetRecipesEvent>(GetEmagLatheRecipes);
             SubscribeLocalEvent<LatheHeatProducingComponent, LatheStartPrintingEvent>(OnHeatStartPrinting);
+
+            SubscribeLocalEvent<LatheHeatProducingComponent, MapInitEvent>(HeatComponentMapInit);
         }
+
+        private void HeatComponentMapInit(Entity<LatheHeatProducingComponent> ent, ref MapInitEvent args)
+        {
+            ent.Comp.NextUpdate = _timing.CurTime + ent.Comp.UpdateInterval;
+        }
+
         public override void Update(float frameTime)
         {
             var query = EntityQueryEnumerator<LatheProducingComponent, LatheComponent>();
@@ -99,33 +102,11 @@ namespace Content.Server.Lathe
             var heatQuery = EntityQueryEnumerator<LatheHeatProducingComponent, LatheProducingComponent, TransformComponent>();
             while (heatQuery.MoveNext(out var uid, out var heatComp, out _, out var xform))
             {
-                if (_timing.CurTime < heatComp.NextSecond)
+                if (_timing.CurTime < heatComp.NextUpdate)
                     continue;
-                heatComp.NextSecond += TimeSpan.FromSeconds(1);
 
-                var position = _transform.GetGridTilePositionOrDefault((uid, xform));
-                _environments.Clear();
-
-                if (_atmosphere.GetTileMixture(xform.GridUid, xform.MapUid, position, true) is { } tileMix)
-                    _environments.Add(tileMix);
-
-                if (xform.GridUid != null)
-                {
-                    var enumerator = _atmosphere.GetAdjacentTileMixtures(xform.GridUid.Value, position, false, true);
-                    while (enumerator.MoveNext(out var mix))
-                    {
-                        _environments.Add(mix);
-                    }
-                }
-
-                if (_environments.Count > 0)
-                {
-                    var heatPerTile = heatComp.EnergyPerSecond / _environments.Count;
-                    foreach (var env in _environments)
-                    {
-                        _atmosphere.AddHeat(env, heatPerTile);
-                    }
-                }
+                heatComp.NextUpdate += heatComp.UpdateInterval;
+                _atmosphere.AddHeatTileMixture((uid, xform), heatComp.EnergyPerSecond);
             }
         }
 
@@ -324,7 +305,7 @@ namespace Content.Server.Lathe
 
         private void OnHeatStartPrinting(EntityUid uid, LatheHeatProducingComponent component, LatheStartPrintingEvent args)
         {
-            component.NextSecond = _timing.CurTime;
+            component.NextUpdate = _timing.CurTime;
         }
 
         private void OnMaterialAmountChanged(EntityUid uid, LatheComponent component, ref MaterialAmountChangedEvent args)

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -57,11 +57,6 @@ namespace Content.Server.Lathe
         [Dependency] private readonly TransformSystem _transform = default!;
         [Dependency] private readonly RadioSystem _radio = default!;
 
-        /// <summary>
-        /// Per-tick cache
-        /// </summary>
-        private readonly List<GasMixture> _environments = new();
-
         public override void Initialize()
         {
             base.Initialize();
@@ -103,29 +98,7 @@ namespace Content.Server.Lathe
                     continue;
                 heatComp.NextSecond += TimeSpan.FromSeconds(1);
 
-                var position = _transform.GetGridTilePositionOrDefault((uid, xform));
-                _environments.Clear();
-
-                if (_atmosphere.GetTileMixture(xform.GridUid, xform.MapUid, position, true) is { } tileMix)
-                    _environments.Add(tileMix);
-
-                if (xform.GridUid != null)
-                {
-                    var enumerator = _atmosphere.GetAdjacentTileMixtures(xform.GridUid.Value, position, false, true);
-                    while (enumerator.MoveNext(out var mix))
-                    {
-                        _environments.Add(mix);
-                    }
-                }
-
-                if (_environments.Count > 0)
-                {
-                    var heatPerTile = heatComp.EnergyPerSecond / _environments.Count;
-                    foreach (var env in _environments)
-                    {
-                        _atmosphere.AddHeat(env, heatPerTile);
-                    }
-                }
+                _atmosphere.AddHeatTileMixture((uid, xform), heatComp.EnergyPerSecond);
             }
         }
 


### PR DESCRIPTION
## About the PR
Adds a new API method to Atmospherics for changing the heat of a tile.

This also updates/fixes lathes keeping all of their heat mostly in one tile.

## Why / Balance
It's better.

## Technical details
Ok so. For some reason Atmospherics will just trap heat and not perform equalizations with other tiles if a star pattern is formed. No I don't know why it occurs. No I don't want to debug it right now, I think it'll be yet another hellbug that takes up way too much of my time.

In general Atmospherics should be handling heat spread and simulating it itself, content systems shouldn't spread it out themselves, which is what LatheSystem was doing.

This just changes it so that lathes will dump their heat to the tile that they're on and lets Atmospherics handle the distribution to its neighbors and beyond.

## Media
b4
<img width="1344" height="771" alt="image" src="https://github.com/user-attachments/assets/bc5d6ada-cf2f-4576-8af3-a89b3f4d3378" />

after
<img width="949" height="557" alt="image" src="https://github.com/user-attachments/assets/3f734a1b-9505-43fc-90bb-6055a20c0cfa" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
<!--
:cl:
- fix: Fixed hyperlathes concentrating their heat and keeping it on the tile that they're on when the room has still air. Atmospherics should now spread it throughout the room.
