### PR TITLE
Allow toggling Cooldown through ActionEvent

### DIFF
--- a/Content.Shared/Actions/ActionEvents.cs
+++ b/Content.Shared/Actions/ActionEvents.cs
@@ -179,4 +179,9 @@ public abstract partial class BaseActionEvent : HandledEntityEventArgs
     /// Should we toggle the action entity?
     /// </summary>
     public bool Toggle;
+
+    /// <summary>
+    /// Should the cooldown automatically start afterwards?
+    /// </summary>
+    public bool StartCooldown = true;
 }

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -585,7 +585,8 @@ public abstract partial class SharedActionsSystem : EntitySystem
         _audio.PlayPredicted(action.Comp.Sound, performer, predicted ? performer : null);
 
         RemoveCooldown((action, action));
-        StartUseDelay((action, action));
+        if (ev.StartCooldown)
+            StartUseDelay((action, action));
 
         UpdateAction(action);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I added a boolean that decides whether the action cooldown is meant to start or not.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This allows for custom cooldowns. I have an action downstream that depends on the situation before it does something.
Depending on what situation it's pressed, the cooldown could be longer. However, for that, I have to modify the UseDelay because the cooldown would always be set back to the normal UseDelay when it exits my code, despite me using SetCooldown in my code.

## Technical details
<!-- Summary of code changes for easier review. -->
Just one itsy boolean.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->