### PR TITLE
Remove `LabelComponent` when removing a label

### DIFF
--- a/Content.Shared/Labels/EntitySystems/LabelSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/LabelSystem.cs
@@ -63,7 +63,7 @@ public sealed partial class LabelSystem : EntitySystem
     // TODO - Change signature to `Label(Entity<LabelComponent?> ent, string? text)`
     public void Label(EntityUid uid, string? text, MetaDataComponent? metadata = null, LabelComponent? label = null)
     {
-        // Remove a blank label
+        // If setting the label to be blank, just remove the label.
         if (string.IsNullOrEmpty(text))
         {
             RemoveLabel((uid, label));
@@ -85,7 +85,7 @@ public sealed partial class LabelSystem : EntitySystem
     /// <returns>true if a label was removed, or false if the entity already didn't have a label.</returns>
     public bool RemoveLabel(Entity<LabelComponent?> ent)
     {
-        return RemCompDeferred<LabelComponent>(ent);
+        return RemComp<LabelComponent>(ent);
     }
 
     /// <summary>

--- a/Content.Shared/Labels/EntitySystems/LabelSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/LabelSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Examine;
 using Content.Shared.Labels.Components;
@@ -44,20 +45,69 @@ public sealed partial class LabelSystem : EntitySystem
     }
 
     /// <summary>
-    /// Apply or remove a label on an entity.
+    /// Add, change, or remove a label on an entity.
     /// </summary>
+    /// <remarks>
+    /// If <paramref name="text"/> is <see langword="null"/> or an empty string, the <see cref="LabelComponent"/> will be removed.
+    /// </remarks>
     /// <param name="uid">EntityUid to change label on</param>
     /// <param name="text">intended label text (null to remove)</param>
     /// <param name="label">label component for resolve</param>
     /// <param name="metadata">metadata component for resolve</param>
+    // TODO - Change signature to `Label(Entity<LabelComponent?> ent, string? text)`
     public void Label(EntityUid uid, string? text, MetaDataComponent? metadata = null, LabelComponent? label = null)
     {
-        label ??= EnsureComp<LabelComponent>(uid);
+        // Remove a blank label
+        if (string.IsNullOrEmpty(text))
+        {
+            RemoveLabel((uid, label));
+            return;
+        }
 
-        label.CurrentLabel = text == null ? null : FormattedMessage.EscapeText(text);
+        label = EnsureComp<LabelComponent>(uid);
+
+        label.CurrentLabel = FormattedMessage.EscapeText(text);
         _nameModifier.RefreshNameModifiers(uid);
 
         Dirty(uid, label);
+    }
+
+    /// <summary>
+    /// Removes the label from an entity.
+    /// </summary>
+    /// <param name="ent">The entity from which the label should be removed</param>
+    /// <returns>true if a label was removed, otherwise false.</returns>
+    public bool RemoveLabel(Entity<LabelComponent?> ent)
+    {
+        if (RemCompDeferred<LabelComponent>(ent))
+        {
+            _nameModifier.RefreshNameModifiers(ent.Owner);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the text of the label from an entity, or <see cref="null"/> if it doesn't have a label.
+    /// </summary>
+    /// <param name="ent">The entity from which to get the label text.</param>
+    [Pure]
+    public string? GetLabelText(Entity<LabelComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp, logMissing: false))
+            return null;
+
+        return ent.Comp.CurrentLabel;
+    }
+
+    /// <summary>
+    /// Returns true if an entity has a visible label.
+    /// </summary>
+    /// <param name="ent">The entity to check for a label.</param>
+    [Pure]
+    public bool HasLabel(EntityUid ent)
+    {
+        return HasComp<LabelComponent>(ent);
     }
 
     private void OnExamine(Entity<LabelComponent> ent, ref ExaminedEvent args)
@@ -75,7 +125,8 @@ public sealed partial class LabelSystem : EntitySystem
 
     private void OnRefreshNameModifiers(Entity<LabelComponent> entity, ref RefreshNameModifiersEvent args)
     {
-        if (!string.IsNullOrEmpty(entity.Comp.CurrentLabel))
+        // We need to check Running so labels queued for deferred removal don't get applied.
+        if (!string.IsNullOrEmpty(entity.Comp.CurrentLabel) && entity.Comp.Running)
             args.AddModifier("comp-label-format", extraArgs: ("label", entity.Comp.CurrentLabel));
     }
 

--- a/Content.Shared/Labels/EntitySystems/LabelSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/LabelSystem.cs
@@ -82,7 +82,7 @@ public sealed partial class LabelSystem : EntitySystem
     /// Removes the label from an entity.
     /// </summary>
     /// <param name="ent">The entity from which the label should be removed.</param>
-    /// <returns>true if a label was removed, otherwise false.</returns>
+    /// <returns>true if a label was removed, or false if the entity already didn't have a label.</returns>
     public bool RemoveLabel(Entity<LabelComponent?> ent)
     {
         return RemCompDeferred<LabelComponent>(ent);

--- a/Content.Shared/Labels/EntitySystems/LabelSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/LabelSystem.cs
@@ -89,7 +89,7 @@ public sealed partial class LabelSystem : EntitySystem
     }
 
     /// <summary>
-    /// Returns the text of the label from an entity, or <see cref="null"/> if it doesn't have a label.
+    /// Returns the text of the label from an entity, or <see langword="null"/> if it doesn't have a label.
     /// </summary>
     /// <param name="ent">The entity from which to get the label text.</param>
     [Pure]

--- a/Content.Shared/Labels/EntitySystems/LabelSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/LabelSystem.cs
@@ -23,6 +23,7 @@ public sealed partial class LabelSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<LabelComponent, MapInitEvent>(OnLabelCompMapInit);
+        SubscribeLocalEvent<LabelComponent, ComponentShutdown>(OnLabelShutdown);
         SubscribeLocalEvent<LabelComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<LabelComponent, RefreshNameModifiersEvent>(OnRefreshNameModifiers);
 
@@ -41,6 +42,11 @@ public sealed partial class LabelSystem : EntitySystem
             Dirty(ent);
         }
 
