### PR TITLE
Turn StatusEffects Query into a HashSet

### DIFF
--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -54,7 +54,8 @@ public sealed partial class StatusEffectsSystem
     {
         // this copies the by-ref event if it is a struct
         var ev = new StatusEffectRelayedEvent<T>(args);
-        var effects = statusEffect.Comp.ActiveStatusEffects?.ContainedEntities.ToList() ?? [];
+        // We copy this to another list to avoid modifying the original collection, e.g. when a status effect causes another to be added.
+        var effects = new List<EntityUid>(statusEffect.Comp.ActiveStatusEffects?.ContainedEntities ?? []);
         foreach (var activeEffect in effects)
         {
             RaiseLocalEvent(activeEffect, ref ev);

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Shared.Body.Events;
 using Content.Shared.Damage.Events;
 using Content.Shared.Damage.Systems;
@@ -53,7 +54,8 @@ public sealed partial class StatusEffectsSystem
     {
         // this copies the by-ref event if it is a struct
         var ev = new StatusEffectRelayedEvent<T>(args);
-        foreach (var activeEffect in statusEffect.Comp.ActiveStatusEffects?.ContainedEntities ?? [])
+        var effects = statusEffect.Comp.ActiveStatusEffects?.ContainedEntities.ToHashSet() ?? [];
+        foreach (var activeEffect in effects)
         {
             RaiseLocalEvent(activeEffect, ref ev);
         }

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -54,7 +54,7 @@ public sealed partial class StatusEffectsSystem
     {
         // this copies the by-ref event if it is a struct
         var ev = new StatusEffectRelayedEvent<T>(args);
-        var effects = statusEffect.Comp.ActiveStatusEffects?.ContainedEntities.ToHashSet() ?? [];
+        var effects = statusEffect.Comp.ActiveStatusEffects?.ContainedEntities.ToList() ?? [];
         foreach (var activeEffect in effects)
         {
             RaiseLocalEvent(activeEffect, ref ev);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I turned the EntityQuery in the StatusEffectsRelaySystem to a HashSet to allow adding statuseffects to it mid relay loop.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's already possible to do so with removing statuseffects, as you can use QueueDel to delete them after the loop.
However, the same isn't possible with adding statuseffects.
I've figured I'd upstream this change, as I can imagine that this functionality would be useful there too.
Though, this is a bandaid fix until something like `QueueAdd` is made. I'm not smart enough to do that though.
## Technical details
<!-- Summary of code changes for easier review. -->
Small C# change
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->