### PR TITLE
Cleanup of lighter.yml

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -416,7 +416,7 @@
     color: yellow
 
 - type: entity
-  parent: [BaseBrandedLighter]
+  parent: [SolutionLighter, BaseBrandedLighter]
   id: DonkcoLighter
   name: Donk Co. flippo
   description: The flippo of choice for the seasoned traitor. A Breaded novelty lighter made by Donk Co.

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -54,10 +54,10 @@
         Quantity: 7.5
 
 - type: entity
-  name: basic lighter
   parent: [SolutionLighter, BaseLighter]
   id: Lighter
-  description: "A simple plastic cigarette lighter."
+  name: basic lighter
+  description: A simple plastic cigarette lighter.
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/lighters.rsi
@@ -84,14 +84,8 @@
           basic_icon_base-9: ""
           basic_icon_base-10: ""
           basic_icon_base-11: ""
-  - type: GenericVisualizer
-    visuals:
-      enum.ToggleableVisuals.Enabled:
-        flame:
-          True: { visible: true }
-          False: { visible: false }
   - type: ToggleableVisuals
-    spriteLayer: lighter_flame
+    spriteLayer: flame
     inhandVisuals:
       left:
       - state: inhand-left-flame
@@ -103,10 +97,10 @@
     sprite: Objects/Tools/Lighters/lighters.rsi
 
 - type: entity
-  name: cheap lighter
-  parent: BaseLighter
+  parent: Lighter
   id: CheapLighter
-  description: "A dangerously inexpensive plastic lighter, don't burn your thumb!"
+  name: cheap lighter
+  description: "A dangerously inexpensive plastic lighter. Don't burn your thumb!"
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/lighters.rsi
@@ -128,79 +122,47 @@
     fuelLitCost: 0.2
 
 - type: entity
-  name: flippo lighter
-  parent: BaseBrandedLighter
-  id: FlippoLighter
-  description: "A rugged metal lighter, lasts quite a while."
+  parent: [ SolutionLighter, BaseLighter ]
+  id: DiscountDanLighter
+  name: Discount Dan's lighter
+  description: The worst lighter ever produced. Lighter burn is inevitable, do not refuel while lit.
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/lighters.rsi
     layers:
-    - state: zippo_icon_base
-      map: ["base"]
-    - state: zippo_top
-      map: ["top"]
-      visible: false
-    - state: zippo_open
-      map: ["open"]
-      visible: false
+    - state: icon_map
+    - state: discount_icon_base
+    - state: basic_icon_top
     - state: lighter_flame
-      map: ["flame"]
       visible: false
       shader: unshaded
+      map: [ "flame" ]
+  - type: Welder # the single worst lighter invented by mankind
+    fuelConsumption: 0.4
+    fuelLitCost: 0.2
+    tankSafe: false
   - type: Item
     sprite: Objects/Tools/Lighters/lighters.rsi
-    heldPrefix: zippo
-  - type: GenericVisualizer
-    visuals:
-      enum.ToggleableVisuals.Enabled:
-        flame:
-          True: { visible: true }
-          False: { visible: false }
-        open:
-          True: { visible: true }
-          False: { visible: false }
-        top:
-          True: { visible: true }
-          False: { visible: false }
-        base:
-          True: { visible: false }
-          False: { visible: true }
   - type: ToggleableVisuals
-    spriteLayer: lighter_flame
+    spriteLayer: flame
     inhandVisuals:
       left:
-      - state: zippo-inhand-left-flame
+      - state: inhand-left-flame
         shader: unshaded
       right:
-      - state: zippo-inhand-right-flame
+      - state: inhand-right-flame
         shader: unshaded
   - type: PointLight
-    radius: 1.2 #slightly stronger than the other lighters
-
-- type: entity
-  name: flippo engraved lighter
-  parent: FlippoLighter
-  id: FlippoEngravedLighter
-  description: "A rugged golden lighter, lasts quite a while. Engravings serve no tactical advantage whatsoever."
-  components:
-  - type: Sprite
-    sprite: Objects/Tools/Lighters/lighters.rsi
-    layers:
-    - state: zippo_engraved_icon_base
-      map: ["base"]
-    - state: zippo_top
-      map: ["top"]
-      visible: false
-    - state: zippo_engraved_open
-      map: ["open"]
-      visible: false
-    - state: lighter_flame
-      map: ["flame"]
-      visible: false
-      shader: unshaded
-  - type: StealTarget
-    stealGroup: FlippoEngravedLighter
+    enabled: false
+    netsync: false
+    radius: 1.5
+    color: yellow
+  - type: ComponentToggler
+    components:
+    - type: DamageOnHolding # todo this needs to make a sound or something to tell people it's burning them
+      damage:
+        types:
+          Heat: 2
 
 - type: entity
   abstract: true
