### PR TITLE
Changeling clone melee, puller and (most of) temperature

### DIFF
--- a/Content.Server/Cloning/CloningSystem.Subscriptions.cs
+++ b/Content.Server/Cloning/CloningSystem.Subscriptions.cs
@@ -6,6 +6,8 @@ using Content.Shared.Inventory;
 using Content.Shared.Labels.Components;
 using Content.Shared.Labels.EntitySystems;
 using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Paper;
 using Content.Shared.Stacks;
@@ -32,6 +34,7 @@ public sealed partial class CloningSystem
     [Dependency] private readonly PaperSystem _paper = default!;
     [Dependency] private readonly VocalSystem _vocal = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifier = default!;
+    [Dependency] private readonly PullingSystem _pulling = default!;
 
     public override void Initialize()
     {
@@ -54,6 +57,7 @@ public sealed partial class CloningSystem
         SubscribeLocalEvent<StorageComponent, CloningEvent>(OnCloneStorage);
         SubscribeLocalEvent<InventoryComponent, CloningEvent>(OnCloneInventory);
         SubscribeLocalEvent<MovementSpeedModifierComponent, CloningEvent>(OnCloneMovementSpeedModifier);
+        SubscribeLocalEvent<PullerComponent, CloningEvent>(OnClonePuller);
     }
 
     private void OnCloneItemStack(Entity<StackComponent> ent, ref CloningItemEvent args)
@@ -126,5 +130,13 @@ public sealed partial class CloningSystem
             return;
 
         _movementSpeedModifier.CopyComponent(ent.AsNullable(), args.CloneUid);
+    }
+
+    private void OnClonePuller(Entity<PullerComponent> ent, ref CloningEvent args)
+    {
+        if (!args.Settings.EventComponents.Contains(Factory.GetRegistration(ent.Comp.GetType()).Name))
+            return;
+
+        _pulling.CopyPullerComponent(ent.AsNullable(), args.CloneUid);
     }
 }

--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -21,7 +21,10 @@ public sealed partial class PullerComponent : Component
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, Access(Other = AccessPermissions.ReadWriteExecute)]
     public TimeSpan NextThrow;
 
-    [DataField]
+    /// <summary>
+    /// Minimum time between pull throws.
+    /// </summary>
+    [DataField, AutoNetworkedField]
     public TimeSpan ThrowCooldown = TimeSpan.FromSeconds(1);
 
     // Before changing how this is updated, please see SharedPullerSystem.RefreshMovementSpeed
@@ -32,15 +35,18 @@ public sealed partial class PullerComponent : Component
     /// <summary>
     /// Entity currently being pulled if applicable.
     /// </summary>
-    [AutoNetworkedField, DataField]
+    [DataField, AutoNetworkedField]
     public EntityUid? Pulling;
 
     /// <summary>
-    ///     Does this entity need hands to be able to pull something?
+    /// Does this entity need hands to be able to pull something?
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool NeedsHands = true;
 
+    /// <summary>
+    /// The alert shown to the puller indicating that they are pulling something.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public ProtoId<AlertPrototype> PullingAlert = "Pulling";
 }

--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -38,10 +38,10 @@ public sealed partial class PullerComponent : Component
     /// <summary>
     ///     Does this entity need hands to be able to pull something?
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool NeedsHands = true;
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public ProtoId<AlertPrototype> PullingAlert = "Pulling";
 }
 

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -614,4 +614,15 @@ public sealed class PullingSystem : EntitySystem
         StopPulling(pullableUid, pullable);
         return true;
     }
+
+    public void CopyPullerComponent(Entity<PullerComponent?> source, EntityUid target)
+    {
+        if (!Resolve(source, ref source.Comp))
+            return;
+
+        var targetComp = EnsureComp<PullerComponent>(target);
+        targetComp.NeedsHands = source.Comp.NeedsHands;
+        targetComp.PullingAlert = source.Comp.PullingAlert;
+        Dirty(target, targetComp);
+    }
 }

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -615,6 +615,11 @@ public sealed class PullingSystem : EntitySystem
         return true;
     }
 
+    /// <summary>
+    /// Copies compatible datafields of <see cref="PullerComponent"/> onto the target entity.
+    /// </summary>
+    /// <param name="source">The target who's component will be taken.</param>
+    /// <param name="target">The target to apply it to.</param>
     public void CopyPullerComponent(Entity<PullerComponent?> source, EntityUid target)
     {
         if (!Resolve(source, ref source.Comp))

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -618,14 +618,15 @@ public sealed class PullingSystem : EntitySystem
     /// <summary>
     /// Copies compatible datafields of <see cref="PullerComponent"/> onto the target entity.
     /// </summary>
-    /// <param name="source">The target who's component will be taken.</param>
-    /// <param name="target">The target to apply it to.</param>
+    /// <param name="source">The entity who's component will be taken.</param>
+    /// <param name="target">The entity to apply it to.</param>
     public void CopyPullerComponent(Entity<PullerComponent?> source, EntityUid target)
     {
         if (!Resolve(source, ref source.Comp))
             return;
 
         var targetComp = EnsureComp<PullerComponent>(target);
+        targetComp.ThrowCooldown = source.Comp.ThrowCooldown;
         targetComp.NeedsHands = source.Comp.NeedsHands;
         targetComp.PullingAlert = source.Comp.PullingAlert;
         Dirty(target, targetComp);

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -130,7 +130,7 @@ public sealed partial class MeleeWeaponComponent : Component
     /// We don't connect it with attack range, because different weapons have different sprites,
     /// and this value should be adjusted manually for every weapon ideally
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float AnimationOffset = 1f;
 
     // Sounds

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -9,17 +9,17 @@
   id: Body
   components:
   # general
+  - CreamPied
   - DetailExaminable
   - Dna
   - Fingerprint
   - Grammar # Pronouns
   - HumanoidProfile # Age, Sex, Gender
+  - MeleeWeapon # Attack animation, damage and sound
   - NpcFactionMember
   - RandomPrice
-  - CreamPied
-  - MeleeWeapon # Attack animation, damage and sound
-  - TemperatureSpeed
   - TemperatureDamage
+  - TemperatureSpeed
   # traits
   - BlackAndWhiteOverlay
   - Clumsy
@@ -62,8 +62,8 @@
   - SpanishAccent
   - StutteringAccent
   eventComponents:
-  - Vocal # voice sounds
   - Puller
+  - Vocal # voice sounds
 
 # for job-specific traits etc.
 - type: cloningSettings

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -17,6 +17,9 @@
   - NpcFactionMember
   - RandomPrice
   - CreamPied
+  - MeleeWeapon # Attack animation, damage and sound
+  - TemperatureSpeed
+  - TemperatureDamage
   # traits
   - BlackAndWhiteOverlay
   - Clumsy
@@ -60,6 +63,7 @@
   - StutteringAccent
   eventComponents:
   - Vocal # voice sounds
+  - Puller
 
 # for job-specific traits etc.
 - type: cloningSettings


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the MeleeWeapon, Puller, TemperatureSpeed and TemperatureDamage onto the Body cloning list.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
All of those are related to the body, which we expect to clone when using things like changeling's transformation.

## Technical details
<!-- Summary of code changes for easier review. -->
Puller was done via an event because it stores an entityuid.
I believe the rest is able to handle itself via CopyComp.
TemperatureComponent should be included but that's being reworked so I left it out. It'd need to be cloned via event so we don't keep the temperature of the person we devour

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
next week
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
