### PR TITLE
Changeling husking

### DIFF
--- a/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
@@ -77,6 +77,13 @@ public sealed partial class ChangelingDevourComponent : Component
     public TimeSpan DevourConsumeTime = TimeSpan.FromSeconds(10);
 
     /// <summary>
+    /// Whether the target should get husked after devouring.
+    /// The husking is reverted after being brought back to alive state.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Husk = true;
+
+    /// <summary>
     /// The currently active devour sound in the world.
     /// </summary>
     [DataField]
@@ -104,9 +111,9 @@ public sealed partial class ChangelingDevourComponent : Component
     {
         DamageDict = new()
         {
-            { "Slash", 20},
-            { "Piercing", 20 },
-            { "Blunt", 10 },
+            { "Slash", 25},
+            { "Caustic", 50 },
+            { "Cellular", 100 }, // Total 200 damage. We don't care about stacking because you cannot devour the same body several times in one go.
         },
     };
 

--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -186,7 +186,8 @@ public sealed class ChangelingDevourSystem : EntitySystem
         var devouredEv = new ChangelingGotDevouredEvent(ent.Owner, target, becomesIdentity, uniqueIdentity, willGrantDna);
         RaiseLocalEvent(target, ref devouredEv); // Don't broadcast this one, all neccessary data is in the previous event already. Just use that one if a broadcast is needed.
 
-        _husk.TryHusk(args.Target.Value);
+        if (ent.Comp.Husk)
+            _husk.TryHusk(args.Target.Value);
 
         EnsureComp<RecentlyDevouredComponent>(target);
 

--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -9,6 +9,8 @@ using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Humanoid;
+using Content.Shared.Husking.Components;
+using Content.Shared.Husking.Systems;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory;
 using Content.Shared.Mobs.Systems;
@@ -33,6 +35,7 @@ public sealed class ChangelingDevourSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedStoreSystem _store = default!;
+    [Dependency] private readonly HuskingSystem _husk = default!;
 
     public override void Initialize()
     {
@@ -183,6 +186,8 @@ public sealed class ChangelingDevourSystem : EntitySystem
         var devouredEv = new ChangelingGotDevouredEvent(ent.Owner, target, becomesIdentity, uniqueIdentity, willGrantDna);
         RaiseLocalEvent(target, ref devouredEv); // Don't broadcast this one, all neccessary data is in the previous event already. Just use that one if a broadcast is needed.
 
+        _husk.TryHusk(args.Target.Value);
+
         EnsureComp<RecentlyDevouredComponent>(target);
 
         // Grants the DNA reward associated with a successful unique devour.
@@ -219,7 +224,7 @@ public sealed class ChangelingDevourSystem : EntitySystem
             return false;
         }
 
