### PR TITLE
[BUGFIX] Shaken sodas now spill again

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/PressurizedSolutionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/PressurizedSolutionSystem.cs
@@ -179,7 +179,7 @@ public sealed partial class PressurizedSolutionSystem : EntitySystem
 
         // Spray the solution onto the ground and anyone nearby
         var coordinates = Transform(entity).Coordinates;
-        _puddle.TrySplashSpillAt(entity.Owner, coordinates, out _, out _, sound: false);
+        _puddle.TrySplashSpillAt(entity.Owner, coordinates, solution, out _, sound: false);
 
         var drinkName = Identity.Entity(entity, EntityManager);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Now a soda popping from over-pressurization no longer evaporates the soda completely!

## Why / Balance
I need to slip security.
Also fixes #43684

## Technical details
from:
<img width="686" height="87" alt="image" src="https://github.com/user-attachments/assets/89baa015-e823-41a9-99d8-2b8d5f390a36" />

to:
<img width="767" height="88" alt="image" src="https://github.com/user-attachments/assets/616f8afb-8988-44c0-80c6-e6cf3128ce92" />

## Test plan
grab any sealed soda, shake it or just toss it, the puddle will appear again

## Media

https://github.com/user-attachments/assets/e84a9a3c-8486-459a-9b82-68d88f79e894



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
- fix: a sealed fizzy soda's contents will no longer disappear when bursting.