### PR TITLE
Split PaperVisualsComponent

### DIFF
--- a/Content.Client/Paper/PaperVisualizerSystem.cs
+++ b/Content.Client/Paper/PaperVisualizerSystem.cs
@@ -1,12 +1,13 @@
+using Content.Shared.Paper;
 using Robust.Client.GameObjects;
 
 using static Content.Shared.Paper.PaperComponent;
 
-namespace Content.Client.Paper.UI;
+namespace Content.Client.Paper;
 
-public sealed class PaperVisualizerSystem : VisualizerSystem<PaperVisualsComponent>
+public sealed class PaperVisualizerSystem : VisualizerSystem<PaperVisualizerComponent>
 {
-    protected override void OnAppearanceChange(EntityUid uid, PaperVisualsComponent component, ref AppearanceChangeEvent args)
+    protected override void OnAppearanceChange(EntityUid uid, PaperVisualizerComponent component, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
             return;
@@ -30,8 +31,11 @@ public sealed class PaperVisualizerSystem : VisualizerSystem<PaperVisualsCompone
     }
 }
 
+/// <summary>
+/// Sprite mapping enum.
+/// </summary>
 public enum PaperVisualLayers
 {
     Stamp,
-    Writing
+    Writing,
 }

--- a/Content.Client/Paper/UI/PaperVisualsComponent.cs
+++ b/Content.Client/Paper/UI/PaperVisualsComponent.cs
@@ -3,58 +3,61 @@ using Robust.Shared.Utility;
 
 namespace Content.Client.Paper.UI;
 
+/// <summary>
+/// Adjusts the UI styling of paper.
+/// </summary>
 [RegisterComponent]
 public sealed partial class PaperVisualsComponent : Component
 {
     /// <summary>
     ///     The path to the image which will be used as a background for the paper itself
     /// </summary>
-    [DataField("backgroundImagePath")]
+    [DataField]
     public string? BackgroundImagePath;
 
     /// <summary>
     ///     An optional patch to configure tiling stretching of the background. Used to set
     ///     the PatchMargin in a <code>StyleBoxTexture</code>
     /// </summary>
-    [DataField("backgroundPatchMargin")]
-    public Box2 BackgroundPatchMargin = default;
+    [DataField]
+    public Box2 BackgroundPatchMargin;
 
     /// <summary>
     ///     Modulate the background image by this color. Can be used to add colorful
     ///     variants of images, without having to create new textures.
     /// </summary>
-    [DataField("backgroundModulate")]
+    [DataField]
     public Color BackgroundModulate = Color.White;
 
     /// <summary>
     ///     Should the background image tile, or be streched? Sets <code>StyleBoxTexture.StrechMode</code>
     /// </summary>
-    [DataField("backgroundImageTile")]
-    public bool BackgroundImageTile = false;
+    [DataField]
+    public bool BackgroundImageTile;
 
     /// <summary>
     ///     An additional scale to apply to the background image
     /// </summary>
-    [DataField("backgroundScale")]
+    [DataField]
     public Vector2 BackgroundScale = Vector2.One;
 
     /// <summary>
     ///     A path to an image which will be used as a header on the paper
     /// </summary>
-    [DataField("headerImagePath")]
+    [DataField]
     public string? HeaderImagePath;
 
     /// <summary>
     ///     Modulate the header image by this color
     /// </summary>
-    [DataField("headerImageModulate")]
+    [DataField]
     public Color HeaderImageModulate = Color.White;
 
     /// <summary>
     ///     Any additional margin to add around the header
     /// </summary>
-    [DataField("headerMargin")]
-    public Box2 HeaderMargin = default;
+    [DataField]
+    public Box2 HeaderMargin;
 
     /// <summary>
     /// A path to an image which will be used as a footer on the paper
@@ -72,7 +75,7 @@ public sealed partial class PaperVisualsComponent : Component
     /// Any additional margin to add around the footer
     /// </summary>
     [DataField]
-    public Box2 FooterMargin = default;
+    public Box2 FooterMargin;
 
     /// <summary>
     ///     Path to an image to use as the background to the "content" of the paper
@@ -80,33 +83,33 @@ public sealed partial class PaperVisualsComponent : Component
     ///     image will be tiled vertically with the property that the bottom of the
     ///     written text will line up with the bottom of this image.
     /// </summary>
-    [DataField("contentImagePath")]
+    [DataField]
     public string? ContentImagePath;
 
     /// <summary>
     ///     Modulate the content image by this color
     /// </summary>
-    [DataField("contentImageModulate")]
+    [DataField]
     public Color ContentImageModulate = Color.White;
 
     /// <summary>
     ///     An additional margin around the content (including header)
     /// </summary>
-    [DataField("contentMargin")]
-    public Box2 ContentMargin = default;
+    [DataField]
+    public Box2 ContentMargin;
 
     /// <summary>
     ///     The number of lines that the content image represents. The
     ///     content image will be vertically tiled after this many lines
     ///     of text.
     /// </summary>
-    [DataField("contentImageNumLines")]
+    [DataField]
     public int ContentImageNumLines = 1;
 
     /// <summary>
     ///     Modulate the style's font by this color
     /// </summary>
-    [DataField("fontAccentColor")]
+    [DataField]
     public Color FontAccentColor = new Color(223, 223, 213);
 
     /// <summary>
@@ -115,6 +118,6 @@ public sealed partial class PaperVisualsComponent : Component
     ///     can be unlimited by specifying a value of zero.
     ///     This will be scaled according to UI scale.
     /// </summary>
-    [DataField("maxWritableArea")]
-    public Vector2? MaxWritableArea = null;
+    [DataField]
+    public Vector2? MaxWritableArea;
 }

