### PR TITLE
Fix radar distance

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -221,7 +221,7 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
                 var gridCentre = Vector2.Transform(gridBody.LocalCenter, curGridToView);
 
                 var mapCoords = _transform.GetWorldPosition(gUid);
-                var gridDistance = Vector2.Distance(mapCoords + Vector2.Abs(new(gridBounds.Width, -gridBounds.Height)) / 2, xform.LocalPosition);
+                var gridDistance = Vector2.Distance(mapCoords, xform.LocalPosition);
 
                 var labelText = Loc.GetString("shuttle-console-iff-label", ("name", labelName),
                     ("distance", $"{gridDistance:0.0}"));

--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -220,11 +220,11 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
 
                 var gridCentre = Vector2.Transform(gridBody.LocalCenter, curGridToView);
 
-                var gridDistance = (gridBody.LocalCenter - xform.LocalPosition).Length();
+                var mapCoords = _transform.GetWorldPosition(gUid);
+                var gridDistance = Vector2.Distance(mapCoords + Vector2.Abs(new(gridBounds.Width, -gridBounds.Height)) / 2, xform.LocalPosition);
+
                 var labelText = Loc.GetString("shuttle-console-iff-label", ("name", labelName),
                     ("distance", $"{gridDistance:0.0}"));
-
-                var mapCoords = _transform.GetWorldPosition(gUid);
                 var coordsText = $"({mapCoords.X:0.0}, {mapCoords.Y:0.0})";
 
                 // yes 1.0 scale is intended here.


### PR DESCRIPTION
## About the PR
Fixes mass scanner and shuttle console distance.

## Why / Balance
Right now distance based on the physics component (???) instead of coordinates. That's all causes distance problems everytime when grid coordinates not around zero.

## Media
### Before
<img width="1064" height="817" alt="before1" src="https://github.com/user-attachments/assets/98e6f2ab-8728-4d6c-98da-58005740dd87" />
(those coordinates are almost static when grid is too away from zero coordinates). 

### After
<img width="1048" height="858" alt="after" src="https://github.com/user-attachments/assets/3848b150-de58-4784-9914-8af97874e94b" />
<img width="1048" height="858" alt="after2" src="https://github.com/user-attachments/assets/1c9d3844-aab9-4972-88c7-909327707e00" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: Fixed shuttle console and mass scanner showing wrong distance between grids.