### PR TITLE
Fixes the Draw Depth of Ghost Pipe Sprites

### DIFF
--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -304,9 +304,9 @@ namespace Content.Client.Construction
                 var dummy = EntityManager.SpawnEntity(targetProtoId, MapCoordinates.Nullspace);
                 var targetSprite = EnsureComp<SpriteComponent>(dummy);
                 EntityManager.System<AppearanceSystem>().OnChangeData(dummy, targetSprite);
-
+                var ghostDrawDepth = sprite.DrawDepth;
                 _sprite.CopySprite((dummy, targetSprite), (ghost.Value, sprite));
-
+                _sprite.SetDrawDepth((ghost.Value, sprite), ghostDrawDepth);
                 for (var i = 0; i < sprite.AllLayers.Count(); i++)
                 {
                     sprite.LayerSetShader(i, "unshaded");


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
In https://github.com/space-wizards/space-station-14/pull/42193, an issue was introduced where creating a pipe ghost makes said ghost invisible if placed over a wall, likely because said ghost was using the draw depth of the sprite itself, as the sprite was being copied.

I added two lines which -should- copy the ghost draw depth and apply it to the sprite, after it being copied, which I -think- is a good solution, but feel free to lock me in a freezer if it's not.

## Why / Balance
Visibility is good, I suppose.

## Technical details
Instead of just copying the entire sprite's details, the construction ghost placement now holds the ghost draw depth and applies it after copying. Two lines.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
* In a body, open the crafting menu.
* Place a pipe on a wall. 
* See that before this PR, the ghost pipe is invisible, as its under the wall, but after this PR, the ghost pipe is visible.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before: (Ghosts are hidden under the walls)
<img width="301" height="207" alt="image" src="https://github.com/user-attachments/assets/4d184a38-91ea-4898-bb27-1bfc41c184c5" />

After:
<img width="190" height="210" alt="image" src="https://github.com/user-attachments/assets/443b856a-1f10-492e-a1e4-d42ffbe8f1d0" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: DevArchwave
- fix: Construction ghosts of pipes and some other things should display correctly again.
