### PR TITLE
Fix extraneous line endings when building some machines

### DIFF
--- a/Content.Server/Construction/Conditions/MachineFrameComplete.cs
+++ b/Content.Server/Construction/Conditions/MachineFrameComplete.cs
@@ -88,8 +88,7 @@ namespace Content.Server.Construction.Conditions
                 var examineName = constructionSys.GetExamineName(info);
                 args.PushMarkup(Loc.GetString("construction-condition-machine-frame-required-element-entry",
                                     ("amount", info.Amount),
-                                    ("elementName", examineName))
-                                + "\n");
+                                    ("elementName", examineName)));
             }
 
             return true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

In any machine construction which uses more than one `TagRequirements`, the examine text has a bunch of extra newlines, which are inconsistent with the rest of the examine text.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bugfix

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:
<img width="473" height="521" alt="2026-04-19_13-45" src="https://github.com/user-attachments/assets/96b0e097-ef20-46e2-9c72-849c50448d3a" />
After:
<img width="497" height="419" alt="2026-04-19_13-50" src="https://github.com/user-attachments/assets/190f335b-462b-42ad-a9bc-32676adea426" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
