### PR TITLE
Add size whitelist to CrateRodentCage

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -451,6 +451,9 @@
   - type: EntityStorage
     capacity: 1
     airtight: false
+    whitelist:
+      sizes:
+      - Tiny
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
## About the PR
Added a size whitelist on CrateRodentCage to prevent people hiding in it

## Why / Balance
Prevents people hiding inside a hamster cage which is silly and not what someone would expect to be possible
Fixes: #23511 where it is labeled as being a Bug

## Technical details
Added whitelist size to the EntityStorage component to limit it to Tiny items as that is the size Hamsters are

## Test plan
Spawn a Hampster cage and observed that you cannot hide in it yourself while you can still put a hampster in it

## Media
No meaningful picture can demonstrate the change in behaviour

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes
None

## Changelog
:cl:
- fix: Hamster cages can no longer contain items larger than a hamster
