### PR TITLE
Ignore C# Dev Kit's new cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -309,3 +309,6 @@ Resources/MapImages
 
 # Direnv stuff
 .direnv/
+
+# C# Dev Kit cache file
+*.lscache


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Starting from C# Dev Kit version 3.20.195 and above, they switch to file based project viewer instead of solution viewer, and they did some caching stuff and output .lscache file next to all .csproj.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->