### PR TITLE
Cleanup - remove zombie hardcoding in RevolutionaryRuleSystem

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -17,16 +17,15 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Humanoid;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mind.Components;
-using Content.Shared.Mindshield.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.NPC.Prototypes;
 using Content.Shared.NPC.Systems;
+using Content.Shared.Revolutionary;
 using Content.Shared.Revolutionary.Components;
 using Content.Shared.Roles.Components;
 using Content.Shared.Stunnable;
-using Content.Shared.Zombies;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared.Cuffs.Components;
@@ -142,16 +141,19 @@ public sealed partial class RevolutionaryRuleSystem : GameRuleSystem<Revolutiona
         if (!_mind.TryGetMind(ev.Target, out var mindId, out var mind) && !alwaysConvertible)
             return;
 
-        if (HasComp<RevolutionaryComponent>(ev.Target) ||
-            HasComp<MindShieldComponent>(ev.Target) ||
-            !HasComp<HumanoidProfileComponent>(ev.Target) &&
+        if (!HasComp<HumanoidProfileComponent>(ev.Target) &&
             !alwaysConvertible ||
             !_mobState.IsAlive(ev.Target) ||
-            HasComp<ZombieComponent>(ev.Target) ||
             !HasComp<RevolutionaryConverterComponent>(ev.Used))
         {
             return;
         }
+
+        var attemptConvertEv = new AttemptConvertRevolutionaryEvent();
+        RaiseLocalEvent(ev.Target, attemptConvertEv);
+
+        if (attemptConvertEv.Cancelled)
+            return;
 
         _npcFaction.AddFaction(ev.Target, RevolutionaryNpcFaction);
         var revComp = EnsureComp<RevolutionaryComponent>(ev.Target);

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -150,7 +150,7 @@ public sealed partial class RevolutionaryRuleSystem : GameRuleSystem<Revolutiona
         }
 
         var attemptConvertEv = new AttemptConvertRevolutionaryEvent();
-        RaiseLocalEvent(ev.Target, attemptConvertEv);
+        RaiseLocalEvent(ev.Target, ref attemptConvertEv);
 
         if (attemptConvertEv.Cancelled)
             return;

--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Roles;
 using Content.Shared.Database;
 using Content.Shared.Implants;
 using Content.Shared.Mindshield.Components;
+using Content.Shared.Revolutionary;
 using Content.Shared.Revolutionary.Components;
 using Content.Shared.Roles.Components;
 using Robust.Shared.Containers;
@@ -28,6 +29,7 @@ public sealed partial class MindShieldSystem : EntitySystem
 
         SubscribeLocalEvent<MindShieldImplantComponent, ImplantImplantedEvent>(OnImplantImplanted);
         SubscribeLocalEvent<MindShieldImplantComponent, ImplantRemovedEvent>(OnImplantRemoved);
+        SubscribeLocalEvent<MindShieldComponent, AttemptConvertRevolutionaryEvent>(OnAttemptConvert);
     }
 
     private void OnImplantImplanted(Entity<MindShieldImplantComponent> ent, ref ImplantImplantedEvent ev)
@@ -58,6 +60,11 @@ public sealed partial class MindShieldSystem : EntitySystem
     private void OnImplantRemoved(Entity<MindShieldImplantComponent> ent, ref ImplantRemovedEvent args)
     {
         RemComp<MindShieldComponent>(args.Implanted);
+    }
+
+    private void OnAttemptConvert(Entity<MindShieldComponent> ent, ref AttemptConvertRevolutionaryEvent args)
+    {
+        args.Cancel();
     }
 }
 

--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -64,7 +64,7 @@ public sealed partial class MindShieldSystem : EntitySystem
 
     private void OnAttemptConvert(Entity<MindShieldComponent> ent, ref AttemptConvertRevolutionaryEvent args)
     {
-        args.Cancel();
+        args.Cancelled = true;
     }
 }
 

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
+using Content.Shared.Revolutionary;
 using Content.Shared.Roles;
 using Content.Shared.Roles.Components;
 using Content.Shared.Weapons.Melee.Events;
