### PR TITLE
WiresSystem API and Cut/Mend Trick

### DIFF
--- a/Content.Server/Access/AccessWireAction.cs
+++ b/Content.Server/Access/AccessWireAction.cs
@@ -21,7 +21,7 @@ public sealed partial class AccessWireAction : ComponentWireAction<AccessReaderC
 
     public override object StatusKey => AccessWireActionKey.Status;
 
-    public override bool Cut(EntityUid user, Wire wire, AccessReaderComponent comp)
+    public override bool Cut(EntityUid? user, Wire wire, AccessReaderComponent comp)
     {
         WiresSystem.TryCancelWireAction(wire.Owner, PulseTimeoutKey.Key);
         EntityManager.System<AccessReaderSystem>().SetActive((wire.Owner, comp), false);
@@ -29,14 +29,14 @@ public sealed partial class AccessWireAction : ComponentWireAction<AccessReaderC
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, AccessReaderComponent comp)
+    public override bool Mend(EntityUid? user, Wire wire, AccessReaderComponent comp)
     {
         EntityManager.System<AccessReaderSystem>().SetActive((wire.Owner, comp), true);
 
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, AccessReaderComponent comp)
+    public override void Pulse(EntityUid? user, Wire wire, AccessReaderComponent comp)
     {
         EntityManager.System<AccessReaderSystem>().SetActive((wire.Owner, comp), false);
         WiresSystem.StartWireAction(wire.Owner, _pulseTimeout, PulseTimeoutKey.Key, new TimedWireEvent(AwaitPulseCancel, wire));

--- a/Content.Server/Access/LogWireAction.cs
+++ b/Content.Server/Access/LogWireAction.cs
@@ -34,7 +34,7 @@ public sealed partial class LogWireAction : ComponentWireAction<AccessReaderComp
         _access = EntityManager.System<AccessReaderSystem>();
     }
 
-    public override bool Cut(EntityUid user, Wire wire, AccessReaderComponent comp)
+    public override bool Cut(EntityUid? user, Wire wire, AccessReaderComponent comp)
     {
         WiresSystem.TryCancelWireAction(wire.Owner, PulseTimeoutKey.Key);
         EntityManager.System<AccessReaderSystem>().SetLoggingActive((wire.Owner, comp), false);
@@ -42,13 +42,13 @@ public sealed partial class LogWireAction : ComponentWireAction<AccessReaderComp
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, AccessReaderComponent comp)
+    public override bool Mend(EntityUid? user, Wire wire, AccessReaderComponent comp)
     {
         EntityManager.System<AccessReaderSystem>().SetLoggingActive((wire.Owner, comp), true);
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, AccessReaderComponent comp)
+    public override void Pulse(EntityUid? user, Wire wire, AccessReaderComponent comp)
     {
         _access.LogAccess((wire.Owner, comp), Loc.GetString(PulseLog));
         EntityManager.System<AccessReaderSystem>().SetLoggingActive((wire.Owner, comp), false);

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -7,6 +7,7 @@ using Content.Server.Hands.Systems;
 using Content.Server.Stack;
 using Content.Server.Station.Systems;
 using Content.Server.Weapons.Ranged.Systems;
+using Content.Server.Wires;
 using Content.Shared.Access;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
@@ -27,6 +28,7 @@ using Content.Shared.Stacks;
 using Content.Shared.Station.Components;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Wires;
 using Robust.Server.Physics;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -52,6 +54,7 @@ public sealed partial class AdminVerbSystem
     [Dependency] private SharedBatterySystem _batterySystem = default!;
     [Dependency] private MetaDataSystem _metaSystem = default!;
     [Dependency] private GunSystem _gun = default!;
+    [Dependency] private WiresSystem _wiresSystem = default!;
 
     private void AddTricksVerbs(GetVerbsEvent<Verb> args)
     {
@@ -208,6 +211,45 @@ public sealed partial class AdminVerbSystem
                 Priority = (int)TricksVerbPriorities.InfiniteBattery,
             };
             args.Verbs.Add(infiniteBattery);
+        }
+
+        if (TryComp<WiresComponent>(args.Target, out var wires))
+        {
+            Verb cutWires = new()
+            {
+                Text = Loc.GetString("admin-verbs-cut-wires"),
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/WireHacking/wire_1_cut.svg.96dpi.png")),
+                Act = () =>
+                {
+                    foreach (var wire in wires.WiresList)
+                    {
+                        _wiresSystem.TryForceWireAction(args.Target, wire, WiresAction.Cut, wires);
+                    }
+                },
+                Impact = LogImpact.Medium,
+                Message = Loc.GetString("admin-trick-cut-wires-description"),
+                Priority = (int)TricksVerbPriorities.CutWires,
+            };
+            args.Verbs.Add(cutWires);
+            
+            Verb mendWires = new()
+            {
+                Text = Loc.GetString("admin-verbs-mend-wires"),
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/WireHacking/wire_1.svg.96dpi.png")),
+                Act = () =>
+                {
+                    foreach (var wire in wires.WiresList)
+                    {
+                        _wiresSystem.TryForceWireAction(args.Target, wire, WiresAction.Mend, wires);
+                    }
+                },
+                Impact = LogImpact.Medium,
+                Message = Loc.GetString("admin-trick-mend-wires-description"),
+                Priority = (int)TricksVerbPriorities.CutWires,
+            };
+            args.Verbs.Add(mendWires);
         }
 
         if (TryComp<AnchorableComponent>(args.Target, out var anchor))
@@ -854,26 +896,28 @@ public sealed partial class AdminVerbSystem
         BlockUnanchoring = -6,
         RefillBattery = -7,
         DrainBattery = -8,
-        RefillOxygen = -9,
-        RefillNitrogen = -10,
-        RefillPlasma = -11,
-        SendToTestArena = -12,
-        GrantAllAccess = -13,
-        RevokeAllAccess = -14,
-        Rejuvenate = -15,
-        AdjustStack = -16,
-        FillStack = -17,
-        Rename = -18,
-        Redescribe = -19,
-        RenameAndRedescribe = -20,
-        BarJobSlots = -21,
-        LocateCargoShuttle = -22,
-        InfiniteBattery = -23,
-        HaltMovement = -24,
-        Unpause = -25,
-        Pause = -26,
-        SnapJoints = -27,
-        MakeMinigun = -28,
-        SetBulletAmount = -29,
+        CutWires = -9,
+        MendWires = -10,
+        RefillOxygen = -11,
+        RefillNitrogen = -12,
+        RefillPlasma = -13,
+        SendToTestArena = -14,
+        GrantAllAccess = -15,
+        RevokeAllAccess = -16,
+        Rejuvenate = -17,
+        AdjustStack = -18,
+        FillStack = -19,
+        Rename = -20,
+        Redescribe = -21,
+        RenameAndRedescribe = -22,
+        BarJobSlots = -23,
+        LocateCargoShuttle = -24,
+        InfiniteBattery = -25,
+        HaltMovement = -26,
+        Unpause = -27,
+        Pause = -28,
+        SnapJoints = -29,
+        MakeMinigun = -30,
+        SetBulletAmount = -31,
     }
 }

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -7,6 +7,7 @@ using Content.Server.Hands.Systems;
 using Content.Server.Stack;
 using Content.Server.Station.Systems;
 using Content.Server.Weapons.Ranged.Systems;
+using Content.Server.Wires;
 using Content.Shared.Access;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
@@ -28,6 +29,7 @@ using Content.Shared.Stacks;
 using Content.Shared.Station.Components;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Wires;
 using Robust.Server.Physics;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -53,6 +55,7 @@ public sealed partial class AdminVerbSystem
     [Dependency] private SharedBatterySystem _batterySystem = default!;
     [Dependency] private MetaDataSystem _metaSystem = default!;
     [Dependency] private GunSystem _gun = default!;
+    [Dependency] private WiresSystem _wiresSystem = default!;
 
     private void AddTricksVerbs(GetVerbsEvent<Verb> args)
     {
@@ -209,6 +212,45 @@ public sealed partial class AdminVerbSystem
                 Priority = (int)TricksVerbPriorities.InfiniteBattery,
             };
             args.Verbs.Add(infiniteBattery);
+        }
+
+        if (TryComp<WiresComponent>(args.Target, out var wires))
+        {
+            Verb cutWires = new()
+            {
+                Text = Loc.GetString("admin-verbs-cut-wires"),
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/WireHacking/wire_1_cut.svg.96dpi.png")),
+                Act = () =>
+                {
+                    foreach (var wire in wires.WiresList)
+                    {
+                        _wiresSystem.TryForceWireAction(args.Target, wire, WiresAction.Cut, wires);
+                    }
+                },
+                Impact = LogImpact.Medium,
+                Message = Loc.GetString("admin-trick-cut-wires-description"),
+                Priority = (int)TricksVerbPriorities.CutWires,
+            };
+            args.Verbs.Add(cutWires);
+            
+            Verb mendWires = new()
+            {
+                Text = Loc.GetString("admin-verbs-mend-wires"),
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/WireHacking/wire_1.svg.96dpi.png")),
+                Act = () =>
+                {
+                    foreach (var wire in wires.WiresList)
+                    {
+                        _wiresSystem.TryForceWireAction(args.Target, wire, WiresAction.Mend, wires);
+                    }
+                },
+                Impact = LogImpact.Medium,
+                Message = Loc.GetString("admin-trick-mend-wires-description"),
+                Priority = (int)TricksVerbPriorities.CutWires,
+            };
+            args.Verbs.Add(mendWires);
         }
 
         if (TryComp<AnchorableComponent>(args.Target, out var anchor))
