### PR TITLE
Correctly warning-only the remaining SVE warnings.

### DIFF
--- a/MSBuild/Content.props
+++ b/MSBuild/Content.props
@@ -12,6 +12,6 @@
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>CS0618,CS0672,CS0612,CS1062,CS1064,NU1903</WarningsNotAsErrors>
+    <WarningsNotAsErrors>CS0618,CS0672,CS0612,CS1062,CS1064,NU1901,NU1902,NU1903,NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
These were always meant to be only warnings. Whoops.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
