### PR TITLE
customvote toolshed commands

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -211,7 +211,7 @@ namespace Content.Server.Voting.Managers
             var start = _timing.RealTime;
             var end = start + options.Duration;
             var reg = new VoteReg(id, entries, options.Title, options.InitiatorText,
-                options.InitiatorPlayer, start, end, options.VoterEligibility, options.DisplayVotes, options.TargetEntity);
+                options.InitiatorPlayer, start, end, options.VoterEligibility, options.SelectedVoters, options.DisplayVotes, options.TargetEntity);
 
             var handle = new VoteHandle(this, reg);
 
@@ -247,7 +247,7 @@ namespace Content.Server.Voting.Managers
             msg.VoteId = v.Id;
             msg.VoteActive = !v.Finished;
 
-            if (!CheckVoterEligibility(player, v.VoterEligibility))
+            if (!CheckVoterEligibility(player, v.VoterEligibility, v.SelectedVoters))
             {
                 msg.VoteActive = false;
                 player.Channel.SendMessage(msg);
@@ -385,7 +385,7 @@ namespace Content.Server.Voting.Managers
             // Remove ineligible votes that somehow slipped through
             foreach (var playerVote in v.CastVotes)
             {
-                if (!CheckVoterEligibility(playerVote.Key, v.VoterEligibility))
+                if (!CheckVoterEligibility(playerVote.Key, v.VoterEligibility, v.SelectedVoters))
                 {
                     v.Entries[playerVote.Value].Votes -= 1;
                     v.CastVotes.Remove(playerVote.Key);
@@ -425,7 +425,7 @@ namespace Content.Server.Voting.Managers
             DirtyCanCallVoteAll();
         }
 
-        public bool CheckVoterEligibility(ICommonSession player, VoterEligibility eligibility)
+        public bool CheckVoterEligibility(ICommonSession player, VoterEligibility eligibility, HashSet<ICommonSession>? selectedVoters = null)
         {
             if (eligibility == VoterEligibility.All)
                 return true;
@@ -451,6 +451,11 @@ namespace Content.Server.Voting.Managers
                 var playtime = _playtimeManager.GetPlayTimes(player);
                 if (!playtime.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out TimeSpan overallTime) || overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                     return false;
+            }
+
+            if (eligibility == VoterEligibility.SelectedPlayers)
+            {
+                return selectedVoters != null && selectedVoters.Contains(player);
             }
 
             return true;
@@ -504,6 +509,7 @@ namespace Content.Server.Voting.Managers
             public readonly TimeSpan EndTime;
             public readonly HashSet<ICommonSession> VotesDirty = new();
             public readonly VoterEligibility VoterEligibility;
+            public readonly HashSet<ICommonSession> SelectedVoters;
             public readonly bool DisplayVotes;
             public readonly NetEntity? TargetEntity;
 
@@ -516,7 +522,7 @@ namespace Content.Server.Voting.Managers
             public ICommonSession? Initiator { get; }
 
             public VoteReg(int id, VoteEntry[] entries, string title, string initiatorText,
-                ICommonSession? initiator, TimeSpan start, TimeSpan end, VoterEligibility voterEligibility, bool displayVotes, NetEntity? targetEntity)
+                ICommonSession? initiator, TimeSpan start, TimeSpan end, VoterEligibility voterEligibility, HashSet<ICommonSession> selectedVoters, bool displayVotes, NetEntity? targetEntity)
             {
                 Id = id;
                 Entries = entries;
@@ -526,6 +532,7 @@ namespace Content.Server.Voting.Managers
                 StartTime = start;
                 EndTime = end;
                 VoterEligibility = voterEligibility;
+                SelectedVoters = selectedVoters;
                 DisplayVotes = displayVotes;
                 TargetEntity = targetEntity;
             }
@@ -549,6 +556,7 @@ namespace Content.Server.Voting.Managers
         {
             All,
             Ghost, // Player needs to be a ghost
+            SelectedPlayers, // Player must belong to a special list of players
             GhostMinimumPlaytime, // Player needs to be a ghost, with a minimum playtime and deathtime as defined by votekick CCvars.
             MinimumPlaytime //Player needs to have a minimum playtime and deathtime as defined by votekick CCvars.
         }

--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -26,6 +26,7 @@ namespace Content.Server.Voting
         public void StartCustomVote(
             ICommonSession? initiator,
             bool showResultsInChat,
+            float duration,
             string title,
             List<string> options,
             IEnumerable<EntityUid>? players = null)
@@ -48,7 +49,7 @@ namespace Content.Server.Voting
             var voteOptions = new VoteOptions
             {
                 Title = title,
-                Duration = TimeSpan.FromSeconds(30),
+                Duration = TimeSpan.FromSeconds(duration),
                 VoterEligibility = players != null ? VoteManager.VoterEligibility.SelectedPlayers : VoteManager.VoterEligibility.All,
                 SelectedVoters = playerSessions,
             };
@@ -174,7 +175,7 @@ namespace Content.Server.Voting
                 options.Add(args[i]);
             }
 
