### PR TITLE
[STAGING] Revert #39173

### DIFF
--- a/Content.Server/Radiation/Systems/RadiationSystem.GridCast.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.GridCast.cs
@@ -1,15 +1,11 @@
-using System.Buffers;
-using System.Collections.Concurrent;
-using System.Linq;
 using System.Numerics;
 using Content.Server.Radiation.Components;
 using Content.Server.Radiation.Events;
 using Content.Shared.Radiation.Components;
 using Content.Shared.Radiation.Systems;
-using JetBrains.Annotations;
+using Robust.Shared.Collections;
 using Robust.Shared.Map.Components;
-using Robust.Shared.Physics;
-using Robust.Shared.Threading;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Radiation.Systems;
@@ -17,62 +13,113 @@ namespace Content.Server.Radiation.Systems;
 // main algorithm that fire radiation rays to target
 public partial class RadiationSystem
 {
+    private List<Entity<MapGridComponent>> _grids = new();
+
     private readonly record struct SourceData(
         float Intensity,
-        float Slope,
-        float MaxRange,
         Entity<RadiationSourceComponent, TransformComponent> Entity,
         Vector2 WorldPosition)
     {
-        public EntityUid Uid => Entity.Owner;
+        public EntityUid? GridUid => Entity.Comp2.GridUid;
+        public float Slope => Entity.Comp1.Slope;
         public TransformComponent Transform => Entity.Comp2;
     }
 
     private void UpdateGridcast()
     {
+        // should we save debug information into rays?
+        // if there is no debug sessions connected - just ignore it
         var debug = _debugSessions.Count > 0;
-        var stopwatch = new Robust.Shared.Timing.Stopwatch();
+
+        var stopwatch = new Stopwatch();
         stopwatch.Start();
 
-        var sourcesCount = _sourceDataMap.Count;
-        if (_activeReceivers.Count == 0 || sourcesCount == 0)
+        _sources.Clear();
+        _sources.EnsureCapacity(Count<RadiationSourceComponent>());
+
+        var sources = EntityQueryEnumerator<RadiationSourceComponent, TransformComponent>();
+        var destinations = EntityQueryEnumerator<RadiationReceiverComponent, TransformComponent>();
+
+        while (sources.MoveNext(out var uid, out var source, out var xform))
         {
-            RaiseLocalEvent(new RadiationSystemUpdatedEvent());
-            return;
+            if (!source.Enabled)
+                continue;
+
+            var worldPos = _transform.GetWorldPosition(xform);
+
+            // Intensity is scaled by stack size.
+            var intensity = source.Intensity * _stack.GetCount(uid);
+
+            // Apply rad modifier if the source is enclosed within a radiation blocking container
+            // Note that this also applies to receivers, and it doesn't bother to check if the container sits between them.
+            // I.e., a source & receiver in the same blocking container will get double-blocked, when no blocking should be applied.
+            intensity = GetAdjustedRadiationIntensity(uid, intensity);
+
+            _sources.Add(new(intensity, (uid, source, xform), worldPos));
         }
 
-        var results = new float[_activeReceivers.Count];
-        var debugRays = debug ? new ConcurrentBag<DebugRadiationRay>() : null;
+        var debugRays = debug ? new List<DebugRadiationRay>() : null;
+        var receiversTotalRads = new ValueList<(Entity<RadiationReceiverComponent>, float)>();
 
-        var job = new RadiationJob
+        // TODO RADIATION Parallelize
+        // Would need to give receiversTotalRads a fixed size.
+        // Also the _grids list needs to be local to a job. (or better yet cached in SourceData)
+        // And I guess disable parallelization when debugging to make populating the debug List<RadiationRay> easier.
+        // Or just make it threadsafe?
+        while (destinations.MoveNext(out var destUid, out var dest, out var destTrs))
         {
-            System = this,
-            SourceTree = _sourceTree,
-            SourceDataMap = _sourceDataMap,
-            Destinations = _activeReceivers,
-            Results = results,
-            DebugRays = debugRays,
-            Debug = debug
-        };
+            var destWorld = _transform.GetWorldPosition(destTrs);
 
-        _parallel.ProcessNow(job, _activeReceivers.Count);
-
-        for (var i = 0; i < _activeReceivers.Count; i++)
-        {
-            var uid = _activeReceivers[i];
-            var rads = results[i];
-
-            if (_receiverQuery.TryComp(uid, out var receiver))
+            var rads = 0f;
+            foreach (var source in _sources)
             {
-                receiver.CurrentRadiation = rads;
-                if (rads > 0)
-                    IrradiateEntity(uid, rads, GridcastUpdateRate);
+                // send ray towards destination entity
+                if (Irradiate(source, destUid, destTrs, destWorld, debug) is not { } ray)
+                    continue;
+
+                // add rads to total rad exposure
+                if (ray.ReachedDestination)
+                    rads += ray.Rads;
+
+                if (!debug)
+                    continue;
+
+                debugRays!.Add(new DebugRadiationRay(
+                    ray.MapId,
+                    GetNetEntity(ray.SourceUid),
+                    ray.Source,
+                    GetNetEntity(ray.DestinationUid),
+                    ray.Destination,
+                    ray.Rads,
+                    ray.Blockers ?? new())
+                );
             }
+
+            // Apply modifier if the destination entity is hidden within a radiation blocking container
+            rads = GetAdjustedRadiationIntensity(destUid, rads);
+
+            receiversTotalRads.Add(((destUid, dest), rads));
         }
 
-        if (debugRays is not null)
-            UpdateGridcastDebugOverlay(stopwatch.Elapsed.TotalMilliseconds, sourcesCount, _activeReceivers.Count, debugRays.ToList());
+        // update information for debug overlay
+        var elapsedTime = stopwatch.Elapsed.TotalMilliseconds;
+        var totalSources = _sources.Count;
+        var totalReceivers = receiversTotalRads.Count;
+        UpdateGridcastDebugOverlay(elapsedTime, totalSources, totalReceivers, debugRays);
 
+        // send rads to each entity
+        foreach (var (receiver, rads) in receiversTotalRads)
+        {
+            // update radiation value of receiver
+            // if no radiation rays reached target, that will set it to 0
+            receiver.Comp.CurrentRadiation = rads;
+
+            // also send an event with combination of total rad
+            if (rads > 0)
+                IrradiateEntity(receiver, rads, GridcastUpdateRate);
+        }
+
+        // raise broadcast event that radiation system has updated
         RaiseLocalEvent(new RadiationSystemUpdatedEvent());
     }
 
@@ -80,27 +127,67 @@ public partial class RadiationSystem
         EntityUid destUid,
         TransformComponent destTrs,
         Vector2 destWorld,
-        bool saveVisitedTiles,
-        List<Entity<MapGridComponent>> gridList)
+        bool saveVisitedTiles)
     {
+        // lets first check that source and destination on the same map
+        if (source.Transform.MapID != destTrs.MapID)
+            return null;
+
         var mapId = destTrs.MapID;
-        var dist = (destWorld - source.WorldPosition).Length();
+
+        // get direction from rad source to destination and its distance
+        var dir = destWorld - source.WorldPosition;
+        var dist = dir.Length();
+
+        // check if receiver is too far away
+        if (dist > GridcastMaxDistance)
+            return null;
+
+        // will it even reach destination considering distance penalty
         var rads = source.Intensity - source.Slope * dist;
         if (rads < MinIntensity)
             return null;
 
+        // create a new radiation ray from source to destination
+        // at first we assume that it doesn't hit any radiation blockers
+        // and has only distance penalty
         var ray = new RadiationRay(mapId, source.Entity, source.WorldPosition, destUid, destWorld, rads);
 
-        var box = Box2.FromTwoPoints(source.WorldPosition, destWorld);
-        gridList.Clear();
-        _mapManager.FindGridsIntersecting(mapId, box, ref gridList, true);
+        // if source and destination on the same grid it's possible that
+        // between them can be another grid (ie. shuttle in center of donut station)
+        // however we can do simplification and ignore that case
+        if (GridcastSimplifiedSameGrid && destTrs.GridUid is { } gridUid && source.GridUid == gridUid)
+        {
+            if (!_gridQuery.TryGetComponent(gridUid, out var gridComponent))
+                return ray;
+            return Gridcast((gridUid, gridComponent, Transform(gridUid)), ref ray, saveVisitedTiles, source.Transform, destTrs);
+        }
 
-        foreach (var grid in gridList)
+        // lets check how many grids are between source and destination
+        // do a box intersection test between target and destination
+        // it's not very precise, but really cheap
+
+        // TODO RADIATION
+        // Consider caching this in SourceData?
+        // I.e., make the lookup for grids as large as the sources's max distance and store the result in SourceData.
+        // Avoids having to do a lookup per source*receiver.
+        var box = Box2.FromTwoPoints(source.WorldPosition, destWorld);
+        _grids.Clear();
+        _mapManager.FindGridsIntersecting(mapId, box, ref _grids, true);
+
+        // gridcast through each grid and try to hit some radiation blockers
+        // the ray will be updated with each grid that has some blockers
+        foreach (var grid in _grids)
         {
             ray = Gridcast((grid.Owner, grid.Comp, Transform(grid)), ref ray, saveVisitedTiles, source.Transform, destTrs);
+
+            // looks like last grid blocked all radiation
+            // we can return right now
             if (ray.Rads <= 0)
                 return ray;
         }
+
+        _grids.Clear();
 
         return ray;
     }
