### PR TITLE
made the electric grill able to heat solutions

### DIFF
--- a/Content.Server/Temperature/Systems/EntityHeaterSystem.cs
+++ b/Content.Server/Temperature/Systems/EntityHeaterSystem.cs
@@ -1,8 +1,10 @@
 using Content.Server.Power.Components;
+using Content.Shared.Chemistry.Components;
 using Content.Shared.Placeable;
 using Content.Shared.Temperature;
 using Content.Shared.Temperature.Components;
 using Content.Shared.Temperature.Systems;
+using Content.Shared.Chemistry.EntitySystems;
 
 namespace Content.Server.Temperature.Systems;
 
@@ -12,6 +14,8 @@ namespace Content.Server.Temperature.Systems;
 public sealed class EntityHeaterSystem : SharedEntityHeaterSystem
 {
     [Dependency] private readonly TemperatureSystem _temperature = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
+
 
     public override void Initialize()
     {
@@ -34,14 +38,19 @@ public sealed class EntityHeaterSystem : SharedEntityHeaterSystem
         {
             if (!power.Powered)
                 continue;
-
             // don't divide by total entities since it's a big grill
             // excess would just be wasted in the air but that's not worth simulating
             // if you want a heater thermomachine just use that...
             var energy = power.PowerReceived * deltaTime;
             foreach (var ent in placer.PlacedEntities)
             {
+                //raise temperature of temperature component
                 _temperature.ChangeHeat(ent, energy);
+                //use energy to heat anything contained.
+                foreach (var solution in _solutionContainer.EnumerateSolutions(ent))
+                {
+                    _solutionContainer.AddThermalEnergy(solution.Solution, energy);
+                }
             }
         }
     }
@@ -50,7 +59,9 @@ public sealed class EntityHeaterSystem : SharedEntityHeaterSystem
     /// <see cref="ApcPowerReceiverComponent"/> doesn't exist on the client, so we need
     /// this server-only override to handle setting the network load.
     /// </remarks>
-    protected override void ChangeSetting(Entity<EntityHeaterComponent> ent, EntityHeaterSetting setting, EntityUid? user = null)
+    protected override void ChangeSetting(Entity<EntityHeaterComponent> ent,
+        EntityHeaterSetting setting,
+        EntityUid? user = null)
     {
         base.ChangeSetting(ent, setting, user);
 

--- a/Resources/Prototypes/Entities/Structures/Machines/grill.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/grill.yml
@@ -5,7 +5,6 @@
   description: A microwave? No, a real man cooks steaks on a grill!
   components:
   - type: Sprite
-    # TODO: draw a sprite
     sprite: Structures/Machines/electric_grill.rsi
     drawdepth: SmallObjects
     snapCardinals: true
@@ -26,6 +25,7 @@
     whitelist:
       components:
       - Temperature
+      - Solution
   - type: PlaceableSurface
   - type: Machine
     board: ElectricGrillMachineCircuitboard


### PR DESCRIPTION
## About the PR
Electric Grill can now heat solutions akin to the chemistry hot plate using its superior logic for temperature change based off received power.

## Why / Balance
Was tinkering earlier with [Ammonia Reaction](https://github.com/space-wizards/space-station-14/pull/43736) and while checking if Botany would be locked out of doing their basic ammonia chemistry, I noticed that the electric grill in the kitchen, which players might use to cook their ammonia, would not heat the solution.
This simple adjustments allows solutions to be heated on a grill with the widest possible whitelist (SolutionComponent)

## Technical details
- Added SolutionComponent to Whitelist for ItemPlacer in Electric Grill Prototype
- Made Entity Heater also supply thermal output to solutions in ItemPlacer.

## Media
[Screencast from 2026-04-26 11-46-48.webm](https://github.com/user-attachments/assets/789916cd-f12b-4aa0-b641-281012a91c44)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes


**Changelog**
:cl:
- add: Kitchen Grills can now heat liquid solutions placed on them!