### PR TITLE
Code Cleanup Example: Admin Log Add tests

### DIFF
--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -26,8 +26,6 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task AddAndGetSingleLog()
     {
-        var sEntities = Server.ResolveDependency<IEntityManager>();
-
         var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
 
         var guid = Guid.NewGuid();
@@ -36,7 +34,7 @@ public sealed class AddTests : GameTest
         var coordinates = Pair.TestMap!.GridCoords;
         await Server.WaitPost(() =>
         {
-            var entity = sEntities.SpawnEntity(null, coordinates);
+            var entity = SEntMan.SpawnEntity(null, coordinates);
 
             sAdminLogSystem.Add(LogType.Unknown, $"{entity:Entity} test log: {guid}");
         });
@@ -68,7 +66,6 @@ public sealed class AddTests : GameTest
     public async Task AddAndGetUnformattedLog()
     {
         var sDatabase = Server.ResolveDependency<IServerDbManager>();
-        var sEntities = Server.ResolveDependency<IEntityManager>();
         var sSystems = Server.ResolveDependency<IEntitySystemManager>();
 
         var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
@@ -80,7 +77,7 @@ public sealed class AddTests : GameTest
         var coordinates = testMap.GridCoords;
         await Server.WaitPost(() =>
         {
-            var entity = sEntities.SpawnEntity(null, coordinates);
+            var entity = SEntMan.SpawnEntity(null, coordinates);
 
             sAdminLogSystem.Add(LogType.Unknown, $"{entity} test log: {guid}");
         });
@@ -128,14 +125,13 @@ public sealed class AddTests : GameTest
     [TestCase(500)]
     public async Task BulkAddLogs(int amount)
     {
-        var sEntities = Server.ResolveDependency<IEntityManager>();
         var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
 
         var testMap = await Pair.CreateTestMap();
         var coordinates = testMap.GridCoords;
         await Server.WaitPost(() =>
         {
-            var entity = sEntities.SpawnEntity(null, coordinates);
+            var entity = SEntMan.SpawnEntity(null, coordinates);
 
             for (var i = 0; i < amount; i++)
             {

--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -37,7 +37,7 @@ public sealed class AddTests : GameTest
         var coordinates = Pair.TestMap!.GridCoords;
         await Server.WaitPost(() =>
         {
-            var entity = SEntMan.SpawnEntity(null, coordinates);
+            var entity = SSpawnAtPosition(null, coordinates);
 
             _sAdminLogManager.Add(LogType.Unknown, $"{entity:Entity} test log: {guid}");
         });
@@ -74,7 +74,7 @@ public sealed class AddTests : GameTest
         var coordinates = testMap.GridCoords;
         await Server.WaitPost(() =>
         {
-            var entity = SEntMan.SpawnEntity(null, coordinates);
+            var entity = SSpawnAtPosition(null, coordinates);
 
             _sAdminLogManager.Add(LogType.Unknown, $"{entity} test log: {guid}");
         });
@@ -126,7 +126,7 @@ public sealed class AddTests : GameTest
         var coordinates = testMap.GridCoords;
         await Server.WaitPost(() =>
         {
-            var entity = SEntMan.SpawnEntity(null, coordinates);
+            var entity = SSpawnAtPosition(null, coordinates);
 
             for (var i = 0; i < amount; i++)
             {

--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -26,23 +26,22 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task AddAndGetSingleLog()
     {
-        var server = Pair.Server;
-        var sEntities = server.ResolveDependency<IEntityManager>();
+        var sEntities = Server.ResolveDependency<IEntityManager>();
 
-        var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
+        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
 
         var guid = Guid.NewGuid();
 
         await Pair.CreateTestMap();
         var coordinates = Pair.TestMap!.GridCoords;
-        await server.WaitPost(() =>
+        await Server.WaitPost(() =>
         {
             var entity = sEntities.SpawnEntity(null, coordinates);
 
             sAdminLogSystem.Add(LogType.Unknown, $"{entity:Entity} test log: {guid}");
         });
 
-        await PoolManager.WaitUntil(server, async () =>
+        await PoolManager.WaitUntil(Server, async () =>
         {
             var logs = sAdminLogSystem.CurrentRoundJson(new LogFilter
             {
@@ -68,20 +67,18 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task AddAndGetUnformattedLog()
     {
-        var server = Pair.Server;
+        var sDatabase = Server.ResolveDependency<IServerDbManager>();
+        var sEntities = Server.ResolveDependency<IEntityManager>();
+        var sSystems = Server.ResolveDependency<IEntitySystemManager>();
 
-        var sDatabase = server.ResolveDependency<IServerDbManager>();
-        var sEntities = server.ResolveDependency<IEntityManager>();
-        var sSystems = server.ResolveDependency<IEntitySystemManager>();
-
-        var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
+        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
         var sGamerTicker = sSystems.GetEntitySystem<GameTicker>();
 
         var guid = Guid.NewGuid();
 
         var testMap = await Pair.CreateTestMap();
         var coordinates = testMap.GridCoords;
-        await server.WaitPost(() =>
+        await Server.WaitPost(() =>
         {
             var entity = sEntities.SpawnEntity(null, coordinates);
 
@@ -90,7 +87,7 @@ public sealed class AddTests : GameTest
 
         SharedAdminLog log = default;
 
-        await PoolManager.WaitUntil(server, async () =>
+        await PoolManager.WaitUntil(Server, async () =>
         {
             var logs = await sAdminLogSystem.CurrentRoundLogs(new LogFilter
             {
@@ -131,14 +128,12 @@ public sealed class AddTests : GameTest
     [TestCase(500)]
     public async Task BulkAddLogs(int amount)
     {
-        var server = Pair.Server;
-
-        var sEntities = server.ResolveDependency<IEntityManager>();
-        var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
+        var sEntities = Server.ResolveDependency<IEntityManager>();
+        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
 
         var testMap = await Pair.CreateTestMap();
         var coordinates = testMap.GridCoords;
-        await server.WaitPost(() =>
+        await Server.WaitPost(() =>
         {
             var entity = sEntities.SpawnEntity(null, coordinates);
 
@@ -148,7 +143,7 @@ public sealed class AddTests : GameTest
             }
         });
 
-        await PoolManager.WaitUntil(server, async () =>
+        await PoolManager.WaitUntil(Server, async () =>
         {
             var messages = await sAdminLogSystem.CurrentRoundLogs();
             return messages.Count >= amount;
@@ -158,14 +153,12 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task AddPlayerSessionLog()
     {
-        var server = Pair.Server;
+        var sPlayers = Server.ResolveDependency<IPlayerManager>();
 
-        var sPlayers = server.ResolveDependency<IPlayerManager>();
-
-        var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
+        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
         Guid playerGuid = default;
 
-        await server.WaitPost(() =>
+        await Server.WaitPost(() =>
         {
             var player = sPlayers.Sessions.First();
             playerGuid = player.UserId;
@@ -176,7 +169,7 @@ public sealed class AddTests : GameTest
             });
         });
 
-        await PoolManager.WaitUntil(server, async () =>
+        await PoolManager.WaitUntil(Server, async () =>
         {
             var logs = await sAdminLogSystem.CurrentRoundLogs();
             if (logs.Count == 0)
@@ -192,21 +185,19 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task DuplicatePlayerDoesNotThrowTest()
     {
-        var server = Pair.Server;
-
-        var sPlayers = server.ResolveDependency<IPlayerManager>();
-        var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
+        var sPlayers = Server.ResolveDependency<IPlayerManager>();
+        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
 
         var guid = Guid.NewGuid();
 
-        await server.WaitPost(() =>
+        await Server.WaitPost(() =>
         {
             var player = sPlayers.Sessions.Single();
 
             sAdminLogSystem.Add(LogType.Unknown, $"{player} {player} test log: {guid}");
         });
 
-        await PoolManager.WaitUntil(server, async () =>
+        await PoolManager.WaitUntil(Server, async () =>
         {
             var logs = await sAdminLogSystem.CurrentRoundLogs(new LogFilter
             {
@@ -225,22 +216,20 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task DuplicatePlayerIdDoesNotThrowTest()
     {
-        var server = Pair.Server;
+        var sPlayers = Server.ResolveDependency<IPlayerManager>();
 
-        var sPlayers = server.ResolveDependency<IPlayerManager>();
-
-        var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
+        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
 
         var guid = Guid.NewGuid();
 
-        await server.WaitPost(() =>
+        await Server.WaitPost(() =>
         {
             var player = sPlayers.Sessions.Single();
 
             sAdminLogSystem.Add(LogType.Unknown, $"{player:first} {player:second} test log: {guid}");
         });
 
-        await PoolManager.WaitUntil(server, async () =>
+        await PoolManager.WaitUntil(Server, async () =>
         {
             var logs = await sAdminLogSystem.CurrentRoundLogs(new LogFilter
             {
@@ -269,29 +258,27 @@ public sealed class PreRoundAddTests : GameTest
     [Test]
     public async Task PreRoundAddAndGetSingle()
     {
-        var server = Pair.Server;
+        var sDatabase = Server.ResolveDependency<IServerDbManager>();
+        var sSystems = Server.ResolveDependency<IEntitySystemManager>();
 
-        var sDatabase = server.ResolveDependency<IServerDbManager>();
-        var sSystems = server.ResolveDependency<IEntitySystemManager>();
-
-        var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
+        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
         var sGamerTicker = sSystems.GetEntitySystem<GameTicker>();
 
         var guid = Guid.NewGuid();
 
-        await server.WaitPost(() =>
+        await Server.WaitPost(() =>
         {
             sAdminLogSystem.Add(LogType.Unknown, $"test log: {guid}");
         });
 
-        await server.WaitPost(() =>
+        await Server.WaitPost(() =>
         {
             sGamerTicker.StartRound(true);
         });
 
         SharedAdminLog log = default;
 
-        await PoolManager.WaitUntil(server, async () =>
+        await PoolManager.WaitUntil(Server, async () =>
         {
             var logs = await sAdminLogSystem.CurrentRoundLogs(new LogFilter
             {

--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -26,16 +26,15 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task AddAndGetSingleLog()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var server = Pair.Server;
         var sEntities = server.ResolveDependency<IEntityManager>();
 
         var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
 
         var guid = Guid.NewGuid();
 
-        await pair.CreateTestMap();
-        var coordinates = pair.TestMap!.GridCoords;
+        await Pair.CreateTestMap();
+        var coordinates = Pair.TestMap!.GridCoords;
         await server.WaitPost(() =>
         {
             var entity = sEntities.SpawnEntity(null, coordinates);
@@ -69,8 +68,7 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task AddAndGetUnformattedLog()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var server = Pair.Server;
 
         var sDatabase = server.ResolveDependency<IServerDbManager>();
         var sEntities = server.ResolveDependency<IEntityManager>();
@@ -81,7 +79,7 @@ public sealed class AddTests : GameTest
 
         var guid = Guid.NewGuid();
 
-        var testMap = await pair.CreateTestMap();
+        var testMap = await Pair.CreateTestMap();
         var coordinates = testMap.GridCoords;
         await server.WaitPost(() =>
         {
@@ -133,13 +131,12 @@ public sealed class AddTests : GameTest
     [TestCase(500)]
     public async Task BulkAddLogs(int amount)
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var server = Pair.Server;
 
         var sEntities = server.ResolveDependency<IEntityManager>();
         var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
 
-        var testMap = await pair.CreateTestMap();
+        var testMap = await Pair.CreateTestMap();
         var coordinates = testMap.GridCoords;
         await server.WaitPost(() =>
         {
@@ -161,8 +158,7 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task AddPlayerSessionLog()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var server = Pair.Server;
 
         var sPlayers = server.ResolveDependency<IPlayerManager>();
 
@@ -196,8 +192,7 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task DuplicatePlayerDoesNotThrowTest()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var server = Pair.Server;
 
         var sPlayers = server.ResolveDependency<IPlayerManager>();
         var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
@@ -230,8 +225,7 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task DuplicatePlayerIdDoesNotThrowTest()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var server = Pair.Server;
 
         var sPlayers = server.ResolveDependency<IPlayerManager>();
 
@@ -275,8 +269,7 @@ public sealed class PreRoundAddTests : GameTest
     [Test]
     public async Task PreRoundAddAndGetSingle()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var server = Pair.Server;
 
         var sDatabase = server.ResolveDependency<IServerDbManager>();
         var sSystems = server.ResolveDependency<IEntitySystemManager>();

--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -2,13 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Server.Administration.Logs;
 using Content.Server.Database;
 using Content.Server.GameTicking;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Robust.Server.Player;
-using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.Administration.Logs;
 
@@ -23,11 +23,14 @@ public sealed class AddTests : GameTest
         Connected = true
     };
 
+    [SidedDependency(Side.Server)] private readonly IAdminLogManager _sAdminLogManager = null!;
+    [SidedDependency(Side.Server)] private readonly IServerDbManager _sDbManager = null!;
+    [SidedDependency(Side.Server)] private readonly GameTicker _sGameTicker = null!;
+    [SidedDependency(Side.Server)] private readonly IPlayerManager _sPlayerManager = null!;
+
     [Test]
     public async Task AddAndGetSingleLog()
     {
-        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
-
         var guid = Guid.NewGuid();
 
         await Pair.CreateTestMap();
@@ -36,12 +39,12 @@ public sealed class AddTests : GameTest
         {
             var entity = SEntMan.SpawnEntity(null, coordinates);
 
-            sAdminLogSystem.Add(LogType.Unknown, $"{entity:Entity} test log: {guid}");
+            _sAdminLogManager.Add(LogType.Unknown, $"{entity:Entity} test log: {guid}");
         });
 
         await PoolManager.WaitUntil(Server, async () =>
         {
-            var logs = sAdminLogSystem.CurrentRoundJson(new LogFilter
+            var logs = _sAdminLogManager.CurrentRoundJson(new LogFilter
             {
                 Search = guid.ToString()
             });
@@ -65,12 +68,6 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task AddAndGetUnformattedLog()
     {
-        var sDatabase = Server.ResolveDependency<IServerDbManager>();
-        var sSystems = Server.ResolveDependency<IEntitySystemManager>();
-
-        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
-        var sGamerTicker = sSystems.GetEntitySystem<GameTicker>();
-
         var guid = Guid.NewGuid();
 
         var testMap = await Pair.CreateTestMap();
@@ -79,14 +76,14 @@ public sealed class AddTests : GameTest
         {
             var entity = SEntMan.SpawnEntity(null, coordinates);
 
-            sAdminLogSystem.Add(LogType.Unknown, $"{entity} test log: {guid}");
+            _sAdminLogManager.Add(LogType.Unknown, $"{entity} test log: {guid}");
         });
 
         SharedAdminLog log = default;
 
         await PoolManager.WaitUntil(Server, async () =>
         {
-            var logs = await sAdminLogSystem.CurrentRoundLogs(new LogFilter
+            var logs = await _sAdminLogManager.CurrentRoundLogs(new LogFilter
             {
                 Search = guid.ToString()
             });
@@ -102,12 +99,12 @@ public sealed class AddTests : GameTest
 
         var filter = new LogFilter
         {
-            Round = sGamerTicker.RoundId,
+            Round = _sGameTicker.RoundId,
             Search = log.Message,
             Types = new HashSet<LogType> { log.Type },
         };
 
-        await foreach (var json in sDatabase.GetAdminLogsJson(filter))
+        await foreach (var json in _sDbManager.GetAdminLogsJson(filter))
         {
             var root = json.RootElement;
 
@@ -125,8 +122,6 @@ public sealed class AddTests : GameTest
     [TestCase(500)]
     public async Task BulkAddLogs(int amount)
     {
-        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
-
         var testMap = await Pair.CreateTestMap();
         var coordinates = testMap.GridCoords;
         await Server.WaitPost(() =>
@@ -135,13 +130,13 @@ public sealed class AddTests : GameTest
 
             for (var i = 0; i < amount; i++)
             {
-                sAdminLogSystem.Add(LogType.Unknown, $"{entity:Entity} test log.");
+                _sAdminLogManager.Add(LogType.Unknown, $"{entity:Entity} test log.");
             }
         });
 
         await PoolManager.WaitUntil(Server, async () =>
         {
-            var messages = await sAdminLogSystem.CurrentRoundLogs();
+            var messages = await _sAdminLogManager.CurrentRoundLogs();
             return messages.Count >= amount;
         });
     }
@@ -149,25 +144,22 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task AddPlayerSessionLog()
     {
-        var sPlayers = Server.ResolveDependency<IPlayerManager>();
-
-        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
         Guid playerGuid = default;
 
         await Server.WaitPost(() =>
         {
-            var player = sPlayers.Sessions.First();
+            var player = _sPlayerManager.Sessions.First();
             playerGuid = player.UserId;
 
             Assert.DoesNotThrow(() =>
             {
-                sAdminLogSystem.Add(LogType.Unknown, $"{player:Player} test log.");
+                _sAdminLogManager.Add(LogType.Unknown, $"{player:Player} test log.");
             });
         });
 
         await PoolManager.WaitUntil(Server, async () =>
         {
-            var logs = await sAdminLogSystem.CurrentRoundLogs();
+            var logs = await _sAdminLogManager.CurrentRoundLogs();
             if (logs.Count == 0)
             {
                 return false;
@@ -181,21 +173,18 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task DuplicatePlayerDoesNotThrowTest()
     {
-        var sPlayers = Server.ResolveDependency<IPlayerManager>();
-        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
-
         var guid = Guid.NewGuid();
 
         await Server.WaitPost(() =>
         {
-            var player = sPlayers.Sessions.Single();
+            var player = _sPlayerManager.Sessions.Single();
 
-            sAdminLogSystem.Add(LogType.Unknown, $"{player} {player} test log: {guid}");
+            _sAdminLogManager.Add(LogType.Unknown, $"{player} {player} test log: {guid}");
         });
 
         await PoolManager.WaitUntil(Server, async () =>
         {
-            var logs = await sAdminLogSystem.CurrentRoundLogs(new LogFilter
+            var logs = await _sAdminLogManager.CurrentRoundLogs(new LogFilter
             {
                 Search = guid.ToString()
             });
@@ -212,22 +201,18 @@ public sealed class AddTests : GameTest
     [Test]
     public async Task DuplicatePlayerIdDoesNotThrowTest()
     {
-        var sPlayers = Server.ResolveDependency<IPlayerManager>();
-
-        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
-
         var guid = Guid.NewGuid();
 
         await Server.WaitPost(() =>
         {
-            var player = sPlayers.Sessions.Single();
+            var player = _sPlayerManager.Sessions.Single();
 
-            sAdminLogSystem.Add(LogType.Unknown, $"{player:first} {player:second} test log: {guid}");
+            _sAdminLogManager.Add(LogType.Unknown, $"{player:first} {player:second} test log: {guid}");
         });
 
         await PoolManager.WaitUntil(Server, async () =>
         {
-            var logs = await sAdminLogSystem.CurrentRoundLogs(new LogFilter
+            var logs = await _sAdminLogManager.CurrentRoundLogs(new LogFilter
             {
                 Search = guid.ToString()
             });
@@ -251,32 +236,30 @@ public sealed class PreRoundAddTests : GameTest
         AdminLogsEnabled = true
     };
 
+    [SidedDependency(Side.Server)] private readonly IAdminLogManager _sAdminLogManager = null!;
+    [SidedDependency(Side.Server)] private readonly IServerDbManager _sDbManager = null!;
+    [SidedDependency(Side.Server)] private readonly GameTicker _sGameTicker = null!;
+
     [Test]
     public async Task PreRoundAddAndGetSingle()
     {
-        var sDatabase = Server.ResolveDependency<IServerDbManager>();
-        var sSystems = Server.ResolveDependency<IEntitySystemManager>();
-
-        var sAdminLogSystem = Server.ResolveDependency<IAdminLogManager>();
-        var sGamerTicker = sSystems.GetEntitySystem<GameTicker>();
-
         var guid = Guid.NewGuid();
 
         await Server.WaitPost(() =>
         {
-            sAdminLogSystem.Add(LogType.Unknown, $"test log: {guid}");
+            _sAdminLogManager.Add(LogType.Unknown, $"test log: {guid}");
         });
 
         await Server.WaitPost(() =>
         {
-            sGamerTicker.StartRound(true);
+            _sGameTicker.StartRound(true);
         });
 
         SharedAdminLog log = default;
 
         await PoolManager.WaitUntil(Server, async () =>
         {
-            var logs = await sAdminLogSystem.CurrentRoundLogs(new LogFilter
+            var logs = await _sAdminLogManager.CurrentRoundLogs(new LogFilter
             {
                 Search = guid.ToString()
             });
@@ -292,12 +275,12 @@ public sealed class PreRoundAddTests : GameTest
 
         var filter = new LogFilter
         {
-            Round = sGamerTicker.RoundId,
+            Round = _sGameTicker.RoundId,
             Search = log.Message,
             Types = new HashSet<LogType> { log.Type },
         };
 
-        await foreach (var json in sDatabase.GetAdminLogsJson(filter))
+        await foreach (var json in _sDbManager.GetAdminLogsJson(filter))
         {
             var root = json.RootElement;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A fairly straightforward cleanup pass on the admin log `AddTests` integration tests to make better use of the features provided by `GameTest`.

This PR is intended to serve as an example of how to do this cleanup on `GameTest`-derived tests, so that we can get them all modernized. The commits on this PR are individual steps in the process and hopefully can be used as a guide for the process.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We want to get all the current tests up-to-date to serve as good examples of how to write new tests.

## Technical details
<!-- Summary of code changes for easier review. -->
See the commits on this PR for a step-by-step breakdown of the cleanup process.

In the interest of keeping each step separate, there are some redundant changes (for example, the first commit converts `var server = pair.Server` to `var server = Pair.Server`, and the second commit removes that line entirely). These can of course be combined when doing actual cleanup.

Some tests, especially older ones, will likely need further cleanup, but this should provide a good starting point for anyone interested in helping.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->