@@ -113,11 +200,18 @@ public partial class RadiationSystem
         TransformComponent destTrs)
     {
         var blockers = saveVisitedTiles ? new List<(Vector2i, float)>() : null;
+
+        // if grid doesn't have resistance map just apply distance penalty
         var gridUid = grid.Owner;
         if (!_resistanceQuery.TryGetComponent(gridUid, out var resistance))
             return ray;
-
         var resistanceMap = resistance.ResistancePerTile;
+
+        // get coordinate of source and destination in grid coordinates
+
+        // TODO Grid overlap. This currently assumes the grid is always parented directly to the map (local matrix == world matrix).
+        // If ever grids are allowed to overlap, this might no longer be true. In that case, this should precompute and cache
+        // inverse world matrices.
 
         Vector2 srcLocal = sourceTrs.ParentUid == grid.Owner
             ? sourceTrs.LocalPosition
@@ -127,20 +221,28 @@ public partial class RadiationSystem
             ? destTrs.LocalPosition
             : Vector2.Transform(ray.Destination, grid.Comp2.InvLocalMatrix);
 
-        Vector2i sourceGrid = new((int)Math.Floor(srcLocal.X / grid.Comp1.TileSize), (int)Math.Floor(srcLocal.Y / grid.Comp1.TileSize));
-        Vector2i destGrid = new((int)Math.Floor(dstLocal.X / grid.Comp1.TileSize), (int)Math.Floor(dstLocal.Y / grid.Comp1.TileSize));
+        Vector2i sourceGrid = new(
+            (int)Math.Floor(srcLocal.X / grid.Comp1.TileSize),
+            (int)Math.Floor(srcLocal.Y / grid.Comp1.TileSize));
 
+        Vector2i destGrid = new(
+            (int)Math.Floor(dstLocal.X / grid.Comp1.TileSize),
+            (int)Math.Floor(dstLocal.Y / grid.Comp1.TileSize));
+
+        // iterate tiles in grid line from source to destination
         var line = new GridLineEnumerator(sourceGrid, destGrid);
         while (line.MoveNext())
         {
             var point = line.Current;
             if (!resistanceMap.TryGetValue(point, out var resData))
                 continue;
-
             ray.Rads -= resData;
-            if (saveVisitedTiles && blockers is not null)
-                blockers.Add((point, ray.Rads));
 
+            // save data for debug
+            if (saveVisitedTiles)
+                blockers!.Add((point, ray.Rads));
+
+            // no intensity left after blocker
             if (ray.Rads <= MinIntensity)
             {
                 ray.Rads = 0;
@@ -148,11 +250,13 @@ public partial class RadiationSystem
             }
         }
 
-        if (blockers is null || blockers.Count == 0)
+        if (!saveVisitedTiles || blockers!.Count <= 0)
             return ray;
 
+        // save data for debug if needed
         ray.Blockers ??= new();
         ray.Blockers.Add(GetNetEntity(gridUid), blockers);
+
         return ray;
     }
 
