### PR TITLE
Can cancel orders from the console you placed it on

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -312,13 +312,18 @@ namespace Content.Server.Cargo.Systems
         {
             var station = _station.GetOwningStation(uid);
 
-            if (component.Mode != CargoOrderConsoleMode.DirectOrder)
+            if (component.Mode == CargoOrderConsoleMode.PrintSlip)
                 return;
 
             if (!TryGetOrderDatabase(station, out var orderDatabase))
                 return;
 
-            RemoveOrder(station.Value, component.Account, args.OrderId, orderDatabase);
+            if (!TryComp<StationBankAccountComponent>(station, out var bank))
+                return;
+
+            var targetAccount = component.Mode == CargoOrderConsoleMode.SendToPrimary ? bank.PrimaryAccount : component.Account;
+
+            RemoveOrder(station.Value, targetAccount, args.OrderId, orderDatabase);
         }
 
         private void OnAddOrderMessageSlipPrinter(EntityUid uid, CargoOrderConsoleComponent component, CargoConsoleAddOrderMessage args, CargoProductPrototype product)


### PR DESCRIPTION
## About the PR
Currently an order placed on a departmental request console can not be canceled using that same request console. It has been changed so that now you can cancel an order placed by a department.

## Why / Balance
#37943 Added "Send To Primary" mode for departmental request consoles. In this change the approve button was hidden for departments but the cancel button is still visible. 
```
if (component.SlipPrinter)
    return;
```
was changed to 
```
if (component.Mode != CargoOrderConsoleMode.DirectOrder)
    return;
```
within the OnRemoveOrderMessagefunction. This leads to consoles in SendToPrimary mode not being able to cancel orders.
This seems to be unintentional and instead only SlipPrinter mode shouldn't be able to cancel orders. (Not that we use that mode anymore)

## Technical details
Changed so only SlipPrinter mode will return in the OnRemoveOrderMessage function.
Copied `targetAccount` code from OnAddOrderMessage to correctly find the right account with the order in it.

## Media
Before

https://github.com/user-attachments/assets/50eaf01a-173a-4675-95b5-481b92f67a3a

After

https://github.com/user-attachments/assets/5272c1e2-4608-4557-b867-e023df109c6e

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: Fixed a bug which prevented departments from canceling their own orders from their departments request console
