### PR TITLE
Added missing localization to cargo sale console

### DIFF
--- a/Resources/Locale/en-US/cargo/cargo-pallet-console-component.ftl
+++ b/Resources/Locale/en-US/cargo/cargo-pallet-console-component.ftl
@@ -5,3 +5,4 @@ cargo-pallet-menu-appraisal-label = Estimated Value:{" "}
 cargo-pallet-menu-count-label = Number of sale items:{" "}
 cargo-pallet-appraise-button = Appraise
 cargo-pallet-sell-button = Sell
+cargo-pallet-menu-no-goods-text = Appraising...


### PR DESCRIPTION
## About the PR
Added missing localization for cargo sale console

## Media
Before

https://github.com/user-attachments/assets/9912ba4f-eef7-4059-b655-2a225bc69814

After

https://github.com/user-attachments/assets/f0b838aa-999c-4fdf-8b02-9612a6005b20



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: Added missing localization to cargo sale console.
