### PR TITLE
Allow Organs to have Markings Displacements again.

### DIFF
--- a/Content.Client/Body/VisualBodySystem.cs
+++ b/Content.Client/Body/VisualBodySystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Client.DisplacementMap;
 using Content.Shared.Body;
 using Content.Shared.CCVar;
 using Content.Shared.Humanoid.Markings;
@@ -15,6 +16,7 @@ public sealed class VisualBodySystem : SharedVisualBodySystem
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly DisplacementMapSystem _displacement = default!;
     [Dependency] private readonly MarkingManager _marking = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
 
@@ -167,8 +169,11 @@ public sealed class VisualBodySystem : SharedVisualBodySystem
         }
     }
 
-    private void ApplyMarkings(Entity<VisualOrganMarkingsComponent> ent, EntityUid target)
+    private void ApplyMarkings(Entity<VisualOrganMarkingsComponent> ent, Entity<SpriteComponent?> target)
     {
+        if (!Resolve(target, ref target.Comp))
+            return;
+
         var applied = new List<Marking>();
         foreach (var marking in AllMarkings(ent))
         {
@@ -177,6 +182,8 @@ public sealed class VisualBodySystem : SharedVisualBodySystem
 
             if (!_sprite.LayerMapTryGet(target, proto.BodyPart, out var index, true))
                 continue;
+
+            ent.Comp.MarkingsDisplacement.TryGetValue(proto.BodyPart, out var displacement);
 
             for (var i = 0; i < proto.Sprites.Count; i++)
             {
@@ -190,8 +197,8 @@ public sealed class VisualBodySystem : SharedVisualBodySystem
 
                 if (!_sprite.LayerMapTryGet(target, layerId, out _, false))
                 {
-                    var layer = _sprite.AddLayer(target, sprite, index + i + 1);
-                    _sprite.LayerMapSet(target, layerId, layer);
+                    var spriteLayer = _sprite.AddLayer(target, sprite, index + i + 1);
+                    _sprite.LayerMapSet(target, layerId, spriteLayer);
                     _sprite.LayerSetSprite(target, layerId, rsi);
                 }
 
@@ -199,6 +206,9 @@ public sealed class VisualBodySystem : SharedVisualBodySystem
                     _sprite.LayerSetColor(target, layerId, marking.MarkingColors[i]);
                 else
                     _sprite.LayerSetColor(target, layerId, Color.White);
+
+                if (displacement != null && proto.CanBeDisplaced)
+                    _displacement.TryAddDisplacement(displacement, (target, target.Comp), index + i + 1, layerId, out _);
             }
 
             applied.Add(marking);
@@ -206,8 +216,11 @@ public sealed class VisualBodySystem : SharedVisualBodySystem
         ent.Comp.AppliedMarkings = applied;
     }
 
-    private void RemoveMarkings(Entity<VisualOrganMarkingsComponent> ent, EntityUid target)
+    private void RemoveMarkings(Entity<VisualOrganMarkingsComponent> ent, Entity<SpriteComponent?> target)
     {
+        if (!Resolve(target, ref target.Comp))
+            return;
+
         foreach (var marking in ent.Comp.AppliedMarkings)
         {
             if (!_marking.TryGetMarking(marking, out var proto))
@@ -220,6 +233,13 @@ public sealed class VisualBodySystem : SharedVisualBodySystem
                     continue;
 
                 var layerId = $"{proto.ID}-{rsi.RsiState}";
+
+                // If this marking is one that can be displaced, we need to remove the displacement as well; otherwise
+                // altering a marking at runtime can lead to the renderer falling over.
+                // The Vulps must be shaved.
+                // (https://github.com/space-wizards/space-station-14/issues/40135).
+                if (proto.CanBeDisplaced)
+                    _displacement.EnsureDisplacementIsNotOnSprite((target, target.Comp), layerId);
 
                 if (!_sprite.LayerMapTryGet(target, layerId, out var index, false))
                     continue;

--- a/Content.Shared/Body/VisualOrganMarkingsComponent.cs
+++ b/Content.Shared/Body/VisualOrganMarkingsComponent.cs
@@ -42,8 +42,8 @@ public sealed partial class VisualOrganMarkingsComponent : Component
     /// Optional displacement data for this organ to apply to markings.
     /// Only applies to markings which support displacement data.
     /// </summary>
-    [DataField]
-    public DisplacementData? MarkingsDisplacement;
+    [DataField, AutoNetworkedField]
+    public Dictionary<HumanoidVisualLayers, DisplacementData> MarkingsDisplacement = new();
 
     /// <summary>
     /// Client only - the last markings applied by this component

--- a/Content.Shared/Body/VisualOrganMarkingsComponent.cs
+++ b/Content.Shared/Body/VisualOrganMarkingsComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.DisplacementMap;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Robust.Shared.GameStates;
@@ -36,6 +37,13 @@ public sealed partial class VisualOrganMarkingsComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public Dictionary<Enum, HashSet<Enum>> DependentHidingLayers = new();
+
+    /// <summary>
+    /// Optional displacement data for this organ to apply to markings.
+    /// Only applies to markings which support displacement data.
+    /// </summary>
+    [DataField]
+    public DisplacementData? MarkingsDisplacement;
 
     /// <summary>
     /// Client only - the last markings applied by this component

--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -314,6 +314,12 @@
     dependentHidingLayers:
       enum.HumanoidVisualLayers.Snout:
       - enum.HumanoidVisualLayers.SnoutCover
+    markingsDisplacement:
+      Hair:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Vox/displacement.rsi
+            state: hair
 
 - type: entity
   parent: [ OrganBaseArmLeft, OrganVoxExternal ]

--- a/Resources/Prototypes/Body/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Body/Species/vulpkanin.yml
@@ -268,6 +268,12 @@
     dependentHidingLayers:
       enum.HumanoidVisualLayers.Snout:
       - enum.HumanoidVisualLayers.SnoutCover
+    markingsDisplacement:
+      Hair:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Vulpkanin/displacement.rsi
+            state: hair
 
 - type: entity
   parent: [ OrganBaseArmLeft, OrganVulpkaninExternal ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Oops! This allows organs to have marking displacements again!
Functionality was removed during Visual Nubody, added it back as it will be needed for dwarves and is desired downstream for some of their funny species. 

Works the same as it did before, except the displacements are defined per organ rather than per body.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Unintended removal.

## Technical details
<!-- Summary of code changes for easier review. -->
Readded some code, and an old comment cause I ran into the vulp bald bug again :goberserk: 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Posting here since they weren't included in old Visual Nubody.
`MarkingsDisplacement` has been moved to `VisualOrganMarkingsComponent` with unchanged functionality otherwise.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
