### PR TITLE
Grilles are no longer rotated. Grilles can no longer be rotated. PART 3!

### DIFF
--- a/Resources/Maps/Dungeon/RandomMap/bagelrandom.yml
+++ b/Resources/Maps/Dungeon/RandomMap/bagelrandom.yml
@@ -1138,25 +1138,21 @@ entities:
   - uid: 158
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,5.5
       parent: 1
   - uid: 159
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,4.5
       parent: 1
   - uid: 160
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,3.5
       parent: 1
   - uid: 161
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,2.5
       parent: 1
   - uid: 172
@@ -1182,13 +1178,11 @@ entities:
   - uid: 207
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 1
   - uid: 208
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,14.5
       parent: 1
 - proto: HolopadGeneralTheater

--- a/Resources/Maps/Dungeon/lava_brig.yml
+++ b/Resources/Maps/Dungeon/lava_brig.yml
@@ -8672,13 +8672,11 @@ entities:
   - uid: 1465
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,43.5
       parent: 588
   - uid: 1466
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,43.5
       parent: 588
 - proto: GrilleBroken

--- a/Resources/Maps/Dungeon/mineshaft.yml
+++ b/Resources/Maps/Dungeon/mineshaft.yml
@@ -2908,25 +2908,21 @@ entities:
   - uid: 288
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,19.5
       parent: 2
   - uid: 289
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,21.5
       parent: 2
   - uid: 290
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,21.5
       parent: 2
   - uid: 359
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,16.5
       parent: 2
   - uid: 374
@@ -2937,25 +2933,21 @@ entities:
   - uid: 375
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,18.5
       parent: 2
   - uid: 462
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,20.5
       parent: 2
   - uid: 472
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,24.5
       parent: 2
   - uid: 599
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,18.5
       parent: 2
   - uid: 732
@@ -2976,49 +2968,41 @@ entities:
   - uid: 740
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,22.5
       parent: 2
   - uid: 745
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,20.5
       parent: 2
   - uid: 748
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,16.5
       parent: 2
   - uid: 749
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,16.5
       parent: 2
   - uid: 750
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,12.5
       parent: 2
   - uid: 751
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,12.5
       parent: 2
   - uid: 1026
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 28.5,16.5
       parent: 2
   - uid: 1028
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 30.5,15.5
       parent: 2
 - proto: GrilleBroken

--- a/Resources/Maps/Dungeon/vgroidinterior.yml
+++ b/Resources/Maps/Dungeon/vgroidinterior.yml
@@ -362,25 +362,21 @@ entities:
   - uid: 51
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,19.5
       parent: 1
   - uid: 52
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,19.5
       parent: 1
   - uid: 53
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,21.5
       parent: 1
   - uid: 54
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,21.5
       parent: 1
   - uid: 470
@@ -391,19 +387,16 @@ entities:
   - uid: 475
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,19.5
       parent: 1
   - uid: 476
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,20.5
       parent: 1
   - uid: 477
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,21.5
       parent: 1
 - proto: GrilleBroken

--- a/Resources/Maps/Lavaland/basalt_ruin.yml
+++ b/Resources/Maps/Lavaland/basalt_ruin.yml
@@ -788,13 +788,11 @@ entities:
   - uid: 36
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
   - uid: 53
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 1
 - proto: LootSpawnerMedicalClassy

--- a/Resources/Maps/Lavaland/crashed_pod_trail.yml
+++ b/Resources/Maps/Lavaland/crashed_pod_trail.yml
@@ -1299,13 +1299,11 @@ entities:
   - uid: 207
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
   - uid: 265
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,4.5
       parent: 1
 - proto: InflatableWall

--- a/Resources/Maps/Lavaland/crasheddropship.yml
+++ b/Resources/Maps/Lavaland/crasheddropship.yml
@@ -559,43 +559,36 @@ entities:
   - uid: 80
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-2.5
       parent: 1
   - uid: 81
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-1.5
       parent: 1
   - uid: 82
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-0.5
       parent: 1
   - uid: 83
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,0.5
       parent: 1
   - uid: 84
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,0.5
       parent: 1
   - uid: 85
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,1.5
       parent: 1
   - uid: 86
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,1.5
       parent: 1
 - proto: LockerSyndicateShipGearBasic

--- a/Resources/Maps/Lavaland/hermit_base.yml
+++ b/Resources/Maps/Lavaland/hermit_base.yml
@@ -952,7 +952,6 @@ entities:
   - uid: 2
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,2.5
       parent: 1
 - proto: hydroponicsSoil

--- a/Resources/Maps/Lavaland/river_village.yml
+++ b/Resources/Maps/Lavaland/river_village.yml
@@ -6196,7 +6196,6 @@ entities:
   - uid: 1313
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,14.5
       parent: 1
 - proto: HydroponicsToolMiniHoe

--- a/Resources/Maps/Lavaland/wrecked_outpost.yml
+++ b/Resources/Maps/Lavaland/wrecked_outpost.yml
@@ -1174,7 +1174,6 @@ entities:
   - uid: 7
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-16.5
       parent: 1
   - uid: 12
@@ -1205,19 +1204,16 @@ entities:
   - uid: 119
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-9.5
       parent: 1
   - uid: 121
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-9.5
       parent: 1
   - uid: 122
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-9.5
       parent: 1
   - uid: 146

--- a/Resources/Maps/Ruins/atmos_interchange.yml
+++ b/Resources/Maps/Ruins/atmos_interchange.yml
@@ -3053,7 +3053,6 @@ entities:
   - uid: 8
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,10.5
       parent: 1
   - uid: 32
@@ -3124,445 +3123,371 @@ entities:
   - uid: 148
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-2.5
       parent: 1
   - uid: 207
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,-0.5
       parent: 1
   - uid: 208
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,8.5
       parent: 1
   - uid: 209
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-0.5
       parent: 1
   - uid: 228
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,0.5
       parent: 1
   - uid: 229
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,1.5
       parent: 1
   - uid: 231
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,3.5
       parent: 1
   - uid: 232
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,3.5
       parent: 1
   - uid: 233
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,2.5
       parent: 1
   - uid: 234
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,1.5
       parent: 1
   - uid: 235
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,0.5
       parent: 1
   - uid: 239
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,-2.5
       parent: 1
   - uid: 245
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,4.5
       parent: 1
   - uid: 246
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,4.5
       parent: 1
   - uid: 294
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,16.5
       parent: 1
   - uid: 297
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,5.5
       parent: 1
   - uid: 314
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,5.5
       parent: 1
   - uid: 326
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,-1.5
       parent: 1
   - uid: 354
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,2.5
       parent: 1
   - uid: 359
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,7.5
       parent: 1
   - uid: 360
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,7.5
       parent: 1
   - uid: 361
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,7.5
       parent: 1
   - uid: 381
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,-1.5
       parent: 1
   - uid: 384
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,-0.5
       parent: 1
   - uid: 385
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,-2.5
       parent: 1
   - uid: 386
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,9.5
       parent: 1
   - uid: 390
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 1
   - uid: 391
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,5.5
       parent: 1
   - uid: 392
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,5.5
       parent: 1
   - uid: 393
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,5.5
       parent: 1
   - uid: 395
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-0.5
       parent: 1
   - uid: 396
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 1
   - uid: 397
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-0.5
       parent: 1
   - uid: 398
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,11.5
       parent: 1
   - uid: 402
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,15.5
       parent: 1
   - uid: 403
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,15.5
       parent: 1
   - uid: 407
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,11.5
       parent: 1
   - uid: 408
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-6.5
       parent: 1
   - uid: 409
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 1
   - uid: 410
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-8.5
       parent: 1
   - uid: 412
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-10.5
       parent: 1
   - uid: 413
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-10.5
       parent: 1
   - uid: 414
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-9.5
       parent: 1
   - uid: 415
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-8.5
       parent: 1
   - uid: 416
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 1
   - uid: 417
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-7.5
       parent: 1
   - uid: 424
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,12.5
       parent: 1
   - uid: 437
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-13.5
       parent: 1
   - uid: 439
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,-13.5
       parent: 1
   - uid: 440
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,18.5
       parent: 1
   - uid: 442
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,22.5
       parent: 1
   - uid: 443
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,18.5
       parent: 1
   - uid: 466
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,3.5
       parent: 1
   - uid: 467
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
   - uid: 468
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,1.5
       parent: 1
   - uid: 469
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,3.5
       parent: 1
   - uid: 474
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-2.5
       parent: 1
   - uid: 475
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-2.5
       parent: 1
   - uid: 477
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,7.5
       parent: 1
   - uid: 478
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,7.5
       parent: 1
   - uid: 479
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,7.5
       parent: 1
   - uid: 480
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -22.5,7.5
       parent: 1
   - uid: 481
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,7.5
       parent: 1
   - uid: 482
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,7.5
       parent: 1
   - uid: 483
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-2.5
       parent: 1
   - uid: 484
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-2.5
       parent: 1
   - uid: 486
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,2.5
       parent: 1
   - uid: 505
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,20.5
       parent: 1
   - uid: 508
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,6.5
       parent: 1
   - uid: 517
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,2.5
       parent: 1
   - uid: 520
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,2.5
       parent: 1
   - uid: 529
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 17.5,2.5
       parent: 1
   - uid: 530
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,2.5
       parent: 1
   - uid: 558
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,21.5
       parent: 1
 - proto: GrilleBroken

--- a/Resources/Maps/Ruins/biodome_satellite.yml
+++ b/Resources/Maps/Ruins/biodome_satellite.yml
@@ -2316,49 +2316,41 @@ entities:
   - uid: 72
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,3.5
       parent: 2
   - uid: 73
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,4.5
       parent: 2
   - uid: 74
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,3.5
       parent: 2
   - uid: 75
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,4.5
       parent: 2
   - uid: 76
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-0.5
       parent: 2
   - uid: 77
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 2
   - uid: 78
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 2
   - uid: 79
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-0.5
       parent: 2
   - uid: 234

--- a/Resources/Maps/Ruins/derelict.yml
+++ b/Resources/Maps/Ruins/derelict.yml
@@ -3811,13 +3811,11 @@ entities:
   - uid: 1948
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,32.5
       parent: 2
   - uid: 1949
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,33.5
       parent: 2
   - uid: 2033

--- a/Resources/Maps/Ruins/displaced_telescience.yml
+++ b/Resources/Maps/Ruins/displaced_telescience.yml
@@ -4001,13 +4001,11 @@ entities:
   - uid: 317
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,1.5
       parent: 1
   - uid: 318
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
 - proto: GrilleBroken

--- a/Resources/Maps/Ruins/empty_flagship.yml
+++ b/Resources/Maps/Ruins/empty_flagship.yml
@@ -5841,7 +5841,6 @@ entities:
   - uid: 1282
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,0.5
       parent: 1
   - uid: 1283
@@ -5852,91 +5851,76 @@ entities:
   - uid: 1289
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-7.5
       parent: 1
   - uid: 1308
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-0.5
       parent: 1
   - uid: 1313
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-8.5
       parent: 1
   - uid: 1316
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-5.5
       parent: 1
   - uid: 1318
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-2.5
       parent: 1
   - uid: 1319
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-4.5
       parent: 1
   - uid: 1368
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-14.5
       parent: 1
   - uid: 1369
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-13.5
       parent: 1
   - uid: 1371
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-16.5
       parent: 1
   - uid: 1372
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-17.5
       parent: 1
   - uid: 1373
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-23.5
       parent: 1
   - uid: 1374
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-22.5
       parent: 1
   - uid: 1375
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-20.5
       parent: 1
   - uid: 1376
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-19.5
       parent: 1
   - uid: 1377
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 123.5,-18.5
       parent: 1
 - proto: GrilleBroken

--- a/Resources/Maps/Ruins/hydro_outpost.yml
+++ b/Resources/Maps/Ruins/hydro_outpost.yml
@@ -1830,85 +1830,71 @@ entities:
   - uid: 56
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,-7.5
       parent: 1
   - uid: 58
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,-9.5
       parent: 1
   - uid: 59
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-9.5
       parent: 1
   - uid: 60
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 1
   - uid: 61
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,-9.5
       parent: 1
   - uid: 62
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,-9.5
       parent: 1
   - uid: 63
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,-8.5
       parent: 1
   - uid: 64
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,-7.5
       parent: 1
   - uid: 297
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,-4.5
       parent: 1
   - uid: 298
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-1.5
       parent: 1
   - uid: 299
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-0.5
       parent: 1
   - uid: 300
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-0.5
       parent: 1
   - uid: 301
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-0.5
       parent: 1
   - uid: 302
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-1.5
       parent: 1
   - uid: 440

--- a/Resources/Maps/Ruins/old_ai_sat.yml
+++ b/Resources/Maps/Ruins/old_ai_sat.yml
@@ -959,7 +959,6 @@ entities:
   - uid: 202
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,22.5
       parent: 1
   - uid: 207
@@ -1125,85 +1124,71 @@ entities:
   - uid: 487
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,31.5
       parent: 1
   - uid: 488
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,31.5
       parent: 1
   - uid: 490
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,31.5
       parent: 1
   - uid: 491
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,31.5
       parent: 1
   - uid: 492
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,31.5
       parent: 1
   - uid: 493
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,31.5
       parent: 1
   - uid: 494
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,31.5
       parent: 1
   - uid: 496
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,31.5
       parent: 1
   - uid: 497
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,31.5
       parent: 1
   - uid: 498
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,31.5
       parent: 1
   - uid: 499
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,31.5
       parent: 1
   - uid: 500
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,31.5
       parent: 1
   - uid: 501
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,31.5
       parent: 1
   - uid: 502
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,31.5
       parent: 1
   - uid: 504

--- a/Resources/Maps/Ruins/syndicate_dropship.yml
+++ b/Resources/Maps/Ruins/syndicate_dropship.yml
@@ -585,61 +585,51 @@ entities:
   - uid: 77
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-4.5
       parent: 1
   - uid: 78
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-3.5
       parent: 1
   - uid: 79
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-3.5
       parent: 1
   - uid: 80
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-2.5
       parent: 1
   - uid: 81
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-1.5
       parent: 1
   - uid: 82
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-0.5
       parent: 1
   - uid: 83
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,0.5
       parent: 1
   - uid: 84
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,0.5
       parent: 1
   - uid: 85
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,1.5
       parent: 1
   - uid: 86
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,1.5
       parent: 1
 - proto: Gyroscope

--- a/Resources/Maps/Ruins/whiteship_bluespacejumper.yml
+++ b/Resources/Maps/Ruins/whiteship_bluespacejumper.yml
@@ -1033,31 +1033,26 @@ entities:
   - uid: 131
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-16.5
       parent: 1
   - uid: 132
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,-16.5
       parent: 1
   - uid: 133
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,-16.5
       parent: 1
   - uid: 134
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-16.5
       parent: 1
   - uid: 135
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,-16.5
       parent: 1
 - proto: MachineFrame

--- a/Resources/Maps/Salvage/medium-crashed-shuttle.yml
+++ b/Resources/Maps/Salvage/medium-crashed-shuttle.yml
@@ -832,25 +832,21 @@ entities:
   - uid: 10
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 166
   - uid: 104
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 166
   - uid: 108
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-6.5
       parent: 166
   - uid: 109
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,-6.5
       parent: 166
   - uid: 146

