### PR TITLE
masks.yml cleaning and fixes and changes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -1,3 +1,5 @@
+# civilian/medical
+
 - type: entity
   parent: ClothingMaskPullableBase
   id: ClothingMaskGas
@@ -19,105 +21,6 @@
     layers:
       Snout: Mask
     hideOnToggle: true
-
-- type: entity
-  parent: [ClothingMaskGas, BaseSecurityContraband]
-  id: ClothingMaskGasSecurity
-  name: security gas mask
-  description: A standard issue Security gas mask.
-  components:
-  - type: Item
-    size: Tiny
-  - type: Sprite
-    sprite: Clothing/Mask/gassecurity.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/gassecurity.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
-
-- type: entity
-  parent: [ClothingMaskGas, BaseSyndicateContraband]
-  id: ClothingMaskGasSyndicate
-  name: syndicate gas mask
-  description: A close-fitting tactical mask that can be connected to an air supply.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/gassyndicate.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/gassyndicate.rsi
-  - type: FlashImmunity
-  - type: EyeProtection
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
-
-- type: entity
-  parent: ClothingMaskGas
-  id: ClothingMaskGasAtmos
-  name: atmospheric gas mask
-  description: Improved gas mask utilized by atmospheric technicians. It's flameproof!
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/gasatmos.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/gasatmos.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Heat: 0.80
-
-- type: entity
-  parent: [ClothingMaskGasAtmos, BaseCommandContraband]
-  id: ClothingMaskGasCaptain
-  name: captain's gas mask
-  description: Nanotrasen cut corners and repainted a spare atmospheric gas mask, but don't tell anyone.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/gascaptain.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/gascaptain.rsi
-  - type: BreathMask
-  - type: IngestionBlocker
-
-- type: entity
-  parent: [ ClothingMaskGasAtmos, BaseCentcommContraband ]
-  id: ClothingMaskGasCentcom
-  name: CentComm gas mask
-  description: Oooh, gold and green. Fancy! This should help as you sit in your office.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/gascentcom.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/gascentcom.rsi
-  - type: BreathMask
-  - type: IngestionBlocker
-
-- type: entity
-  parent: [ClothingMaskGas, BaseCargoContraband]
-  id: ClothingMaskGasExplorer
-  name: explorer gas mask
-  description: A military-grade gas mask that can be connected to an air supply.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/gasexplorer.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/gasexplorer.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Piercing: 0.95
-        Heat: 0.95
 
 - type: entity
   parent: ClothingMaskPullableBase
@@ -148,8 +51,6 @@
   name: military-style medical mask
   description: A medical mask with a small layer of protection against damage and viruses, similar to the one used in the medical units of the first corporate war.
   components:
-  - type: Item
-    size: Tiny
   - type: Sprite
     sprite: Clothing/Mask/medicalsecurity.rsi
   - type: Clothing
@@ -188,136 +89,27 @@
     price: 30 # increases in price after decomposed into raw materials
 
 - type: entity
-  parent: ClothingMaskBase
-  id: ClothingMaskClownBase
-  abstract: true
-  name: clown wig and mask
-  description: A true prankster's facial attire. A clown is incomplete without his wig and mask.
+  parent: ClothingMaskGas
+  id: ClothingMaskWeldingGas
+  name: welding gas mask
+  description: A gas mask with built in welding goggles and face shield. Looks like a skull, clearly designed by a nerd.
   components:
   - type: Sprite
-    sprite: Clothing/Mask/clown.rsi
+    sprite: Clothing/Mask/welding-gas.rsi
+    state: icon
   - type: Clothing
-    sprite: Clothing/Mask/clown.rsi
-  - type: BreathMask
-  - type: IdentityBlocker
+    sprite: Clothing/Mask/welding-gas.rsi
+  - type: FlashImmunity
+  - type: EyeProtection
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 200
+      Glass: 100
+  - type: StaticPrice
+    price: 100
   - type: Tag
     tags:
-    - ClownMask
     - WhitelistChameleon
