### PR TITLE
Reduced AI static overlay checkbox for photosensitivity

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -7,6 +7,7 @@
                 <Label Text="{Loc 'ui-options-accessability-header-visuals'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="ReducedMotionCheckBox" Text="{Loc 'ui-options-reduced-motion'}" />
+                <CheckBox Name="DisableAiStaticCheckBox" Text="{Loc 'ui-options-disable-ai-static'}" />
                 <CheckBox Name="EnableColorNameCheckBox" Text="{Loc 'ui-options-enable-color-name'}" />
                 <CheckBox Name="ColorblindFriendlyCheckBox" Text="{Loc 'ui-options-colorblind-friendly'}" />
                 <ui:OptionSlider Name="ScreenShakeIntensitySlider" Title="{Loc 'ui-options-screen-shake-intensity'}" />

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -15,6 +15,7 @@ public sealed partial class AccessibilityTab : Control
         Control.AddOptionCheckBox(CCVars.ChatEnableColorName, EnableColorNameCheckBox);
         Control.AddOptionCheckBox(CCVars.AccessibilityColorblindFriendly, ColorblindFriendlyCheckBox);
         Control.AddOptionCheckBox(CCVars.ReducedMotion, ReducedMotionCheckBox);
+        Control.AddOptionCheckBox(CCVars.DisableAiStatic, DisableAiStaticCheckBox);
         Control.AddOptionPercentSlider(CCVars.ScreenShakeIntensity, ScreenShakeIntensitySlider);
         Control.AddOptionPercentSlider(CCVars.ChatWindowOpacity, ChatWindowOpacitySlider);
         Control.AddOptionPercentSlider(CCVars.SpeechBubbleTextOpacity, SpeechBubbleTextOpacitySlider);

--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -33,12 +33,20 @@ public sealed partial class StationAiOverlay : Overlay
 
     private readonly OverlayResourceCache<CachedResources> _resources = new();
 
