### PR TITLE
HeatContainer codeownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,7 @@
 
 /Content.*/Forensics/ @ficcialfaint
 
-/Content.*/Trigger/ @slarticodefast
+/Content.*/HeatContainer/ @slarticodefast
 
 /Content.*/Stunnable/ @Princess-Cheeseballs
 /Content.*/Nutrition/ @Princess-Cheeseballs


### PR DESCRIPTION
To prevent physics crimes.
Also dropped triggers because those are pretty much done.