-        if (HasComp<RecentlyDevouredComponent>(victim))
+        if (HasComp<RecentlyDevouredComponent>(victim) || HasComp<HuskedComponent>(victim))
         {
             if (showPopup)
                 _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-devoured-recently"), changeling.Owner, changeling.Owner, PopupType.Medium);

--- a/Content.Shared/Husking/Components/HuskedComponent.cs
+++ b/Content.Shared/Husking/Components/HuskedComponent.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Husking.Systems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Husking.Components;
+
+/// <summary>
+/// Means this entity has been husked. They are unrecognizable until healed.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(HuskingSystem))]
+public sealed partial class HuskedComponent : Component
+{
+    /// <summary>
+    /// The entity storing the original appearance of this entity.
+    /// </summary>
+    [DataField]
+    public EntityUid? OriginalAppearance;
+}

--- a/Content.Shared/Husking/Systems/HuskingSystem.cs
+++ b/Content.Shared/Husking/Systems/HuskingSystem.cs
@@ -1,0 +1,117 @@
+using Content.Shared.Body;
+using Content.Shared.Cloning;
+using Content.Shared.Examine;
+using Content.Shared.Humanoid;
+using Content.Shared.Husking.Components;
+using Content.Shared.IdentityManagement;
+using Content.Shared.IdentityManagement.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Rejuvenate;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Husking.Systems;
+
+/// <summary>
+/// Handles logic regarding the <see cref="HuskedComponent"/>.
+/// Marks entities as husked, hiding their identity until healed.
+/// </summary>
+public sealed class HuskingSystem : EntitySystem
+{
+    [Dependency] private readonly SharedVisualBodySystem _visualBody = default!;
+    [Dependency] private readonly IdentitySystem _identity = default!;
+    [Dependency] private readonly SharedCloningSystem _cloning = default!;
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
+
+    private static readonly ProtoId<CloningSettingsPrototype> BaseCloningSettings = "Body";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<HuskedComponent, SeeIdentityAttemptEvent>(OnSeeIdentity);
+        SubscribeLocalEvent<HuskedComponent, ExaminedEvent>(OnHuskExamined);
+
+        SubscribeLocalEvent<HuskedComponent, ComponentShutdown>(OnHuskedShutdown);
+        SubscribeLocalEvent<HuskedComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<HuskedComponent, RejuvenateEvent>(OnRejuvenate);
+    }
+
+    private void OnMobStateChanged(Entity<HuskedComponent> ent, ref MobStateChangedEvent args)
+    {
+        if (args.NewMobState != MobState.Alive)
+            return;
+
+        Unhusk(ent.Owner);
+    }
+
+    private void OnRejuvenate(Entity<HuskedComponent> ent, ref RejuvenateEvent args)
+    {
+        Unhusk(ent.Owner);
+    }
+
+    private void OnHuskedShutdown(Entity<HuskedComponent> ent, ref ComponentShutdown args)
+    {
+        _identity.QueueIdentityUpdate(ent.Owner);
+
+        if (ent.Comp.OriginalAppearance == null)
+            return;
+
+        _visualBody.CopyAppearanceFrom(ent.Comp.OriginalAppearance.Value, ent.Owner);
+        QueueDel(ent.Comp.OriginalAppearance);
+
+        Unhusk(ent.Owner);
+    }
+
+    private void OnSeeIdentity(Entity<HuskedComponent> ent, ref SeeIdentityAttemptEvent args)
+    {
+        var species = Loc.GetString("husking-corpse-husked-species-backup");
+        if (TryComp<HumanoidProfileComponent>(ent, out var humanoid) && _protoMan.TryIndex(humanoid.Species, out var speciesPrototype))
+            species = Loc.GetString(speciesPrototype.Name).ToLower();
+
+        args.NameOverride = Loc.GetString("husking-corpse-husked", ("species", species));
+        args.TotalCoverage |= IdentityBlockerCoverage.FULL;
+    }
+
+    private void OnHuskExamined(Entity<HuskedComponent> ent, ref ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("husking-corpse-examine", ("target", Identity.Entity(ent, EntityManager))));
+    }
+
+    /// <summary>
+    /// Husks the target, hiding their identity and causing them to take on a default appearance.
+    /// Only works on valid humanoids with a valid species.
+    /// </summary>
+    /// <param name="target">The entity to husk.</param>
+    public bool TryHusk(EntityUid target)
+    {
+        if (!TryComp<HumanoidProfileComponent>(target, out var humanoid)
+            || !_protoMan.TryIndex(humanoid.Species, out var speciesPrototype))
+            return false;
+
+        if (!_cloning.TryCloning(target, MapCoordinates.Nullspace, BaseCloningSettings, out var clone))
+            return false;
+
+        var comp = EnsureComp<HuskedComponent>(target);
+        comp.OriginalAppearance = clone;
+
+        var huskedBodyAppearance = Spawn(speciesPrototype.Prototype, MapCoordinates.Nullspace);
+        _visualBody.CopyAppearanceFrom(huskedBodyAppearance, target);
+        QueueDel(huskedBodyAppearance); // We only care about it for the initial clone.
+        _identity.QueueIdentityUpdate(target);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Removes the husking effect from an entity, restoring their identity and appearance to what it was previously.
+    /// </summary>
+    /// <param name="ent">The entity to unhusk.</param>
+    public void Unhusk(Entity<HuskedComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
+            return;
+
+        RemCompDeferred<HuskedComponent>(ent);
+    }
+}

--- a/Resources/Locale/en-US/husking/husking.ftl
+++ b/Resources/Locale/en-US/husking/husking.ftl
@@ -1,0 +1,3 @@
+husking-corpse-husked = mangled {$species}
+husking-corpse-husked-species-backup = corpse
+husking-corpse-examine = [color=red]{CAPITALIZE(POSS-ADJ($target))} body is mangled beyond recognition![/color]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added husking for changeling, hiding the identity of devoured entities.
As an implementation detail, this is only temporary and gets reverted upon being revived.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Desired feature for the changeling, at least partially.
Initially husking was supposed to RR fully, however we are trying to avoid RR where possible.

Something something https://github.com/space-wizards/space-station-14/issues/39439

## Technical details
<!-- Summary of code changes for easier review. -->
When we husk an entity we clone their current appearance into nullspace for safekeeping.
When the component is removed, the nullspace dummy clones their appearance back and gets deleted.
Also the component overwrites the identity of the entity and grants it unique examine text.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/ebd30c93-bbf8-47e7-b63f-dffe8435bf6e

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
