### PR TITLE
Change GetLargestGrid to compare grid areas instead of LengthSquared

### DIFF
--- a/Content.Shared/Station/SharedStationSystem.cs
+++ b/Content.Shared/Station/SharedStationSystem.cs
@@ -24,21 +24,29 @@ public abstract partial class SharedStationSystem : EntitySystem
     /// <summary>
     /// Gets the largest member grid from a station.
     /// </summary>
+    /// <remarks>
+    /// "Largest" is determined by the total area of the grid's bounding box, not by the tile count.
+    /// If two of the station's grids have the same area, this method returns whichever happens to
+    /// be first in the station's grid list.
+    /// </remarks>
     public EntityUid? GetLargestGrid(Entity<StationDataComponent?> ent)
     {
         if (!Resolve(ent, ref ent.Comp))
             return null;
 
         EntityUid? largestGrid = null;
-        Box2 largestBounds = new Box2();
+        var largestArea = 0.0f;
 
         foreach (var gridUid in ent.Comp.Grids)
         {
-            if (!TryComp<MapGridComponent>(gridUid, out var grid) ||
-                grid.LocalAABB.Size.LengthSquared() < largestBounds.Size.LengthSquared())
+            if (!TryComp<MapGridComponent>(gridUid, out var grid))
                 continue;
 
-            largestBounds = grid.LocalAABB;
+            var gridArea = Box2.Area(grid.LocalAABB);
+            if (gridArea < largestArea)
+                continue;
+
+            largestArea = gridArea;
             largestGrid = gridUid;
         }
 


### PR DESCRIPTION
## About the PR
Changes `SharedStationSystem.GetLargestGrid()` to pick grids by area instead of the squared vector magnitude.

## Why / Balance
For most practical purposes, this PR makes no difference. When picking between a 250x250 station grid and Tidus Grey's microshittle offcut, the previous code was absolutely adequate. However, on ship-based forks like Frontier, where player-constructed ships can easily approach prefab ships in size, the use of `LengthSquared()` causes problems.

Refresher: `v.LengthSquared()` is `v.Dot(v)`, aka `v.X * v.X + v.Y * v.Y`. This is obviously quite different from the area of the grid, which would be `v.X * v.Y`. A filled 6x6 grid has a lengthsquared of 6\*6 + 6\*6 = 72, while a row of 9 tiles (1x9) gets up to a whopping 1\*1 + 9\*9 = 82. 

<img width="610" height="526" alt="image" src="https://github.com/user-attachments/assets/06fcfa34-630a-4486-ac57-ea0fc989ecb6" />

I don't know about you, but the 1x9 doesn't intuitively feel _larger_ than the 6x6 here... :)

I believe using the grid's area better matches the player's expectations.

It would be possible to use `GetTileCount()`, but given that this method is mostly used with station-sized grids, that would be prohibitively expensive. There's no need to enumerate over thousands of tiles when a cached AABB suffices for 99.9% of use cases.

## Technical details
Some fairly simple C#.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
I can't imagine the old behaviour is somehow load-bearing. If it is, I don't know what to do about that.

**Changelog**
N/A, doesn't affect gameplay.