### PR TITLE
Tradestation now has automated atmos!

### DIFF
--- a/Resources/Maps/Shuttles/trading_outpost.yml
+++ b/Resources/Maps/Shuttles/trading_outpost.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 260.2.0
+  engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/28/2025 08:16:27
-  entityCount: 1096
+  time: 05/17/2026 11:34:03
+  entityCount: 1104
 maps: []
 grids:
 - 2
@@ -529,7 +529,8 @@ entities:
           -1,-7:
             1: 43694
           0,-6:
-            0: 2730
+            2: 546
+            3: 2184
           -1,-6:
             1: 35562
           1,-8:
@@ -568,37 +569,26 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 21.824879
-          - 82.10312
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
         - volume: 2500
           immutable: True
+          moles: {}
+        - volume: 2500
+          temperature: 293.15
           moles:
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 6666.982
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Nitrogen: 6666.982
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: ImplicitRoof
+    - type: TileHistory
+      chunkHistory: {}
+    - type: ExplosionAirtightGrid
 - proto: AirAlarm
   entities:
   - uid: 424
@@ -613,6 +603,8 @@ entities:
       - 402
       - 411
       - 400
+    - type: Fixtures
+      fixtures: {}
   - uid: 803
     components:
     - type: Transform
@@ -625,6 +617,8 @@ entities:
       - 402
       - 400
       - 411
+    - type: Fixtures
+      fixtures: {}
   - uid: 805
     components:
     - type: Transform
@@ -635,11 +629,15 @@ entities:
       devices:
       - 1036
       - 1037
+    - type: Fixtures
+      fixtures: {}
   - uid: 1025
     components:
     - type: Transform
       pos: 6.5,-12.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 1026
     components:
     - type: Transform
@@ -650,6 +648,8 @@ entities:
       devices:
       - 305
       - 515
+    - type: Fixtures
+      fixtures: {}
   - uid: 1075
     components:
     - type: Transform
@@ -660,6 +660,8 @@ entities:
       devices:
       - 1086
       - 1088
+    - type: Fixtures
+      fixtures: {}
   - uid: 1076
     components:
     - type: Transform
@@ -670,6 +672,15 @@ entities:
       devices:
       - 1087
       - 1089
+    - type: Fixtures
+      fixtures: {}
+- proto: AirCanister
+  entities:
+  - uid: 1104
+    components:
+    - type: Transform
+      pos: 4.5,-17.5
+      parent: 2
 - proto: AirlockAtmosphericsLocked
   entities:
   - uid: 23
@@ -787,42 +798,56 @@ entities:
       rot: 3.141592653589793 rad
       pos: 6.5,-25.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 597
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 657
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,6.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 867
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-27.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 891
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-13.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 904
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-13.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 1019
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-9.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: AtmosDeviceFanDirectional
   entities:
   - uid: 560
@@ -872,6 +897,40 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-2.5
+      parent: 2
+- proto: AtmosFixNitrogenMarker
+  entities:
+  - uid: 1097
+    components:
+    - type: Transform
+      pos: 3.5,-23.5
+      parent: 2
+  - uid: 1098
+    components:
+    - type: Transform
+      pos: 3.5,-22.5
+      parent: 2
+  - uid: 1099
+    components:
+    - type: Transform
+      pos: 3.5,-21.5
+      parent: 2
+- proto: AtmosFixOxygenMarker
+  entities:
+  - uid: 1100
+    components:
+    - type: Transform
+      pos: 1.5,-23.5
+      parent: 2
+  - uid: 1101
+    components:
+    - type: Transform
+      pos: 1.5,-22.5
+      parent: 2
+  - uid: 1102
+    components:
+    - type: Transform
+      pos: 1.5,-21.5
       parent: 2
 - proto: Bed
   entities:
@@ -3366,12 +3425,16 @@ entities:
       rot: 3.141592653589793 rad
       pos: 5.5,0.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-9.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: filingCabinetDrawerRandom
   entities:
   - uid: 306
@@ -3395,6 +3458,8 @@ entities:
       - 555
       - 583
       - 584
+    - type: Fixtures
+      fixtures: {}
   - uid: 586
     components:
     - type: Transform
@@ -3409,6 +3474,8 @@ entities:
       - 555
       - 572
       - 582
+    - type: Fixtures
+      fixtures: {}
 - proto: FirelockEdge
   entities:
   - uid: 572
@@ -3503,13 +3570,18 @@ entities:
       parent: 2
 - proto: GasMixerFlipped
   entities:
