### PR TITLE
fix: no more weh injectors

### DIFF
--- a/Resources/Maps/serpentcrest.yml
+++ b/Resources/Maps/serpentcrest.yml
@@ -183746,7 +183746,7 @@ entities:
     - type: Transform
       pos: 3.4193826,-19.583563
       parent: 2
-- proto: WehMedipen
+- proto: PlushieLizardMirrored
   entities:
   - uid: 839
     components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -722,6 +722,8 @@
   parent: ChemicalMedipen
   id: WehMedipen
   name: weh auto-injector
+  suffix: DO NOT MAP
+  categories: [ DoNotMap ]
   description: A non-refillable medipen containing multiple doses of weh.
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Replaces the weh injectors in the serpentcrest secret lizard room by mirrored (not inverted) lizard plushies.

## Why / Balance
Resolves #43516. Weh injectors are admeme/debug items, are overpowered and thus shouldn't be mapped.

## Technical details
Nothing really interesting here.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes
None

**Changelog**

:cl:
- fix: removed weh injectors from Serpentcrest

