### PR TITLE
Allow PaperVisualsComponent to specify default text colour

### DIFF
--- a/Content.Client/Paper/UI/PaperVisualsComponent.cs
+++ b/Content.Client/Paper/UI/PaperVisualsComponent.cs
@@ -107,10 +107,12 @@ public sealed partial class PaperVisualsComponent : Component
     public int ContentImageNumLines = 1;
 
     /// <summary>
-    ///     Modulate the style's font by this color
+    ///     Optional default color for text written on the paper. Useful to
+    ///     specify light color text for use on dark backgrounds. Paper text
+    ///     can still use markup to override color for subsections.
     /// </summary>
     [DataField]
-    public Color FontAccentColor = new Color(223, 223, 213);
+    public Color? DefaultTextColor = null;
 
     /// <summary>
     ///     This can enforce that your paper has a limited area to write in.

--- a/Content.Client/Paper/UI/PaperWindow.xaml.cs
+++ b/Content.Client/Paper/UI/PaperWindow.xaml.cs
@@ -23,7 +23,9 @@ namespace Content.Client.Paper.UI
 
         private static Color DefaultTextColor = new(25, 25, 25);
 
-        // <summary>
+        // Default color for text which hasn't been changed using markup
+        private Color _writtenTextColor = DefaultTextColor;
+
         // Size of resize handles around the paper
         private const int DRAG_MARGIN_SIZE = 16;
 
@@ -152,8 +154,7 @@ namespace Content.Client.Paper.UI
                     visuals.FooterMargin.Right, visuals.FooterMargin.Bottom);
 
             PaperContent.ModulateSelfOverride = visuals.ContentImageModulate;
-            WrittenTextLabel.ModulateSelfOverride = visuals.FontAccentColor;
-            FillStatus.ModulateSelfOverride = visuals.FontAccentColor;
+            _writtenTextColor = visuals.DefaultTextColor ?? DefaultTextColor;
 
             var contentImage = visuals.ContentImagePath != null ? _resCache.GetResource<TextureResource>(visuals.ContentImagePath) : null;
             if (contentImage != null)
@@ -271,7 +272,7 @@ namespace Content.Client.Paper.UI
             {
                 msg.AddMarkupPermissive("\r\n");
             }
-            WrittenTextLabel.SetMessage(msg, UserFormattableTags.BaseAllowedTags, DefaultTextColor);
+            WrittenTextLabel.SetMessage(msg, UserFormattableTags.BaseAllowedTags, _writtenTextColor);
 
             WrittenTextLabel.Visible = !isEditing && state.Text.Length > 0;
             BlankPaperIndicator.Visible = !isEditing && state.Text.Length == 0;

--- a/Content.Client/Tips/TippyUI.xaml.cs
+++ b/Content.Client/Tips/TippyUI.xaml.cs
@@ -23,7 +23,10 @@ public sealed partial class TippyUI : UIWidget
         if (visuals == null)
             return;
 
-        Label.ModulateSelfOverride = visuals.FontAccentColor;
+        if (visuals.DefaultTextColor != null)
+        {
+            Label.ModulateSelfOverride = visuals.DefaultTextColor;
+        }
 
         if (visuals.BackgroundImagePath == null)
             return;

--- a/Content.Client/Tips/TippyUI.xaml.cs
+++ b/Content.Client/Tips/TippyUI.xaml.cs
@@ -24,9 +24,7 @@ public sealed partial class TippyUI : UIWidget
             return;
 
         if (visuals.DefaultTextColor != null)
-        {
             Label.ModulateSelfOverride = visuals.DefaultTextColor;
-        }
 
         if (visuals.BackgroundImagePath == null)
             return;

--- a/Content.Client/Tips/TippyUIController.cs
+++ b/Content.Client/Tips/TippyUIController.cs
@@ -143,7 +143,7 @@ public sealed class TippyUIController : UIController
                     paper.BackgroundImagePath = "/Textures/Interface/Paper/paper_background_default.svg.96dpi.png";
                     paper.BackgroundPatchMargin = new(16f, 16f, 16f, 16f);
                     paper.BackgroundModulate = new(255, 255, 204);
-                    paper.FontAccentColor = new(0, 0, 0);
+                    paper.DefaultTextColor = new(0, 0, 0);
                 }
                 tippy.InitLabel(EntityManager.GetComponentOrNull<PaperVisualsComponent>(_entity), _resCache);
 

--- a/Resources/Prototypes/Entities/Debugging/tippy.yml
+++ b/Resources/Prototypes/Entities/Debugging/tippy.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: Tippy
   categories: [ HideSpawnMenu ]
   components:
@@ -17,7 +17,7 @@
       state: down
       visible: false
       map: [ "speaking" ]
-  # footstep sounds wile waddling onto the screen. 
+  # footstep sounds while waddling onto the screen.
   - type: FootstepModifier
     footstepSoundCollection:
       collection: FootstepClown
@@ -27,4 +27,4 @@
     backgroundImagePath: "/Textures/Interface/Paper/paper_background_default.svg.96dpi.png"
     backgroundPatchMargin: 16.0, 16.0, 16.0, 16.0
     backgroundModulate: "#ffffcc"
-    fontAccentColor: "#000000"
+    defaultTextColor: "#000000"

--- a/Resources/Prototypes/Entities/Objects/Misc/business_card.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/business_card.yml
@@ -20,6 +20,7 @@
       headerImagePath: "/Textures/Interface/Paper/paper_heading_syndicate_logo.svg.96dpi.png"
       headerMargin: 0.0, 0.0, 0.0, 2.0
       backgroundImagePath: "/Textures/Interface/Paper/paper_background_blood_red.svg.96dpi.png"
+      defaultTextColor: "#dbe1e8"
       backgroundPatchMargin: 16.0, 16.0, 16.0, 16.0
       contentMargin: 4.0, 4.0, 4.0, 4.0
       maxWritableArea: 400.0, 256.0


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Allow PaperVisualsComponent to specify default colour for text. Fixes #43834.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

PaperVisualsComponent currently has a FontAccentColor, which is used to modulate the text colour. This may have been useful once upon a time, but now, as the default text colour is very dark, it can't reasonably control the text colour at all, and text will always appear somewhere between very dark and very very very dark.

Replacing this field with a `DefaultTextColor` allows for much more flexibility here. People writing papers can still use markup to specify custom colours as they deem fit, but now a prototype can specify a sane default without players having to do so.

## Technical details
<!-- Summary of code changes for easier review. -->

All very straightforward.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

As an example of how this is more useful, this PR also modifies the syndicate business card, which is the only paper with a dark background. Previously, the business card had eye-straining text:

<img width="446" height="317" alt="CardBefore" src="https://github.com/user-attachments/assets/16ff6a20-0343-44f3-8fc8-bee078e5b4b9" />

And now it's much more pleasant:

<img width="469" height="334" alt="CardAfter" src="https://github.com/user-attachments/assets/c35ae255-3844-4d3c-888d-df766a38ba2e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

`PaperVisualsComponent.FontAccentColor` has been replaced with a much more flexible `PaperVisualsComponent.DefaultTextColor`, allowing you to specify the default color for text written on the paper. 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
