### PR TITLE
 build task configuration fix 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,6 +270,8 @@ __pycache__/
 !.vscode/extensions.json
 !.vscode/launch.json
 !.vscode/tasks.json
+# Visual Studio Code C# Dev kit cache files.
+*.csproj.lscache
 
 # Release package files go here:
 release/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,7 +49,6 @@
                 "Server",
                 "Client"
             ],
-            "preLaunchTask": "build"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,6 +18,24 @@
             "problemMatcher": "$msCompile"
         },
         {
+            "label": "build (legacy)",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "/property:GenerateFullPaths=true", // Ask dotnet build to generate full paths for file names.
+                "/consoleloggerparameters:'ForceNoAlign;NoSummary'" // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+            ],
+            "group": {
+                "kind": "build",
+           
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
             "label": "build-yaml-linter",
             "command": "dotnet",
             "type": "process",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -27,8 +27,7 @@
                 "/consoleloggerparameters:'ForceNoAlign;NoSummary'" // Do not generate summary otherwise it leads to duplicate errors in Problems panel
             ],
             "group": {
-                "kind": "build",
-           
+                "kind": "build",    
             },
             "presentation": {
                 "reveal": "silent"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,13 +5,9 @@
     "tasks": [
         {
             "label": "build",
-            "command": "dotnet",
-            "type": "shell",
-            "args": [
-                "build",
-                "/property:GenerateFullPaths=true", // Ask dotnet build to generate full paths for file names.
-                "/consoleloggerparameters:'ForceNoAlign;NoSummary'" // Do not generate summary otherwise it leads to duplicate errors in Problems panel
-            ],
+            "type": "dotnet",
+            "task": "build",
+            "icon": { "id": "build","color": "terminal.ansiBlue" },
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,10 +4,14 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "build",
+            "label": "build (C# Dev Kit)",
+            "detail": "needs C# Dev Kit extention. use the (build) task instead if you dont have the extention.",
             "type": "dotnet",
             "task": "build",
-            "icon": { "id": "build","color": "terminal.ansiBlue" },
+            "icon": {
+                "id": "build",
+                "color": "terminal.ansiBlue"
+            },
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -15,10 +19,13 @@
             "presentation": {
                 "reveal": "silent"
             },
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "runOptions": {
+                "instanceLimit": 1
+            }
         },
         {
-            "label": "build (legacy)",
+            "label": "build",
             "command": "dotnet",
             "type": "shell",
             "args": [
@@ -27,12 +34,15 @@
                 "/consoleloggerparameters:'ForceNoAlign;NoSummary'" // Do not generate summary otherwise it leads to duplicate errors in Problems panel
             ],
             "group": {
-                "kind": "build",    
+                "kind": "build"
             },
             "presentation": {
                 "reveal": "silent"
             },
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "runOptions": {
+                "instanceLimit": 1
+            }
         },
         {
             "label": "build-yaml-linter",


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
changed build task to use the in the [c# dev kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) defined type "dotnet". 
which allows the build to switch config with the toolbar in vscode 
<img width="238" height="39" alt="image" src="https://github.com/user-attachments/assets/7a014727-7628-4ad4-a928-7f45da2a25a2" />
which was previously ignored as the task was static and just ran dotnet build with default config 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
i noticed that i got assert exceptions while on tools or on release which they should have been ignored on them.
i did a bit of testing and researching and found that the C# dev kit extention supplied the option to change the config in the tool bar but the build task not actually changing when its used and i fixed that 
## Technical details
<!-- Summary of code changes for easier review. -->
replaced type `shell` with `dotnet`
added an blue build icon to the task
removed args as they arent needed anymore as the extention handles them 
removed predebugtask from the client/server launch task

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

- vscode: default build task requires  [c# dev kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit)  extension
- removed predebugtask build from client/server launch task. build now needs to be done seperatly from starting debug