@@ -855,26 +897,28 @@ public sealed partial class AdminVerbSystem
         BlockUnanchoring = -6,
         RefillBattery = -7,
         DrainBattery = -8,
-        RefillOxygen = -9,
-        RefillNitrogen = -10,
-        RefillPlasma = -11,
-        SendToTestArena = -12,
-        GrantAllAccess = -13,
-        RevokeAllAccess = -14,
-        Rejuvenate = -15,
-        AdjustStack = -16,
-        FillStack = -17,
-        Rename = -18,
-        Redescribe = -19,
-        RenameAndRedescribe = -20,
-        BarJobSlots = -21,
-        LocateCargoShuttle = -22,
-        InfiniteBattery = -23,
-        HaltMovement = -24,
-        Unpause = -25,
-        Pause = -26,
-        SnapJoints = -27,
-        MakeMinigun = -28,
-        SetBulletAmount = -29,
+        CutWires = -9,
+        MendWires = -10,
+        RefillOxygen = -11,
+        RefillNitrogen = -12,
+        RefillPlasma = -13,
+        SendToTestArena = -14,
+        GrantAllAccess = -15,
+        RevokeAllAccess = -16,
+        Rejuvenate = -17,
+        AdjustStack = -18,
+        FillStack = -19,
+        Rename = -20,
+        Redescribe = -21,
+        RenameAndRedescribe = -22,
+        BarJobSlots = -23,
+        LocateCargoShuttle = -24,
+        InfiniteBattery = -25,
+        HaltMovement = -26,
+        Unpause = -27,
+        Pause = -28,
+        SnapJoints = -29,
+        MakeMinigun = -30,
+        SetBulletAmount = -31,
     }
 }

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -7,6 +7,7 @@ using Content.Server.Hands.Systems;
 using Content.Server.Stack;
 using Content.Server.Station.Systems;
 using Content.Server.Weapons.Ranged.Systems;
+using Content.Server.Wires;
 using Content.Shared.Access;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
@@ -28,6 +29,7 @@ using Content.Shared.Stacks;
 using Content.Shared.Station.Components;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Wires;
 using Robust.Server.Physics;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -53,6 +55,7 @@ public sealed partial class AdminVerbSystem
     [Dependency] private readonly SharedBatterySystem _batterySystem = default!;
     [Dependency] private readonly MetaDataSystem _metaSystem = default!;
     [Dependency] private readonly GunSystem _gun = default!;
+    [Dependency] private readonly WiresSystem _wiresSystem = default!;
 
     private void AddTricksVerbs(GetVerbsEvent<Verb> args)
     {
@@ -209,6 +212,45 @@ public sealed partial class AdminVerbSystem
                 Priority = (int)TricksVerbPriorities.InfiniteBattery,
             };
             args.Verbs.Add(infiniteBattery);
+        }
+
+        if (TryComp<WiresComponent>(args.Target, out var wires))
+        {
+            Verb cutWires = new()
+            {
+                Text = Loc.GetString("admin-verbs-cut-wires"),
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/WireHacking/wire_1_cut.svg.96dpi.png")),
+                Act = () =>
+                {
+                    foreach (var wire in wires.WiresList)
+                    {
+                        _wiresSystem.TryForceWireAction(args.Target, wire, WiresAction.Cut, wires);
+                    }
+                },
+                Impact = LogImpact.Medium,
+                Message = Loc.GetString("admin-trick-cut-wires-description"),
+                Priority = (int)TricksVerbPriorities.CutWires,
+            };
+            args.Verbs.Add(cutWires);
+            
+            Verb mendWires = new()
+            {
+                Text = Loc.GetString("admin-verbs-mend-wires"),
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/WireHacking/wire_1.svg.96dpi.png")),
+                Act = () =>
+                {
+                    foreach (var wire in wires.WiresList)
+                    {
+                        _wiresSystem.TryForceWireAction(args.Target, wire, WiresAction.Mend, wires);
+                    }
+                },
+                Impact = LogImpact.Medium,
+                Message = Loc.GetString("admin-trick-mend-wires-description"),
+                Priority = (int)TricksVerbPriorities.CutWires,
+            };
+            args.Verbs.Add(mendWires);
         }
 
         if (TryComp<AnchorableComponent>(args.Target, out var anchor))
@@ -855,26 +897,28 @@ public sealed partial class AdminVerbSystem
         BlockUnanchoring = -6,
         RefillBattery = -7,
         DrainBattery = -8,
-        RefillOxygen = -9,
-        RefillNitrogen = -10,
-        RefillPlasma = -11,
-        SendToTestArena = -12,
-        GrantAllAccess = -13,
-        RevokeAllAccess = -14,
-        Rejuvenate = -15,
-        AdjustStack = -16,
-        FillStack = -17,
-        Rename = -18,
-        Redescribe = -19,
-        RenameAndRedescribe = -20,
-        BarJobSlots = -21,
-        LocateCargoShuttle = -22,
-        InfiniteBattery = -23,
-        HaltMovement = -24,
-        Unpause = -25,
-        Pause = -26,
-        SnapJoints = -27,
-        MakeMinigun = -28,
-        SetBulletAmount = -29,
+        CutWires = -9,
+        MendWires = -10,
+        RefillOxygen = -11,
+        RefillNitrogen = -12,
+        RefillPlasma = -13,
+        SendToTestArena = -14,
+        GrantAllAccess = -15,
+        RevokeAllAccess = -16,
+        Rejuvenate = -17,
+        AdjustStack = -18,
+        FillStack = -19,
+        Rename = -20,
+        Redescribe = -21,
+        RenameAndRedescribe = -22,
+        BarJobSlots = -23,
+        LocateCargoShuttle = -24,
+        InfiniteBattery = -25,
+        HaltMovement = -26,
+        Unpause = -27,
+        Pause = -28,
+        SnapJoints = -29,
+        MakeMinigun = -30,
+        SetBulletAmount = -31,
     }
 }

--- a/Content.Server/Atmos/Monitor/WireActions/AirAlarmPanicWire.cs
+++ b/Content.Server/Atmos/Monitor/WireActions/AirAlarmPanicWire.cs
@@ -28,7 +28,7 @@ public sealed partial class AirAlarmPanicWire : ComponentWireAction<AirAlarmComp
         _airAlarmSystem = EntityManager.System<AirAlarmSystem>();
     }
 
