### PR TITLE
Minor PR description template change

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ Small fixes/refactors are exempt. Media may be used in SS14 progress reports wit
 <!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
 This will be posted in #codebase-changes. -->
 
-**Changelog**
+## Changelog
 <!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
 Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
 Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->


### PR DESCRIPTION
I want try and make the labeler automatically post breaking changes on discourse so that we don't have to do this manually each time.
This PR standardizes the formatting and makes the breaking changes section easier to parse since I just need to read until the next header.

The changelog bot should not be affected as that just searches for the cl emoji