### PR TITLE
Convert IsAfkCommand to Toolshed

### DIFF
--- a/Content.Server/Afk/IsAfkCommand.cs
+++ b/Content.Server/Afk/IsAfkCommand.cs
@@ -10,6 +10,7 @@ public sealed class IsAfkCommand : ToolshedCommand
 {
     [Dependency] private readonly IAfkManager _afkManager = default!;
 
+    [CommandImplementation]
     public void IsAfk(IInvocationContext ctx, ICommonSession player)
     {
         ctx.WriteLine(Loc.GetString(_afkManager.IsAfk(player) ? "cmd-isafk-true" : "cmd-isafk-false"));

--- a/Content.Server/Afk/IsAfkCommand.cs
+++ b/Content.Server/Afk/IsAfkCommand.cs
@@ -10,7 +10,6 @@ public sealed class IsAfkCommand : ToolshedCommand
 {
     [Dependency] private readonly IAfkManager _afkManager = default!;
 
-    [CommandImplementation]
     public void IsAfk(IInvocationContext ctx, ICommonSession player)
     {
         ctx.WriteLine(Loc.GetString(_afkManager.IsAfk(player) ? "cmd-isafk-true" : "cmd-isafk-false"));

--- a/Content.Server/Afk/IsAfkCommand.cs
+++ b/Content.Server/Afk/IsAfkCommand.cs
@@ -1,45 +1,17 @@
 ﻿using Content.Server.Administration;
 using Content.Shared.Administration;
-using Robust.Server.Player;
-using Robust.Shared.Console;
+using Robust.Shared.Player;
+using Robust.Shared.Toolshed;
 
-namespace Content.Server.Afk
+namespace Content.Server.Afk;
+
+[ToolshedCommand, AdminCommand(AdminFlags.Admin)]
+public sealed class IsAfkCommand : ToolshedCommand
 {
-    [AdminCommand(AdminFlags.Admin)]
-    public sealed class IsAfkCommand : LocalizedCommands
+    [Dependency] private readonly IAfkManager _afkManager = default!;
+
+    public void IsAfk(IInvocationContext ctx, ICommonSession player)
     {
-        [Dependency] private readonly IAfkManager _afkManager = default!;
-        [Dependency] private readonly IPlayerManager _players = default!;
-
-        public override string Command => "isafk";
-
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
-        {
-            if (args.Length == 0)
-            {
-                shell.WriteError(Loc.GetString($"shell-need-exactly-one-argument"));
-                return;
-            }
-
-            if (!_players.TryGetSessionByUsername(args[0], out var player))
-            {
-                shell.WriteError(Loc.GetString($"shell-target-player-does-not-exist"));
-                return;
-            }
-
-            shell.WriteLine(Loc.GetString(_afkManager.IsAfk(player) ? "cmd-isafk-true" : "cmd-isafk-false"));
-        }
-
-        public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
-        {
-            if (args.Length == 1)
-            {
-                return CompletionResult.FromHintOptions(
-                    CompletionHelper.SessionNames(players: _players),
-                    "<playerName>");
-            }
-
-            return CompletionResult.Empty;
-        }
+        ctx.WriteLine(Loc.GetString(_afkManager.IsAfk(player) ? "cmd-isafk-true" : "cmd-isafk-false"));
     }
 }

--- a/Resources/Locale/en-US/commands/is-afk-command.ftl
+++ b/Resources/Locale/en-US/commands/is-afk-command.ftl
@@ -1,4 +1,3 @@
-﻿cmd-isafk-desc = Checks if a specified player is AFK.
-cmd-isafk-help = Usage: isafk <playerName>
+﻿command-description-isafk = Checks if a specified player is AFK.
 cmd-isafk-true = They are indeed AFK.
 cmd-isafk-false = They are not AFK.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Convert IsAfkCommand to ToolshedCommand.

Incredibly simple conversion here. ICommonSession autocomplete is provided by Toolshed.
Not really a whole lot to explain here. Most of the logic that you needed to specify and handle in IConsoleCommand
is handled by ToolshedCommand like argument type parsing and required arguments. 

<img width="404" height="168" alt="image" src="https://github.com/user-attachments/assets/ddf24752-3ec6-4434-b02f-df14c16a0ad5" />

## Test Plan
Open the console.
> isafk

Pick an item from the autocomplete.
Observe isafk is functional.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
ADMIN:
- tweak: isafk execution flow has changed and must now be ran with remote. > isafk