-            _entSysManager.GetEntitySystem<CustomVoteSystem>().StartCustomVote(shell.Player, true, args[0], options);
+            _entSysManager.GetEntitySystem<CustomVoteSystem>().StartCustomVote(shell.Player, true, 30, args[0], options);
         }
 
         public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
@@ -201,14 +202,14 @@ namespace Content.Server.Voting
         public void StartAll(IInvocationContext ctx, string title, params string[] options)
         {
             _customVote = _entSysManager.GetEntitySystem<CustomVoteSystem>();
-            _customVote.StartCustomVote(ctx.Session, true, title, options.ToList());
+            _customVote.StartCustomVote(ctx.Session, true, 30, title, options.ToList());
         }
 
         [CommandImplementation("startfor")]
-        public void StartFor(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> players, bool showResultsInChar, string title, params string[] options)
+        public void StartFor(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> players, bool showResultsInChar, float duration, string title, params string[] options)
         {
             _customVote = _entSysManager.GetEntitySystem<CustomVoteSystem>();
-            _customVote.StartCustomVote(ctx.Session, showResultsInChar, title, options.ToList(), players);
+            _customVote.StartCustomVote(ctx.Session, showResultsInChar, duration, title, options.ToList(), players);
         }
     }
 

--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -53,9 +53,9 @@ namespace Content.Server.Voting
                 SelectedVoters = playerSessions,
             };
 
-            for (var i = 1; i <= options.Count; i++)
+            for (var i = 0; i < options.Count; i++)
             {
-                voteOptions.Options.Add((options[i-1], i));
+                voteOptions.Options.Add((options[i], i+1));
             }
 
             voteOptions.SetInitiatorOrServer(initiator);

--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -208,7 +208,7 @@ namespace Content.Server.Voting
         public void StartFor(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> players, bool showResultsInChar, string title, params string[] options)
         {
             _customVote = _entSysManager.GetEntitySystem<CustomVoteSystem>();
-            _customVote.StartCustomVote(ctx.Session, showResultsInChar, title, options.ToList());
+            _customVote.StartCustomVote(ctx.Session, showResultsInChar, title, options.ToList(), players);
         }
     }
 