--- a/Resources/Maps/Salvage/wh-salvage.yml
+++ b/Resources/Maps/Salvage/wh-salvage.yml
@@ -1022,133 +1022,111 @@ entities:
   - uid: 140
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,-4.5
       parent: 374
   - uid: 141
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,-3.5
       parent: 374
   - uid: 142
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,-2.5
       parent: 374
   - uid: 144
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,-0.5
       parent: 374
   - uid: 146
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,1.5
       parent: 374
   - uid: 147
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,2.5
       parent: 374
   - uid: 148
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,3.5
       parent: 374
   - uid: 149
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,-5.5
       parent: 374
   - uid: 150
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,-5.5
       parent: 374
   - uid: 151
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,-5.5
       parent: 374
   - uid: 153
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,-5.5
       parent: 374
   - uid: 154
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,-5.5
       parent: 374
   - uid: 155
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-5.5
       parent: 374
   - uid: 157
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-5.5
       parent: 374
   - uid: 158
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 374
   - uid: 159
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-5.5
       parent: 374
   - uid: 160
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,-4.5
       parent: 374
   - uid: 161
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-2.5
       parent: 374
   - uid: 162
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,-2.5
       parent: 374
   - uid: 163
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-2.5
       parent: 374
   - uid: 164
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-5.5
       parent: 374
   - uid: 165
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-5.5
       parent: 374
 - proto: GroundCannabis

--- a/Resources/Maps/Shuttles/AdminSpawn/ERT-Large-Base.yml
+++ b/Resources/Maps/Shuttles/AdminSpawn/ERT-Large-Base.yml
@@ -2302,43 +2302,36 @@ entities:
   - uid: 34
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,16.5
       parent: 1
   - uid: 35
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,16.5
       parent: 1
   - uid: 103
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,7.5
       parent: 1
   - uid: 104
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 1
   - uid: 106
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-6.5
       parent: 1
   - uid: 107
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-5.5
       parent: 1
   - uid: 108
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,2.5
       parent: 1
   - uid: 109
@@ -2359,19 +2352,16 @@ entities:
   - uid: 112
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,15.5
       parent: 1
   - uid: 115
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,6.5
       parent: 1
   - uid: 116
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,16.5
       parent: 1
   - uid: 118
@@ -2417,109 +2407,91 @@ entities:
   - uid: 128
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-7.5
       parent: 1
   - uid: 129
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,9.5
       parent: 1
   - uid: 130
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 1
   - uid: 131
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-8.5
       parent: 1
   - uid: 133
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,9.5
       parent: 1
   - uid: 134
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,7.5
       parent: 1
   - uid: 135
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,14.5
       parent: 1
   - uid: 136
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,10.5
       parent: 1
   - uid: 138
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,5.5
       parent: 1
   - uid: 139
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,15.5
       parent: 1
   - uid: 140
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,16.5
       parent: 1
   - uid: 171
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,3.5
       parent: 1
   - uid: 353
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,16.5
       parent: 1
   - uid: 354
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,16.5
       parent: 1
   - uid: 355
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,16.5
       parent: 1
   - uid: 356
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,16.5
       parent: 1
   - uid: 359
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,16.5
       parent: 1
   - uid: 360
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,16.5
       parent: 1
   - uid: 411

--- a/Resources/Maps/Shuttles/AdminSpawn/ERT-Large-Med-Sec.yml
+++ b/Resources/Maps/Shuttles/AdminSpawn/ERT-Large-Med-Sec.yml
@@ -5213,73 +5213,61 @@ entities:
   - uid: 638
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,7.5
       parent: 1
   - uid: 639
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 1
   - uid: 640
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,16.5
       parent: 1
   - uid: 641
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,1.5
       parent: 1
   - uid: 642
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,5.5
       parent: 1
   - uid: 643
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-6.5
       parent: 1
   - uid: 644
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-5.5
       parent: 1
   - uid: 645
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,4.5
       parent: 1
   - uid: 646
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,1.5
       parent: 1
   - uid: 647
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,7.5
       parent: 1
   - uid: 648
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
   - uid: 649
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,2.5
       parent: 1
   - uid: 650
@@ -5300,7 +5288,6 @@ entities:
   - uid: 653
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,15.5
       parent: 1
   - uid: 654
@@ -5321,7 +5308,6 @@ entities:
   - uid: 657
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,16.5
       parent: 1
   - uid: 658
@@ -5377,43 +5363,36 @@ entities:
   - uid: 668
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,16.5
       parent: 1
   - uid: 669
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-7.5
       parent: 1
   - uid: 670
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,9.5
       parent: 1
   - uid: 671
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 1
   - uid: 672
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-8.5
       parent: 1
   - uid: 673
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,8.5
       parent: 1
   - uid: 674
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
   - uid: 675
@@ -5424,55 +5403,46 @@ entities:
   - uid: 676
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,7.5
       parent: 1
   - uid: 677
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,14.5
       parent: 1
   - uid: 678
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,10.5
       parent: 1
   - uid: 679
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,11.5
       parent: 1
   - uid: 680
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,5.5
       parent: 1
   - uid: 681
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,15.5
       parent: 1
   - uid: 682
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,16.5
       parent: 1
   - uid: 683
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,16.5
       parent: 1
   - uid: 684
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,16.5
       parent: 1
 - proto: Gyroscope

--- a/Resources/Maps/Shuttles/AdminSpawn/ERT-Medium-Eng-Jani.yml
+++ b/Resources/Maps/Shuttles/AdminSpawn/ERT-Medium-Eng-Jani.yml
@@ -2907,13 +2907,11 @@ entities:
   - uid: 95
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,6.5
       parent: 1
   - uid: 96
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,5.5
       parent: 1
   - uid: 166

--- a/Resources/Maps/Shuttles/AdminSpawn/ERT-Medium-Med.yml
+++ b/Resources/Maps/Shuttles/AdminSpawn/ERT-Medium-Med.yml
@@ -2784,13 +2784,11 @@ entities:
   - uid: 95
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,3.5
       parent: 1
   - uid: 96
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,3.5
       parent: 1
   - uid: 107
@@ -2801,13 +2799,11 @@ entities:
   - uid: 158
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 1
   - uid: 159
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
   - uid: 178

--- a/Resources/Maps/Shuttles/AdminSpawn/ERT-Medium-Sec.yml
+++ b/Resources/Maps/Shuttles/AdminSpawn/ERT-Medium-Sec.yml
@@ -2841,19 +2841,16 @@ entities:
   - uid: 224
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
   - uid: 225
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,7.5
       parent: 1
   - uid: 226
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
   - uid: 227
@@ -2964,19 +2961,16 @@ entities:
   - uid: 249
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 1
   - uid: 250
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,14.5
       parent: 1
   - uid: 251
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,8.5
       parent: 1
 - proto: GunSafe

--- a/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-Base.yml
+++ b/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-Base.yml
@@ -1088,67 +1088,56 @@ entities:
   - uid: 94
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
   - uid: 95
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
   - uid: 96
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
   - uid: 97
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
   - uid: 98
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
   - uid: 99
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 1
   - uid: 100
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
   - uid: 101
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,5.5
       parent: 1
   - uid: 102
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 1
   - uid: 103
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
   - uid: 104
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
   - uid: 217

--- a/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-CBURN.yml
+++ b/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-CBURN.yml
@@ -1205,67 +1205,56 @@ entities:
   - uid: 102
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
   - uid: 103
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
   - uid: 104
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
   - uid: 105
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
   - uid: 106
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
   - uid: 107
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 1
   - uid: 108
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
   - uid: 109
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,5.5
       parent: 1
   - uid: 110
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 1
   - uid: 111
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
   - uid: 112
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
 - proto: Gyroscope

--- a/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-Deathsquad.yml
+++ b/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-Deathsquad.yml
@@ -1234,67 +1234,56 @@ entities:
   - uid: 185
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
   - uid: 186
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
   - uid: 187
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
   - uid: 188
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
   - uid: 189
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
   - uid: 190
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 1
   - uid: 191
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
   - uid: 192
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,5.5
       parent: 1
   - uid: 193
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 1
   - uid: 194
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
   - uid: 195
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
 - proto: Gyroscope

--- a/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-Eng.yml
+++ b/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-Eng.yml
@@ -1495,67 +1495,56 @@ entities:
   - uid: 94
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
   - uid: 95
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
   - uid: 96
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
   - uid: 97
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
   - uid: 98
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
   - uid: 99
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 1
   - uid: 100
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
   - uid: 101
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,5.5
       parent: 1
   - uid: 102
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 1
   - uid: 103
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
   - uid: 104
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
   - uid: 179

--- a/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-Jani.yml
+++ b/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-Jani.yml
@@ -1377,67 +1377,56 @@ entities:
   - uid: 99
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
   - uid: 100
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
   - uid: 101
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
   - uid: 102
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
   - uid: 103
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
   - uid: 104
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 1
   - uid: 105
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
   - uid: 106
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,5.5
       parent: 1
   - uid: 107
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 1
   - uid: 108
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
   - uid: 109
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
   - uid: 243

--- a/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-Med.yml
+++ b/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-Med.yml
@@ -1255,61 +1255,51 @@ entities:
   - uid: 111
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,5.5
       parent: 1
   - uid: 113
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
   - uid: 114
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
   - uid: 115
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
   - uid: 117
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 1
   - uid: 118
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
   - uid: 119
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,5.5
       parent: 1
   - uid: 120
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 1
   - uid: 121
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
   - uid: 122
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
 - proto: Gyroscope

--- a/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-Sec.yml
+++ b/Resources/Maps/Shuttles/AdminSpawn/ERT-Small-Sec.yml
@@ -1280,85 +1280,71 @@ entities:
   - uid: 108
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,5.5
       parent: 1
   - uid: 109
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
   - uid: 110
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
   - uid: 111
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
   - uid: 112
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 1
   - uid: 113
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
   - uid: 114
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
   - uid: 115
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 1
   - uid: 116
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
   - uid: 117
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
   - uid: 118
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,5.5
       parent: 1
   - uid: 119
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 1
   - uid: 120
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
   - uid: 121
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
 - proto: Gyroscope

--- a/Resources/Maps/Shuttles/ShuttleEvent/honki.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/honki.yml
@@ -1658,103 +1658,86 @@ entities:
   - uid: 224
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,2.5
       parent: 1
   - uid: 225
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,3.5
       parent: 1
   - uid: 226
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 1
   - uid: 227
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,3.5
       parent: 1
   - uid: 228
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,2.5
       parent: 1
   - uid: 229
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,0.5
       parent: 1
   - uid: 230
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,0.5
       parent: 1
   - uid: 231
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,0.5
       parent: 1
   - uid: 232
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,0.5
       parent: 1
   - uid: 233
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,0.5
       parent: 1
   - uid: 234
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,0.5
       parent: 1
   - uid: 235
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,-4.5
       parent: 1
   - uid: 236
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,-5.5
       parent: 1
   - uid: 237
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,-6.5
       parent: 1
   - uid: 238
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-4.5
       parent: 1
   - uid: 239
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-5.5
       parent: 1
   - uid: 240
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-6.5
       parent: 1
   - uid: 241

--- a/Resources/Maps/Shuttles/ShuttleEvent/manowar.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/manowar.yml
@@ -2361,49 +2361,41 @@ entities:
   - uid: 242
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
   - uid: 243
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 1
   - uid: 244
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-1.5
       parent: 1
   - uid: 245
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
   - uid: 246
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
   - uid: 247
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
   - uid: 248
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,7.5
       parent: 1
   - uid: 249
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,7.5
       parent: 1
 - proto: Gyroscope

--- a/Resources/Maps/Shuttles/ShuttleEvent/quark.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/quark.yml
@@ -1371,67 +1371,56 @@ entities:
   - uid: 94
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
   - uid: 95
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
   - uid: 96
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
   - uid: 97
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
   - uid: 98
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
   - uid: 99
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 1
   - uid: 100
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
   - uid: 101
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,5.5
       parent: 1
   - uid: 102
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 1
   - uid: 103
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
   - uid: 104
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
   - uid: 217

--- a/Resources/Maps/Shuttles/ShuttleEvent/striker.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/striker.yml
@@ -1057,25 +1057,21 @@ entities:
   - uid: 50
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,-5.5
       parent: 325
   - uid: 51
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 325
   - uid: 52
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,-5.5
       parent: 325
   - uid: 53
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,-4.5
       parent: 325
 - proto: Gyroscope

--- a/Resources/Maps/Shuttles/arrivals_relic.yml
+++ b/Resources/Maps/Shuttles/arrivals_relic.yml
@@ -1053,13 +1053,11 @@ entities:
   - uid: 80
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,19.5
       parent: 2
   - uid: 81
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,19.5
       parent: 2
   - uid: 112

--- a/Resources/Maps/Shuttles/briggle.yml
+++ b/Resources/Maps/Shuttles/briggle.yml
@@ -762,31 +762,26 @@ entities:
   - uid: 149
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
   - uid: 151
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
   - uid: 152
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,2.5
       parent: 1
   - uid: 153
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,0.5
       parent: 1
   - uid: 154
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-0.5
       parent: 1
 - proto: Gyroscope

--- a/Resources/Maps/Shuttles/cargo_core.yml
+++ b/Resources/Maps/Shuttles/cargo_core.yml
@@ -704,37 +704,31 @@ entities:
   - uid: 65
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 2
   - uid: 66
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 2
   - uid: 67
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 2
   - uid: 68
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 2
   - uid: 69
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 2
   - uid: 70
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 2
 - proto: Gyroscope

--- a/Resources/Maps/Shuttles/cargo_elkridge.yml
+++ b/Resources/Maps/Shuttles/cargo_elkridge.yml
@@ -934,31 +934,26 @@ entities:
   - uid: 112
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,4.5
       parent: 1
   - uid: 113
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,0.5
       parent: 1
   - uid: 114
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,1.5
       parent: 1
   - uid: 115
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,4.5
       parent: 1
   - uid: 116
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-3.5
       parent: 1
 - proto: Gyroscope

--- a/Resources/Maps/Shuttles/cargo_exo.yml
+++ b/Resources/Maps/Shuttles/cargo_exo.yml
@@ -886,7 +886,6 @@ entities:
   - uid: 47
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,10.5
       parent: 173
   - uid: 59
@@ -907,13 +906,11 @@ entities:
   - uid: 142
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,10.5
       parent: 173
   - uid: 143
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,10.5
       parent: 173
   - uid: 157

--- a/Resources/Maps/Shuttles/cargo_plasma.yml
+++ b/Resources/Maps/Shuttles/cargo_plasma.yml
@@ -927,13 +927,11 @@ entities:
   - uid: 61
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,1.5
       parent: 1
   - uid: 66
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,2.5
       parent: 1
   - uid: 67

--- a/Resources/Maps/Shuttles/cargo_relic.yml
+++ b/Resources/Maps/Shuttles/cargo_relic.yml
@@ -602,7 +602,6 @@ entities:
   - uid: 10
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
   - uid: 17
@@ -643,7 +642,6 @@ entities:
   - uid: 45
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
   - uid: 51
@@ -654,7 +652,6 @@ entities:
   - uid: 88
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
 - proto: Gyroscope

