### PR TITLE
Migrate Atmospherics to TensorPrimitives

### DIFF
--- a/Content.Benchmarks/DeltaPressureBenchmark.cs
+++ b/Content.Benchmarks/DeltaPressureBenchmark.cs
@@ -32,7 +32,7 @@ public class DeltaPressureBenchmark
     /// <summary>
     /// Number of entities (windows, really) to spawn with a <see cref="DeltaPressureComponent"/>.
     /// </summary>
-    [Params(1, 10, 100, 1000, 5000, 10000, 50000, 100000)]
+    [Params(100, 1000, 5000, 10000)]
     public int EntityCount;
 
     /// <summary>

--- a/Content.Client/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Client/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -1,3 +1,4 @@
+using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Reactions;
@@ -26,15 +27,15 @@ public sealed partial class AtmosphereSystem
     public override bool IsMixtureFuel(GasMixture mixture, float epsilon = Atmospherics.Epsilon)
     {
         var tmp = new float[Atmospherics.AdjustedNumberOfGases];
-        NumericsHelpers.Multiply(mixture.Moles, GasFuelMask, tmp);
-        return NumericsHelpers.HorizontalAdd(tmp) > epsilon;
+        TensorPrimitives.Multiply(mixture.Moles, GasFuelMask, tmp);
+        return TensorPrimitives.Sum(tmp) > epsilon;
     }
 
     public override bool IsMixtureOxidizer(GasMixture mixture, float epsilon = Atmospherics.Epsilon)
     {
         var tmp = new float[Atmospherics.AdjustedNumberOfGases];
-        NumericsHelpers.Multiply(mixture.Moles, GasOxidizerMask, tmp);
-        return NumericsHelpers.HorizontalAdd(tmp) > epsilon;
+        TensorPrimitives.Multiply(mixture.Moles, GasOxidizerMask, tmp);
+        return TensorPrimitives.Sum(tmp) > epsilon;
     }
 
     public override float GetMass(GasMixture mix)
@@ -45,17 +46,17 @@ public sealed partial class AtmosphereSystem
     public override float GetMass(float[] moles)
     {
         var tmp = new float[moles.Length];
-        NumericsHelpers.Multiply(moles, GasMolarMasses, tmp);
+        TensorPrimitives.Multiply(moles, GasMolarMasses, tmp);
 
         // Conversion of grams to kilograms.
-        return NumericsHelpers.HorizontalAdd(tmp) * Atmospherics.gToKg;
+        return TensorPrimitives.Sum(tmp) * Atmospherics.gToKg;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected override float GetHeatCapacityCalculation(float[] moles, bool space)
     {
         // Little hack to make space gas mixtures have heat capacity, therefore allowing them to cool down rooms.
-        if (space && MathHelper.CloseTo(NumericsHelpers.HorizontalAdd(moles), 0f))
+        if (space && MathHelper.CloseTo(TensorPrimitives.Sum(moles), 0f))
         {
             return Atmospherics.SpaceHeatCapacity;
         }
@@ -65,9 +66,9 @@ public sealed partial class AtmosphereSystem
         // though this isnt the hottest code path so it should be fine
         // the gc can eat a little as a treat
         var tmp = new float[moles.Length];
-        NumericsHelpers.Multiply(moles, GasMolarHeatCapacities, tmp);
+        TensorPrimitives.Multiply(moles, GasMolarHeatCapacities, tmp);
         // Adjust heat capacity by speedup, because this is primarily what
         // determines how quickly gases heat up/cool.
-        return MathF.Max(NumericsHelpers.HorizontalAdd(tmp), Atmospherics.MinimumHeatCapacity);
+        return MathF.Max(TensorPrimitives.Sum(tmp), Atmospherics.MinimumHeatCapacity);
     }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Diagnostics;
+using System.Numerics.Tensors;
 using Content.Server.NodeContainer.NodeGroups;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
@@ -366,10 +367,9 @@ public partial class AtmosphereSystem
                 mixtMoles[i] = mixture.TotalMoles;
             }
 
