### PR TITLE
Skeleton Nerfs and Cleanup

### DIFF
--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -154,6 +154,7 @@ namespace Content.Shared.Interaction
         private void OnBoundInterfaceInteractAttempt(Entity<UserInterfaceComponent> ent, ref BoundUserInterfaceMessageAttempt ev)
         {
             _uiQuery.TryComp(ev.Target, out var aUiComp);
+
             if (!_actionBlockerSystem.CanInteract(ev.Actor, ev.Target))
             {
                 // We permit ghosts to open uis unless explicitly blocked
@@ -178,6 +179,10 @@ namespace Content.Shared.Interaction
             }
 
             if (aUiComp == null)
+                return;
+
+            // Key shouldn't ever be null.
+            if (!aUiComp.Key.Equals(ev.UiKey))
                 return;
 
             if (aUiComp.SingleUser && aUiComp.CurrentSingleUser != null && aUiComp.CurrentSingleUser != ev.Actor)

--- a/Content.Shared/UserInterface/ActivatableUIComponent.cs
+++ b/Content.Shared/UserInterface/ActivatableUIComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.UserInterface
     public sealed partial class ActivatableUIComponent : Component
     {
         [DataField(required: true, customTypeSerializer: typeof(EnumSerializer))]
-        public Enum? Key;
+        public Enum Key;
 
         /// <summary>
         /// Whether the item must be held in one of the user's hands to work.

--- a/Resources/Prototypes/Body/Species/skeleton.yml
+++ b/Resources/Prototypes/Body/Species/skeleton.yml
@@ -166,7 +166,7 @@
     heatDamage:
       types:
         Heat: 0.1 # bones don't burn easily.
-        Brute: 0.5 #oof ouch oof my bones are micro-fracturing!!!
+        Blunt: 0.5 #oof ouch oof my bones are micro-fracturing!!!
   - type: FlashImmunity
     showInExamine: false
   - type: Instrument

--- a/Resources/Prototypes/Body/Species/skeleton.yml
+++ b/Resources/Prototypes/Body/Species/skeleton.yml
@@ -71,6 +71,7 @@
   parent:
   - AppearanceSkeletonPerson
   - BaseSpeciesMob
+  - MobFlammable
   id: MobSkeletonPerson
   name: Urist McBones
   components:
@@ -87,14 +88,13 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Critical
-      150: Dead
+      100: Dead
   - type: TransferMindOnGib
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 150
+        damage: 100
       behaviors:
       - !type:GibBehavior
   - type: SlowOnDamage
@@ -157,6 +157,16 @@
           probability: 0.5
   - type: FireVisuals
     alternateState: Standing
+  - type: Flammable
+    minIgnitionTemperature: 873.15 # Lower bound of when bone begins to burn. These skeletons are ancient so this is probably accurate. Currently does nothing.
+  - type: Temperature
+  - type: TemperatureDamage
+    heatDamageThreshold: 373.15 # Beyond boiling point bone begins to slowly fracture and shrink, even though it doesn't burn till about 600 C
+    coldDamageThreshold: 0
+    heatDamage:
+      types:
+        Heat: 0.1 # bones don't burn easily.
+        Brute: 0.5 #oof ouch oof my bones are micro-fracturing!!!
   - type: FlashImmunity
     showInExamine: false
   - type: Instrument
@@ -202,6 +212,7 @@
   - type: VisualOrganMarkings
     markingData:
       group: Skeleton
+  - type: GibbableOrgan
 
 - type: entity
   parent: [ OrganBaseTorsoSexed, OrganBaseTorso, OrganSkeletonPersonExternal ]
@@ -210,6 +221,9 @@
 - type: entity
   parent: [ OrganBaseHead, OrganSkeletonPersonExternal ]
   id: OrganSkeletonPersonHead
+  components:
+  - type: Sprite
+    state: skull_icon
 
 - type: entity
   parent: [ OrganBaseArmLeft, OrganSkeletonPersonExternal ]

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -229,9 +229,7 @@
 - type: damageModifierSet
   id: Skeleton
   coefficients:
-    Blunt: 1.1
-    Slash: 0.8
-    Piercing: 0.6
+    Blunt: 2
     Cold: 0.0
     Poison: 0.0
     Radiation: 0.0

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -229,7 +229,7 @@
 - type: damageModifierSet
   id: Skeleton
   coefficients:
-    Blunt: 2
+    Blunt: 1.5 # Oof ouch my bones
     Cold: 0.0
     Poison: 0.0
     Radiation: 0.0
@@ -237,8 +237,6 @@
     Bloodloss: 0.0
     Cellular: 0.0
     Holy: 0.5
-  flatReductions:
-    Blunt: 5
 
 # hurt a lot by blunt, immune to a good amount of other stuff because they're a cookie
 - type: damageModifierSet


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.
Resolves #43218
Skeleton was kind of a do it all role, great resistances, great speed, great healing. 
This PR reigns it in to a more defined role as a glass cannon.
It also fixes a number of skeleton bugs, mainly skeletons now drop their bones again when they gib, and their skull once again has the correct sprite. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Skeleton can be quite oppressively strong and space law crew dynamics are weird such that having to deal with a hostile skeleton comes with questions about trying to revive them and such, which is difficult because they can only be healed with milk.
This PR fixes that with a number of changes
- Removes skeleton resistances to slash and pierce
- Raises their blunt weakness to double damage, they still have their -5 damage meaning they will only take extra blunt damage from any weapon that does more than 10 blunt (So toolboxes and higher) 
- Makes their death and gib threshold 100 HP down from 150. This means skeletons no longer have a crit state and are instantly round removed when they take too much damage
- Makes skeletons actually flammable. Based on their YAML this was intended but never worked.

This makes skeletons a "live fast die fast" role which plays into the openness of the role in general. The world is your oyster but you only have one very fragile shot. The reduced resistances mean that a skeleton will have to be extra careful with their engagements and makes trying to solo the station near impossible. 

Being flammable is cool and aesthetic and also prevents them from plasma firing without consequence. Also when we have proper fire and burn temperatures it means skeletons can cosplay as ghost rider. 

Overall this means skeletons have a lot more to worry about if they decide to be an asshole since they're far easier to deal with on both sides of the isle. This should make them healthier in the future 

## Technical details
<!-- Summary of code changes for easier review. -->
YAML slop with sone bugfixes
Notably, make it so Activatable UI cancellation only happens for the correct UI by checking keys. 
This prevents a skeleton being played as an instrument from being unable to be stripped.
Next, make skeleton limbs gibbable so they drop on gib, and change their sprite icon to their OG skull sprite as god intended. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Skeletons have been made weaker to brute damage, and now gib at 100 damage instead of 150. 
- tweak: Skeletons are now flammable. 
