### PR TITLE
Make Changelog Button Green 

### DIFF
--- a/Content.Client/Changelog/ChangelogButton.cs
+++ b/Content.Client/Changelog/ChangelogButton.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client.Stylesheets;
+using Content.Client.Stylesheets;
 using Robust.Client.UserInterface.Controls;
 
 namespace Content.Client.Changelog
@@ -36,12 +36,12 @@ namespace Content.Client.Changelog
             if (_changelogManager.NewChangelogEntries)
             {
                 Text = Loc.GetString("changelog-button-new-entries");
-                StyleClasses.Add(StyleClass.Negative);
+                StyleClasses.Add(StyleClass.Positive);
             }
             else
             {
                 Text = Loc.GetString("changelog-button");
-                StyleClasses.Remove(StyleClass.Negative);
+                StyleClasses.Remove(StyleClass.Positive);
             }
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

I changed the Changelog Button's palette from `negative` to `positive`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The red color generally signifies something dangerous to do (like quit), but here's its used as just another accent color to get attention. Instead, we can use positive (green) to still make it stand out. (Realistically, `highlight` would be better if it had a style associated...)

## Technical details
<!-- Summary of code changes for easier review. -->

Two line change.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<details>
<summary>
New
</summary>
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/cd0993c0-efd9-46c1-b52d-24ae1477ae96" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/9bdcf230-1361-404d-accd-d9d90944dd7c" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/f4278d48-8a16-4aca-9511-12608677602f" />
</details>

<details>
<summary>
Old
</summary>
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/4993d55c-5609-469f-9760-a6b9cf58c72e" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/1ed0c014-cc7a-4154-b593-1c84aef3a864" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/c67c27ea-da5e-41fb-89a1-e81dbe9af144" />
</details>

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

No CL, just a minor visual tweak.