### PR TITLE
Mini Gravity Generator requires charging

### DIFF
--- a/Resources/Maps/reach.yml
+++ b/Resources/Maps/reach.yml
@@ -11475,6 +11475,8 @@ entities:
       parent: 2
     - type: PointLight
       radius: 175.75
+    - type: PowerCharge
+      charge: 1
 - proto: Grille
   entities:
   - uid: 19

--- a/Resources/Maps/reach.yml
+++ b/Resources/Maps/reach.yml
@@ -11475,8 +11475,6 @@ entities:
       parent: 2
     - type: PointLight
       radius: 175.75
-    - type: PowerCharge
-      charge: 1
 - proto: Grille
   entities:
   - uid: 19

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1289,7 +1289,7 @@
   - type: Sprite
     state: supply
   - type: MachineBoard
-    prototype: GravityGeneratorMini
+    prototype: GravityGeneratorMiniUncharged
     stackRequirements:
       Manipulator: 7
       Steel: 5

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -144,11 +144,7 @@
 - type: entity
   id: GravityGeneratorMiniUncharged
   parent: GravityGeneratorMini
-  name: mini gravity generator
   suffix: Uncharged
-  description: It's what keeps you to the floor, now in fun size.
   components:
   - type: PowerCharge
-    idlePower: 15
-    activePower: 500
     charge: 0

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -84,6 +84,7 @@
   id: GravityGeneratorMini
   parent: [ GravityGenerator, ConstructibleMachine ]
   name: mini gravity generator
+  suffix: Charged
   description: It's what keeps you to the floor, now in fun size.
   components:
   - type: StationAiWhitelist
@@ -134,9 +135,20 @@
   - type: PowerCharge
     idlePower: 15
     activePower: 500
-    charge: 0
   - type: GravityGenerator
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
   - type: StaticPrice
     price: 2000
+
+- type: entity
+  id: GravityGeneratorMiniUncharged
+  parent: GravityGeneratorMini
+  name: mini gravity generator
+  suffix: Uncharged
+  description: It's what keeps you to the floor, now in fun size.
+  components:
+  - type: PowerCharge
+    idlePower: 15
+    activePower: 500
+    charge: 0

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
-  id: GravityGenerator
   parent: BaseMachinePowered
+  id: GravityGenerator
   name: gravity generator
   description: It's what keeps you to the floor.
   placement:
@@ -81,8 +81,8 @@
     price: 5000
 
 - type: entity
-  id: GravityGeneratorMini
   parent: [ GravityGenerator, ConstructibleMachine ]
+  id: GravityGeneratorMini
   name: mini gravity generator
   suffix: Charged
   description: It's what keeps you to the floor, now in fun size.

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -134,6 +134,7 @@
   - type: PowerCharge
     idlePower: 15
     activePower: 500
+    charge: 0
   - type: GravityGenerator
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Miniature gravity generator starts uncharged when constructed.

Also fixed YAML ordering in the gravity gen file.

Resolves #29817

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This makes small gravity generators start uncharged on construction. This makes shuttle building more engaging and prevents a disassemble/reassemble for instant charge.

## Technical details
<!-- Summary of code changes for easier review. -->
Created a modified gravity generator prototype for an uncharged mini grav gen

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Start up a localhost, spawn a mini grav gen. Remains unpowered.
Spawn in reach, ensure gravity is present.
Deconstruct and reconstruct a mini grav gen, ensure charge is reset.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Behavior remains the same, but mappers should place the `Charged` suffixed miniature gravity generator in roundstart shuttles.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Nem
- fix: mini grav gens now start uncharged when constructed.