### PR TITLE
Improve performance of `GameRuleSystem.TryFindRandomTileOnStation`

### DIFF
--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -95,7 +95,7 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
             if (!TryComp<MapGridComponent>(possibleTarget, out var comp))
                 continue;
 
-            weights.Add((possibleTarget, comp), _map.GetAllTiles(possibleTarget, comp).Count());
+            weights.Add((possibleTarget, comp), _map.GetFilledTileCount((possibleTarget, comp)));
         }
 
         if (weights.Count == 0)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Improved the performance of `GameRuleSystem.TryFindRandomTileOnStation` by using `SharedMapSystem.GetFilledTileCount` instead of `SharedMapSystem.GetAllTiles().Count()`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The existing code does a lot of unnecessary work. While it's not exactly a hot code path, this method is called a fair bit by various game rules.

## Technical details
<!-- Summary of code changes for easier review. -->
Swapped out code which iterates over every single `TileRef` on the grid to count them. Swapped in calling a new helper method that returns the sum of the `FilledTiles` counts from each grid chunk.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->