### PR TITLE
Fix a `HeatContainerHelpers` generic issue

### DIFF
--- a/Content.Shared/Temperature/HeatContainer/HeatContainerHelpers.Conduct.cs
+++ b/Content.Shared/Temperature/HeatContainer/HeatContainerHelpers.Conduct.cs
@@ -55,7 +55,9 @@ public static partial class HeatContainerHelpers
     /// integration steps with adaptive step size.
     /// </remarks>
     [PublicAPI]
-    public static float ConductHeat<T>(ref T cA, ref T cB, float deltaTime, float g) where T : IHeatContainer
+    public static float ConductHeat<T1, T2>(ref T1 cA, ref T2 cB, float deltaTime, float g)
+        where T1 : IHeatContainer
+        where T2 : IHeatContainer
     {
         var dQ = ConductHeatQuery(ref cA, ref cB, deltaTime, g);
         AddHeat(ref cA, dQ);


### PR DESCRIPTION
## About the PR
Fixes an issue where `ConductHeat`, which conducts between a `cA` and a `cB`, was only allowing one type `T` where `T : IHeatContainer` instead of allowing a `T1, T2` where both were `IHeatContainer`.

## Why / Balance
API issue
## Technical details
Same as about the PR
## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`HeatContainerHelpers.ConductHeat` has been changed to take in multiple generics, so it's possible to conduct heat between multiple objects that implement `IHeatContainer`. `<T>` to `<T1, T2>` effectively.

**Changelog**
n/a
