### PR TITLE
Fix dragon carps not being able to speak

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -77,8 +77,6 @@
         - Carp
         - DoorBumpOpener
         - CannotSuicide
-    - type: ReplacementAccent
-      accent: genericAggressive
     - type: Speech
       speechVerb: LargeMob
     - type: InteractionPopup
@@ -89,7 +87,8 @@
 
 - type: entity
   parent: BaseMobCarp
-  id: MobCarp
+  id: BaseMobCarpVisuals
+  abstract: true
   components:
   - type: Sprite
     layers:
@@ -106,6 +105,13 @@
         mouth: ""
 
 - type: entity
+  parent: BaseMobCarpVisuals
+  id: MobCarp
+  components:
+  - type: ReplacementAccent
+    accent: genericAggressive
+
+- type: entity
   name: magicarp
   parent: BaseMobCarp
   id: MobCarpMagic
@@ -115,6 +121,8 @@
     sprite: Mobs/Aliens/Carps/magic.rsi
   - type: TypingIndicator
     proto: guardian
+  - type: ReplacementAccent
+    accent: genericAggressive
 
 - type: entity
   name: holocarp
@@ -138,6 +146,8 @@
         - Opaque
   - type: TypingIndicator
     proto: robot
+  - type: ReplacementAccent
+    accent: genericAggressive
 
 - type: entity
   parent: MobCarp
@@ -166,7 +176,7 @@
   name: space carp
   id: MobCarpDragon
   suffix: DragonBrood
-  parent: MobCarp
+  parent: BaseMobCarpVisuals
   components:
     - type: GhostRole
       allowMovement: true
@@ -254,6 +264,8 @@
         types:
           Slash: 10
           Bloodloss: 5
+    - type: ReplacementAccent
+      accent: genericAggressive
 
 - type: entity
   id: MobSharkSalvage


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Rename mobcarp into "Visual" so I can make space carps be able to speak.
Dragon carps from the start should have been able to speak, but since they inherited the accent, it prevented them to.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's a fun feature from ss13, it technically always been here but it's broken.
## Technical details
<!-- Summary of code changes for easier review. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="210" height="148" alt="image" src="https://github.com/user-attachments/assets/c2a41ead-ab70-4a14-ac89-d4d55fbca3cd" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Dragon Brood space carps not being able to speak.