-  - uid: 457
+  - uid: 409
     components:
     - type: Transform
-      pos: 3.5,-17.5
+      pos: 3.5,-16.5
       parent: 2
+    - type: GasMixer
+      inletTwoConcentration: 0.79
+      inletOneConcentration: 0.21
+      targetPressure: 202.75
+      enabled: True
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#03FCD3FF'
 - proto: GasPassiveVent
   entities:
   - uid: 188
@@ -3519,7 +3591,7 @@ entities:
       pos: 1.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#0335FCFF'
   - uid: 383
     components:
     - type: Transform
@@ -3535,7 +3607,7 @@ entities:
       pos: 3.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#FF1212FF'
 - proto: GasPipeBend
   entities:
   - uid: 285
@@ -3546,14 +3618,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 409
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-17.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 458
     components:
     - type: Transform
@@ -3615,6 +3679,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 512
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 1079
     components:
     - type: Transform
@@ -3654,11 +3726,10 @@ entities:
   - uid: 258
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-16.5
+      pos: 1.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#0335FCFF'
   - uid: 311
     components:
     - type: Transform
@@ -3801,6 +3872,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 457
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 459
     components:
     - type: Transform
@@ -4098,14 +4177,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 512
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-17.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 656
     components:
     - type: Transform
@@ -4129,7 +4200,7 @@ entities:
       pos: 3.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#FF1212FF'
   - uid: 873
     components:
     - type: Transform
@@ -4137,7 +4208,7 @@ entities:
       pos: 3.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#FF1212FF'
   - uid: 874
     components:
     - type: Transform
@@ -4145,7 +4216,7 @@ entities:
       pos: 1.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#0335FCFF'
   - uid: 906
     components:
     - type: Transform
@@ -4153,7 +4224,7 @@ entities:
       pos: 1.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#0335FCFF'
   - uid: 910
     components:
     - type: Transform
@@ -4161,7 +4232,7 @@ entities:
       pos: 3.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#FF1212FF'
   - uid: 911
     components:
     - type: Transform
@@ -4169,7 +4240,7 @@ entities:
       pos: 1.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#0335FCFF'
   - uid: 1052
     components:
     - type: Transform
@@ -4382,6 +4453,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 1103
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
 - proto: GasPipeTJunction
   entities:
   - uid: 261
@@ -4495,6 +4574,8 @@ entities:
     - type: Transform
       pos: 4.5,-13.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPressurePump
   entities:
   - uid: 892
@@ -5491,6 +5572,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,-26.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: PottedPlantRandom
   entities:
   - uid: 295
@@ -5997,6 +6080,8 @@ entities:
         290:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
   - uid: 549
     components:
     - type: Transform
@@ -6008,6 +6093,8 @@ entities:
         288:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
   - uid: 550
     components:
     - type: Transform
@@ -6019,6 +6106,8 @@ entities:
         279:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
   - uid: 551
     components:
     - type: Transform
@@ -6030,6 +6119,8 @@ entities:
         289:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
 - proto: SignAtmos
   entities:
   - uid: 28
@@ -6038,6 +6129,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-12.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignCargoDock
   entities:
   - uid: 271
@@ -6045,11 +6138,15 @@ entities:
     - type: Transform
       pos: 13.5,-4.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 287
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignEngineering
   entities:
   - uid: 884
@@ -6057,11 +6154,15 @@ entities:
     - type: Transform
       pos: 9.5,-12.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 1015
     components:
     - type: Transform
       pos: 9.5,-25.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignSecureMed
   entities:
   - uid: 144
@@ -6070,12 +6171,16 @@ entities:
       rot: 3.141592653589793 rad
       pos: 5.5,-8.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-0.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SMESAdvanced
   entities:
   - uid: 527


### PR DESCRIPTION
## About the PR
Made it so that the gas mixer in ATS is now ON on map initialization
Fixed the wrongly colored pipes
Added missing atmos fix makers
Added an air tank

## Why / Balance
I was annoyed that atmos on ATS wasn't automatic, and thanks to @kontakt we can finally automate it! Automated Trade Station is finally fully automated!

## Technical details

## Test plan
1. In dev map, type `loadgrid 1 /Maps/shuttles/trade_station.yml 0 0 0` to spawn ats
2. Look that atmos is now working

## Media
<img width="895" height="464" alt="image" src="https://github.com/user-attachments/assets/58b0bd42-7cbe-4b96-a400-22b0a9a2828a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
:cl:
MAPS:
- tweak: On Trade Station - Atmos systems are now fully automated
