### PR TITLE
Fix foolbox storage insertion heisentest

### DIFF
--- a/Content.Shared/Containers/ContainerFillSystem.cs
+++ b/Content.Shared/Containers/ContainerFillSystem.cs
@@ -1,8 +1,10 @@
 using System.Linq;
 using System.Numerics;
 using Content.Shared.EntityTable;
+using Content.Shared.Item;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Containers;
 
@@ -11,6 +13,8 @@ public sealed partial class ContainerFillSystem : EntitySystem
     [Dependency] private SharedContainerSystem _containerSystem = default!;
     [Dependency] private EntityTableSystem _entityTable = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private IPrototypeManager _protoMan = default!;
+    [Dependency] private IComponentFactory _compFactory = default!;
 
     public override void Initialize()
     {
@@ -68,7 +72,14 @@ public sealed partial class ContainerFillSystem : EntitySystem
                 continue;
             }
 
-            var spawns = _entityTable.GetSpawns(table);
+            var spawns = _entityTable.GetSpawns(table).ToList();
+
+            if (ent.Comp.Sort)
+            {
+                // Reverse order since we want to insert larger items first, and the list is sorted smallest to largest.
+                spawns.Sort((a, b) => CompareSize(b, a));
+            }
+
             foreach (var proto in spawns)
             {
                 var spawn = Spawn(proto, coords);
@@ -81,5 +92,25 @@ public sealed partial class ContainerFillSystem : EntitySystem
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Sorts two protos by <see cref="ItemComponent"/> size, from smallest to largest.
+    /// </summary>
+    /// <param name="a">The first proto.</param>
+    /// <param name="b">The second proto.</param>
+    /// <returns> Less than 0 if a is smaller, greater than 0 if a is larger,
+    /// 0 if they are the same or either proto doesn't have an <see cref="ItemComponent"/>. </returns>
+    private int CompareSize(EntProtoId a, EntProtoId b)
+    {
+        var protoA = _protoMan.Index(a);
+        var protoB = _protoMan.Index(b);
+        if (!protoA.TryGetComponent<ItemComponent>(out var compA, _compFactory) ||
+            !protoB.TryGetComponent<ItemComponent>(out var compB, _compFactory))
+        {
+            return 0;
+        }
+
+        return _protoMan.Index(compA.Size).CompareTo(_protoMan.Index(compB.Size));
     }
 }

--- a/Content.Shared/Containers/ContainerFillSystem.cs
+++ b/Content.Shared/Containers/ContainerFillSystem.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using System.Numerics;
 using Content.Shared.EntityTable;
-using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Item;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 
@@ -12,7 +12,7 @@ public sealed partial class ContainerFillSystem : EntitySystem
     [Dependency] private SharedContainerSystem _containerSystem = default!;
     [Dependency] private EntityTableSystem _entityTable = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
-    [Dependency] private SharedStorageSystem _storageSys = default!;
+    [Dependency] private SharedItemSystem _itemSys = default!;
 
     public override void Initialize()
     {
@@ -75,7 +75,7 @@ public sealed partial class ContainerFillSystem : EntitySystem
             if (ent.Comp.Sort)
             {
                 // Reverse order since we want to insert larger items first, and the list is sorted smallest to largest.
-                spawns.Sort((a, b) => _storageSys.CompareSize(b, a));
+                spawns.Sort((a, b) => _itemSys.CompareSize(b, a));
             }
 
             foreach (var proto in spawns)

--- a/Content.Shared/Containers/ContainerFillSystem.cs
+++ b/Content.Shared/Containers/ContainerFillSystem.cs
@@ -1,10 +1,9 @@
 using System.Linq;
 using System.Numerics;
 using Content.Shared.EntityTable;
-using Content.Shared.Item;
+using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
-using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Containers;
 
@@ -13,8 +12,7 @@ public sealed partial class ContainerFillSystem : EntitySystem
     [Dependency] private SharedContainerSystem _containerSystem = default!;
     [Dependency] private EntityTableSystem _entityTable = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
-    [Dependency] private IPrototypeManager _protoMan = default!;
-    [Dependency] private IComponentFactory _compFactory = default!;
+    [Dependency] private SharedStorageSystem _storageSys = default!;
 
     public override void Initialize()
     {
@@ -77,7 +75,7 @@ public sealed partial class ContainerFillSystem : EntitySystem
             if (ent.Comp.Sort)
             {
                 // Reverse order since we want to insert larger items first, and the list is sorted smallest to largest.
-                spawns.Sort((a, b) => CompareSize(b, a));
+                spawns.Sort((a, b) => _storageSys.CompareSize(b, a));
             }
 
             foreach (var proto in spawns)
@@ -92,25 +90,5 @@ public sealed partial class ContainerFillSystem : EntitySystem
                 }
             }
         }
