### PR TITLE
Fix access removal causing misspredicts

### DIFF
--- a/Content.Shared/Access/Components/AccessReaderComponent.cs
+++ b/Content.Shared/Access/Components/AccessReaderComponent.cs
@@ -12,6 +12,7 @@ namespace Content.Shared.Access.Components;
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(AccessReaderSystem))]
+[AutoGenerateComponentState]
 public sealed partial class AccessReaderComponent : Component
 {
     /// <summary>
@@ -31,7 +32,7 @@ public sealed partial class AccessReaderComponent : Component
     /// List of access groups that grant access to this reader. Only a single matching group is required to gain access.
     /// A group matches if it is a subset of the set being checked against.
     /// </summary>
-    [DataField("access")]
+    [DataField("access"), AutoNetworkedField]
     public List<HashSet<ProtoId<AccessLevelPrototype>>> AccessLists = new();
 
     /// <summary>
@@ -40,7 +41,7 @@ public sealed partial class AccessReaderComponent : Component
     /// <remarks>
     /// If null, the access lists of this entity have not been modified yet.
     /// </remarks>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public List<HashSet<ProtoId<AccessLevelPrototype>>>? AccessListsOriginal = null;
 
     /// <summary>

--- a/Content.Shared/Access/Components/AccessReaderComponent.cs
+++ b/Content.Shared/Access/Components/AccessReaderComponent.cs
@@ -12,7 +12,6 @@ namespace Content.Shared.Access.Components;
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(AccessReaderSystem))]
-[AutoGenerateComponentState]
 public sealed partial class AccessReaderComponent : Component
 {
     /// <summary>
@@ -32,16 +31,16 @@ public sealed partial class AccessReaderComponent : Component
     /// List of access groups that grant access to this reader. Only a single matching group is required to gain access.
     /// A group matches if it is a subset of the set being checked against.
     /// </summary>
-    [DataField("access"), AutoNetworkedField]
+    [DataField("access")]
     public List<HashSet<ProtoId<AccessLevelPrototype>>> AccessLists = new();
 
     /// <summary>
     /// An unmodified copy of the original list of the access groups that grant access to this reader.
     /// </summary>
     /// <remarks>
-    /// If null, the access lists of this entity have not been modified yet.
+    /// If null, entity isn't intialized yet.
     /// </remarks>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public List<HashSet<ProtoId<AccessLevelPrototype>>>? AccessListsOriginal = null;
 
     /// <summary>

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -41,23 +41,25 @@ public sealed class AccessReaderSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<AccessReaderComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<AccessReaderComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<AccessReaderComponent, GotEmaggedEvent>(OnEmagged);
         SubscribeLocalEvent<AccessReaderComponent, LinkAttemptEvent>(OnLinkAttempt);
         SubscribeLocalEvent<AccessReaderComponent, AccessReaderConfigurationAttemptEvent>(OnConfigurationAttempt);
         SubscribeLocalEvent<AccessReaderComponent, FindAvailableLocksEvent>(OnFindAvailableLocks);
         SubscribeLocalEvent<AccessReaderComponent, CheckUserHasLockAccessEvent>(OnCheckLockAccess);
+    }
 
-        SubscribeLocalEvent<AccessReaderComponent, ComponentGetState>(OnGetState);
-        SubscribeLocalEvent<AccessReaderComponent, ComponentHandleState>(OnHandleState);
+    private void OnMapInit(Entity<AccessReaderComponent> ent, ref MapInitEvent args)
+    {
+        ent.Comp.AccessListsOriginal ??= [.. ent.Comp.AccessLists];
+        Dirty(ent);
     }
 
     private void OnExamined(Entity<AccessReaderComponent> ent, ref ExaminedEvent args)
     {
-        if (!GetMainAccessReader(ent, out var mainAccessReader))
+        if (!GetMainAccessReader(ent, out var mainAccessReader) || mainAccessReader.Value.Comp.AccessListsOriginal == null)
             return;
-
-        mainAccessReader.Value.Comp.AccessListsOriginal ??= new(mainAccessReader.Value.Comp.AccessLists);
 
         var accessHasBeenModified = mainAccessReader.Value.Comp.AccessLists.Count != mainAccessReader.Value.Comp.AccessListsOriginal.Count;
 
@@ -100,40 +102,6 @@ public sealed class AccessReaderSystem : EntitySystem
         var originalAccessesFormatted = ContentLocalizationManager.FormatListToOr(localizedOriginalNames);
         var originalSettingsMessage = Loc.GetString(mainAccessReader.Value.Comp.ExaminationText, ("access", originalAccessesFormatted));
         args.PushMarkup(originalSettingsMessage);
-    }
-
-    private void OnGetState(EntityUid uid, AccessReaderComponent component, ref ComponentGetState args)
-    {
-        args.State = new AccessReaderComponentState(
-            component.Enabled,
-            component.DenyTags,
-            component.AccessLists,
-            component.AccessListsOriginal,
-            _recordsSystem.Convert(component.AccessKeys),
-            component.AccessLog,
-            component.AccessLogLimit);
-    }
-
-    private void OnHandleState(EntityUid uid, AccessReaderComponent component, ref ComponentHandleState args)
-    {
-        if (args.Current is not AccessReaderComponentState state)
-            return;
-        component.Enabled = state.Enabled;
-        component.AccessKeys.Clear();
-        foreach (var key in state.AccessKeys)
-        {
-            var id = EnsureEntity<AccessReaderComponent>(key.Item1, uid);
-            if (!id.IsValid())
-                continue;
-
-            component.AccessKeys.Add(new StationRecordKey(key.Item2, id));
-        }
-
-        component.AccessLists = new(state.AccessLists);
-        component.AccessListsOriginal = state.AccessListsOriginal == null ? null : new(state.AccessListsOriginal);
-        component.DenyTags = new(state.DenyTags);
-        component.AccessLog = new(state.AccessLog);
-        component.AccessLogLimit = state.AccessLogLimit;
     }
 
     private void OnLinkAttempt(EntityUid uid, AccessReaderComponent component, LinkAttemptEvent args)

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -48,6 +48,9 @@ public sealed class AccessReaderSystem : EntitySystem
         SubscribeLocalEvent<AccessReaderComponent, AccessReaderConfigurationAttemptEvent>(OnConfigurationAttempt);
         SubscribeLocalEvent<AccessReaderComponent, FindAvailableLocksEvent>(OnFindAvailableLocks);
         SubscribeLocalEvent<AccessReaderComponent, CheckUserHasLockAccessEvent>(OnCheckLockAccess);
