### PR TITLE
randomize markings, when building a random character appearance.

### DIFF
--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -21,7 +21,11 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
     public Color SkinColor { get; set; } = Color.FromHsv(new Vector4(0.07f, 0.2f, 1f, 1f));
 
     [DataField]
-    public Dictionary<ProtoId<OrganCategoryPrototype>, Dictionary<HumanoidVisualLayers, List<Marking>>> Markings { get; set; } = new();
+    public Dictionary<ProtoId<OrganCategoryPrototype>, Dictionary<HumanoidVisualLayers, List<Marking>>> Markings
+    {
+        get;
+        set;
+    } = new();
 
     public HumanoidCharacterAppearance(
         Color eyeColor,
@@ -36,7 +40,6 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
     public HumanoidCharacterAppearance(HumanoidCharacterAppearance other) :
         this(other.EyeColor, other.SkinColor, new(other.Markings))
     {
-
     }
 
     public HumanoidCharacterAppearance WithEyeColor(Color newColor)
@@ -49,7 +52,8 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         return new(EyeColor, newColor, Markings);
     }
 
-    public HumanoidCharacterAppearance WithMarkings(Dictionary<ProtoId<OrganCategoryPrototype>, Dictionary<HumanoidVisualLayers, List<Marking>>> newMarkings)
+    public HumanoidCharacterAppearance WithMarkings(
+        Dictionary<ProtoId<OrganCategoryPrototype>, Dictionary<HumanoidVisualLayers, List<Marking>>> newMarkings)
     {
         return new(EyeColor, SkinColor, newMarkings);
     }
@@ -87,26 +91,101 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
     {
         var random = IoCManager.Resolve<IRobustRandom>();
         var markingManager = IoCManager.Resolve<MarkingManager>();
+        var protoMan = IoCManager.Resolve<IPrototypeManager>();
+        var speciesPrototype = protoMan.Index<SpeciesPrototype>(species);
 
-        // TODO: Add random markings
+        Dictionary<ProtoId<OrganCategoryPrototype>, Dictionary<HumanoidVisualLayers, List<Marking>>> compiledMarkings =
+            new();
+        //build a color pallet for all parts.
+        var colours = Enumerable.Range(0, 255)
+            .Select(e => new Color(random.NextByte(), random.NextByte(), random.NextByte()))
+            .ToArray();
+        //most likely list of simple physical traits.
+        HumanoidVisualLayers[] layerFilter =
+        [
+        HumanoidVisualLayers.Hair,
+        HumanoidVisualLayers.Tail,
+        HumanoidVisualLayers.FacialHair,
+        HumanoidVisualLayers.Fire,
+        HumanoidVisualLayers.Snout,
+        ];
+
+        //build organ for organ
+        foreach (var organ in markingManager.GetOrgans(species))
+        {
+            //get the marking data for that organ
+            if (!markingManager.TryGetMarkingData(organ.Value, out var organMarkingData))
+                continue;
+            //extract the group based on the organ
+            var group = protoMan.Index<MarkingsGroupPrototype>(organMarkingData.Value.Group.Id);
+            // setup an empty dictionary of layers
+            compiledMarkings[organ.Key] = new();
+            //layer for layer.
+            foreach (var layer in organMarkingData.Value.Layers)
+            {
+                //only randomize physical traits.
+                if(!layerFilter.Contains(layer))
+                    continue;
+                //get all markings for that layer, sex, group and flatten to markings.
+                var markings =
+                    markingManager.MarkingsByLayerAndGroupAndSex(layer, organMarkingData.Value.Group, sex)
+                        .Select(e => e.Value.AsMarking())
+                        .ToArray();
+                //skip if no matches
+                if(markings.Length==0)
+                    continue;
+                //check restrictions for the layer
+                int limitOfMarking;
+                if (!group.Limits.TryGetValue(layer, out var limits))
+                {
+                    limitOfMarking = markings.Length;
+                }
+                else
+                {
+                    limitOfMarking = limits.Limit;
+                    //blatant skip chance unless required.
+                    if (!limits.Required && limitOfMarking==1 && random.NextDouble() < 0.5)
+                             continue;
+                }
+
+                //pick random feature list within limit
+                compiledMarkings[organ.Key][layer] = Enumerable.Range(0,limitOfMarking==1?1:random.Next(limitOfMarking))
+                    .Select(e =>
+                    {
+                       // return random.Pick(markings);
+                              var baseMarking = random.Pick(markings);
+                              for (var i = 0; i < baseMarking.MarkingColors.Count&&i<colours.Length; i++)
+                              {
+                               baseMarking= baseMarking.WithColorAt(i, colours[i]);
+                              }
+                              return baseMarking;
+                              //    return baseMarking.WithColor(color);
+                    })
+                    .ToList();
+            }
+        }
 
         var newEyeColor = random.Pick(_realisticEyeColors);
 
-        var protoMan = IoCManager.Resolve<IPrototypeManager>();
-        var skinType = protoMan.Index<SpeciesPrototype>(species).SkinColoration;
+        var skinType = speciesPrototype.SkinColoration;
         var strategy = protoMan.Index(skinType).Strategy;
 
         var newSkinColor = strategy.InputType switch
         {
             SkinColorationStrategyInput.Unary => strategy.FromUnary(random.NextFloat(0f, 100f)),
-            SkinColorationStrategyInput.Color => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
+            SkinColorationStrategyInput.Color => strategy.ClosestSkinColor(new Color(random.NextFloat(1),
+                random.NextFloat(1),
+                random.NextFloat(1),
+                1)),
             _ => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
         };
 
+
         // Safety step. Most systems which called Random() also called this, and not doing so caused issues with markings.
         // In the future it could *maybe* be removed, but it's probably worth the extra CPU cycles to validate this info.
+
         return EnsureValid(
-            new HumanoidCharacterAppearance(newEyeColor, newSkinColor, new()),
+            new HumanoidCharacterAppearance(newEyeColor, newSkinColor, compiledMarkings),
             species,
             sex);
     }
