### PR TITLE
Speedboots Nerf

### DIFF
--- a/.run/Content Server+Client.run.xml
+++ b/.run/Content Server+Client.run.xml
@@ -1,7 +1,5 @@
 ﻿<component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Content Server+Client" type="CompoundRunConfigurationType">
-    <toRun name="Content.Client" type="DotNetProject" />
-    <toRun name="Content.Server" type="DotNetProject" />
     <method v="2" />
   </configuration>
 </component>

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -136,8 +136,8 @@
   - type: ToggleClothing
     action: ActionToggleSpeedBoots
   - type: ClothingSpeedModifier
-    walkModifier: 1.5
-    sprintModifier: 1.5
+    walkModifier: 1.2
+    sprintModifier: 1.2
     standing: true
   - type: Appearance
   - type: GenericVisualizer
@@ -149,7 +149,7 @@
   - type: StaticPrice
     price: 500
   - type: PowerCellDraw
-    drawRate: 4
+    drawRate: 15
   - type: ToggleCellDraw
   - type: ItemSlots
     slots:


### PR DESCRIPTION
## About the PR
Nerfs speedboots reducing their speed from 1.5x to 1,2x and increases their power draw to 15 from 4 so it actually detracts from microcells overtime

## Why / Balance
Speedboots are incredibly oppressive, speed is one of the biggest factors in a fight and this gives free speed for next to no cost at all. The changes seek to reign them in just a tad bit more whilst still keeping them strong. 20% extra speed is still huge but it's actually tolerable to fight. 

## Technical details
Just yaml

## Media

https://github.com/user-attachments/assets/c1644fe4-221f-4de1-a53d-8a527cee01d2




## Requirements
 [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
 [x] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes

**Changelog**
:cl:
- tweak: Reduced speed of speedboots and increased their power consumption

