### PR TITLE
Parcel wrap bugfix + multihandedness enhancement

### DIFF
--- a/Content.Shared/ParcelWrap/Components/WrappedParcelComponent.cs
+++ b/Content.Shared/ParcelWrap/Components/WrappedParcelComponent.cs
@@ -62,6 +62,13 @@ public sealed partial class WrappedParcelComponent : Component
     public bool GetsShapeFromContent;
 
     /// <summary>
+    /// If true, the owner of this entity has <see cref="MultiHandedItemComponent"/> added if any item inserted into
+    /// <see cref="Container"/> has that component.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool GetsMultiHandednessFromContent = true;
+
+    /// <summary>
     /// If a player trapped inside this parcel can escape from it by unwrapping it.
     /// This is set by the <see cref="ParcelWrapComponent" /> used to create the parcel.
     /// </summary>

--- a/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.ParcelWrap.cs
+++ b/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.ParcelWrap.cs
@@ -89,7 +89,7 @@ public sealed partial class ParcelWrappingSystem
     {
         var duration = wrapper.Comp.WrapDelay;
 
-        if (TryComp<ParcelWrapOverrideComponent>(target, out var overrideComp) &&
+        if (_parcelWrapOverrideQuery.TryComp(target, out var overrideComp) &&
             overrideComp.WrapDelay is { } wrapDelayOverride)
             duration = wrapDelayOverride;
 

--- a/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.WrappedParcel.cs
+++ b/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.WrappedParcel.cs
@@ -32,7 +32,10 @@ public sealed partial class ParcelWrappingSystem
         entity.Comp.Contents = _container.EnsureContainer<ContainerSlot>(entity, entity.Comp.ContainerId);
     }
 
-    private void OnEntInsertedIntoContainer(Entity<WrappedParcelComponent> entity, ref EntInsertedIntoContainerMessage args)
+    private void OnEntInsertedIntoContainer(
+        Entity<WrappedParcelComponent> entity,
+        ref EntInsertedIntoContainerMessage args
+    )
     {
         // If the entity was inserted because of a server state application, assume that the item's state is applied
         // correctly as well and that deriving them from the contents is unneeded.
@@ -40,12 +43,10 @@ public sealed partial class ParcelWrappingSystem
             return;
 
         if (args.Container != entity.Comp.Contents ||
-            !TryComp<ItemComponent>(entity, out var parcelItemComp))
+            !_itemQuery.TryComp(entity, out var parcelItemComp))
             return;
 
-        // If this wrap maintains the size when wrapping, set the parcel's size to the target's size, or the fallback
-        // size if the target does not have a size.
-        var targetItemComp = CompOrNull<ItemComponent>(args.Entity);
+        var targetItemComp = _itemQuery.CompOrNull(args.Entity);
         if (entity.Comp.GetsSizeFromContent)
         {
             var size = targetItemComp?.Size ?? _fallbackParcelSize;
@@ -53,11 +54,15 @@ public sealed partial class ParcelWrappingSystem
             _appearance.SetData(entity, WrappedParcelVisuals.Size, size.Id);
         }
 
-        // If this wrap maintains the shape when wrapping and the item has a shape override, copy the shape override to
-        // the parcel.
         if (entity.Comp.GetsShapeFromContent)
         {
             _item.SetShape(entity, targetItemComp?.Shape, parcelItemComp);
+        }
+
+        if (entity.Comp.GetsMultiHandednessFromContent &&
+            _multiHandedItemQuery.TryComp(args.Entity, out var multiHandedItemComp))
+        {
+            EnsureComp<MultiHandedItemComponent>(entity).HandsNeeded = multiHandedItemComp.HandsNeeded;
         }
     }
 
@@ -69,8 +74,10 @@ public sealed partial class ParcelWrappingSystem
         args.Handled = TryStartUnwrapDoAfter(args.User, entity);
     }
 
