### PR TITLE
Improve Escape Menu

### DIFF
--- a/Content.Client/Options/UI/EscapeMenu.xaml
+++ b/Content.Client/Options/UI/EscapeMenu.xaml
@@ -1,9 +1,9 @@
 ﻿<ui1:EscapeMenu xmlns="https://spacestation14.io"
-            xmlns:changelog="clr-namespace:Content.Client.Changelog"
-            xmlns:ui="clr-namespace:Content.Client.Voting.UI"
-            xmlns:ui1="clr-namespace:Content.Client.Options.UI"
-            Title="{Loc 'ui-escape-title'}"
-            Resizable="False">
+                xmlns:changelog="clr-namespace:Content.Client.Changelog"
+                xmlns:ui="clr-namespace:Content.Client.Voting.UI"
+                xmlns:ui1="clr-namespace:Content.Client.Options.UI"
+                Title="{Loc 'ui-escape-title'}"
+                Resizable="False">
 
     <BoxContainer Orientation="Vertical" SeparationOverride="4" MinWidth="150">
         <ui:VoteCallMenuButton />
@@ -12,7 +12,7 @@
         <Button Access="Public" Name="GuidebookButton" Text="{Loc 'ui-escape-guidebook'}" />
         <Button Access="Public" Name="WikiButton" Text="{Loc 'ui-escape-wiki'}" />
         <changelog:ChangelogButton Access="Public" Name="ChangelogButton" />
-        <Button Access="Public" Name="FeedbackButton" Text="{Loc 'ui-escape-feedback'}"/>
+        <Button Access="Public" Name="FeedbackButton" Text="{Loc 'ui-escape-feedback'}" />
         <PanelContainer StyleClasses="LowDivider" Margin="0 2.5 0 2.5" />
         <Button Access="Public" Name="OptionsButton" Text="{Loc 'ui-escape-options'}" />
         <PanelContainer StyleClasses="LowDivider" Margin="0 2.5 0 2.5" />

--- a/Content.Client/Options/UI/EscapeMenu.xaml
+++ b/Content.Client/Options/UI/EscapeMenu.xaml
@@ -17,6 +17,6 @@
         <Button Access="Public" Name="OptionsButton" Text="{Loc 'ui-escape-options'}" />
         <PanelContainer StyleClasses="LowDivider" Margin="0 2.5 0 2.5" />
         <Button Access="Public" Name="DisconnectButton" Text="{Loc 'ui-escape-disconnect'}" />
-        <Button Access="Public" Name="QuitButton" Text="{Loc 'ui-escape-quit'}" StyleClasses="ButtonColorRed" />
+        <Button Access="Public" Name="QuitButton" Text="{Loc 'ui-escape-quit'}" StyleClasses="negative" />
     </BoxContainer>
 </ui1:EscapeMenu>

--- a/Content.Client/Options/UI/EscapeMenu.xaml
+++ b/Content.Client/Options/UI/EscapeMenu.xaml
@@ -2,21 +2,32 @@
                 xmlns:changelog="clr-namespace:Content.Client.Changelog"
                 xmlns:ui="clr-namespace:Content.Client.Voting.UI"
                 xmlns:ui1="clr-namespace:Content.Client.Options.UI"
+                xmlns:system="clr-namespace:System;assembly=System.Runtime"
                 Title="{Loc 'ui-escape-title'}"
                 Resizable="False">
 
     <BoxContainer Orientation="Vertical" SeparationOverride="4" MinWidth="150">
         <ui:VoteCallMenuButton />
         <PanelContainer StyleClasses="LowDivider" Margin="0 2.5 0 2.5" />
-        <Button Access="Public" Name="RulesButton" Text="{Loc 'ui-escape-rules'}" />
-        <Button Access="Public" Name="GuidebookButton" Text="{Loc 'ui-escape-guidebook'}" />
-        <Button Access="Public" Name="WikiButton" Text="{Loc 'ui-escape-wiki'}" />
-        <changelog:ChangelogButton Access="Public" Name="ChangelogButton" />
-        <Button Access="Public" Name="FeedbackButton" Text="{Loc 'ui-escape-feedback'}" />
+        <Button Access="Public" Name="RulesButton" Text="{Loc 'ui-escape-rules'}" StyleClasses="OpenLeft" />
+        <Button Access="Public" Name="GuidebookButton" Text="{Loc 'ui-escape-guidebook'}" StyleClasses="OpenBoth" />
+        <Button Access="Public" Name="WikiButton" Text="{Loc 'ui-escape-wiki'}" StyleClasses="OpenBoth" />
+        <changelog:ChangelogButton Access="Public" Name="ChangelogButton" StyleClasses="OpenBoth"/>
+        <Button Access="Public" Name="FeedbackButton" Text="{Loc 'ui-escape-feedback'}" StyleClasses="OpenRight"/>
         <PanelContainer StyleClasses="LowDivider" Margin="0 2.5 0 2.5" />
         <Button Access="Public" Name="OptionsButton" Text="{Loc 'ui-escape-options'}" />
         <PanelContainer StyleClasses="LowDivider" Margin="0 2.5 0 2.5" />
-        <Button Access="Public" Name="DisconnectButton" Text="{Loc 'ui-escape-disconnect'}" />
-        <Button Access="Public" Name="QuitButton" Text="{Loc 'ui-escape-quit'}" StyleClasses="negative" />
+        <Button Access="Public" Name="DisconnectButton" Text="{Loc 'ui-escape-disconnect'}">
+            <Control.StyleClasses>
+                <system:String>negative</system:String>
+                <system:String>OpenLeft</system:String>
+            </Control.StyleClasses>
+        </Button>
+        <Button Access="Public" Name="QuitButton" Text="{Loc 'ui-escape-quit'}">
+            <Control.StyleClasses>
+                <system:String>negative</system:String>
+                <system:String>OpenRight</system:String>
+            </Control.StyleClasses>
+        </Button>
     </BoxContainer>
 </ui1:EscapeMenu>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

I shaped the buttons in the Escape Menu, and made the disconnect/quit buttons red.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Buttons felt discontinuous the way they were laid out earlier, now they feel "connected".

Plus, you always gotta make the quit/disconnect buttons the big scary red color

## Technical details
<!-- Summary of code changes for easier review. -->

Just modified XAML.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

New:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/9d7f9c2b-6fee-4e98-8c19-ebc8d5598d70" />

Old:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/4bd725b1-3b91-4e9b-8641-5cbe487091a7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

No CL, only minor visual tweak