-    public override bool Cut(EntityUid user, Wire wire, AirAlarmComponent comp)
+    public override bool Cut(EntityUid? user, Wire wire, AirAlarmComponent comp)
     {
         comp.PanicWireCut = true;
         if (EntityManager.TryGetComponent<DeviceNetworkComponent>(wire.Owner, out var devNet))
@@ -39,7 +39,7 @@ public sealed partial class AirAlarmPanicWire : ComponentWireAction<AirAlarmComp
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, AirAlarmComponent alarm)
+    public override bool Mend(EntityUid? user, Wire wire, AirAlarmComponent alarm)
     {
         alarm.PanicWireCut = false;
         if (EntityManager.TryGetComponent<DeviceNetworkComponent>(wire.Owner, out var devNet)
@@ -51,7 +51,7 @@ public sealed partial class AirAlarmPanicWire : ComponentWireAction<AirAlarmComp
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, AirAlarmComponent comp)
+    public override void Pulse(EntityUid? user, Wire wire, AirAlarmComponent comp)
     {
         if (EntityManager.TryGetComponent<DeviceNetworkComponent>(wire.Owner, out var devNet))
         {

--- a/Content.Server/Atmos/Monitor/WireActions/AtmosAlarmableAlarmWire.cs
+++ b/Content.Server/Atmos/Monitor/WireActions/AtmosAlarmableAlarmWire.cs
@@ -39,19 +39,19 @@ public sealed partial class AtmosMonitorDeviceNetWire : ComponentWireAction<Atmo
         _atmosAlarmableSystem = EntityManager.System<AtmosAlarmableSystem>();
     }
 
-    public override bool Cut(EntityUid user, Wire wire, AtmosAlarmableComponent comp)
+    public override bool Cut(EntityUid? user, Wire wire, AtmosAlarmableComponent comp)
     {
         comp.IgnoreAlarms = true;
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, AtmosAlarmableComponent comp)
+    public override bool Mend(EntityUid? user, Wire wire, AtmosAlarmableComponent comp)
     {
         comp.IgnoreAlarms = false;
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, AtmosAlarmableComponent comp)
+    public override void Pulse(EntityUid? user, Wire wire, AtmosAlarmableComponent comp)
     {
         if (_alarmOnPulse)
             _atmosAlarmableSystem.ForceAlert(wire.Owner, AtmosAlarmType.Danger, comp);

--- a/Content.Server/Defusable/Systems/DefusableSystem.cs
+++ b/Content.Server/Defusable/Systems/DefusableSystem.cs
@@ -123,7 +123,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
 
     #region Public
 
-    public void TryStartCountdown(EntityUid uid, EntityUid user, DefusableComponent comp)
+    public void TryStartCountdown(EntityUid uid, EntityUid? user, DefusableComponent comp)
     {
         if (!comp.Usable)
         {
@@ -152,7 +152,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
             _wiresSystem.TogglePanel(uid, wiresPanelComponent, false);
     }
 
-    public void TryDetonateBomb(EntityUid uid, EntityUid detonator, DefusableComponent comp)
+    public void TryDetonateBomb(EntityUid uid, EntityUid? detonator, DefusableComponent comp)
     {
         if (!comp.Activated)
             return;
@@ -234,7 +234,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
 
     #region Wires
 
-    public void DelayWirePulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public void DelayWirePulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (comp is not { Activated: true, DelayWireUsed: false })
             return;
@@ -244,7 +244,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
         comp.DelayWireUsed = true;
     }
 
-    public bool ProceedWireCut(EntityUid user, Wire wire, DefusableComponent comp)
+    public bool ProceedWireCut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (comp is not { Activated: true, ProceedWireCut: false })
             return true;
@@ -256,7 +256,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
         return true;
     }
 
-    public void ProceedWirePulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public void ProceedWirePulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (comp is { Activated: true, ProceedWireUsed: false })
         {
@@ -267,7 +267,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
         _popup.PopupEntity(Loc.GetString("defusable-popup-wire-proceed-pulse", ("name", wire.Owner)), wire.Owner);
     }
 
-    public bool ActivateWireCut(EntityUid user, Wire wire, DefusableComponent comp)
+    public bool ActivateWireCut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         // if you cut the wire it just defuses the bomb
 
@@ -282,7 +282,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
         return true;
     }
 
-    public void ActivateWirePulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public void ActivateWirePulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         // if the component isnt active, just start the countdown
         // if it is and it isn't already used then delay it
@@ -302,7 +302,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
         }
     }
 
-    public bool BoomWireCut(EntityUid user, Wire wire, DefusableComponent comp)
+    public bool BoomWireCut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (comp.Activated)
         {
@@ -315,7 +315,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
         return true;
     }
 
-    public bool BoomWireMend(EntityUid user, Wire wire, DefusableComponent comp)
+    public bool BoomWireMend(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (comp is { Activated: false, Usable: false })
         {
@@ -325,7 +325,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
         return true;
     }
 
-    public void BoomWirePulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public void BoomWirePulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (comp.Activated)
         {
@@ -333,7 +333,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
         }
     }
 
-    public bool BoltWireMend(EntityUid user, Wire wire, DefusableComponent comp)
+    public bool BoltWireMend(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (!comp.Activated)
             return true;
@@ -345,7 +345,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
         return true;
     }
 
-    public bool BoltWireCut(EntityUid user, Wire wire, DefusableComponent comp)
+    public bool BoltWireCut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (!comp.Activated)
             return true;
@@ -357,7 +357,7 @@ public sealed partial class DefusableSystem : SharedDefusableSystem
         return true;
     }
 
-    public void BoltWirePulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public void BoltWirePulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         _popup.PopupEntity(Loc.GetString("defusable-popup-wire-bolt-pulse", ("name", wire.Owner)), wire.Owner);
     }

--- a/Content.Server/Defusable/Systems/DefusableSystem.cs
+++ b/Content.Server/Defusable/Systems/DefusableSystem.cs
@@ -123,7 +123,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
 
     #region Public
 
-    public void TryStartCountdown(EntityUid uid, EntityUid user, DefusableComponent comp)
+    public void TryStartCountdown(EntityUid uid, EntityUid? user, DefusableComponent comp)
     {
         if (!comp.Usable)
         {
@@ -152,7 +152,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
             _wiresSystem.TogglePanel(uid, wiresPanelComponent, false);
     }
 
-    public void TryDetonateBomb(EntityUid uid, EntityUid detonator, DefusableComponent comp)
+    public void TryDetonateBomb(EntityUid uid, EntityUid? detonator, DefusableComponent comp)
     {
         if (!comp.Activated)
             return;
@@ -234,7 +234,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
 
     #region Wires
 
-    public void DelayWirePulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public void DelayWirePulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (comp is not { Activated: true, DelayWireUsed: false })
             return;
@@ -244,7 +244,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
         comp.DelayWireUsed = true;
     }
 
-    public bool ProceedWireCut(EntityUid user, Wire wire, DefusableComponent comp)
+    public bool ProceedWireCut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (comp is not { Activated: true, ProceedWireCut: false })
             return true;
@@ -256,7 +256,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
         return true;
     }
 
-    public void ProceedWirePulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public void ProceedWirePulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (comp is { Activated: true, ProceedWireUsed: false })
         {
@@ -267,7 +267,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
         _popup.PopupEntity(Loc.GetString("defusable-popup-wire-proceed-pulse", ("name", wire.Owner)), wire.Owner);
     }
 
-    public bool ActivateWireCut(EntityUid user, Wire wire, DefusableComponent comp)
+    public bool ActivateWireCut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         // if you cut the wire it just defuses the bomb
 
@@ -282,7 +282,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
         return true;
     }
 
-    public void ActivateWirePulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public void ActivateWirePulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         // if the component isnt active, just start the countdown
         // if it is and it isn't already used then delay it
@@ -302,7 +302,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
         }
     }
 
-    public bool BoomWireCut(EntityUid user, Wire wire, DefusableComponent comp)
+    public bool BoomWireCut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (comp.Activated)
         {
@@ -315,7 +315,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
         return true;
     }
 
-    public bool BoomWireMend(EntityUid user, Wire wire, DefusableComponent comp)
+    public bool BoomWireMend(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (comp is { Activated: false, Usable: false })
         {
@@ -325,7 +325,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
         return true;
     }
 
-    public void BoomWirePulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public void BoomWirePulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (comp.Activated)
         {
@@ -333,7 +333,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
         }
     }
 
-    public bool BoltWireMend(EntityUid user, Wire wire, DefusableComponent comp)
+    public bool BoltWireMend(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (!comp.Activated)
             return true;
@@ -345,7 +345,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
         return true;
     }
 
-    public bool BoltWireCut(EntityUid user, Wire wire, DefusableComponent comp)
+    public bool BoltWireCut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         if (!comp.Activated)
             return true;
@@ -357,7 +357,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
         return true;
     }
 
-    public void BoltWirePulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public void BoltWirePulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         _popup.PopupEntity(Loc.GetString("defusable-popup-wire-bolt-pulse", ("name", wire.Owner)), wire.Owner);
     }

--- a/Content.Server/Defusable/WireActions/ActivateWireAction.cs
+++ b/Content.Server/Defusable/WireActions/ActivateWireAction.cs
@@ -23,19 +23,19 @@ public sealed partial class ActivateWireAction : ComponentWireAction<DefusableCo
 
     public override object StatusKey { get; } = DefusableWireStatus.LiveIndicator;
 
-    public override bool Cut(EntityUid user, Wire wire, DefusableComponent comp)
+    public override bool Cut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         return EntityManager.System<DefusableSystem>().ActivateWireCut(user, wire, comp);
     }
 
-    public override bool Mend(EntityUid user, Wire wire, DefusableComponent comp)
+    public override bool Mend(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         // if its not disposable defusable system already handles* this
         // *probably
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public override void Pulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         EntityManager.System<DefusableSystem>().ActivateWirePulse(user, wire, comp);
     }

--- a/Content.Server/Defusable/WireActions/BoltWireAction.cs
+++ b/Content.Server/Defusable/WireActions/BoltWireAction.cs
@@ -21,17 +21,17 @@ public sealed partial class BoltWireAction : ComponentWireAction<DefusableCompon
 
     public override object StatusKey { get; } = DefusableWireStatus.BoltIndicator;
 
-    public override bool Cut(EntityUid user, Wire wire, DefusableComponent comp)
+    public override bool Cut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         return EntityManager.System<DefusableSystem>().BoltWireCut(user, wire, comp);
     }
 
-    public override bool Mend(EntityUid user, Wire wire, DefusableComponent comp)
+    public override bool Mend(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         return EntityManager.System<DefusableSystem>().BoltWireMend(user, wire, comp);
     }
 
-    public override void Pulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public override void Pulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         EntityManager.System<DefusableSystem>().BoltWirePulse(user, wire, comp);
     }