--- a/Resources/Maps/Shuttles/emergency_accordia.yml
+++ b/Resources/Maps/Shuttles/emergency_accordia.yml
@@ -4644,247 +4644,206 @@ entities:
   - uid: 21
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-24.5
       parent: 1
   - uid: 163
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-5.5
       parent: 1
   - uid: 164
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-4.5
       parent: 1
   - uid: 165
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-3.5
       parent: 1
   - uid: 166
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-15.5
       parent: 1
   - uid: 167
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-16.5
       parent: 1
   - uid: 168
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-17.5
       parent: 1
   - uid: 169
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-15.5
       parent: 1
   - uid: 170
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-16.5
       parent: 1
   - uid: 171
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-17.5
       parent: 1
   - uid: 172
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-23.5
       parent: 1
   - uid: 173
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-24.5
       parent: 1
   - uid: 175
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-23.5
       parent: 1
   - uid: 176
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-24.5
       parent: 1
   - uid: 178
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,17.5
       parent: 1
   - uid: 179
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,18.5
       parent: 1
   - uid: 180
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,18.5
       parent: 1
   - uid: 181
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,18.5
       parent: 1
   - uid: 182
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,18.5
       parent: 1
   - uid: 183
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,18.5
       parent: 1
   - uid: 184
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,18.5
       parent: 1
   - uid: 185
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,18.5
       parent: 1
   - uid: 186
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,17.5
       parent: 1
   - uid: 187
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,10.5
       parent: 1
   - uid: 188
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,11.5
       parent: 1
   - uid: 189
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,12.5
       parent: 1
   - uid: 190
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,10.5
       parent: 1
   - uid: 191
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,11.5
       parent: 1
   - uid: 192
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,12.5
       parent: 1
   - uid: 193
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,15.5
       parent: 1
   - uid: 194
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,15.5
       parent: 1
   - uid: 199
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,8.5
       parent: 1
   - uid: 203
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 1
   - uid: 235
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-15.5
       parent: 1
   - uid: 236
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-15.5
       parent: 1
   - uid: 237
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-9.5
       parent: 1
   - uid: 238
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-9.5
       parent: 1
   - uid: 239
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
   - uid: 240
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 1
   - uid: 241
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,5.5
       parent: 1
   - uid: 242
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 1
   - uid: 289
@@ -4910,61 +4869,51 @@ entities:
   - uid: 324
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 1
   - uid: 325
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-1.5
       parent: 1
   - uid: 326
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-2.5
       parent: 1
   - uid: 327
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-5.5
       parent: 1
   - uid: 328
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 1
   - uid: 329
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-8.5
       parent: 1
   - uid: 330
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-9.5
       parent: 1
   - uid: 364
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,8.5
       parent: 1
   - uid: 367
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,8.5
       parent: 1
   - uid: 386
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-24.5
       parent: 1
   - uid: 404

--- a/Resources/Maps/Shuttles/emergency_cluster.yml
+++ b/Resources/Maps/Shuttles/emergency_cluster.yml
@@ -2452,25 +2452,21 @@ entities:
   - uid: 321
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,1.5
       parent: 2
   - uid: 322
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,0.5
       parent: 2
   - uid: 323
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,1.5
       parent: 2
   - uid: 324
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,1.5
       parent: 2
   - uid: 325
@@ -2481,25 +2477,21 @@ entities:
   - uid: 326
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,1.5
       parent: 2
   - uid: 327
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,1.5
       parent: 2
   - uid: 328
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,1.5
       parent: 2
   - uid: 329
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,1.5
       parent: 2
   - uid: 330
@@ -2510,31 +2502,26 @@ entities:
   - uid: 331
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,1.5
       parent: 2
   - uid: 332
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-6.5
       parent: 2
   - uid: 333
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,-6.5
       parent: 2
   - uid: 334
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-6.5
       parent: 2
   - uid: 335
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-6.5
       parent: 2
   - uid: 478

--- a/Resources/Maps/Shuttles/emergency_exo.yml
+++ b/Resources/Maps/Shuttles/emergency_exo.yml
@@ -4784,7 +4784,6 @@ entities:
   - uid: 18
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,10.5
       parent: 2
   - uid: 99
@@ -4895,25 +4894,21 @@ entities:
   - uid: 481
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,10.5
       parent: 2
   - uid: 482
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,2.5
       parent: 2
   - uid: 489
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,10.5
       parent: 2
   - uid: 544
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,10.5
       parent: 2
   - uid: 590
@@ -4954,7 +4949,6 @@ entities:
   - uid: 600
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,5.5
       parent: 2
   - uid: 604
@@ -4970,7 +4964,6 @@ entities:
   - uid: 627
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,4.5
       parent: 2
   - uid: 652
@@ -4991,13 +4984,11 @@ entities:
   - uid: 656
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,0.5
       parent: 2
   - uid: 657
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-8.5
       parent: 2
 - proto: GrilleBroken

--- a/Resources/Maps/Shuttles/emergency_raven.yml
+++ b/Resources/Maps/Shuttles/emergency_raven.yml
@@ -10961,7 +10961,6 @@ entities:
   - uid: 110
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,15.5
       parent: 1
   - uid: 114
@@ -11002,7 +11001,6 @@ entities:
   - uid: 122
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,15.5
       parent: 1
   - uid: 123

--- a/Resources/Maps/Shuttles/emergency_syndicate.yml
+++ b/Resources/Maps/Shuttles/emergency_syndicate.yml
@@ -2529,199 +2529,166 @@ entities:
   - uid: 102
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-18.5
       parent: 1
   - uid: 138
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,-18.5
       parent: 1
   - uid: 161
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-19.5
       parent: 1
   - uid: 162
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-21.5
       parent: 1
   - uid: 233
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-20.5
       parent: 1
   - uid: 468
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,-12.5
       parent: 1
   - uid: 469
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,-11.5
       parent: 1
   - uid: 470
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-14.5
       parent: 1
   - uid: 471
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-14.5
       parent: 1
   - uid: 472
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,-12.5
       parent: 1
   - uid: 473
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,-11.5
       parent: 1
   - uid: 474
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-9.5
       parent: 1
   - uid: 475
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-9.5
       parent: 1
   - uid: 476
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,-6.5
       parent: 1
   - uid: 477
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,-6.5
       parent: 1
   - uid: 478
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,-4.5
       parent: 1
   - uid: 479
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 1
   - uid: 480
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
   - uid: 481
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
   - uid: 482
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
   - uid: 483
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
   - uid: 484
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
   - uid: 485
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
   - uid: 486
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 1
   - uid: 487
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 1
   - uid: 488
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
   - uid: 489
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,0.5
       parent: 1
   - uid: 490
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-1.5
       parent: 1
   - uid: 491
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-2.5
       parent: 1
   - uid: 492
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 1
   - uid: 493
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-4.5
       parent: 1
   - uid: 494
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-6.5
       parent: 1
   - uid: 495
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 1
 - proto: HolopadCentCommEvacShuttle

--- a/Resources/Maps/Shuttles/infiltrator.yml
+++ b/Resources/Maps/Shuttles/infiltrator.yml
@@ -3356,7 +3356,6 @@ entities:
   - uid: 463
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,-7.5
       parent: 1
   - uid: 464
@@ -3457,7 +3456,6 @@ entities:
   - uid: 483
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-19.5
       parent: 1
   - uid: 484

--- a/Resources/Maps/Shuttles/mothership.yml
+++ b/Resources/Maps/Shuttles/mothership.yml
@@ -2374,7 +2374,6 @@ entities:
   - uid: 296
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,0.5
       parent: 1
   - uid: 329
@@ -2385,13 +2384,11 @@ entities:
   - uid: 357
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 1
   - uid: 358
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 1
 - proto: Gyroscope

--- a/Resources/Maps/Shuttles/pirate.yml
+++ b/Resources/Maps/Shuttles/pirate.yml
@@ -2872,7 +2872,6 @@ entities:
   - uid: 431
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,13.5
       parent: 1
   - uid: 432
@@ -2888,13 +2887,11 @@ entities:
   - uid: 434
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,3.5
       parent: 1
   - uid: 435
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,13.5
       parent: 1
   - uid: 436
@@ -2950,7 +2947,6 @@ entities:
   - uid: 446
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,13.5
       parent: 1
   - uid: 447
@@ -2961,49 +2957,41 @@ entities:
   - uid: 448
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,1.5
       parent: 1
   - uid: 449
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,14.5
       parent: 1
   - uid: 450
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,14.5
       parent: 1
   - uid: 451
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,13.5
       parent: 1
   - uid: 452
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,14.5
       parent: 1
   - uid: 453
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,6.5
       parent: 1
   - uid: 454
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,3.5
       parent: 1
   - uid: 455
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,1.5
       parent: 1
 - proto: GrilleDiagonal

--- a/Resources/Maps/Shuttles/trading_outpost.yml
+++ b/Resources/Maps/Shuttles/trading_outpost.yml
@@ -4996,7 +4996,6 @@ entities:
   - uid: 519
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-19.5
       parent: 2
   - uid: 554

--- a/Resources/Maps/Shuttles/wizard.yml
+++ b/Resources/Maps/Shuttles/wizard.yml
@@ -2880,7 +2880,6 @@ entities:
   - uid: 120
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-0.5
       parent: 768
   - uid: 121
@@ -3001,13 +3000,11 @@ entities:
   - uid: 775
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-2.5
       parent: 768
   - uid: 776
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-0.5
       parent: 768
 - proto: Gyroscope

--- a/Resources/Maps/Test/test_teg.yml
+++ b/Resources/Maps/Test/test_teg.yml
@@ -1546,91 +1546,76 @@ entities:
   - uid: 50
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 2
   - uid: 51
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,-5.5
       parent: 2
   - uid: 52
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,-5.5
       parent: 2
   - uid: 57
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,-5.5
       parent: 2
   - uid: 58
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,-5.5
       parent: 2
   - uid: 111
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,9.5
       parent: 2
   - uid: 113
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,9.5
       parent: 2
   - uid: 114
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,9.5
       parent: 2
   - uid: 115
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,9.5
       parent: 2
   - uid: 116
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,9.5
       parent: 2
   - uid: 123
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,6.5
       parent: 2
   - uid: 124
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,8.5
       parent: 2
   - uid: 126
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 2
   - uid: 127
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 2
   - uid: 130
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,5.5
       parent: 2
   - uid: 133

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -101914,25 +101914,21 @@ entities:
   - uid: 336
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,-2.5
       parent: 60
   - uid: 342
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,-3.5
       parent: 60
   - uid: 352
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,-1.5
       parent: 60
   - uid: 356
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,-0.5
       parent: 60
   - uid: 369
@@ -102018,7 +102014,6 @@ entities:
   - uid: 549
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,-21.5
       parent: 60
   - uid: 571
@@ -102064,7 +102059,6 @@ entities:
   - uid: 766
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-12.5
       parent: 60
   - uid: 784
@@ -102110,7 +102104,6 @@ entities:
   - uid: 1145
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-21.5
       parent: 60
   - uid: 1184
@@ -102166,7 +102159,6 @@ entities:
   - uid: 1293
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-13.5
       parent: 60
   - uid: 1330
@@ -102262,7 +102254,6 @@ entities:
   - uid: 1901
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-14.5
       parent: 60
   - uid: 1911
@@ -102273,13 +102264,11 @@ entities:
   - uid: 1919
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,-10.5
       parent: 60
   - uid: 1925
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,-9.5
       parent: 60
   - uid: 1984
@@ -102300,7 +102289,6 @@ entities:
   - uid: 2115
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-15.5
       parent: 60
   - uid: 2135
@@ -102491,7 +102479,6 @@ entities:
   - uid: 3072
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-19.5
       parent: 60
   - uid: 3079
@@ -102847,7 +102834,6 @@ entities:
   - uid: 4017
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-21.5
       parent: 60
   - uid: 4038
@@ -102913,7 +102899,6 @@ entities:
   - uid: 4147
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-21.5
       parent: 60
   - uid: 4295
@@ -104209,13 +104194,11 @@ entities:
   - uid: 8231
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,-12.5
       parent: 60
   - uid: 8232
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,-12.5
       parent: 60
   - uid: 8262
@@ -105151,7 +105134,6 @@ entities:
   - uid: 13478
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-16.5
       parent: 60
   - uid: 13484
@@ -105167,7 +105149,6 @@ entities:
   - uid: 13567
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-17.5
       parent: 60
   - uid: 13572
@@ -105183,7 +105164,6 @@ entities:
   - uid: 13676
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,-17.5
       parent: 60
   - uid: 13680
@@ -105474,7 +105454,6 @@ entities:
   - uid: 14863
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -22.5,47.5
       parent: 60
   - uid: 14864
@@ -105650,7 +105629,6 @@ entities:
   - uid: 15023
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,47.5
       parent: 60
   - uid: 15024
@@ -105706,7 +105684,6 @@ entities:
   - uid: 15173
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,51.5
       parent: 60
   - uid: 15181
@@ -105742,79 +105719,66 @@ entities:
   - uid: 15353
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,47.5
       parent: 60
   - uid: 15359
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,47.5
       parent: 60
   - uid: 15365
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,52.5
       parent: 60
   - uid: 15369
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,50.5
       parent: 60
   - uid: 15393
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,54.5
       parent: 60
   - uid: 15394
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,53.5
       parent: 60
   - uid: 15407
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,50.5
       parent: 60
   - uid: 15426
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,53.5
       parent: 60
   - uid: 15428
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,54.5
       parent: 60
   - uid: 15434
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,51.5
       parent: 60
   - uid: 15485
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,54.5
       parent: 60
   - uid: 15486
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,47.5
       parent: 60
   - uid: 15488
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,50.5
       parent: 60
   - uid: 15492
@@ -105930,7 +105894,6 @@ entities:
   - uid: 16002
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,47.5
       parent: 60
   - uid: 16006
@@ -106011,7 +105974,6 @@ entities:
   - uid: 16145
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,47.5
       parent: 60
   - uid: 16173
@@ -106177,7 +106139,6 @@ entities:
   - uid: 16958
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,55.5
       parent: 60
   - uid: 16972
@@ -106208,7 +106169,6 @@ entities:
   - uid: 16981
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,47.5
       parent: 60
   - uid: 17034

--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -128707,7 +128707,6 @@ entities:
   - uid: 25249
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,-92.5
       parent: 8364
   - uid: 25407
@@ -128828,7 +128827,6 @@ entities:
   - uid: 27618
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,-95.5
       parent: 8364
   - uid: 27791
@@ -129019,19 +129017,16 @@ entities:
   - uid: 28777
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,-95.5
       parent: 8364
   - uid: 28779
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,-94.5
       parent: 8364
   - uid: 28780
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,-93.5
       parent: 8364
   - uid: 28784

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -40608,13 +40608,11 @@ entities:
   - uid: 1588
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,7.5
       parent: 1668
   - uid: 1601
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,12.5
       parent: 1668
   - uid: 1612
@@ -40630,19 +40628,16 @@ entities:
   - uid: 1684
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,12.5
       parent: 1668
   - uid: 1746
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,10.5
       parent: 1668
   - uid: 1747
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,10.5
       parent: 1668
   - uid: 1879
