### PR TITLE
[Issue-43571] EmitterSystem should use DestructionEvent rather than DestructionAttempt Event

### DIFF
--- a/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
@@ -50,7 +50,7 @@ namespace Content.Server.Singularity.EntitySystems
             SubscribeLocalEvent<EmitterComponent, ActivateInWorldEvent>(OnActivate);
             SubscribeLocalEvent<EmitterComponent, AnchorStateChangedEvent>(OnAnchorStateChanged);
             SubscribeLocalEvent<EmitterComponent, SignalReceivedEvent>(OnSignalReceived);
-            SubscribeLocalEvent<EmitterComponent, DestructionAttemptEvent>(OnDestructionAttempted);
+            SubscribeLocalEvent<EmitterComponent, DestructionEventArgs>(OnDestruction);
             SubscribeLocalEvent<EmitterComponent, MachineDeconstructedEvent>(OnDeconstructed); // you shouldn't be able to deconstruct locked emitters but out of scope to fix
             SubscribeLocalEvent<EmitterComponent, LockToggledEvent>(OnLockToggled);
         }
@@ -297,11 +297,9 @@ namespace Content.Server.Singularity.EntitySystems
             }
         }
 
-        private void OnDestructionAttempted(Entity<EmitterComponent> ent, ref DestructionAttemptEvent args)
+        private void OnDestruction(Entity<EmitterComponent> ent, ref DestructionEventArgs args)
         {
-            // warn engineering their containment engine needs IMMEDIATE repairs
-            // this doesn't change much for natural loosing through emitter destruction given any meteor warning serves the same purpose
-            // can also be used to scare engineering though given it broadcasts its location you need a renamed station beacon to really scare them
+            // Engineering needs to know if an emitter is destroyed so they can replace it before the engine looses.
             AlertRadio(ent, ent.Comp.LocDestroyed);
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Set the EmitterSystem to use the DestructionEvent rather than DestructionAttempt.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
DestructionEvent is cancellable, meaning some other process could cancel the destruction of the emitter but the alert message for the emitter being destroyed would still happen.
Resolves #43571

## Technical details
<!-- Summary of code changes for easier review. -->
Change the signature of the event subscription setup.
Changed the signature of the onDestruction (previously onDestructionAttempt) event.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
