### PR TITLE
Disposals dynamic power consumption

### DIFF
--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
@@ -55,6 +55,7 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private SharedTransformSystem _xform = default!;
     [Dependency] private INetManager _net = default!;
+    [Dependency] private SharedPowerStateSystem _powerState = default!;
 
     public override void Initialize()
     {
@@ -259,9 +260,15 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
 
         ent.Comp.State = state;
 
-        if (state == DisposalsPressureState.Ready)
+        switch (state)
         {
-            ent.Comp.NextPressurized = TimeSpan.Zero;
+            case DisposalsPressureState.Ready:
+                ent.Comp.NextPressurized = TimeSpan.Zero;
+                _powerState.SetWorkingState(ent.Owner, false);
+                break;
+            case DisposalsPressureState.Pressurizing:
+                _powerState.SetWorkingState(ent.Owner, true);
+                break;
         }
 
         RecalculateFlushTime(ent, true);

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -40,11 +40,11 @@
       enum.DisposalUnitVisuals.IsReady:
         enum.DisposalUnitVisualLayers.Base:
           True: { state: disposal }
-          False: { state: disposal-charging }         
+          False: { state: disposal-charging }
       enum.DisposalUnitVisuals.IsFlushing:
         enum.DisposalUnitVisualLayers.OverlayFlushing:
           True: { visible: true }
-          False: { visible: false }      
+          False: { visible: false }
       enum.DisposalUnitVisuals.IsEngaged:
         enum.DisposalUnitVisualLayers.OverlayEngaged:
           True: { visible: true }
@@ -67,7 +67,7 @@
           True: { state: disposal }
           False: { state: condisposal }
         enum.DisposalUnitVisualLayers.OverlayEngaged:
-          False: { visible: false } 
+          False: { visible: false }
         enum.DisposalUnitVisualLayers.OverlayCharging:
           False: { visible: false }
         enum.DisposalUnitVisualLayers.OverlayFull:
@@ -120,6 +120,9 @@
   - type: StaticPrice
     price: 70
   - type: PowerSwitch
+  - type: PowerState
+    idlePowerDraw: 5
+    workingPowerDraw: 1000
 
 - type: entity
   id: DisposalUnit
@@ -191,7 +194,7 @@
           True: { state: mailing }
           False: { state: conmailing }
         enum.DisposalUnitVisualLayers.OverlayEngaged:
-          False: { visible: false } 
+          False: { visible: false }
         enum.DisposalUnitVisualLayers.OverlayCharging:
           False: { visible: false }
         enum.DisposalUnitVisualLayers.OverlayFull:

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -120,6 +120,8 @@
   - type: StaticPrice
     price: 70
   - type: PowerSwitch
+  - type: ApcPowerReceiver
+    powerLoad: 5
   - type: PowerState
     idlePowerDraw: 5
     workingPowerDraw: 1000


### PR DESCRIPTION
## About the PR
Disposals units, mailing units, and toilets now dynamically consume power depending on whether they are charging or not.

## Why / Balance
A million of these things across the station consuming a kW each for absolutely no reason is a bit silly. And it makes it harder to balance power to be somewhat reasonable.

## Technical details
Simple state switch in the middle of `DisposalSystem`'s state handling.

## Test plan
I tested deconstruction, unanchoring, reanchoring, reconstruction, power connect/disconnect, and they all change state perfectly fine. When the machine is expected to be unpowered or stop charging, draw returns to 5 W, and when the device is charging, draw resumes to 1 kW.

## Media

https://github.com/user-attachments/assets/a327bdb0-43fb-48bf-b133-2d7325ff0fb9


Before and after pics for Bagel as well.
<img width="556" height="199" alt="image" src="https://github.com/user-attachments/assets/d5b9cccc-cdfb-4e3a-889e-c9e4e547b135" />
<img width="492" height="213" alt="image" src="https://github.com/user-attachments/assets/3913d086-08aa-4963-89fd-5d34e6fc50de" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

## Changelog
:cl:
- tweak: Disposals units, mailing units, and toilets now dynamically consume power depending on if they are working or not. This has dropped the idle power draw of stations drastically.