-            // TODO NumericsHelpers need a method that substitutes NaNs with zeros. AVX-512 has one iirc but for 256/128 we need to do some masking bs
-            NumericsHelpers.Multiply(mixtMoles, Atmospherics.R);
-            NumericsHelpers.Multiply(mixtMoles, mixtTemp);
-            NumericsHelpers.Divide(mixtMoles, mixtVol, pressures);
+            TensorPrimitives.Multiply(mixtMoles, Atmospherics.R, mixtMoles);
+            TensorPrimitives.Multiply(mixtMoles, mixtTemp, mixtMoles);
+            TensorPrimitives.Divide(mixtMoles, mixtVol, pressures);
         }
         finally
         {

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.DeltaPressure.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.DeltaPressure.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Numerics.Tensors;
 using Content.Server.Atmos.Components;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
@@ -162,9 +163,9 @@ public sealed partial class AtmosphereSystem
             }
 
             // Time to get crankin
-            NumericsHelpers.Max(groupA, groupB, groupMax);
-            NumericsHelpers.Sub(groupA, groupB);
-            NumericsHelpers.Abs(groupA);
+            TensorPrimitives.Max(groupA, groupB, groupMax);
+            TensorPrimitives.Subtract(groupA, groupB, groupA);
+            TensorPrimitives.Abs(groupA, groupA);
 
             // Now go through each entity and determine their max pressure & delta pressure.
             // Queue for damage if necessary.

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
 using Content.Server.Atmos.Reactions;
 using Content.Shared.Atmos;
@@ -36,40 +37,40 @@ namespace Content.Server.Atmos.EntitySystems
         public override float GetMass(float[] moles)
         {
             Span<float> tmp = stackalloc float[moles.Length];
-            NumericsHelpers.Multiply(moles, GasMolarMasses, tmp);
+            TensorPrimitives.Multiply(moles, GasMolarMasses, tmp);
 
             // Conversion of grams to kilograms.
-            return NumericsHelpers.HorizontalAdd(tmp) * Atmospherics.gToKg;
+            return TensorPrimitives.Sum(tmp) * Atmospherics.gToKg;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected override float GetHeatCapacityCalculation(float[] moles, bool space)
         {
             // Little hack to make space gas mixtures have heat capacity, therefore allowing them to cool down rooms.
-            if (space && MathHelper.CloseTo(NumericsHelpers.HorizontalAdd(moles), 0f))
+            if (space && MathHelper.CloseTo(TensorPrimitives.Sum(moles), 0f))
             {
                 return Atmospherics.SpaceHeatCapacity;
             }
 
             Span<float> tmp = stackalloc float[moles.Length];
-            NumericsHelpers.Multiply(moles, GasMolarHeatCapacities, tmp);
+            TensorPrimitives.Multiply(moles, GasMolarHeatCapacities, tmp);
             // Adjust heat capacity by speedup, because this is primarily what
             // determines how quickly gases heat up/cool.
-            return MathF.Max(NumericsHelpers.HorizontalAdd(tmp), Atmospherics.MinimumHeatCapacity);
+            return MathF.Max(TensorPrimitives.Sum(tmp), Atmospherics.MinimumHeatCapacity);
         }
 
         public override bool IsMixtureFuel(GasMixture mixture, float epsilon = Atmospherics.Epsilon)
         {
             Span<float> tmp = stackalloc float[Atmospherics.AdjustedNumberOfGases];
-            NumericsHelpers.Multiply(mixture.Moles, GasFuelMask, tmp);
-            return NumericsHelpers.HorizontalAdd(tmp) > epsilon;
+            TensorPrimitives.Multiply(mixture.Moles, GasFuelMask, tmp);
+            return TensorPrimitives.Sum(tmp) > epsilon;
         }
 
         public override bool IsMixtureOxidizer(GasMixture mixture, float epsilon = Atmospherics.Epsilon)
         {
             Span<float> tmp = stackalloc float[Atmospherics.AdjustedNumberOfGases];
-            NumericsHelpers.Multiply(mixture.Moles, GasOxidizerMask, tmp);
-            return NumericsHelpers.HorizontalAdd(tmp) > epsilon;
+            TensorPrimitives.Multiply(mixture.Moles, GasOxidizerMask, tmp);
+            return TensorPrimitives.Sum(tmp) > epsilon;
         }
 
         /// <summary>
@@ -131,8 +132,8 @@ namespace Content.Server.Atmos.EntitySystems
                 }
 
                 // transfer moles
-                NumericsHelpers.Multiply(source.Moles, fraction, buffer);
-                NumericsHelpers.Add(receiver.Moles, buffer);
+                TensorPrimitives.Multiply(source.Moles, fraction, buffer);
+                TensorPrimitives.Add(receiver.Moles, buffer, receiver.Moles);
             }
         }
 
