### PR TITLE
Adjustments to booze/soda dispensers' roundstart inventories + reorganized Booze-O-Mat inventory

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -267,19 +267,22 @@
   parent: CrateFreezer
   id: CrateServiceSodaDispenser
   name: soda dispenser refill crate
-  description: Contains refills for soda dispensers.
+  description: Contains one full refill for a soda dispenser.
   components:
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:AllSelector
         children:
+        - id: DrinkCoconutWaterJug
         - id: DrinkCoffeeJug
         - id: DrinkColaBottleFull
         - id: DrinkCreamCartonXL
         - id: DrinkDrGibbJug
         - id: DrinkEnergyDrinkJug
         - id: DrinkGreenTeaJug
+        - id: DrinkGrenadineBottleFull
         - id: DrinkIceJug
+        - id: DrinkJuiceLemonCartonXL
         - id: DrinkJuiceLimeCartonXL
         - id: DrinkJuiceOrangeCartonXL
         - id: DrinkLemonLimeJug
@@ -296,19 +299,22 @@
   parent: CrateFreezer
   id: CrateServiceBoozeDispenser
   name: booze dispenser refill crate
-  description: Contains refills for booze dispensers.
+  description: Contains one full refill for a booze dispenser.
   components:
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:AllSelector
         children:
+        - id: DrinkAbsintheBottleFull
         - id: DrinkAleBottleFullGrowler
         - id: DrinkBeerGrowler
+        - id: DrinkBlueCuracaoBottleFull
         - id: DrinkCoffeeLiqueurBottleFull
         - id: DrinkCognacBottleFull
         - id: DrinkGinBottleFull
-        - id: DrinkMeadJug
+        - id: DrinkMelonLiquorBottleFull
         - id: DrinkRumBottleFull
+        - id: DrinkSakeBottleFull
         - id: DrinkTequilaBottleFull
         - id: DrinkVermouthBottleFull
         - id: DrinkVodkaBottleFull

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
@@ -1,52 +1,58 @@
 - type: vendingMachineInventory
   id: BoozeOMatInventory
   startingInventory:
-    DrinkGlass: 20 #Kept glasses at top for ease to differentiate from booze.
-    DrinkShotGlass: 10
+    # Glassware
+    DrinkGlass: 20
     DrinkGlassCoupeShaped: 10
-    DrinkVacuumFlask: 5
+    DrinkShotGlass: 10
     DrinkFlaskBar: 5
+    DrinkVacuumFlask: 5
+    # Bartending tools
     DrinkShaker: 5
     DrinkJigger: 5
-    DrinkIceBucket: 2
     BarSpoon: 3
-    CustomDrinkJug: 2 #to allow for custom drinks in the soda/booze dispensers
+    CustomDrinkJug: 2 # to allow bartenders to place custom drinks in the dispensers
+    # "Single-serving" drinks
+    DrinkBeerCan: 5
+    DrinkWineCan: 5
+    # Booze dispenser restocks
     DrinkAbsintheBottleFull: 2
     DrinkAleBottleFull: 5
     DrinkBeerBottleFull: 5
     DrinkBlueCuracaoBottleFull: 2
-    DrinkCognacBottleFull: 4
-    DrinkCoconutWaterCarton: 3
-    DrinkColaBottleFull: 4
-    DrinkEnergyDrinkCan: 8
-    DrinkMilkCarton: 2
-    DrinkCreamCarton: 5
-    DrinkGinBottleFull: 3
-    DrinkGildlagerBottleFull: 2 #if champagne gets less because its premium, then gildlager should match this and have two
-    DrinkGrenadineBottleFull: 2
-    DrinkJuiceLimeCarton: 3
-    DrinkJuiceLemonCarton: 3
-    DrinkJuicePineappleCarton: 3
-    DrinkJuiceOrangeCarton: 3
-    DrinkJuiceTomatoCarton: 3
     DrinkCoffeeLiqueurBottleFull: 3
+    DrinkCognacBottleFull: 4
+    DrinkGinBottleFull: 3
     DrinkMelonLiquorBottleFull: 3
-    DrinkPatronBottleFull: 2
     DrinkRumBottleFull: 4
-    DrinkSodaWaterCan: 8
-    DrinkSolDryCan: 8
-    DrinkSpaceMountainWindBottleFull: 3
-    DrinkSpaceUpBottleFull: 3
+    DrinkSakeBottleFull: 3
     DrinkTequilaBottleFull: 3
-    DrinkTonicWaterCan: 8
     DrinkVermouthBottleFull: 5
     DrinkVodkaBottleFull: 5
     DrinkWhiskeyBottleFull: 5
     DrinkWineBottleFull: 5
