### PR TITLE
Fix AI eye warp examine text

### DIFF
--- a/Content.Shared/Warps/WarpPointSystem.cs
+++ b/Content.Shared/Warps/WarpPointSystem.cs
@@ -16,7 +16,7 @@ public sealed class WarpPointSystem : EntitySystem
         if (!HasComp<GhostComponent>(args.Examiner))
             return;
 
-        var loc = component.Location == null ? MetaData(uid).EntityName : component.Location;
+        var loc = component.Location == null ? Name(uid) : component.Location;
         args.PushText(Loc.GetString("warp-point-component-on-examine-success", ("location", loc)));
     }
 }

--- a/Content.Shared/Warps/WarpPointSystem.cs
+++ b/Content.Shared/Warps/WarpPointSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Examine;
+using Content.Shared.Examine;
 using Content.Shared.Ghost;
 
 namespace Content.Shared.Warps;
@@ -16,7 +16,7 @@ public sealed class WarpPointSystem : EntitySystem
         if (!HasComp<GhostComponent>(args.Examiner))
             return;
 
-        var loc = component.Location == null ? "<null>" : $"'{component.Location}'";
+        var loc = component.Location == null ? MetaData(uid).EntityName : component.Location;
         args.PushText(Loc.GetString("warp-point-component-on-examine-success", ("location", loc)));
     }
 }

--- a/Resources/Locale/en-US/warps/warp-point-component.ftl
+++ b/Resources/Locale/en-US/warps/warp-point-component.ftl
@@ -1,1 +1,1 @@
-warp-point-component-on-examine-success = This one's location ID is {$location}
+warp-point-component-on-examine-success = This one's location ID is '{$location}'


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

When examining the AI eye as a ghost, the description text will always say "This one's location ID is <null>" - this looks bad and is a bug. Fix that to show the correct location.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The AI eye's WarpPointComponent has a null location which WarpPointSystem.OnWarpPointExamine was attempting to handle by using `<null>` as a string - however, this was inconsistent with other systems which handle null `WarpPointComponent.Location` by falling back to the entity name.


## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:
<img width="477" height="202" alt="2026-04-19_14-29" src="https://github.com/user-attachments/assets/0543d999-f29a-45a0-a062-445d3584a3d0" />
After:
<img width="508" height="175" alt="2026-04-19_14-32" src="https://github.com/user-attachments/assets/da2ee5eb-dfec-46b2-b047-4b3d67f3241c" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
