### PR TITLE
Moved SuicideSystem.cs to its own folder

### DIFF
--- a/Content.Server/Chat/Commands/SuicideCommand.cs
+++ b/Content.Server/Chat/Commands/SuicideCommand.cs
@@ -5,6 +5,7 @@ using Content.Shared.Chat;
 using Content.Shared.Mind;
 using Robust.Shared.Console;
 using Robust.Shared.Enums;
+using Content.Server.Suicide;
 
 namespace Content.Server.Chat.Commands
 {

--- a/Content.Server/Suicide/SuicideSystem.cs
+++ b/Content.Server/Suicide/SuicideSystem.cs
@@ -16,7 +16,7 @@ using Content.Shared.Tag;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
-namespace Content.Server.Chat;
+namespace Content.Server.Suicide;
 
 public sealed partial class SuicideSystem : EntitySystem
 {


### PR DESCRIPTION
Moved SuicideSystem.cs from server/chat to server/suicide

## About the PR
Moved SuicideSystem.cs from Content.Server/Chat/ to its own folder at Content.Server/Suicide/. Updated the namespace from Content.Server.Chat to Content.Server.Suicide and updated the using directive in SuicideCommand.cs to match.

## Why / Balance
SuicideSystem.cs was located in the Chat folder because /suicide is a chat command, but the system itself has nothing to do with chat

Closes Issue #43957

## Technical details
Moved SuicideSystem.cs from Content.Server/Chat/ to Content.Server/Suicide/
Updated namespace to Content.Server.Suicide
Added "using Content.Server.Suicide" to SuicideCommand.cs

## Test plan
Built the project and confirmed it compiled with no errors. Tested suicide in game and it worked

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
SuicideSystem namespace changed from Content.Server.Chat to Content.Server.Suicide.

## Changelog
N/A
