### PR TITLE
Fix dupe bug  caused by StackSystem

### DIFF
--- a/Content.Shared/Stacks/SharedStackSystem.API.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.API.cs
@@ -28,9 +28,7 @@ public abstract partial class SharedStackSystem
         var stackId = _prototype.Index(stackEnt.Comp.StackTypeId);
         var entityUid = PredictedSpawnNextToOrDrop(stackId.Spawn, stackEnt.Owner);
 
-        if (TryComp<StackComponent>(entityUid, out var stackComponent))
-            SetCount((entityUid, stackComponent), 1);
-
+        SetCount(entityUid, 1);
         return entityUid;
     }
 

--- a/Content.Shared/Stacks/SharedStackSystem.API.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.API.cs
@@ -26,7 +26,12 @@ public abstract partial class SharedStackSystem
 
         ReduceCount(stackEnt, 1);
         var stackId = _prototype.Index(stackEnt.Comp.StackTypeId);
-        return PredictedSpawnNextToOrDrop(stackId.Spawn, stackEnt.Owner);
+        var entityUid = PredictedSpawnNextToOrDrop(stackId.Spawn, stackEnt.Owner);
+
+        if (TryComp<StackComponent>(entityUid, out var stackComponent))
+            SetCount((entityUid, stackComponent), 1);
+
+        return entityUid;
     }
 
     #endregion


### PR DESCRIPTION
## About the PR
Fixed dupe with all items, which have BallisticAmmoProviderComponent

Steps to reproduce: 
1. Pick up an item with a stack size > 1
2. Left-click on an item that has a BallisticAmmoProviderComponent

When BallisticAmmoProviderSystem attempted to retrieve a single item from the stack, GetOne function created a full stack

## Technical details
-  Added stack check in GetOne 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
