### PR TITLE
Log error fix for TryGatherMarkingsData

### DIFF
--- a/Content.Shared/Body/SharedVisualBodySystem.Modifiers.cs
+++ b/Content.Shared/Body/SharedVisualBodySystem.Modifiers.cs
@@ -82,7 +82,7 @@ public abstract partial class SharedVisualBodySystem
         [NotNullWhen(true)] out Dictionary<ProtoId<OrganCategoryPrototype>, OrganMarkingData>? markings,
         [NotNullWhen(true)] out Dictionary<ProtoId<OrganCategoryPrototype>, Dictionary<HumanoidVisualLayers, List<Marking>>>? applied)
     {
-        if (!Resolve(ent, ref ent.Comp))
+        if (!Resolve(ent, ref ent.Comp, logMissing: false))
         {
             profiles = null;
             markings = null;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Implemented [#43559](https://github.com/space-wizards/space-station-14/issues/43559) by adding `logMissing: false` to the `Resolve` call near the top of the `TryGatherMarkingsData` method.

## Why / Balance
Prevents the errors originating from trying to apply non applicable body marking data (i.e. zombie markings to a mouse)

## Technical details
Added `logMissing:false ` to the `Resolve` method on line 85 of SharedVisualBodySystem.Modifiers.cs


## Requirements
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes
None that I know of.


:cl:
- fix: Fixed errors originating from trying to apply non applicable body markings to certain entities as described in issue [#43559](https://github.com/space-wizards/space-station-14/issues/43559).