--- a/Content.Server/Defusable/WireActions/BoomWireAction.cs
+++ b/Content.Server/Defusable/WireActions/BoomWireAction.cs
@@ -22,17 +22,17 @@ public sealed partial class BoomWireAction : ComponentWireAction<DefusableCompon
 
     public override object StatusKey { get; } = DefusableWireStatus.BoomIndicator;
 
-    public override bool Cut(EntityUid user, Wire wire, DefusableComponent comp)
+    public override bool Cut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         return EntityManager.System<DefusableSystem>().BoomWireCut(user, wire, comp);
     }
 
-    public override bool Mend(EntityUid user, Wire wire, DefusableComponent comp)
+    public override bool Mend(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         return EntityManager.System<DefusableSystem>().BoomWireMend(user, wire, comp);
     }
 
-    public override void Pulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public override void Pulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         EntityManager.System<DefusableSystem>().BoomWirePulse(user, wire, comp);
     }

--- a/Content.Server/Defusable/WireActions/DelayWireAction.cs
+++ b/Content.Server/Defusable/WireActions/DelayWireAction.cs
@@ -27,17 +27,17 @@ public sealed partial class DelayWireAction : ComponentWireAction<DefusableCompo
 
     public override object StatusKey { get; } = DefusableWireStatus.DelayIndicator;
 
-    public override bool Cut(EntityUid user, Wire wire, DefusableComponent comp)
+    public override bool Cut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, DefusableComponent comp)
+    public override bool Mend(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public override void Pulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         EntityManager.System<DefusableSystem>().DelayWirePulse(user, wire, comp);
     }

--- a/Content.Server/Defusable/WireActions/ProceedWireAction.cs
+++ b/Content.Server/Defusable/WireActions/ProceedWireAction.cs
@@ -24,17 +24,17 @@ public sealed partial class ProceedWireAction : ComponentWireAction<DefusableCom
 
     public override object StatusKey { get; } = DefusableWireStatus.ProceedIndicator;
 
-    public override bool Cut(EntityUid user, Wire wire, DefusableComponent comp)
+    public override bool Cut(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         return EntityManager.System<DefusableSystem>().ProceedWireCut(user, wire, comp);
     }
 
-    public override bool Mend(EntityUid user, Wire wire, DefusableComponent comp)
+    public override bool Mend(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, DefusableComponent comp)
+    public override void Pulse(EntityUid? user, Wire wire, DefusableComponent comp)
     {
         EntityManager.System<DefusableSystem>().ProceedWirePulse(user, wire, comp);
     }

--- a/Content.Server/Doors/WireActions/DoorBoltLightWireAction.cs
+++ b/Content.Server/Doors/WireActions/DoorBoltLightWireAction.cs
@@ -16,19 +16,19 @@ public sealed partial class DoorBoltLightWireAction : ComponentWireAction<DoorBo
 
     public override object StatusKey { get; } = AirlockWireStatus.BoltLightIndicator;
 
-    public override bool Cut(EntityUid user, Wire wire, DoorBoltComponent door)
+    public override bool Cut(EntityUid? user, Wire wire, DoorBoltComponent door)
     {
         EntityManager.System<DoorSystem>().SetBoltLightsEnabled((wire.Owner, door), false);
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, DoorBoltComponent door)
+    public override bool Mend(EntityUid? user, Wire wire, DoorBoltComponent door)
     {
         EntityManager.System<DoorSystem>().SetBoltLightsEnabled((wire.Owner, door), true);
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, DoorBoltComponent door)
+    public override void Pulse(EntityUid? user, Wire wire, DoorBoltComponent door)
     {
         EntityManager.System<DoorSystem>().SetBoltLightsEnabled((wire.Owner, door), !door.BoltLightsEnabled);
     }

--- a/Content.Server/Doors/WireActions/DoorBoltWireAction.cs
+++ b/Content.Server/Doors/WireActions/DoorBoltWireAction.cs
@@ -16,7 +16,7 @@ public sealed partial class DoorBoltWireAction : ComponentWireAction<DoorBoltCom
 
     public override object StatusKey { get; } = AirlockWireStatus.BoltIndicator;
 
