### PR TITLE
Minor door animation tweak

### DIFF
--- a/Content.Client/Doors/DoorSystem.cs
+++ b/Content.Client/Doors/DoorSystem.cs
@@ -81,7 +81,10 @@ public sealed class DoorSystem : SharedDoorSystem
 
     private void OnAnimationCompleted(Entity<DoorComponent> ent, ref AnimationCompletedEvent args)
     {
-        if (args.Key != DoorComponent.OpenCloseKey || !TryComp<SpriteComponent>(ent, out var sprite))
+        if (args.Key != DoorComponent.OpenKey && args.Key != DoorComponent.CloseKey)
+            return;
+
+        if (!TryComp<SpriteComponent>(ent, out var sprite))
             return;
 
         switch (ent.Comp.State)
@@ -130,8 +133,14 @@ public sealed class DoorSystem : SharedDoorSystem
         switch (state)
         {
             case DoorState.Open:
-                if (_animationSystem.HasRunningAnimation(entity, DoorComponent.OpenCloseKey))
+                if (_animationSystem.HasRunningAnimation(entity, DoorComponent.OpenKey))
                     return;
+
+                if (_animationSystem.HasRunningAnimation(entity, DoorComponent.CloseKey))
+                {
+                    _animationSystem.Stop(entity, null, DoorComponent.CloseKey);
+                    _animationSystem.Play(entity, (Animation)entity.Comp.OpeningAnimation, DoorComponent.OpenKey);
+                }
 
                 foreach (var (layer, layerState) in entity.Comp.OpenSpriteStates)
                 {
@@ -143,8 +152,14 @@ public sealed class DoorSystem : SharedDoorSystem
 
                 return;
             case DoorState.Closed:
-                if (_animationSystem.HasRunningAnimation(entity, DoorComponent.OpenCloseKey))
+                if (_animationSystem.HasRunningAnimation(entity, DoorComponent.CloseKey))
                     return;
+
+                if (_animationSystem.HasRunningAnimation(entity, DoorComponent.OpenKey))
+                {
+                    _animationSystem.Stop(entity, null, DoorComponent.OpenKey);
+                    _animationSystem.Play(entity, (Animation)entity.Comp.OpeningAnimation, DoorComponent.CloseKey);
+                }
 
                 foreach (var (layer, layerState) in entity.Comp.ClosedSpriteStates)
                 {
@@ -157,20 +172,20 @@ public sealed class DoorSystem : SharedDoorSystem
                 if (entity.Comp.OpeningAnimationTime == TimeSpan.Zero)
                     return;
 
-                if (_animationSystem.HasRunningAnimation(entity, DoorComponent.OpenCloseKey))
+                if (_animationSystem.HasRunningAnimation(entity, DoorComponent.OpenKey))
                     return;
 
-                _animationSystem.Play(entity, (Animation)entity.Comp.OpeningAnimation, DoorComponent.OpenCloseKey);
+                _animationSystem.Play(entity, (Animation)entity.Comp.OpeningAnimation, DoorComponent.OpenKey);
 
                 return;
             case DoorState.Closing:
                 if (entity.Comp.ClosingAnimationTime == TimeSpan.Zero)
                     return;
 
-                if (_animationSystem.HasRunningAnimation(entity, DoorComponent.OpenCloseKey))
+                if (_animationSystem.HasRunningAnimation(entity, DoorComponent.CloseKey))
                     return;
 
-                _animationSystem.Play(entity, (Animation)entity.Comp.ClosingAnimation, DoorComponent.OpenCloseKey);
+                _animationSystem.Play(entity, (Animation)entity.Comp.ClosingAnimation, DoorComponent.CloseKey);
 
                 return;
             case DoorState.Denying:

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -137,10 +137,10 @@ public sealed partial class DoorComponent : Component
 
     #region Graphics
 
-    /// <summary>
-    /// The key used when playing door opening/closing/emagging/deny animations.
-    /// </summary>
-    public const string OpenCloseKey = "door_animation_openclose";
+
+    public const string OpenKey = "door_animation_open";
+
+    public const string CloseKey = "door_animation_close";
 
     /// <summary>
     /// The key used when playing door deny animations.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
currently if you walk into a door as its closing it shuts all the way and snaps open, this will make interrupt the current animation and then play the open animation instead.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
its not perfect but its better than current

## Technical details
<!-- Summary of code changes for easier review. -->
Changed OpenCloseKey to be a separate open and close key and some checks.
Tweaked the door animations a bit so they'll play the open door animation if the animation for closing is playing while the door is open and vice versa
Its still a bit janky but it's a bit of an improvement over current state, i guess


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
AFTER:

https://github.com/user-attachments/assets/664c40ff-a467-463a-9be5-5662aa50ef12


BEFORE:

https://github.com/user-attachments/assets/71e9d2f9-a47e-4165-8065-aff3b5dc28e4




## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`OpenCloseKey` in `DoorComponent` has been split into `OpenKey` and `CloseKey`

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