-    private void OnGetVerbsForWrappedParcel(Entity<WrappedParcelComponent> entity,
-        ref GetVerbsEvent<InteractionVerb> args)
+    private void OnGetVerbsForWrappedParcel(
+        Entity<WrappedParcelComponent> entity,
+        ref GetVerbsEvent<InteractionVerb> args
+    )
     {
         if (!args.CanAccess || !args.CanComplexInteract)
             return;
@@ -93,7 +100,7 @@ public sealed partial class ParcelWrappingSystem
         if (args.Handled || args.Cancelled)
             return;
 
-        if (args.Target is { } target && TryComp<WrappedParcelComponent>(target, out var parcel))
+        if (args.Target is { } target && _wrappedParcelQuery.TryComp(target, out var parcel))
         {
             UnwrapInternal(args.User, (target, parcel));
             args.Handled = true;

--- a/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.cs
+++ b/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.cs
@@ -1,10 +1,10 @@
 using Content.Shared.Charges.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Item;
-using JetBrains.Annotations;
 using Content.Shared.ParcelWrap.Components;
 using Content.Shared.Popups;
 using Content.Shared.Whitelist;
+using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Physics;

--- a/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.cs
+++ b/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.cs
@@ -1,10 +1,10 @@
 using Content.Shared.Charges.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Item;
+using JetBrains.Annotations;
 using Content.Shared.ParcelWrap.Components;
 using Content.Shared.Popups;
 using Content.Shared.Whitelist;
-using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Physics;

--- a/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.cs
+++ b/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.cs
@@ -4,8 +4,11 @@ using Content.Shared.Item;
 using Content.Shared.ParcelWrap.Components;
 using Content.Shared.Popups;
 using Content.Shared.Whitelist;
+using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 
 namespace Content.Shared.ParcelWrap.Systems;
 
@@ -27,6 +30,12 @@ public sealed partial class ParcelWrappingSystem : EntitySystem
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
 
+    [Dependency] private readonly EntityQuery<ItemComponent> _itemQuery = default!;
+    [Dependency] private readonly EntityQuery<MultiHandedItemComponent> _multiHandedItemQuery = default!;
+    [Dependency] private readonly EntityQuery<ParcelWrapOverrideComponent> _parcelWrapOverrideQuery = default!;
+    [Dependency] private readonly EntityQuery<PhysicsComponent> _physicsQuery = default!;
+    [Dependency] private readonly EntityQuery<WrappedParcelComponent> _wrappedParcelQuery = default!;
+
     /// <inheritdoc/>
     public override void Initialize()
     {
@@ -42,6 +51,7 @@ public sealed partial class ParcelWrappingSystem : EntitySystem
     /// <param name="wrapper">The entity doing the wrapping.</param>
     /// <param name="target">The entity to be wrapped.</param>
     /// <returns>True if <paramref name="wrapper"/> can be used to wrap <paramref name="target"/>, false otherwise.</returns>
+    [PublicAPI]
     public bool IsWrappable(Entity<ParcelWrapComponent> wrapper, EntityUid target)
     {
         return
@@ -49,6 +59,8 @@ public sealed partial class ParcelWrappingSystem : EntitySystem
             wrapper.Owner != target &&
             // Wrapper should never be empty, but may as well make sure.
             !_charges.IsEmpty(wrapper.Owner) &&
-            _whitelist.CheckBoth(target, wrapper.Comp.Blacklist, wrapper.Comp.Whitelist);
+            _whitelist.CheckBoth(target, wrapper.Comp.Blacklist, wrapper.Comp.Whitelist) &&
+            // If it can't be moved, it shouldn't be able to go into a parcel and picked up.
+            _physicsQuery.TryComp(target, out var physics) && physics.BodyType != BodyType.Static;
     }
 }

--- a/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.cs
+++ b/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.cs
@@ -30,11 +30,11 @@ public sealed partial class ParcelWrappingSystem : EntitySystem
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
 
-    [Dependency] private readonly EntityQuery<ItemComponent> _itemQuery = default!;
-    [Dependency] private readonly EntityQuery<MultiHandedItemComponent> _multiHandedItemQuery = default!;
-    [Dependency] private readonly EntityQuery<ParcelWrapOverrideComponent> _parcelWrapOverrideQuery = default!;
-    [Dependency] private readonly EntityQuery<PhysicsComponent> _physicsQuery = default!;
-    [Dependency] private readonly EntityQuery<WrappedParcelComponent> _wrappedParcelQuery = default!;
+    [Dependency] private EntityQuery<ItemComponent> _itemQuery = default!;
+    [Dependency] private EntityQuery<MultiHandedItemComponent> _multiHandedItemQuery = default!;
+    [Dependency] private EntityQuery<ParcelWrapOverrideComponent> _parcelWrapOverrideQuery = default!;
+    [Dependency] private EntityQuery<PhysicsComponent> _physicsQuery = default!;
+    [Dependency] private EntityQuery<WrappedParcelComponent> _wrappedParcelQuery = default!;
 
     /// <inheritdoc/>
     public override void Initialize()


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- bugfix: can't wrap stuff that can't be picked up because it's static (ie. usually anchored, maybe other cases, idk)
- enhancement: multi-handedness is inherited by the parcel from its contents
- technical: migrate to `EntityQuery` dependencies for all component lookups.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix good because you could wrap atmos pipes, microwaves, power sinks, etc. even while they're anchored without ever actually un-anchoring them. Probably lots of jank potential there.

Enhancement good to prevent hand-arbitrage. IMO there's some value in "wrap stuff to get better space economy", but that's not implemented at all, so this is just to make it so you can't wrap multi-handed things and then carry one in each hand.

Entity queries are good for perf, or so I have been told, so I am just migrating them whenever I touch nearby code.
Also parcel wrap is my baby, so I want to see it grow up to be good quality code 🥺 

## Technical details
<!-- Summary of code changes for easier review. -->
- Multihandedness adds a new field to the parcel component which just says whether or not multihandedness is copied from inserted contents.
  - relevant system code to implement this
- The bugfix is just an additional check for whether or not the to-wrap entity has a static physics body (copied from "Can pick up to hand"), and disallows wrapping if it does\
- EntityQueries should be self-explanatory
- Also some small formatting stuff that shouldn't affect behavior

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a; small

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a; addative

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- fix: Parcel wrap can no longer be used to wrap anchored items like atmos pipes while they are still anchored.
- tweak: Parcel wrapping an item which requires two hands to pick up will now cause the resulting parcel to also require two hands to pick up.
