### PR TITLE
Convert owoify to toolshed.

### DIFF
--- a/Content.Server/Administration/Commands/OwoifyCommand.cs
+++ b/Content.Server/Administration/Commands/OwoifyCommand.cs
@@ -1,46 +1,31 @@
 using Content.Server.Speech.EntitySystems;
 using Content.Shared.Administration;
-using Robust.Shared.Console;
+using Robust.Shared.Toolshed;
 
 namespace Content.Server.Administration.Commands;
 
-[AdminCommand(AdminFlags.Fun)]
-public sealed class OwoifyCommand : IConsoleCommand
+[ToolshedCommand, AdminCommand(AdminFlags.Fun)]
+public sealed class OwoifyCommand : ToolshedCommand
 {
-    [Dependency] private readonly IEntityManager _entManager = default!;
+    private MetaDataSystem? _metaSystem;
+    private OwOAccentSystem? _owoSystem;
 
-    public string Command => "owoify";
-
-    public string Description => "For when you need everything to be cat. Uses OwOAccent's formatting on the name and description of an entity.";
-
-    public string Help => "owoify <id>";
-
-    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    [CommandImplementation]
+    public void Owoify(EntityUid entity)
     {
-        if (args.Length != 1)
+        var meta = Comp<MetaDataComponent>(entity);
+        _owoSystem ??=GetSys<OwOAccentSystem>();
+        _metaSystem ??= GetSys<MetaDataSystem>();
+        _metaSystem.SetEntityName(entity, _owoSystem.Accentuate(meta.EntityName), meta);
+        _metaSystem.SetEntityDescription(entity, _owoSystem.Accentuate(meta.EntityDescription), meta);
+    }
+
+    [CommandImplementation]
+    public void Owoify([PipedArgument] IEnumerable<EntityUid> entities)
+    {
+        foreach (var entity in entities)
         {
-            shell.WriteLine(Loc.GetString("shell-wrong-arguments-number"));
-            return;
+            Owoify(entity);
         }
-
-        if (!int.TryParse(args[0], out var targetId))
-        {
-            shell.WriteLine(Loc.GetString("shell-argument-must-be-number"));
-            return;
-        }
-
-        var nent = new NetEntity(targetId);
-
-        if (!_entManager.TryGetEntity(nent, out var eUid))
-        {
-            return;
-        }
-
-        var meta = _entManager.GetComponent<MetaDataComponent>(eUid.Value);
-
-        var owoSys = _entManager.System<OwOAccentSystem>();
-        var metaDataSys = _entManager.System<MetaDataSystem>();
-        metaDataSys.SetEntityName(eUid.Value, owoSys.Accentuate(meta.EntityName), meta);
-        metaDataSys.SetEntityDescription(eUid.Value, owoSys.Accentuate(meta.EntityDescription), meta);
     }
 }

--- a/Resources/Locale/en-US/commands/toolshed/owoify-command.ftl
+++ b/Resources/Locale/en-US/commands/toolshed/owoify-command.ftl
@@ -1,0 +1,1 @@
+﻿command-description-owoify = For when you need everything to be cat. Uses OwOAccent's formatting on the name and description of an entity.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Accidentally cucked my work on the last one. Whoops lmao

Converts owoify to toolshed. Incredibly simple conversion.

## Why / Balance
Toolshed and cleanup good.

## Technical details
Remove the now redundant argument checks and conversions. Toolshed handles all of it.
Localized the command description. Added an implementation for mass owoifying.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="341" height="262" alt="{5F71FC1B-FFD3-410E-97B2-41138D0A64EB}" src="https://github.com/user-attachments/assets/ea5cde54-d837-44aa-b937-a1bbcbbd47aa" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: owoify execution flow has changed. the command must now be run remotely using > owoify <entity uid>.
- add: you can now pipe in a list of entities to owoify for mass owoification. > entities owoify.
