### PR TITLE
Rework BallisticAmmoProviderComponent to include 'protos' parameter

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -13,14 +13,14 @@ public sealed partial class GunSystem
         // TODO: Combine with TakeAmmo
         if (ent.Comp.Entities.Count > 0)
         {
-            var existing = ent.Comp.Entities[^1];
-            ent.Comp.Entities.RemoveAt(ent.Comp.Entities.Count - 1);
+            var existing = ent.Comp.Entities[0];
+            ent.Comp.Entities.RemoveAt(0);
             DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.Entities));
-
             Containers.Remove(existing, ent.Comp.Container);
             EnsureShootable(existing);
+            ammoEnt = existing;
         }
-        else if (ent.Comp.UnspawnedCount > 0)
+        else if (ent.Comp.UnspawnedCount > 0 && ent.Comp.Proto != null)
         {
             ent.Comp.UnspawnedCount--;
             DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.UnspawnedCount));

--- a/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
@@ -18,6 +18,9 @@ public sealed partial class BallisticAmmoProviderComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public EntProtoId? Proto;
+    
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public List<EntProtoId> Protos = new();
 
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public int Capacity = 30;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -15,9 +15,9 @@ namespace Content.Shared.Weapons.Ranged.Systems;
 
 public abstract partial class SharedGunSystem
 {
-    [Dependency] private SharedDoAfterSystem _doAfter = default!;
-    [Dependency] private SharedInteractionSystem _interaction = default!;
-    [Dependency] private SharedStackSystem _stack = null!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly SharedStackSystem _stack = null!;
 
     [MustCallBase]
     protected virtual void InitializeBallistic()
@@ -225,7 +225,24 @@ public abstract partial class SharedGunSystem
     {
         // TODO this should be part of the prototype, not set on map init.
         // Alternatively, just track spawned count, instead of unspawned count.
-        if (ent.Comp.Proto != null)
+        if (ent.Comp.Protos.Count > 0)
+        {
+            var spawnCount = Math.Min(ent.Comp.Protos.Count, ent.Comp.Capacity);
+    
+            for (var i = 0; i < spawnCount; i++)
+            {
+                var ammo = Spawn(ent.Comp.Protos[i], Transform(ent).Coordinates);
+                Containers.Insert(ammo, ent.Comp.Container);
+                ent.Comp.Entities.Add(ammo);
+            }
+    
+            ent.Comp.UnspawnedCount = 0;
+            DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.Entities));
+            DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.UnspawnedCount));
+            UpdateBallisticAppearance(ent);
+            return;
+        }
+        else if (ent.Comp.Proto != null)
         {
             ent.Comp.UnspawnedCount = Math.Max(0, ent.Comp.Capacity - ent.Comp.Container.ContainedEntities.Count);
             UpdateBallisticAppearance(ent);
@@ -245,8 +262,8 @@ public abstract partial class SharedGunSystem
             EntityUid? ammoEntity = null;
             if (ent.Comp.Entities.Count > 0)
             {
-                var existingEnt = ent.Comp.Entities[^1];
-                ent.Comp.Entities.RemoveAt(ent.Comp.Entities.Count - 1);
+                var existingEnt = ent.Comp.Entities[0];
+                ent.Comp.Entities.RemoveAt(0);
                 DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.Entities));
                 Containers.Remove(existingEnt, ent.Comp.Container);
                 ammoEntity = existingEnt;
@@ -257,17 +274,17 @@ public abstract partial class SharedGunSystem
                 DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.UnspawnedCount));
                 ammoEntity = Spawn(ent.Comp.Proto, args.Coordinates);
             }
-
+    
             if (ammoEntity is not { } ammoEnt)
                 continue;
 
             args.Ammo.Add((ammoEnt, EnsureShootable(ammoEnt)));
+    
             if (TryComp<BallisticAmmoSelfRefillerComponent>(ent, out var refiller))
             {
                 PauseSelfRefill((ent, refiller));
             }
         }
-
         UpdateBallisticAppearance(ent);
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a new `protos` parameter for `BallisticAmmoProviderComponent`. `protos` acts as an ordered list of ammunition prototypes, allowing magazines to contain multiple cartridge types in a specific order.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It will help in the creation of new magazines with alternating shells, and will also provide the opportunity to create new prototypes for events.
## Technical details
<!-- Summary of code changes for easier review. -->
Added support for sequential ammunition loading using `protos` in `BallisticAmmoProviderComponent`.
Magazines can now define an ordered list of ammunition prototypes instead of using only a single `proto`.
Implemented FIFO ammo extraction for ordered ammunition lists so firing and manual cycling preserve the configured order.
Legacy `proto` behavior remains unchanged.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Tested in-game with a custom pistol magazine configured with mixed ammunition types.

Test steps:
1. Create a magazine using the new `protos` field.
2. Insert different cartridge types in a specific order.
3. Fire the weapon and verify cartridges are fired in the configured order.
4. Manually cycle/unload the magazine and verify cartridges eject in the same order.
5. Verify legacy magazines using `proto` still function correctly.
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
