### PR TITLE
[Hotfix] Fix MenuButton Missing Negative Style

### DIFF
--- a/Content.Client/Stylesheets/Sheetlets/MenuButtonSheetlet.cs
+++ b/Content.Client/Stylesheets/Sheetlets/MenuButtonSheetlet.cs
@@ -74,6 +74,8 @@ public sealed class MenuButtonSheetlet<T> : Sheetlet<T> where T : PalettedStyles
         };
 
         ButtonSheetlet<T>.MakeButtonRules<MenuButton>(rules, cfg.ButtonPalette, null);
+        ButtonSheetlet<T>.MakeButtonRules<MenuButton>(rules, cfg.PositiveButtonPalette, StyleClass.Positive);
+        ButtonSheetlet<T>.MakeButtonRules<MenuButton>(rules, cfg.NegativeButtonPalette, StyleClass.Negative);
 
         return rules.ToArray();
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

(ADMINS ARE **NOT** HAPPY.)

I added the styling behavior for MenuButtons to handle positive/negative.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

#43908 changed the way that button rules scoping changed. It used the `CButton()` selector that is already common to scope rules to only style buttons that explicitly opt-into styling via the `ContainerButton.StyleClassButton`. 

The root of the problem was that the original StyleNano removal/Sheetlet PR added this unscoped behavior and didn't completely port over the original StyleNano behavior for the MenuButtons. It originally had a specific scoped styleclass for the MenuButton's negative state, but the sheetlet PR didn't keep that functionality and instead the unscoped rule masked it. That unscoped rule introduced a bug that the PR fixed, but fixing that exposed this other porting bug.

Ultimately, I just added new rules for positive/negative to MenuButton to handle these cases. I added positive because why not.

## Technical details
<!-- Summary of code changes for easier review. -->

Added 2 lines to add negative/positive style support.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Launch 2 clients.
2. Deadmin one
3. Send ahelp
4. Other should have the red MenuButton

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="495" height="90" alt="image" src="https://github.com/user-attachments/assets/b187985d-e33d-4e0b-9bcc-0fadd207f3f1" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

N/A

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

N/A, minor visual bug fix