### PR TITLE
ID card console: respect existing, unsettable access tags (Revives #34142)

### DIFF
--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -195,7 +195,6 @@ public sealed partial class IdCardConsoleSystem : SharedIdCardConsoleSystem
         // Find the set of tags that the original ID had that the console _didn't_know about.
         var hiddenChanges = oldTags.Except(component.AccessLevels);
 
-        // NULL SAFETY: PrivilegedIdIsAuthorized checked this earlier.
         var privilegedPerms = _accessReader.FindAccessTags(privilegedId.Value);
         if (!visibleChanges.All(privilegedPerms.Contains))
         {

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -193,7 +193,7 @@ public sealed partial class IdCardConsoleSystem : SharedIdCardConsoleSystem
         // Find tags that the console changed and knew about.
         var visibleChanges = changedTags.Intersect(component.AccessLevels);
         // Find tags that the original ID had that the console can't change.
-        var hiddenChanges = oldTags.Except(component.AccessLevels);
+        var hiddenTags = oldTags.Except(component.AccessLevels);
 
         var privilegedPerms = _accessReader.FindAccessTags(privilegedId.Value);
         if (!visibleChanges.All(privilegedPerms.Contains))
@@ -203,15 +203,16 @@ public sealed partial class IdCardConsoleSystem : SharedIdCardConsoleSystem
         }
 
         // Restore all hidden tags to the newly requested set.
-        var finalTags = newAccessList.Union(hiddenChanges);
-        _access.TrySetTags(targetId, finalTags);
+        newAccessList.AddRange(hiddenTags);
+        _access.TrySetTags(targetId, newAccessList);
 
-        var changes = addedTags.Select(tag => "+" + tag).Union(removedTags.Except(hiddenChanges).Select(tag => "-" + tag));
+        var changeStrings = addedTags.Select(tag => "+" + tag) // All added tags.
+            .Concat(removedTags.Except(newAccessList).Select(tag => "-" + tag)); // All removed tags (except new set due to hidden tags)
 
         /*TODO: ECS SharedIdCardConsoleComponent and then log on card ejection, together with the save.
         This current implementation is pretty shit as it logs 27 entries (27 lines) if someone decides to give themselves AA*/
         _adminLogger.Add(LogType.Action,
-            $"{player} has modified {targetId} with the following accesses: [{string.Join(", ", changes)}] [{string.Join(", ", finalTags)}]");
+            $"{player} has modified {targetId} with the following accesses: [{string.Join(", ", changeStrings)}] [{string.Join(", ", newAccessList)}]");
     }
 
     /// <summary>

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -174,7 +174,7 @@ public sealed partial class IdCardConsoleSystem : SharedIdCardConsoleSystem
             Comp<IdCardComponent>(targetId).JobPrototype = newJobProto;
         }
 
-        if (!newAccessList.TrueForAll(x => component.AccessLevels.Contains(x)))
+        if (!newAccessList.All(component.AccessLevels.Contains))
         {
             _sawmill.Warning($"User {ToPrettyString(uid)} tried to write unknown access tag.");
             return;
@@ -185,24 +185,32 @@ public sealed partial class IdCardConsoleSystem : SharedIdCardConsoleSystem
         if (oldTags.SequenceEqual(newAccessList))
             return;
 
-        // I hate that C# doesn't have an option for this and don't desire to write this out the hard way.
-        // var difference = newAccessList.Difference(oldTags);
-        var difference = newAccessList.Union(oldTags).Except(newAccessList.Intersect(oldTags)).ToHashSet();
+        // Sets for the requested changes to the access card.
+        var addedTags = newAccessList.Except(oldTags);
+        var removedTags = oldTags.Except(newAccessList);
+        var changedTags = addedTags.Union(removedTags);
+
+        // Find the set of tags that the console changed and knew about, and the set of tags that the ID card had initially.
+        var visibleChanges = changedTags.Intersect(component.AccessLevels);
+        var hiddenChanges = oldTags.Except(component.AccessLevels);
+
+        // NULL SAFETY: PrivilegedIdIsAuthorized checked this earlier.
         var privilegedPerms = _accessReader.FindAccessTags(privilegedId.Value);
-        if (!difference.IsSubsetOf(privilegedPerms))
+        if (!visibleChanges.All(privilegedPerms.Contains))
         {
             _sawmill.Warning($"User {ToPrettyString(uid)} tried to modify permissions they could not give/take!");
             return;
         }
 
-        var addedTags = newAccessList.Except(oldTags).Select(tag => "+" + tag).ToList();
-        var removedTags = oldTags.Except(newAccessList).Select(tag => "-" + tag).ToList();
-        _access.TrySetTags(targetId, newAccessList);
+        var finalTags = newAccessList.Union(hiddenChanges);
+        _access.TrySetTags(targetId, finalTags);
+
+        var changes = addedTags.Select(tag => "+" + tag).Union(removedTags.Except(hiddenChanges).Select(tag => "-" + tag));
 
         /*TODO: ECS SharedIdCardConsoleComponent and then log on card ejection, together with the save.
         This current implementation is pretty shit as it logs 27 entries (27 lines) if someone decides to give themselves AA*/
         _adminLogger.Add(LogType.Action,
-            $"{player} has modified {targetId} with the following accesses: [{string.Join(", ", addedTags.Union(removedTags))}] [{string.Join(", ", newAccessList)}]");
+            $"{player} has modified {targetId} with the following accesses: [{string.Join(", ", changes)}] [{string.Join(", ", finalTags)}]");
     }
 
     /// <summary>

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -190,8 +190,9 @@ public sealed partial class IdCardConsoleSystem : SharedIdCardConsoleSystem
         var removedTags = oldTags.Except(newAccessList);
         var changedTags = addedTags.Union(removedTags);
 