@@ -186,93 +290,5 @@ public partial class RadiationSystem
         }
 
         return rads;
-    }
-
-    [UsedImplicitly]
-    private readonly record struct RadiationJob : IParallelRobustJob
-    {
-        public int BatchSize => 5;
-        public required RadiationSystem System { get; init; }
-        public required B2DynamicTree<EntityUid> SourceTree { get; init; }
-        public required Dictionary<EntityUid, SourceData> SourceDataMap { get; init; }
-        public required List<EntityUid> Destinations { get; init; }
-        public required float[] Results { get; init; }
-        public required ConcurrentBag<DebugRadiationRay>? DebugRays { get; init; }
-        public required bool Debug { get; init; }
-
-        public void Execute(int index)
-        {
-            var destUid = Destinations[index];
-            if (System.Deleted(destUid) || !System.TryComp(destUid, out TransformComponent? destTrs))
-            {
-                Results[index] = 0;
-                return;
-            }
-
-            var nearbySourcesArray = ArrayPool<EntityUid>.Shared.Rent(256);
-
-            var gridList = new List<Entity<MapGridComponent>>(8);
-
-            try
-            {
-                var destWorld = System._transform.GetWorldPosition(destTrs);
-                var rads = 0f;
-                var destMapId = destTrs.MapID;
-
-                var queryAabb = new Box2(destWorld, destWorld);
-
-                var state = (nearbySourcesArray, 0, SourceTree);
-                SourceTree.Query(ref state,
-                    static (ref (EntityUid[] arr, int count, B2DynamicTree<EntityUid> tree) tuple,
-                        DynamicTree.Proxy proxy) =>
-                    {
-                        if (tuple.count >= tuple.arr.Length)
-                            return true;
-
-                        var uid = tuple.tree.GetUserData(proxy);
-                        tuple.arr[tuple.count++] = uid;
-                        return true;
-                    },
-                    in queryAabb);
-
-                var nearbySourcesSpan = nearbySourcesArray.AsSpan(0, state.Item2);
-
-                foreach (var sourceUid in nearbySourcesSpan)
-                {
-                    if (!SourceDataMap.TryGetValue(sourceUid, out var source)
-                        || source.Transform.MapID != destMapId)
-                        continue;
-                    var delta = source.WorldPosition - destWorld;
-                    if (delta.LengthSquared() > source.MaxRange * source.MaxRange)
-                        continue;
-                    var dist = delta.Length();
-                    var radsAfterDist = source.Intensity - source.Slope * dist;
-                    if (radsAfterDist < System.MinIntensity)
-                        continue;
-                    if (System.Irradiate(source, destUid, destTrs, destWorld, Debug, gridList) is not { } ray)
-                        continue;
-
-                    if (ray.ReachedDestination)
-                        rads += ray.Rads;
-
-                    DebugRays?.Add(new DebugRadiationRay(
-                        ray.MapId,
-                        System.GetNetEntity(ray.SourceUid),
-                        ray.Source,
-                        System.GetNetEntity(ray.DestinationUid),
-                        ray.Destination,
-                        ray.Rads,
-                        ray.Blockers ?? new Dictionary<NetEntity, List<(Vector2i, float)>>())
-                    );
-                }
-
-                rads = System.GetAdjustedRadiationIntensity(destUid, rads);
-                Results[index] = rads;
-            }
-            finally
-            {
-                ArrayPool<EntityUid>.Shared.Return(nearbySourcesArray);
-            }
-        }
     }
 }