+    private ProtoId<ShaderPrototype> _activeShader = CameraStaticShader;
     private float _updateRate = 1f / 30f;
     private float _accumulator;
 
     public StationAiOverlay()
     {
         IoCManager.InjectDependencies(this);
+        _cfg.OnValueChanged(CCVars.DisableAiStatic, OnAiStaticChanged, invokeImmediately: true);
+
+    }
+
+    private void OnAiStaticChanged(bool toggle)
+    {
+        _activeShader = toggle ? CameraStaticAccessibleShader : CameraStaticShader;
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -101,9 +109,7 @@ public sealed partial class StationAiOverlay : Overlay
             () =>
             {
                 worldHandle.SetTransform(invMatrix);
-                var shader = _cfg.GetCVar(CCVars.DisableAiStatic) ?
-                    _proto.Index(CameraStaticAccessibleShader).Instance() :
-                    _proto.Index(CameraStaticShader).Instance();
+                var shader = _proto.Index(_activeShader).Instance();
                 worldHandle.UseShader(shader);
                 worldHandle.DrawRect(worldBounds, Color.White);
             },

--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -1,8 +1,10 @@
 using System.Numerics;
 using Content.Client.Graphics;
+using Content.Shared.CCVar;
 using Content.Shared.Silicons.StationAi;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
@@ -14,10 +16,12 @@ namespace Content.Client.Silicons.StationAi;
 public sealed partial class StationAiOverlay : Overlay
 {
     private static readonly ProtoId<ShaderPrototype> CameraStaticShader = "CameraStatic";
+    private static readonly ProtoId<ShaderPrototype> CameraStaticAccessibleShader = "CameraStaticAccessible";
     private static readonly ProtoId<ShaderPrototype> StencilMaskShader = "StencilMask";
     private static readonly ProtoId<ShaderPrototype> StencilDrawShader = "StencilDraw";
 
     [Dependency] private IClyde _clyde = default!;
+    [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private IEntityManager _entManager = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IPlayerManager _player = default!;
@@ -97,7 +101,9 @@ public sealed partial class StationAiOverlay : Overlay
             () =>
             {
                 worldHandle.SetTransform(invMatrix);
-                var shader = _proto.Index(CameraStaticShader).Instance();
+                var shader = _cfg.GetCVar(CCVars.DisableAiStatic) ?
+                    _proto.Index(CameraStaticAccessibleShader).Instance() :
+                    _proto.Index(CameraStaticShader).Instance();
                 worldHandle.UseShader(shader);
                 worldHandle.DrawRect(worldBounds, Color.White);
             },

--- a/Content.Shared/CCVar/CCVars.Accessibility.cs
+++ b/Content.Shared/CCVar/CCVars.Accessibility.cs
@@ -19,6 +19,13 @@ public sealed partial class CCVars
     public static readonly CVarDef<bool> ReducedMotion =
         CVarDef.Create("accessibility.reduced_motion", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 
+    /// <summary>
+    ///     Replaces the AI static camera effect with a plain gradient.
+    ///     Used for photosensitivity triggers.
+    /// </summary>
+    public static readonly CVarDef<bool> DisableAiStatic =
+        CVarDef.Create("accessibility.disable_ai_static", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
     public static readonly CVarDef<bool> ChatEnableColorName =
         CVarDef.Create("accessibility.enable_color_name",
             true,

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -366,6 +366,7 @@ ui-options-accessability-header-content = Content
 ui-options-enable-color-name = Add colors to character names
 ui-options-colorblind-friendly = Colorblind friendly mode
 ui-options-reduced-motion = Reduce motion of visual effects
+ui-options-disable-ai-static = Disable the static effect on the AI camera overlay
 ui-options-screen-shake-intensity = Screen shake intensity
 
 ui-options-chat-window-opacity = Chat window opacity

--- a/Resources/Prototypes/Shaders/shaders.yml
+++ b/Resources/Prototypes/Shaders/shaders.yml
@@ -59,6 +59,11 @@
   path: "/Textures/Shaders/camera_static.swsl"
 
 - type: shader
+  id: CameraStaticAccessible
+  kind: source
+  path: "/Textures/Shaders/Shaders/camera_static_accessible.swsl"
+
+- type: shader
   id: Drunk
   kind: source
   path: "/Textures/Shaders/drunk.swsl"
@@ -115,7 +120,7 @@
   id: Hologram
   kind: source
   path: "/Textures/Shaders/hologram.swsl"
-  
+
 - type: shader
   id: HeatBlur
   kind: source

--- a/Resources/Prototypes/Shaders/shaders.yml
+++ b/Resources/Prototypes/Shaders/shaders.yml
@@ -61,7 +61,7 @@
 - type: shader
   id: CameraStaticAccessible
   kind: source
-  path: "/Textures/Shaders/Shaders/camera_static_accessible.swsl"
+  path: "/Textures/Shaders/camera_static_accessible.swsl"
 
 - type: shader
   id: Drunk

--- a/Resources/Textures/Shaders/camera_static_accessible.swsl
+++ b/Resources/Textures/Shaders/camera_static_accessible.swsl
@@ -1,0 +1,6 @@
+void fragment() {
+    highp vec2 coords = FRAGCOORD.xy;
+    highp vec2 value = vec2(coords * SCREEN_PIXEL_SIZE);
+    highp vec3 color = vec3(0.0,value.x/3.0,value.x/2.0);
+    COLOR = vec4(0.1 * color,1.0);
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
added an option to the accessibility menu to toggle the ai's static overlay.
when this reduced option is on, the static overlay will be replaced by a generic gradient.

## Why / Balance
the existing ai static effect can trigger photosensitivity or epilepsy related adverse reactions.
this replacement shader isnt perfect (im not the best at writing shading code) but it gets the job done.

added a new checkbox instead of using the existing 'reduced motion' checkbox as it is generally better to leave accessibility options modular when possible to emphasize player agency. can change it if its absolutely desired but would prefer not to

## Technical details
new shader, new cvar, ternary operator 👍

## Test plan
1. b button -> toggle ai overlay
2. options -> accessibility -> toggle on 'reduce ai static' -> save
3. look

## Media

https://github.com/user-attachments/assets/d300bab3-a055-465e-a2eb-e2ef16fca6b8

(video contains additional accessibility options in menu, those arent in this pr)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog

:cl:
- add: A toggle in the Accessibility menu will now allow you to turn off the static in the AI camera overlay.
