### PR TITLE
Changeling move when transforming

### DIFF
--- a/Content.Shared/Changeling/Components/ChangelingTransformComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingTransformComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class ChangelingTransformComponent : Component
     /// Time it takes to Transform
     /// </summary>
     [DataField, AutoNetworkedField]
-    public TimeSpan TransformWindup = TimeSpan.FromSeconds(5);
+    public TimeSpan TransformWindup = TimeSpan.FromSeconds(4f);
 
     /// <summary>
     /// The noise used when attempting to transform

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
@@ -173,6 +173,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
             ent.Comp.CurrentTransformSound = _audio.Stop(ent.Comp.CurrentTransformSound);
             return;
         }
+        ent.Comp.CurrentTransformSound = null;
 
         if (!_prototype.Resolve(ent.Comp.TransformCloningSettings, out var settings))
             return;

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
@@ -156,8 +156,6 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
             ent,
             target: targetIdentity)
         {
-            BreakOnMove = true,
-            BreakOnWeightlessMove = true,
             DuplicateCondition = DuplicateConditions.None,
             RequireCanInteract = false,
             DistanceThreshold = null,
@@ -168,10 +166,13 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
         ref ChangelingTransformDoAfterEvent args)
     {
         args.Handled = true;
-        ent.Comp.CurrentTransformSound = _audio.Stop(ent.Comp.CurrentTransformSound);
 
         if (args.Cancelled)
+        {
+            // Only stop the sound if we finish transforming successfully.
+            ent.Comp.CurrentTransformSound = _audio.Stop(ent.Comp.CurrentTransformSound);
             return;
+        }
 
         if (!_prototype.Resolve(ent.Comp.TransformCloningSettings, out var settings))
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.
Also made transform 1s faster.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
My biggest annoyance with transform is that the changeling isn't able to use it while moving. Being able to use it to disappear into the crowd definitely seems very fun.
Working towards #39439

## Technical details
<!-- Summary of code changes for easier review. -->
Only cancel the sound if the ability is cancelled.
As a result, the sound lingers a little bit (which is an interesting tell).
It sounds SLIGHTLY off so it can be cut if needed, or transformation time kept at 5s.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/b07c62e7-2a46-4085-9986-43cc0b2aec26

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