@@ -40708,13 +40703,11 @@ entities:
   - uid: 2071
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,13.5
       parent: 1668
   - uid: 2077
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,11.5
       parent: 1668
   - uid: 2144
@@ -41000,7 +40993,6 @@ entities:
   - uid: 2700
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,9.5
       parent: 1668
   - uid: 2730
@@ -41066,25 +41058,21 @@ entities:
   - uid: 3032
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,13.5
       parent: 1668
   - uid: 3033
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,13.5
       parent: 1668
   - uid: 3039
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,17.5
       parent: 1668
   - uid: 3040
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,17.5
       parent: 1668
   - uid: 3181
@@ -41150,13 +41138,11 @@ entities:
   - uid: 3411
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,2.5
       parent: 1668
   - uid: 3412
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,2.5
       parent: 1668
   - uid: 3413
@@ -41177,13 +41163,11 @@ entities:
   - uid: 3417
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,2.5
       parent: 1668
   - uid: 3418
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,2.5
       parent: 1668
   - uid: 3419
@@ -41434,13 +41418,11 @@ entities:
   - uid: 4319
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,13.5
       parent: 1668
   - uid: 4320
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,13.5
       parent: 1668
   - uid: 4406
@@ -42066,55 +42048,46 @@ entities:
   - uid: 7258
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,7.5
       parent: 1668
   - uid: 7259
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,7.5
       parent: 1668
   - uid: 7260
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -44.5,7.5
       parent: 1668
   - uid: 7261
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -48.5,7.5
       parent: 1668
   - uid: 7262
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -49.5,7.5
       parent: 1668
   - uid: 7263
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -50.5,7.5
       parent: 1668
   - uid: 7264
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -48.5,-8.5
       parent: 1668
   - uid: 7265
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -49.5,-8.5
       parent: 1668
   - uid: 7266
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -50.5,-8.5
       parent: 1668
   - uid: 7267

--- a/Resources/Maps/elkridge.yml
+++ b/Resources/Maps/elkridge.yml
@@ -84877,7 +84877,6 @@ entities:
   - uid: 858
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 29.5,56.5
       parent: 2
   - uid: 1108
@@ -84908,13 +84907,11 @@ entities:
   - uid: 1180
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,-19.5
       parent: 2
   - uid: 1189
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 27.5,-19.5
       parent: 2
   - uid: 1197
@@ -84930,7 +84927,6 @@ entities:
   - uid: 1337
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,-19.5
       parent: 2
   - uid: 1339
@@ -84941,25 +84937,21 @@ entities:
   - uid: 1349
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,-21.5
       parent: 2
   - uid: 1350
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,-19.5
       parent: 2
   - uid: 1351
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,-20.5
       parent: 2
   - uid: 1352
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,-21.5
       parent: 2
   - uid: 1379
@@ -85150,7 +85142,6 @@ entities:
   - uid: 1704
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,-30.5
       parent: 2
   - uid: 1707
@@ -85296,13 +85287,11 @@ entities:
   - uid: 2236
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-37.5
       parent: 2
   - uid: 2238
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-36.5
       parent: 2
   - uid: 2239
@@ -85433,7 +85422,6 @@ entities:
   - uid: 2408
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-39.5
       parent: 2
   - uid: 2449
@@ -85449,13 +85437,11 @@ entities:
   - uid: 2474
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-38.5
       parent: 2
   - uid: 2494
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-40.5
       parent: 2
   - uid: 2521
@@ -85671,7 +85657,6 @@ entities:
   - uid: 3480
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,19.5
       parent: 2
   - uid: 3508
@@ -85697,7 +85682,6 @@ entities:
   - uid: 3608
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -66.5,-28.5
       parent: 2
   - uid: 3627
@@ -85708,103 +85692,86 @@ entities:
   - uid: 3630
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -65.5,-28.5
       parent: 2
   - uid: 3631
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -64.5,-28.5
       parent: 2
   - uid: 3632
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -66.5,-32.5
       parent: 2
   - uid: 3633
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -65.5,-32.5
       parent: 2
   - uid: 3634
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -64.5,-32.5
       parent: 2
   - uid: 3635
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,-28.5
       parent: 2
   - uid: 3636
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,-28.5
       parent: 2
   - uid: 3637
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,-28.5
       parent: 2
   - uid: 3638
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,-28.5
       parent: 2
   - uid: 3639
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,-28.5
       parent: 2
   - uid: 3640
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -48.5,-28.5
       parent: 2
   - uid: 3641
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -48.5,-32.5
       parent: 2
   - uid: 3642
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,-32.5
       parent: 2
   - uid: 3643
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,-32.5
       parent: 2
   - uid: 3644
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,-32.5
       parent: 2
   - uid: 3645
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,-32.5
       parent: 2
   - uid: 3646
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,-32.5
       parent: 2
   - uid: 3698
@@ -85845,7 +85812,6 @@ entities:
   - uid: 3735
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,-5.5
       parent: 2
   - uid: 3750
@@ -85861,7 +85827,6 @@ entities:
   - uid: 3823
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 53.5,-28.5
       parent: 2
   - uid: 3889
@@ -85872,43 +85837,36 @@ entities:
   - uid: 3937
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 31.5,20.5
       parent: 2
   - uid: 3938
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 32.5,20.5
       parent: 2
   - uid: 3939
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 35.5,6.5
       parent: 2
   - uid: 3940
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 36.5,6.5
       parent: 2
   - uid: 3941
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,6.5
       parent: 2
   - uid: 3974
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,43.5
       parent: 2
   - uid: 3992
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,42.5
       parent: 2
   - uid: 4155
@@ -85934,61 +85892,51 @@ entities:
   - uid: 4345
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-7.5
       parent: 2
   - uid: 4346
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -36.5,-4.5
       parent: 2
   - uid: 4356
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,-4.5
       parent: 2
   - uid: 4375
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,-13.5
       parent: 2
   - uid: 4377
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-6.5
       parent: 2
   - uid: 4385
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -32.5,-4.5
       parent: 2
   - uid: 4403
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,-4.5
       parent: 2
   - uid: 4416
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-8.5
       parent: 2
   - uid: 4436
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-4.5
       parent: 2
   - uid: 4439
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,-4.5
       parent: 2
   - uid: 4441
@@ -86014,61 +85962,51 @@ entities:
   - uid: 4509
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-8.5
       parent: 2
   - uid: 4510
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-7.5
       parent: 2
   - uid: 4511
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-6.5
       parent: 2
   - uid: 4512
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-1.5
       parent: 2
   - uid: 4513
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,-1.5
       parent: 2
   - uid: 4516
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,-1.5
       parent: 2
   - uid: 4519
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-2.5
       parent: 2
   - uid: 4521
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,-1.5
       parent: 2
   - uid: 4522
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-3.5
       parent: 2
   - uid: 4523
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-1.5
       parent: 2
   - uid: 4525
@@ -86109,7 +86047,6 @@ entities:
   - uid: 4741
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,-10.5
       parent: 2
   - uid: 4900
@@ -86180,13 +86117,11 @@ entities:
   - uid: 5548
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 30.5,-44.5
       parent: 2
   - uid: 5568
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,-19.5
       parent: 2
   - uid: 5585
@@ -86217,7 +86152,6 @@ entities:
   - uid: 5945
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 21.5,-26.5
       parent: 2
   - uid: 6004
@@ -86713,97 +86647,81 @@ entities:
   - uid: 7145
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,57.5
       parent: 2
   - uid: 7194
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,48.5
       parent: 2
   - uid: 7195
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,47.5
       parent: 2
   - uid: 7196
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,46.5
       parent: 2
   - uid: 7197
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,51.5
       parent: 2
   - uid: 7198
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,50.5
       parent: 2
   - uid: 7199
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,49.5
       parent: 2
   - uid: 7200
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,48.5
       parent: 2
   - uid: 7201
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,44.5
       parent: 2
   - uid: 7202
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,43.5
       parent: 2
   - uid: 7203
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,42.5
       parent: 2
   - uid: 7204
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,41.5
       parent: 2
   - uid: 7205
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,37.5
       parent: 2
   - uid: 7206
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,36.5
       parent: 2
   - uid: 7207
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,35.5
       parent: 2
   - uid: 7208
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,34.5
       parent: 2
   - uid: 7486
@@ -86819,25 +86737,21 @@ entities:
   - uid: 7660
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,41.5
       parent: 2
   - uid: 7661
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,41.5
       parent: 2
   - uid: 7662
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 20.5,41.5
       parent: 2
   - uid: 7665
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,43.5
       parent: 2
   - uid: 7731
@@ -86918,115 +86832,96 @@ entities:
   - uid: 7909
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 31.5,32.5
       parent: 2
   - uid: 7910
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,32.5
       parent: 2
   - uid: 7958
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,-19.5
       parent: 2
   - uid: 7959
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,-19.5
       parent: 2
   - uid: 8001
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,-3.5
       parent: 2
   - uid: 8036
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,-1.5
       parent: 2
   - uid: 8037
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,-1.5
       parent: 2
   - uid: 8041
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 60.5,0.5
       parent: 2
   - uid: 8043
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 60.5,-1.5
       parent: 2
   - uid: 8044
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 58.5,-3.5
       parent: 2
   - uid: 8045
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 57.5,-3.5
       parent: 2
   - uid: 8046
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 56.5,-3.5
       parent: 2
   - uid: 8150
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 62.5,-2.5
       parent: 2
   - uid: 8151
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 62.5,-1.5
       parent: 2
   - uid: 8152
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 62.5,-0.5
       parent: 2
   - uid: 8154
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 62.5,1.5
       parent: 2
   - uid: 8158
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 55.5,-5.5
       parent: 2
   - uid: 8159
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 56.5,-5.5
       parent: 2
   - uid: 8161
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,-5.5
       parent: 2
   - uid: 8166
@@ -87047,181 +86942,151 @@ entities:
   - uid: 8196
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,30.5
       parent: 2
   - uid: 8197
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,29.5
       parent: 2
   - uid: 8198
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,28.5
       parent: 2
   - uid: 8199
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,31.5
       parent: 2
   - uid: 8200
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,30.5
       parent: 2
   - uid: 8201
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,29.5
       parent: 2
   - uid: 8202
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,28.5
       parent: 2
   - uid: 8204
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,24.5
       parent: 2
   - uid: 8205
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,23.5
       parent: 2
   - uid: 8206
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,22.5
       parent: 2
   - uid: 8209
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,23.5
       parent: 2
   - uid: 8210
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,22.5
       parent: 2
   - uid: 8211
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,19.5
       parent: 2
   - uid: 8212
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,18.5
       parent: 2
   - uid: 8213
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,17.5
       parent: 2
   - uid: 8214
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,16.5
       parent: 2
   - uid: 8215
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,20.5
       parent: 2
   - uid: 8216
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,20.5
       parent: 2
   - uid: 8219
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,17.5
       parent: 2
   - uid: 8220
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,16.5
       parent: 2
   - uid: 8221
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,12.5
       parent: 2
   - uid: 8222
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,11.5
       parent: 2
   - uid: 8223
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 62.5,11.5
       parent: 2
   - uid: 8224
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,11.5
       parent: 2
   - uid: 8225
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,10.5
       parent: 2
   - uid: 8226
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,9.5
       parent: 2
   - uid: 8227
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 60.5,9.5
       parent: 2
   - uid: 8228
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,9.5
       parent: 2
   - uid: 8231
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,13.5
       parent: 2
   - uid: 8232
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,12.5
       parent: 2
   - uid: 8262
@@ -87242,199 +87107,166 @@ entities:
   - uid: 8294
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -69.5,-10.5
       parent: 2
   - uid: 8295
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,14.5
       parent: 2
   - uid: 8296
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,14.5
       parent: 2
   - uid: 8297
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -66.5,-10.5
       parent: 2
   - uid: 8298
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -68.5,-10.5
       parent: 2
   - uid: 8299
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,-10.5
       parent: 2
   - uid: 8300
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,-10.5
       parent: 2
   - uid: 8301
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -62.5,-10.5
       parent: 2
   - uid: 8302
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -61.5,-10.5
       parent: 2
   - uid: 8305
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -59.5,-13.5
       parent: 2
   - uid: 8306
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -60.5,-13.5
       parent: 2
   - uid: 8307
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -61.5,-13.5
       parent: 2
   - uid: 8309
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,-13.5
       parent: 2
   - uid: 8310
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -66.5,-13.5
       parent: 2
   - uid: 8312
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -68.5,-13.5
       parent: 2
   - uid: 8313
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -69.5,-13.5
       parent: 2
   - uid: 8314
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,-13.5
       parent: 2
   - uid: 8315
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,63.5
       parent: 2
   - uid: 8317
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,63.5
       parent: 2
   - uid: 8318
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,63.5
       parent: 2
   - uid: 8319
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,65.5
       parent: 2
   - uid: 8328
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,65.5
       parent: 2
   - uid: 8329
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,65.5
       parent: 2
   - uid: 8330
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,65.5
       parent: 2
   - uid: 8331
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,65.5
       parent: 2
   - uid: 8332
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,65.5
       parent: 2
   - uid: 8333
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,65.5
       parent: 2
   - uid: 8334
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,65.5
       parent: 2
   - uid: 8335
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,65.5
       parent: 2
   - uid: 8344
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,63.5
       parent: 2
   - uid: 8346
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,63.5
       parent: 2
   - uid: 8347
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,63.5
       parent: 2
   - uid: 8350
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,63.5
       parent: 2
   - uid: 8386
@@ -87495,7 +87327,6 @@ entities:
   - uid: 8687
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-48.5
       parent: 2
   - uid: 8743
@@ -87506,25 +87337,21 @@ entities:
   - uid: 8876
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,-28.5
       parent: 2
   - uid: 8946
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-37.5
       parent: 2
   - uid: 8947
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-39.5
       parent: 2
   - uid: 8948
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-35.5
       parent: 2
   - uid: 9043
@@ -87550,31 +87377,26 @@ entities:
   - uid: 9211
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 26.5,-19.5
       parent: 2
   - uid: 9212
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,-26.5
       parent: 2
   - uid: 9232
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,-19.5
       parent: 2
   - uid: 9314
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-49.5
       parent: 2
   - uid: 9315
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-45.5
       parent: 2
   - uid: 9555
@@ -87605,7 +87427,6 @@ entities:
   - uid: 10231
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-44.5
       parent: 2
   - uid: 10251
@@ -87636,7 +87457,6 @@ entities:
   - uid: 10681
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-55.5
       parent: 2
   - uid: 10774
@@ -87657,7 +87477,6 @@ entities:
   - uid: 10800
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-56.5
       parent: 2
   - uid: 11129
@@ -87683,7 +87502,6 @@ entities:
   - uid: 11244
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -18.5,14.5
       parent: 2
   - uid: 11256
@@ -87774,7 +87592,6 @@ entities:
   - uid: 12673
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-34.5
       parent: 2
   - uid: 12781
@@ -87810,7 +87627,6 @@ entities:
   - uid: 13973
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,-4.5
       parent: 2
   - uid: 13986
@@ -87836,13 +87652,11 @@ entities:
   - uid: 14222
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,-48.5
       parent: 2
   - uid: 14230
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-48.5
       parent: 2
   - uid: 14244
@@ -87978,7 +87792,6 @@ entities:
   - uid: 14534
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-35.5
       parent: 2
   - uid: 14618
