### PR TITLE
Let security glasses correct near-sighted vision

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -192,6 +192,7 @@
     - Antagonists
   - type: IdentityBlocker
     coverage: EYES
+  - type: VisionCorrection
 
 - type: entity
   parent: [ClothingEyesBase, BaseCommandContraband]
@@ -301,3 +302,4 @@
     tags:
     - HamsterWearable
     - WhitelistChameleon
+  - type: VisionCorrection


### PR DESCRIPTION
## About the PR
Lets players with the near-sighted trait use security (and tech-noir) glasses.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
If a character with the near-sighted trait rolls security, they are at a disadvantage since they have to contend with either having no security HUD or not being able to see properly. Players shouldn't be forced into having to negatively impact their gameplay experience. I don't think it's a stretch to believe that high tech glasses could have some form of built-in vision correction technology.

This QoL change should have minimal impact on game balance; I doubt many players use the near-sighted trait in the first place. Players who do still want to make the trade-off of needing to wear non-security glasses can still do so of their own accord.

I thought about making unique prescription security glasses, but then that means they can't be replaced if stolen/lost. I figured the simple solution was the best route (at least for now).

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Security and noir-tech glasses now correct the vision of characters with the near-sighted trait.
