### PR TITLE
Make skeletons more vulnerable to blunt damage

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -229,7 +229,7 @@
 - type: damageModifierSet
   id: Skeleton
   coefficients:
-    Blunt: 1.1
+    Blunt: 1.8 # significant blunt damage should cause their bones to crumble
     Slash: 0.8
     Piercing: 0.6
     Cold: 0.0
@@ -240,7 +240,7 @@
     Cellular: 0.0
     Holy: 0.5
   flatReductions:
-    Blunt: 5
+    Blunt: 5 # no soft tissue to be affected by minor blunt damage
 
 # hurt a lot by blunt, immune to a good amount of other stuff because they're a cookie
 - type: damageModifierSet


### PR DESCRIPTION
## About the PR
Skeletons now take increased blunt damage yet still retain their flat blunt reduction.

## Why / Balance
Imagine hitting a pile of bones with a baseball bat and it not crumbling smh...
Skeletons had no damage weaknesses. Let this be one of them.

Previous `(X-5)*1.1` blunt damage calculation formula meant that skeletons take reduced blunt damage if they receive less than 55 blunt per hit. Have you seen any 55+ damage blunt weapons? Me neither.
By making blunt damage multiplier `1.8`, we make sure that skeletons take reduced blunt damage if they receive less than 11,25 blunt per hit instead. That would mean receiving 10 blunt will give a skeleton 9 damage, while receiving 20 blunt will give a skeleton 27 damage.

This will encourage skeletons to avoid melee encounters with the crew. Skeletons aren't affected by slowdowns so it shouldn't be a problem for them.

This rebalance is related to the current attempts of maintainers to make skeletons more interesting and playable from the gameplay perspective.

## Technical details
Increased `Blunt` coefficient for `Skeleton` `damageModifierSet` from `1.1` to `1.8`.

## Media
<img width="498" height="332" alt="18f28c4f3468343bcdab42609a27fa45" src="https://github.com/user-attachments/assets/3f11e394-fd49-46d3-8289-c9b5b04f41d2" />
<img width="582" height="1014" alt="unknown_2026 04 25-00 28_2" src="https://github.com/user-attachments/assets/1af22be9-4216-49e3-9167-ad45d8cd24d3" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl: HyperB
- tweak: Skeletons are now more vulnerable to blunt damage.