@@ -88019,19 +87832,16 @@ entities:
   - uid: 15658
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,-6.5
       parent: 2
   - uid: 15659
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,-7.5
       parent: 2
   - uid: 15676
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-47.5
       parent: 2
   - uid: 15682
@@ -88072,85 +87882,71 @@ entities:
   - uid: 15732
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-52.5
       parent: 2
   - uid: 15733
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-53.5
       parent: 2
   - uid: 15740
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-57.5
       parent: 2
   - uid: 15741
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-56.5
       parent: 2
   - uid: 15742
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-53.5
       parent: 2
   - uid: 15743
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-52.5
       parent: 2
   - uid: 15744
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-51.5
       parent: 2
   - uid: 15745
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-49.5
       parent: 2
   - uid: 15746
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-48.5
       parent: 2
   - uid: 15748
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-45.5
       parent: 2
   - uid: 15749
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-44.5
       parent: 2
   - uid: 15750
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-43.5
       parent: 2
   - uid: 15757
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,56.5
       parent: 2
   - uid: 15758
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,55.5
       parent: 2
   - uid: 15835
@@ -88171,19 +87967,16 @@ entities:
   - uid: 15906
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 20.5,-26.5
       parent: 2
   - uid: 15959
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -44.5,-33.5
       parent: 2
   - uid: 15960
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -44.5,-34.5
       parent: 2
   - uid: 15975
@@ -88244,7 +88037,6 @@ entities:
   - uid: 16167
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,19.5
       parent: 2
   - uid: 16205
@@ -88310,19 +88102,16 @@ entities:
   - uid: 16621
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 31.5,-44.5
       parent: 2
   - uid: 16636
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,3.5
       parent: 2
   - uid: 16637
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,5.5
       parent: 2
   - uid: 17083
@@ -88518,25 +88307,21 @@ entities:
   - uid: 18168
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 54.5,5.5
       parent: 2
   - uid: 18169
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 55.5,5.5
       parent: 2
   - uid: 18171
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 57.5,5.5
       parent: 2
   - uid: 18172
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 58.5,5.5
       parent: 2
   - uid: 18226
@@ -88547,13 +88332,11 @@ entities:
   - uid: 18664
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,-30.5
       parent: 2
   - uid: 18677
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,-44.5
       parent: 2
 - proto: GrilleBroken

--- a/Resources/Maps/exo.yml
+++ b/Resources/Maps/exo.yml
@@ -86038,7 +86038,6 @@ entities:
   - uid: 19378
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,-102.5
       parent: 2
   - uid: 19384
@@ -86144,43 +86143,36 @@ entities:
   - uid: 19495
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 40.5,-102.5
       parent: 2
   - uid: 19497
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 41.5,-102.5
       parent: 2
   - uid: 19511
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,-95.5
       parent: 2
   - uid: 19512
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,-95.5
       parent: 2
   - uid: 19543
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 38.5,-102.5
       parent: 2
   - uid: 19549
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,-102.5
       parent: 2
   - uid: 19552
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,-95.5
       parent: 2
   - uid: 19721

--- a/Resources/Maps/exo.yml
+++ b/Resources/Maps/exo.yml
@@ -82308,7 +82308,6 @@ entities:
   - uid: 975
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,-55.5
       parent: 2
   - uid: 1078
@@ -82774,7 +82773,6 @@ entities:
   - uid: 1823
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,-12.5
       parent: 2
   - uid: 1824
@@ -82950,7 +82948,6 @@ entities:
   - uid: 2228
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 92.5,-46.5
       parent: 2
   - uid: 2231
@@ -83546,7 +83543,6 @@ entities:
   - uid: 3373
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,-66.5
       parent: 2
   - uid: 3421
@@ -83602,7 +83598,6 @@ entities:
   - uid: 3855
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 101.5,-61.5
       parent: 2
   - uid: 3922
@@ -84888,7 +84883,6 @@ entities:
   - uid: 7452
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 53.5,-66.5
       parent: 2
   - uid: 7477
@@ -84929,7 +84923,6 @@ entities:
   - uid: 7530
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 91.5,-44.5
       parent: 2
   - uid: 7541
@@ -84995,13 +84988,11 @@ entities:
   - uid: 8092
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 91.5,-46.5
       parent: 2
   - uid: 8093
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 92.5,-44.5
       parent: 2
   - uid: 8232
@@ -85047,7 +85038,6 @@ entities:
   - uid: 8793
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 101.5,-29.5
       parent: 2
   - uid: 8805
@@ -85108,7 +85098,6 @@ entities:
   - uid: 9602
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,-13.5
       parent: 2
   - uid: 9721
@@ -85274,7 +85263,6 @@ entities:
   - uid: 12872
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,-66.5
       parent: 2
   - uid: 13189
@@ -85425,7 +85413,6 @@ entities:
   - uid: 14152
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -32.5,-15.5
       parent: 2
   - uid: 14201
@@ -85476,7 +85463,6 @@ entities:
   - uid: 14827
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 50.5,-65.5
       parent: 2
   - uid: 14862
@@ -85527,7 +85513,6 @@ entities:
   - uid: 15218
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 53.5,-64.5
       parent: 2
   - uid: 15220
@@ -86079,7 +86064,6 @@ entities:
   - uid: 19395
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -32.5,-14.5
       parent: 2
   - uid: 19415

--- a/Resources/Maps/marathon.yml
+++ b/Resources/Maps/marathon.yml
@@ -102891,55 +102891,46 @@ entities:
   - uid: 23834
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -74.5,63.5
       parent: 30
   - uid: 23835
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -73.5,63.5
       parent: 30
   - uid: 23836
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -72.5,63.5
       parent: 30
   - uid: 23837
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -71.5,63.5
       parent: 30
   - uid: 23839
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -69.5,63.5
       parent: 30
   - uid: 23840
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -68.5,63.5
       parent: 30
   - uid: 23841
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -67.5,63.5
       parent: 30
   - uid: 23842
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -66.5,63.5
       parent: 30
   - uid: 23843
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,63.5
       parent: 30
   - uid: 23874

--- a/Resources/Maps/packed.yml
+++ b/Resources/Maps/packed.yml
@@ -67560,7 +67560,6 @@ entities:
   - uid: 3332
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,51.5
       parent: 2
   - uid: 3364
@@ -68016,7 +68015,6 @@ entities:
   - uid: 4699
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,29.5
       parent: 2
   - uid: 4957
@@ -68052,7 +68050,6 @@ entities:
   - uid: 5413
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 47.5,37.5
       parent: 2
   - uid: 5428
@@ -68073,7 +68070,6 @@ entities:
   - uid: 5491
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,32.5
       parent: 2
   - uid: 5506
@@ -68714,13 +68710,11 @@ entities:
   - uid: 8531
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,28.5
       parent: 2
   - uid: 8532
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,28.5
       parent: 2
   - uid: 8545
@@ -68751,7 +68745,6 @@ entities:
   - uid: 8598
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 73.5,31.5
       parent: 2
   - uid: 8626
@@ -69212,7 +69205,6 @@ entities:
   - uid: 9261
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 62.5,26.5
       parent: 2
   - uid: 9293
@@ -69223,13 +69215,11 @@ entities:
   - uid: 9331
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,51.5
       parent: 2
   - uid: 9335
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 60.5,53.5
       parent: 2
   - uid: 9349
@@ -69270,7 +69260,6 @@ entities:
   - uid: 10867
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 52.5,23.5
       parent: 2
   - uid: 10951
@@ -69891,7 +69880,6 @@ entities:
   - uid: 11679
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,51.5
       parent: 2
   - uid: 11686
@@ -69917,13 +69905,11 @@ entities:
   - uid: 11695
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 30.5,51.5
       parent: 2
   - uid: 11697
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 28.5,51.5
       parent: 2
   - uid: 11757
@@ -69984,7 +69970,6 @@ entities:
   - uid: 11895
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,51.5
       parent: 2
   - uid: 11902
@@ -70005,7 +69990,6 @@ entities:
   - uid: 11998
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 41.5,48.5
       parent: 2
   - uid: 12155
@@ -70016,7 +70000,6 @@ entities:
   - uid: 12183
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 31.5,51.5
       parent: 2
   - uid: 12220
@@ -70037,7 +70020,6 @@ entities:
   - uid: 12299
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 25.5,51.5
       parent: 2
   - uid: 12370
@@ -70463,19 +70445,16 @@ entities:
   - uid: 13522
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,32.5
       parent: 2
   - uid: 13586
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 23.5,51.5
       parent: 2
   - uid: 13590
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 89.5,36.5
       parent: 2
   - uid: 13637
@@ -70886,7 +70865,6 @@ entities:
   - uid: 14376
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,34.5
       parent: 2
   - uid: 14409
@@ -70967,7 +70945,6 @@ entities:
   - uid: 14646
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,51.5
       parent: 2
   - uid: 14762
@@ -71113,7 +71090,6 @@ entities:
   - uid: 15199
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,51.5
       parent: 2
   - uid: 15206
@@ -71259,19 +71235,16 @@ entities:
   - uid: 15651
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 61.5,53.5
       parent: 2
   - uid: 15652
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 62.5,53.5
       parent: 2
   - uid: 15654
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 64.5,53.5
       parent: 2
   - uid: 15655

--- a/Resources/Maps/reach.yml
+++ b/Resources/Maps/reach.yml
@@ -11635,7 +11635,6 @@ entities:
   - uid: 605
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,15.5
       parent: 2
   - uid: 613
@@ -11691,7 +11690,6 @@ entities:
   - uid: 1288
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,16.5
       parent: 2
   - uid: 1522
@@ -12142,7 +12140,6 @@ entities:
   - uid: 2130
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,17.5
       parent: 2
   - uid: 2405
@@ -12153,25 +12150,21 @@ entities:
   - uid: 2410
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-16.5
       parent: 2
   - uid: 2452
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-16.5
       parent: 2
   - uid: 2503
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-13.5
       parent: 2
   - uid: 2506
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,17.5
       parent: 2
   - uid: 2519
@@ -12222,25 +12215,21 @@ entities:
   - uid: 2651
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-17.5
       parent: 2
   - uid: 2652
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-18.5
       parent: 2
   - uid: 2653
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-17.5
       parent: 2
   - uid: 2654
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-18.5
       parent: 2
   - uid: 2660
@@ -12541,7 +12530,6 @@ entities:
   - uid: 2721
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-8.5
       parent: 2
   - uid: 2722
@@ -12687,25 +12675,21 @@ entities:
   - uid: 2750
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-8.5
       parent: 2
   - uid: 2751
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,-8.5
       parent: 2
   - uid: 2752
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,-8.5
       parent: 2
   - uid: 2753
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-8.5
       parent: 2
   - uid: 2755

--- a/Resources/Maps/relic.yml
+++ b/Resources/Maps/relic.yml
@@ -45145,7 +45145,6 @@ entities:
   - uid: 2185
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,46.5
       parent: 2
   - uid: 2191
@@ -45416,37 +45415,31 @@ entities:
   - uid: 3573
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-39.5
       parent: 3564
   - uid: 3574
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-40.5
       parent: 3564
   - uid: 3575
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-42.5
       parent: 3564
   - uid: 3576
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-43.5
       parent: 3564
   - uid: 3588
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-44.5
       parent: 3564
   - uid: 3700
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-45.5
       parent: 3564
   - uid: 3753
@@ -45462,13 +45455,11 @@ entities:
   - uid: 3923
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,34.5
       parent: 2
   - uid: 3924
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 46.5,34.5
       parent: 2
   - uid: 4024
@@ -45544,7 +45535,6 @@ entities:
   - uid: 6344
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,32.5
       parent: 2
   - uid: 6673
@@ -45650,7 +45640,6 @@ entities:
   - uid: 7573
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 47.5,26.5
       parent: 2
   - uid: 7748
@@ -47401,157 +47390,131 @@ entities:
   - uid: 8188
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,47.5
       parent: 2
   - uid: 8189
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,48.5
       parent: 2
   - uid: 8190
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,49.5
       parent: 2
   - uid: 8191
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,49.5
       parent: 2
   - uid: 8192
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,49.5
       parent: 2
   - uid: 8193
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,49.5
       parent: 2
   - uid: 8194
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,49.5
       parent: 2
   - uid: 8195
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,49.5
       parent: 2
   - uid: 8196
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,45.5
       parent: 2
   - uid: 8197
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,44.5
       parent: 2
   - uid: 8198
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,43.5
       parent: 2
   - uid: 8199
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,42.5
       parent: 2
   - uid: 8200
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,41.5
       parent: 2
   - uid: 8201
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,40.5
       parent: 2
   - uid: 8202
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,45.5
       parent: 2
   - uid: 8203
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,45.5
       parent: 2
   - uid: 8204
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,45.5
       parent: 2
   - uid: 8205
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,45.5
       parent: 2
   - uid: 8206
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,44.5
       parent: 2
   - uid: 8207
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,43.5
       parent: 2
   - uid: 8208
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,42.5
       parent: 2
   - uid: 8209
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,41.5
       parent: 2
   - uid: 8210
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,40.5
       parent: 2
   - uid: 8211
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,39.5
       parent: 2
   - uid: 8212
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,38.5
       parent: 2
   - uid: 8213
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,37.5
       parent: 2
   - uid: 8301
@@ -47562,19 +47525,16 @@ entities:
   - uid: 8310
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,26.5
       parent: 2
   - uid: 8311
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,26.5
       parent: 2
   - uid: 8315
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,26.5
       parent: 2
   - uid: 8495

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -44733,7 +44733,6 @@ entities:
   - uid: 77
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,-14.5
       parent: 31
   - uid: 78
@@ -44794,7 +44793,6 @@ entities:
   - uid: 526
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,-0.5
       parent: 31
   - uid: 571
@@ -44845,7 +44843,6 @@ entities:
   - uid: 757
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 42.5,-14.5
       parent: 31
   - uid: 772
@@ -44921,7 +44918,6 @@ entities:
   - uid: 1133
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,18.5
       parent: 31
   - uid: 1180
@@ -44987,7 +44983,6 @@ entities:
   - uid: 1436
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,-8.5
       parent: 31
   - uid: 1443
@@ -45093,7 +45088,6 @@ entities:
   - uid: 1604
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,-8.5
       parent: 31
   - uid: 1629
@@ -45354,7 +45348,6 @@ entities:
   - uid: 2277
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-24.5
       parent: 31
   - uid: 2307
@@ -45410,7 +45403,6 @@ entities:
   - uid: 3842
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,13.5
       parent: 31
   - uid: 4032
@@ -45461,7 +45453,6 @@ entities:
   - uid: 4386
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,-26.5
       parent: 31
   - uid: 4393
@@ -45477,13 +45468,11 @@ entities:
   - uid: 4399
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,1.5
       parent: 31
   - uid: 4403
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,3.5
       parent: 31
   - uid: 4445
@@ -45494,7 +45483,6 @@ entities:
   - uid: 4460
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,-24.5
       parent: 31
   - uid: 4487
@@ -45515,7 +45503,6 @@ entities:
   - uid: 4532
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,-22.5
       parent: 31
   - uid: 4595
@@ -45551,7 +45538,6 @@ entities:
   - uid: 4612
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,-26.5
       parent: 31
   - uid: 4614