@@ -116,7 +195,9 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         return new(color.RByte, color.GByte, color.BByte);
     }
 
-    public static HumanoidCharacterAppearance EnsureValid(HumanoidCharacterAppearance appearance, ProtoId<SpeciesPrototype> species, Sex sex)
+    public static HumanoidCharacterAppearance EnsureValid(HumanoidCharacterAppearance appearance,
+        ProtoId<SpeciesPrototype> species,
+        Sex sex)
     {
         var eyeColor = ClampColor(appearance.EyeColor);
 
@@ -151,7 +232,11 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
                 markingManager.EnsureValidColors(actualMarkings);
                 markingManager.EnsureValidGroupAndSex(actualMarkings, organData.Value.Group, sex);
                 markingManager.EnsureValidLayers(actualMarkings, organData.Value.Layers);
-                markingManager.EnsureValidLimits(actualMarkings, organData.Value.Group, organData.Value.Layers, skinColor, eyeColor);
+                markingManager.EnsureValidLimits(actualMarkings,
+                    organData.Value.Group,
+                    organData.Value.Layers,
+                    skinColor,
+                    eyeColor);
 
                 validatedMarkings[organ] = actualMarkings;
             }
@@ -165,8 +250,10 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
 
     public bool Equals(HumanoidCharacterAppearance? other)
     {
-        if (ReferenceEquals(null, other)) return false;
-        if (ReferenceEquals(this, other)) return true;
+        if (ReferenceEquals(null, other))
+            return false;
+        if (ReferenceEquals(this, other))
+            return true;
         return EyeColor.Equals(other.EyeColor) &&
                SkinColor.Equals(other.SkinColor) &&
                MarkingManager.MarkingsAreEqual(Markings, other.Markings);

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -96,12 +96,29 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
 
         Dictionary<ProtoId<OrganCategoryPrototype>, Dictionary<HumanoidVisualLayers, List<Marking>>> compiledMarkings =
             new();
-        //build a color pallet for all parts.
-        var colours = Enumerable.Range(0, 255)
-            .Select(e => new Color(random.NextByte(), random.NextByte(), random.NextByte()))
+
+        var skinType = speciesPrototype.SkinColoration;
+        var strategy = protoMan.Index(skinType).Strategy;
+        //hair colors can go pretty wild
+        var hairColour = new Color(random.NextFloat(1),
+            random.NextFloat(1),
+            random.NextFloat(1),
+            1);
+
+        //build a color pallet for all organic parts, which should be a skin color
+        var organicColors = Enumerable.Range(0, 255)
+            .Select(e => strategy.InputType switch
+            {
+                SkinColorationStrategyInput.Unary => strategy.FromUnary(random.NextFloat(0f, 100f)),
+                SkinColorationStrategyInput.Color => strategy.ClosestSkinColor(new Color(random.NextFloat(1),
+                    random.NextFloat(1),
+                    random.NextFloat(1),
+                    1)),
+                _ => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
+            })
             .ToArray();
         //most likely list of simple physical traits.
-        HumanoidVisualLayers[] layerFilter =
+        HumanoidVisualLayers[] organicLayerFilter =
         [
         HumanoidVisualLayers.Hair,
         HumanoidVisualLayers.Tail,
@@ -110,8 +127,10 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         HumanoidVisualLayers.Snout,
         ];
 
-        //build organ for organ
-        foreach (var organ in markingManager.GetOrgans(species))
+        //build organ for organ (in random order)
+        var organList = markingManager.GetOrgans(species).ToList();
+        random.Shuffle(organList);
+        foreach (var organ in organList)
         {
             //get the marking data for that organ
             if (!markingManager.TryGetMarkingData(organ.Value, out var organMarkingData))
@@ -120,11 +139,13 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
             var group = protoMan.Index<MarkingsGroupPrototype>(organMarkingData.Value.Group.Id);
             // setup an empty dictionary of layers
             compiledMarkings[organ.Key] = new();
-            //layer for layer.
-            foreach (var layer in organMarkingData.Value.Layers)
+            //layer for layer (in random order)
+            var layers = organMarkingData.Value.Layers.ToList();
+            random.Shuffle(layers);
+            foreach (var layer in layers)
             {
                 //only randomize physical traits.
-                if(!layerFilter.Contains(layer))
+                if(!organicLayerFilter.Contains(layer))
                     continue;
                 //get all markings for that layer, sex, group and flatten to markings.
                 var markings =
@@ -138,7 +159,11 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
                 int limitOfMarking;
                 if (!group.Limits.TryGetValue(layer, out var limits))
                 {
+                    //make up to as many marking as we have options
                     limitOfMarking = markings.Length;
+                    //flip coin to see if we skip.
+                    if(limitOfMarking==1 && random.NextDouble() < 0.5)
+                        continue;
                 }
                 else
                 {
@@ -154,9 +179,13 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
                     {
                        // return random.Pick(markings);
                               var baseMarking = random.Pick(markings);
-                              for (var i = 0; i < baseMarking.MarkingColors.Count&&i<colours.Length; i++)
+                              if (layer is HumanoidVisualLayers.Hair or HumanoidVisualLayers.FacialHair)
                               {
-                               baseMarking= baseMarking.WithColorAt(i, colours[i]);
+                                  return baseMarking.WithColor(hairColour);
+                              }
+                              for (var i = 0; i < baseMarking.MarkingColors.Count&&i<organicColors.Length; i++)
+                              {
+                               baseMarking= baseMarking.WithColorAt(i, organicColors[i]);
                               }
                               return baseMarking;
                               //    return baseMarking.WithColor(color);
@@ -167,8 +196,7 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
 
         var newEyeColor = random.Pick(_realisticEyeColors);
 
-        var skinType = speciesPrototype.SkinColoration;
-        var strategy = protoMan.Index(skinType).Strategy;
+
 
         var newSkinColor = strategy.InputType switch
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added Marking Randomization to Random Appearance Maker

## Why / Balance
DNA Scrambler and similar methods to re-roll your appearance during a round, run into the issue of creating bland characters.
With this change at least the most striking physical features should always be randomized.
was inspired by this issue: #43220 

## Technical details
<!-- Summary of code changes for easier review. -->
Just iterating over the organs and relevant visual layers, trying to observe the marking limit per feature. Characters will be assigned a fixed color pallet which might look a bit weird, but then again this is all about randomness.

## Media
https://youtu.be/J9xtQ8Nk9Ms

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- tweak: DNA Scrambler will now add random hair and other body features!