### PR TITLE
A couple more Max Cap fixes/rebalances

### DIFF
--- a/Content.Client/Atmos/EntitySystems/MaxPressureVisualsSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/MaxPressureVisualsSystem.cs
@@ -46,10 +46,10 @@ public sealed class MaxPressureVisualsSystem : EntitySystem
         if (args.Sprite is not { } sprite)
             return;
 
-        if (!args.AppearanceData.TryGetValue(GasIntegrity.Integrity, out var obj) || obj is not int integrity)
+        if (!args.AppearanceData.TryGetValue(GasIntegrity.Integrity, out var obj) || obj is not float integrity)
             return;
 
-        if (!args.AppearanceData.TryGetValue(GasIntegrity.MaxIntegrity, out obj) || obj is not int maxIntegrity)
+        if (!args.AppearanceData.TryGetValue(GasIntegrity.MaxIntegrity, out obj) || obj is not float maxIntegrity)
             return;
 
         // We don't want visuals at max integrity, so we return if we're at max.

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -21,7 +21,7 @@ public sealed class GasTankSystem : SharedGasTankSystem
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!;
 
-    private const float MinimumSoundValvePressure = 21.3f; // Artibrary number
+    private const float MinimumSoundValvePressure = 21.3f; // Arbitrary number
 
     private const float ReleaseArea = 0.001f; // About 10cm^2
 

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -23,7 +23,7 @@ public sealed class GasTankSystem : SharedGasTankSystem
 
     private const float MinimumSoundValvePressure = 21.3f; // Arbitrary number
 
-    private const float ReleaseArea = 0.001f; // About 10cm^2
+    private const float ReleaseArea = 0.0005f; // About 5cm^2
 
     // A vector bias for throwing our gas tanks in radians. Averages about -43 degrees since the sprite is at a 45-degree angle.
     private static readonly Vector2 ThrowVector = new (-1.0f, -0.5f);
@@ -139,12 +139,6 @@ public sealed class GasTankSystem : SharedGasTankSystem
     public GasMixture RemoveAir(Entity<GasTankComponent> gasTank, float amount)
     {
         return gasTank.Comp.Air.Remove(amount);
-    }
-
-    public void AssumeAir(Entity<GasTankComponent> ent, GasMixture giver)
-    {
-        _atmosphereSystem.Merge(ent.Comp.Air, giver);
-        CheckStatus(ent);
     }
 
     protected override void SafetyMeasures(Entity<GasTankComponent> entity)

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -21,9 +21,9 @@ public sealed class GasTankSystem : SharedGasTankSystem
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!;
 
-    private const float MinimumSoundValvePressure = 10.0f;
+    private const float MinimumSoundValvePressure = 21.3f; // Artibrary number
 
-    private const float ReleaseArea = 0.0001f; // About 1cm^2
+    private const float ReleaseArea = 0.001f; // About 10cm^2
 
     // A vector bias for throwing our gas tanks in radians. Averages about -43 degrees since the sprite is at a 45-degree angle.
     private static readonly Vector2 ThrowVector = new (-1.0f, -0.5f);
@@ -106,7 +106,7 @@ public sealed class GasTankSystem : SharedGasTankSystem
             _atmosphereSystem.Merge(environment, removed);
 
         // If we wouldn't produce a sound, don't throw or play a sound.
-        if (deltaP < MinimumSoundValvePressure)
+        if (removed.Pressure < MinimumSoundValvePressure)
             return;
 
         Audio.PlayPvs(entity.Comp.ReleaseSound, entity);

--- a/Content.Shared/Atmos/Components/GasMaxPressureHolderComponent.cs
+++ b/Content.Shared/Atmos/Components/GasMaxPressureHolderComponent.cs
@@ -49,7 +49,10 @@ public abstract partial class GasMaxPressureHolderComponent : Component, IGasMax
     /// Sound made when air is leaked out of this device.
     /// </summary>
     [DataField]
