### PR TITLE
Prevent RRs by letting Arcryox heal poison too

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1334,6 +1334,7 @@
         damage:
           Brute: -3
           Burn: -3
+          Poison: -0.5
 
 - type: reagent
   id : Aloxadone


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Arcyox now heals posion at a rate of 0.5

## Why / Balance
PR #43103 claims to remove Necrosol in favour of Arcyox which heals regardless of damage. It doesn't instead healing (3 brute & burn).

Necrosol was a very valuable chem to medical since it was the only thing that made it so 195+ poison wasn’t completely incurable and an RR. It served a niche purpose of healing poison for dead people, without being overpowered because of its recipe costing Omnizine.

Giving arcryox the (slight) ability to heal poison (0.5 rate compered to 2) can reduce RRs from things like foamspills or overdosing.

## Technical details
N/A

## Media
N/A 

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Arcyox can now heal poison (rate of 0.5) on the dead

