### PR TITLE
Cargo order computer order cap is able to change

### DIFF
--- a/Content.Client/Cargo/BUI/CargoOrderConsoleBoundUserInterface.cs
+++ b/Content.Client/Cargo/BUI/CargoOrderConsoleBoundUserInterface.cs
@@ -142,6 +142,11 @@ namespace Content.Client.Cargo.BUI
                 return;
 
             _menu.ProductCatalogue = cState.Products;
+            _menu.ShuttleCapacityLabel.Text = Loc.GetString(
+                "cargo-console-menu-order-capacity-number",
+                ("count", OrderCount),
+                ("capacity", OrderCapacity)
+            );
 
             _menu?.UpdateStation(station);
             Populate(cState.Orders);

--- a/Content.Client/Cargo/UI/CargoConsoleMenu.xaml
+++ b/Content.Client/Cargo/UI/CargoConsoleMenu.xaml
@@ -52,7 +52,8 @@
                           <PanelContainer StyleClasses="LowDivider" Margin="0 -2 0 -1"/>
 
                           <Label Name="ShuttleCapacityLabel"
-                              Text="0/20"
+                              Text="0/0"
+                              Access="Public"
                               Margin="4 0"/>
                       </GridContainer>
 

--- a/Resources/Locale/en-US/cargo/cargo-console-component.ftl
+++ b/Resources/Locale/en-US/cargo/cargo-console-component.ftl
@@ -13,6 +13,7 @@ cargo-console-menu-points-amount = ${$amount}
 cargo-console-menu-shuttle-status-label = Shuttle status:{" "}
 cargo-console-menu-shuttle-status-away-text = Away
 cargo-console-menu-order-capacity-label = Order capacity:{" "}
+cargo-console-menu-order-capacity-number = {$count}/{$capacity}
 cargo-console-menu-call-shuttle-button = Activate telepad
 cargo-console-menu-permissions-button = Permissions
 cargo-console-menu-categories-label = Categories:{" "}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed the current Order capacity on the cargo request computer is hard coded as 0/20.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The outstanding orders number currently doesn't change however if any system did make us of it the it might aswell work.
Fixed it instead of removing it beacuse #43928 fixes the outstanding orders and it would probably need a bigger overhaul of the UI.

## Technical details
<!-- Summary of code changes for easier review. -->
Updates the label within `UpdateState()` inside the BUI. The capacity and count variables are already there.
Added loc for the text.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/a. Currently no ingame change

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->