### PR TITLE
Add xmldocs to NUnit constraint extensions

### DIFF
--- a/Content.IntegrationTests/NUnit/Constraints/CompConstraintExtensions.cs
+++ b/Content.IntegrationTests/NUnit/Constraints/CompConstraintExtensions.cs
@@ -20,12 +20,14 @@ public static class CompConstraintExtensions
 {
     extension(Has)
     {
+        /// <inheritdoc cref="extension(ConstraintExpression).Comp{T}"/>
         public static ResolvableConstraintExpression Comp<T>(IIntegrationInstance instance)
             where T : IComponent
         {
             return new ConstraintExpression().Comp<T>(instance);
         }
 
+        /// <inheritdoc cref="extension(ConstraintExpression).Comp(Type, IIntegrationInstance)"/>
         public static ResolvableConstraintExpression Comp(Type t, IIntegrationInstance instance)
         {
             return new ConstraintExpression().Comp(t, instance);
@@ -34,12 +36,52 @@ public static class CompConstraintExtensions
 
     extension(ConstraintExpression expr)
     {
+        /// <summary>
+        /// Returns a new constraint which will either test for the existence of a <typeparamref name="T"/>
+        /// on the entity being tested or apply any following constraint to that component.
+        /// </summary>
+        /// <typeparam name="T">The component Type to check for.</typeparam>
+        /// <param name="instance">The <see cref="IIntegrationInstance"/> (i.e. Server or Client) on which to perform the test.</param>
+        /// <example>
+        /// <code>
+        ///     // Assert that the server-sided entity myEntity has an ItemComponent on the server.
+        ///     Assert.That(myEntity, Has.Comp&lt;ItemComponent&gt;(Server));
+        ///
+        ///     // Assert that the server-sided entity myEntity has an ItemComponent with a Size field equal to "Small"
+        ///     Assert.That(myEntity,
+        ///         Has
+        ///             .Comp&lt;ItemComponent&gt;(Server)
+        ///             .Property(nameof(ItemComponent.Size))
+        ///             .EqualTo("Small")
+        ///     );
+        /// </code>
+        /// </example>
         public ResolvableConstraintExpression Comp<T>(IIntegrationInstance instance)
             where T : IComponent
         {
             return expr.Append(new CompOperator(typeof(T), instance));
         }
 
+        /// <summary>
+        /// Returns a new constraint which will either test for the existence of a component of the specified type
+        /// on the entity being tested or apply any following constraint to that component.
+        /// </summary>
+        /// <param name="t">The Type of the component to check for.</param>
+        /// <param name="instance">The <see cref="IIntegrationInstance"/> (i.e. Server or Client) on which to perform the test.</param>
+        /// <example>
+        /// <code>
+        ///     // Assert that the server-sided entity myEntity has an ItemComponent on the server.
+        ///     Assert.That(myEntity, Has.Comp(typeof(ItemComponent), Server));
+        ///
+        ///     // Assert that the server-sided entity myEntity has an ItemComponent with a Size field equal to "Small"
+        ///     Assert.That(myEntity,
+        ///         Has
+        ///             .Comp(typeof(ItemComponent), Server)
+        ///             .Property(nameof(ItemComponent.Size))
+        ///             .EqualTo("Small")
+        ///     );
+        /// </code>
+        /// </example>
         public ResolvableConstraintExpression Comp(Type t, IIntegrationInstance instance)
         {
             return expr.Append(new CompOperator(t, instance));

--- a/Content.IntegrationTests/NUnit/Constraints/LifeStageConstraint.cs
+++ b/Content.IntegrationTests/NUnit/Constraints/LifeStageConstraint.cs
@@ -56,36 +56,43 @@ public static class LifeStageConstraintExtensions
 {
     extension(Is)
     {
+        /// <inheritdoc cref="extension(ConstraintExpression).LifeStage"/>
         public static LifeStageConstraint LifeStage(EntityLifeStage stage, IIntegrationInstance instance)
         {
             return new LifeStageConstraint(stage, instance);
         }
 
+        /// <inheritdoc cref="extension(ConstraintExpression).PreInit"/>
         public static LifeStageConstraint PreInit(IIntegrationInstance instance)
         {
             return Is.LifeStage(EntityLifeStage.PreInit, instance);
         }
 
+        /// <inheritdoc cref="extension(ConstraintExpression).Initializing"/>
         public static LifeStageConstraint Initializing(IIntegrationInstance instance)
         {
             return Is.LifeStage(EntityLifeStage.Initializing, instance);
         }
 
+        /// <inheritdoc cref="extension(ConstraintExpression).Initialized"/>
         public static LifeStageConstraint Initialized(IIntegrationInstance instance)
         {
             return Is.LifeStage(EntityLifeStage.Initialized, instance);
         }
 
+        /// <inheritdoc cref="extension(ConstraintExpression).MapInitialized"/>
         public static LifeStageConstraint MapInitialized(IIntegrationInstance instance)
         {
             return Is.LifeStage(EntityLifeStage.MapInitialized, instance);
         }
 
+        /// <inheritdoc cref="extension(ConstraintExpression).Terminating"/>
         public static LifeStageConstraint Terminating(IIntegrationInstance instance)
         {
             return Is.LifeStage(EntityLifeStage.Terminating, instance);
         }
 
+        /// <inheritdoc cref="extension(ConstraintExpression).Deleted"/>
         public static LifeStageConstraint Deleted(IIntegrationInstance instance)
         {
             return Is.LifeStage(EntityLifeStage.Deleted, instance);
@@ -94,6 +101,17 @@ public static class LifeStageConstraintExtensions
 
     extension(ConstraintExpression expr)
     {
+        /// <summary>
+        /// Returns a new constraint that checks if the entity is in the given lifestage.
+        /// </summary>
+        /// <param name="stage">The <see cref="EntityLifeStage"/> to check for.</param>
+        /// <param name="instance">The <see cref="IIntegrationInstance"/> (i.e. Server or Client) on which to perform the test.</param>
+        /// <example>
+        /// <code>
+        ///     // Assert that the server-sided entity myEntity is MapInitialized.
+        ///     Assert.That(myEntity, Is.LifeStage(EntityLifeStage.MapInitialized, Server));
+        /// </code>
+        /// </example>
         public LifeStageConstraint LifeStage(EntityLifeStage stage, IIntegrationInstance instance)
         {
             var c = new LifeStageConstraint(stage, instance);
@@ -103,31 +121,91 @@ public static class LifeStageConstraintExtensions
             return c;
         }
 
+        /// <summary>
+        /// Returns a new constraint that checks if the entity is in the PreInit lifestage.
+        /// </summary>
+        /// <param name="instance">The <see cref="IIntegrationInstance"/> (i.e. Server or Client) on which to perform the test.</param>
+        /// <example>
+        /// <code>
+        ///     // Assert that the server-sided entity myEntity has not yet been initialized.
+        ///     Assert.That(myEntity, Is.PreInit(Server));
+        /// </code>
+        /// </example>
         public LifeStageConstraint PreInit(IIntegrationInstance instance)
         {
             return expr.LifeStage(EntityLifeStage.PreInit, instance);
         }
 
+        /// <summary>
+        /// Returns a new constraint that checks if the entity is in the Intializing lifestage.
+        /// </summary>
+        /// <param name="instance">The <see cref="IIntegrationInstance"/> (i.e. Server or Client) on which to perform the test.</param>
+        /// <example>
+        /// <code>
+        ///     // Assert that the server-sided entity myEntity is Initializing.
+        ///     Assert.That(myEntity, Is.Initializing(Server));
+        /// </code>
+        /// </example>
         public LifeStageConstraint Initializing(IIntegrationInstance instance)
         {
             return expr.LifeStage(EntityLifeStage.Initializing, instance);
         }
 
+        /// <summary>
+        /// Returns a new constraint that checks if the entity is in the Initialized lifestage.
+        /// </summary>
+        /// <param name="instance">The <see cref="IIntegrationInstance"/> (i.e. Server or Client) on which to perform the test.</param>
+        /// <example>
+        /// <code>
+        ///     // Assert that the server-sided entity myEntity is Initialized.
+        ///     Assert.That(myEntity, Is.Initialized(Server));
+        /// </code>
+        /// </example>
         public LifeStageConstraint Initialized(IIntegrationInstance instance)
         {
             return expr.LifeStage(EntityLifeStage.Initialized, instance);
         }
 
+        /// <summary>
+        /// Returns a new constraint that checks if the entity is in the MapInitialized lifestage.
+        /// </summary>
+        /// <param name="instance">The <see cref="IIntegrationInstance"/> (i.e. Server or Client) on which to perform the test.</param>
+        /// <example>
+        /// <code>
+        ///     // Assert that the server-sided entity myEntity is MapInitialized.
+        ///     Assert.That(myEntity, Is.MapInitialized(Server));
+        /// </code>
+        /// </example>
         public LifeStageConstraint MapInitialized(IIntegrationInstance instance)
         {
             return expr.LifeStage(EntityLifeStage.MapInitialized, instance);
         }
 
+        /// <summary>
+        /// Returns a new constraint that checks if the entity is in the Terminating lifestage.
+        /// </summary>
+        /// <param name="instance">The <see cref="IIntegrationInstance"/> (i.e. Server or Client) on which to perform the test.</param>
+        /// <example>
+        /// <code>
+        ///     // Assert that the server-sided entity myEntity is Terminating.
+        ///     Assert.That(myEntity, Is.Terminating(Server));
+        /// </code>
+        /// </example>
         public LifeStageConstraint Terminating(IIntegrationInstance instance)
         {
             return expr.LifeStage(EntityLifeStage.Terminating, instance);
         }
 
+        /// <summary>
+        /// Returns a new constraint that checks if the entity is in the Deleted lifestage.
+        /// </summary>
+        /// <param name="instance">The <see cref="IIntegrationInstance"/> (i.e. Server or Client) on which to perform the test.</param>
+        /// <example>
+        /// <code>
+        ///     // Assert that the server-sided entity myEntity is Deleted.
+        ///     Assert.That(myEntity, Is.Deleted(Server));
+        /// </code>
+        /// </example>
         public LifeStageConstraint Deleted(IIntegrationInstance instance)
         {
             return expr.LifeStage(EntityLifeStage.Deleted, instance);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added more extensive xmldoc documentation to the custom NUnit constraints added by https://github.com/space-wizards/space-station-14/pull/43182 (`Comp`, `LifeStage`, and their variants).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Documentation is good!

## Technical details
<!-- Summary of code changes for easier review. -->
Just xmldocs.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->