### PR TITLE
Make atmos devices respect map serialized enables

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/AtmosMapLoadSettingsTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/AtmosMapLoadSettingsTest.cs
@@ -1,0 +1,77 @@
+﻿using Content.Server.Atmos.Piping.Trinary.Components;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Atmos.Piping.Binary.Components;
+using Robust.Shared.Utility;
+
+namespace Content.IntegrationTests.Tests.Atmos;
+
+/// <summary>
+/// Test for ensuring that atmospherics components deserialize and spawn with settings applied.
+/// </summary>
+[TestFixture]
+public sealed class AtmosMapLoadSettingsTest : AtmosTest
+{
+    // These values correspond to settings in the test map.
+    private const float pumpSetting = 180f;
+    private const float mixerMainSetting = 0.1f;
+    private const float mixerSideSetting = 0.9f;
+
+    /// <summary>
+    /// Test map containing saved atmos components.
+    /// </summary>
+    protected override ResPath? TestMapPath => new("Maps/Test/Atmospherics/load_atmos_test_room.yml");
+
+    /// <summary>
+    /// Test to verify that the settings have been properly applied.
+    /// </summary>
+    [Test]
+    public async Task TestMapLoading()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var volumePumpQuery = SEntMan.EntityQueryEnumerator<GasVolumePumpComponent>();
+            while (volumePumpQuery.MoveNext(out var volumePump))
+            {
+                Assert.That(volumePump.Enabled, Is.True, "Volume pump did not load enabled!");
+                Assert.That(
+                    volumePump.TransferRate,
+                    Is.EqualTo(pumpSetting),
+                    "Volume pump did not load correct setting!"
+                    );
+            }
+
+            var pressurePumpQuery = SEntMan.EntityQueryEnumerator<GasPressurePumpComponent>();
+            while (pressurePumpQuery.MoveNext(out var pressurePump))
+            {
+                Assert.That(pressurePump.Enabled, Is.True, "Pressure pump did not load enabled!");
+                Assert.That(
+                    pressurePump.TargetPressure,
+                    Is.EqualTo(pumpSetting),
+                    "Pressure pump did not load correct setting!"
+                    );
+            }
+
+            var mixerQuery = SEntMan.EntityQueryEnumerator<GasMixerComponent>();
+            while (mixerQuery.MoveNext(out var mixer))
+            {
+                Assert.That(mixer.Enabled, Is.True, "Mixer did not load enabled!");
+                Assert.That(
+                    mixer.TargetPressure,
+                    Is.EqualTo(pumpSetting),
+                    "Mixer pump did not load correct setting!"
+                    );
+                Assert.That(
+                    mixer.InletOneConcentration,
+                    Is.EqualTo(mixerMainSetting),
+                    "Mixer split did not load correct setting!"
+                    );
+                Assert.That(
+                    mixer.InletTwoConcentration,
+                    Is.EqualTo(mixerSideSetting),
+                    "Mixer split did not load correct setting!"
+                    );
+            }
+
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/Atmos/AtmosMapLoadSettingsTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/AtmosMapLoadSettingsTest.cs
@@ -12,9 +12,9 @@ namespace Content.IntegrationTests.Tests.Atmos;
 public sealed class AtmosMapLoadSettingsTest : AtmosTest
 {
     // These values correspond to settings in the test map.
-    private const float pumpSetting = 180f;
-    private const float mixerMainSetting = 0.1f;
-    private const float mixerSideSetting = 0.9f;
+    private const float PumpSetting = 180f;
+    private const float MixerMainSetting = 0.1f;
+    private const float MixerSideSetting = 0.9f;
 
     /// <summary>
     /// Test map containing saved atmos components.
@@ -32,44 +32,53 @@ public sealed class AtmosMapLoadSettingsTest : AtmosTest
             var volumePumpQuery = SEntMan.EntityQueryEnumerator<GasVolumePumpComponent>();
             while (volumePumpQuery.MoveNext(out var volumePump))
             {
-                Assert.That(volumePump.Enabled, Is.True, "Volume pump did not load enabled!");
-                Assert.That(
-                    volumePump.TransferRate,
-                    Is.EqualTo(pumpSetting),
-                    "Volume pump did not load correct setting!"
-                    );
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(volumePump.Enabled, Is.True, "Volume pump did not load enabled!");
+                    Assert.That(
+                        volumePump.TransferRate,
+                        Is.EqualTo(PumpSetting),
+                        "Volume pump did not load correct setting!"
+                        );
+                }
             }
 
             var pressurePumpQuery = SEntMan.EntityQueryEnumerator<GasPressurePumpComponent>();
             while (pressurePumpQuery.MoveNext(out var pressurePump))
             {
-                Assert.That(pressurePump.Enabled, Is.True, "Pressure pump did not load enabled!");
-                Assert.That(
-                    pressurePump.TargetPressure,
-                    Is.EqualTo(pumpSetting),
-                    "Pressure pump did not load correct setting!"
-                    );
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(pressurePump.Enabled, Is.True, "Pressure pump did not load enabled!");
+                    Assert.That(
+                        pressurePump.TargetPressure,
+                        Is.EqualTo(PumpSetting),
+                        "Pressure pump did not load correct setting!"
+                        );
+                }
             }
 
             var mixerQuery = SEntMan.EntityQueryEnumerator<GasMixerComponent>();
             while (mixerQuery.MoveNext(out var mixer))
             {
-                Assert.That(mixer.Enabled, Is.True, "Mixer did not load enabled!");
-                Assert.That(
-                    mixer.TargetPressure,
-                    Is.EqualTo(pumpSetting),
-                    "Mixer pump did not load correct setting!"
-                    );
-                Assert.That(
-                    mixer.InletOneConcentration,
-                    Is.EqualTo(mixerMainSetting),
-                    "Mixer split did not load correct setting!"
-                    );
-                Assert.That(
-                    mixer.InletTwoConcentration,
-                    Is.EqualTo(mixerSideSetting),
-                    "Mixer split did not load correct setting!"
-                    );
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(mixer.Enabled, Is.True, "Mixer did not load enabled!");
+                    Assert.That(
+                        mixer.TargetPressure,
+                        Is.EqualTo(PumpSetting),
+                        "Mixer pump did not load correct setting!"
+                        );
+                    Assert.That(
+                        mixer.InletOneConcentration,
+                        Is.EqualTo(MixerMainSetting),
+                        "Mixer split did not load correct setting!"
+                        );
+                    Assert.That(
+                        mixer.InletTwoConcentration,
+                        Is.EqualTo(MixerSideSetting),
+                        "Mixer split did not load correct setting!"
+                        );
+                }
             }
 
         });