-    DrinkChampagneBottleFull: 2 #because the premium drink
-    DrinkSakeBottleFull: 3
-    DrinkBeerCan: 5
-    DrinkWineCan: 5
+    # Soda dispenser restocks
+    DrinkCoconutWaterCarton: 3
+    DrinkEnergyDrinkCan: 8
+    DrinkGrenadineBottleFull: 2
+    DrinkIceBucket: 2
+    DrinkJuiceLemonCarton: 3
+    DrinkJuiceLimeCarton: 3
+    DrinkMilkCarton: 2
+    DrinkCreamCarton: 5
+    DrinkJuiceOrangeCarton: 3
+    DrinkJuicePineappleCarton: 3
+    DrinkSodaWaterCan: 8
+    DrinkSolDryCan: 8
+    DrinkColaBottleFull: 4
+    DrinkSpaceMountainWindBottleFull: 3
+    DrinkSpaceUpBottleFull: 3
+    DrinkJuiceTomatoCarton: 3
+    DrinkTonicWaterCan: 8
+    # "Premium" drinks
+    DrinkChampagneBottleFull: 2
+    DrinkGildlagerBottleFull: 2
+    DrinkPatronBottleFull: 2
   contrabandInventory:
     ChemistryBottleEthanol: 3
     DrinkBottleOfNothingFull: 1

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
@@ -265,6 +265,22 @@
 
 - type: entity
   parent: [DrinkBaseMaterialPlastic, DrinkCartonBaseLargeFull]
+  id: DrinkJuiceLemonCartonXL
+  name: lemon juice
+  description: First it's sour, then it's still sour.
+  components:
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: JuiceLemon
+        Quantity: 240
+  - type: Label
+    currentLabel: reagent-name-juice-lemon
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/lemonjuice.rsi
+
+- type: entity
+  parent: [DrinkBaseMaterialPlastic, DrinkCartonBaseLargeFull]
   id: DrinkJuiceLimeCartonXL
   name: lime juice XL
   description: Sweet-sour goodness.

--- a/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
@@ -35,13 +35,16 @@
     containers:
       storagebase: !type:AllSelector
         children:
+        - id: DrinkAbsintheBottleFull
         - id: DrinkAleBottleFullGrowler
         - id: DrinkBeerGrowler
+        - id: DrinkBlueCuracaoBottleFull
         - id: DrinkCoffeeLiqueurBottleFull
         - id: DrinkCognacBottleFull
         - id: DrinkGinBottleFull
-        - id: DrinkMeadJug
+        - id: DrinkMelonLiquorBottleFull
         - id: DrinkRumBottleFull
+        - id: DrinkSakeBottleFull
         - id: DrinkTequilaBottleFull
         - id: DrinkVermouthBottleFull
         - id: DrinkVodkaBottleFull

--- a/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
@@ -40,7 +40,9 @@
         - id: DrinkDrGibbJug
         - id: DrinkEnergyDrinkJug
         - id: DrinkGreenTeaJug
+        - id: DrinkGrenadineBottleFull
         - id: DrinkIceJug
+        - id: DrinkJuiceLemonCartonXL
         - id: DrinkJuiceLimeCartonXL
         - id: DrinkJuiceOrangeCartonXL
         - id: DrinkLemonLimeJug


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR + Why/Balance
A collection of small tweaks to the bar's roundstart inventory.

- Absinthe, blue curacao, melon liquor, and sake now spawn in the booze dispenser roundstart.
  - These drinks are all already available in the Booze-O-Mat, so this just saves bartenders the convenience of needing to stock the machine on their own.
  - Champagne, Gildlager, and Patron have intentionally been excluded here, since thematically speaking those are "expensive" drinks that would generally be reserved for special occasions.
- Mead no longer spawns in the booze dispenser roundstart.
  - Unlike the other drinks in the booze dispenser, mead has an actual "recipe" (just sugar and universal enzyme), so placing it in the dispenser by default seems somewhat out-of-place.
- Grenadine and lemon juice now spawn in the soda dispenser roundstart.
  - Like the above booze dispenser additions, these ingredients are already available in the Booze-O-Mat.
  - I'd like to add more drinks to this list (since there's a few other ingredients that are in the Booze-O-Mat but not the dispenser, e.g milk, pineapple juice, tomato juice), but if I added any more, the roundstart inventory would be large enough that you'd need to scroll the window, which feels like it'd be unintuitive. I chose these two because, at least in my experience, they're ingredients for common drinks I see bartenders make pretty frequently (lemonade, shirley temple, roy rogers, etc).
- Adjusted booze dispenser / soda dispenser refill crates to reflect the adjusted roundstart inventories.
- Booze-O-Mat inventory is now sorted in the order of glasses -> tools -> "single-serving" bottles -> "restock" bottles -> "expensive" bottles.

A more comprehensive trim/rebalance of the bar's roundstart inventory probably needs to be done down the line, but that'd be a more involved process because we'd need to iron out:
- what ingredients the bar "should" have roundstart (as opposed to needing to buy from Cargo, have Hydroponics grow for them, etc)
- how much of any given ingredient the bar "should" have (which may be different for different ingredients; e.g, the bar probably should have more beer than champagne)

This PR is just intended to be a small quality-of-life tweak without significant impact on the "balance" of the bar, so this kind of rebalance would be out of scope.

## Technical details
<!-- Summary of code changes for easier review. -->
YAML changes only.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A (small fix)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Absinthe, blue curacao, melon liquor, and sake now spawn in the booze dispenser roundstart.
- remove: Mead no longer spawns in the booze dispenser roundstart.
- add: Grenadine and lemon juice now spawn in the soda dispenser roundstart.
- tweak: The Booze-O-Mat's inventory has been reorganized.