### PR TITLE
Removes Blunt and Heat gib for real this time.

### DIFF
--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -189,28 +189,6 @@
     thresholds:
     - trigger:
         !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 400
-      behaviors:
-      - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          FoodMeatChickenFriedVox:
-            min: 3
-            max: 5
-      - !type:BurnBodyBehavior
-        popupMessage: bodyburn-vox-text-others
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
-    - trigger:
-        !type:DamageTypeTrigger
         damageType: Radiation
         damage: 15
       behaviors:

--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -186,7 +186,6 @@
     - id: FoodMeatChicken
       amount: 5
   - type: Destructible
-    thresholds:
   - type: PassiveDamage
     # Augment normal health regen to be able to tank some Poison damage
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.

--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -185,7 +185,6 @@
     spawned:
     - id: FoodMeatChicken
       amount: 5
-  - type: Destructible
   - type: PassiveDamage
     # Augment normal health regen to be able to tank some Poison damage
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.

--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -187,21 +187,6 @@
       amount: 5
   - type: Destructible
     thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Radiation
-        damage: 15
-      behaviors:
-      - !type:PopupBehavior
-        popup: mouth-taste-metal
-        popupType: LargeCaution
-        targetOnly: true
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Radiation
-        damage: 40
-      behaviors:
-      - !type:VomitBehavior
   - type: PassiveDamage
     # Augment normal health regen to be able to tank some Poison damage
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -75,27 +75,6 @@
     thresholds:
     - trigger:
         !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 400
-      behaviors:
-      - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          Ash:
-            min: 1
-            max: 1
-      - !type:BurnBodyBehavior
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
-    - trigger:
-        !type:DamageTypeTrigger
         damageType: Radiation
         damage: 15
       behaviors:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed blunt and heat based gibbing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With very few exceptions, killing players with blunt damage is extremely easy, and often times requires no forethought. Extremely easy methods for round removal removes all tension from the round, or any actions antagonists attempt to take.
Instant gibbing methods of round removal will remain, such as the recyclers, crushers, and meatspikes, as these require some forwards planning that isn't "hit corpse with air tank until poof".
Indirectly, this will nerf explosives being used as tools to remove bodies, and this will make completing "kill X" objectives harder. It will also likely result in antags attempting to eject bodies into space, which should keep other departments busy, such as paramedics, sec, and engineering.

If someone wants to code a solution for making high yield explosions destroy bodies again, such a feature may be desired. However, the current implementation of gibbing leads to boring, and to a point, toxic gameplay.

Removing extremely easy round removal is a step towards removing 2.9 as a rule from Wizden servers as well.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed the gib behavior from humans, which all human mobs parent off of, and removed it specifically from Vox as well. Other mobs with defined gib behavior will continue to gib, mobs without this defined will not as they tend to default to humans for this.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1920" height="1080" alt="{3CD2AF15-87CA-404C-A088-BE153B42BA63}" src="https://github.com/user-attachments/assets/0a03e771-cdb6-4492-9f14-477eaf9249c7" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
This PR removes gib behavior from most humanoid mobs. If you don't want to merge this, do not merge this commit, or readd the gib behavior on your own time.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Blunt and heat based gibbing has been removed.