--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -15,6 +15,88 @@ using Robust.Shared.Toolshed;
 
 namespace Content.Server.Voting
 {
+    public sealed partial class CustomVoteSystem : EntitySystem
+    {
+        [Dependency] private IVoteManager _voteManager = default!;
+        [Dependency] private IAdminLogManager _adminLogger = default!;
+        [Dependency] private IChatManager _chatManager = default!;
+        [Dependency] private VoteWebhooks _voteWebhooks = default!;
+        [Dependency] private IConfigurationManager _cfg = default!;
+
+        public void StartCustomVote(
+            ICommonSession? initiator,
+            bool showResultsInChat,
+            string title,
+            List<string> options,
+            IEnumerable<EntityUid>? players = null)
+        {
+            if (options.Count is < 2 or > 9)
+                return;
+
+            var playerSessions = new HashSet<ICommonSession>();
+            if (players != null)
+            {
+                foreach (var playerEnt in players)
+                {
+                    if (!TryComp<ActorComponent>(playerEnt, out var actor))
+                        continue;
+
+                    playerSessions.Add(actor.PlayerSession);
+                }
+            }
+
+            var voteOptions = new VoteOptions
+            {
+                Title = title,
+                Duration = TimeSpan.FromSeconds(30),
+                VoterEligibility = players != null ? VoteManager.VoterEligibility.SelectedPlayers : VoteManager.VoterEligibility.All,
+                SelectedVoters = playerSessions,
+            };
+
+            for (var i = 1; i <= options.Count; i++)
+            {
+                voteOptions.Options.Add((options[i-1], i));
+            }
+
+            voteOptions.SetInitiatorOrServer(initiator);
+
+            if (initiator != null)
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"{initiator} initiated a custom vote: {voteOptions.Title} - {string.Join("; ", voteOptions.Options.Select(x => x.text))}");
+            else
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Initiated a custom vote: {voteOptions.Title} - {string.Join("; ", voteOptions.Options.Select(x => x.text))}");
+
+            var vote = _voteManager.CreateVote(voteOptions);
+
+            var webhookState = _voteWebhooks.CreateWebhookIfConfigured(voteOptions, _cfg.GetCVar(CCVars.DiscordVoteWebhook));
+
+            vote.OnFinished += (_, eventArgs) =>
+            {
+                if (eventArgs.Winner == null)
+                {
+                    var ties = string.Join(", ", eventArgs.Winners.Select(c => options[(int) c]));
+                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished as tie: {ties}");
+
+                    if (showResultsInChat)
+                        _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-tie", ("title", voteOptions.Title), ("ties", ties)));
+                }
+                else
+                {
+                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished: {options[(int) eventArgs.Winner]}");
+
+                    if (showResultsInChat)
+                        _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-win", ("title", voteOptions.Title), ("winner", options[(int) eventArgs.Winner])));
+                }
+
+                _voteWebhooks.UpdateWebhookIfConfigured(webhookState, eventArgs);
+            };
+
+            vote.OnCancelled += _ =>
+            {
+                _voteWebhooks.UpdateCancelledWebhookIfConfigured(webhookState);
+            };
+        }
+    }
+
     [AnyCommand]
     public sealed partial class CreateVoteCommand : LocalizedEntityCommands
     {
@@ -68,67 +150,7 @@ namespace Content.Server.Voting
     [AdminCommand(AdminFlags.Round)]
     public sealed partial class CreateCustomCommand : LocalizedEntityCommands
     {
-        [Dependency] private IVoteManager _voteManager = default!;
-        [Dependency] private IAdminLogManager _adminLogger = default!;
-        [Dependency] private IChatManager _chatManager = default!;
-        [Dependency] private VoteWebhooks _voteWebhooks = default!;
-        [Dependency] private IConfigurationManager _cfg = default!;
-
-        // TODO: move this somewhere else to remove duplicated code
-        public void StartCustomVote(ICommonSession? initiator, bool showResultsInChat, string title, List<string> options)
-        {
-            if (options.Count is < 2 or > 9)
-                return;
-
-            var voteOptions = new VoteOptions
-            {
-                Title = title,
-                Duration = TimeSpan.FromSeconds(30),
-                VoterEligibility = VoteManager.VoterEligibility.All,
-            };
-
-            for (var i = 1; i <= options.Count; i++)
-            {
-                voteOptions.Options.Add((options[i-1], i));
-            }
-
-            voteOptions.SetInitiatorOrServer(initiator);
-
-            if (initiator != null)
-                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"{initiator} initiated a custom vote: {voteOptions.Title} - {string.Join("; ", voteOptions.Options.Select(x => x.text))}");
-            else
-                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Initiated a custom vote: {voteOptions.Title} - {string.Join("; ", voteOptions.Options.Select(x => x.text))}");
-
-            var vote = _voteManager.CreateVote(voteOptions);
-
-            var webhookState = _voteWebhooks.CreateWebhookIfConfigured(voteOptions, _cfg.GetCVar(CCVars.DiscordVoteWebhook));
-
-            vote.OnFinished += (_, eventArgs) =>
-            {
-                if (eventArgs.Winner == null)
-                {
-                    var ties = string.Join(", ", eventArgs.Winners.Select(c => options[(int) c]));
-                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished as tie: {ties}");
-
-                    if (showResultsInChat)
-                        _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-tie", ("title", voteOptions.Title), ("ties", ties)));
-                }
-                else
-                {
-                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished: {options[(int) eventArgs.Winner]}");
-
-                    if (showResultsInChat)
-                        _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-win", ("title", voteOptions.Title), ("winner", options[(int) eventArgs.Winner])));
-                }
-
-                _voteWebhooks.UpdateWebhookIfConfigured(webhookState, eventArgs);
-            };
-
-            vote.OnCancelled += _ =>
-            {
-                _voteWebhooks.UpdateCancelledWebhookIfConfigured(webhookState);
-            };
-        }
+        [Dependency] private IEntitySystemManager _entSysManager = default!;
 
         private const int MaxArgCount = 10;
 
@@ -148,7 +170,7 @@ namespace Content.Server.Voting
                 options.Add(args[i]);
             }
 
-            StartCustomVote(shell.Player, true, args[0], options);
+            _entSysManager.GetEntitySystem<CustomVoteSystem>().StartCustomVote(shell.Player, true, args[0], options);
         }
 
         public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