-    }
-
-    /// <summary>
-    /// Sorts two protos by <see cref="ItemComponent"/> size, from smallest to largest.
-    /// </summary>
-    /// <param name="a">The first proto.</param>
-    /// <param name="b">The second proto.</param>
-    /// <returns> Less than 0 if a is smaller, greater than 0 if a is larger,
-    /// 0 if they are the same or either proto doesn't have an <see cref="ItemComponent"/>. </returns>
-    private int CompareSize(EntProtoId a, EntProtoId b)
-    {
-        var protoA = _protoMan.Index(a);
-        var protoB = _protoMan.Index(b);
-        if (!protoA.TryGetComponent<ItemComponent>(out var compA, _compFactory) ||
-            !protoB.TryGetComponent<ItemComponent>(out var compB, _compFactory))
-        {
-            return 0;
-        }
-
-        return _protoMan.Index(compA.Size).CompareTo(_protoMan.Index(compB.Size));
     }
 }

--- a/Content.Shared/Containers/EntityTableContainerFillComponent.cs
+++ b/Content.Shared/Containers/EntityTableContainerFillComponent.cs
@@ -10,4 +10,11 @@ public sealed partial class EntityTableContainerFillComponent : Component
 {
     [DataField]
     public Dictionary<string, EntityTableSelector> Containers = new();
+
+    /// <summary>
+    /// Whether to sort the contents of the table by size before inserting.
+    /// Helps with fitting items into containers.
+    /// </summary>
+    [DataField]
+    public bool Sort;
 }

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -18,6 +18,7 @@ public abstract partial class SharedItemSystem : EntitySystem
     [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private SharedHandsSystem _handsSystem = default!;
     [Dependency] protected SharedContainerSystem Container = default!;
+    [Dependency] private IComponentFactory _compFactory = default!;
 
     public override void Initialize()
     {
@@ -270,5 +271,26 @@ public abstract partial class SharedItemSystem : EntitySystem
                 SetSize(uid, (ProtoId<ItemSizePrototype>) itemToggleSize.DeactivatedSize, item);
             }
         }
+    }
+
+    /// <summary>
+    /// Sorts two protos by <see cref="ItemComponent"/> size, from smallest to largest.
+    /// </summary>
+    /// <param name="a">The first proto.</param>
+    /// <param name="b">The second proto.</param>
+    /// <returns> Less than 0 if a is smaller, greater than 0 if a is larger,
+    /// 0 if they are the same or either proto doesn't have an <see cref="ItemComponent"/>.</returns>
+    [PublicAPI]
+    public int CompareSize(EntProtoId a, EntProtoId b)
+    {
+        var protoA = _prototype.Index(a);
+        var protoB = _prototype.Index(b);
+        if (!protoA.TryGetComponent<ItemComponent>(out var compA, _compFactory) ||
+            !protoB.TryGetComponent<ItemComponent>(out var compB, _compFactory))
+        {
+            return 0;
+        }
+
+        return _prototype.Index(compA.Size).CompareTo(_prototype.Index(compB.Size));
     }
 }

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -42,7 +42,6 @@ using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Content.Shared.Rounding;
-using JetBrains.Annotations;
 using Robust.Shared.Collections;
 using Robust.Shared.Map.Enumerators;
 
@@ -73,7 +72,6 @@ public abstract partial class SharedStorageSystem : EntitySystem
     [Dependency] protected SharedUserInterfaceSystem UI = default!;
     [Dependency] private TagSystem _tag = default!;
     [Dependency] protected UseDelaySystem UseDelay = default!;
-    [Dependency] private IComponentFactory _compFactory = default!;
 
     [Dependency] private EntityQuery<ItemComponent> _itemQuery = default!;
     [Dependency] private EntityQuery<StackComponent> _stackQuery = default!;
@@ -1994,27 +1992,6 @@ public abstract partial class SharedStorageSystem : EntitySystem
 
         item = new(itemUid.Value, itemComp);
         return true;
