### PR TITLE
Fix gun upgrades not immediately updating gun effects

### DIFF
--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -84,10 +84,10 @@ public sealed class GunUpgradeSystem : EntitySystem
             return;
         }
 
+        args.Handled = _container.Insert(args.Used, _container.GetContainer(ent, ent.Comp.UpgradesContainerId));
         _audio.PlayPredicted(ent.Comp.InsertSound, ent, args.User);
         _popup.PopupClient(Loc.GetString("gun-upgrade-popup-insert", ("upgrade", args.Used),("gun", ent.Owner)), args.User);
         _gun.RefreshModifiers(ent.Owner);
-        args.Handled = _container.Insert(args.Used, _container.GetContainer(ent, ent.Comp.UpgradesContainerId));
 
         _adminLog.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(args.User):player} inserted gun upgrade {ToPrettyString(args.Used)} into {ToPrettyString(ent.Owner)}.");
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Bugfix so that PKA mods apply their effects immediately instead of needing you to wield the thing to force it to update.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfix

## Technical details
<!-- Summary of code changes for easier review. Only required for complex changes-->
Previously, it worked like
- click PKA mod on PKA
- "you clicked the PKA" handler runs
  - it does a bunch of checks
  - it refreshes gun mod modifiers
  - it finally inserts the PKA mod

The issue is that the insertion happens after the modifier recalculation, which looks at inserted modules to determine effects.
Dumb bug.

Fix by reordering. e z p z

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Small, n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: PKA mods now apply their effects immediately upon inserting, instead of requiring somebody to wield them to update with the mods' effects.