--- a/Content.Shared/Paper/PaperVisualizerComponent.cs
+++ b/Content.Shared/Paper/PaperVisualizerComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared.Paper;
+
+/// <summary>
+/// Visualizer adjusting the written and stamps states for a paper sprite.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PaperVisualizerComponent : Component
+{
+}

--- a/Content.Shared/Paper/PaperVisualizerComponent.cs
+++ b/Content.Shared/Paper/PaperVisualizerComponent.cs
@@ -4,6 +4,4 @@ namespace Content.Shared.Paper;
 /// Visualizer adjusting the written and stamps states for a paper sprite.
 /// </summary>
 [RegisterComponent]
-public sealed partial class PaperVisualizerComponent : Component
-{
-}
+public sealed partial class PaperVisualizerComponent : Component;

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -62,10 +62,10 @@
   - type: PhysicalComposition
 
 - type: entity
-  name: paper
   parent: BasePaper
   id: Paper
-  description: 'A piece of white paper.'
+  name: paper
+  description: A piece of white paper.
   components:
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi
@@ -87,6 +87,7 @@
       enum.PaperUiKey.Key:
         type: PaperBoundUserInterface
   - type: FaxableObject
+  - type: PaperVisualizer
   - type: PaperVisuals
   - type: StationAiWhitelist
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`PaperVisualsComponent` has had part of its code split off to `PaperVisualizerComponent`, specifically the visualizer for setting sprite states.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Components should only do one thing, but this component was doing two. It was used to set the UI styling for a paper, but also to set the appearance data for the sprite. This made the two inextricably linked, making it impossible to adjust the UI without also mapping the appearance for the sprite.

Books already do use `PaperVisualsComponent` without mapping the sprite, and they survive only by the grace of not having an `AppearanceComponent`. So now books can have that, if they want.

## Technical details
<!-- Summary of code changes for easier review. -->
The code was already very siloed. I just added a new component and used it in the visualizer. The visualizer file was moved out of the UI subdirectory.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Still works.
<img width="163" height="134" alt="image" src="https://github.com/user-attachments/assets/d8a48dc1-cd49-46b7-b5f0-786df8add5b6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`PaperVisualsComponent` has had part of its code split off into `PaperVisualizerComponent`. If you want an entity's sprite to change according to the written and stamped state as it did before, and you're not already inheriting from `id: Paper`, you'll need to add the visualizer component. 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Not player facing