-  - type: HideLayerClothing
-    slots:
-    - Snout
-
-- type: entity
-  parent: [ClothingMaskClownBase, BaseFoldable]
-  id: ClothingMaskClown
-  description: A clown mask featuring a foldable wig; a true prankster's attire.
-  components:
-  - type: Appearance
-  - type: Foldable
-    canFoldInsideContainer: true
-  - type: FoldableClothing
-    foldedEquippedPrefix: opened
-    foldedHeldPrefix: opened
-  - type: Sprite
-    sprite: Clothing/Mask/clown.rsi
-    layers:
-    - state: icon
-      map: [ "unfoldedLayer" ]
-    - state: icon-opened
-      map: [ "foldedLayer" ]
-      visible: false
-  - type: Tag
-    tags:
-    - ClownMask
-    - HamsterWearable
-    - WhitelistChameleon
-  - type: HideLayerClothing
-    slots:
-    - Snout
-
-- type: entity
-  parent: ClothingMaskClownBase
-  id: ClothingMaskClownBanana
-  name: banana clown wig and mask
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/clown_banana.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/clown_banana.rsi
-  - type: Construction
-    graph: BananaClownMask
-    node: mask
-  - type: Tag
-    tags:
-    - ClownMask
-    - HamsterWearable
-    - WhitelistChameleon
-  - type: HideLayerClothing
-    slots:
-    - Snout
-
-- type: entity
-  parent: [ClothingMaskClownBase, BaseSecurityContraband]
-  id: ClothingMaskClownSecurity
-  name: security clown wig and mask
-  description: A debatably oxymoronic but protective mask and wig.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/clown_security.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/clown_security.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
-  - type: Tag
-    tags:
-    - ClownMask
-    - HamsterWearable
-    - WhitelistChameleon
-  - type: HideLayerClothing
-    slots:
-    - Snout
-
-- type: entity
-  parent: ClothingMaskBase
-  id: ClothingMaskJoy
-  name: joy mask
-  description: Express your happiness or hide your sorrows with this laughing face with crying tears of joy cutout.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/joy.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/joy.rsi
-  - type: BreathMask
-  - type: IdentityBlocker
-  - type: HideLayerClothing
-    slots:
-    - Snout
-
-- type: entity
-  parent: ClothingMaskBase
-  id: ClothingMaskMime
-  name: mime mask
-  description: The traditional mime's mask. It has an eerie facial posture.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/mime.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/mime.rsi
-  - type: BreathMask
-  - type: IdentityBlocker
-  - type: Tag
-    tags:
-    - HamsterWearable
-    - WhitelistChameleon
-  - type: HideLayerClothing
-    slots:
-    - Snout
 
 - type: entity
   parent: ClothingMaskPullableBase
@@ -364,38 +156,73 @@
     graph: Muzzle
     node: muzzle
 
-- type: entity
-  parent: ClothingMaskPullableBase
-  id: ClothingMaskPlague
-  name: plague doctor mask
-  description: A bad omen.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/plaguedoctormask.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/plaguedoctormask.rsi
-  - type: BreathMask
-  - type: IngestionBlocker
-  - type: IdentityBlocker
-  - type: HideLayerClothing
-    slots:
-    - Snout
-    hideOnToggle: true
+# Department/Command
 
 - type: entity
-  parent: ClothingMaskClownBase
-  id: ClothingMaskCluwne
-  name: cluwne face and hair
-  suffix: Unremoveable
-  description: Cursed cluwne face and hair.
+  parent: [ClothingMaskGas, BaseSecurityContraband]
+  id: ClothingMaskGasSecurity
+  name: security gas mask
+  description: A standard issue Security gas mask.
+  components:
+  - type: Item
+    size: Tiny
+  - type: IdentityBlocker
+    coverage: MOUTH
+  - type: Sprite
+    sprite: Clothing/Mask/gassecurity.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/gassecurity.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
+        Heat: 0.95
+
+- type: entity
+  parent: [ClothingMaskGas, BaseEngineeringContraband]
+  id: ClothingMaskGasAtmos
+  name: atmospheric gas mask
+  description: Improved gas mask utilized by atmospheric technicians. It's flameproof!
   components:
   - type: Sprite
-    sprite: Clothing/Mask/cluwne.rsi
+    sprite: Clothing/Mask/gasatmos.rsi
   - type: Clothing
