### PR TITLE
Adds temperature protection to scarves

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
@@ -37,6 +37,9 @@
   parent: ClothingNeckBase
   id: ClothingScarfBase
   components:
+  - type: TemperatureProtection
+    heatingCoefficient: 1.025
+    coolingCoefficient: 0.5
   - type: Tag
     tags:
     - Scarf

--- a/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
@@ -37,12 +37,12 @@
   parent: ClothingNeckBase
   id: ClothingScarfBase
   components:
-  - type: TemperatureProtection
-    heatingCoefficient: 1.025
-    coolingCoefficient: 0.5
   - type: Tag
     tags:
     - Scarf
     - ClothMade
     - Recyclable
     - WhitelistChameleon
+  - type: TemperatureProtection
+    heatingCoefficient: 1.025
+    coolingCoefficient: 0.5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR adds temperature protection to scarves equivalent to that of winter boots

Changelog is... probably fine. I'm not sure if I should state "it also makes you more vulnerable to heat" or how I could even fit that in. It gets across the main thing

## Why / Balance
I fully assumed scarves would help insulate from cold and they don't
This PR also provides an alternative to winter coats for people who don't want to compromise as much on fashion when on cold maps or whatever

This probably shouldn't matter *that* much in terms of balance? Becoming effectively immune to being cooled down in space can already be done with a hooded winter coat and boots.

Boots and a scarf aren't enough to protect from space temps. Neither is a scarf+hoodless winter coat+winter boots combo

I'm not sure about balancing. I'm usually not

## Media
<img width="722" height="113" alt="image" src="https://github.com/user-attachments/assets/40137f45-bb90-421b-a39a-bc1e34f1ad0c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- tweak: Scarves now help insulate from cold temperatures. This is equivalent to the protection of winter boots.