@@ -45607,7 +45593,6 @@ entities:
   - uid: 4702
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,18.5
       parent: 31
   - uid: 4844
@@ -45823,7 +45808,6 @@ entities:
   - uid: 6415
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,17.5
       parent: 31
   - uid: 6440
@@ -45839,7 +45823,6 @@ entities:
   - uid: 6453
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,15.5
       parent: 31
   - uid: 6455
@@ -45850,7 +45833,6 @@ entities:
   - uid: 6456
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,16.5
       parent: 31
   - uid: 6458
@@ -45871,13 +45853,11 @@ entities:
   - uid: 6481
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,24.5
       parent: 31
   - uid: 6503
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 55.5,24.5
       parent: 31
   - uid: 6504
@@ -45888,7 +45868,6 @@ entities:
   - uid: 6505
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 49.5,24.5
       parent: 31
   - uid: 6508
@@ -45934,7 +45913,6 @@ entities:
   - uid: 6645
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 58.5,23.5
       parent: 31
   - uid: 6690
@@ -45950,37 +45928,31 @@ entities:
   - uid: 6725
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 58.5,22.5
       parent: 31
   - uid: 6726
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 53.5,24.5
       parent: 31
   - uid: 6728
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 58.5,24.5
       parent: 31
   - uid: 6729
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 56.5,24.5
       parent: 31
   - uid: 6730
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 57.5,24.5
       parent: 31
   - uid: 6731
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,24.5
       parent: 31
   - uid: 6742
@@ -45991,7 +45963,6 @@ entities:
   - uid: 6812
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,-42.5
       parent: 31
   - uid: 6815
@@ -46012,7 +45983,6 @@ entities:
   - uid: 6847
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,24.5
       parent: 31
   - uid: 6863
@@ -46028,7 +45998,6 @@ entities:
   - uid: 6874
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,24.5
       parent: 31
   - uid: 6933
@@ -46179,13 +46148,11 @@ entities:
   - uid: 7038
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,-22.5
       parent: 31
   - uid: 7039
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,-22.5
       parent: 31
   - uid: 7044
@@ -46226,7 +46193,6 @@ entities:
   - uid: 7358
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,15.5
       parent: 31
   - uid: 7375
@@ -46247,25 +46213,21 @@ entities:
   - uid: 7447
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-32.5
       parent: 31
   - uid: 7448
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-32.5
       parent: 31
   - uid: 7449
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-32.5
       parent: 31
   - uid: 7450
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,-32.5
       parent: 31
   - uid: 7471
@@ -46491,31 +46453,26 @@ entities:
   - uid: 8108
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,0.5
       parent: 31
   - uid: 8109
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,1.5
       parent: 31
   - uid: 8110
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,2.5
       parent: 31
   - uid: 8111
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,3.5
       parent: 31
   - uid: 8112
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,4.5
       parent: 31
   - uid: 8145
@@ -46526,13 +46483,11 @@ entities:
   - uid: 8216
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,-26.5
       parent: 31
   - uid: 8217
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-24.5
       parent: 31
   - uid: 8222
@@ -46553,7 +46508,6 @@ entities:
   - uid: 8305
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 58.5,-29.5
       parent: 31
   - uid: 8306
@@ -46564,19 +46518,16 @@ entities:
   - uid: 8309
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 58.5,-32.5
       parent: 31
   - uid: 8310
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 58.5,-33.5
       parent: 31
   - uid: 8313
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,14.5
       parent: 31
   - uid: 8329
@@ -46792,7 +46743,6 @@ entities:
   - uid: 8601
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-32.5
       parent: 31
   - uid: 8819
@@ -46808,19 +46758,16 @@ entities:
   - uid: 8946
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,2.5
       parent: 31
   - uid: 8947
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,2.5
       parent: 31
   - uid: 8948
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,2.5
       parent: 31
   - uid: 9012
@@ -46886,7 +46833,6 @@ entities:
   - uid: 9219
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,12.5
       parent: 31
   - uid: 9231
@@ -46937,19 +46883,16 @@ entities:
   - uid: 9291
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-30.5
       parent: 31
   - uid: 9331
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,2.5
       parent: 31
   - uid: 9332
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,2.5
       parent: 31
   - uid: 9362
@@ -47010,31 +46953,26 @@ entities:
   - uid: 9515
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 49.5,-12.5
       parent: 31
   - uid: 9525
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-41.5
       parent: 31
   - uid: 9535
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 50.5,-12.5
       parent: 31
   - uid: 9536
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,-12.5
       parent: 31
   - uid: 9598
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-14.5
       parent: 31
   - uid: 9658
@@ -47065,19 +47003,16 @@ entities:
   - uid: 9692
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-40.5
       parent: 31
   - uid: 9693
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-42.5
       parent: 31
   - uid: 9700
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 58.5,-30.5
       parent: 31
   - uid: 9723
@@ -47093,19 +47028,16 @@ entities:
   - uid: 9805
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-34.5
       parent: 31
   - uid: 9806
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-35.5
       parent: 31
   - uid: 9807
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-36.5
       parent: 31
   - uid: 9808
@@ -47191,7 +47123,6 @@ entities:
   - uid: 9889
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,13.5
       parent: 31
   - uid: 9896
@@ -47202,61 +47133,51 @@ entities:
   - uid: 9949
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,-14.5
       parent: 31
   - uid: 10061
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,27.5
       parent: 31
   - uid: 10064
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,26.5
       parent: 31
   - uid: 10065
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,26.5
       parent: 31
   - uid: 10066
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,27.5
       parent: 31
   - uid: 10067
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,23.5
       parent: 31
   - uid: 10068
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,24.5
       parent: 31
   - uid: 10069
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,24.5
       parent: 31
   - uid: 10070
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,23.5
       parent: 31
   - uid: 10080
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,28.5
       parent: 31
   - uid: 10126
@@ -47287,7 +47208,6 @@ entities:
   - uid: 10372
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,14.5
       parent: 31
   - uid: 10438
@@ -47363,19 +47283,16 @@ entities:
   - uid: 11408
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -43.5,-4.5
       parent: 31
   - uid: 11409
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-2.5
       parent: 31
   - uid: 11410
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-6.5
       parent: 31
 - proto: GrilleBroken

--- a/Resources/Maps/serpentcrest.yml
+++ b/Resources/Maps/serpentcrest.yml
@@ -116839,7 +116839,6 @@ entities:
   - uid: 22
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,2.5
       parent: 2
   - uid: 57
@@ -116925,7 +116924,6 @@ entities:
   - uid: 311
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-37.5
       parent: 2
   - uid: 313
@@ -116966,7 +116964,6 @@ entities:
   - uid: 322
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-37.5
       parent: 2
   - uid: 324
@@ -117032,7 +117029,6 @@ entities:
   - uid: 350
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,-37.5
       parent: 2
   - uid: 359
@@ -117043,49 +117039,41 @@ entities:
   - uid: 407
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-79.5
       parent: 2
   - uid: 444
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-75.5
       parent: 2
   - uid: 445
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-75.5
       parent: 2
   - uid: 465
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -46.5,44.5
       parent: 2
   - uid: 466
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -45.5,44.5
       parent: 2
   - uid: 467
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -54.5,44.5
       parent: 2
   - uid: 469
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -49.5,43.5
       parent: 2
   - uid: 475
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-35.5
       parent: 2
   - uid: 476
@@ -117096,19 +117084,16 @@ entities:
   - uid: 483
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,-43.5
       parent: 2
   - uid: 488
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,-6.5
       parent: 2
   - uid: 526
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,-34.5
       parent: 2
   - uid: 621
@@ -117124,37 +117109,31 @@ entities:
   - uid: 637
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,-64.5
       parent: 2
   - uid: 688
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -83.5,-21.5
       parent: 2
   - uid: 702
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,6.5
       parent: 2
   - uid: 708
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,7.5
       parent: 2
   - uid: 709
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,8.5
       parent: 2
   - uid: 810
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-53.5
       parent: 2
   - uid: 858
@@ -117205,7 +117184,6 @@ entities:
   - uid: 1084
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,55.5
       parent: 2
   - uid: 1118
@@ -117241,25 +117219,21 @@ entities:
   - uid: 1508
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,-1.5
       parent: 2
   - uid: 1531
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,-0.5
       parent: 2
   - uid: 1532
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,0.5
       parent: 2
   - uid: 1542
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,7.5
       parent: 2
   - uid: 1575
@@ -117275,31 +117249,26 @@ entities:
   - uid: 1628
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-56.5
       parent: 2
   - uid: 1632
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-57.5
       parent: 2
   - uid: 1644
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-55.5
       parent: 2
   - uid: 1661
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,11.5
       parent: 2
   - uid: 1665
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,-46.5
       parent: 2
   - uid: 1698
@@ -117335,43 +117304,36 @@ entities:
   - uid: 1733
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -52.5,44.5
       parent: 2
   - uid: 1734
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -52.5,43.5
       parent: 2
   - uid: 1735
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -51.5,43.5
       parent: 2
   - uid: 1736
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -50.5,43.5
       parent: 2
   - uid: 1739
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -48.5,44.5
       parent: 2
   - uid: 1760
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -53.5,44.5
       parent: 2
   - uid: 1761
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -47.5,44.5
       parent: 2
   - uid: 1770
@@ -117432,7 +117394,6 @@ entities:
   - uid: 1840
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -48.5,43.5
       parent: 2
   - uid: 1852
@@ -117448,7 +117409,6 @@ entities:
   - uid: 2006
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,36.5
       parent: 2
   - uid: 2010
@@ -117469,7 +117429,6 @@ entities:
   - uid: 2285
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-59.5
       parent: 2
   - uid: 2292
@@ -117495,7 +117454,6 @@ entities:
   - uid: 2370
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,-53.5
       parent: 2
   - uid: 2373
@@ -117506,7 +117464,6 @@ entities:
   - uid: 2434
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,52.5
       parent: 2
   - uid: 2536
@@ -117517,7 +117474,6 @@ entities:
   - uid: 2538
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,46.5
       parent: 2
   - uid: 2540
@@ -117533,7 +117489,6 @@ entities:
   - uid: 2628
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,-2.5
       parent: 2
   - uid: 2638
@@ -117549,7 +117504,6 @@ entities:
   - uid: 2757
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -59.5,-39.5
       parent: 2
   - uid: 2778
@@ -117570,19 +117524,16 @@ entities:
   - uid: 2919
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,52.5
       parent: 2
   - uid: 2921
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,51.5
       parent: 2
   - uid: 2922
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,50.5
       parent: 2
   - uid: 2938
@@ -117638,19 +117589,16 @@ entities:
   - uid: 3124
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,10.5
       parent: 2
   - uid: 3125
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-12.5
       parent: 2
   - uid: 3126
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,37.5
       parent: 2
   - uid: 3133
@@ -117661,7 +117609,6 @@ entities:
   - uid: 3139
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,9.5
       parent: 2
   - uid: 3160
@@ -117707,7 +117654,6 @@ entities:
   - uid: 3241
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-11.5
       parent: 2
   - uid: 3242
@@ -117718,13 +117664,11 @@ entities:
   - uid: 3307
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,-16.5
       parent: 2
   - uid: 3339
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,40.5
       parent: 2
   - uid: 3513
@@ -117740,7 +117684,6 @@ entities:
   - uid: 3570
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,38.5
       parent: 2
   - uid: 3615
@@ -117751,37 +117694,31 @@ entities:
   - uid: 3676
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 60.5,-24.5
       parent: 2
   - uid: 3688
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 63.5,-29.5
       parent: 2
   - uid: 3795
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,-26.5
       parent: 2
   - uid: 3797
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 63.5,-28.5
       parent: 2
   - uid: 3798
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 63.5,-27.5
       parent: 2
   - uid: 3852
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,44.5
       parent: 2
   - uid: 3861
@@ -117792,13 +117729,11 @@ entities:
   - uid: 3863
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,10.5
       parent: 2
   - uid: 3870
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 41.5,38.5
       parent: 2
   - uid: 3914
@@ -117849,13 +117784,11 @@ entities:
   - uid: 4006
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 56.5,-12.5
       parent: 2
   - uid: 4009
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 56.5,-11.5
       parent: 2
   - uid: 4029
@@ -117881,25 +117814,21 @@ entities:
   - uid: 4083
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 49.5,49.5
       parent: 2
   - uid: 4124
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -35.5,-27.5
       parent: 2
   - uid: 4143
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -55.5,15.5
       parent: 2
   - uid: 4275
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -39.5,10.5
       parent: 2
   - uid: 4461
@@ -117915,7 +117844,6 @@ entities:
   - uid: 4800
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,55.5
       parent: 2
   - uid: 4852
@@ -117946,13 +117874,11 @@ entities:
   - uid: 5004
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,53.5
       parent: 2
   - uid: 5014
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,-1.5
       parent: 2
   - uid: 5021
@@ -117968,19 +117894,16 @@ entities:
   - uid: 5023
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,-1.5
       parent: 2
   - uid: 5029
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-1.5
       parent: 2
   - uid: 5179
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,53.5
       parent: 2
   - uid: 5296
@@ -117991,61 +117914,51 @@ entities:
   - uid: 5364
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-49.5
       parent: 2
   - uid: 5505
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 23.5,51.5
       parent: 2
   - uid: 5507
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 25.5,51.5
       parent: 2
   - uid: 5750
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 58.5,-14.5
       parent: 2
   - uid: 5751
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-40.5
       parent: 2
   - uid: 5753
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-46.5
       parent: 2
   - uid: 5756
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-49.5
       parent: 2
   - uid: 5757
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-49.5
       parent: 2
   - uid: 5758
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-49.5
       parent: 2
   - uid: 5760
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -43.5,-1.5
       parent: 2
   - uid: 5781
@@ -118071,7 +117984,6 @@ entities:
   - uid: 5941
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,31.5
       parent: 2
   - uid: 6105
@@ -118092,13 +118004,11 @@ entities:
   - uid: 6135
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -49.5,-12.5
       parent: 2
   - uid: 6216
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 26.5,51.5
       parent: 2
   - uid: 6219
@@ -118124,19 +118034,16 @@ entities:
   - uid: 6527
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 55.5,27.5
       parent: 2
   - uid: 6528
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 56.5,27.5
       parent: 2
   - uid: 6529
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 57.5,27.5
       parent: 2
   - uid: 6559
@@ -118147,13 +118054,11 @@ entities:
   - uid: 6719
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-44.5
       parent: 2
   - uid: 6731
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-49.5
       parent: 2
   - uid: 6760
@@ -118169,19 +118074,16 @@ entities:
   - uid: 6844
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,-43.5
       parent: 2
   - uid: 6846
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,-43.5
       parent: 2
   - uid: 6848
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,51.5
       parent: 2
   - uid: 6851
@@ -118192,19 +118094,16 @@ entities:
   - uid: 6852
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-43.5
       parent: 2
   - uid: 6868
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,-16.5
       parent: 2
   - uid: 6886
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,51.5
       parent: 2
   - uid: 6908
@@ -118270,31 +118169,26 @@ entities:
   - uid: 7755
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -31.5,-45.5
       parent: 2
   - uid: 7759
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,-49.5
       parent: 2
   - uid: 7823
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -56.5,-6.5
       parent: 2
   - uid: 7829
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -60.5,-6.5
       parent: 2
   - uid: 7891
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,-49.5
       parent: 2
   - uid: 7916