-    sprite: Clothing/Mask/cluwne.rsi
-  - type: Unremoveable
-  - type: AddAccentClothing
-    accent: StutteringAccent
+    sprite: Clothing/Mask/gasatmos.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Heat: 0.80
+
+- type: entity
+  parent: [ClothingMaskGasAtmos, BaseCommandContraband]
+  id: ClothingMaskGasCaptain
+  name: captain's gas mask
+  description: Nanotrasen cut corners and repainted a spare atmospheric gas mask, but don't tell anyone.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/gascaptain.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/gascaptain.rsi
+
+- type: entity
+  parent: [ClothingMaskGas, BaseCargoContraband]
+  id: ClothingMaskGasExplorer
+  name: explorer gas mask
+  description: A military-grade gas mask that can be connected to an air supply.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/gasexplorer.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/gasexplorer.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.90
+        Slash: 0.90
+        Piercing: 0.95
+        Heat: 0.95
 
 - type: entity
   parent: [ ClothingMaskGas, BaseSecurityContraband ]
@@ -425,44 +252,78 @@
         Piercing: 0.95
         Heat: 0.95
 
-- type: entity
-  parent: [ ClothingMaskGas, BaseSecurityCargoContraband ]
-  id: ClothingMaskGasMerc
-  name: mercenary gas mask
-  description: Slightly outdated, but reliable military-style gas mask.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/merc.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/merc.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Piercing: 0.95
-        Heat: 0.95
+# Clown masks
 
 - type: entity
-  parent: [ ClothingMaskGas, BaseCentcommContraband ]
-  id: ClothingMaskGasERT
-  name: ert gas mask
-  description: The gas mask of the elite squad of the ERT.
+  parent: ClothingMaskBase
+  id: ClothingMaskClownBase
+  abstract: true
+  name: clown wig and mask
+  description: A true prankster's facial attire. A clown is incomplete without his wig and mask.
   components:
   - type: Sprite
-    sprite: Clothing/Mask/ert.rsi
+    sprite: Clothing/Mask/clown.rsi
   - type: Clothing
-    sprite: Clothing/Mask/ert.rsi
+    sprite: Clothing/Mask/clown.rsi
+  - type: BreathMask # clown special prevliage
+  - type: IdentityBlocker
   - type: Tag
     tags:
+    - ClownMask
     - WhitelistChameleon
   - type: HideLayerClothing
     slots:
-    - Hair
     - Snout
-    hideOnToggle: true
-  - type: FlashImmunity
-  - type: EyeProtection
+
+- type: entity
+  parent: [ClothingMaskClownBase, BaseFoldable]
+  id: ClothingMaskClown
+  description: A clown mask featuring a foldable wig; a true prankster's attire.
+  components:
+  - type: Appearance
+  - type: Foldable
+    canFoldInsideContainer: true
+  - type: FoldableClothing
+    foldedEquippedPrefix: opened
+    foldedHeldPrefix: opened
+  - type: Sprite
+    sprite: Clothing/Mask/clown.rsi
+    layers:
+    - state: icon
+      map: [ "unfoldedLayer" ]
+    - state: icon-opened
+      map: [ "foldedLayer" ]
+      visible: false
+  - type: Tag
+    tags:
+    - HamsterWearable
+
+- type: entity
+  parent: ClothingMaskClownBase
+  id: ClothingMaskClownBanana
+  name: banana clown wig and mask
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/clown_banana.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/clown_banana.rsi
+  - type: Construction
+    graph: BananaClownMask
+    node: mask
+  - type: Tag
+    tags:
+    - HamsterWearable
+
+- type: entity
+  parent: [ClothingMaskClownBase, BaseSecurityContraband]
+  id: ClothingMaskClownSecurity
+  name: security clown wig and mask
+  description: A debatably oxymoronic but protective mask and wig.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/clown_security.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/clown_security.rsi
   - type: Armor
     modifiers:
       coefficients:
@@ -470,171 +331,9 @@
         Slash: 0.95
         Piercing: 0.95
         Heat: 0.95
-
-- type: entity
-  parent: ClothingMaskGasERT
-  id: ClothingMaskGasDeathSquad
-  name: death squad gas mask
-  description: A unique gas mask for the NT's most elite squad.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/squadron.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/squadron.rsi
-  - type: HideLayerClothing
-    slots:
-    - Hair
-    - HeadTop
-    - HeadSide
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.80
-        Slash: 0.80
-        Piercing: 0.90
-        Heat: 0.90
-
-- type: entity
-  parent: ClothingMaskBase
-  id: ClothingMaskRat
-  name: rat mask
-  description: A mask of a rat that looks like a rat. Perhaps they will take you for a fellow rat.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/rat.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/rat.rsi
-  - type: BreathMask
   - type: Tag
     tags:
     - HamsterWearable