-        // Find the set of tags that the console changed and knew about, and the set of tags that the ID card had initially.
+        // Find the set of tags that the console changed and knew about.
         var visibleChanges = changedTags.Intersect(component.AccessLevels);
+        // Find the set of tags that the original ID had that the console _didn't_know about.
         var hiddenChanges = oldTags.Except(component.AccessLevels);
 
         // NULL SAFETY: PrivilegedIdIsAuthorized checked this earlier.
@@ -202,6 +203,7 @@ public sealed partial class IdCardConsoleSystem : SharedIdCardConsoleSystem
             return;
         }
 
+        // Restore all hidden tags to the newly requested set.
         var finalTags = newAccessList.Union(hiddenChanges);
         _access.TrySetTags(targetId, finalTags);
 

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -190,9 +190,9 @@ public sealed partial class IdCardConsoleSystem : SharedIdCardConsoleSystem
         var removedTags = oldTags.Except(newAccessList);
         var changedTags = addedTags.Union(removedTags);
 
-        // Find the set of tags that the console changed and knew about.
+        // Find tags that the console changed and knew about.
         var visibleChanges = changedTags.Intersect(component.AccessLevels);
-        // Find the set of tags that the original ID had that the console _didn't_know about.
+        // Find tags that the original ID had that the console can't change.
         var hiddenChanges = oldTags.Except(component.AccessLevels);
 
         var privilegedPerms = _accessReader.FindAccessTags(privilegedId.Value);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Revives #34142 (~1 year, no changes w/ outstanding merge conflicts), with a few minor changes for set sanity, comment clarity, and removing one unnecessary ToHashSet call.

The set of access tags that the ID card console can change are now respected - any tags that an ID card has that a given console or ID cannot change will remain on the card, and requests to set or clear accesses on a card with other accesses that the privileged ID itself does not have will function as expected.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Resolves #34100.
Resolves #41316.

Useful for forks that may want ID card consoles with smaller, more granular sets of access levels (as tested in the test plan).

## Technical details
<!-- Summary of code changes for easier review. -->

Largely the same set logic as #34142, though the hidden set is derived from the IDs on the original cards, rather than from the set of changes (functionally identical, but simpler to think about, IMO).

If the comments are too verbose, if `.All(x.Contains)` reads strangely, or if the changelog needs work, just let me know.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

0. Add the following entity definition to any YAML file:
```yml
# TEST ENTITY
- type: entity
  parent: ComputerId
  id: ComputerIdCargo
  name: cargo ID card computer
  components:
  - type: IdCardConsole
    accessLevels:
    - Cargo
    - Quartermaster
```
1. Spawn a cargo PDA, an engineer ID card, an ID card computer and a _cargo_ ID card computer (definition above)
2. Insert the engineer ID card into the _regular_ ID card computer, confirm that all expected engineering buttons are enabled (Atmos, Engineering, External, Maintenance)
3. Remove the ID card from the cargo PDA, insert it into the _cargo_ ID card computer.
4. Insert the engineering card into the _cargo_ ID card computer.
5. Add the Cargo access and eject the target ID.
6. Insert the engineering card back into the _regular_ ID card computer.  It should have the Cargo tag, plus the original set of accesses.
7. Eject the engineering card, insert it into the _cargo_ ID card computer again.
8. Remove the Cargo access from the ID card, eject the engineering ID card.
9. Insert the ID card into the _regular_ ID card computer, it should only have its original set of accesses.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

The test plan above (approximately) followed.

https://github.com/user-attachments/assets/a7dd470b-f8b0-4f2c-b88d-bbfa121af2e3

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Peque-e
- fix: The ID card console now correctly sets and clears accesses that any privileged ID has, and respects existing accesses the console cannot set.