@@ -234,9 +196,6 @@
   - type: GenericVisualizer
     visuals:
       enum.ToggleableVisuals.Enabled:
-        flame:
-          True: { visible: true }
-          False: { visible: false }
         open:
           True: { visible: true }
           False: { visible: false }
@@ -247,7 +206,7 @@
           True: { visible: false }
           False: { visible: true }
   - type: ToggleableVisuals
-    spriteLayer: lighter_flame
+    spriteLayer: flame
     inhandVisuals:
       left:
       - state: inhand-left-lit
@@ -255,6 +214,65 @@
       right:
       - state: inhand-right-lit
         shader: unshaded
+  - type: PointLight
+    radius: 1.5 #slightly stronger than the other lighters
+
+- type: entity
+  parent: BaseBrandedLighter
+  id: FlippoLighter
+  name: flippo lighter
+  description: A rugged metal lighter that lasts quite a while.
+  components:
+  - type: Sprite
+    sprite: Objects/Tools/Lighters/lighters.rsi
+    layers:
+    - state: zippo_icon_base
+      map: ["base"]
+    - state: zippo_top
+      map: ["top"]
+      visible: false
+    - state: zippo_open
+      map: ["open"]
+      visible: false
+    - state: lighter_flame
+      map: ["flame"]
+      visible: false
+      shader: unshaded
+  - type: Item
+    sprite: Objects/Tools/Lighters/lighters.rsi
+    heldPrefix: zippo
+  - type: ToggleableVisuals
+    inhandVisuals:
+      left:
+      - state: zippo-inhand-left-flame
+        shader: unshaded
+      right:
+      - state: zippo-inhand-right-flame
+        shader: unshaded
+
+- type: entity
+  parent: FlippoLighter
+  id: FlippoEngravedLighter
+  name: flippo engraved lighter
+  description: A rugged golden lighter that lasts quite a while. Engravings serve no tactical advantage whatsoever.
+  components:
+  - type: Sprite
+    sprite: Objects/Tools/Lighters/lighters.rsi
+    layers:
+    - state: zippo_engraved_icon_base
+      map: ["base"]
+    - state: zippo_top
+      map: ["top"]
+      visible: false
+    - state: zippo_engraved_open
+      map: ["open"]
+      visible: false
+    - state: lighter_flame
+      map: ["flame"]
+      visible: false
+      shader: unshaded
+  - type: StealTarget
+    stealGroup: FlippoEngravedLighter
 
 - type: entity
   parent: [BaseBrandedLighter, BaseSyndicateContraband]
@@ -266,82 +284,20 @@
     sprite: Objects/Tools/Lighters/syndielighter.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/syndielighter.rsi
-  - type: Welder
-    fuelConsumption: 0.005
-    fuelLitCost: 0.01
-    tankSafe: true
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 2
     color: green
-
-- type: entity
-  parent: Lighter
-  id: DiscountDanLighter
-  name: Discount Dan's lighter
-  description: "The worst lighter ever produced, lighterburn is inevitable, do not refuel while lit."
-  components:
-  - type: Sprite
-    sprite: Objects/Tools/Lighters/lighters.rsi
-    layers:
-    - state: icon_map
-    - state: discount_icon_base
-      map: [ "skin" ]
-    - state: basic_icon_top
-    - state: lighter_flame
-      visible: false
-      shader: unshaded
-      map: [ "flame" ]
-  - type: Welder # the single worst lighter invented by mankind
-    fuelConsumption: 0.4
-    fuelLitCost: 0.2
-    tankSafe: false
-  - type: Item
-    sprite: Objects/Tools/Lighters/lighters.rsi
-  - type: ToggleableVisuals
-    spriteLayer: lighter_flame
-    inhandVisuals:
-      left:
-      - state: inhand-left-flame
-        shader: unshaded
-      right:
-      - state: inhand-right-flame
-        shader: unshaded
-  - type: RandomSprite
-    available:
-      - skin:
-          discount_icon_base: ""
-  - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 1.5
-    color: yellow
-  - type: ComponentToggler
-    components:
-    - type: DamageOnHolding
-      damage:
-        types:
-          Heat: 2
 
 - type: entity
   parent: [BaseBrandedLighter, BaseSyndicateContraband]
   id: CybersunFlippo
   name: CyberSun Flippo
