### PR TITLE
Make xenoborg death announcement work properly

### DIFF
--- a/Content.Server/Xenoborgs/XenoborgSystem.cs
+++ b/Content.Server/Xenoborgs/XenoborgSystem.cs
@@ -35,16 +35,34 @@ public sealed partial class XenoborgSystem : EntitySystem
 
     private void OnXenoborgDestroyed(EntityUid uid, XenoborgComponent component, DestructionEventArgs args)
     {
-        // if a xenoborg is destroyed, it will check to see if it was the last one
-        var xenoborgQuery = AllEntityQuery<XenoborgComponent, ActorComponent>(); // paused xenoborgs still count
-        while (xenoborgQuery.MoveNext(out var xenoborg, out _, out _))
-        {
-            if (xenoborg != uid)
-                return;
-        }
+        // do nothing if the uid was in fact the mothership core
+        // let OnCoreDestroyed deal with that
+        if (HasComp<MothershipCoreComponent>(uid))
+            return;
 
-        var mothershipCoreQuery = AllEntityQuery<MothershipCoreComponent>(); // paused mothership cores still count
-        var mothershipCoreAlive = mothershipCoreQuery.MoveNext(out _, out _);
+        var mothershipCoreAlive = false;
+
+        // if a xenoborg is destroyed, it will check to see if it was the last one
+        // and if the mothership core still exists
+        var xenoborgQuery = AllEntityQuery<XenoborgComponent>(); // paused xenoborgs still count
+        while (xenoborgQuery.MoveNext(out var xenoborg, out _))
+        {
+            // check if this xenoborg is actually the mothership core
+            if (HasComp<MothershipCoreComponent>(xenoborg))
+            {
+                mothershipCoreAlive = true;
+                continue;
+            }
+
+            // we don't care about xenoborgs that are not being controlled by a player
+            if (!HasComp<ActorComponent>(xenoborg))
+                continue;
+
+            // found a xenoborg different from the one being destroyed that still exists
+            // and is being controlled by a player
+            if (xenoborg != uid)
+                return; // in this case, the fight is not over and there is no need to send any announcement
+        }
 
         var xenoborgsRuleQuery = EntityQueryEnumerator<XenoborgsRuleComponent>();
         if (xenoborgsRuleQuery.MoveNext(out var xenoborgsRuleEnt, out var xenoborgsRuleComp))

--- a/Content.Server/Xenoborgs/XenoborgSystem.cs
+++ b/Content.Server/Xenoborgs/XenoborgSystem.cs
@@ -36,8 +36,8 @@ public sealed partial class XenoborgSystem : EntitySystem
     private void OnXenoborgDestroyed(EntityUid uid, XenoborgComponent component, DestructionEventArgs args)
     {
         // if a xenoborg is destroyed, it will check to see if it was the last one
-        var xenoborgQuery = AllEntityQuery<XenoborgComponent>(); // paused xenoborgs still count
-        while (xenoborgQuery.MoveNext(out var xenoborg, out _))
+        var xenoborgQuery = AllEntityQuery<XenoborgComponent, ActorComponent>(); // paused xenoborgs still count
+        while (xenoborgQuery.MoveNext(out var xenoborg, out _, out _))
         {
             if (xenoborg != uid)
                 return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
When a xenoborg was destroyed, the game checked to see if there was any other and if there wasn't, it would make the announcement saying all xenoborgs are dead. however, if the query didn't care if the xenoborg in question was controlled or not. so if the core had a brainless xenoborg chassi in their core (common strat btw) the announcement wouldn't play when the last player xenoborg died.

Now the query only checks for xenoborgs with the actor component, which makes sure it only checks for xenoborgs that are being controlled by a player.
<!-- What did you change? -->

## Why / Balance
Bug bad, fix good.

For real, that announcement would almost never play, so the crew had to just guess if the xenoborgs are dead or not.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Just made the query at OnXenoborgDestroyed, also check for ActorComponent.
<!-- Summary of code changes for easier review. -->

## Media
no need
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Samuka
- fix: The announcement that says all xenoborgs are dead now is properly made when the last player controlled xenoborg is destroyed.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