@@ -118305,31 +118199,26 @@ entities:
   - uid: 7948
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -39.5,9.5
       parent: 2
   - uid: 7956
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,-24.5
       parent: 2
   - uid: 7961
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,-2.5
       parent: 2
   - uid: 8027
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -31.5,-46.5
       parent: 2
   - uid: 8052
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -33.5,-9.5
       parent: 2
   - uid: 8113
@@ -118345,13 +118234,11 @@ entities:
   - uid: 8160
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,36.5
       parent: 2
   - uid: 8174
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -34.5,-9.5
       parent: 2
   - uid: 8282
@@ -118362,13 +118249,11 @@ entities:
   - uid: 8391
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-75.5
       parent: 2
   - uid: 8421
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 44.5,38.5
       parent: 2
   - uid: 8425
@@ -118384,25 +118269,21 @@ entities:
   - uid: 8442
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -31.5,-47.5
       parent: 2
   - uid: 8444
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,-22.5
       parent: 2
   - uid: 8448
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,-30.5
       parent: 2
   - uid: 8451
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,-31.5
       parent: 2
   - uid: 9008
@@ -118413,13 +118294,11 @@ entities:
   - uid: 9118
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 46.5,49.5
       parent: 2
   - uid: 9286
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,32.5
       parent: 2
   - uid: 9299
@@ -118435,67 +118314,56 @@ entities:
   - uid: 9307
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -83.5,-23.5
       parent: 2
   - uid: 9309
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -83.5,-7.5
       parent: 2
   - uid: 9310
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -83.5,-9.5
       parent: 2
   - uid: 9316
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -86.5,-7.5
       parent: 2
   - uid: 9317
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -86.5,-21.5
       parent: 2
   - uid: 9318
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -86.5,-23.5
       parent: 2
   - uid: 9319
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -86.5,-9.5
       parent: 2
   - uid: 9359
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 73.5,7.5
       parent: 2
   - uid: 9363
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 73.5,4.5
       parent: 2
   - uid: 9367
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 50.5,49.5
       parent: 2
   - uid: 9373
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,49.5
       parent: 2
   - uid: 9434
@@ -118506,211 +118374,176 @@ entities:
   - uid: 9541
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 49.5,50.5
       parent: 2
   - uid: 9542
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 49.5,51.5
       parent: 2
   - uid: 9543
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 49.5,52.5
       parent: 2
   - uid: 9544
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,52.5
       parent: 2
   - uid: 9545
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,51.5
       parent: 2
   - uid: 9546
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 47.5,50.5
       parent: 2
   - uid: 9547
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 73.5,5.5
       parent: 2
   - uid: 9551
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 74.5,5.5
       parent: 2
   - uid: 9552
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 75.5,5.5
       parent: 2
   - uid: 9553
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 76.5,5.5
       parent: 2
   - uid: 9554
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 74.5,7.5
       parent: 2
   - uid: 9555
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 75.5,7.5
       parent: 2
   - uid: 9556
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 76.5,7.5
       parent: 2
   - uid: 9577
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -62.5,-30.5
       parent: 2
   - uid: 9578
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,-30.5
       parent: 2
   - uid: 9579
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,-30.5
       parent: 2
   - uid: 9580
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,-30.5
       parent: 2
   - uid: 9581
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,-32.5
       parent: 2
   - uid: 9582
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,-32.5
       parent: 2
   - uid: 9583
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -62.5,-32.5
       parent: 2
   - uid: 9584
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,-32.5
       parent: 2
   - uid: 9606
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,-56.5
       parent: 2
   - uid: 9609
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -34.5,-27.5
       parent: 2
   - uid: 9610
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,-38.5
       parent: 2
   - uid: 9611
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,-37.5
       parent: 2
   - uid: 9622
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -41.5,-1.5
       parent: 2
   - uid: 9623
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,34.5
       parent: 2
   - uid: 9624
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,28.5
       parent: 2
   - uid: 9626
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -73.5,-2.5
       parent: 2
   - uid: 9627
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -74.5,-2.5
       parent: 2
   - uid: 9628
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -69.5,-0.5
       parent: 2
   - uid: 9688
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,-49.5
       parent: 2
   - uid: 9701
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,-12.5
       parent: 2
   - uid: 9741
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -69.5,0.5
       parent: 2
   - uid: 9752
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,-34.5
       parent: 2
   - uid: 9822
@@ -118731,49 +118564,41 @@ entities:
   - uid: 9843
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -69.5,1.5
       parent: 2
   - uid: 9852
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,-34.5
       parent: 2
   - uid: 9856
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 69.5,-6.5
       parent: 2
   - uid: 9866
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 69.5,-5.5
       parent: 2
   - uid: 9867
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 69.5,-4.5
       parent: 2
   - uid: 9893
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -22.5,-24.5
       parent: 2
   - uid: 9894
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -35.5,-13.5
       parent: 2
   - uid: 9900
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-35.5
       parent: 2
   - uid: 9929
@@ -118784,37 +118609,31 @@ entities:
   - uid: 9932
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-35.5
       parent: 2
   - uid: 9935
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-34.5
       parent: 2
   - uid: 9941
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,-34.5
       parent: 2
   - uid: 9948
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,-34.5
       parent: 2
   - uid: 9959
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,33.5
       parent: 2
   - uid: 9961
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,-7.5
       parent: 2
   - uid: 10092
@@ -118835,7 +118654,6 @@ entities:
   - uid: 10111
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 53.5,45.5
       parent: 2
   - uid: 10161
@@ -118846,19 +118664,16 @@ entities:
   - uid: 10172
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,45.5
       parent: 2
   - uid: 10173
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,45.5
       parent: 2
   - uid: 10176
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-68.5
       parent: 2
   - uid: 10197
@@ -119014,217 +118829,181 @@ entities:
   - uid: 10575
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,-75.5
       parent: 2
   - uid: 10576
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-77.5
       parent: 2
   - uid: 10577
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-77.5
       parent: 2
   - uid: 10578
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,-77.5
       parent: 2
   - uid: 10579
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-79.5
       parent: 2
   - uid: 10580
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-79.5
       parent: 2
   - uid: 10581
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,-79.5
       parent: 2
   - uid: 10582
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-83.5
       parent: 2
   - uid: 10583
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,-83.5
       parent: 2
   - uid: 10584
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-83.5
       parent: 2
   - uid: 10585
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-85.5
       parent: 2
   - uid: 10586
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,-85.5
       parent: 2
   - uid: 10587
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-85.5
       parent: 2
   - uid: 10588
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-87.5
       parent: 2
   - uid: 10589
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-87.5
       parent: 2
   - uid: 10590
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,-87.5
       parent: 2
   - uid: 10591
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-87.5
       parent: 2
   - uid: 10592
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-87.5
       parent: 2
   - uid: 10593
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-87.5
       parent: 2
   - uid: 10594
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-85.5
       parent: 2
   - uid: 10595
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-85.5
       parent: 2
   - uid: 10596
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-85.5
       parent: 2
   - uid: 10597
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-83.5
       parent: 2
   - uid: 10598
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-83.5
       parent: 2
   - uid: 10599
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-83.5
       parent: 2
   - uid: 10600
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-79.5
       parent: 2
   - uid: 10601
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-79.5
       parent: 2
   - uid: 10602
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-79.5
       parent: 2
   - uid: 10603
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-75.5
       parent: 2
   - uid: 10604
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-75.5
       parent: 2
   - uid: 10605
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-75.5
       parent: 2
   - uid: 10607
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-77.5
       parent: 2
   - uid: 10608
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-77.5
       parent: 2
   - uid: 10609
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-77.5
       parent: 2
   - uid: 10639
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-69.5
       parent: 2
   - uid: 10641
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-71.5
       parent: 2
   - uid: 10644
@@ -119235,109 +119014,91 @@ entities:
   - uid: 10648
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-74.5
       parent: 2
   - uid: 10649
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-70.5
       parent: 2
   - uid: 10650
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-71.5
       parent: 2
   - uid: 10651
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-67.5
       parent: 2
   - uid: 10652
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-67.5
       parent: 2
   - uid: 10653
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,-67.5
       parent: 2
   - uid: 10654
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,-67.5
       parent: 2
   - uid: 10655
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,-67.5
       parent: 2
   - uid: 10656
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-67.5
       parent: 2
   - uid: 10657
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-67.5
       parent: 2
   - uid: 10658
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,-67.5
       parent: 2
   - uid: 10659
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-67.5
       parent: 2
   - uid: 10660
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,-67.5
       parent: 2
   - uid: 10661
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-71.5
       parent: 2
   - uid: 10662
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-70.5
       parent: 2
   - uid: 10663
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-74.5
       parent: 2
   - uid: 10664
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-80.5
       parent: 2
   - uid: 10665
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-82.5
       parent: 2
   - uid: 10668
@@ -119368,97 +119129,81 @@ entities:
   - uid: 10680
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-87.5
       parent: 2
   - uid: 10682
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-83.5
       parent: 2
   - uid: 10683
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-79.5
       parent: 2
   - uid: 10685
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-79.5
       parent: 2
   - uid: 10686
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-75.5
       parent: 2
   - uid: 10687
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-77.5
       parent: 2
   - uid: 10688
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-77.5
       parent: 2
   - uid: 10689
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-83.5
       parent: 2
   - uid: 10690
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-80.5
       parent: 2
   - uid: 10692
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-82.5
       parent: 2
   - uid: 10694
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-85.5
       parent: 2
   - uid: 10695
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-85.5
       parent: 2
   - uid: 10698
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-75.5
       parent: 2
   - uid: 10699
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-82.5
       parent: 2
   - uid: 10700
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-80.5
       parent: 2
   - uid: 10701
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-74.5
       parent: 2
   - uid: 10703
@@ -119469,13 +119214,11 @@ entities:
   - uid: 10706
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-88.5
       parent: 2
   - uid: 10708
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-87.5
       parent: 2
   - uid: 10715
@@ -119506,115 +119249,96 @@ entities:
   - uid: 10724
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -13.5,-70.5
       parent: 2
   - uid: 10728
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-70.5
       parent: 2
   - uid: 10729
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-71.5
       parent: 2
   - uid: 10730
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-79.5
       parent: 2
   - uid: 10731
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-79.5
       parent: 2
   - uid: 10733
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-75.5
       parent: 2
   - uid: 10734
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-75.5
       parent: 2
   - uid: 10737
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-77.5
       parent: 2
   - uid: 10738
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-77.5
       parent: 2
   - uid: 10739
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-74.5
       parent: 2
   - uid: 10740
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-80.5
       parent: 2
   - uid: 10741
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-83.5
       parent: 2
   - uid: 10742
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-82.5
       parent: 2
   - uid: 10743
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-83.5
       parent: 2
   - uid: 10745
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-85.5
       parent: 2
   - uid: 10746
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-85.5
       parent: 2
   - uid: 10749
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-87.5
       parent: 2
   - uid: 10750
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-87.5
       parent: 2
   - uid: 10751
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-88.5
       parent: 2
   - uid: 10779
@@ -119665,25 +119389,21 @@ entities:
   - uid: 10840
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-25.5
       parent: 2
   - uid: 10846
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-24.5
       parent: 2
   - uid: 10847
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-38.5
       parent: 2
   - uid: 10849
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-38.5
       parent: 2
   - uid: 10917
@@ -119709,31 +119429,26 @@ entities:
   - uid: 11826
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 41.5,-59.5
       parent: 2
   - uid: 11830
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,-63.5
       parent: 2
   - uid: 11834
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,-63.5
       parent: 2
   - uid: 11838
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 41.5,-61.5
       parent: 2
   - uid: 11842
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,-64.5
       parent: 2
   - uid: 11938
@@ -119744,31 +119459,26 @@ entities:
   - uid: 11940
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,-65.5
       parent: 2
   - uid: 11947
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,-82.5
       parent: 2
   - uid: 11966
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 46.5,-60.5
       parent: 2
   - uid: 11969
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,-84.5
       parent: 2
   - uid: 12217
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,-65.5
       parent: 2
   - uid: 12348
@@ -119779,7 +119489,6 @@ entities:
   - uid: 12429
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,-38.5
       parent: 2
   - uid: 12436
@@ -119815,25 +119524,21 @@ entities:
   - uid: 12547
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,-9.5
       parent: 2
   - uid: 12571
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,-68.5
       parent: 2
   - uid: 12736
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 55.5,7.5
       parent: 2
   - uid: 12818
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 56.5,7.5
       parent: 2
   - uid: 12856
@@ -119854,7 +119559,6 @@ entities:
   - uid: 12887
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -18.5,-68.5
       parent: 2
   - uid: 13140
@@ -119875,31 +119579,26 @@ entities:
   - uid: 13143
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,47.5
       parent: 2
   - uid: 13144
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,42.5
       parent: 2
   - uid: 13145
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,47.5
       parent: 2
   - uid: 13146
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,42.5
       parent: 2
   - uid: 13147
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,47.5
       parent: 2
   - uid: 13148
@@ -119960,13 +119659,11 @@ entities:
   - uid: 13899
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,-68.5
       parent: 2
   - uid: 14108
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-75.5
       parent: 2
   - uid: 14828
@@ -119997,217 +119694,181 @@ entities:
   - uid: 15248
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,-20.5
       parent: 2
   - uid: 15249
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,-21.5
       parent: 2
   - uid: 15575
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,13.5
       parent: 2
   - uid: 16908
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,-17.5
       parent: 2
   - uid: 17014
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 39.5,-15.5
       parent: 2
   - uid: 17076
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,-37.5
       parent: 2
   - uid: 17105
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -37.5,8.5
       parent: 2
   - uid: 17106
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -47.5,2.5
       parent: 2
   - uid: 17107
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -59.5,2.5
       parent: 2
   - uid: 17108
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,2.5
       parent: 2
   - uid: 17109
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,2.5
       parent: 2
   - uid: 17110
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,7.5
       parent: 2
   - uid: 17121
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -59.5,14.5
       parent: 2
   - uid: 17123
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,7.5
       parent: 2
   - uid: 17174
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,-47.5
       parent: 2
   - uid: 17220
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,25.5
       parent: 2
   - uid: 17227
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,14.5
       parent: 2
   - uid: 17229
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 50.5,2.5
       parent: 2
   - uid: 17263
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 48.5,2.5
       parent: 2
   - uid: 17274
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-6.5
       parent: 2
   - uid: 17342
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 50.5,-13.5
       parent: 2
   - uid: 17484
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,-28.5
       parent: 2
   - uid: 17546
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,-47.5
       parent: 2
   - uid: 17547
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-54.5
       parent: 2
   - uid: 17548
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-51.5
       parent: 2
   - uid: 17776
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-47.5
       parent: 2
   - uid: 17800
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 53.5,-47.5
       parent: 2
   - uid: 17801
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 56.5,-45.5
       parent: 2
   - uid: 17802
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 56.5,-46.5
       parent: 2
   - uid: 17938
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,-23.5
       parent: 2
   - uid: 18000
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,-32.5
       parent: 2
   - uid: 18088
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 56.5,-47.5
       parent: 2
   - uid: 18126
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 53.5,-46.5
       parent: 2
   - uid: 18820
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-49.5
       parent: 2
   - uid: 19276
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 53.5,-45.5
       parent: 2
   - uid: 19503
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-55.5
       parent: 2
   - uid: 19967