@@ -167,72 +189,22 @@ namespace Content.Server.Voting
     [ToolshedCommand, AdminCommand(AdminFlags.Admin)]
     public sealed partial class CustomVoteCommand : ToolshedCommand
     {
-        [Dependency] private IVoteManager _voteManager = default!;
-        [Dependency] private IAdminLogManager _adminLogger = default!;
-        [Dependency] private IChatManager _chatManager = default!;
-        [Dependency] private VoteWebhooks _voteWebhooks = default!;
-        [Dependency] private IConfigurationManager _cfg = default!;
+        [Dependency] private IEntitySystemManager _entSysManager = default!;
 
-        // TODO: move this somewhere else to remove duplicated code
-        public void StartCustomVote(ICommonSession? initiator, bool showResultsInChat, string title, List<string> options)
-        {
-            if (options.Count is < 2 or > 9)
-                return;
-
-            var voteOptions = new VoteOptions
-            {
-                Title = title,
-                Duration = TimeSpan.FromSeconds(30),
-                VoterEligibility = VoteManager.VoterEligibility.All,
-            };
-
-            for (var i = 1; i <= options.Count; i++)
-            {
-                voteOptions.Options.Add((options[i-1], i));
-            }
-
-            voteOptions.SetInitiatorOrServer(initiator);
-
-            if (initiator != null)
-                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"{initiator} initiated a custom vote: {voteOptions.Title} - {string.Join("; ", voteOptions.Options.Select(x => x.text))}");
-            else
-                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Initiated a custom vote: {voteOptions.Title} - {string.Join("; ", voteOptions.Options.Select(x => x.text))}");
-
-            var vote = _voteManager.CreateVote(voteOptions);
-
-            var webhookState = _voteWebhooks.CreateWebhookIfConfigured(voteOptions, _cfg.GetCVar(CCVars.DiscordVoteWebhook));
-
-            vote.OnFinished += (_, eventArgs) =>
-            {
-                if (eventArgs.Winner == null)
-                {
-                    var ties = string.Join(", ", eventArgs.Winners.Select(c => options[(int) c]));
-                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished as tie: {ties}");
-
-                    if (showResultsInChat)
-                        _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-tie", ("title", voteOptions.Title), ("ties", ties)));
-                }
-                else
-                {
-                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished: {options[(int) eventArgs.Winner]}");
-
-                    if (showResultsInChat)
-                        _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-win", ("title", voteOptions.Title), ("winner", options[(int) eventArgs.Winner])));
-                }
-
-                _voteWebhooks.UpdateWebhookIfConfigured(webhookState, eventArgs);
-            };
-
-            vote.OnCancelled += _ =>
-            {
-                _voteWebhooks.UpdateCancelledWebhookIfConfigured(webhookState);
-            };
-        }
+        private CustomVoteSystem? _customVote;
 
         [CommandImplementation("startall")]
         public void StartAll(IInvocationContext ctx, string title, params string[] options)
         {
-            StartCustomVote(ctx.Session, true, title, options.ToList());
+            _customVote = _entSysManager.GetEntitySystem<CustomVoteSystem>();
+            _customVote.StartCustomVote(ctx.Session, true, title, options.ToList());
+        }
+
+        [CommandImplementation("startfor")]
+        public void StartFor(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> players, bool showResultsInChar, string title, params string[] options)
+        {
+            _customVote = _entSysManager.GetEntitySystem<CustomVoteSystem>();
+            _customVote.StartCustomVote(ctx.Session, showResultsInChar, title, options.ToList());
         }
     }
 

--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -73,7 +73,10 @@ namespace Content.Server.Voting
             {
                 if (eventArgs.Winner == null)
                 {
-                    var ties = string.Join(", ", eventArgs.Winners.Select(c => options[(int) c]));
+                    var winners = voteOptions.Options
+                        .Where(t => eventArgs.Winners.Contains(t.data))
+                        .Select(t => t.text);
+                    var ties = string.Join(", ", winners);
                     _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished as tie: {ties}");
 
                     if (showResultsInChat)
@@ -81,10 +84,11 @@ namespace Content.Server.Voting
                 }
                 else
                 {
-                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished: {options[(int) eventArgs.Winner]}");
+                    var winner = voteOptions.Options.FirstOrDefault(t => t.data == eventArgs.Winner).text;
+                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished: {winner}");
 
                     if (showResultsInChat)
-                        _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-win", ("title", voteOptions.Title), ("winner", options[(int) eventArgs.Winner])));
+                        _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-win", ("title", voteOptions.Title), ("winner", winner)));
                 }
 
                 _voteWebhooks.UpdateWebhookIfConfigured(webhookState, eventArgs);

--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -63,8 +63,7 @@ namespace Content.Server.Voting
         }
     }
 