-  description: "A Sleek black and magenta flippo lighter, bearing the logo and iconography of CyberSun Industries."
+  description: A sleek black and magenta flippo lighter, bearing the logo and iconography of CyberSun Industries.
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/cybersun.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/cybersun.rsi
-  - type: Welder #
-    fuelConsumption: 0.005
-    fuelLitCost: 0.01
-    tankSafe: true
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 2
     color: magenta
 
 - type: entity
@@ -354,42 +310,25 @@
     sprite: Objects/Tools/Lighters/interdyne.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/interdyne.rsi
-  - type: Welder #
-    fuelConsumption: 0.005
-    fuelLitCost: 0.01
-    tankSafe: true
-  - type: ItemToggleMeleeWeapon
-    activatedDamage:
-        types:
-          Radiation: 1
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 2
     color: cyan
 
 - type: entity
   parent: [BaseBrandedLighter]
   id: NanotrasenFlippo
   name: Nanotrasen Flippo
-  description: "A navy blue luxury flippo, generally handed out to loyal heads of staff instead of a payraise. Fueled with liquid plasma"
+  description: A navy blue luxury flippo, generally handed out to loyal heads of staff instead of a pay raise. Fueled with liquid plasma.
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/nanotrasen.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/nanotrasen.rsi
-  - type: Welder #
+  - type: Welder
     fuelConsumption: 0.005
     fuelLitCost: 1
     fuelReagent: Plasma
-    tankSafe: true
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 2
     color: blue
-  - type: RefillableSolution
-    solution: welder
   - type: Solution
     solution:
       reagents:
@@ -400,7 +339,7 @@
   parent: [SolutionToolWelderExperimental, BaseBrandedLighter, BaseCentcommContraband]
   id: CentCommFlippo
   name: Gilded CentComm Flippo
-  description: "An Ornate, jade embossed and gilded flippo frame containing a bluespace powered jet. The latch is secured by a miniature access reader that only responds to CentComm officials. The nicest lighter known to man."
+  description: An Ornate, jade embossed and gilded flippo frame containing a bluespace powered jet. The latch is secured by a miniature access reader that only responds to CentComm officials. The nicest lighter known to man.
   suffix: DO NOT MAP
   components:
   - type: Sprite
@@ -409,18 +348,13 @@
     sprite: Objects/Tools/Lighters/centcomm.rsi
   - type: ItemToggleRequiresLock
     requireLocked: false
-  - type: Welder #
+  - type: Welder
     fuelConsumption: 0.0
     fuelLitCost: 10
     fuelReagent: Plasma
-    tankSafe: true
   - type: PointLight
-    enabled: false
-    netsync: false
     radius: 4 #Excessively powerful
     color: Gold
-  - type: RefillableSolution
-    solution: Welder
   - type: Tool
     useSound:
       collection: Welder
@@ -433,118 +367,56 @@
   parent: [BaseBrandedLighter, BaseMajorContraband]
   id: SpiderclanFlippo
   name: Spider-Clan lighter
-  description: "A high tech jet lighter, engineered to function even in deep space. Runs on a tiny microfusion cell."
+  description: A high tech jet lighter, engineered to function even in deep space. Runs on a tiny microfusion cell.
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/spiderclan.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/spiderclan.rsi
-  - type: Welder #
+  - type: Welder
     fuelConsumption: 0
     fuelLitCost: 0
-    tankSafe: true
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 2
     color: green
 
 - type: entity
   parent: [BaseBrandedLighter, BaseSyndicateContraband]
   id: WaffleCoFlippo
   name: Waffle Co. flippo
-  description: "A robust mass produced lighter. The Waffle Co. logo turns the spark wheel when pushed up, minimising risk of lighter burns for even the most inept user."
+  description: A robust mass produced lighter. The Waffle Co. logo turns the spark wheel when pushed up, minimising risk of lighter burns for even the most inept user.
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/waffleco.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/waffleco.rsi
-  - type: Welder #
-    fuelConsumption: 0.005
-    fuelLitCost: 0.05
-    tankSafe: true
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 2
     color: brown
 
 - type: entity
   parent: [BaseBrandedLighter]
   id: HonkCoFlippo
   name: Honk Co. flippo
-  description: "A slippery gag lighter produced by Honk Co. hidden inside of a real banana peel."
+  description: A gag lighter hidden inside of a banana peel. Produced by Honk Co.
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/honkco.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/honkco.rsi
-  - type: ComponentToggler # This is super cursed and ends up deleting the fixtures when toggled off
-    components:
-    - type: Slippery
-    - type: StepTrigger
-      intersectRatio: 0.2
-    - type: CollisionWake
-      enabled: false
-    - type: Physics
-      bodyType: Dynamic
-    - type: Fixtures
-      fixtures:
-        slips:
-          shape:
-            !type:PhysShapeAabb
-            bounds: "-0.4,-0.3,0.4,0.3"
-          layer:
-          - SlipLayer
-          hard: false
-        fix1:
-          shape:
-            !type:PhysShapeAabb
-            bounds: "-0.4,-0.3,0.4,0.3"
-          density: 10
-          mask:
-          - ItemMask
-  - type: Welder #
+  - type: Welder
     fuelConsumption: 0.1
     fuelLitCost: 1