-    }
-
-    /// <summary>
-    /// Sorts two protos by <see cref="ItemComponent"/> size, from smallest to largest.
-    /// </summary>
-    /// <param name="a">The first proto.</param>
-    /// <param name="b">The second proto.</param>
-    /// <returns> Less than 0 if a is smaller, greater than 0 if a is larger,
-    /// 0 if they are the same or either proto doesn't have an <see cref="ItemComponent"/>.</returns>
-    [PublicAPI]
-    public int CompareSize(EntProtoId a, EntProtoId b)
-    {
-        var protoA = _prototype.Index(a);
-        var protoB = _prototype.Index(b);
-        if (!protoA.TryGetComponent<ItemComponent>(out var compA, _compFactory) ||
-            !protoB.TryGetComponent<ItemComponent>(out var compB, _compFactory))
-        {
-            return 0;
-        }
-
-        return _prototype.Index(compA.Size).CompareTo(_prototype.Index(compB.Size));
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -42,6 +42,7 @@ using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Content.Shared.Rounding;
+using JetBrains.Annotations;
 using Robust.Shared.Collections;
 using Robust.Shared.Map.Enumerators;
 
@@ -72,6 +73,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
     [Dependency] protected SharedUserInterfaceSystem UI = default!;
     [Dependency] private TagSystem _tag = default!;
     [Dependency] protected UseDelaySystem UseDelay = default!;
+    [Dependency] private IComponentFactory _compFactory = default!;
 
     [Dependency] private EntityQuery<ItemComponent> _itemQuery = default!;
     [Dependency] private EntityQuery<StackComponent> _stackQuery = default!;
@@ -1992,6 +1994,27 @@ public abstract partial class SharedStorageSystem : EntitySystem
 
         item = new(itemUid.Value, itemComp);
         return true;
+    }
+
+    /// <summary>
+    /// Sorts two protos by <see cref="ItemComponent"/> size, from smallest to largest.
+    /// </summary>
+    /// <param name="a">The first proto.</param>
+    /// <param name="b">The second proto.</param>
+    /// <returns> Less than 0 if a is smaller, greater than 0 if a is larger,
+    /// 0 if they are the same or either proto doesn't have an <see cref="ItemComponent"/>.</returns>
+    [PublicAPI]
+    public int CompareSize(EntProtoId a, EntProtoId b)
+    {
+        var protoA = _prototype.Index(a);
+        var protoB = _prototype.Index(b);
+        if (!protoA.TryGetComponent<ItemComponent>(out var compA, _compFactory) ||
+            !protoB.TryGetComponent<ItemComponent>(out var compB, _compFactory))
+        {
+            return 0;
+        }
+
+        return _prototype.Index(compA.Size).CompareTo(_prototype.Index(compB.Size));
     }
 
     [Serializable, NetSerializable]

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -164,6 +164,7 @@
   suffix: Filled
   components:
   - type: EntityTableContainerFill
+    sort: true
     containers:
       storagebase: !type:NestedSelector
         tableId: FoolboxTable
@@ -210,7 +211,6 @@
       - id: EnergySword # ~1/1001
         weight: 0.001
     - !type:GroupSelector # Rarer clown tools
-      rolls: 2
       children:
       - !type:NestedSelector
         tableId: AllMiscToysTable
@@ -232,7 +232,6 @@
       - id: RubberStampCaptain # ~1/100
         weight: 0.2
     - !type:GroupSelector # Common clown consumables
-      rolls: 2
       children:
       - !type:NestedSelector
         tableId: SlipTable

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -210,7 +210,7 @@
       - id: EnergySword # ~1/1001
         weight: 0.001
     - !type:GroupSelector # Rarer clown tools
-      rolls: 1
+      rolls: 2
       children:
       - !type:NestedSelector
         tableId: AllMiscToysTable
@@ -232,7 +232,7 @@
       - id: RubberStampCaptain # ~1/100
         weight: 0.2
     - !type:GroupSelector # Common clown consumables
-      rolls: 1
+      rolls: 2
       children:
       - !type:NestedSelector
         tableId: SlipTable

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -210,7 +210,7 @@
       - id: EnergySword # ~1/1001
         weight: 0.001
     - !type:GroupSelector # Rarer clown tools
-      rolls: 2
+      rolls: 1
       children:
       - !type:NestedSelector
         tableId: AllMiscToysTable
@@ -232,7 +232,7 @@
       - id: RubberStampCaptain # ~1/100
         weight: 0.2
     - !type:GroupSelector # Common clown consumables
-      rolls: 2
+      rolls: 1
       children:
       - !type:NestedSelector
         tableId: SlipTable


### PR DESCRIPTION
## About the PR
Fixes the foolbox heisentest by slightly adjusting the items that are rolled. Overall you will get a bit less things in the foolbox.

## Why / Balance
This test is genuinely driving me insane. It has such a high chance to trigger compared to our other tests. We desperately need a test that checks entity tables and all of the possible configurations so that this type of fail doesn't happen at a random chance.

Fixes https://github.com/space-wizards/space-station-14/issues/43354

## Technical details
Overall probabilities/repeats for items that take up a lot of space were lowered.

## Test plan
I am an absolute master at fixing storage heisentests. Behold:
```C#
using Content.IntegrationTests.Fixtures;
using Robust.Shared.Prototypes;

namespace Content.IntegrationTests.Tests;

public sealed class EntStorageTest : GameTest
{
    private const int TestEntityCount = 200000;
    private readonly EntProtoId _testEntProtoId = "FoolboxFilled";

    [Test]
    public async Task TestEntStorage()
    {
        for (var i = 0; i < TestEntityCount; i++)
        {
            await Spawn(_testEntProtoId);
        }
    }
}
```

Requires 50+ GiB of memory.

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

## Changelog
:cl:
- tweak: Filled foolboxes have slightly less items in them, as there was a chance to overfill the box and spawn an item outside of it.
