### PR TITLE
Fix Nuke Target Station Map

### DIFF
--- a/Content.Server/GameTicking/GameTicker.GameRule.cs
+++ b/Content.Server/GameTicking/GameTicker.GameRule.cs
@@ -309,7 +309,7 @@ public sealed partial class GameTicker
     }
 
     /// <summary>
-    /// Gets all the gamerule entities which are currently active.
+    /// Gets all the gamerule entities that have been added.
     /// </summary>
     public IEnumerable<EntityUid> GetAddedGameRules()
     {
@@ -322,6 +322,20 @@ public sealed partial class GameTicker
     }
 
     /// <summary>
+    /// Gets all the gamerule entities with {T} component that have been added.
+    /// </summary>
+    public IEnumerable<Entity<T>> GetAddedGameRules<T>() where T : Component
+    {
+        var query = EntityQueryEnumerator<T, GameRuleComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var ruleData))
+        {
+            if (IsGameRuleAdded(uid, ruleData))
+                yield return (uid, comp);
+        }
+    }
+
+
+    /// <summary>
     /// Gets all the gamerule entities which are currently active.
     /// </summary>
     public IEnumerable<EntityUid> GetActiveGameRules()
@@ -330,6 +344,18 @@ public sealed partial class GameTicker
         while (query.MoveNext(out var uid, out _, out _))
         {
             yield return uid;
+        }
+    }
+
+    /// <summary>
+    /// Gets all the gamerule entities with {T} component that are currently active.
+    /// </summary>
+    public IEnumerable<Entity<T>> GetActiveGameRules<T>() where T : Component
+    {
+        var query = EntityQueryEnumerator<T, ActiveGameRuleComponent, GameRuleComponent>();
+        while (query.MoveNext(out var uid, out var comp, out _, out _))
+        {
+            yield return (uid, comp);
         }
     }
 

--- a/Content.Server/Pinpointer/StationMapSystem.cs
+++ b/Content.Server/Pinpointer/StationMapSystem.cs
@@ -22,9 +22,11 @@ public sealed class StationMapSystem : EntitySystem
         SubscribeLocalEvent<StationMapComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<StationMapUserComponent, EntParentChangedMessage>(OnUserParentChanged);
 
-        SubscribeLocalEvent<NukeopsStationMapComponent, NukeopsTargetStationSelectedEvent>(OnNukeopsStationSelected);
+        SubscribeLocalEvent<NukeopsStationMapComponent, ChooseStationMapEvent>(OnNukeOpsStationMap);
+        SubscribeLocalEvent<NukeopsTargetStationSelectedEvent>(OnNukeopsStationSelected);
 
-        Subs.BuiEvents<StationMapComponent>(StationMapUiKey.Key, subs =>
+        Subs.BuiEvents<StationMapComponent>(StationMapUiKey.Key,
+            subs =>
         {
             subs.Event<BoundUIOpenedEvent>(OnStationMapOpened);
             subs.Event<BoundUIClosedEvent>(OnStationMapClosed);
@@ -36,18 +38,13 @@ public sealed class StationMapSystem : EntitySystem
         if (!ent.Comp.InitializeWithStation)
             return;
 
-        // If we ever find a need to make more exceptions like this, just turn this into an event.
-        if (HasComp<NukeopsStationMapComponent>(ent))
+        var ev = new ChooseStationMapEvent();
+        RaiseLocalEvent(ent, ref ev);
+        if (ev.Handled)
         {
-            foreach (var rule in _gameTicker.GetActiveGameRules())
-            {
-                if (TryComp<NukeopsRuleComponent>(rule, out var nukeopsRule) && nukeopsRule.TargetStation != null)
-                {
-                    ent.Comp.TargetGrid = _station.GetLargestGrid((nukeopsRule.TargetStation.Value, null));
-                    Dirty(ent);
-                    return;
-                }
-            }
+            ent.Comp.TargetGrid = ev.TargetGrid;
+            Dirty(ent);
+            return;
         }
 
         var station = _station.GetStationInMap(_xform.GetMapId(ent.Owner));
@@ -80,18 +77,50 @@ public sealed class StationMapSystem : EntitySystem
         comp.Map = uid;
     }
 
-    private void OnNukeopsStationSelected(Entity<NukeopsStationMapComponent> ent, ref NukeopsTargetStationSelectedEvent args)
+    private void OnNukeOpsStationMap(Entity<NukeopsStationMapComponent> entity, ref ChooseStationMapEvent args)
     {
-        if (args.TargetStation == null)
+        // If we have this component, we don't want a fallback map!
+        args.Handle();
+
+        foreach (var rule in _gameTicker.GetActiveGameRules<NukeopsRuleComponent>())
+        {
+            if (rule.Comp.TargetStation == null)
+                continue;
+
+            args.TargetGrid = _station.GetLargestGrid((rule.Comp.TargetStation.Value, null));
+            return;
+        }
+    }
+
+    private void OnNukeopsStationSelected(ref NukeopsTargetStationSelectedEvent args)
+    {
+        if (args.TargetStation == null || !TryComp<RuleGridsComponent>(args.RuleEntity, out var ruleGrids))
             return;
 
-        if (!TryComp<StationMapComponent>(ent, out var stationMap) || !TryComp<RuleGridsComponent>(args.RuleEntity, out var ruleGrids))
-            return;
+        var mapquery = EntityQueryEnumerator<NukeopsStationMapComponent, StationMapComponent>();
+        while (mapquery.MoveNext(out var uid, out _, out var map))
+        {
+            if (Transform(uid).MapID != ruleGrids.Map)
+                continue;
 
-        if (Transform(ent).MapID != ruleGrids.Map)
-            return;
+            map.TargetGrid = _station.GetLargestGrid((args.TargetStation.Value, null));
+            Dirty(uid, map);
+        }
+    }
+}
 
-        stationMap.TargetGrid = _station.GetLargestGrid((args.TargetStation.Value, null));
-        Dirty(ent);
+/// <summary>
+/// Selects an alternative target for our station map!
+/// If handled, this will not get the map of the current station.
+/// </summary>
+[ByRefEvent]
+public record struct ChooseStationMapEvent
+{
+    public EntityUid? TargetGrid;
+    public bool Handled { get; private set; }
+
+    public void Handle()
+    {
+        Handled = true;
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Made it so the map actually loads when it is spawned via gamerule.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Buge.

## Technical details
<!-- Summary of code changes for easier review. -->
The event that would override the map was being subscribed to by a single entity, yet the event being raised was being broadcast, meaning it was never actually handling the event. I fixed this and changed it to use an entity query enumerator.

In addition I cleaned up the spawning logic for if you spawn a nukie station map after the gamerule has already started. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1915" height="1079" alt="image" src="https://github.com/user-attachments/assets/caaa6432-a542-428f-9ab6-1bff261ad8c7" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Target station map at the nuclear operative outpost will now show the target station. 