### PR TITLE
Reorder Cow and Goat Mob parent order to give correct stomach type

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -863,7 +863,7 @@
 
 - type: entity
   name: cow
-  parent: [ SimpleMobBase, BaseMobRuminant ]
+  parent: [ BaseMobRuminant, SimpleMobBase ]
   id: MobCow
   description: Moo.
   components:
@@ -1022,7 +1022,7 @@
 
 - type: entity
   name: goat
-  parent: [ SimpleMobBase, BaseMobRuminant ]
+  parent: [ BaseMobRuminant, SimpleMobBase ]
   id: MobGoat
   description: Her spine consists of long sharp segments, no wonder she is so grumpy.
   components:


### PR DESCRIPTION
## About the PR
Swapped the order of parents for the Cow and Goat mobs

## Why / Balance
This is to correct the issue that neither Mob is able to eat wheat or similar food
It also causes them to drop the correct stomach type when gibbed
Fixes: #43642 

## Technical details
Only change is to swap the order of BaseMobRuminant and SimpleMobBase in the parent of goat and cow mobs

## Test plan
Spawn a cow or goat, Wheat and attempt to feed the animal to see that is is able to eat it
Gib animal to observe that it drops a `OrganRuminantStomach` instead of an `OrganAnimalStomach`

## Media
<img width="387" height="322" alt="cow_correct_stomach" src="https://github.com/user-attachments/assets/764e5a58-0f56-4cfb-aae8-da941a5fcf8d" />
<img width="347" height="234" alt="cow_feeding" src="https://github.com/user-attachments/assets/60cdded5-c09e-4b72-be64-37d39827989e" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes
None

## Changelog
:cl:
- fix: Cows and Goats are now able to eat wheat as intended