-    tankSafe: true
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 2
     color: yellow
 
 - type: entity
   parent: [BaseBrandedLighter]
   id: DonkcoLighter
   name: Donk Co. flippo
-  description: "The flippo of choice for the seasoned traitor. A Breaded novelty lighter made by Donk Co. Somehow edible while lit."
+  description: The flippo of choice for the seasoned traitor. A breaded novelty lighter made by Donk Co.
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/donkco.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/donkco.rsi
-  - type: Welder #
-    fuelConsumption: 0.02
-    fuelLitCost: 0.1
-    tankSafe: true
-  - type: Tag
-    tags:
-    - DonkPocket
-    - Meat
-  - type: SolutionManager
-    solutions:
-    - SolutionFoodDonkpocketWarm
-  - type: FlavorProfile
-    flavors:
-      - bread
-      - meaty
-      - cheap
-  - type: ComponentToggler
-    components:
-    - type: Edible # This shouldn't be component toggler, but doesn't work when it's not
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 2
     color: orange

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -53,6 +53,8 @@
       - ReagentId: WeldingFuel
         Quantity: 7.5
 
+## Basic
+
 - type: entity
   parent: [SolutionLighter, BaseLighter]
   id: Lighter
@@ -153,8 +155,6 @@
       - state: inhand-right-flame
         shader: unshaded
   - type: PointLight
-    enabled: false
-    netsync: false
     radius: 1.5
     color: yellow
   - type: ComponentToggler
@@ -163,6 +163,8 @@
       damage:
         types:
           Heat: 2
+
+## Flippos
 
 - type: entity
   abstract: true
@@ -409,6 +411,7 @@
   - type: Welder
     fuelConsumption: 0.1
     fuelLitCost: 1
+    # Used to be slippery while lit, but worked very poorly and caused the fixtures to disappear
   - type: PointLight
     color: yellow
 
@@ -416,7 +419,7 @@
   parent: [BaseBrandedLighter]
   id: DonkcoLighter
   name: Donk Co. flippo
-  description: The flippo of choice for the seasoned traitor. A breaded novelty lighter made by Donk Co.
+  description: The flippo of choice for the seasoned traitor. A Breaded novelty lighter made by Donk Co.
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/donkco.rsi
@@ -424,3 +427,18 @@
     sprite: Objects/Tools/Lighters/donkco.rsi
   - type: PointLight
     color: orange
+  - type: Tag
+    tags:
+    - DonkPocket
+    - Meat
+  - type: SolutionManager
+    solutions:
+    - SolutionFoodDonkpocketWarm
+  - type: FlavorProfile
+    flavors:
+    - bread
+    - meaty
+    - cheap
+  - type: Edible
+    trash:
+    - DiscountDanLighter # A prize hidden inside the donk!

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -310,6 +310,10 @@
     sprite: Objects/Tools/Lighters/interdyne.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/interdyne.rsi
+  - type: ItemToggleMeleeWeapon
+    activatedDamage:
+      types:
+        Radiation: 1
   - type: PointLight
     color: cyan
 

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -419,7 +419,7 @@
   parent: [SolutionLighter, BaseBrandedLighter]
   id: DonkcoLighter
   name: Donk Co. flippo
-  description: The flippo of choice for the seasoned traitor. A Breaded novelty lighter made by Donk Co.
+  description: The flippo of choice for the seasoned traitor. An edible novelty lighter made by Donk Co.
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/donkco.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Lighters were cleaned up and better standardized. Fixed some bugs with their visuals. It also nerfs the fuel usage of most of the special flippos to be the same as regular lighters, but these values were extreme and made them practically never run out. The default values were already very long lasting.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mostly a cleanup PR removing redundant datafields and fixing the ordering.

## Technical details
<!-- Summary of code changes for easier review. -->
Donk co lighter used to only be edible *because* of component toggler, but thankfully that cursed "feature" got fixed and it can be normal now.

Honk co lighter was unfortunately de slipped. The use of component toggler made a mess of things and would cause problems like removing the fixtures and collision wake.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="297" height="339" alt="image" src="https://github.com/user-attachments/assets/05a8ac3f-4ce9-46a5-81c1-6eef643e660c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->