-    [AdminCommand(AdminFlags.Round)]
-    public sealed partial class CreateCustomCommand : LocalizedEntityCommands
+    public abstract partial class BaseCreateCustomVoteCommand : LocalizedEntityCommands
     {
         [Dependency] private IVoteManager _voteManager = default!;
         [Dependency] private IAdminLogManager _adminLogger = default!;
@@ -75,6 +74,8 @@ namespace Content.Server.Voting
         private const int MaxArgCount = 10;
 
         public override string Command => "customvote";
+        public abstract bool GhostOnly { get; }
+        public abstract bool ShowResultsInChat { get; }
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
@@ -90,6 +91,7 @@ namespace Content.Server.Voting
             {
                 Title = title,
                 Duration = TimeSpan.FromSeconds(30),
+                VoterEligibility = GhostOnly ? VoteManager.VoterEligibility.Ghost : VoteManager.VoterEligibility.All,
             };
 
             for (var i = 1; i < args.Length; i++)
@@ -114,12 +116,16 @@ namespace Content.Server.Voting
                 {
                     var ties = string.Join(", ", eventArgs.Winners.Select(c => args[(int) c]));
                     _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {options.Title} finished as tie: {ties}");
-                    _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-tie", ("title", options.Title), ("ties", ties)));
+
+                    if (ShowResultsInChat)
+                        _chatManager.DispatchServerAnnouncement(Loc.GetString($"cmd-{Command}-on-finished-tie", ("title", options.Title), ("ties", ties)));
                 }
                 else
                 {
                     _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {options.Title} finished: {args[(int) eventArgs.Winner]}");
-                    _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-win", ("title", options.Title), ("winner", args[(int) eventArgs.Winner])));
+
+                    if (ShowResultsInChat)
+                        _chatManager.DispatchServerAnnouncement(Loc.GetString($"cmd-{Command}-on-finished-win", ("title", options.Title), ("winner", args[(int) eventArgs.Winner])));
                 }
 
                 _voteWebhooks.UpdateWebhookIfConfigured(webhookState, eventArgs);
@@ -134,14 +140,30 @@ namespace Content.Server.Voting
         public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
         {
             if (args.Length == 1)
-                return CompletionResult.FromHint(Loc.GetString("cmd-customvote-arg-title"));
+                return CompletionResult.FromHint(Loc.GetString($"cmd-{Command}-arg-title"));
 
             if (args.Length > MaxArgCount)
                 return CompletionResult.Empty;
 
             var n = args.Length - 1;
-            return CompletionResult.FromHint(Loc.GetString("cmd-customvote-arg-option-n", ("n", n)));
+            return CompletionResult.FromHint(Loc.GetString($"cmd-{Command}-arg-option-n", ("n", n)));
         }
+    }
+
+    [AdminCommand(AdminFlags.Round)]
+    public sealed partial class CreateCustomCommand : BaseCreateCustomVoteCommand
+    {
+        public override string Command => "customvote";
+        public override bool GhostOnly => false;
+        public override bool ShowResultsInChat => true;
+    }
+
+    [AdminCommand(AdminFlags.Round)]
+    public sealed partial class CreateCustomGhostVoteCommand : BaseCreateCustomVoteCommand
+    {
+        public override string Command => "customghostvote";
+        public override bool GhostOnly => true;
+        public override bool ShowResultsInChat => false;
     }
 
     [AnyCommand]

--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -10,6 +10,8 @@ using Content.Shared.Database;
 using Content.Shared.Voting;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
+using Robust.Shared.Player;
+using Robust.Shared.Toolshed;
 
 namespace Content.Server.Voting
 {
@@ -63,7 +65,8 @@ namespace Content.Server.Voting
         }
     }
 
-    public abstract partial class BaseCreateCustomVoteCommand : LocalizedEntityCommands
+    [AdminCommand(AdminFlags.Round)]
+    public sealed partial class CreateCustomCommand : LocalizedEntityCommands
     {
         [Dependency] private IVoteManager _voteManager = default!;
         [Dependency] private IAdminLogManager _adminLogger = default!;
@@ -71,61 +74,51 @@ namespace Content.Server.Voting
         [Dependency] private VoteWebhooks _voteWebhooks = default!;
         [Dependency] private IConfigurationManager _cfg = default!;
 
-        private const int MaxArgCount = 10;
-
-        public override string Command => "customvote";
-        public abstract bool GhostOnly { get; }
-        public abstract bool ShowResultsInChat { get; }
-
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
+        // TODO: move this somewhere else to reduce duplicated code
+        public void StartCustomVote(ICommonSession? initiator, bool showResultsInChat, string title, List<string> options)
         {
-            if (args.Length < 3 || args.Length > MaxArgCount)
-            {
-                shell.WriteError(Loc.GetString("shell-need-between-arguments",("lower", 3), ("upper", 10)));
+            if (options.Count is < 2 or > 9)
                 return;
-            }
 
-            var title = args[0];
-
-            var options = new VoteOptions
+            var voteOptions = new VoteOptions
             {
                 Title = title,
                 Duration = TimeSpan.FromSeconds(30),
-                VoterEligibility = GhostOnly ? VoteManager.VoterEligibility.Ghost : VoteManager.VoterEligibility.All,
+                VoterEligibility = VoteManager.VoterEligibility.All,
             };
 
-            for (var i = 1; i < args.Length; i++)
+            for (var i = 1; i <= options.Count; i++)
             {
-                options.Options.Add((args[i], i));
+                voteOptions.Options.Add((options[i-1], i));
             }
 
-            options.SetInitiatorOrServer(shell.Player);
+            voteOptions.SetInitiatorOrServer(initiator);
 
-            if (shell.Player != null)
-                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"{shell.Player} initiated a custom vote: {options.Title} - {string.Join("; ", options.Options.Select(x => x.text))}");
+            if (initiator != null)
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"{initiator} initiated a custom vote: {voteOptions.Title} - {string.Join("; ", voteOptions.Options.Select(x => x.text))}");
             else
