### PR TITLE
Fix Humanoid Heisentest

### DIFF
--- a/Content.Shared/Humanoid/SkinColorationPrototype.cs
+++ b/Content.Shared/Humanoid/SkinColorationPrototype.cs
@@ -314,10 +314,11 @@ internal static class SkinColorationUtils
     public const float EpsilonHue = 0.00277f;
 
     /// <summary>
-    /// A value derived by dividing 1 by 256.
-    /// Due to the way these values are stored and deconstructed we can't expect much more precision than this..
+    /// Value is somewhat arbitrary. Due to RGB colors being clamped to 8 bits, precision is lost during
+    /// transformation to HSL or HSV. Calculating the exact deviation possible through those
+    /// transforms is nontrivial and not worth the time.
     /// </summary>
-    public const float Epsilon = 0.00390625f;
+    public const float Epsilon = 0.005f;
 
     /// <summary>
     /// Checks if a hue value is within a specified range, correctly handling ranges that wrap around 1.0 (e.g., reds).

--- a/Content.Shared/Humanoid/SkinColorationPrototype.cs
+++ b/Content.Shared/Humanoid/SkinColorationPrototype.cs
@@ -314,11 +314,9 @@ internal static class SkinColorationUtils
     public const float EpsilonHue = 0.00277f;
 
     /// <summary>
-    /// Value is somewhat arbitrary. Due to RGB colors being clamped to 8 bits, precision is lost during
-    /// transformation to HSL or HSV. Calculating the exact deviation possible through those
-    /// transforms is nontrivial and not worth the time.
+    /// Due to RGB colors being clamped to 8 bits, precision is lost during transformation to HSL or HSV.
     /// </summary>
-    public const float Epsilon = 0.005f;
+    public const float Epsilon = 0.0056f;
 
     /// <summary>
     /// Checks if a hue value is within a specified range, correctly handling ranges that wrap around 1.0 (e.g., reds).

--- a/Content.Shared/Humanoid/SkinColorationPrototype.cs
+++ b/Content.Shared/Humanoid/SkinColorationPrototype.cs
@@ -315,6 +315,7 @@ internal static class SkinColorationUtils
 
     /// <summary>
     /// Due to RGB colors being clamped to 8 bits, precision is lost during transformation to HSL or HSV.
+    /// The precision of the result is approximately 1/180.
     /// </summary>
     public const float Epsilon = 0.0056f;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Resolves #43780

Dug into this and triggered the testfail locally for debugging a handful of times.
The issue is stemming from the clamping. When a new character is generated, it clamps the max HSL per the species limits.
However, that value is then cast to 8-bit values. This can sometimes be enough to push the HSL out of bounds.

Epsilon was calculated based on 1/256. This would work for validating the RGB values, but does not work for validating the HSL or HSV.

I currently have this running until failure on my computer. ~The largest deviation I have seen in testing has been `0.00479045`. If I see any fails at `0.005` I will increase it further.~
The precision was given as 1/180, the epsilon has been increased to match.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Heisentests make everyone suffer.

## Technical details
<!-- Summary of code changes for easier review. -->
Made epsilon a bit bigger for skin color testing.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nothing player facing.