### PR TITLE
All zombies are now re-ghostable.

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -307,7 +307,7 @@ public sealed partial class ZombieSystem
             _npc.WakeNPC(target, htn);
         }
 
-        if (!HasComp<GhostRoleMobSpawnerComponent>(target) && !hasMind) //this specific component gives build test trouble so pop off, ig
+        if (!HasComp<GhostRoleMobSpawnerComponent>(target)) //this specific component gives build test trouble so pop off, ig
         {
             //yet more hardcoding. Visit zombie.ftl for more information.
             var ghostRole = EnsureComp<GhostRoleComponent>(target);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Currently, when a player (or any entity with a mind) gets infected by the zombie virus and then uses /ghost, it will just become an NPC zombie who isn't a ghost role, while a zombified NPC is a ghost role and will stay a ghost role even if the player controlling it uses /ghost.

This makes the player zombies ghost roles.

## Why / Balance

It was strange that you could re-ghost, for instance, a monkey zombie forever while a crewmember zombie (who is only marginally stronger than the infected zombie).

All advantages that you could get by ghosting and unghosting as a zombie (namely knowing where survivors are) are already available to weaker zombies, so they shouldn't be a problem.

Finally, some players always /ghost when they get infected. This allows players who enjoy playing as zombies to control their discarded characters. 

## Technical details

One-liner, removed a check.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

None.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

None.

**Changelog**

:cl:
- tweak: Player zombies become ghost roles too.