-                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Initiated a custom vote: {options.Title} - {string.Join("; ", options.Options.Select(x => x.text))}");
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Initiated a custom vote: {voteOptions.Title} - {string.Join("; ", voteOptions.Options.Select(x => x.text))}");
 
-            var vote = _voteManager.CreateVote(options);
+            var vote = _voteManager.CreateVote(voteOptions);
 
-            var webhookState = _voteWebhooks.CreateWebhookIfConfigured(options, _cfg.GetCVar(CCVars.DiscordVoteWebhook));
+            var webhookState = _voteWebhooks.CreateWebhookIfConfigured(voteOptions, _cfg.GetCVar(CCVars.DiscordVoteWebhook));
 
             vote.OnFinished += (_, eventArgs) =>
             {
                 if (eventArgs.Winner == null)
                 {
-                    var ties = string.Join(", ", eventArgs.Winners.Select(c => args[(int) c]));
-                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {options.Title} finished as tie: {ties}");
+                    var ties = string.Join(", ", eventArgs.Winners.Select(c => options[(int) c]));
+                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished as tie: {ties}");
 
-                    if (ShowResultsInChat)
-                        _chatManager.DispatchServerAnnouncement(Loc.GetString($"cmd-{Command}-on-finished-tie", ("title", options.Title), ("ties", ties)));
+                    if (showResultsInChat)
+                        _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-tie", ("title", voteOptions.Title), ("ties", ties)));
                 }
                 else
                 {
-                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {options.Title} finished: {args[(int) eventArgs.Winner]}");
+                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished: {options[(int) eventArgs.Winner]}");
 
-                    if (ShowResultsInChat)
-                        _chatManager.DispatchServerAnnouncement(Loc.GetString($"cmd-{Command}-on-finished-win", ("title", options.Title), ("winner", args[(int) eventArgs.Winner])));
+                    if (showResultsInChat)
+                        _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-win", ("title", voteOptions.Title), ("winner", options[(int) eventArgs.Winner])));
                 }
 
                 _voteWebhooks.UpdateWebhookIfConfigured(webhookState, eventArgs);
@@ -135,6 +128,27 @@ namespace Content.Server.Voting
             {
                 _voteWebhooks.UpdateCancelledWebhookIfConfigured(webhookState);
             };
+        }
+
+        private const int MaxArgCount = 10;
+
+        public override string Command => "customvote";
+
+        public override void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (args.Length is < 3 or > MaxArgCount)
+            {
+                shell.WriteError(Loc.GetString("shell-need-between-arguments",("lower", 3), ("upper", 10)));
+                return;
+            }
+
+            var options = new List<string>();
+            for (var i = 1; i < args.Length; i++)
+            {
+                options.Add(args[i]);
+            }
+
+            StartCustomVote(shell.Player, true, args[0], options);
         }
 
         public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
@@ -150,20 +164,76 @@ namespace Content.Server.Voting
         }
     }
 
-    [AdminCommand(AdminFlags.Round)]
-    public sealed partial class CreateCustomCommand : BaseCreateCustomVoteCommand
+    [ToolshedCommand, AdminCommand(AdminFlags.Admin)]
+    public sealed partial class CustomVoteCommand : ToolshedCommand
     {
-        public override string Command => "customvote";
-        public override bool GhostOnly => false;
-        public override bool ShowResultsInChat => true;
-    }
+        [Dependency] private IVoteManager _voteManager = default!;
+        [Dependency] private IAdminLogManager _adminLogger = default!;
+        [Dependency] private IChatManager _chatManager = default!;
+        [Dependency] private VoteWebhooks _voteWebhooks = default!;
+        [Dependency] private IConfigurationManager _cfg = default!;
 