@@ -325,13 +326,8 @@ namespace Content.Server.Atmos.EntitySystems
         [PublicAPI]
         public static void AddMolsToMixture(GasMixture mixture, ReadOnlySpan<float> molsToAdd)
         {
-            // Span length should be as long as the length of the gas array.
-            // Technically this is a redundant check because NumericsHelpers will do the same thing,
-            // but eh.
-            ArgumentOutOfRangeException.ThrowIfNotEqual(mixture.Moles.Length, molsToAdd.Length, nameof(mixture.Moles.Length));
-
-            NumericsHelpers.Add(mixture.Moles, molsToAdd);
-            NumericsHelpers.Max(mixture.Moles, 0f);
+            TensorPrimitives.Add(mixture.Moles, molsToAdd, mixture.Moles);
+            TensorPrimitives.Max(mixture.Moles, 0f, mixture.Moles);
         }
 
         public enum GasCompareResult

--- a/Content.Shared/Atmos/EntitySystems/SharedAtmosphereSystem.Gases.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedAtmosphereSystem.Gases.cs
@@ -1,3 +1,4 @@
+using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
 using Content.Shared.Atmos.Prototypes;
 using Content.Shared.Atmos.Reactions;
@@ -110,7 +111,7 @@ public abstract partial class SharedAtmosphereSystem
     [PublicAPI]
     public void GetFlammableMoles(GasMixture mixture, float[] buffer)
     {
-        NumericsHelpers.Multiply(mixture.Moles, GasOxidiserFuelMask, buffer);
+        TensorPrimitives.Multiply(mixture.Moles, GasOxidiserFuelMask, buffer);
     }
 
     /// <summary>
@@ -213,7 +214,7 @@ public abstract partial class SharedAtmosphereSystem
             }
         }
 
-        NumericsHelpers.Add(receiver.Moles, giver.Moles);
+        TensorPrimitives.Add(receiver.Moles, giver.Moles, receiver.Moles);
     }
 
     /// <summary>

--- a/Content.Shared/Atmos/GasMixture.cs
+++ b/Content.Shared/Atmos/GasMixture.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
 using Content.Shared.Atmos.EntitySystems;
 using Content.Shared.Atmos.Reactions;
@@ -42,7 +43,7 @@ namespace Content.Shared.Atmos
         public float TotalMoles
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => NumericsHelpers.HorizontalAdd(Moles);
+            get => TensorPrimitives.Sum(Moles);
         }
 
         [ViewVariables]
@@ -177,9 +178,9 @@ namespace Content.Shared.Atmos
             var removed = new GasMixture(Volume) { Temperature = Temperature };
 
             Moles.CopyTo(removed.Moles.AsSpan());
-            NumericsHelpers.Multiply(removed.Moles, ratio);
+            TensorPrimitives.Multiply(removed.Moles, ratio, removed.Moles);
             if (!Immutable)
