### PR TITLE
Fix Context Menus Not Orphaning Correctly

### DIFF
--- a/Content.Client/ContextMenu/UI/ContextMenuElement.xaml.cs
+++ b/Content.Client/ContextMenu/UI/ContextMenuElement.xaml.cs
@@ -55,10 +55,10 @@ namespace Content.Client.ContextMenu.UI
                 Text = text;
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void ExitedTree()
         {
-            base.Dispose(disposing);
-            _subMenu?.Dispose();
+            base.ExitedTree();
+            _subMenu?.Orphan();
             _subMenu = null;
             ParentMenu = null;
         }

--- a/Content.Client/ContextMenu/UI/ContextMenuPopup.xaml.cs
+++ b/Content.Client/ContextMenu/UI/ContextMenuPopup.xaml.cs
@@ -70,11 +70,11 @@ namespace Content.Client.ContextMenu.UI
             };
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void ExitedTree()
         {
+            base.ExitedTree();
             MenuBody.OnChildRemoved -= ctrl => _uiController.OnRemoveElement(this, ctrl);
             ParentElement = null;
-            base.Dispose(disposing);
         }
     }
 }

--- a/Content.Client/ContextMenu/UI/ContextMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/ContextMenuUIController.cs
@@ -86,7 +86,7 @@ namespace Content.Client.ContextMenu.UI
 
             Close();
             RootMenu.OnPopupHide -= Close;
-            RootMenu.Dispose();
+            RootMenu.Orphan();
             RootMenu = default!;
         }
 

--- a/Content.Client/ContextMenu/UI/EntityMenuElement.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuElement.cs
@@ -41,9 +41,9 @@ namespace Content.Client.ContextMenu.UI
             UpdateEntity();
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void ExitedTree()
         {
-            base.Dispose(disposing);
+            base.ExitedTree();
             Entity = null;
             Count = 0;
         }

--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -312,7 +312,7 @@ namespace Content.Client.ContextMenu.UI
 
             // remove the element
             var parent = element.ParentMenu?.ParentElement;
-            element.Dispose();
+            element.Orphan();
             Elements.Remove(entity);
 
             // update any parent elements
@@ -340,7 +340,7 @@ namespace Content.Client.ContextMenu.UI
             if (entity == null)
             {
                 // This whole element has no associated entities. We should remove it
-                element.Dispose();
+                element.Orphan();
                 return;
             }
 
@@ -352,7 +352,7 @@ namespace Content.Client.ContextMenu.UI
                 // There was only one entity in the sub-menu. So we will just remove the sub-menu and point directly to
                 // that entity.
                 element.Entity = entity;
-                element.SubMenu.Dispose();
+                element.SubMenu.Orphan();
                 element.SubMenu = null;
                 Elements[entity.Value] = element;
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

The change to remove DisposeAllChildren in favor of RemoveAllChildren in #39848 didn't account for the fact that some controls have custom Dispose behavior that wasn't getting triggered after the change.

I fixed it by switching the associated controls to using ExitedTree + Orphan, which made it work again.

Related to #37930, but separate to ensure this specific fix doesn't get stuck in cleanup review limbo.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

SubMenus in ContextWindows (that right click window) wouldn't properly get closed anymore after that change.

For example, suit sensors being set used to close the Sensor buttons, so that once you set it it disappeared. Instead, the parent context menu would disappear, but the submenu with the buttons wouldn't.

It also happened when working with many entities in a tile, which the submenu also won't disappear when interacted with (primarily useful for mass-butchering clothes).

## Technical details
<!-- Summary of code changes for easier review. -->

Replace `override Dispose` with `override ExitedTree`, and `Dispose()` with `Orphan()`.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Launch client
2. Right click your suit
3. Go to sensors, change the sensor value
4. All associated submenus should now disappear.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

N/A

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

N/A, minor UI bug fix