-    [AdminCommand(AdminFlags.Round)]
-    public sealed partial class CreateCustomGhostVoteCommand : BaseCreateCustomVoteCommand
-    {
-        public override string Command => "customghostvote";
-        public override bool GhostOnly => true;
-        public override bool ShowResultsInChat => false;
+        // TODO: move this somewhere else to reduce duplicated code
+        public void StartCustomVote(ICommonSession? initiator, bool showResultsInChat, string title, List<string> options)
+        {
+            if (options.Count is < 2 or > 9)
+                return;
+
+            var voteOptions = new VoteOptions
+            {
+                Title = title,
+                Duration = TimeSpan.FromSeconds(30),
+                VoterEligibility = VoteManager.VoterEligibility.All,
+            };
+
+            for (var i = 1; i <= options.Count; i++)
+            {
+                voteOptions.Options.Add((options[i-1], i));
+            }
+
+            voteOptions.SetInitiatorOrServer(initiator);
+
+            if (initiator != null)
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"{initiator} initiated a custom vote: {voteOptions.Title} - {string.Join("; ", voteOptions.Options.Select(x => x.text))}");
+            else
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Initiated a custom vote: {voteOptions.Title} - {string.Join("; ", voteOptions.Options.Select(x => x.text))}");
+
+            var vote = _voteManager.CreateVote(voteOptions);
+
+            var webhookState = _voteWebhooks.CreateWebhookIfConfigured(voteOptions, _cfg.GetCVar(CCVars.DiscordVoteWebhook));
+
+            vote.OnFinished += (_, eventArgs) =>
+            {
+                if (eventArgs.Winner == null)
+                {
+                    var ties = string.Join(", ", eventArgs.Winners.Select(c => options[(int) c]));
+                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished as tie: {ties}");
+
+                    if (showResultsInChat)
+                        _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-tie", ("title", voteOptions.Title), ("ties", ties)));
+                }
+                else
+                {
+                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Custom vote {voteOptions.Title} finished: {options[(int) eventArgs.Winner]}");
+
+                    if (showResultsInChat)
+                        _chatManager.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-win", ("title", voteOptions.Title), ("winner", options[(int) eventArgs.Winner])));
+                }
+
+                _voteWebhooks.UpdateWebhookIfConfigured(webhookState, eventArgs);
+            };
+
+            vote.OnCancelled += _ =>
+            {
+                _voteWebhooks.UpdateCancelledWebhookIfConfigured(webhookState);
+            };
+        }
+
+        [CommandImplementation("startall")]
+        public void StartAll(IInvocationContext ctx, string title, params string[] options)
+        {
+            StartCustomVote(ctx.Session, true, title, options.ToList());
+        }
     }
 
     [AnyCommand]

--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -180,13 +180,13 @@ namespace Content.Server.Voting
         public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
         {
             if (args.Length == 1)
-                return CompletionResult.FromHint(Loc.GetString($"cmd-{Command}-arg-title"));
+                return CompletionResult.FromHint(Loc.GetString("cmd-customvote-arg-title"));
 
             if (args.Length > MaxArgCount)
                 return CompletionResult.Empty;
 
             var n = args.Length - 1;
-            return CompletionResult.FromHint(Loc.GetString($"cmd-{Command}-arg-option-n", ("n", n)));
+            return CompletionResult.FromHint(Loc.GetString("cmd-customvote-arg-option-n", ("n", n)));
         }
     }
 

--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -74,7 +74,7 @@ namespace Content.Server.Voting
         [Dependency] private VoteWebhooks _voteWebhooks = default!;
         [Dependency] private IConfigurationManager _cfg = default!;
 