-    public SoundSpecifier? ReleaseSound { get; set; } = new SoundPathSpecifier("/Audio/Effects/spray.ogg");
+    public SoundSpecifier? ReleaseSound { get; set; } = new SoundPathSpecifier("/Audio/Effects/spray.ogg")
+    {
+        Params = AudioParams.Default.WithVolume(-5f),
+    };
 
     /// <summary>
     /// The mixture of air contained in this device.
@@ -67,7 +70,7 @@ public abstract partial class GasMaxPressureHolderComponent : Component, IGasMax
     public float SafetyPressure { get; set; } = 15 * Atmospherics.OneAtmosphere;
 
     [DataField]
-    public float Overpressure { get; set; } = 20 * Atmospherics.OneAtmosphere;
+    public float Overpressure { get; set; } = 15 * Atmospherics.OneAtmosphere;
 
     [DataField]
     public LocId? SafetyAlert { get; set; } = "gas-max-pressure-alert";

--- a/Content.Shared/Atmos/Components/GasMaxPressureHolderComponent.cs
+++ b/Content.Shared/Atmos/Components/GasMaxPressureHolderComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Atmos.Components;
 /// </summary>
 public abstract partial class GasMaxPressureHolderComponent : Component, IGasMaxPressureHolder
 {
-    private const int DefaultIntegrity = 5;
+    private const float DefaultIntegrity = 3f;
     private const float DefaultOutputPressure = Atmospherics.OneAtmosphere;
 
     /// <summary>
@@ -70,14 +70,14 @@ public abstract partial class GasMaxPressureHolderComponent : Component, IGasMax
     public float SafetyPressure { get; set; } = 15 * Atmospherics.OneAtmosphere;
 
     [DataField]
-    public float Overpressure { get; set; } = 15 * Atmospherics.OneAtmosphere;
+    public float Overpressure { get; set; } = 20 * Atmospherics.OneAtmosphere;
 
     [DataField]
     public LocId? SafetyAlert { get; set; } = "gas-max-pressure-alert";
 
     [DataField]
-    public int MaxIntegrity { get; set; } = DefaultIntegrity;
+    public float MaxIntegrity { get; set; } = DefaultIntegrity;
 
     [DataField]
-    public int Integrity { get; set; } = DefaultIntegrity;
+    public float Integrity { get; set; } = DefaultIntegrity;
 }

--- a/Content.Shared/Atmos/Components/IGasMaxPressureHolder.cs
+++ b/Content.Shared/Atmos/Components/IGasMaxPressureHolder.cs
@@ -33,12 +33,12 @@ public interface IGasMaxPressureHolder : IGasMixtureHolder
     ///     An overpressure is defined as pressure exceeding <see cref="Overpressure"/>
     ///     This determines the maximum value
     /// </summary>
-    int MaxIntegrity { get; set; }
+    float MaxIntegrity { get; set; }
 
     /// <summary>
     ///     How many over-pressures until this gas tank detonates.
     ///     An overpressure is defined as pressure exceeding <see cref="Overpressure"/>
     ///     This determines the current value
     /// </summary>
-    int Integrity { get; set; }
+    float Integrity { get; set; }
 }

--- a/Content.Shared/Atmos/EntitySystems/GasMaxPressureSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/GasMaxPressureSystem.cs
@@ -38,7 +38,7 @@ public abstract class GasMaxPressureSystem<T> : EntitySystem where T : IGasMaxPr
     private void OnDeviceUpdated(Entity<T> entity, ref AtmosDeviceUpdateEvent args)
     {
         // We don't update our atmos device if it's in the process of being deleted.
-        if (CheckStatus(entity))
+        if (CheckStatus(entity, args.dt))
             DeviceUpdated(entity, ref args);
     }
 
@@ -89,8 +89,9 @@ public abstract class GasMaxPressureSystem<T> : EntitySystem where T : IGasMaxPr
     /// Checks the status of an atmos device that has a specified max pressure, and handles overpressure issues.
     /// </summary>
     /// <param name="entity">Gas holding atmos device.</param>
