### PR TITLE
NPCs no longer target invisible entities

### DIFF
--- a/Content.Server/NPC/Queries/Considerations/TargetIsVisibleCon.cs
+++ b/Content.Server/NPC/Queries/Considerations/TargetIsVisibleCon.cs
@@ -1,0 +1,5 @@
+namespace Content.Server.NPC.Queries.Considerations;
+
+public sealed partial class TargetIsVisibleCon : UtilityConsideration
+{
+}

--- a/Content.Server/NPC/Queries/Considerations/TargetIsVisibleCon.cs
+++ b/Content.Server/NPC/Queries/Considerations/TargetIsVisibleCon.cs
@@ -1,5 +1,3 @@
 namespace Content.Server.NPC.Queries.Considerations;
 
-public sealed partial class TargetIsVisibleCon : UtilityConsideration
-{
-}
+public sealed partial class TargetIsVisibleCon : UtilityConsideration;

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -32,6 +32,8 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Temperature.Components;
+using Content.Shared.Stealth;
+using Content.Shared.Stealth.Components;
 
 namespace Content.Server.NPC.Systems;
 
@@ -57,6 +59,7 @@ public sealed class NPCUtilitySystem : EntitySystem
     [Dependency] private readonly MobThresholdSystem _thresholdSystem = default!;
     [Dependency] private readonly TurretTargetSettingsSystem _turretTargetSettings = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedStealthSystem _stealth = default!;
 
     private EntityQuery<PuddleComponent> _puddleQuery;
     private EntityQuery<TransformComponent> _xformQuery;
@@ -285,6 +288,15 @@ public sealed class NPCUtilitySystem : EntitySystem
                 }
 
                 return Math.Clamp(distance / radius, 0f, 1f);
+            }
+            case TargetIsVisibleCon:
+            {
+                if (!TryComp(targetUid, out StealthComponent? stealth))
+                    return 1f; // If there is no StealthComponent, we see it.
+
+                // Checking the visibility level
+                var visibility = _stealth.GetVisibility(targetUid, stealth);
+                return visibility >= 0.5f ? 1f : 0f; // Visibility threshold 0.5
             }
             case TargetAmmoCon:
             {

--- a/Resources/Prototypes/NPCs/utility_queries.yml
+++ b/Resources/Prototypes/NPCs/utility_queries.yml
@@ -88,6 +88,8 @@
   considerations:
     - !type:TargetIsAliveCon
       curve: !type:BoolCurve
+    - !type:TargetIsVisibleCon
+      curve: !type:BoolCurve
     - !type:TargetDistanceCon
       curve: !type:PresetCurve
         preset: TargetDistance


### PR DESCRIPTION
## About the PR
This PR suggests slightly changing the logic of finding a target for an attack from an NPC.

## Why / Balance
Ninja often appears during the "survival" mode, and the player has to not only hide from the crew members, but also choose the route very carefully. After all, any NPCs (for example, a dragon, carp or spiders) immediately attack him, completely ignoring invisibility. So I suggest making life a little easier for the players.

## Technical details
Another option for defining a target has been added in the getScore() method of the NPCUtilitySystem. The "NearbyMeleeTargets" prototype has also been changed and the TargetIsVisibleCon class has been created.

## Media
Before the changes

https://github.com/user-attachments/assets/31d9f596-f031-43ca-8bdf-f5a220e19534

After

https://github.com/user-attachments/assets/b4d42e93-3088-4f22-9af9-fa39e76303be


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: BeatusCrow
- add: NPCs no longer detect invisible targets.

