### PR TITLE
Fix ghost follow on antag spawn

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared.Administration.Logs;
 using Content.Shared.Antag;
 using Content.Shared.Clothing;
 using Content.Shared.Database;
+using Content.Shared.Follower;
 using Content.Shared.GameTicking;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Mind;
@@ -64,6 +65,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     [Dependency] private readonly ArrivalsSystem _arrivals = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly FollowerSystem _follower = default!;
     [Dependency] private readonly GhostRoleSystem _ghostRole = default!;
     [Dependency] private readonly JobSystem _jobs = default!;
     [Dependency] private readonly LoadoutSystem _loadout = default!;
@@ -159,6 +161,10 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         PreSelectSession((rule, select), def, args.Player);
         InitializeAntag((rule, select), def, uid.Value, args.Player);
         args.TookRole = true;
+
+        // Move ghosts that were watching the raffle on the spawner over to the freshly spawned antag.
+        _follower.TransferFollowers(ent, uid.Value);
+
         _ghostRole.UnregisterGhostRole((ent, Comp<GhostRoleComponent>(ent)));
     }
 

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -163,7 +163,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         args.TookRole = true;
 
         // Move ghosts that were watching the raffle on the spawner over to the freshly spawned antag.
-        _follower.TransferFollowers(ent, uid.Value);
+        _follower.TransferFollowers(ent.Owner, uid.Value);
 
         _ghostRole.UnregisterGhostRole((ent, Comp<GhostRoleComponent>(ent)));
     }

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -159,11 +159,7 @@ public sealed class FollowerSystem : EntitySystem
 
     private void OnFollowedPolymorphed(Entity<FollowedComponent> entity, ref PolymorphedEvent args)
     {
-        foreach (var follower in entity.Comp.Following)
-        {
-            // Stop following the target's old entity and start following the new one
-            StartFollowingEntity(follower, args.NewEntity);
-        }
+        TransferFollowers(entity, args.NewEntity, entity.Comp);
     }
 
     // TODO: Slartibarfast mentioned that ideally this should be generalized and made part of SetRelay in SharedMoverController.Relay.cs.
@@ -173,8 +169,7 @@ public sealed class FollowerSystem : EntitySystem
         if (args.NewRemoteEntity == null)
             return;
 
-        foreach (var follower in entity.Comp.Following)
-            StartFollowingEntity(follower, args.NewRemoteEntity.Value);
+        TransferFollowers(entity, args.NewRemoteEntity.Value, entity.Comp);
     }
 
     /// <summary>
@@ -304,6 +299,21 @@ public sealed class FollowerSystem : EntitySystem
         {
             StopFollowingEntity(player, uid, followed);
         }
+    }
+
+    /// <summary>
+    ///     Moves every follower of <paramref name="from"/> over to <paramref name="to"/>.
+    ///     Use this when an entity is being replaced (polymorph, remote swap, ghost role spawn) and
+    ///     its watchers should ride along to the successor instead of being detached.
+    /// </summary>
+    public void TransferFollowers(EntityUid from, EntityUid to, FollowedComponent? followed = null)
+    {
+        if (from == to || !Resolve(from, ref followed, false))
+            return;
+
+        // Snapshot since HashSet is mutated down the line
+        foreach (var follower in followed.Following.ToArray())
+            StartFollowingEntity(follower, to);
     }
 
     /// <summary>

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -159,7 +159,7 @@ public sealed class FollowerSystem : EntitySystem
 
     private void OnFollowedPolymorphed(Entity<FollowedComponent> entity, ref PolymorphedEvent args)
     {
-        TransferFollowers(entity, args.NewEntity, entity.Comp);
+        TransferFollowers(entity.AsNullable(), args.NewEntity);
     }
 
     // TODO: Slartibarfast mentioned that ideally this should be generalized and made part of SetRelay in SharedMoverController.Relay.cs.
@@ -169,7 +169,7 @@ public sealed class FollowerSystem : EntitySystem
         if (args.NewRemoteEntity == null)
             return;
 
-        TransferFollowers(entity, args.NewRemoteEntity.Value, entity.Comp);
+        TransferFollowers(entity.AsNullable(), args.NewRemoteEntity.Value);
     }
 
     /// <summary>
@@ -306,13 +306,13 @@ public sealed class FollowerSystem : EntitySystem
     ///     Use this when an entity is being replaced (polymorph, remote swap, ghost role spawn) and
     ///     its watchers should ride along to the successor instead of being detached.
     /// </summary>
-    public void TransferFollowers(EntityUid from, EntityUid to, FollowedComponent? followed = null)
+    public void TransferFollowers(Entity<FollowedComponent?> from, EntityUid to)
     {
-        if (from == to || !Resolve(from, ref followed, false))
+        if (from.Owner == to || !Resolve(from, ref from.Comp, false))
             return;
 
         // Snapshot since HashSet is mutated down the line
-        foreach (var follower in followed.Following.ToArray())
+        foreach (var follower in from.Comp.Following.ToArray())
             StartFollowingEntity(follower, to);
     }
 


### PR DESCRIPTION
## About the PR
Ghosts observing antag spawn markers now automatically follow the freshly spawned antags.
Previously they remained on the marker entity.

## Why / Balance
https://github.com/space-wizards/space-station-14/issues/42645

## Technical details
Added new helper method to transfer ghosts from one entity to another.
Also fixed a potential exception?
Currently we're mutating a HashSet mid-iteration.

## Media
It works trust me bro
I have a hard time capturing several clients with OBS

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