+        _nameModifier.RefreshNameModifiers(ent.Owner);
+    }
+
+    private void OnLabelShutdown(Entity<LabelComponent> ent, ref ComponentShutdown args)
+    {
         _nameModifier.RefreshNameModifiers(ent.Owner);
     }
 
@@ -75,16 +81,11 @@ public sealed partial class LabelSystem : EntitySystem
     /// <summary>
     /// Removes the label from an entity.
     /// </summary>
-    /// <param name="ent">The entity from which the label should be removed</param>
+    /// <param name="ent">The entity from which the label should be removed.</param>
     /// <returns>true if a label was removed, otherwise false.</returns>
     public bool RemoveLabel(Entity<LabelComponent?> ent)
     {
-        if (RemCompDeferred<LabelComponent>(ent))
-        {
-            _nameModifier.RefreshNameModifiers(ent.Owner);
-            return true;
-        }
-        return false;
+        return RemCompDeferred<LabelComponent>(ent);
     }
 
     /// <summary>
@@ -125,8 +126,8 @@ public sealed partial class LabelSystem : EntitySystem
 
     private void OnRefreshNameModifiers(Entity<LabelComponent> entity, ref RefreshNameModifiersEvent args)
     {
-        // We need to check Running so labels queued for deferred removal don't get applied.
-        if (!string.IsNullOrEmpty(entity.Comp.CurrentLabel) && entity.Comp.Running)
+        // We need to check lifestage so labels queued for deferred removal don't get applied.
+        if (!string.IsNullOrEmpty(entity.Comp.CurrentLabel) && entity.Comp.LifeStage < ComponentLifeStage.Stopping)
             args.AddModifier("comp-label-format", extraArgs: ("label", entity.Comp.CurrentLabel));
     }
 

--- a/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
@@ -96,6 +96,7 @@ public abstract partial class SharedHandLabelerSystem : EntitySystem
 
         var user = args.User;   // can't use ref parameter in lambdas
 
+        // Don't add the Label verb if the labeler's text is blank.
         if (ent.Comp.AssignedLabel != string.Empty)
         {
             var labelVerb = new UtilityVerb()
@@ -110,10 +111,10 @@ public abstract partial class SharedHandLabelerSystem : EntitySystem
             args.Verbs.Add(labelVerb);
         }
 
-        // Only add the unlabel verb if the target is already labeled.
+        // Add the Remove Label verb whether or not the labeler's text is blank,
+        // but only if the target is already labeled.
         if (_labelSystem.HasLabel(target))
         {
-            // add the unlabel verb to the menu even when the labeler has text
             var unLabelVerb = new UtilityVerb()
             {
                 Act = () =>

--- a/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
@@ -110,18 +110,22 @@ public abstract partial class SharedHandLabelerSystem : EntitySystem
             args.Verbs.Add(labelVerb);
         }
 
-        // add the unlabel verb to the menu even when the labeler has text
-        var unLabelVerb = new UtilityVerb()
+        // Only add the unlabel verb if the target is already labeled.
+        if (_labelSystem.HasLabel(target))
         {
-            Act = () =>
+            // add the unlabel verb to the menu even when the labeler has text
+            var unLabelVerb = new UtilityVerb()
             {
-                RemoveLabelFrom(ent, user, target);
-            },
-            Text = Loc.GetString("hand-labeler-remove-label-text"),
-            Priority = -1,
-        };
+                Act = () =>
+                {
+                    RemoveLabelFrom(ent, user, target);
+                },
+                Text = Loc.GetString("hand-labeler-remove-label-text"),
+                Priority = -1,
+            };
 
-        args.Verbs.Add(unLabelVerb);
+            args.Verbs.Add(unLabelVerb);
+        }
     }
 
     private void AfterInteractOn(Entity<HandLabelerComponent> ent, ref AfterInteractEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The `LabelComponent` on an entity is now removed when setting a blank label.

Also, I was annoyed that the "Remove label" verb shows up on items without labels (which the labeler is in-hand), so I changed it so it doesn't.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Labels should clean up after themselves and not leave junk components behind.

## Technical details
<!-- Summary of code changes for easier review. -->
- Calling `LabelSystem.Label` with null or a blank string now does a deferred component removal of the `LabelComponent`.
- Removing a `LabelComponent` now triggers a name modifier refresh.
- Added a few methods to flesh out the API for `LabelSystem` a little (`RemoveLabel`, `HasLabel`, and `GetLabelText`).
- Made `SharedHandLabelerSystem.OnUtilityVerb` call `LabelSystem.HasLabel` before adding the "Remove label" verb.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
- Spawn Hand Labeler.
- Grab or spawn some items (I used the soda can on Dev).
- Open the hand labeler UI and set some text.
- Right-click an item and check that the "Remove label" verb isn't shown.
- Click to label an item.
- Examine the item to check that the label is applied.
- Right-click the item and check that the "Remove label" verb is shown now.
- Clear the hand labeler UI textfield.
- Click the item to remove the label.
- Examine to check that the item name is restored.
- Use VV to check the item's components and check that the `LabelComponent` has been removed.
- Also try removing the label with the "Remove label" verb and by removing the component with VV.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->