-    - WhitelistChameleon
-  - type: HideLayerClothing
-    slots:
-    - Snout
-  - type: IdentityBlocker
-
-- type: entity
-  parent: ClothingMaskBase
-  id: ClothingMaskFox
-  name: fox mask
-  description: What does the fox say?
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/fox.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/fox.rsi
-  - type: BreathMask
-  - type: IdentityBlocker
-  - type: HideLayerClothing
-    slots:
-    - Snout
-
-- type: entity
-  parent: ClothingMaskBase
-  id: ClothingMaskBee
-  name: bee mask
-  description: For the queen!
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/bee.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/bee.rsi
-  - type: BreathMask
-  - type: IdentityBlocker
-  - type: HideLayerClothing
-    slots:
-    - Snout
-
-- type: entity
-  parent: ClothingMaskBase
-  id: ClothingMaskBear
-  name: bear mask
-  description: I'm a cloudy, cloudy, cloudy, I'm not a bear at all.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/bear.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/bear.rsi
-  - type: BreathMask
-  - type: IdentityBlocker
-  - type: HideLayerClothing
-    slots:
-    - Snout
-
-- type: entity
-  parent: ClothingMaskBase
-  id: ClothingMaskRaven
-  name: raven mask
-  description: Where I am, death... or glitter.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/raven.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/raven.rsi
-  - type: BreathMask
-  - type: IdentityBlocker
-  - type: HideLayerClothing
-    slots:
-    - Snout
-
-- type: entity
-  parent: ClothingMaskBase
-  id: ClothingMaskJackal
-  name: jackal mask
-  description: It is better not to turn your back to the owner of the mask, it may bite.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/jackal.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/jackal.rsi
-  - type: BreathMask
-  - type: IdentityBlocker
-  - type: HideLayerClothing
-    slots:
-    - Snout
-
-- type: entity
-  parent: ClothingMaskBase
-  id: ClothingMaskBat
-  name: bat mask
-  description: A bloodsucker by night, and a cute, blinded beast by day.
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/bat.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/bat.rsi
-  - type: BreathMask
-  - type: IdentityBlocker
-  - type: HideLayerClothing
-    slots:
-    - Snout
-
-- type: entity
-  parent: ClothingMaskBase
-  id: ClothingMaskNeckGaiter
-  name: neck gaiter
-  description: Stylish neck gaiter for your neck, can protect from the cosmic wind?...
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/neckgaiter.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/neckgaiter.rsi
-  - type: IdentityBlocker
-    coverage: MOUTH
-  - type: Tag
-    tags:
-    - WhitelistChameleon
-
-- type: entity
-  parent: ClothingMaskNeckGaiter
-  id: ClothingMaskNeckGaiterRed
-  name: red neck gaiter
-  components:
-  - type: Sprite
-    sprite: Clothing/Mask/neckgaiterred.rsi
-  - type: Clothing
-    sprite: Clothing/Mask/neckgaiterred.rsi
 
 - type: entity
   parent: ClothingMaskClownBase
@@ -646,6 +345,43 @@
     sprite: Clothing/Mask/blushingclown.rsi
   - type: Clothing
     sprite: Clothing/Mask/blushingclown.rsi
+
+- type: entity
+  parent: ClothingMaskClownBase
+  id: ClothingMaskCluwne
+  name: cluwne face and hair
+  suffix: Unremoveable
+  description: Cursed cluwne face and hair.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/cluwne.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/cluwne.rsi
+  - type: Unremoveable
+  - type: AddAccentClothing
+    accent: StutteringAccent
+
+# Mime
+
+- type: entity
+  parent: ClothingMaskBase
+  id: ClothingMaskMime
+  name: mime mask
+  description: The traditional mime's mask. It has an eerie facial posture.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/mime.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/mime.rsi
+  - type: BreathMask # mime special privlage
+  - type: IdentityBlocker
+  - type: Tag
+    tags:
+    - HamsterWearable
+    - WhitelistChameleon
+  - type: HideLayerClothing
+    slots:
+    - Snout
 
 - type: entity
   parent: ClothingMaskMime
