### PR TITLE
Fix Grindable Guide Entries

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -257,6 +257,11 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
         bool errorOnMissing = false)
     {
         solution = null;
+        if (entProto.TryGetComponent<SolutionComponent>(out var sol, Factory) && sol.Id == name)
+        {
+            solution = sol.Solution;
+            return true;
+        }
 
         if (!TryGetSolutionFill(entProto, out var solutions))
             return false;
@@ -266,7 +271,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
             if (!PrototypeManager.Resolve(protoId, out var proto))
                 continue;
 
-            if (!proto.TryGetComponent<SolutionComponent>(out var sol, Factory))
+            if (!proto.TryGetComponent(out sol, Factory))
             {
                 Log.Error($"Entity prototype {proto}, tried to spawn in a solution container in prototype {entProto.ID}, but had no {nameof(SolutionComponent)}");
                 continue;
@@ -323,16 +328,6 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
 
             yield return (sol.Id, sol.Solution);
         }
-    }
-
-    private bool TryGetSolutionFill(Entity<SolutionManagerComponent?> entity, [NotNullWhen(true)] out List<EntProtoId>? fill)
-    {
-        fill = null;
-        if (!SolutionManagerQuery.Resolve(entity, ref entity.Comp))
-            return false;
-
-        fill = entity.Comp.SolutionEnts;
-        return true;
     }
 
     private bool TryGetSolutionFill(EntityPrototype entProto, [NotNullWhen(true)] out List<EntProtoId>? fill)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Code to get solutions from a prototype was old, older than adding solutions to entities so I forgot to update it.
It now checks the entity prototype itself for a solution.
Helps with #43726

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Buge.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a check for a SolutionComponent on the EntityPrototype itself
Removed an unused API method which won't work anymore anyways once some other fixes are merged. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Grindable entities as sources of reagents show up in the chemistry guidebook again.