--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosDeviceSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosDeviceSystem.cs
@@ -112,6 +112,10 @@ namespace Content.Server.Atmos.Piping.EntitySystems
 
         private void OnDeviceParentChanged(Entity<AtmosDeviceComponent> ent, ref EntParentChangedMessage args)
         {
+            // Skips rejoining atmos on mapload
+            if (args.OldParent is null)
+                return;
+
             RejoinAtmosphere(ent);
         }
 

--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosDeviceSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosDeviceSystem.cs
@@ -112,7 +112,9 @@ namespace Content.Server.Atmos.Piping.EntitySystems
 
         private void OnDeviceParentChanged(Entity<AtmosDeviceComponent> ent, ref EntParentChangedMessage args)
         {
-            // Skips rejoining atmos on mapload
+            // Event is raised when a map is loaded in. Since this event mutates comp.Enabled,
+            // it will overwrite whatever saved value it had
+            // (so devices saved as enabled will just be disabled).
             if (args.OldParent is null)
                 return;
 

--- a/Resources/Maps/Test/Atmospherics/load_atmos_test_room.yml
+++ b/Resources/Maps/Test/Atmospherics/load_atmos_test_room.yml
@@ -1,0 +1,205 @@
+meta:
+  format: 7
+  category: Map
+  engineVersion: 277.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 05/17/2026 04:58:27
+  entityCount: 22
+maps:
+- 1
+grids:
+- 2
+orphans: []
+nullspace: []
+tilemap:
+  1: Space
+  0: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Map Entity
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: GridTree
+    - type: Broadphase
+    - type: OccluderTree
+  - uid: 2
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: 2.754969,-0.5660831
+      parent: 1
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: TileHistory
+      chunkHistory: {}
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: ImplicitRoof
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes: []
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 61152
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ExplosionAirtightGrid
+- proto: DebugAPCRecharging
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: GasMixer
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 2
+    - type: GasMixer
+      inletTwoConcentration: 0.9
+      inletOneConcentration: 0.1
+      targetPressure: 180
+      enabled: True
+- proto: GasPressurePump
+  entities:
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 2
+    - type: GasPressurePump
+      targetPressure: 180
+      enabled: True
+- proto: GasVolumePump
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 2
+    - type: GasVolumePump
+      transferRate: 180
+      enabled: True
+- proto: WallReinforced
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 2
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 2
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 2
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 2
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+...


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Skipped a case that was resetting atmos devices at mapinit.

This has been tested with configured and unconfigured devices. 
Default behavior remains with the device off, but enabling the device during mapping results in a properly serialized state that is restored on map load.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This allows atmos devices to respect serialized enable states.

## Technical details
<!-- Summary of code changes for easier review. -->
`EntParentChangedMessage` is raised every time the parent changes, as expected. 
However, this also occurs when the entity is loaded into the map. 
By adding a fallout for when the old parent is null (which to my knowledge and some inspection, should really only happen for a new entity) we can avoid triggering `RejoinAtmosphere`, which leaves and rejoins the atmos system. Leaving the atmos system turns the device off. 
Joining is handled by a different step, so the device is correctly initialized.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="415" height="300" alt="image" src="https://github.com/user-attachments/assets/e149d9b1-615a-42d1-b930-708520721ca8" />

These pumps just came like this. (After saving the map with them enabled)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Nem
- fix: Atmos devices can now be mapped in an enabled state.