-    public override bool Cut(EntityUid user, Wire wire, DoorBoltComponent airlock)
+    public override bool Cut(EntityUid? user, Wire wire, DoorBoltComponent airlock)
     {
         EntityManager.System<DoorSystem>().SetBoltWireCut((wire.Owner, airlock), true);
         if (!airlock.BoltsDown && IsPowered(wire.Owner))
@@ -25,13 +25,13 @@ public sealed partial class DoorBoltWireAction : ComponentWireAction<DoorBoltCom
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, DoorBoltComponent door)
+    public override bool Mend(EntityUid? user, Wire wire, DoorBoltComponent door)
     {
         EntityManager.System<DoorSystem>().SetBoltWireCut((wire.Owner, door), false);
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, DoorBoltComponent door)
+    public override void Pulse(EntityUid? user, Wire wire, DoorBoltComponent door)
     {
         if (IsPowered(wire.Owner))
             EntityManager.System<DoorSystem>().SetBoltsDown((wire.Owner, door), !door.BoltsDown);

--- a/Content.Server/Doors/WireActions/DoorSafetyWireAction.cs
+++ b/Content.Server/Doors/WireActions/DoorSafetyWireAction.cs
@@ -20,20 +20,20 @@ public sealed partial class DoorSafetyWireAction : ComponentWireAction<AirlockCo
 
     public override object StatusKey { get; } = AirlockWireStatus.SafetyIndicator;
 
-    public override bool Cut(EntityUid user, Wire wire, AirlockComponent door)
+    public override bool Cut(EntityUid? user, Wire wire, AirlockComponent door)
     {
         WiresSystem.TryCancelWireAction(wire.Owner, PulseTimeoutKey.Key);
         EntityManager.System<SharedAirlockSystem>().SetSafety(door, false);
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, AirlockComponent door)
+    public override bool Mend(EntityUid? user, Wire wire, AirlockComponent door)
     {
         EntityManager.System<SharedAirlockSystem>().SetSafety(door, true);
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, AirlockComponent door)
+    public override void Pulse(EntityUid? user, Wire wire, AirlockComponent door)
     {
         EntityManager.System<SharedAirlockSystem>().SetSafety(door, false);
         WiresSystem.StartWireAction(wire.Owner, _timeout, PulseTimeoutKey.Key, new TimedWireEvent(AwaitSafetyTimerFinish, wire));

--- a/Content.Server/Doors/WireActions/DoorTimingWireAction.cs
+++ b/Content.Server/Doors/WireActions/DoorTimingWireAction.cs
@@ -29,20 +29,20 @@ public sealed partial class DoorTimingWireAction : ComponentWireAction<AirlockCo
 
     public override object StatusKey { get; } = AirlockWireStatus.TimingIndicator;
 
-    public override bool Cut(EntityUid user, Wire wire, AirlockComponent door)
+    public override bool Cut(EntityUid? user, Wire wire, AirlockComponent door)
     {
         WiresSystem.TryCancelWireAction(wire.Owner, PulseTimeoutKey.Key);
         EntityManager.System<SharedAirlockSystem>().SetAutoCloseDelayModifier(door, 0.01f);
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, AirlockComponent door)
+    public override bool Mend(EntityUid? user, Wire wire, AirlockComponent door)
     {
         EntityManager.System<SharedAirlockSystem>().SetAutoCloseDelayModifier(door, 1f);
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, AirlockComponent door)
+    public override void Pulse(EntityUid? user, Wire wire, AirlockComponent door)
     {
         EntityManager.System<SharedAirlockSystem>().SetAutoCloseDelayModifier(door, 0.5f);
         WiresSystem.StartWireAction(wire.Owner, _timeout, PulseTimeoutKey.Key, new TimedWireEvent(AwaitTimingTimerFinish, wire));

--- a/Content.Server/Medical/CryoPodEjectLockWireAction.cs
+++ b/Content.Server/Medical/CryoPodEjectLockWireAction.cs
@@ -14,7 +14,7 @@ public sealed partial class CryoPodEjectLockWireAction : ComponentWireAction<Cry
     public override bool LightRequiresPower { get; set; } = false;
 
     public override object? StatusKey { get; } = CryoPodWireActionKey.Key;
-    public override bool Cut(EntityUid user, Wire wire, CryoPodComponent cryoPodComponent)
+    public override bool Cut(EntityUid? user, Wire wire, CryoPodComponent cryoPodComponent)
     {
         if (!cryoPodComponent.PermaLocked)
         {
@@ -25,7 +25,7 @@ public sealed partial class CryoPodEjectLockWireAction : ComponentWireAction<Cry
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, CryoPodComponent cryoPodComponent)
+    public override bool Mend(EntityUid? user, Wire wire, CryoPodComponent cryoPodComponent)
     {
         if (!cryoPodComponent.PermaLocked)
         {
@@ -36,7 +36,7 @@ public sealed partial class CryoPodEjectLockWireAction : ComponentWireAction<Cry
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, CryoPodComponent cryoPodComponent) { }
+    public override void Pulse(EntityUid? user, Wire wire, CryoPodComponent cryoPodComponent) { }
 
     public override StatusLightState? GetLightState(Wire wire, CryoPodComponent comp)
         => comp.Locked ? StatusLightState.On : StatusLightState.Off;

--- a/Content.Server/ParticleAccelerator/Wires/ParticleAcceleratorInterfaceWireAction.cs
+++ b/Content.Server/ParticleAccelerator/Wires/ParticleAcceleratorInterfaceWireAction.cs
@@ -17,7 +17,7 @@ public sealed partial class ParticleAcceleratorKeyboardWireAction : ComponentWir
         return component.InterfaceDisabled ? StatusLightState.BlinkingFast : StatusLightState.On;
     }
 
-    public override bool Cut(EntityUid user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
+    public override bool Cut(EntityUid? user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
     {
         controller.InterfaceDisabled = true;
         var paSystem = EntityManager.System<ParticleAcceleratorSystem>();
@@ -25,7 +25,7 @@ public sealed partial class ParticleAcceleratorKeyboardWireAction : ComponentWir
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
+    public override bool Mend(EntityUid? user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
     {
         controller.InterfaceDisabled = false;
         var paSystem = EntityManager.System<ParticleAcceleratorSystem>();
@@ -33,7 +33,7 @@ public sealed partial class ParticleAcceleratorKeyboardWireAction : ComponentWir
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
+    public override void Pulse(EntityUid? user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
     {
         controller.InterfaceDisabled = !controller.InterfaceDisabled;
     }

--- a/Content.Server/ParticleAccelerator/Wires/ParticleAcceleratorLimiterWireAction.cs
+++ b/Content.Server/ParticleAccelerator/Wires/ParticleAcceleratorLimiterWireAction.cs
@@ -31,7 +31,7 @@ public sealed partial class ParticleAcceleratorLimiterWireAction : ComponentWire
         return StatusLightState.On;
     }
 
-    public override bool Cut(EntityUid user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
+    public override bool Cut(EntityUid? user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
     {
         controller.MaxStrength = ParticleAcceleratorPowerState.Level3;
         var paSystem = EntityManager.System<ParticleAcceleratorSystem>();
@@ -39,7 +39,7 @@ public sealed partial class ParticleAcceleratorLimiterWireAction : ComponentWire
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
+    public override bool Mend(EntityUid? user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
     {
 
         controller.MaxStrength = ParticleAcceleratorPowerState.Level2;
@@ -54,12 +54,12 @@ public sealed partial class ParticleAcceleratorLimiterWireAction : ComponentWire
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
+    public override void Pulse(EntityUid? user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
     {
         EntityManager.System<PopupSystem>()
             .PopupEntity(
             Loc.GetString("particle-accelerator-control-box-component-wires-update-limiter-on-pulse"),
-            user,
+            wire.Owner,
             PopupType.SmallCaution
         );
     }

--- a/Content.Server/ParticleAccelerator/Wires/ParticleAcceleratorStrengthWireAction.cs
+++ b/Content.Server/ParticleAccelerator/Wires/ParticleAcceleratorStrengthWireAction.cs
@@ -18,7 +18,7 @@ public sealed partial class ParticleAcceleratorStrengthWireAction : ComponentWir
         return component.StrengthLocked ? StatusLightState.BlinkingSlow : StatusLightState.On;
     }
 
-    public override bool Cut(EntityUid user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
+    public override bool Cut(EntityUid? user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
     {
         controller.StrengthLocked = true;
         var paSystem = EntityManager.System<ParticleAcceleratorSystem>();
@@ -26,7 +26,7 @@ public sealed partial class ParticleAcceleratorStrengthWireAction : ComponentWir
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
+    public override bool Mend(EntityUid? user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
     {
         controller.StrengthLocked = false;
         var paSystem = EntityManager.System<ParticleAcceleratorSystem>();
@@ -34,7 +34,7 @@ public sealed partial class ParticleAcceleratorStrengthWireAction : ComponentWir
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
+    public override void Pulse(EntityUid? user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
     {
         var paSystem = EntityManager.System<ParticleAcceleratorSystem>();
         paSystem.SetStrength(wire.Owner, (ParticleAcceleratorPowerState) ((int) controller.SelectedStrength + 1), user, controller);

--- a/Content.Server/ParticleAccelerator/Wires/ParticleAcceleratorToggleWireAction.cs
+++ b/Content.Server/ParticleAccelerator/Wires/ParticleAcceleratorToggleWireAction.cs
@@ -21,7 +21,7 @@ public sealed partial class ParticleAcceleratorPowerWireAction : ComponentWireAc
         return component.Enabled ? StatusLightState.On : StatusLightState.BlinkingSlow;
     }
 
-    public override bool Cut(EntityUid user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
+    public override bool Cut(EntityUid? user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
     {
         var paSystem = EntityManager.System<ParticleAcceleratorSystem>();
 
@@ -30,13 +30,13 @@ public sealed partial class ParticleAcceleratorPowerWireAction : ComponentWireAc
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
+    public override bool Mend(EntityUid? user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
     {
         controller.CanBeEnabled = true;
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
+    public override void Pulse(EntityUid? user, Wire wire, ParticleAcceleratorControlBoxComponent controller)
     {
         var paSystem = EntityManager.System<ParticleAcceleratorSystem>();
         var multipartMachine = EntityManager.System<MultipartMachineSystem>();

--- a/Content.Server/Power/PowerWireAction.cs
+++ b/Content.Server/Power/PowerWireAction.cs
@@ -113,7 +113,7 @@ public sealed partial class PowerWireAction : BaseWireAction
     }
 
     /// <returns>false if failed, true otherwise, or if the entity cannot be electrified</returns>
-    private bool TrySetElectrocution(EntityUid user, Wire wire, bool timed = false)
+    private bool TrySetElectrocution(EntityUid? user, Wire wire, bool timed = false)
     {
         if (!EntityManager.TryGetComponent<ElectrifiedComponent>(wire.Owner, out var electrified))
         {
@@ -123,7 +123,10 @@ public sealed partial class PowerWireAction : BaseWireAction
         // always set this to true
         SetElectrified(wire.Owner, true, electrified);
 
-        var electrifiedAttempt = _electrocution.TryDoElectrifiedAct(wire.Owner, user);
+        if (user is null)
+            return true;
+
+        var electrifiedAttempt = _electrocution.TryDoElectrifiedAct(wire.Owner, user.Value);
 
         // if we were electrified, then return false
         return !electrifiedAttempt;
@@ -186,7 +189,7 @@ public sealed partial class PowerWireAction : BaseWireAction
         return true;
     }
 
-    public override bool Cut(EntityUid user, Wire wire)
+    public override bool Cut(EntityUid? user, Wire wire)
     {
         base.Cut(user, wire);
         if (!TrySetElectrocution(user, wire))
@@ -199,7 +202,7 @@ public sealed partial class PowerWireAction : BaseWireAction
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire)
+    public override bool Mend(EntityUid? user, Wire wire)
     {
         base.Mend(user, wire);
         if (!TrySetElectrocution(user, wire))
@@ -216,7 +219,7 @@ public sealed partial class PowerWireAction : BaseWireAction
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire)
+    public override void Pulse(EntityUid? user, Wire wire)
     {
         base.Pulse(user, wire);
         WiresSystem.TryCancelWireAction(wire.Owner, PowerWireActionKey.ElectrifiedCancel);

--- a/Content.Server/Power/PowerWireAction.cs
+++ b/Content.Server/Power/PowerWireAction.cs
@@ -115,9 +115,6 @@ public sealed partial class PowerWireAction : BaseWireAction
     /// <returns>false if failed, true otherwise, or if the entity cannot be electrified</returns>
     private bool TrySetElectrocution(EntityUid? user, Wire wire, bool timed = false)
     {
-        if (user is null)
-            return true;
-        
         if (!EntityManager.TryGetComponent<ElectrifiedComponent>(wire.Owner, out var electrified))
         {
             return true;
@@ -125,6 +122,9 @@ public sealed partial class PowerWireAction : BaseWireAction
 
         // always set this to true
         SetElectrified(wire.Owner, true, electrified);
+
+        if (user is null)
+            return true;
 
         var electrifiedAttempt = _electrocution.TryDoElectrifiedAct(wire.Owner, user.Value);
 

--- a/Content.Server/Power/PowerWireAction.cs
+++ b/Content.Server/Power/PowerWireAction.cs
@@ -113,8 +113,11 @@ public sealed partial class PowerWireAction : BaseWireAction
     }
 
     /// <returns>false if failed, true otherwise, or if the entity cannot be electrified</returns>
-    private bool TrySetElectrocution(EntityUid user, Wire wire, bool timed = false)
+    private bool TrySetElectrocution(EntityUid? user, Wire wire, bool timed = false)
     {
+        if (user is null)
+            return true;
+        
         if (!EntityManager.TryGetComponent<ElectrifiedComponent>(wire.Owner, out var electrified))
         {
             return true;
@@ -123,7 +126,7 @@ public sealed partial class PowerWireAction : BaseWireAction
         // always set this to true
         SetElectrified(wire.Owner, true, electrified);
 
-        var electrifiedAttempt = _electrocution.TryDoElectrifiedAct(wire.Owner, user);
+        var electrifiedAttempt = _electrocution.TryDoElectrifiedAct(wire.Owner, user.Value);
 
         // if we were electrified, then return false
         return !electrifiedAttempt;
@@ -186,7 +189,7 @@ public sealed partial class PowerWireAction : BaseWireAction
         return true;
     }
 
-    public override bool Cut(EntityUid user, Wire wire)
+    public override bool Cut(EntityUid? user, Wire wire)
     {
         base.Cut(user, wire);
         if (!TrySetElectrocution(user, wire))
@@ -199,7 +202,7 @@ public sealed partial class PowerWireAction : BaseWireAction
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire)
+    public override bool Mend(EntityUid? user, Wire wire)
     {
         base.Mend(user, wire);
         if (!TrySetElectrocution(user, wire))
@@ -216,7 +219,7 @@ public sealed partial class PowerWireAction : BaseWireAction
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire)
+    public override void Pulse(EntityUid? user, Wire wire)
     {
         base.Pulse(user, wire);
         WiresSystem.TryCancelWireAction(wire.Owner, PowerWireActionKey.ElectrifiedCancel);

--- a/Content.Server/Silicons/StationAi/AiInteractWireAction.cs
+++ b/Content.Server/Silicons/StationAi/AiInteractWireAction.cs
@@ -19,19 +19,19 @@ public sealed partial class AiInteractWireAction : ComponentWireAction<StationAi
         return component.Enabled ? StatusLightState.On : StatusLightState.Off;
     }
 
-    public override bool Cut(EntityUid user, Wire wire, StationAiWhitelistComponent component)
+    public override bool Cut(EntityUid? user, Wire wire, StationAiWhitelistComponent component)
     {
         return EntityManager.System<SharedStationAiSystem>()
             .SetWhitelistEnabled((wire.Owner, component), false, announce: true);
     }
 
-    public override bool Mend(EntityUid user, Wire wire, StationAiWhitelistComponent component)
+    public override bool Mend(EntityUid? user, Wire wire, StationAiWhitelistComponent component)
     {
         return EntityManager.System<SharedStationAiSystem>()
             .SetWhitelistEnabled((wire.Owner, component), true);
     }
 
-    public override void Pulse(EntityUid user, Wire wire, StationAiWhitelistComponent component)
+    public override void Pulse(EntityUid? user, Wire wire, StationAiWhitelistComponent component)
     {
     }
 }

--- a/Content.Server/Silicons/StationAi/AiVisionWireAction.cs
+++ b/Content.Server/Silicons/StationAi/AiVisionWireAction.cs
@@ -20,19 +20,19 @@ public sealed partial class AiVisionWireAction : ComponentWireAction<StationAiVi
         return component.Enabled ? StatusLightState.On : StatusLightState.Off;
     }
 
-    public override bool Cut(EntityUid user, Wire wire, StationAiVisionComponent component)
+    public override bool Cut(EntityUid? user, Wire wire, StationAiVisionComponent component)
     {
         return EntityManager.System<SharedStationAiSystem>()
             .SetVisionEnabled((wire.Owner, component), false, announce: true);
     }
 
-    public override bool Mend(EntityUid user, Wire wire, StationAiVisionComponent component)
+    public override bool Mend(EntityUid? user, Wire wire, StationAiVisionComponent component)
     {
         return EntityManager.System<SharedStationAiSystem>()
             .SetVisionEnabled((wire.Owner, component), true);
     }
 
-    public override void Pulse(EntityUid user, Wire wire, StationAiVisionComponent component)
+    public override void Pulse(EntityUid? user, Wire wire, StationAiVisionComponent component)
     {
         // TODO: This should turn it off for a bit
         // Need timer cleanup first out of scope.

--- a/Content.Server/Speech/Components/ListenWireAction.cs
+++ b/Content.Server/Speech/Components/ListenWireAction.cs
@@ -68,7 +68,7 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
         return !EntityManager.HasComponent<BlockListeningComponent>(owner);
     }
 
-    public override void Pulse(EntityUid user, Wire wire)
+    public override void Pulse(EntityUid? user, Wire wire)
     {
         if (!GetValue(wire.Owner) || !IsPowered(wire.Owner))
             return;

--- a/Content.Server/Speech/Components/SpeechWireAction.cs
+++ b/Content.Server/Speech/Components/SpeechWireAction.cs
@@ -26,19 +26,19 @@ public sealed partial class SpeechWireAction : ComponentWireAction<SpeechCompone
         _popup = EntityManager.System<PopupSystem>();
     }
 
-    public override bool Cut(EntityUid user, Wire wire, SpeechComponent component)
+    public override bool Cut(EntityUid? user, Wire wire, SpeechComponent component)
     {
         _speech.SetSpeech(wire.Owner, false, component);
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, SpeechComponent component)
+    public override bool Mend(EntityUid? user, Wire wire, SpeechComponent component)
     {
         _speech.SetSpeech(wire.Owner, true, component);
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, SpeechComponent component)
+    public override void Pulse(EntityUid? user, Wire wire, SpeechComponent component)
     {
         _popup.PopupEntity(Loc.GetString("wire-speech-pulse", ("name", wire.Owner)), wire.Owner);
     }

--- a/Content.Server/Speech/ListenWireAction.cs
+++ b/Content.Server/Speech/ListenWireAction.cs
@@ -68,7 +68,7 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
         return !EntityManager.HasComponent<BlockListeningComponent>(owner);
     }
 
-    public override void Pulse(EntityUid user, Wire wire)
+    public override void Pulse(EntityUid? user, Wire wire)
     {
         if (!GetValue(wire.Owner) || !IsPowered(wire.Owner))
             return;

--- a/Content.Server/Speech/SpeechWireAction.cs
+++ b/Content.Server/Speech/SpeechWireAction.cs
@@ -26,19 +26,19 @@ public sealed partial class SpeechWireAction : ComponentWireAction<SpeechCompone
         _popup = EntityManager.System<PopupSystem>();
     }
 
-    public override bool Cut(EntityUid user, Wire wire, SpeechComponent component)
+    public override bool Cut(EntityUid? user, Wire wire, SpeechComponent component)
     {
         _speech.SetSpeech(wire.Owner, false, component);
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, SpeechComponent component)
+    public override bool Mend(EntityUid? user, Wire wire, SpeechComponent component)
     {
         _speech.SetSpeech(wire.Owner, true, component);
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, SpeechComponent component)
+    public override void Pulse(EntityUid? user, Wire wire, SpeechComponent component)
     {
         _popup.PopupEntity(Loc.GetString("wire-speech-pulse", ("name", wire.Owner)), wire.Owner);
     }

--- a/Content.Server/SurveillanceCamera/CameraMapVisibilityWireAction.cs
+++ b/Content.Server/SurveillanceCamera/CameraMapVisibilityWireAction.cs
@@ -19,19 +19,19 @@ public sealed partial class CameraMapVisibilityWireAction : ComponentWireAction<
             : StatusLightState.Off;
     }
 
-    public override bool Cut(EntityUid user, Wire wire, SurveillanceCameraComponent component)
+    public override bool Cut(EntityUid? user, Wire wire, SurveillanceCameraComponent component)
     {
         _cameraMapSystem.SetCameraVisibility(wire.Owner, false);
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, SurveillanceCameraComponent component)
+    public override bool Mend(EntityUid? user, Wire wire, SurveillanceCameraComponent component)
     {
         _cameraMapSystem.SetCameraVisibility(wire.Owner, true);
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, SurveillanceCameraComponent component)
+    public override void Pulse(EntityUid? user, Wire wire, SurveillanceCameraComponent component)
     {
 
     }

--- a/Content.Server/VendingMachines/VendingMachineEjectItemWireAction.cs
+++ b/Content.Server/VendingMachines/VendingMachineEjectItemWireAction.cs
@@ -23,19 +23,19 @@ public sealed partial class VendingMachineEjectItemWireAction : ComponentWireAct
         _vendingMachineSystem = EntityManager.System<VendingMachineSystem>();
     }
 
-    public override bool Cut(EntityUid user, Wire wire, VendingMachineComponent vending)
+    public override bool Cut(EntityUid? user, Wire wire, VendingMachineComponent vending)
     {
         _vendingMachineSystem.SetShooting(wire.Owner, true, vending);
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire, VendingMachineComponent vending)
+    public override bool Mend(EntityUid? user, Wire wire, VendingMachineComponent vending)
     {
         _vendingMachineSystem.SetShooting(wire.Owner, false, vending);
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire, VendingMachineComponent vending)
+    public override void Pulse(EntityUid? user, Wire wire, VendingMachineComponent vending)
     {
         _vendingMachineSystem.EjectRandom(wire.Owner, true, vendComponent: vending);
     }

--- a/Content.Server/Wires/BaseToggleWireAction.cs
+++ b/Content.Server/Wires/BaseToggleWireAction.cs
@@ -27,7 +27,7 @@ public abstract partial class BaseToggleWireAction : BaseWireAction
     public virtual object? TimeoutKey { get; } = null;
     public virtual int Delay { get; } = 30;
 
-    public override bool Cut(EntityUid user, Wire wire)
+    public override bool Cut(EntityUid? user, Wire wire)
     {
         base.Cut(user, wire);
         ToggleValue(wire.Owner, false);
@@ -40,7 +40,7 @@ public abstract partial class BaseToggleWireAction : BaseWireAction
         return true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire)
+    public override bool Mend(EntityUid? user, Wire wire)
     {
         base.Mend(user, wire);
         ToggleValue(wire.Owner, true);
@@ -48,7 +48,7 @@ public abstract partial class BaseToggleWireAction : BaseWireAction
         return true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire)
+    public override void Pulse(EntityUid? user, Wire wire)
     {
         base.Pulse(user, wire);
         ToggleValue(wire.Owner, !GetValue(wire.Owner));

--- a/Content.Server/Wires/BaseWireAction.cs
+++ b/Content.Server/Wires/BaseWireAction.cs
@@ -59,11 +59,11 @@ public abstract partial class BaseWireAction : IWireAction
     }
 
     public virtual bool AddWire(Wire wire, int count) => count == 1;
-    public virtual bool Cut(EntityUid user, Wire wire) => Log(user, wire, "cut");
-    public virtual bool Mend(EntityUid user, Wire wire) => Log(user, wire, "mended");
-    public virtual void Pulse(EntityUid user, Wire wire) => Log(user, wire, "pulsed");
+    public virtual bool Cut(EntityUid? user, Wire wire) => Log(user, wire, "cut");
+    public virtual bool Mend(EntityUid? user, Wire wire) => Log(user, wire, "mended");
+    public virtual void Pulse(EntityUid? user, Wire wire) => Log(user, wire, "pulsed");
 
-    private bool Log(EntityUid user, Wire wire, string verb)
+    private bool Log(EntityUid? user, Wire wire, string verb)
     {
         var player = EntityManager.ToPrettyString(user);
         var owner = EntityManager.ToPrettyString(wire.Owner);
@@ -72,7 +72,11 @@ public abstract partial class BaseWireAction : IWireAction
         var action = GetType().Name;
 
         // logs something like "... mended red POWR wire (PowerWireAction) in ...."
-        _adminLogger.Add(LogType.WireHacking, LogImpact.Medium, $"{player} {verb} {color} {name} wire ({action}) in {owner}");
+        if (user is not null)
+            _adminLogger.Add(LogType.WireHacking, LogImpact.Medium, $"{player} {verb} {color} {name} wire ({action}) in {owner}");
+        else
+            // Lower impact if being caused without a user.
+            _adminLogger.Add(LogType.WireHacking, LogImpact.Low, $"{color} {name} {verb} ({action}) in {owner}");
         return true;
     }
 

--- a/Content.Server/Wires/ComponentWireAction.cs
+++ b/Content.Server/Wires/ComponentWireAction.cs
@@ -15,24 +15,24 @@ public abstract partial class ComponentWireAction<TComponent> : BaseWireAction w
             : StatusLightState.Off;
     }
 
-    public abstract bool Cut(EntityUid user, Wire wire, TComponent component);
-    public abstract bool Mend(EntityUid user, Wire wire, TComponent component);
-    public abstract void Pulse(EntityUid user, Wire wire, TComponent component);
+    public abstract bool Cut(EntityUid? user, Wire wire, TComponent component);
+    public abstract bool Mend(EntityUid? user, Wire wire, TComponent component);
+    public abstract void Pulse(EntityUid? user, Wire wire, TComponent component);
 
-    public override bool Cut(EntityUid user, Wire wire)
+    public override bool Cut(EntityUid? user, Wire wire)
     {
         base.Cut(user, wire);
         // if the entity doesn't exist, we need to return true otherwise the wire sprite is never updated
         return EntityManager.TryGetComponent(wire.Owner, out TComponent? component) ? Cut(user, wire, component) : true;
     }
 
-    public override bool Mend(EntityUid user, Wire wire)
+    public override bool Mend(EntityUid? user, Wire wire)
     {
         base.Mend(user, wire);
         return EntityManager.TryGetComponent(wire.Owner, out TComponent? component) ? Mend(user, wire, component) : true;
     }
 
-    public override void Pulse(EntityUid user, Wire wire)
+    public override void Pulse(EntityUid? user, Wire wire)
     {
         base.Pulse(user, wire);
         if (EntityManager.TryGetComponent(wire.Owner, out TComponent? component))

--- a/Content.Server/Wires/IWireAction.cs
+++ b/Content.Server/Wires/IWireAction.cs
@@ -46,7 +46,7 @@ public interface IWireAction
     /// <param name="user">The user attempting to interact with the wire.</param>
     /// <param name="wire">The wire being interacted with.</param>
     /// <returns>true if successful, false otherwise.</returns>
-    public bool Cut(EntityUid user, Wire wire);
+    public bool Cut(EntityUid? user, Wire wire);
 
     /// <summary>
     ///     What happens when this wire is mended. If this returns false, the wire will not actually get cut.
@@ -54,14 +54,14 @@ public interface IWireAction
     /// <param name="user">The user attempting to interact with the wire.</param>
     /// <param name="wire">The wire being interacted with.</param>
     /// <returns>true if successful, false otherwise.</returns>
-    public bool Mend(EntityUid user, Wire wire);
+    public bool Mend(EntityUid? user, Wire wire);
 
     /// <summary>
     ///     This method gets called when the wire is pulsed..
     /// </summary>
     /// <param name="user">The user attempting to interact with the wire.</param>
     /// <param name="wire">The wire being interacted with.</param>
-    public void Pulse(EntityUid user, Wire wire);
+    public void Pulse(EntityUid? user, Wire wire);
 
     /// <summary>
     ///     Used when a wire's state on an entity needs to be updated.

--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -786,6 +786,13 @@ public sealed partial class WiresSystem : SharedWiresSystem
         wires.WiresQueue.Remove(id);
     }
 
+    /// <summary>
+    /// Causes the passed wire action to be activated on the target entity and wire ID.
+    /// </summary>
+    /// <param name="uid">The target entity</param>
+    /// <param name="id">The ID of the wire to call the action on</param>
+    /// <param name="action">The wire action to activate</param>
+    /// <returns>True if the action was called, false otherwise</returns>
     public bool TryForceWireAction(EntityUid uid, int id, WiresAction action, WiresComponent? wires = null)
     {
         if (!Resolve(uid, ref wires))
@@ -798,6 +805,13 @@ public sealed partial class WiresSystem : SharedWiresSystem
         return TryForceWireAction(uid, wire, action, wires);
     }
 
+    /// <summary>
+    /// Causes the passed wire action to be activated on the target entity and wire.
+    /// </summary>
+    /// <param name="uid">The target entity</param>
+    /// <param name="wire">The wire to call the action on</param>
+    /// <param name="action">The wire action to activate</param>
+    /// <returns>True if the action was called, false otherwise</returns>
     public bool TryForceWireAction(EntityUid uid, Wire wire, WiresAction action, WiresComponent? wires = null)
     {
         if (!Resolve(uid, ref wires))

--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -786,6 +786,54 @@ public sealed partial class WiresSystem : SharedWiresSystem
         wires.WiresQueue.Remove(id);
     }
 
+    public bool TryForceWireAction(EntityUid uid, int id, WiresAction action, WiresComponent? wires = null)
+    {
+        if (!Resolve(uid, ref wires))
+            return false;
+        
+        var wire = TryGetWire(uid, id, wires);
+        if (wire == null)
+            return false;
+
+        return TryForceWireAction(uid, wire, action, wires);
+    }
+
+    public bool TryForceWireAction(EntityUid uid, Wire wire, WiresAction action, WiresComponent? wires = null)
+    {
+        if (!Resolve(uid, ref wires))
+            return false;
+
+        if (wire.Owner != uid)
+            return false;
+        
+        switch (action)
+        {
+            case WiresAction.Cut:
+                if (wire.Action == null || wire.Action.Cut(null, wire))
+                {
+                    wire.IsCut = true;
+                }
+
+                UpdateUserInterface(uid);
+                break;
+            case WiresAction.Mend:
+                if (wire.Action == null || wire.Action.Mend(null, wire))
+                {
+                    wire.IsCut = false;
+                }
+
+                UpdateUserInterface(uid);
+                break;
+            case WiresAction.Pulse:
+                wire.Action?.Pulse(null, wire);
+
+                UpdateUserInterface(uid);
+                break;
+        }
+
+        return true;
+    }
+
     /// <summary>
     ///     Tries to get the stateful data stored in this entity's WiresComponent.
     /// </summary>

--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -788,6 +788,68 @@ public sealed partial class WiresSystem : SharedWiresSystem
     }
 
     /// <summary>
+    /// Causes the passed wire action to be activated on the target entity and wire ID.
+    /// </summary>
+    /// <param name="uid">The target entity</param>
+    /// <param name="id">The ID of the wire to call the action on</param>
+    /// <param name="action">The wire action to activate</param>
+    /// <returns>True if the action was called, false otherwise</returns>
+    public bool TryForceWireAction(EntityUid uid, int id, WiresAction action, WiresComponent? wires = null)
+    {
+        if (!Resolve(uid, ref wires))
+            return false;
+        
+        var wire = TryGetWire(uid, id, wires);
+        if (wire == null)
+            return false;
+
+        return TryForceWireAction(uid, wire, action, wires);
+    }
+
+    /// <summary>
+    /// Causes the passed wire action to be activated on the target entity and wire.
+    /// </summary>
+    /// <param name="uid">The target entity</param>
+    /// <param name="wire">The wire to call the action on</param>
+    /// <param name="action">The wire action to activate</param>
+    /// <returns>True if the action was called, false otherwise</returns>
+    public bool TryForceWireAction(EntityUid uid, Wire wire, WiresAction action, WiresComponent? wires = null)
+    {
+        if (!Resolve(uid, ref wires))
+            return false;
+
+        if (wire.Owner != uid)
+            return false;
+        
+        switch (action)
+        {
+            case WiresAction.Cut:
+                if (wire.Action == null || wire.Action.Cut(null, wire))
+                {
+                    wire.IsCut = true;
+                }
+
+                UpdateUserInterface(uid);
+                break;
+            case WiresAction.Mend:
+                if (wire.Action == null || wire.Action.Mend(null, wire))
+                {
+                    wire.IsCut = false;
+                }
+
+                UpdateUserInterface(uid);
+                break;
+            case WiresAction.Pulse:
+                wire.Action?.Pulse(null, wire);
+
+                UpdateUserInterface(uid);
+                break;
+        }
+
+        return true;
+    }
+
+    /// <summary>
     ///     Tries to get the stateful data stored in this entity's WiresComponent.
     /// </summary>
     /// <param name="identifier">The key that stores the data in the WiresComponent.</param>

--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -775,6 +775,54 @@ public sealed class WiresSystem : SharedWiresSystem
         wires.WiresQueue.Remove(id);
     }
 
+    public bool TryForceWireAction(EntityUid uid, int id, WiresAction action, WiresComponent? wires = null)
+    {
+        if (!Resolve(uid, ref wires))
+            return false;
+        
+        var wire = TryGetWire(uid, id, wires);
+        if (wire == null)
+            return false;
+
+        return TryForceWireAction(uid, wire, action, wires);
+    }
+
+    public bool TryForceWireAction(EntityUid uid, Wire wire, WiresAction action, WiresComponent? wires = null)
+    {
+        if (!Resolve(uid, ref wires))
+            return false;
+
+        if (wire.Owner != uid)
+            return false;
+        
+        switch (action)
+        {
+            case WiresAction.Cut:
+                if (wire.Action == null || wire.Action.Cut(null, wire))
+                {
+                    wire.IsCut = true;
+                }
+
+                UpdateUserInterface(uid);
+                break;
+            case WiresAction.Mend:
+                if (wire.Action == null || wire.Action.Mend(null, wire))
+                {
+                    wire.IsCut = false;
+                }
+
+                UpdateUserInterface(uid);
+                break;
+            case WiresAction.Pulse:
+                wire.Action?.Pulse(null, wire);
+
+                UpdateUserInterface(uid);
+                break;
+        }
+
+        return true;
+    }
+
     /// <summary>
     ///     Tries to get the stateful data stored in this entity's WiresComponent.
     /// </summary>

--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -775,6 +775,13 @@ public sealed class WiresSystem : SharedWiresSystem
         wires.WiresQueue.Remove(id);
     }
 
+    /// <summary>
+    /// Causes the passed wire action to be activated on the target entity and wire ID.
+    /// </summary>
+    /// <param name="uid">The target entity</param>
+    /// <param name="id">The ID of the wire to call the action on</param>
+    /// <param name="action">The wire action to activate</param>
+    /// <returns>True if the action was called, false otherwise</returns>
     public bool TryForceWireAction(EntityUid uid, int id, WiresAction action, WiresComponent? wires = null)
     {
         if (!Resolve(uid, ref wires))
@@ -787,6 +794,13 @@ public sealed class WiresSystem : SharedWiresSystem
         return TryForceWireAction(uid, wire, action, wires);
     }
 
+    /// <summary>
+    /// Causes the passed wire action to be activated on the target entity and wire.
+    /// </summary>
+    /// <param name="uid">The target entity</param>
+    /// <param name="wire">The wire to call the action on</param>
+    /// <param name="action">The wire action to activate</param>
+    /// <returns>True if the action was called, false otherwise</returns>
     public bool TryForceWireAction(EntityUid uid, Wire wire, WiresAction action, WiresComponent? wires = null)
     {
         if (!Resolve(uid, ref wires))

--- a/Resources/Locale/en-US/administration/admin-verbs.ftl
+++ b/Resources/Locale/en-US/administration/admin-verbs.ftl
@@ -47,6 +47,8 @@ admin-verbs-pause-map = Pause Map
 admin-verbs-snap-joints = Snap Joints
 admin-verbs-make-minigun = Make Minigun
 admin-verbs-set-bullet-amount = Set Bullet Amount
+admin-verbs-cut-wires = Cut Wires
+admin-verbs-mend-wires = Mend Wires
 
 # Toggles verbs
 admin-verbs-bolt = Bolt

--- a/Resources/Locale/en-US/administration/admin-verbs.ftl
+++ b/Resources/Locale/en-US/administration/admin-verbs.ftl
@@ -48,6 +48,8 @@ admin-verbs-pause-map = Pause Map
 admin-verbs-snap-joints = Snap Joints
 admin-verbs-make-minigun = Make Minigun
 admin-verbs-set-bullet-amount = Set Bullet Amount
+admin-verbs-cut-wires = Cut Wires
+admin-verbs-mend-wires = Mend Wires
 
 # Toggles verbs
 admin-verbs-bolt = Bolt

--- a/Resources/Locale/en-US/administration/smites.ftl
+++ b/Resources/Locale/en-US/administration/smites.ftl
@@ -147,3 +147,5 @@ admin-trick-pause-map-description = Pause the selected map. Note this doesn't en
 admin-trick-snap-joints-description = Remove all physics joints from an object. Unfortunately does not snap every bone in their body.
 admin-trick-minigun-fire-description = Makes the targetted gun fire like a minigun (very fast).
 admin-trick-set-bullet-amount-description = Quickly set the amount of unspawned bullets in a gun.
+admin-trick-cut-wires-description = Cuts all of the wires on this device.
+admin-trick-mend-wires-description = Mends all of the wires on this device.

--- a/Resources/Locale/en-US/administration/smites.ftl
+++ b/Resources/Locale/en-US/administration/smites.ftl
@@ -149,3 +149,5 @@ admin-trick-pause-map-description = Pause the selected map. Note this doesn't en
 admin-trick-snap-joints-description = Remove all physics joints from an object. Unfortunately does not snap every bone in their body.
 admin-trick-minigun-fire-description = Makes the targetted gun fire like a minigun (very fast).
 admin-trick-set-bullet-amount-description = Quickly set the amount of unspawned bullets in a gun.
+admin-trick-cut-wires-description = Cuts all of the wires on this device.
+admin-trick-mend-wires-description = Mends all of the wires on this device.


### PR DESCRIPTION
## About the PR
Added an admin trick for cutting and mending wires on a device, and an API to WiresSystem that allows a wire action to occur without a user and tool.

## Why / Balance
WiresSystem not having a way for other systems to interact with wires was a pain. The tricks are more just to demonstrate that that API works.

The tricks don't do anything clever with wire order, it's liable to bolt doors and detonate bombs if you use it on them.

## Technical details
Added a new TryForceWireAction function to WiresSystem that just takes the entity, the wire, and the action to perform. It skips all of the "Does this user have the right tools" checks. It also makes the `user` in wire actions nullable to facilitate the fact that the action may be occurring without a user now.

## Media

https://github.com/user-attachments/assets/2a29cb5b-e760-4ae2-8ecd-cad24dd40007



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
`Cut`, `Mend`, and `Pulse` in IWireAction now take an `EntityUid?` for user instead of an `EntityUid`. The user is presently null when another system is causing actions using the new `TryForceWireAction`.

**Changelog**
:cl:
ADMIN
- add: Added admin verbs for cutting and mending all wires in a machine.