--- a/Content.Server/Radiation/Systems/RadiationSystem.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.cs
@@ -17,10 +17,9 @@ public sealed partial class RadiationSystem : SharedRadiationSystem
     [Dependency] private readonly SharedStackSystem _stack = default!;
     [Dependency] private readonly SharedMapSystem _maps = default!;
 
-    private EntityQuery<RadiationBlockingContainerComponent> _blockerQuery;
-    private EntityQuery<RadiationGridResistanceComponent> _resistanceQuery;
-    private EntityQuery<MapGridComponent> _gridQuery;
-    private EntityQuery<StackComponent> _stackQuery;
+    [Dependency] private readonly EntityQuery<RadiationBlockingContainerComponent> _blockerQuery = default!;
+    [Dependency] private readonly EntityQuery<RadiationGridResistanceComponent> _resistanceQuery = default!;
+    [Dependency] private readonly EntityQuery<MapGridComponent> _gridQuery = default!;
 
     private float _accumulator;
     private List<SourceData> _sources = new();
@@ -30,11 +29,6 @@ public sealed partial class RadiationSystem : SharedRadiationSystem
         base.Initialize();
         SubscribeCvars();
         InitRadBlocking();
-
-        _blockerQuery = GetEntityQuery<RadiationBlockingContainerComponent>();
-        _resistanceQuery = GetEntityQuery<RadiationGridResistanceComponent>();
-        _gridQuery = GetEntityQuery<MapGridComponent>();
-        _stackQuery = GetEntityQuery<StackComponent>();
     }
 
     public override void Update(float frameTime)