@@ -120223,115 +119884,96 @@ entities:
   - uid: 20041
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 22.5,-66.5
       parent: 2
   - uid: 20288
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,55.5
       parent: 2
   - uid: 20335
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,26.5
       parent: 2
   - uid: 20336
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,25.5
       parent: 2
   - uid: 20337
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,24.5
       parent: 2
   - uid: 20338
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,22.5
       parent: 2
   - uid: 20339
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,21.5
       parent: 2
   - uid: 20340
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,20.5
       parent: 2
   - uid: 20341
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,19.5
       parent: 2
   - uid: 20342
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,18.5
       parent: 2
   - uid: 20343
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,17.5
       parent: 2
   - uid: 20344
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,16.5
       parent: 2
   - uid: 20345
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,23.5
       parent: 2
   - uid: 20346
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,14.5
       parent: 2
   - uid: 20347
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,15.5
       parent: 2
   - uid: 20348
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,13.5
       parent: 2
   - uid: 20349
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,12.5
       parent: 2
   - uid: 20523
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 21.5,-66.5
       parent: 2
   - uid: 20616
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,18.5
       parent: 2
   - uid: 20644
@@ -120357,31 +119999,26 @@ entities:
   - uid: 21184
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,7.5
       parent: 2
   - uid: 21241
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-87.5
       parent: 2
   - uid: 21242
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-79.5
       parent: 2
   - uid: 21320
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-85.5
       parent: 2
   - uid: 21334
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,-77.5
       parent: 2
   - uid: 21370
@@ -120392,19 +120029,16 @@ entities:
   - uid: 21485
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -35.5,-6.5
       parent: 2
   - uid: 21488
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -35.5,-5.5
       parent: 2
   - uid: 21490
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -35.5,-14.5
       parent: 2
   - uid: 21492
@@ -120440,19 +120074,16 @@ entities:
   - uid: 21513
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,40.5
       parent: 2
   - uid: 21514
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,40.5
       parent: 2
   - uid: 21515
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -32.5,40.5
       parent: 2
   - uid: 21571
@@ -120498,25 +120129,21 @@ entities:
   - uid: 21598
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,82.5
       parent: 2
   - uid: 21599
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,82.5
       parent: 2
   - uid: 21600
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,82.5
       parent: 2
   - uid: 21604
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,6.5
       parent: 2
   - uid: 21654
@@ -120527,19 +120154,16 @@ entities:
   - uid: 21659
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 70.5,17.5
       parent: 2
   - uid: 21664
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 70.5,18.5
       parent: 2
   - uid: 21665
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 70.5,16.5
       parent: 2
   - uid: 21669
@@ -120565,55 +120189,46 @@ entities:
   - uid: 21684
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 71.5,36.5
       parent: 2
   - uid: 21685
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 38.5,-56.5
       parent: 2
   - uid: 21686
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 71.5,37.5
       parent: 2
   - uid: 21687
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,35.5
       parent: 2
   - uid: 21688
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,36.5
       parent: 2
   - uid: 21749
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,-15.5
       parent: 2
   - uid: 21750
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-33.5
       parent: 2
   - uid: 21757
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,34.5
       parent: 2
   - uid: 21771
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-34.5
       parent: 2
   - uid: 21772
@@ -120624,49 +120239,41 @@ entities:
   - uid: 21777
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,57.5
       parent: 2
   - uid: 21856
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -42.5,-54.5
       parent: 2
   - uid: 21857
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -42.5,-55.5
       parent: 2
   - uid: 21860
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -42.5,-56.5
       parent: 2
   - uid: 21871
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,57.5
       parent: 2
   - uid: 21917
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -53.5,-18.5
       parent: 2
   - uid: 21918
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -53.5,-17.5
       parent: 2
   - uid: 21922
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -53.5,-16.5
       parent: 2
   - uid: 21927
@@ -120677,67 +120284,56 @@ entities:
   - uid: 22105
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 34.5,-9.5
       parent: 2
   - uid: 22106
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,-9.5
       parent: 2
   - uid: 22107
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,-9.5
       parent: 2
   - uid: 22115
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 34.5,-11.5
       parent: 2
   - uid: 22118
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,-11.5
       parent: 2
   - uid: 22226
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,-11.5
       parent: 2
   - uid: 22237
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 61.5,-24.5
       parent: 2
   - uid: 22238
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 55.5,-55.5
       parent: 2
   - uid: 22243
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -35.5,-7.5
       parent: 2
   - uid: 22298
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 54.5,-55.5
       parent: 2
   - uid: 22401
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,40.5
       parent: 2
   - uid: 22420
@@ -120768,31 +120364,26 @@ entities:
   - uid: 22470
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,40.5
       parent: 2
   - uid: 22633
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,-39.5
       parent: 2
   - uid: 22673
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,31.5
       parent: 2
   - uid: 22674
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 34.5,31.5
       parent: 2
   - uid: 22878
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,-5.5
       parent: 2
   - uid: 22919
@@ -120808,7 +120399,6 @@ entities:
   - uid: 22935
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -55.5,44.5
       parent: 2
   - uid: 22939
@@ -122689,13 +122279,11 @@ entities:
   - uid: 23562
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,-40.5
       parent: 2
   - uid: 23712
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -39.5,8.5
       parent: 2
   - uid: 23748
@@ -122716,25 +122304,21 @@ entities:
   - uid: 23763
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 58.5,-24.5
       parent: 2
   - uid: 23774
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -37.5,9.5
       parent: 2
   - uid: 23781
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-46.5
       parent: 2
   - uid: 24325
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-44.5
       parent: 2
   - uid: 24517
@@ -122745,61 +122329,51 @@ entities:
   - uid: 24864
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-50.5
       parent: 2
   - uid: 24865
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-49.5
       parent: 2
   - uid: 24867
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-48.5
       parent: 2
   - uid: 24868
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-47.5
       parent: 2
   - uid: 24871
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-45.5
       parent: 2
   - uid: 24874
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-44.5
       parent: 2
   - uid: 24894
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-42.5
       parent: 2
   - uid: 24895
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-41.5
       parent: 2
   - uid: 24897
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-39.5
       parent: 2
   - uid: 24898
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-40.5
       parent: 2
   - uid: 24903
@@ -122820,115 +122394,96 @@ entities:
   - uid: 24921
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-43.5
       parent: 2
   - uid: 24925
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-33.5
       parent: 2
   - uid: 24926
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-34.5
       parent: 2
   - uid: 24927
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-35.5
       parent: 2
   - uid: 24931
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-36.5
       parent: 2
   - uid: 24932
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-37.5
       parent: 2
   - uid: 25018
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 62.5,-53.5
       parent: 2
   - uid: 25020
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 62.5,-54.5
       parent: 2
   - uid: 25026
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 62.5,-55.5
       parent: 2
   - uid: 25151
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,35.5
       parent: 2
   - uid: 25252
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,-16.5
       parent: 2
   - uid: 25253
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,-17.5
       parent: 2
   - uid: 25255
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 17.5,-35.5
       parent: 2
   - uid: 25273
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -33.5,-11.5
       parent: 2
   - uid: 25274
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -31.5,-11.5
       parent: 2
   - uid: 25275
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -32.5,-11.5
       parent: 2
   - uid: 25281
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -32.5,-9.5
       parent: 2
   - uid: 25282
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -31.5,-9.5
       parent: 2
   - uid: 25287
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -34.5,-11.5
       parent: 2
   - uid: 25402
@@ -123049,19 +122604,16 @@ entities:
   - uid: 25661
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -34.5,9.5
       parent: 2
   - uid: 25738
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,28.5
       parent: 2
   - uid: 25760
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,7.5
       parent: 2
   - uid: 25770
@@ -123077,25 +122629,21 @@ entities:
   - uid: 25790
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-83.5
       parent: 2
   - uid: 25791
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-77.5
       parent: 2
   - uid: 25793
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,-88.5
       parent: 2
   - uid: 25815
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,-85.5
       parent: 2
   - uid: 25828
@@ -123116,13 +122664,11 @@ entities:
   - uid: 25891
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -34.5,8.5
       parent: 2
   - uid: 26018
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 40.5,38.5
       parent: 2
   - uid: 26197
@@ -123153,7 +122699,6 @@ entities:
   - uid: 26275
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,40.5
       parent: 2
   - uid: 26288
@@ -123184,43 +122729,36 @@ entities:
   - uid: 26325
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 26286
   - uid: 26326
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 26286
   - uid: 26330
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 26286
   - uid: 26933
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -34.5,10.5
       parent: 2
   - uid: 27118
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,41.5
       parent: 2
   - uid: 27119
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,40.5
       parent: 2
   - uid: 27120
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -27.5,41.5
       parent: 2
   - uid: 27141
@@ -123486,13 +123024,11 @@ entities:
   - uid: 27352
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,-88.5
       parent: 2
   - uid: 27353
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,40.5
       parent: 2
   - uid: 27356
@@ -123503,13 +123039,11 @@ entities:
   - uid: 27538
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-87.5
       parent: 2
   - uid: 27539
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,-83.5
       parent: 2
   - uid: 27575
@@ -123520,7 +123054,6 @@ entities:
   - uid: 27668
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,54.5
       parent: 2
   - uid: 27706
@@ -123531,31 +123064,26 @@ entities:
   - uid: 27730
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,41.5
       parent: 2
   - uid: 27739
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 43.5,38.5
       parent: 2
   - uid: 27753
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,43.5
       parent: 2
   - uid: 27775
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,56.5
       parent: 2
   - uid: 27942
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,-63.5
       parent: 2
   - uid: 28309
@@ -123571,13 +123099,11 @@ entities:
   - uid: 28539
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,19.5
       parent: 2
   - uid: 28540
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,20.5
       parent: 2
   - uid: 28564
@@ -123733,115 +123259,96 @@ entities:
   - uid: 28942
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 41.5,-60.5
       parent: 2
   - uid: 28959
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,-84.5
       parent: 2
   - uid: 28960
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,-84.5
       parent: 2
   - uid: 28961
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,-84.5
       parent: 2
   - uid: 28962
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-84.5
       parent: 2
   - uid: 28963
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,-83.5
       parent: 2
   - uid: 28964
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 34.5,-83.5
       parent: 2
   - uid: 28965
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 35.5,-83.5
       parent: 2
   - uid: 28966
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,-83.5
       parent: 2
   - uid: 28967
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,-83.5
       parent: 2
   - uid: 28968
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 39.5,-83.5
       parent: 2
   - uid: 28969
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 40.5,-83.5
       parent: 2
   - uid: 28970
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 42.5,-83.5
       parent: 2
   - uid: 28971
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 43.5,-83.5
       parent: 2
   - uid: 28972
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 44.5,-83.5
       parent: 2
   - uid: 28973
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 45.5,-83.5
       parent: 2
   - uid: 28974
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 46.5,-83.5
       parent: 2
   - uid: 28975
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,-81.5
       parent: 2
   - uid: 28976
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 46.5,-82.5
       parent: 2
 - proto: GrilleBroken

--- a/Resources/Maps/snowball.yml
+++ b/Resources/Maps/snowball.yml
@@ -82939,7 +82939,6 @@ entities:
   - uid: 6652
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 59.5,38.5
       parent: 1
   - uid: 6788
@@ -82960,13 +82959,11 @@ entities:
   - uid: 7073
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 57.5,38.5
       parent: 1
   - uid: 7244
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 58.5,38.5
       parent: 1
   - uid: 7306
@@ -83002,7 +82999,6 @@ entities:
   - uid: 7839
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 57.5,40.5
       parent: 1
   - uid: 8487
@@ -83018,7 +83014,6 @@ entities:
   - uid: 8762
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 57.5,39.5
       parent: 1
   - uid: 8901
@@ -83119,13 +83114,11 @@ entities:
   - uid: 10802
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 60.5,38.5
       parent: 1
   - uid: 10818
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 61.5,38.5
       parent: 1
   - uid: 10820

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -4,6 +4,8 @@
   name: grille
   description: A flimsy framework of iron rods.
   components:
+    - type: Transform
+      noRot: true
     - type: MeleeSound
       soundGroups:
         Brute:

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -4,7 +4,7 @@
   name: grille
   description: A flimsy framework of iron rods.
   components:
-    - type: Transform
+    - type: Transform # required
       noRot: true
     - type: MeleeSound
       soundGroups:

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -176,6 +176,8 @@
   parent: Grille
   name: diagonal grille
   components:
+  - type: Transform
+    noRot: false
   - type: Sprite
     drawdepth: Walls
     sprite: Structures/Walls/grille.rsi
@@ -214,6 +216,8 @@
   parent: ClockworkGrille
   name: diagonal clockwork grille
   components:
+  - type: Transform
+    noRot: false
   - type: Sprite
     drawdepth: Walls
     sprite: Structures/Walls/clockwork_grille.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
All grilles have had their rot attribute within transform removed. Grilles are now norot true
#43621 got closed due to stupid

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #31943
Obsoletes #31959
#31943 was brought up as an issue, and found that via #31959
## Technical details
<!-- Summary of code changes for easier review. -->
Grille now norot, but diagonal Grilles are still norot false!!!!!!!!!!!!!

Every single instance of rotation in a grille removed on all maps with following regex with replace functionality in VS
`(?<=- proto: Grille\r\n  entities:\r\n(?>  - uid: \d+\r\n    components:\r\n    - type: Transform\r\n(?>      rot: -?\d+\.\d+ rad\r\n)?      pos: -?\d+\.\d+,-?\d+\.\d+\r\n      parent: \d+\r\n)*?(?>  - uid: \d+\r\n    components:\r\n    - type: Transform\r\n))      rot: -?\d+\.\d+ rad\r\n(?=(?>      pos: -?\d+\.\d+,-?\d+\.\d+\r\n      parent: \d+\r\n))`
went through Box by hand multiple times to check that nothing broke while making said regex and worked correctly (scrolled through the file, checked that it worked in game), checked Snowball in file because i was convinced i did something wrong (didn't)
notify me if an explanation of the regex is deemed necessary
Checked by hand that there are no ClockworkGrilles which are rotated (there are not)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1113" height="557" alt="image" src="https://github.com/user-attachments/assets/be705d24-e44f-4e6d-91ee-47ab81abc9a5" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Grilles can no longer exist in a rotated state (minus disgonal grilles). You can use the following regex expression to mostly fix maps that were affected by this:

```
(?<=- proto: Grille\r\n  entities:\r\n(?>  - uid: \d+\r\n    components:\r\n    - type: Transform\r\n(?>      rot: -?\d+\.\d+ rad\r\n)?      pos: -?\d+\.\d+,-?\d+\.\d+\r\n      parent: \d+\r\n)*?(?>  - uid: \d+\r\n    components:\r\n    - type: Transform\r\n))      rot: -?\d+\.\d+ rad\r\n(?=(?>      pos: -?\d+\.\d+,-?\d+\.\d+\r\n      parent: \d+\r\n))
```

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!---->
:cl:
- fix: Grilles are no longer rotated. Grilles can no longer be rotated.
