### PR TITLE
Fix `StoreDiscountAndRefund` integration test

### DIFF
--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Content.IntegrationTests.Fixtures;
-using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Server.PDA.Ringer;
 using Content.Server.Traitor.Uplink;
 using Content.Shared.FixedPoint;
@@ -33,18 +32,6 @@ public sealed class StoreTests : GameTest
 ";
 
     [Test]
-    [Ignore("""
-        This currently causes the client to crash, failing the test.
-        When this is fixed, this test should be removed and StoreDiscountAndRefund
-        should just use the default pair config.
-    """)]
-    public async Task StoreDiscountAndRefundWithClient()
-    {
-        await StoreDiscountAndRefund();
-    }
-
-    [Test]
-    [PairConfig(nameof(PsDisconnected))]
     public async Task StoreDiscountAndRefund()
     {
         var pair = Pair;
@@ -80,7 +67,7 @@ public sealed class StoreTests : GameTest
             var invSystem = entManager.System<InventorySystem>();
             var mindSystem = entManager.System<SharedMindSystem>();
 
-            human = entManager.SpawnEntity("HumanUniformDummy", coordinates);
+            human = entManager.SpawnEntity("MobHuman", coordinates);
             uniform = entManager.SpawnEntity("UniformDummy", coordinates);
             pda = entManager.SpawnEntity("InventoryPdaDummy", coordinates);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a bug causing `StoreDiscountAndRefund` to need to run disconnected.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
`StoreDiscountAndRefund` is currently configured to use a disconnected test pair to avoid a bug that causes the client to crash during the test. This fix allows it to run normally.

## Technical details
<!-- Summary of code changes for easier review. -->
The `HumanUniformDummy` test prototype is unsuitable for equipping clothing, since it doesn't have the basic components needed for clothing visualization (like `SpriteComponent`). This simply swaps it for `MobHuman`, which can handle it.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->