--- a/Content.Server/Radiation/Systems/RadiationSystem.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.cs
@@ -1,13 +1,11 @@
 using Content.Server.Radiation.Components;
 using Content.Shared.Radiation.Components;
 using Content.Shared.Radiation.Events;
+using Content.Shared.Radiation.Systems;
 using Content.Shared.Stacks;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
-using Robust.Shared.Physics;
-using Robust.Shared.Threading;
-using System.Numerics;
-using Content.Shared.Radiation.Systems;
+using Robust.Shared.Map.Components;
 
 namespace Content.Server.Radiation.Systems;
 
@@ -18,17 +16,14 @@ public sealed partial class RadiationSystem : SharedRadiationSystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedStackSystem _stack = default!;
     [Dependency] private readonly SharedMapSystem _maps = default!;
-    [Dependency] private readonly IParallelManager _parallel = default!;
 
-    [Dependency] private readonly EntityQuery<RadiationReceiverComponent> _receiverQuery = default!;
-    [Dependency] private EntityQuery<RadiationBlockingContainerComponent> _blockerQuery = default;
-    [Dependency] private EntityQuery<RadiationGridResistanceComponent> _resistanceQuery = default;
-
-    private readonly B2DynamicTree<EntityUid> _sourceTree = new();
-    private readonly Dictionary<EntityUid, SourceData> _sourceDataMap = new();
-    private readonly List<EntityUid> _activeReceivers = new();
+    private EntityQuery<RadiationBlockingContainerComponent> _blockerQuery;
+    private EntityQuery<RadiationGridResistanceComponent> _resistanceQuery;
+    private EntityQuery<MapGridComponent> _gridQuery;
+    private EntityQuery<StackComponent> _stackQuery;
 
     private float _accumulator;
+    private List<SourceData> _sources = new();
 
     public override void Initialize()
     {
@@ -36,100 +31,10 @@ public sealed partial class RadiationSystem : SharedRadiationSystem
         SubscribeCvars();
         InitRadBlocking();
 
-        SubscribeLocalEvent<RadiationSourceComponent, ComponentStartup>(OnSourceStartup);
-        SubscribeLocalEvent<RadiationSourceComponent, ComponentShutdown>(OnSourceShutdown);
-        SubscribeLocalEvent<RadiationSourceComponent, MoveEvent>(OnSourceMove);
-        SubscribeLocalEvent<RadiationSourceComponent, StackCountChangedEvent>(OnSourceStackChanged);
-
-        SubscribeLocalEvent<RadiationReceiverComponent, ComponentStartup>(OnReceiverStartup);
-        SubscribeLocalEvent<RadiationReceiverComponent, ComponentShutdown>(OnReceiverShutdown);
-    }
-
-    private void OnSourceStartup(Entity<RadiationSourceComponent> entity, ref ComponentStartup args)
-    {
-        UpdateSource(entity);
-    }
-
-    private void OnSourceShutdown(EntityUid uid, RadiationSourceComponent component, ComponentShutdown args)
-    {
-        if (component.Proxy != DynamicTree.Proxy.Free)
-        {
-            _sourceTree.DestroyProxy(component.Proxy);
-            component.Proxy = DynamicTree.Proxy.Free;
-        }
-        _sourceDataMap.Remove(uid);
-    }
-
-    private void OnSourceMove(Entity<RadiationSourceComponent> entity, ref MoveEvent args)
-    {
-        if (args.NewPosition.EntityId == args.OldPosition.EntityId &&
-            args.NewPosition.Position.EqualsApprox(args.OldPosition.Position))
-            return;
-
-        UpdateSource(entity);
-    }
-
-    private void OnSourceStackChanged(Entity<RadiationSourceComponent> entity, ref StackCountChangedEvent args)
-    {
-        UpdateSource(entity);
-    }
-
-    private void OnReceiverStartup(EntityUid uid, RadiationReceiverComponent component, ComponentStartup args)
-    {
-        _activeReceivers.Add(uid);
-    }
-
-    private void OnReceiverShutdown(EntityUid uid, RadiationReceiverComponent component, ComponentShutdown args)
-    {
-        _activeReceivers.Remove(uid);
-    }
-
-    protected override void UpdateSource(Entity<RadiationSourceComponent> entity)
-    {
-        var (uid, component) = entity;
-        var xform = Transform(uid);
-
-        if (!component.Enabled || Terminating(uid))
-        {
-            if (component.Proxy != DynamicTree.Proxy.Free)
-            {
-                _sourceTree.DestroyProxy(component.Proxy);
-                component.Proxy = DynamicTree.Proxy.Free;
-            }
-            _sourceDataMap.Remove(uid);
-            return;
-        }
-
-        var worldPos = _transform.GetWorldPosition(xform);
-        var intensity = component.Intensity * _stack.GetCount(uid);
-        intensity = GetAdjustedRadiationIntensity(uid, intensity);
-
-        if (intensity <= 0)
-        {
-            if (component.Proxy != DynamicTree.Proxy.Free)
-            {
-                _sourceTree.DestroyProxy(component.Proxy);
-                component.Proxy = DynamicTree.Proxy.Free;
-            }
-            _sourceDataMap.Remove(uid);
-            return;
-        }
-
-        // Avoid division by 0
-        var maxRange = component.Slope >= float.Epsilon ? intensity / component.Slope : GridcastMaxDistance;
-        maxRange = Math.Min(maxRange, GridcastMaxDistance);
-
-        _sourceDataMap[uid] = new SourceData(intensity, component.Slope, maxRange, (uid, component, xform), worldPos);
-        var aabb = Box2.CenteredAround(worldPos, new Vector2(maxRange * 2, maxRange * 2));
-
-        if (component.Proxy != DynamicTree.Proxy.Free)
-        {
-            _sourceTree.MoveProxy(component.Proxy, in aabb);
-        }
-        else
-        {
-            component.Proxy = _sourceTree.CreateProxy(in aabb, uint.MaxValue, uid);
-        }
+        _blockerQuery = GetEntityQuery<RadiationBlockingContainerComponent>();
+        _resistanceQuery = GetEntityQuery<RadiationGridResistanceComponent>();
+        _gridQuery = GetEntityQuery<MapGridComponent>();
+        _stackQuery = GetEntityQuery<StackComponent>();
     }
 
     public override void Update(float frameTime)