-                NumericsHelpers.Sub(Moles, removed.Moles);
+                TensorPrimitives.Subtract(Moles, removed.Moles, Moles);
 
             for (var i = 0; i < Moles.Length; i++)
             {
@@ -223,7 +224,7 @@ namespace Content.Shared.Atmos
         public void Multiply(float multiplier)
         {
             if (Immutable) return;
-            NumericsHelpers.Multiply(Moles, multiplier);
+            TensorPrimitives.Multiply(Moles, multiplier, Moles);
         }
 
         void ISerializationHooks.AfterDeserialization()

--- a/Content.Shared/Content.Shared.csproj
+++ b/Content.Shared/Content.Shared.csproj
@@ -6,6 +6,7 @@
   <Import Project="../MSBuild/Content.props" />
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
+    <PackageReference Include="System.Numerics.Tensors" />
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 

--- a/Content.Tests/Server/Atmos/AddMolsToMixtureTest.cs
+++ b/Content.Tests/Server/Atmos/AddMolsToMixtureTest.cs
@@ -21,10 +21,8 @@ public sealed class AddMolsToMixtureTest
         var mixture = new GasMixture();
         var wrongLength = new float[Atmospherics.AdjustedNumberOfGases + num];
 
-        var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.Throws<ArgumentException>(() =>
             AtmosphereSystem.AddMolsToMixture(mixture, wrongLength));
-
-        Assert.That(ex!.ParamName, Is.EqualTo("Length"));
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
Migrates Atmospherics away from `NumericsHelpers` and over to `TensorPrimitives` which is a much better library for SIMD-accelerated numerics.

Overall, math-heavy operations like `DeltaPressure` are a little bit faster (if you're running a CPU with `AVX-512` intrinsics available). Forks with larger gas arrays may see some marginal improvements.

## Why / Balance
In the pursuit of smaller numbers.

## Technical details
Not much else to say other than a search and replace to an extent. The syntax is a bit different - a destination often has to be explicitly provided instead of `NumericsHelpers`' assumed implicit "overwrite array" standard.

## Test plan
Load up Dev:
- Break the actively running burn chamber
- Test the pipelines for room filling/siphoning
- Break the fans blocking the plasma can to see the fireball properly spreading through the volume.  

Atmostests cover common Atmospherics numerics pretty well.

## Media
Benchmarks show a general improvement for `DeltaPressure`.

```
BenchmarkDotNet v0.15.8, Linux Gentoo Linux
AMD Ryzen 9 7900X 3.94GHz, 1 CPU, 24 logical and 12 physical cores
.NET SDK 10.0.103
  [Host]     : .NET 10.0.3 (10.0.3, 10.0.326.7603), X64 RyuJIT x86-64-v4
  Job-WHXHOJ : .NET 10.0.1 (10.0.1, 10.0.125.57005), X64 RyuJIT x86-64-v4

Server=True  Toolchain=.NET 10.0  
```

| Method                  | EntityCount | BatchSize | EntitiesPerIteration | Mean      | Error     | StdDev    |
|------------------------ |------------ |---------- |--------------------- |----------:|----------:|----------:|
| PerformFullProcess      | 100         | 10        | 1000                 |  19.28 μs |  0.384 μs |  0.801 μs |
| PerformSingleRunProcess | 100         | 10        | 1000                 |  19.46 μs |  0.382 μs |  0.805 μs |
| PerformFullProcess      | 1000        | 10        | 1000                 |  73.47 μs |  1.465 μs |  1.799 μs |
| PerformSingleRunProcess | 1000        | 10        | 1000                 |  72.20 μs |  1.432 μs |  1.811 μs |
| PerformFullProcess      | 5000        | 10        | 1000                 | 339.46 μs |  6.391 μs |  6.276 μs |
| PerformSingleRunProcess | 5000        | 10        | 1000                 | 349.94 μs |  5.934 μs |  5.550 μs |
| PerformFullProcess      | 10000       | 10        | 1000                 | 627.85 μs | 12.067 μs | 12.392 μs |
| PerformSingleRunProcess | 10000       | 10        | 1000                 | 690.34 μs | 13.081 μs | 15.064 μs |

| Method                  | EntityCount | BatchSize | EntitiesPerIteration | Mean      | Error    | StdDev   |
|------------------------ |------------ |---------- |--------------------- |----------:|---------:|---------:|
| PerformFullProcess      | 100         | 10        | 1000                 |  18.51 μs | 0.404 μs | 1.192 μs |
| PerformSingleRunProcess | 100         | 10        | 1000                 |  17.16 μs | 0.343 μs | 0.921 μs |
| PerformFullProcess      | 1000        | 10        | 1000                 |  59.83 μs | 1.187 μs | 1.585 μs |
| PerformSingleRunProcess | 1000        | 10        | 1000                 |  60.76 μs | 1.155 μs | 0.964 μs |
| PerformFullProcess      | 5000        | 10        | 1000                 | 275.26 μs | 4.497 μs | 5.179 μs |
| PerformSingleRunProcess | 5000        | 10        | 1000                 | 269.94 μs | 3.614 μs | 3.018 μs |
| PerformFullProcess      | 10000       | 10        | 1000                 | 537.27 μs | 6.789 μs | 6.350 μs |
| PerformSingleRunProcess | 10000       | 10        | 1000                 | 551.54 μs | 9.221 μs | 9.056 μs |



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Atmospherics now uses the SIMD-accelerated numerics library `System.Numerics.Tensors` (only `TensorPrimitives`) instead of the engine-provided `NumericsHelpers`. It is recommended to migrate your numerics over to the new methods. This means a few things:
- Improved performance for math-heavy processing states like `DeltaPressure`.
- Probably a marginal improvement for gas array math for higher numbers of gases. 
- The `ROBUST_NUMERICS_AVX` environment variable no longer globally controls SIMD-accelerated mathematics.

## Changelog
n/a
