### PR TITLE
Fix spawning as ghost on devmap

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -209,7 +209,12 @@ namespace Content.Server.GameTicking
                     speciesId = weights.Pick(_robustRandom);
                 }
 
-                character = HumanoidCharacterProfile.RandomWithSpecies(speciesId);
+                // The random profile must retain the job priorities set by the player
+                var jobs = character.JobPriorities;
+                character = HumanoidCharacterProfile.RandomWithSpecies(speciesId).WithJobPriorities(jobs);
+
+                // This does not utilize overflow job slots, so if the character profile
+                // had no available job priorities (ie Captain on Dev) set, then the player will spawn as a ghost
             }
 
             // We raise this event to allow other systems to handle spawning this player themselves. (e.g. late-join wizard, etc)

--- a/Resources/Prototypes/Maps/debug.yml
+++ b/Resources/Prototypes/Maps/debug.yml
@@ -27,6 +27,7 @@
         - type: StationJobs
           availableJobs:
             Captain: [ -1, -1 ]
+            Passenger: [ -1, -1 ] # Remove passenger slots once new characters are automatically forced to enable Captain
 
 - type: gameMap
   id: TestTeg

--- a/Resources/Prototypes/Maps/debug.yml
+++ b/Resources/Prototypes/Maps/debug.yml
@@ -27,7 +27,6 @@
         - type: StationJobs
           availableJobs:
             Captain: [ -1, -1 ]
-            Passenger: [ -1, -1 ] # Remove passenger slots once new characters are automatically forced to enable Captain
 
 - type: gameMap
   id: TestTeg


### PR DESCRIPTION
## About the PR
It is now possible to spawn on Dev again, so long that the character has Captain enabled

#44120 configures the development server for this to be the default for all newly created characters. Existing characters of existing users will still need to have Captain manually enabled on them, from the character management UI

## Why / Balance
Fixes #44058

## Technical details
As per #44058, currently, you can't spawn on Dev if the Random Characters feature is enabled. (Which it always is by default)
This is a result of a needed fix to Overflow jobs. It used to ignore the preferences of the character, which Dev used as a feature so that players without the Captain job enabled still got forced into that job slot. But we can no longer rely on this.

`GameTicker.Spawning.SpawnPlayer()` will now transfer over the saved character's Job priorities to the randomized character, instead of just setting it as the default Passenger. This makes it possible to spawn into the Captain job slot (which is the only one available on Dev), if the character has the Captain job enabled. For existing characters, this needs to be done manually from the lobby

## Test plan
If still experiencing the unspawnable behavior:
Spawn on Dev
Use `golobby`
In the lobby, add the Captain job to the character with any priority
Afterwards, the character will properly spawn in dev, even right after launch. No need to go to the lobby again

#44120 will make all newly created characters automatically have this fix applied.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
