### PR TITLE
Fixing a Permissions vulnerability

### DIFF
--- a/Content.Server/Administration/UI/PermissionsEui.cs
+++ b/Content.Server/Administration/UI/PermissionsEui.cs
@@ -240,6 +240,12 @@ namespace Content.Server.Administration.UI
                 return;
             }
 
+            var (bad, rankName) = await FetchAndCheckRank(ua.RankId);
+            if (bad)
+            {
+                return;
+            }
+
             var admin = await _db.GetAdminDataForAsync(ua.UserId);
             if (admin == null)
             {
@@ -261,12 +267,6 @@ namespace Content.Server.Administration.UI
             await _db.UpdateAdminAsync(admin);
 
             var playerRecord = await _db.GetPlayerRecordByUserId(ua.UserId);
-            var (bad, rankName) = await FetchAndCheckRank(ua.RankId);
-            if (bad)
-            {
-                return;
-            }
-
             var name = playerRecord?.LastSeenUserName ?? ua.UserId.ToString();
             var title = ua.Title ?? "<no title>";
             var flags = AdminFlagsHelper.PosNegFlagsText(ua.PosFlags, ua.NegFlags);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed a critical validation bypass in `HandleUpdateAdmin`. Previously, admin data was saved to the database before validating the assigned rank via `FetchAndCheckRank`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
If the server has admin ranks, you can grant yourself the privileges of those ranks simply by having the “Permissions” admin flag.

## Test plan
1. Attempt to assign yourself a rank that, in theory, should be impossible to assign.
2. Check the database - the administrator rank should remain unchanged.
3. Verify that rank updates with valid values still function correctly and synchronize with the current session.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->