### PR TITLE
Fix holopad maintenance panel sprite inverting on reconnect

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -51,8 +51,8 @@
           True: { visible: false }
       enum.WiresVisuals.MaintenancePanelState:
         enum.WiresVisualLayers.MaintenancePanel:
-          True: { visible: false }
-          False: { visible: true }
+          True: { visible: true }
+          False: { visible: false }
   - type: Machine
     board: HolopadMachineCircuitboard
   - type: StationAiWhitelist

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -49,10 +49,6 @@
         enum.PowerDeviceVisualLayers.Powered:
           False: { visible: true }
           True: { visible: false }
-      enum.WiresVisuals.MaintenancePanelState:
-        enum.WiresVisualLayers.MaintenancePanel:
-          True: { visible: true }
-          False: { visible: false }
   - type: Machine
     board: HolopadMachineCircuitboard
   - type: StationAiWhitelist


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fix inverted visual states for holopad maintenance panel


## Why / Balance

[Holopad sprite has an incorrect state #43232](https://github.com/space-wizards/space-station-14/issues/43232)

## Technical details
Changed the values of enum.WiresVisualLayers.MaintenancePanel in holopad.yml such that true = visible: true and false = visible: false to match the behavior of WiresVisualizerSystem

## Media

Before, the sprite would invert on disconnect / reconnect:
<img width="426" height="240" alt="BeforeFix" src="https://github.com/user-attachments/assets/6aaabeb3-16ee-482c-a479-6b12b8174add" />
After: seems to be resolved
<img width="426" height="240" alt="AfterFix" src="https://github.com/user-attachments/assets/fb999189-908e-4a93-83cf-348171e0bd2d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed the holopad maintenance panel displaying an inverted state when the player reconnects.
