### PR TITLE
fixes for the AntagSelectionSystem

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -95,7 +95,6 @@ public sealed partial class AntagSelectionSystem
                 continue;
 
             count += GetTargetAntagCount(antag, playerCount, ref runningCount);
-            runningCount += count * antag.PlayerRatio;
         }
 
         return count;
@@ -170,7 +169,7 @@ public sealed partial class AntagSelectionSystem
     [PublicAPI]
     public bool AllAntagsAssigned(Entity<AntagSelectionComponent> gameRule, AntagSpecifierPrototype proto, int players)
     {
-        return GetAssignedAntagCount(gameRule, proto) < GetTargetAntagCount(gameRule, players, proto);
+        return GetAssignedAntagCount(gameRule, proto) >= GetTargetAntagCount(gameRule, players, proto);
     }
 
     /// <summary>

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -637,6 +637,15 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         AntagSpecifierPrototype prototype,
         ICommonSession player)
     {
+        // Re-check entity validity now that the player has spawned.
+        // Pre-selection bypasses the blacklist (AttachedEntity was null at that time),
+        // so we must verify here before applying antag components.
+        if (player.AttachedEntity is { } existing && !IsEntityValid(existing, prototype))
+        {
+            DeSelectSession(gameRule, prototype, player);
+            return false;
+        }
+
         // Get a valid entity to initialize
         if (!TryGetAntagEntity(gameRule, prototype, player, out var antagEnt))
         {
@@ -644,11 +653,11 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             return false;
         }
 
-        // Re-check entity validity now that the player has spawned.
-        // Pre-selection bypasses the blacklist (AttachedEntity was null at that time),
-        // so we must verify here before applying antag components.
+        // Rechecking the first case.
         if (!IsEntityValid(antagEnt.Value, prototype))
         {
+            if (antagEnt.Value != player.AttachedEntity)
+                QueueDel(antagEnt.Value);
             DeSelectSession(gameRule, prototype, player);
             return false;
         }

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -644,6 +644,15 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             return false;
         }
 
+        // Re-check entity validity now that the player has spawned.
+        // Pre-selection bypasses the blacklist (AttachedEntity was null at that time),
+        // so we must verify here before applying antag components.
+        if (!IsEntityValid(antagEnt.Value, prototype))
+        {
+            DeSelectSession(gameRule, prototype, player);
+            return false;
+        }
+
         InitializeAntag(gameRule, prototype, antagEnt.Value, player);
         return true;
     }

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -637,15 +637,6 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         AntagSpecifierPrototype prototype,
         ICommonSession player)
     {
-        // Re-check entity validity now that the player has spawned.
-        // Pre-selection bypasses the blacklist (AttachedEntity was null at that time),
-        // so we must verify here before applying antag components.
-        if (player.AttachedEntity is { } existing && !IsEntityValid(existing, prototype))
-        {
-            DeSelectSession(gameRule, prototype, player);
-            return false;
-        }
-
         // Get a valid entity to initialize
         if (!TryGetAntagEntity(gameRule, prototype, player, out var antagEnt))
         {
@@ -653,7 +644,9 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             return false;
         }
 
-        // Rechecking the first case.
+        // Re-check entity validity now that the player has spawned.
+        // Pre-selection bypasses the blacklist (AttachedEntity was null at that time),
+        // so we must verify here before applying antag components.
         if (!IsEntityValid(antagEnt.Value, prototype))
         {
             if (antagEnt.Value != player.AttachedEntity)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
* runningCount in GetTotalAntagCount - GetTargetAntagCount already incrementing the runningCount. As a result, the number of antagonists decreases, I guess it wasn't intended that way.
* AllAntagsAssigned - (╯°□°）╯︵ ┻━┻
* TryInitializeAntag - IsSessionValid skips entity check if AttachedEntity == null (I assume it can be in lobby, in my case it was TestAllGamemodesCanStart in fork for race that can't get infected by zombies. I hope no one else will suffer from this.). After spawn, player could be in blacklist, but antagonist components were still applied.

## Technical details
Minor fixes and additional DeSelectSession in TryInitializeAntag.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
