### PR TITLE
make TestAdminLogsWindow more reliable

### DIFF
--- a/Content.IntegrationTests/Tests/Administration/Logs/LogWindowTest.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/LogWindowTest.cs
@@ -40,9 +40,9 @@ public sealed class LogWindowTest : InteractionTest
         // Search for the log we added earlier.
         await Client.WaitPost(() => search.Text = guid.ToString());
         await ClickControl(refresh);
-        await RunTicks(5);
+        await RunTicks(10);
         var searchResult = cont.Children.Where(x => x.Visible && x is AdminLogLabel).Cast<AdminLogLabel>().ToArray();
-        Assert.That(searchResult.Length, Is.EqualTo(1));
+        Assert.That(searchResult, Has.Length.EqualTo(1));
         Assert.That(searchResult[0].Log.Message, Contains.Substring($" test log 1: {guid}"));
 
         // Add a new log
@@ -52,9 +52,9 @@ public sealed class LogWindowTest : InteractionTest
         // Update the search and refresh
         await Client.WaitPost(() => search.Text = guid.ToString());
         await ClickControl(refresh);
-        await RunTicks(5);
+        await RunTicks(10);
         searchResult = cont.Children.Where(x => x.Visible && x is AdminLogLabel).Cast<AdminLogLabel>().ToArray();
-        Assert.That(searchResult.Length, Is.EqualTo(1));
+        Assert.That(searchResult, Has.Length.EqualTo(1));
         Assert.That(searchResult[0].Log.Message, Contains.Substring($" test log 2: {guid}"));
     }
 }


### PR DESCRIPTION
## About the PR

This PR gives the TestAdminLogsWindow a bit more time to load.

## Why / Balance

The test is currently unreliable.

## Technical details

Wait 10 (instead of 5) ticks after clicking.

## Media

No

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