+    /// <param name="dt">Time since the last status update.</param>
     /// <returns>True if the device hasn't failed. False if the device has failed and been destroyed.</returns>
-    protected bool CheckStatus(Entity<T> entity)
+    protected bool CheckStatus(Entity<T> entity, float dt)
     {
         var pressure = entity.Comp.Air.Pressure;
 
@@ -117,13 +118,13 @@ public abstract class GasMaxPressureSystem<T> : EntitySystem where T : IGasMaxPr
         if (pressure > entity.Comp.Overpressure)
         {
             IntegrityLost(entity);
-            entity.Comp.Integrity--;
+            entity.Comp.Integrity -= dt;
             Appearance.SetData(entity.Owner, GasIntegrity.Integrity, entity.Comp.Integrity);
             Appearance.SetData(entity.Owner, GasIntegrity.MaxIntegrity, entity.Comp.MaxIntegrity);
         }
         else if (entity.Comp.Integrity < entity.Comp.MaxIntegrity)
         {
-            entity.Comp.Integrity++;
+            entity.Comp.Integrity = Math.Min(entity.Comp.Integrity + dt, entity.Comp.MaxIntegrity);
             Appearance.SetData(entity.Owner, GasIntegrity.Integrity, entity.Comp.Integrity);
             Appearance.SetData(entity.Owner, GasIntegrity.MaxIntegrity, entity.Comp.MaxIntegrity);
         }

--- a/Content.Shared/Atmos/EntitySystems/SharedAtmosphereSystem.Gases.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedAtmosphereSystem.Gases.cs
@@ -421,7 +421,7 @@ public abstract partial class SharedAtmosphereSystem
         if (deltaP <= 0)
             return null;
 
-        return ReleaseGasAt(mixture, (float)GetFlowVolume(mixture, deltaP, area, dt), deltaP);
+        return ReleaseGasAt(mixture, (float)GetFlowVolume(mixture, deltaP, area, dt), mixture.Pressure);
     }
 
     /// <summary>

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -53,7 +53,7 @@
   abbreviation: gas-tritium-abbreviation
   molarHeatCapacity: 10
   heatCapacityRatio: 1.3
-  molarMass: 6
+  molarMass: 3
   gasOverlaySprite:
     sprite: /Textures/Effects/atmospherics.rsi
     state: tritium

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -217,6 +217,33 @@
       temperature: 373.149
 
 - type: entity
+  parent: AirTank
+  id: MaxCapPlasma # As of currently writing, tanks have an explosion intensity of about 125, which is about as powerful as an explosive grenade.
+  suffix: DEBUG, Max Cap, Plasma
+  components:
+  - type: GasTank
+    air:
+      volume: 5
+      moles:
+        Oxygen: 1.0
+        Plasma: 0.3
+      temperature: 500
+
+- type: entity
+  parent: AirTank
+  id: MaxCapMix # As of currently writing, tanks have an explosion intensity of about 125, which is about as powerful as an explosive grenade.
+  suffix: DEBUG, Max Cap, Plasma/Trit
+  components:
+  - type: GasTank
+    air:
+      volume: 5
+      moles:
+        Oxygen: 0.8 # If trit fire burn ratio is ever changed, this value will need to be adjusted.
+        Tritium: 0.4
+        Plasma: 0.3 # High mass to slow flow rate
+      temperature: 373.149
+
+- type: entity
   parent: EmergencyOxygenTank
   id: MaxCapSmall # As of currently writing, mini tanks have an explosion intensity of about 40.
   suffix: DEBUG, Max Cap

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -217,33 +217,6 @@
       temperature: 373.149
 
 - type: entity
