### PR TITLE
Fixes in TargetOutlineSystem

### DIFF
--- a/Content.Client/Outline/TargetOutlineSystem.cs
+++ b/Content.Client/Outline/TargetOutlineSystem.cs
@@ -60,7 +60,7 @@ public sealed class TargetOutlineSystem : EntitySystem
     /// <remarks>
     ///     If a target is further than this distance, they will still be highlighted in a different color.
     /// </remarks>
-    public float Range = -1;
+    public float? Range = null;
 
     /// <summary>
     ///     Whether to check if the player is unobstructed to the target;
@@ -96,7 +96,7 @@ public sealed class TargetOutlineSystem : EntitySystem
         RemoveHighlights();
     }
 
-    public void Enable(float range, bool checkObstructions, Func<EntityUid, bool>? predicate, EntityWhitelist? whitelist, EntityWhitelist? blacklist, CancellableEntityEventArgs? validationEvent)
+    public void Enable(float? range, bool checkObstructions, Func<EntityUid, bool>? predicate, EntityWhitelist? whitelist, EntityWhitelist? blacklist, CancellableEntityEventArgs? validationEvent)
     {
         Range = range;
         CheckObstruction = checkObstructions;
@@ -130,7 +130,7 @@ public sealed class TargetOutlineSystem : EntitySystem
         // TODO: Duplicated in SpriteSystem and DragDropSystem. Should probably be cached somewhere for a frame?
         var mousePos = _eyeManager.PixelToMap(_inputManager.MouseScreenPosition).Position;
         var bounds = new Box2(mousePos - LookupVector, mousePos + LookupVector);
-        var pvsEntities = _lookup.GetEntitiesIntersecting(_eyeManager.CurrentEye.Position.MapId, bounds, LookupFlags.Approximate | LookupFlags.Static);
+        var pvsEntities = _lookup.GetEntitiesIntersecting(_eyeManager.CurrentEye.Position.MapId, bounds, LookupFlags.Approximate | LookupFlags.Static | LookupFlags.Dynamic);
 
         foreach (var entity in pvsEntities)
         {
@@ -141,8 +141,8 @@ public sealed class TargetOutlineSystem : EntitySystem
             var valid = Predicate?.Invoke(entity) ?? true;
 
             // check the entity whitelist
-            if (valid && Whitelist != null)
-                valid = _whitelistSystem.IsWhitelistPass(Whitelist, entity);
+            if (valid)
+                valid = _whitelistSystem.CheckBoth(entity, Blacklist, Whitelist);
 
             // and check the cancellable event
             if (valid && ValidationEvent != null)
@@ -165,19 +165,19 @@ public sealed class TargetOutlineSystem : EntitySystem
             }
 
             // Range check
-            if (CheckObstruction)
-                valid = _interactionSystem.InRangeUnobstructed(player, entity, Range);
-            else if (Range >= 0)
+            if (CheckObstruction && Range is not null)
+                valid = _interactionSystem.InRangeUnobstructed(player, entity, Range.Value);
+            else if (Range is not null)
             {
                 var origin = _transformSystem.GetWorldPosition(player);
                 var target = _transformSystem.GetWorldPosition(entity);
-                valid = (origin - target).LengthSquared() <= Range;
+                valid = (origin - target).LengthSquared() <= Range * Range;
             }
 
             if (sprite.PostShader != null &&
                 sprite.PostShader != _shaderTargetValid &&
                 sprite.PostShader != _shaderTargetInvalid)
-                return;
+                continue;
 
             // highlight depending on whether its in or out of range
             sprite.PostShader = valid ? _shaderTargetValid : _shaderTargetInvalid;

--- a/Content.Client/Outline/TargetOutlineSystem.cs
+++ b/Content.Client/Outline/TargetOutlineSystem.cs
@@ -130,7 +130,8 @@ public sealed class TargetOutlineSystem : EntitySystem
         // TODO: Duplicated in SpriteSystem and DragDropSystem. Should probably be cached somewhere for a frame?
         var mousePos = _eyeManager.PixelToMap(_inputManager.MouseScreenPosition).Position;
         var bounds = new Box2(mousePos - LookupVector, mousePos + LookupVector);
-        var pvsEntities = _lookup.GetEntitiesIntersecting(_eyeManager.CurrentEye.Position.MapId, bounds, LookupFlags.Approximate | LookupFlags.Static | LookupFlags.Dynamic);
+        var pvsEntities = _lookup.GetEntitiesIntersecting(_eyeManager.CurrentEye.Position.MapId, bounds,
+                LookupFlags.Approximate | LookupFlags.Static | LookupFlags.Dynamic | LookupFlags.Sundries);
 
         foreach (var entity in pvsEntities)
         {

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -840,7 +840,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (!entity.CanTargetSelf)
             predicate = e => e != attachedEnt;
 
-        var range = target.CheckCanAccess ? target.Range : -1;
+        var range = target.CheckCanAccess ? target.Range : (float?)null;
 
         _interactionOutline?.SetEnabled(false);
         _targetOutline?.Enable(range, target.CheckCanAccess, predicate, entity.Whitelist, entity.Blacklist, null);


### PR DESCRIPTION
## About the PR
Made some cleanups in TargetOutlineSystem similar to those in #43303
Also made it so that the TargetOutlineSystem queries Dynamic entities as well, allowing the highlighting to also match, for example, mobs that would be valid targets.

## Why / Balance
It's really nice for things like the Dragon's devour to also correctly highlight mobs that can be devoured.

## Technical details
Made range nullable and squared it so that the range check is more accurate.
Added the `LookupFlags.Dynamic` to the `GetEntitiesIntersecting` check so that it also returns items and mobs.

## Media
Here's a dragon devour actually highlighting a downed corpse now.
https://github.com/user-attachments/assets/f9c1f97b-640f-46aa-b754-1b5ab43aa9d3



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
TargetOutlineSystem.Enable now takes a nullable float as range. Use this instead of -1 to disable range checks.

**Changelog**
