### PR TITLE
Forbid literal GameRule ProtoIds on `GameTicker` methods

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/RuleMaxTimeRestartTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/RuleMaxTimeRestartTest.cs
@@ -4,6 +4,7 @@ using Content.Server.GameTicking.Rules;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Shared.GameTicking.Components;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.IntegrationTests.Tests.GameRules
@@ -13,6 +14,8 @@ namespace Content.IntegrationTests.Tests.GameRules
     public sealed class RuleMaxTimeRestartTest : GameTest
     {
         public override PoolSettings PoolSettings => new() { InLobby = true };
+
+        private static readonly EntProtoId MaxTimeRestartGameRule = "MaxTimeRestart";
 
         [Test]
         public async Task RestartTest()
@@ -30,7 +33,7 @@ namespace Content.IntegrationTests.Tests.GameRules
             MaxTimeRestartRuleComponent maxTime = null;
             await server.WaitPost(() =>
             {
-                sGameTicker.StartGameRule("MaxTimeRestart", out var ruleEntity);
+                sGameTicker.StartGameRule(MaxTimeRestartGameRule, out var ruleEntity);
                 Assert.That(entityManager.TryGetComponent<MaxTimeRestartRuleComponent>(ruleEntity, out maxTime));
             });
 

--- a/Content.IntegrationTests/Tests/GameRules/SecretStartsTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/SecretStartsTest.cs
@@ -2,6 +2,7 @@
 using Content.IntegrationTests.Fixtures;
 using Content.Server.GameTicking;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.GameRules;
 
@@ -9,6 +10,8 @@ namespace Content.IntegrationTests.Tests.GameRules;
 public sealed class SecretStartsTest : GameTest
 {
     public override PoolSettings PoolSettings => new PoolSettings { Dirty = true };
+
+    private static readonly EntProtoId SecretGameRule = "Secret";
 
     /// <summary>
     ///     Tests that when secret is started, all of the game rules it successfully adds are also started.
@@ -27,7 +30,7 @@ public sealed class SecretStartsTest : GameTest
         {
             // this mimics roundflow:
             // rules added, then round starts
-            gameTicker.AddGameRule("Secret");
+            gameTicker.AddGameRule(SecretGameRule);
             gameTicker.StartGamePresetRules();
         });
 

--- a/Content.Server/GameTicking/GameTicker.GameRule.cs
+++ b/Content.Server/GameTicking/GameTicker.GameRule.cs
@@ -83,7 +83,7 @@ public sealed partial class GameTicker
     /// start it yet, instead waiting until the rule is actually started by other code (usually roundstart)
     /// </summary>
     /// <returns>The entity for the added gamerule</returns>
-    public EntityUid AddGameRule(string ruleId)
+    public EntityUid AddGameRule([ForbidLiteral] string ruleId)
     {
         var ruleEntity = Spawn(ruleId, MapCoordinates.Nullspace);
         _sawmill.Info($"Added game rule {ToPrettyString(ruleEntity)}");
@@ -116,7 +116,7 @@ public sealed partial class GameTicker
     /// </summary>
     /// <param name="gameRule">Game rule entity that we are trying to spawn</param>
     /// <returns>The entityUid of the spawned game rule, if it wasn't ignored.</returns>
-    public EntityUid? AddFilteredGameRule(EntProtoId gameRule)
+    public EntityUid? AddFilteredGameRule([ForbidLiteral] EntProtoId gameRule)
     {
         if (IsIgnored(gameRule))
             return null;
@@ -129,7 +129,7 @@ public sealed partial class GameTicker
     /// </summary>
     /// <param name="gameRule">GameRule we are trying to validate</param>
     /// <returns>True if the gamerule should be ignored and not spawned.</returns>
-    public bool IsIgnored(EntProtoId gameRule)
+    public bool IsIgnored([ForbidLiteral] EntProtoId gameRule)
     {
         return _ignoredRules.Contains(gameRule);
     }
@@ -138,7 +138,7 @@ public sealed partial class GameTicker
     /// Game rules can be 'started' separately from being added. 'Starting' them usually
     /// happens at round start while they can be added and removed before then.
     /// </summary>
-    public bool StartGameRule(string ruleId)
+    public bool StartGameRule([ForbidLiteral] string ruleId)
     {
         return StartGameRule(ruleId, out _);
     }
@@ -147,7 +147,7 @@ public sealed partial class GameTicker
     /// Game rules can be 'started' separately from being added. 'Starting' them usually
     /// happens at round start while they can be added and removed before then.
     /// </summary>
-    public bool StartGameRule(string ruleId, out EntityUid ruleEntity)
+    public bool StartGameRule([ForbidLiteral] string ruleId, out EntityUid ruleEntity)
     {
         ruleEntity = AddGameRule(ruleId);
         return StartGameRule(ruleEntity);
@@ -261,7 +261,7 @@ public sealed partial class GameTicker
         return Resolve(ruleEntity, ref component) && !HasComp<EndedGameRuleComponent>(ruleEntity);
     }
 
-    public bool IsGameRuleAdded(string rule)
+    public bool IsGameRuleAdded([ForbidLiteral] string rule)
     {
         foreach (var ruleEntity in GetAddedGameRules())
         {
@@ -309,7 +309,7 @@ public sealed partial class GameTicker
         return Resolve(ruleEntity, ref component) && HasComp<ActiveGameRuleComponent>(ruleEntity);
     }
 
-    public bool IsGameRuleActive(string rule)
+    public bool IsGameRuleActive([ForbidLiteral] string rule)
     {
         foreach (var ruleEntity in GetActiveGameRules())
         {

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -67,6 +67,12 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     private static readonly ProtoId<CurrencyPrototype> TelecrystalCurrencyPrototype = "Telecrystal";
     private static readonly ProtoId<TagPrototype> NukeOpsUplinkTagPrototype = "NukeOpsUplink";
 
+    // TODO: This shouldn't be matching by ProtoId.
+    // It would be better if this were checked by component or something,
+    // but it needs to be distinct between the full Nukeops and Loneops rules,
+    // which NukeopsRuleComponent currently isn't.
+    // Better yet, maybe the behaviors this is used for could be moved to the rule component.
+    private static readonly EntProtoId NukeopsGameRule = "Nukeops";
 
     public override void Initialize()
     {
@@ -206,8 +212,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 if (ev.OwningStation == GetOutpost(uid))
                 {
                     nukeops.WinConditions.Add(WinCondition.NukeExplodedOnNukieOutpost);
-                    SetWinType((uid, nukeops), WinType.CrewMajor, GameTicker.IsGameRuleActive("Nukeops")); // End the round ONLY if the actual gamemode is NukeOps.
-                    if (!GameTicker.IsGameRuleActive("Nukeops")) // End the rule if the LoneOp shuttle got nuked, because that particular LoneOp clearly failed, and should not be considered a Syndie victory even if a future LoneOp wins.
+                    SetWinType((uid, nukeops), WinType.CrewMajor, GameTicker.IsGameRuleActive(NukeopsGameRule)); // End the round ONLY if the actual gamemode is NukeOps.
+                    if (!GameTicker.IsGameRuleActive(NukeopsGameRule)) // End the rule if the LoneOp shuttle got nuked, because that particular LoneOp clearly failed, and should not be considered a Syndie victory even if a future LoneOp wins.
                         GameTicker.EndGameRule(uid);
                     continue;
                 }
@@ -238,7 +244,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 nukeops.WinConditions.Add(WinCondition.NukeExplodedOnIncorrectLocation);
             }
 
-            if (GameTicker.IsGameRuleActive("Nukeops")) // If it's Nukeops then end the round on any detonation
+            if (GameTicker.IsGameRuleActive(NukeopsGameRule)) // If it's Nukeops then end the round on any detonation
             {
                 _roundEndSystem.EndRound();
             }

--- a/Content.Server/Magic/MagicSystem.cs
+++ b/Content.Server/Magic/MagicSystem.cs
@@ -17,6 +17,7 @@ public sealed class MagicSystem : SharedMagicSystem
     [Dependency] private readonly SharedMindSystem _mind = default!;
 
     private static readonly ProtoId<TagPrototype> InvalidForSurvivorAntagTag = "InvalidForSurvivorAntag";
+    private static readonly EntProtoId SurvivorGameRule = "Survivor";
 
     public override void Initialize()
     {
@@ -46,9 +47,7 @@ public sealed class MagicSystem : SharedMagicSystem
         if (_mind.TryGetMind(ev.Performer, out var mind, out _) && !_tag.HasTag(mind, InvalidForSurvivorAntagTag))
             _tag.AddTag(mind, InvalidForSurvivorAntagTag);
 
-        EntProtoId survivorRule = "Survivor";
-
         if (!_gameTicker.IsGameRuleActive<SurvivorRuleComponent>())
-            _gameTicker.StartGameRule(survivorRule);
+            _gameTicker.StartGameRule(SurvivorGameRule);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds `[ForbidLiteral]` to `GameTicker` methods that take a `GameRule` `EntProtoId` as a parameter, and cleans up violations exposed by those changes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Magic strings are bad.

## Technical details
<!-- Summary of code changes for easier review. -->
Added some `private static readonly EntProtoId`s to replace magic strings with validated IDs.

Added a TODO comment to `NukeopsRuleSystem` explaining how the ID comparison should be replaced in the future, which is out of scope for this PR.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`GameTicker` methods taking a GameRule `EntProtoId` as a parameter will now raise a warning if a string literal is passed in. Use a `static readonly EntProtoId` field to ensure prototypes are validated.