### PR TITLE
Remove Wand of Entrance from Magic Event Spell

### DIFF
--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -198,8 +198,6 @@
         orGroup: Magics
       - id: WeaponWandFireball
         orGroup: Magics
-      - id: WeaponWandPolymorphDoor
-        orGroup: Magics
       - id: WeaponWandCluwne
         orGroup: Magics
       - id: WeaponWandPolymorphBread


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I removed the wand of entrance from the wizard magic item event spell.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The Staff of entrance, which does the same thing and recharges, is in the pool so it makes it so much more common in the event. to get a entrance magic item than the other items, I didn't remove the Wand of Entrance completely as it is a wizard grimoire wand, and those should not recharge on their own.
<img width="991" height="562" alt="image" src="https://github.com/user-attachments/assets/17c64d39-a12b-41e1-9bc9-c590099abe8f" />


## Technical details
<!-- Summary of code changes for easier review. -->
YAML
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
🆑 
- tweak: The Wand of Entrance is no longer in the random magic item spell pool, note the Staff of Entrance is.