@@ -26,7 +27,6 @@ using Content.Shared.Zombies;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
-using Content.Shared.Revolutionary;
 
 namespace Content.Server.Zombies
 {
@@ -325,7 +325,7 @@ namespace Content.Server.Zombies
 
         private void OnAttemptConvert(Entity<ZombieComponent> ent, ref AttemptConvertRevolutionaryEvent args)
         {
-            args.Cancel();
+            args.Cancelled = true;
         }
     }
 }

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -26,6 +26,7 @@ using Content.Shared.Zombies;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Content.Shared.Revolutionary;
 
 namespace Content.Server.Zombies
 {
@@ -71,6 +72,7 @@ namespace Content.Server.Zombies
             SubscribeLocalEvent<ZombieComponent, GetCharacterUnrevivableIcEvent>(OnGetCharacterUnrevivableIC);
             SubscribeLocalEvent<ZombieComponent, MindAddedMessage>(OnMindAdded);
             SubscribeLocalEvent<ZombieComponent, MindRemovedMessage>(OnMindRemoved);
+            SubscribeLocalEvent<ZombieComponent, AttemptConvertRevolutionaryEvent>(OnAttemptConvert);
 
             SubscribeLocalEvent<PendingZombieComponent, MapInitEvent>(OnPendingMapInit);
             SubscribeLocalEvent<PendingZombieComponent, BeforeRemoveAnomalyOnDeathEvent>(OnBeforeRemoveAnomalyOnDeath);
@@ -319,6 +321,11 @@ namespace Content.Server.Zombies
         private void OnMindRemoved(Entity<ZombieComponent> ent, ref MindRemovedMessage args)
         {
             _role.MindRemoveRole<ZombieRoleComponent>((args.Mind.Owner,  args.Mind.Comp));
+        }
+
+        private void OnAttemptConvert(Entity<ZombieComponent> ent, ref AttemptConvertRevolutionaryEvent args)
+        {
+            args.Cancel();
         }
     }
 }

--- a/Content.Shared/Revolutionary/SharedRevolutionary.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionary.cs
@@ -1,8 +1,5 @@
 namespace Content.Shared.Revolutionary;
 
-public sealed class AttemptConvertRevolutionaryEvent : CancellableEntityEventArgs
-{
-
 /// <summary>
 /// Raised when a revolutionary conversion is being attempted on an entity.
 /// </summary>

--- a/Content.Shared/Revolutionary/SharedRevolutionary.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionary.cs
@@ -3,4 +3,7 @@ namespace Content.Shared.Revolutionary;
 public sealed class AttemptConvertRevolutionaryEvent : CancellableEntityEventArgs
 {
 
-}
+/// <summary>
+/// Raised when a revolutionary conversion is being attempted on an entity.
+/// </summary>
+public sealed class AttemptConvertRevolutionaryEvent : CancellableEntityEventArgs;

--- a/Content.Shared/Revolutionary/SharedRevolutionary.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionary.cs
@@ -3,4 +3,5 @@ namespace Content.Shared.Revolutionary;
 /// <summary>
 /// Raised when a revolutionary conversion is being attempted on an entity.
 /// </summary>
-public sealed class AttemptConvertRevolutionaryEvent : CancellableEntityEventArgs;
+[ByRefEvent]
+public record struct AttemptConvertRevolutionaryEvent(bool Cancelled);

--- a/Content.Shared/Revolutionary/SharedRevolutionary.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionary.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared.Revolutionary;
+
+public sealed class AttemptConvertRevolutionaryEvent : CancellableEntityEventArgs
+{
+
+}

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -104,6 +104,6 @@ public abstract partial class SharedRevolutionarySystem : EntitySystem
 
     private void OnAttemptConvert(Entity<RevolutionaryComponent> ent, ref AttemptConvertRevolutionaryEvent args)
     {
-        args.Cancel();
+        args.Cancelled = true;
     }
 }

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -24,6 +24,7 @@ public abstract partial class SharedRevolutionarySystem : EntitySystem
         SubscribeLocalEvent<RevolutionaryComponent, ComponentStartup>(DirtyRevComps);
         SubscribeLocalEvent<HeadRevolutionaryComponent, ComponentStartup>(DirtyRevComps);
         SubscribeLocalEvent<ShowAntagIconsComponent, ComponentStartup>(DirtyRevComps);
+        SubscribeLocalEvent<RevolutionaryComponent, AttemptConvertRevolutionaryEvent>(OnAttemptConvert);
     }
 
     /// <summary>
@@ -99,5 +100,10 @@ public abstract partial class SharedRevolutionarySystem : EntitySystem
         {
             Dirty(uid, comp);
         }
+    }
+
+    private void OnAttemptConvert(Entity<RevolutionaryComponent> ent, ref AttemptConvertRevolutionaryEvent args)
+    {
+        args.Cancel();
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR removes the hard-coded reference to zombies in RevolutionaryRuleSystem.

Fixes #24170 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Cleanup

## Technical details
<!-- Summary of code changes for easier review. -->

This simply replaces the HasComp check with a cancellable event. I went ahead and replaced a couple other HasComps too just for fun.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Setup: Use Antag Control to set yourself as Head Rev and log in with a second client for the test subject

1. Attempt to convert someone with a Mind Shield = **not converted**
2. Attempt to convert a player zombie = **not converted**
3. Attempt to convert an already converted player = **not converted**
4. Attempt to convert a non-rev, non-zombie player = **converted**

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

N/A