@@ -155,11 +60,8 @@ public sealed partial class RadiationSystem : SharedRadiationSystem
     {
         if (!Resolve(entity, ref entity.Comp, false))
             return;
-        if (entity.Comp.Enabled == val)
-            return;
 
         entity.Comp.Enabled = val;
-        UpdateSource((entity.Owner, entity.Comp));
     }
 
     /// <summary>

--- a/Content.Shared/Radiation/Components/RadiationSourceComponent.cs
+++ b/Content.Shared/Radiation/Components/RadiationSourceComponent.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Radiation.Systems;
-using Robust.Shared.Physics;
 
 namespace Content.Shared.Radiation.Components;
 
@@ -30,7 +29,4 @@ public sealed partial class RadiationSourceComponent : Component
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool Enabled = true;
-
-    [ViewVariables]
-    public DynamicTree.Proxy Proxy = DynamicTree.Proxy.Free;
 }

--- a/Content.Shared/Radiation/Systems/SharedRadiationSystem.cs
+++ b/Content.Shared/Radiation/Systems/SharedRadiationSystem.cs
@@ -17,11 +17,5 @@ public abstract partial class SharedRadiationSystem : EntitySystem
             return;
 
         entity.Comp.Intensity = intensity;
-        UpdateSource((entity, entity.Comp));
     }
-
-    /// <summary>
-    /// Updates the radiation source cache. Does nothing on client, see server!
-    /// </summary>
-    protected virtual void UpdateSource(Entity<RadiationSourceComponent> entity) { }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Reverts #39173 due to the bug listed in #43698

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
There is no quick fix for this bug that doesn't either degrade performance so much that it makes it worse than the original system. As such a proper fix is needed, which requires a pretty substantial change to how the fixture positions and entity positions are cached and updated. 
Ideally we should be inheriting from the physics dynamic tree if possible so that way we can use its updated global positions without much extra overhead but doing so is a significant overhaul. Either that or we need to find some other performance efficient way to update the position of each source and their proxy. 

## Technical details
<!-- Summary of code changes for easier review. -->
Revert commit, but keep changes from moving radiation system to shared.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
#39173 has been reverted.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