-  parent: AirTank
-  id: MaxCapPlasma # As of currently writing, tanks have an explosion intensity of about 125, which is about as powerful as an explosive grenade.
-  suffix: DEBUG, Max Cap, Plasma
-  components:
-  - type: GasTank
-    air:
-      volume: 5
-      moles:
-        Oxygen: 1.0
-        Plasma: 0.3
-      temperature: 500
-
-- type: entity
-  parent: AirTank
-  id: MaxCapMix # As of currently writing, tanks have an explosion intensity of about 125, which is about as powerful as an explosive grenade.
-  suffix: DEBUG, Max Cap, Plasma/Trit
-  components:
-  - type: GasTank
-    air:
-      volume: 5
-      moles:
-        Oxygen: 0.8 # If trit fire burn ratio is ever changed, this value will need to be adjusted.
-        Tritium: 0.4
-        Plasma: 0.3 # High mass to slow flow rate
-      temperature: 373.149
-
-- type: entity
   parent: EmergencyOxygenTank
   id: MaxCapSmall # As of currently writing, mini tanks have an explosion intensity of about 40.
   suffix: DEBUG, Max Cap
@@ -252,8 +225,9 @@
     air:
       volume: 0.66
       moles:
-        Oxygen:  0.1805213564
-        Tritium: 0.0902606782
+        Oxygen: 0.1 # If trit fire burn ratio is ever changed, this value will need to be adjusted.
+        Tritium: 0.05
+        Plasma: 0.06 # High mass to slow flow rate
       temperature: 373.149
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -241,11 +241,6 @@
     sprite: Objects/Tanks/Jetpacks/security.rsi
   - type: Clothing
     sprite: Objects/Tanks/Jetpacks/security.rsi
-  - type: GasTank
-    maxIntegrity: 5 # You may ask why this microbalance? The answer is: Sec jetpacks sprite is based off regular jetpacks, and I'm too lazy to make their sprite data different.
-    integrity: 5
-  - type: MaxPressureVisuals
-    steps: 5
 
 #Filled security
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -124,8 +124,8 @@
     - type: MaxPressureVisuals
       integrityMask: mask-grey
     - type: GasCanister
-      maxIntegrity: 25 # 5 times stronger than a gas tank
-      integrity: 25
+      maxIntegrity: 15 # 5 times stronger than a gas tank
+      integrity: 15
       maxReleasePressure: 1013.25
       safetyPressure: 10132.5 # High enough that liquid tanks don't burst immediately, with an extra 33% wiggle room to work with
       overpressure: 20265 # Purposefully high because cans react really fucking fast, may need to redo this value if reactions change!

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -127,7 +127,7 @@
       maxIntegrity: 25 # 5 times stronger than a gas tank
       integrity: 25
       maxReleasePressure: 1013.25
-      safetyPressure: 7599.375 # High enough that liquid tanks don't burst immediately
+      safetyPressure: 10132.5 # High enough that liquid tanks don't burst immediately, with an extra 33% wiggle room to work with
       overpressure: 20265 # Purposefully high because cans react really fucking fast, may need to redo this value if reactions change!
       gasTankSlot:
         name: comp-gas-canister-slot-name-gas-tank


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A number of things have been changed.
Firstly, raised the minimum pressure threshold for a sound to be made and then made it based on the released gas mixture to reduce the amount of noise. Also reduced the release sound by 5db. Ideally we should have a sound that's far less annoying.

Increased the release valve area for gas tanks to about 10cm^2 which is quite large but does feel a lot better.

Reduced the overpressure threshold for gas tanks to compensate, since they release gas faster they also need to take damage faster. This results in a detonation time that is about the same with a similar explosive power. 

Reduced molar mass of Trit from 6 to 3 to match the other molar mass reductions, this means trit leaks out a bit faster making the creation of max caps a bit more difficult when using just trit. This makes using plasma as a stuffer really good because plasma is extremely dense and tends to choke the release valves allowing for a better burn.

Fixed FlowGas caluclating the amount of mols it needed to removed based on deltaP and not the actual pressure of the gas mixture it's removing the mols from (oops)

Raised the safety pressure of gas canisters to 10k pKA that way atmos techs don't accidentally trigger overpressure when stuffing their cans using volumetric pumps

Added two new max cap debug items for testing purposes. 

Reinvented the wheel.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
Basically all of the above but in code form.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`Integrity` and `MaxIntegrity` in `IGasMaxPressureHolder` are now floats instead of ints.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