-        // TODO: move this somewhere else to reduce duplicated code
+        // TODO: move this somewhere else to remove duplicated code
         public void StartCustomVote(ICommonSession? initiator, bool showResultsInChat, string title, List<string> options)
         {
             if (options.Count is < 2 or > 9)
@@ -173,7 +173,7 @@ namespace Content.Server.Voting
         [Dependency] private VoteWebhooks _voteWebhooks = default!;
         [Dependency] private IConfigurationManager _cfg = default!;
 
-        // TODO: move this somewhere else to reduce duplicated code
+        // TODO: move this somewhere else to remove duplicated code
         public void StartCustomVote(ICommonSession? initiator, bool showResultsInChat, string title, List<string> options)
         {
             if (options.Count is < 2 or > 9)

--- a/Content.Server/Voting/VoteOptions.cs
+++ b/Content.Server/Voting/VoteOptions.cs
@@ -45,6 +45,11 @@ namespace Content.Server.Voting
         public VoteManager.VoterEligibility VoterEligibility = VoteManager.VoterEligibility.All;
 
         /// <summary>
+        /// List of specific players to send the vote. Only used when <see cref="VoterEligibility"/> is set to SelectedPlayers
+        /// </summary>
+        public HashSet<ICommonSession> SelectedVoters = new();
+
+        /// <summary>
         ///     Whether the vote should send and display the number of votes to the clients. Being an admin defaults this option to true for your client.
         /// </summary>
         public bool DisplayVotes = true;

--- a/Resources/Locale/en-US/commands/toolshed/customvote-command.ftl
+++ b/Resources/Locale/en-US/commands/toolshed/customvote-command.ftl
@@ -1,0 +1,2 @@
+command-description-customvote-startall = Starts a vote for all players (identical to customvote)
+command-description-customvote-startfor = Starts a vote only for the piped entities

--- a/Resources/Locale/en-US/voting/vote-commands.ftl
+++ b/Resources/Locale/en-US/voting/vote-commands.ftl
@@ -17,6 +17,13 @@ cmd-customvote-on-finished-win = The vote '{$title}' has finished: {$winner} win
 cmd-customvote-arg-title = <title>
 cmd-customvote-arg-option-n = <option{ $n }>
 
+## 'customghostvote' command
+
+cmd-customghostvote-desc = Creates a custom ghost vote only ghosts can see and vote
+cmd-customghostvote-help = Usage: customghostvote <title> <option1> <option2> [option3...]
+cmd-customghostvote-arg-title = <title>
+cmd-customghostvote-arg-option-n = <option{ $n }>
+
 ## 'vote' command
 
 cmd-vote-desc = Votes on an active vote

--- a/Resources/Locale/en-US/voting/vote-commands.ftl
+++ b/Resources/Locale/en-US/voting/vote-commands.ftl
@@ -17,13 +17,6 @@ cmd-customvote-on-finished-win = The vote '{$title}' has finished: {$winner} win
 cmd-customvote-arg-title = <title>
 cmd-customvote-arg-option-n = <option{ $n }>
 
-## 'customghostvote' command
-
-cmd-customghostvote-desc = Creates a custom ghost vote only ghosts can see and vote
-cmd-customghostvote-help = Usage: customghostvote <title> <option1> <option2> [option3...]
-cmd-customghostvote-arg-title = <title>
-cmd-customghostvote-arg-option-n = <option{ $n }>
-
 ## 'vote' command
 
 cmd-vote-desc = Votes on an active vote


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the customvote toolshed commands

`customvote:startall` does the same thing as `customvote`
`customvote:startfor` takes one extra argument to say if the results should be sent in chat. and it takes the piped entities as input to tell who to send the vote for

e.g. `> entities with Ghost customvote:startfor false "Kill the captain with a heart attack" "yes" "no"`
would send the vote only for ghost players and it would not send the results in chat

<!-- What did you change? -->

## Why / Balance
Sometimes I want to make a vote only for ghosts, as to not spoil things for the players that are still alive.
e.g. `customghostvote "give the nukies a disposable turret?" "yes" "no"`
if this vote was not only for ghosts, all living players would know there are nukies in the round.

TL:DR More ways for admins to ~abuse~ debug the round

I choose to let the old `customvote` command stay instead of replacing it with `customvote:startall` since
not all people like to use or know how to use toolshed and `customvote` is a pretty essencial tool for admins.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Created a entity system with a method to start a custom vote

I call said method from the old customvote command so it works the same

Created the customvote toolshed command with 2 commands, one for all players and another for only the piped entities.

both call the method from the CustomVoteSystem.

added another flag to VoterEligibility, the SelectedPlayers.
when VoterEligibility is SelectedPlayers. then a player is only eligible to vote if they are in the list of selected voters which is passed along side the vote options and to CheckVoterEligibility
<!-- Summary of code changes for easier review. -->

## Media
<img width="589" height="111" alt="image" src="https://github.com/user-attachments/assets/281fb694-f83e-43b7-bfa2-b5ec97dd9211" />

<img width="566" height="115" alt="image" src="https://github.com/user-attachments/assets/f7bbbac5-1110-4c49-8cc9-91fda5c29ea4" />

<img width="541" height="88" alt="image" src="https://github.com/user-attachments/assets/eea0a063-36f5-452e-936e-ac625157b74d" />

<img width="1417" height="662" alt="image" src="https://github.com/user-attachments/assets/b0558761-d65c-4796-9d1b-fef4c16ff1d8" />
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Samuka
ADMIN:
- add: Added customvote toolshed commands! now it is possible to choose exactly who can vote and if the vote results will be sent in chat.

<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