@@ -698,6 +434,41 @@
         Piercing: 0.95
         Heat: 0.95
 
+# Theater
+
+- type: entity
+  parent: ClothingMaskPullableBase
+  id: ClothingMaskPlague
+  name: plague doctor mask
+  description: A bad omen.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/plaguedoctormask.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/plaguedoctormask.rsi
+  - type: BreathMask
+  - type: IngestionBlocker
+  - type: IdentityBlocker
+  - type: HideLayerClothing
+    slots:
+    - Snout
+    hideOnToggle: true
+
+- type: entity
+  parent: ClothingMaskBase
+  id: ClothingMaskJoy
+  name: joy mask
+  description: Express your happiness or hide your sorrows with this laughing face with crying tears of joy cutout.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/joy.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/joy.rsi
+  - type: IdentityBlocker
+  - type: HideLayerClothing
+    slots:
+    - Snout
+
 - type: entity
   parent: ClothingMaskBase
   id: ClothingMaskItalianMoustache
@@ -710,6 +481,162 @@
     sprite: Clothing/Mask/italian_moustache.rsi
   - type: Item
     storedRotation: -90
+
+# Animals
+
+- type: entity
+  parent: ClothingMaskBase
+  id: ClothingMaskAnimalBase
+  components:
+  - type: IdentityBlocker
+  - type: Tag
+    tags:
+    - WhitelistChameleon
+  - type: HideLayerClothing
+    slots:
+    - Snout
+
+- type: entity
+  parent: ClothingMaskAnimalBase
+  id: ClothingMaskRat
+  name: rat mask
+  description: A mask of a rat that looks like a rat. Perhaps they will take you for a fellow rat.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/rat.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/rat.rsi
+  - type: Tag
+    tags:
+    - HamsterWearable
+
+- type: entity
+  parent: ClothingMaskAnimalBase
+  id: ClothingMaskFox
+  name: fox mask
+  description: What does the fox say?
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/fox.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/fox.rsi
+
+- type: entity
+  parent: ClothingMaskAnimalBase
+  id: ClothingMaskBee
+  name: bee mask
+  description: For the queen!
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/bee.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/bee.rsi
+
+- type: entity
+  parent: ClothingMaskAnimalBase
+  id: ClothingMaskBear
+  name: bear mask
+  description: I'm a cloudy, cloudy, cloudy, I'm not a bear at all.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/bear.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/bear.rsi
+
+- type: entity
+  parent: ClothingMaskAnimalBase
+  id: ClothingMaskRaven
+  name: raven mask
+  description: Where I am, death... or glitter.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/raven.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/raven.rsi
+
+- type: entity
+  parent: ClothingMaskAnimalBase
+  id: ClothingMaskJackal
+  name: jackal mask
+  description: It is better not to turn your back to the owner of the mask, it may bite.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/jackal.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/jackal.rsi
+
+- type: entity
+  parent: ClothingMaskAnimalBase
+  id: ClothingMaskBat
+  name: bat mask
+  description: A bloodsucker by night, and a cute, blinded beast by day.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/bat.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/bat.rsi
+
+- type: entityTable
+  id: AnimalMaskTable
+  table: !type:GroupSelector
+    children:
+    - id: ClothingMaskFox
+    - id: ClothingMaskBat
+    - id: ClothingMaskBear
+    - id: ClothingMaskBee
+    - id: ClothingMaskRaven
+    - id: ClothingMaskRat
+    - id: ClothingMaskJackal
+
+# Neck Gaiter
+
+- type: entity
+  parent: ClothingMaskBase
+  id: ClothingMaskNeckGaiter
+  name: neck gaiter
+  description: Stylish neck gaiter for your neck, can protect from the cosmic wind?...
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/neckgaiter.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/neckgaiter.rsi
+  - type: IdentityBlocker
+    coverage: MOUTH
+  - type: Tag
+    tags:
+    - WhitelistChameleon
+
+- type: entity
+  parent: ClothingMaskNeckGaiter
+  id: ClothingMaskNeckGaiterRed
+  name: red neck gaiter
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/neckgaiterred.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/neckgaiterred.rsi
+
+# Antag
+
+- type: entity
+  parent: [ClothingMaskGas, BaseSyndicateContraband]
+  id: ClothingMaskGasSyndicate
+  name: syndicate gas mask
+  description: A close-fitting tactical mask that can be connected to an air supply.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/gassyndicate.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/gassyndicate.rsi
+  - type: FlashImmunity
+  - type: EyeProtection
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
+        Heat: 0.95
 
 - type: entity
   parent: ClothingMaskBase
