### PR TITLE
StatusEffect On Trigger

### DIFF
--- a/Content.Shared/Trigger/Components/Effects/RemoveStatusEffectOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/RemoveStatusEffectOnTriggerComponent.cs
@@ -1,0 +1,19 @@
+using Content.Shared.StatusEffectNew.Components;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Trigger.Components.Effects;
+
+/// <summary>
+/// Removes a status effect when triggered.
+/// If TargetUser is true the user loses the status.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RemoveStatusEffectOnTriggerComponent : BaseXOnTriggerComponent
+{
+    /// <summary>
+    /// Status effect to be removed.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntProtoId<StatusEffectComponent> Status;
+}

--- a/Content.Shared/Trigger/Components/Effects/SetStatusEffectOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/SetStatusEffectOnTriggerComponent.cs
@@ -1,0 +1,25 @@
+using Content.Shared.StatusEffectNew.Components;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Trigger.Components.Effects;
+
+/// <summary>
+/// Adds a status effect when triggered.
+/// If TargetUser is true the user will gain the effect.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class SetStatusEffectOnTriggerComponent : BaseXOnTriggerComponent
+{
+    /// <summary>
+    /// Status effect to be added.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntProtoId<StatusEffectComponent> Status;
+
+    /// <summary>
+    /// How long the status lasts. Permanent until removed if null.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan? Duration;
+}

--- a/Content.Shared/Trigger/Systems/StatusEffectOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/StatusEffectOnTriggerSystem.cs
@@ -1,0 +1,24 @@
+using Content.Shared.StatusEffectNew;
+using Content.Shared.Trigger.Components.Effects;
+
+namespace Content.Shared.Trigger.Systems;
+
+public sealed class SetStatusEffectOnTriggerSystem : XOnTriggerSystem<SetStatusEffectOnTriggerComponent>
+{
+    [Dependency] private readonly StatusEffectsSystem _status = default!;
+
+    protected override void OnTrigger(Entity<SetStatusEffectOnTriggerComponent> ent, EntityUid target, ref TriggerEvent args)
+    {
+        args.Handled |= _status.TrySetStatusEffectDuration(target, ent.Comp.Status, ent.Comp.Duration);
+    }
+}
+
+public sealed class RemoveStatusEffectOnTriggerSystem : XOnTriggerSystem<RemoveStatusEffectOnTriggerComponent>
+{
+    [Dependency] private readonly StatusEffectsSystem _status = default!;
+
+    protected override void OnTrigger(Entity<RemoveStatusEffectOnTriggerComponent> ent, EntityUid target, ref TriggerEvent args)
+    {
+        args.Handled |=  _status.TryRemoveStatusEffect(target, ent.Comp.Status);
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Trigger components for new status effects.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
While new triggers are generally not wanted without an immediate use, this one has a few reasons to exist. First is that status effects have very broad application and so this trigger can be used in a lot of different ways. Second is to prevent a regression in the `JitterSystem` refactor #43664 with the removal of `JitterOnTriggerComponent`.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->