### PR TITLE
Markings Displacement returns

### DIFF
--- a/Content.Client/Body/Systems/MarkingDisplacementSystem.cs
+++ b/Content.Client/Body/Systems/MarkingDisplacementSystem.cs
@@ -12,7 +12,7 @@ namespace Content.Client.Body;
 /// Applies displacement maps to marking layers (Hair, FacialHair, etc.) after they are rendered.
 /// Works with <see cref="MarkingDisplacementComponent"/> on the organ entity.
 /// </summary>
-public sealed class CEMarkingDisplacementSystem : EntitySystem
+public sealed class MarkingDisplacementSystem : EntitySystem
 {
     [Dependency] private readonly DisplacementMapSystem _displacement = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;

--- a/Content.Client/Body/Systems/MarkingDisplacementSystem.cs
+++ b/Content.Client/Body/Systems/MarkingDisplacementSystem.cs
@@ -24,11 +24,20 @@ public sealed class MarkingDisplacementSystem : EntitySystem
 
         SubscribeLocalEvent<MarkingDisplacementComponent, OrganGotInsertedEvent>(OnInserted, after: [typeof(VisualBodySystem)]);
         SubscribeLocalEvent<MarkingDisplacementComponent, OrganGotRemovedEvent>(OnRemoved, after: [typeof(VisualBodySystem)]);
+        SubscribeLocalEvent<MarkingDisplacementComponent, BodyRelayedEvent<ApplyOrganMarkingsEvent>>(OnMarkingsApplied, after: [typeof(SharedVisualBodySystem)]);
     }
 
     private void OnInserted(Entity<MarkingDisplacementComponent> ent, ref OrganGotInsertedEvent args)
     {
         ApplyDisplacements(ent, args.Target);
+    }
+
+    private void OnMarkingsApplied(Entity<MarkingDisplacementComponent> ent, ref BodyRelayedEvent<ApplyOrganMarkingsEvent> args)
+    {
+        if (Comp<OrganComponent>(ent).Body is not { } body)
+            return;
+
+        ApplyDisplacements(ent, body);
     }
 
     private void OnRemoved(Entity<MarkingDisplacementComponent> ent, ref OrganGotRemovedEvent args)

--- a/Content.Client/Body/Systems/MarkingDisplacementSystem.cs
+++ b/Content.Client/Body/Systems/MarkingDisplacementSystem.cs
@@ -1,0 +1,90 @@
+using Content.Client.Body;
+using Content.Client.DisplacementMap;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Humanoid.Markings;
+using Robust.Client.GameObjects;
+using Robust.Shared.Utility;
+
+namespace Content.Client.Body;
+
+/// <summary>
+/// Applies displacement maps to marking layers (Hair, FacialHair, etc.) after they are rendered.
+/// Works with <see cref="MarkingDisplacementComponent"/> on the organ entity.
+/// </summary>
+public sealed class CEMarkingDisplacementSystem : EntitySystem
+{
+    [Dependency] private readonly DisplacementMapSystem _displacement = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+    [Dependency] private readonly MarkingManager _markingManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MarkingDisplacementComponent, OrganGotInsertedEvent>(OnInserted, after: [typeof(VisualBodySystem)]);
+        SubscribeLocalEvent<MarkingDisplacementComponent, OrganGotRemovedEvent>(OnRemoved, after: [typeof(VisualBodySystem)]);
+    }
+
+    private void OnInserted(Entity<MarkingDisplacementComponent> ent, ref OrganGotInsertedEvent args)
+    {
+        ApplyDisplacements(ent, args.Target);
+    }
+
+    private void OnRemoved(Entity<MarkingDisplacementComponent> ent, ref OrganGotRemovedEvent args)
+    {
+        RemoveDisplacements(ent, args.Target);
+    }
+
+    private void ApplyDisplacements(Entity<MarkingDisplacementComponent> ent, EntityUid body)
+    {
+        if (!TryComp<SpriteComponent>(body, out var sprite))
+            return;
+
+        if (!TryComp<VisualOrganMarkingsComponent>(ent, out var markings))
+            return;
+
+        // Clean up previous displacement layers
+        RemoveDisplacements(ent, body);
+
+        foreach (var marking in markings.AppliedMarkings)
+        {
+            if (!_markingManager.TryGetMarking(marking, out var proto))
+                continue;
+
+            if (!ent.Comp.Displacements.TryGetValue(proto.BodyPart, out var displacementData))
+                continue;
+
+            foreach (var spriteSpec in proto.Sprites)
+            {
+                DebugTools.Assert(spriteSpec is SpriteSpecifier.Rsi);
+                if (spriteSpec is not SpriteSpecifier.Rsi rsi)
+                    continue;
+
+                var layerId = $"{proto.ID}-{rsi.RsiState}";
+
+                if (!_sprite.LayerMapTryGet(body, layerId, out var index, false))
+                    continue;
+
+                if (_displacement.TryAddDisplacement(displacementData, (body, sprite), index, layerId,
+                    out var displacementKey))
+                {
+                    ent.Comp.TrackedKeys.Add(displacementKey);
+                }
+            }
+        }
+    }
+
+    private void RemoveDisplacements(Entity<MarkingDisplacementComponent> ent, EntityUid body)
+    {
+        if (ent.Comp.TrackedKeys.Count == 0)
+            return;
+
+        foreach (var key in ent.Comp.TrackedKeys)
+        {
+            _sprite.RemoveLayer(body, key, false);
+        }
+
+        ent.Comp.TrackedKeys.Clear();
+    }
+}

--- a/Content.Shared/Body/MarkingDisplacementComponent.cs
+++ b/Content.Shared/Body/MarkingDisplacementComponent.cs
@@ -1,0 +1,25 @@
+using Content.Shared.DisplacementMap;
+using Content.Shared.Humanoid;
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.Body;
+
+/// <summary>
+/// Stores displacement maps for marking layers (Hair, FacialHair, etc.).
+/// Applied to visual organ entities to shift marking sprites for non-standard body shapes.
+/// </summary>
+[RegisterComponent]
+public sealed partial class MarkingDisplacementComponent : Component
+{
+    /// <summary>
+    /// Displacement maps keyed by HumanoidVisualLayers.
+    /// </summary>
+    [DataField]
+    public Dictionary<HumanoidVisualLayers, DisplacementData> Displacements = new();
+
+    /// <summary>
+    /// Tracks displacement layer keys added to the body sprite, for cleanup.
+    /// </summary>
+    [ViewVariables]
+    public List<string> TrackedKeys = new();
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Nubody removed support for markingDisplacements. We're bringing it back, since this refactor made it very easy to do.

Using example:
```yml
- type: entity
  parent: [ OrganBaseHeadSexed, OrganBaseHead, OrganGoblinExternal ]
  id: OrganGoblinHead
  components:
  - type: VisualOrganMarkings
    hideableLayers:
    - enum.HumanoidVisualLayers.Hair
    - enum.HumanoidVisualLayers.Snout
  - type: MarkingDisplacement
    displacements:
      Hair:
        sizeMaps:
          32:
            sprite: _CE/Mobs/Species/Goblin/displacement.rsi
            state: hair
          48:
            sprite: _CE/Mobs/Species/Goblin/displacement48.rsi
            state: hair
```

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

no cl no fun
