### PR TITLE
Bring cargo order menu to the front when selecting a new item

### DIFF
--- a/Content.Client/Cargo/BUI/CargoOrderConsoleBoundUserInterface.cs
+++ b/Content.Client/Cargo/BUI/CargoOrderConsoleBoundUserInterface.cs
@@ -89,6 +89,7 @@ namespace Content.Client.Cargo.BUI
                 _orderMenu.Amount.Value = 1;
 
                 _orderMenu.OpenCentered();
+                _orderMenu.SetPositionLast();
             };
             _menu.OnOrderApproved += ApproveOrder;
             _menu.OnOrderCanceled += RemoveOrder;


### PR DESCRIPTION
## About the PR
Order menu moves to the front when selecting a new item from the list. Before it would stay behind other selected windows.

## Why / Balance
It's unnecessarily confusing if you accidentally click on the main window while having an order open and clicking on new items doesn't open the window again as it is hidden behind the main window.

## Technical details
Added `_orderMenu.SetPositionLast();` when you click on an item which puts the order menu to the front of the UI

## Media
Before

https://github.com/user-attachments/assets/b713073b-d87e-4b1e-8453-848130d0fcb9

After

https://github.com/user-attachments/assets/129287aa-3f13-4d79-94d3-c99bc0ce0589

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: Selecting a new item in the request computer will bring the order menu to the front