+
+        SubscribeLocalEvent<AccessReaderComponent, ComponentGetState>(OnGetState);
+        SubscribeLocalEvent<AccessReaderComponent, ComponentHandleState>(OnHandleState);
     }
 
     private void OnMapInit(Entity<AccessReaderComponent> ent, ref MapInitEvent args)
@@ -58,7 +61,8 @@ public sealed class AccessReaderSystem : EntitySystem
 
     private void OnExamined(Entity<AccessReaderComponent> ent, ref ExaminedEvent args)
     {
-        if (!GetMainAccessReader(ent, out var mainAccessReader) || mainAccessReader.Value.Comp.AccessListsOriginal == null)
+        if (!GetMainAccessReader(ent, out var mainAccessReader) ||
+            mainAccessReader.Value.Comp.AccessListsOriginal == null)
             return;
 
         var accessHasBeenModified = mainAccessReader.Value.Comp.AccessLists.Count != mainAccessReader.Value.Comp.AccessListsOriginal.Count;
@@ -102,6 +106,40 @@ public sealed class AccessReaderSystem : EntitySystem
         var originalAccessesFormatted = ContentLocalizationManager.FormatListToOr(localizedOriginalNames);
         var originalSettingsMessage = Loc.GetString(mainAccessReader.Value.Comp.ExaminationText, ("access", originalAccessesFormatted));
         args.PushMarkup(originalSettingsMessage);
+    }
+
+    private void OnGetState(EntityUid uid, AccessReaderComponent component, ref ComponentGetState args)
+    {
+        args.State = new AccessReaderComponentState(
+            component.Enabled,
+            component.DenyTags,
+            component.AccessLists,
+            component.AccessListsOriginal,
+            _recordsSystem.Convert(component.AccessKeys),
+            component.AccessLog,
+            component.AccessLogLimit);
+    }
+
+    private void OnHandleState(EntityUid uid, AccessReaderComponent component, ref ComponentHandleState args)
+    {
+        if (args.Current is not AccessReaderComponentState state)
+            return;
+        component.Enabled = state.Enabled;
+        component.AccessKeys.Clear();
+        foreach (var key in state.AccessKeys)
+        {
+            var id = EnsureEntity<AccessReaderComponent>(key.Item1, uid);
+            if (!id.IsValid())
+                continue;
+
+            component.AccessKeys.Add(new StationRecordKey(key.Item2, id));
+        }
+
+        component.AccessLists = new(state.AccessLists);
+        component.AccessListsOriginal = state.AccessListsOriginal == null ? null : new(state.AccessListsOriginal);
+        component.DenyTags = new(state.DenyTags);
+        component.AccessLog = new(state.AccessLog);
+        component.AccessLogLimit = state.AccessLogLimit;
     }
 
     private void OnLinkAttempt(EntityUid uid, AccessReaderComponent component, LinkAttemptEvent args)


### PR DESCRIPTION
## Why / Balance
Right now `AccessListsOriginal` based on the examine itself. That's causes different examine message on different clients if entity never was examined.
That's all causes metaops where person can examine airlock and claim that it has been emagged.

## Technical details
AccessListsOriginal now updates on mapinit.

## Media
### Before
https://github.com/user-attachments/assets/04b96fb1-1ab8-4b8f-aa5e-44a552e49243
### After
https://github.com/user-attachments/assets/67768227-45b0-439a-bf59-3086920c1042

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: Airlocks that were hacked via access breaker no longer have buggy examine window.