@@ -727,38 +654,84 @@
   - type: BreathMask
   - type: IdentityBlocker
 
+# admeme
+
 - type: entity
-  parent: ClothingMaskGas
-  id: ClothingMaskWeldingGas
-  name: welding gas mask
-  description: A gas mask with built in welding goggles and face shield. Looks like a skull, clearly designed by a nerd.
+  parent: [ ClothingMaskGas, BaseSecurityCargoContraband ]
+  id: ClothingMaskGasMerc
+  name: mercenary gas mask
+  description: Slightly outdated, but reliable military-style gas mask.
   components:
   - type: Sprite
-    sprite: Clothing/Mask/welding-gas.rsi
-    state: icon
+    sprite: Clothing/Mask/merc.rsi
   - type: Clothing
-    sprite: Clothing/Mask/welding-gas.rsi
-  - type: FlashImmunity
-  - type: EyeProtection
-  - type: PhysicalComposition
-    materialComposition:
-      Steel: 200
-      Glass: 100
-  - type: StaticPrice
-    price: 100
+    sprite: Clothing/Mask/merc.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.90
+        Slash: 0.90
+        Piercing: 0.95
+        Heat: 0.95
+
+- type: entity
+  parent: [ ClothingMaskGasAtmos, BaseCentcommContraband ]
+  id: ClothingMaskGasCentcom
+  name: CentComm gas mask
+  description: Oooh, gold and green. Fancy! This should help as you sit in your office.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/gascentcom.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/gascentcom.rsi
+
+- type: entity
+  parent: [ ClothingMaskGas, BaseCentcommContraband ]
+  id: ClothingMaskGasERT
+  name: ert gas mask
+  description: The gas mask of the elite squad of the ERT.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/ert.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/ert.rsi
   - type: Tag
     tags:
     - WhitelistChameleon
+  - type: HideLayerClothing
+    slots:
+    - Hair
+    - Snout
+    hideOnToggle: true
+  - type: FlashImmunity
+  - type: EyeProtection
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
+        Heat: 0.95
 
-# Entity tables
-- type: entityTable
-  id: AnimalMaskTable
-  table: !type:GroupSelector
-    children:
-    - id: ClothingMaskFox
-    - id: ClothingMaskBat
-    - id: ClothingMaskBear
-    - id: ClothingMaskBee
-    - id: ClothingMaskRaven
-    - id: ClothingMaskRat
-    - id: ClothingMaskJackal
+- type: entity
+  parent: [ClothingMaskGasERT, BaseCentcommContraband ]
+  id: ClothingMaskGasDeathSquad
+  name: death squad gas mask
+  description: A unique gas mask for the NT's most elite squad.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/squadron.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/squadron.rsi
+  - type: HideLayerClothing
+    slots:
+    - Hair
+    - HeadTop
+    - HeadSide
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.80
+        Slash: 0.80
+        Piercing: 0.90
+        Heat: 0.90

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -485,6 +485,7 @@
 # Animals
 
 - type: entity
+  abstract: true
   parent: ClothingMaskBase
   id: ClothingMaskAnimalBase
   components:


### PR DESCRIPTION
## About the PR
mask.yml cleanup, small fixes and small tweaks
security gas mask now only covers the mouth instead of full face
atmos gas mask is now engi contra
animal mask no longer act as breathing masks, but dont block you from eating (theres a mouth hole in most of the masks)
all animal masks are can now be accessed thru chameleon menu

## Why / Balance
I wanted to fix the salv mask, but it wasn't broken, so i decided to clean the file, tweaked some strange things and fixed some things

## Technical details
General cleaning
There are now categories of masks in the file
Animal masks now have parent of ClothingMaskAnimalBase
Removed a bunch of components that were already in the parent

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Animal masks no longer act as gas masks
- fix: Security gas masks now only covers the mouth instead of whole face
- fix: Atmos gas mask is now engineering contraband