### PR TITLE
Add scream emote for chasm falls

### DIFF
--- a/Content.Shared/Chasm/ChasmSystem.cs
+++ b/Content.Shared/Chasm/ChasmSystem.cs
@@ -2,6 +2,8 @@
 using Content.Shared.Movement.Events;
 using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Weapons.Misc;
+using Content.Shared.Mind;
+using Content.Shared.Chat;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
@@ -18,6 +20,8 @@ public sealed partial class ChasmSystem : EntitySystem
     [Dependency] private INetManager _net = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedGrapplingGunSystem _grapple = default!;
+    [Dependency] private SharedMindSystem _mind = default!;
+    [Dependency] private SharedChatSystem _chat = default!;
 
     public override void Initialize()
     {
@@ -63,7 +67,13 @@ public sealed partial class ChasmSystem : EntitySystem
         _blocker.UpdateCanMove(tripper);
 
         if (playSound)
-            _audio.PlayPredicted(component.FallingSound, chasm, tripper);
+            {
+
+                if (_mind.TryGetMind(tripper, out var mindId, out var mind))
+                    _chat.TryEmoteWithChat(tripper, "Scream");
+
+                _audio.PlayPredicted(component.FallingSound, chasm, tripper);
+            }
     }
 
     private void OnStepTriggerAttempt(EntityUid uid, ChasmComponent component, ref StepTriggerAttemptEvent args)


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
If the entity is controlled by a player, it will attempt to scream when falling.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Players fall silently into the chasm, which seems odd. In real life, people scream when they fall.
## Technical details
<!-- Summary of code changes for easier review. -->
When an entity starts falling into a chasm, the system now checks whether it is mind-controlled by a player. If so, it triggers a scream emote before playing the fall sound.
The change is implemented in `ChasmSystem.StartFalling()` and uses `SharedMindSystem` and `SharedChatSystem`.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
- Step onto a chasm as a player-controlled entity and verify that the scream emote is triggered.
- Step onto a chasm as a non-player-controlled entity and verify that no scream emote is triggered.

## Media
https://github.com/user-attachments/assets/54273fcd-9ff7-4dc6-91d7-af76b065d154

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
- tweak: Player-controlled entities now attempt to scream when falling into a chasm.